### PR TITLE
Start adding support for Kokkos and the Nvidia compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ include(SetupParaView)
 
 add_subdirectory(external)
 
+include(SetupKokkos)
+
 include(SetupLIBCXXCharm)
 # The precompiled header must be setup after all libraries have been found
 if (USE_PCH)

--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -125,15 +125,6 @@ target_compile_definitions(Blaze
   BLAZE_USE_ALWAYS_INLINE=${_BLAZE_USE_ALWAYS_INLINE}
   )
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug"
-    AND NOT USE_PCH)
-  # We need to make sure csignal is included. It is included in the PCH
-  # (see tools/SpectrePch.hpp). If there's no PCH, we need to include it here.
-  target_compile_options(Blaze
-    INTERFACE
-    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include csignal>")
-endif()
-
 target_compile_options(Blaze
   INTERFACE
   "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include ${CMAKE_SOURCE_DIR}/tools/BlazeExceptions.hpp>")

--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -125,33 +125,18 @@ target_compile_definitions(Blaze
   BLAZE_USE_ALWAYS_INLINE=${_BLAZE_USE_ALWAYS_INLINE}
   )
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # CMake doesn't like function macros in target_compile_definitions, so we
-  # have to define it separately. We also need to make sure csignal is
-  # included. It is included in the PCH (see tools/SpectrePch.hpp).
-  # If there's no PCH, we need to include it here.
-  if (NOT USE_PCH)
-    target_compile_options(Blaze
-      INTERFACE
-      "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include csignal>")
-  endif()
+if (CMAKE_BUILD_TYPE STREQUAL "Debug"
+    AND NOT USE_PCH)
+  # We need to make sure csignal is included. It is included in the PCH
+  # (see tools/SpectrePch.hpp). If there's no PCH, we need to include it here.
   target_compile_options(Blaze
     INTERFACE
-    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:
-    -D 'BLAZE_THROW(EXCEPTION)=struct sigaction handler{}\;handler.sa_handler=\
-SIG_IGN\;handler.sa_flags=0\;sigemptyset(&handler.sa_mask)\;\
-sigaction(SIGTRAP,&handler,nullptr)\;raise(SIGTRAP)\;throw EXCEPTION'
-    >")
-else()
-  # In release mode disable checks completely.
-  set_property(TARGET Blaze
-    APPEND PROPERTY
-    INTERFACE_COMPILE_OPTIONS
-    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:
-    -D 'BLAZE_THROW(EXCEPTION)='
-    >")
+    "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include csignal>")
 endif()
 
+target_compile_options(Blaze
+  INTERFACE
+  "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include ${CMAKE_SOURCE_DIR}/tools/BlazeExceptions.hpp>")
 
 add_interface_lib_headers(
   TARGET Blaze

--- a/cmake/SetupKokkos.cmake
+++ b/cmake/SetupKokkos.cmake
@@ -1,0 +1,38 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(SPECTRE_KOKKOS "Use Kokkos" OFF)
+
+if(SPECTRE_KOKKOS)
+  set(Kokkos_ENABLE_AGGRESSIVE_VECTORIZATION ON CACHE BOOL
+     "Kokkos aggressive vectorization")
+
+   if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR SPECTRE_DEBUG)
+     message(STATUS "Enabling Kokkos debug mode")
+     set(Kokkos_ENABLE_DEBUG ON CACHE BOOL "Most general debug settings")
+     set(Kokkos_ENABLE_DEBUG_BOUNDS_CHECK ON CACHE BOOL
+       "Bounds checking on Kokkos views")
+     set(Kokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK ON CACHE BOOL
+       "Sanity checks on Kokkos DualView")
+   endif()
+
+  if(Kokkos_ENABLE_CUDA)
+    set(CMAKE_CUDA_STANDARD 20)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    enable_language(CUDA)
+    find_package(CUDAToolkit REQUIRED)
+    set(Kokkos_ENABLE_CUDA_LAMBDA ON CACHE BOOL
+      "Enable lambda expressions in CUDA")
+  endif()
+
+  find_package(Kokkos REQUIRED)
+
+  if (TARGET Kokkos::kokkos AND Kokkos_ENABLE_CUDA)
+    set_property(TARGET Kokkos::kokkos
+      APPEND PROPERTY
+      INTERFACE_COMPILE_OPTIONS
+      $<$<COMPILE_LANGUAGE:CXX>:
+      -Xcudafe;"--diag_suppress=186,191,554,1301,1305,2189,3060">
+    )
+  endif()
+endif()

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -190,6 +190,8 @@ alphabetical order):
   - Minimum priority of input file tests to run. Possible values are: `low` (not
     usually run on CI), `normal` (run at least once on CI), `high` (run always
     on CI). (default is `normal`)
+- SPECTRE_KOKKOS (default: `OFF`)
+  - Enable Kokkos support. You must have Kokkos installed and detectable.
 - SPECTRE_LTO
   - Enable link-time optimization if the compiler supports it.
 - SPECTRE_LTO_CORES
@@ -527,3 +529,22 @@ To further aid in reproducibility, the `printenv` output and
 ```
 h5dump -d /src.tar.gz -b LE -o src.tar.gz /path/to/hdf5/file.h5
 ```
+
+# Using Kokkos
+
+Kokkos support is still extremely experimental, but can be enabled by passing
+`-D SPECTRE_KOKKOS=ON` to CMake. You must pass additional CMake flags that
+Kokkos will use to configure itself. For example, to enable CUDA support you
+must pass `-D Kokkos_ENABLE_CUDA=ON`. See the
+[Kokkos documentation](https://kokkos.org/kokkos-core-wiki/keywords.html) for
+details.
+
+## Nvidia Compiler
+
+If you are using CUDA to compile for Nvidia GPUs but do not have the target GPU
+on the system you are compiling on then you must also tell CMake what CUDA
+architecture to use. You can do this by passing `-D CMAKE_CUDA_ARCHITECTURES=80`
+to CMake. You must choose the architecture that will be compatible with the GPU
+you plan to use. Note that this is actually called the compute capability
+version by Nvidia and can be viewed
+[here](https://developer.nvidia.com/cuda-gpus).

--- a/src/DataStructures/Tensor/EagerMath/CartesianToSpherical.cpp
+++ b/src/DataStructures/Tensor/EagerMath/CartesianToSpherical.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"

--- a/src/DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.cpp
+++ b/src/DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 

--- a/src/DataStructures/Tensor/EagerMath/Trace.cpp
+++ b/src/DataStructures/Tensor/EagerMath/Trace.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -1003,7 +1003,7 @@ SPECTRE_ALWAYS_INLINE auto operator-(
       (... and tt::is_time_index<Args>::value),
       "Can only subtract a number from a tensor expression that evaluates to a "
       "rank 0 tensor.");
-  return t + tenex::NumberAsExpression(-number);
+  return t + tenex::NumberAsExpression<N>(-number);
 }
 template <typename T, typename X, typename Symm, typename IndexList,
           typename... Args, typename N,
@@ -1015,7 +1015,7 @@ SPECTRE_ALWAYS_INLINE auto operator-(
       (... and tt::is_time_index<Args>::value),
       "Can only subtract a number from a tensor expression that evaluates to a "
       "rank 0 tensor.");
-  return tenex::NumberAsExpression(number) - t;
+  return tenex::NumberAsExpression<N>(number) - t;
 }
 template <typename T, typename X, typename Symm, typename IndexList,
           typename... Args, typename N>
@@ -1037,6 +1037,6 @@ SPECTRE_ALWAYS_INLINE auto operator-(
       (... and tt::is_time_index<Args>::value),
       "Can only subtract a number from a tensor expression that evaluates to a "
       "rank 0 tensor.");
-  return tenex::NumberAsExpression(number) - t;
+  return tenex::NumberAsExpression<N>(number) - t;
 }
 /// @}

