### PR TITLE
Observe DimensionfulSpinVector on horizons

### DIFF
--- a/src/IO/Observer/ReductionActions.cpp
+++ b/src/IO/Observer/ReductionActions.cpp
@@ -21,4 +21,10 @@ void append_to_reduction_data(
   all_reduction_data->insert(all_reduction_data->end(), t.begin(), t.end());
 }
 
+void append_to_reduction_data(
+    const gsl::not_null<std::vector<double>*> all_reduction_data,
+    const std::array<double, 3>& t) {
+    all_reduction_data->insert(all_reduction_data->end(), t.begin(), t.end());
+}
+
 }  // namespace observers::ThreadedActions::ReductionActions_detail

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -229,6 +229,10 @@ void append_to_reduction_data(
     const gsl::not_null<std::vector<double>*> all_reduction_data,
     const std::vector<double>& t);
 
+void append_to_reduction_data(
+    gsl::not_null<std::vector<double>*> all_reduction_data,
+    const std::array<double, 3>& t);
+
 template <typename... Ts, size_t... Is>
 void write_data(const std::string& subfile_name,
                 const std::string& input_source,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
@@ -41,9 +41,8 @@ using tags_for_observing = tmpl::list<
     gr::surfaces::Tags::IrreducibleMassCompute<Frame>,
     ylm::Tags::MaxRicciScalarCompute, ylm::Tags::MinRicciScalarCompute,
     gr::surfaces::Tags::ChristodoulouMassCompute<Frame>,
-    gr::surfaces::Tags::DimensionlessSpinMagnitudeCompute<Frame>
-    // Needs `ObserveTimeSeriesOnSurface` to be able to write a `std::array`
-    // gr::surfaces::Tags::DimensionlessSpinVectorCompute<Frame, Frame>
+    gr::surfaces::Tags::DimensionlessSpinMagnitudeCompute<Frame>,
+    gr::surfaces::Tags::DimensionfulSpinVectorCompute<Frame, Frame>
     >;
 
 using surface_tags_for_observing = tmpl::list<ylm::Tags::RicciScalar>;

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.cpp
@@ -636,7 +636,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE,
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Grid, Frame::Distorted, Frame::Inertial),
-                        (Frame::Inertial))
+                        (Frame::Inertial, Frame::Distorted))
 #undef INSTANTIATE
 #undef MEASUREMENTFRAME
 #undef METRICFRAME


### PR DESCRIPTION
## Proposed changes
With these changes black hole and binary black hole simulations will output the spin of each black hole. This allows constraint energy control to be done just as in SpEC.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

In the make_legend() function a special case is set aside for when the tag is included, this is a terrible solution for obvious reasons so I slightly editted this version to query the return_type variable in every tag and will accommodate the legend appropriately but that may not be the most efficient solution. Any ideas welcome.