--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -72,65 +72,67 @@ constexpr bool check_index_symmetry_v =
  * \ingroup TensorGroup
  * \brief Add a spatial index to the front of a Tensor
  *
- * \tparam Tensor the tensor type to which the new index is prepended
+ * \tparam TheTensor the tensor type to which the new index is prepended
  * \tparam VolumeDim the volume dimension of the tensor index to prepend
  * \tparam Fr the ::Frame of the tensor index to prepend
  */
-template <typename Tensor, std::size_t VolumeDim, UpLo Ul,
+template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
           typename Fr = Frame::Grid>
 using prepend_spatial_index = ::Tensor<
-    typename Tensor::type,
+    typename TheTensor::type,
     tmpl::push_front<
-        typename Tensor::symmetry,
+        typename TheTensor::symmetry,
         tmpl::int32_t<
-            1 + tmpl::fold<typename Tensor::symmetry, tmpl::int32_t<0>,
+            1 + tmpl::fold<typename TheTensor::symmetry, tmpl::int32_t<0>,
                            tmpl::max<tmpl::_state, tmpl::_element>>::value>>,
-    tmpl::push_front<typename Tensor::index_list,
+    tmpl::push_front<typename TheTensor::index_list,
                      SpatialIndex<VolumeDim, Ul, Fr>>>;
 
 /*!
  * \ingroup TensorGroup
  * \brief Add a spacetime index to the front of a Tensor
  *
- * \tparam Tensor the tensor type to which the new index is prepended
+ * \tparam TheTensor the tensor type to which the new index is prepended
  * \tparam VolumeDim the volume dimension of the tensor index to prepend
  * \tparam Fr the ::Frame of the tensor index to prepend
  */
-template <typename Tensor, std::size_t VolumeDim, UpLo Ul,
+template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
           typename Fr = Frame::Grid>
 using prepend_spacetime_index = ::Tensor<
-    typename Tensor::type,
+    typename TheTensor::type,
     tmpl::push_front<
-        typename Tensor::symmetry,
+        typename TheTensor::symmetry,
         tmpl::int32_t<
-            1 + tmpl::fold<typename Tensor::symmetry, tmpl::int32_t<0>,
+            1 + tmpl::fold<typename TheTensor::symmetry, tmpl::int32_t<0>,
                            tmpl::max<tmpl::_state, tmpl::_element>>::value>>,
-    tmpl::push_front<typename Tensor::index_list,
+    tmpl::push_front<typename TheTensor::index_list,
                      SpacetimeIndex<VolumeDim, Ul, Fr>>>;
 
 /// \ingroup TensorGroup
 /// \brief remove the first index of a tensor
-/// \tparam Tensor the tensor type whose first index is removed
-template <typename Tensor>
+/// \tparam TheTensor the tensor type whose first index is removed
+template <typename TheTensor>
 using remove_first_index =
-    ::Tensor<typename Tensor::type, tmpl::pop_front<typename Tensor::symmetry>,
-             tmpl::pop_front<typename Tensor::index_list>>;
+    ::Tensor<typename TheTensor::type,
+             tmpl::pop_front<typename TheTensor::symmetry>,
+             tmpl::pop_front<typename TheTensor::index_list>>;
 
 /// \ingroup TensorGroup
 /// \brief Swap the valences of all indices on a Tensor
-template <typename Tensor>
+template <typename TheTensor>
 using change_all_valences =
-    ::Tensor<typename Tensor::type, typename Tensor::symmetry,
-             tmpl::transform<typename Tensor::index_list,
+    ::Tensor<typename TheTensor::type, typename TheTensor::symmetry,
+             tmpl::transform<typename TheTensor::index_list,
                              tmpl::bind<change_index_up_lo, tmpl::_1>>>;
 
 /// \ingroup TensorGroup
 /// \brief Swap the data type of a tensor for a new type
 /// \tparam NewType the new data type
-/// \tparam Tensor the tensor from which to keep symmetry and index information
-template <typename NewType, typename Tensor>
-using swap_type =
-    ::Tensor<NewType, typename Tensor::symmetry, typename Tensor::index_list>;
+/// \tparam TheTensor the tensor from which to keep symmetry and index
+/// information
+template <typename NewType, typename TheTensor>
+using swap_type = ::Tensor<NewType, typename TheTensor::symmetry,
+                           typename TheTensor::index_list>;
 
 namespace detail {
 template <typename T, typename Frame>
@@ -140,15 +142,16 @@ using frame_is_the_same = std::is_same<typename T::Frame, Frame>;
 /// \ingroup TensorGroup
 /// \brief Return tmpl::true_type if any indices of the Tensor are in the
 /// frame Frame.
-template <typename Tensor, typename Frame>
+template <typename TheTensor, typename Frame>
 using any_index_in_frame =
-    tmpl::any<typename Tensor::index_list,
+    tmpl::any<typename TheTensor::index_list,
               tmpl::bind<detail::frame_is_the_same, tmpl::_1, Frame>>;
 
 /// \ingroup TensorGroup
 /// \brief Return true if any indices of the Tensor are in the
 /// frame Frame.
-template <typename Tensor, typename Frame>
-constexpr bool any_index_in_frame_v = any_index_in_frame<Tensor, Frame>::value;
+template <typename TheTensor, typename Frame>
+constexpr bool any_index_in_frame_v =
+    any_index_in_frame<TheTensor, Frame>::value;
 
 }  // namespace TensorMetafunctions

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -29,6 +29,7 @@
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/MathWrapper.hpp"
+#include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -94,6 +94,7 @@ target_link_libraries(
   Boost::boost
   Brigand
   ErrorHandling
+  SpectreKokkos
   PRIVATE
   Printf
   )

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Kokkos)
 add_subdirectory(Simd)
 
 set(LIBRARY Utilities)

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -16,6 +16,7 @@
 #include <utility>
 
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/Kokkos/KokkosCore.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -69,7 +70,8 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) cube(const T& x) {
  * \note The largest representable factorial is 20!. It is up to the user to
  * ensure this is satisfied
  */
-constexpr uint64_t falling_factorial(const uint64_t x, const uint64_t n) {
+KOKKOS_FUNCTION constexpr uint64_t falling_factorial(const uint64_t x,
+                                                     const uint64_t n) {
   // clang-tidy: don't warn about STL internals, I can't fix them
   assert(n <= x);  // NOLINT
   uint64_t r = 1;
@@ -83,7 +85,7 @@ constexpr uint64_t falling_factorial(const uint64_t x, const uint64_t n) {
  * \ingroup ConstantExpressionsGroup
  * \brief Compute the factorial of \f$n!\f$
  */
-constexpr uint64_t factorial(const uint64_t n) {
+KOKKOS_FUNCTION constexpr uint64_t factorial(const uint64_t n) {
   assert(n <= 20);  // NOLINT
   return falling_factorial(n, n);
 }
@@ -165,30 +167,30 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) pow(const T& t) {
 /// The argument must be comparable to an int and must be negatable.
 template <typename T, Requires<tt::is_integer_v<T> or
                                std::is_floating_point_v<T>> = nullptr>
-SPECTRE_ALWAYS_INLINE constexpr T ce_abs(const T& x) {
+KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr T ce_abs(const T& x) {
   return x < 0 ? -x : x;
 }
 
 /// \cond
 template <>
-SPECTRE_ALWAYS_INLINE constexpr double ce_abs(const double& x) {
+KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr double ce_abs(const double& x) {
   return __builtin_fabs(x);
 }
 
 template <>
-SPECTRE_ALWAYS_INLINE constexpr float ce_abs(const float& x) {
+KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr float ce_abs(const float& x) {
   return __builtin_fabsf(x);
 }
 /// \endcond
 
 /// \ingroup ConstantExpressionsGroup
 /// \brief Compute the absolute value of its argument
-constexpr SPECTRE_ALWAYS_INLINE double ce_fabs(const double x) {
-  return __builtin_fabs(x);
+KOKKOS_FUNCTION constexpr SPECTRE_ALWAYS_INLINE double ce_fabs(const double x) {
+  return ce_abs(x);
 }
 
-constexpr SPECTRE_ALWAYS_INLINE float ce_fabs(const float x) {
-  return __builtin_fabsf(x);
+KOKKOS_FUNCTION constexpr SPECTRE_ALWAYS_INLINE float ce_fabs(const float x) {
+  return ce_abs(x);
 }
 
 namespace ConstantExpressions_detail {

--- a/src/Utilities/ErrorHandling/Error.hpp
+++ b/src/Utilities/ErrorHandling/Error.hpp
@@ -63,6 +63,11 @@ template <typename ExceptionTypeToThrow, typename F>
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
+#ifdef __CUDA_ARCH__
+#define ERROR(m)                                              \
+  printf("Error in file %s on line %d.", __FILE__, __LINE__); \
+  __trap();
+#else
 #define ERROR(m)                                                             \
   do {                                                                       \
     if (__builtin_is_constant_evaluated()) {                                 \
@@ -76,6 +81,7 @@ template <typename ExceptionTypeToThrow, typename F>
           });                                                                \
     }                                                                        \
   } while (false)
+#endif
 
 /*!
  * \ingroup ErrorHandlingGroup
@@ -85,6 +91,11 @@ template <typename ExceptionTypeToThrow, typename F>
  * \note Any exception types used must have an associated explicit
  * instantiation in `Utilities/ErrorHandling/AbortWithErrorMessage.cpp`
  */
+#ifdef __CUDA_ARCH__
+#define ERROR_AS(m, EXCEPTION_TYPE)                           \
+  printf("Error in file %s on line %d.", __FILE__, __LINE__); \
+  __trap();
+#else
 #define ERROR_AS(m, EXCEPTION_TYPE)                                          \
   do {                                                                       \
     if (__builtin_is_constant_evaluated()) {                                 \
@@ -98,12 +109,18 @@ template <typename ExceptionTypeToThrow, typename F>
           });                                                                \
     }                                                                        \
   } while (false)
+#endif
 
 /*!
  * \ingroup ErrorHandlingGroup
  * \brief Same as ERROR but does not print a backtrace. Intended to be used for
  * user errors, such as incorrect values in an input file.
  */
+#ifdef __CUDA_ARCH__
+#define ERROR_NO_TRACE(m)                                     \
+  printf("Error in file %s on line %d.", __FILE__, __LINE__); \
+  __trap();
+#else
 #define ERROR_NO_TRACE(m)                                                    \
   do {                                                                       \
     if (__builtin_is_constant_evaluated()) {                                 \
@@ -115,3 +132,4 @@ template <typename ExceptionTypeToThrow, typename F>
           MakeString{} << std::setprecision(18) << std::scientific << m);    \
     }                                                                        \
   } while (false)
+#endif

--- a/src/Utilities/Gsl.hpp
+++ b/src/Utilities/Gsl.hpp
@@ -38,6 +38,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "Utilities/Array.hpp"
 #include "Utilities/ErrorHandling/ExpectsAndEnsures.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Literals.hpp"
@@ -123,6 +124,20 @@ SPECTRE_ALWAYS_INLINE T narrow(U u) {
  */
 template <class T, std::size_t N, typename Size>
 SPECTRE_ALWAYS_INLINE constexpr T& at(std::array<T, N>& arr, Size index) {
+  Expects(index >= 0 and index < narrow_cast<Size>(N));
+  return arr[static_cast<std::size_t>(index)];
+}
+
+template <class T, std::size_t N, typename Size>
+KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr T& at(cpp20::array<T, N>& arr,
+                                                      Size index) {
+  Expects(index >= 0 and index < narrow_cast<Size>(N));
+  return arr[static_cast<std::size_t>(index)];
+}
+
+template <class T, std::size_t N, typename Size>
+KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr const T& at(
+    const cpp20::array<T, N>& arr, Size index) {
   Expects(index >= 0 and index < narrow_cast<Size>(N));
   return arr[static_cast<std::size_t>(index)];
 }

--- a/src/Utilities/Kokkos/CMakeLists.txt
+++ b/src/Utilities/Kokkos/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY SpectreKokkos)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  KokkosCore.hpp
+)
+
+if(TARGET Kokkos::kokkos)
+  target_link_libraries(
+    ${LIBRARY}
+    INTERFACE
+    Kokkos::kokkos
+  )
+endif()

--- a/src/Utilities/Kokkos/KokkosCore.hpp
+++ b/src/Utilities/Kokkos/KokkosCore.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#if __has_include(<Kokkos_Core.hpp>)
+#include <Kokkos_Core.hpp>
+
+/// \brief If defined then SpECTRE is using Kokkos
+#define SPECTRE_KOKKOS 1
+
+#else  // #if __has_include(<Kokkos_Core.hpp>)
+#define KOKKOS_FUNCTION
+#define KOKKOS_INLINE_FUNCTION
+#endif  // #if __has_include(<Kokkos_Core.hpp>)

--- a/src/Utilities/Simd/Simd.hpp
+++ b/src/Utilities/Simd/Simd.hpp
@@ -242,17 +242,33 @@ T select(const bool cond, const T true_branch, const T false_branch) {
 }
 
 inline std::pair<float, float> sincos(const float val) {
+  // The nvcc compiler's built-in __sincos is for GPU code, not CPU code. In
+  // the case that we are running on a GPU (__CUDA_ARCH__ is defined) or we
+  // are not using nvcc then use the builtin, otherwise call sin and cos
+  // separately.
+#if (defined(__CUDACC__) && defined(__CUDA_ARCH__)) or (not defined(__CUDACC__))
   float result_sin{};
   float result_cos{};
   __sincosf(val, &result_sin, &result_cos);
-  return std::make_pair(result_sin, result_cos);
+  return std::pair{result_sin, result_cos};
+#else
+  return std::pair{sin(val), cos(val)};
+#endif
 }
 
 inline std::pair<double, double> sincos(const double val) {
+  // The nvcc compiler's built-in __sincos is for GPU code, not CPU code. In
+  // the case that we are running on a GPU (__CUDA_ARCH__ is defined) or we
+  // are not using nvcc then use the builtin, otherwise call sin and cos
+  // separately.
+#if (defined(__CUDACC__) && defined(__CUDA_ARCH__)) or (not defined(__CUDACC__))
   double result_sin{};
   double result_cos{};
   __sincos(val, &result_sin, &result_cos);
-  return std::make_pair(result_sin, result_cos);
+  return std::pair{result_sin, result_cos};
+#else
+  return std::pair{sin(val), cos(val)};
+#endif
 }
 
 template <typename T, Requires<std::is_integral_v<T>> = nullptr>

--- a/tools/BlazeExceptions.hpp
+++ b/tools/BlazeExceptions.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#ifndef SPECTRE_BLAZE_EXCEPTIONS_HPP
+#define SPECTRE_BLAZE_EXCEPTIONS_HPP
+
+#ifdef SPECTRE_DEBUG
+#define BLAZE_THROW(EXCEPTION)           \
+  struct sigaction handler {};           \
+  handler.sa_handler = SIG_IGN;          \
+  handler.sa_flags = 0;                  \
+  sigemptyset(&handler.sa_mask);         \
+  sigaction(SIGTRAP, &handler, nullptr); \
+  raise(SIGTRAP);                        \
+  throw EXCEPTION
+#else  // SPECTRE_DEBUG
+#define BLAZE_THROW(EXCEPTION)
+#endif  // SPECTRE_DEBUG
+#endif  // BLAZE_EXCEPTIONSSPECTRE_BLAZE_EXCEPTIONS_HPP

--- a/tools/BlazeExceptions.hpp
+++ b/tools/BlazeExceptions.hpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <csignal>
+
 #ifndef SPECTRE_BLAZE_EXCEPTIONS_HPP
 #define SPECTRE_BLAZE_EXCEPTIONS_HPP
 

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -534,7 +534,8 @@ standard_checks+=(ls_list)
 pragma_once() {
     is_includible "$1" && \
         whitelist "$1" \
-                  'tools/SpectrePch.hpp$' && \
+                  'tools/SpectrePch.hpp$' \
+                  'tools/BlazeExceptions.hpp$' && \
         ! staged_grep -q -x '#pragma once' "$1"
 }
 pragma_once_report() {


### PR DESCRIPTION
## Proposed changes

My plan is to first get support for nvcc (the Nvidia compiler) to compile our code. nvcc uses the Edison Design Group (EDG) compiler front end, and so will parse code differently from GCC and Clang. I plan on first getting the code to compile with nvcc without target GPUs. Once that's working I'll continue getting the necessary bits to run on a GPU. The functions with `KOKKOS_FUNCTION` in front are ones that are compiled with nvcc to run on the GPU.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
