### PR TITLE
Control center of mass and linear momentum in initial data.

### DIFF
--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -28,6 +28,9 @@ Parallelization:
 Background: &background
   Binary:
     XCoords: [&x_left {{ XLeft }}, &x_right {{ XRight }}]
+    CenterOfMassOffset:
+      - &y_offset 0.
+      - &z_offset 0.
     ObjectLeft: &kerr_left
       KerrSchild:
         Mass: &mass_left {{ MassLeft }}
@@ -64,7 +67,7 @@ DomainCreator:
       Interior:
         ExciseWithBoundaryCondition:
           ApparentHorizon:
-            Center: [*x_right, 0., 0.]
+            Center: [*x_right, *y_offset, *z_offset]
             Rotation:
               - {{ HorizonRotationRight_x }}
               - {{ HorizonRotationRight_y }}
@@ -79,7 +82,7 @@ DomainCreator:
       Interior:
         ExciseWithBoundaryCondition:
           ApparentHorizon:
-            Center: [*x_left, 0., 0.]
+            Center: [*x_left, *y_offset, *z_offset]
             Rotation:
               - {{ HorizonRotationLeft_x }}
               - {{ HorizonRotationLeft_y }}
@@ -87,6 +90,7 @@ DomainCreator:
             Lapse: *kerr_left
             NegativeExpansion: *kerr_left
       UseLogarithmicMap: True
+    CenterOfMassOffset: [*y_offset, *z_offset]
     Envelope:
       Radius: &outer_shell_inner_radius 60.
       RadialDistribution: Projective

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -14,6 +14,17 @@ Next:
     control: {{ control }}
     control_refinement_level: {{ L }}
     control_polynomial_order: {{ P }}
+    control_params:
+      mass_A: {{ MassRight }}
+      mass_B: {{ MassLeft }}
+      spin_A:
+        - {{ DimensionlessSpinRight_x }}
+        - {{ DimensionlessSpinRight_y }}
+        - {{ DimensionlessSpinRight_z }}
+      spin_B:
+        - {{ DimensionlessSpinLeft_x }}
+        - {{ DimensionlessSpinLeft_y }}
+        - {{ DimensionlessSpinLeft_z }}
     evolve: {{ evolve }}
     scheduler: {{ scheduler | default("None") }}
     copy_executable: {{ copy_executable | default("None") }}
@@ -29,8 +40,8 @@ Background: &background
   Binary:
     XCoords: [&x_left {{ XLeft }}, &x_right {{ XRight }}]
     CenterOfMassOffset:
-      - &y_offset 0.
-      - &z_offset 0.
+      - &y_offset {{ CenterOfMassOffset_y }}
+      - &z_offset {{ CenterOfMassOffset_z }}
     ObjectLeft: &kerr_left
       KerrSchild:
         Mass: &mass_left {{ MassLeft }}
@@ -51,7 +62,10 @@ Background: &background
         Velocity: [0., 0., 0.]
     AngularVelocity: {{ OrbitalAngularVelocity }}
     Expansion: {{ RadialExpansionVelocity }}
-    LinearVelocity: [0., 0., 0.]
+    LinearVelocity:
+      - {{ LinearVelocity_x }}
+      - {{ LinearVelocity_y }}
+      - {{ LinearVelocity_z }}
     FalloffWidths:
       - {{ FalloffWidthLeft }}
       - {{ FalloffWidthRight }}

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -151,6 +151,8 @@ def inspiral_parameters(
         "ExcisionRadiusB": id_domain_creator["ObjectB"]["InnerRadius"],
         "XCoordA": id_domain_creator["ObjectA"]["XCoord"],
         "XCoordB": id_domain_creator["ObjectB"]["XCoord"],
+        "CenterOfMassOffset_y": id_domain_creator["CenterOfMassOffset"][0],
+        "CenterOfMassOffset_z": id_domain_creator["CenterOfMassOffset"][1],
         # Initial functions of time
         "InitialAngularVelocity": id_binary["AngularVelocity"],
         "RadialExpansionVelocity": float(id_binary["Expansion"]),

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -63,6 +63,9 @@ DomainCreator:
         ExciseWithBoundaryCondition:
           DemandOutgoingCharSpeeds:
       UseLogarithmicMap: true
+    CenterOfMassOffset:
+      - &YOffset {{ CenterOfMassOffset_y }}
+      - &ZOffset {{ CenterOfMassOffset_z }}
     Envelope:
       Radius: 100.0
       # Radial distribution is logarithmic to transition from grid point
@@ -180,11 +183,11 @@ EvolutionSystem:
         Gaussian1:
           Amplitude: {{ Gamma0LeftAmplitude }}
           Width: {{ Gamma0LeftWidth }}
-          Center: [*XCoordA, 0.0, 0.0]
+          Center: [*XCoordA, *YOffset, *ZOffset]
         Gaussian2:
           Amplitude: {{ Gamma0RightAmplitude }}
           Width:  {{ Gamma0RightWidth }}
-          Center: [*XCoordB, 0.0, 0.0]
+          Center: [*XCoordB, *YOffset, *ZOffset]
         Gaussian3:
           Amplitude: {{ Gamma0OriginAmplitude }}
           Width: {{ Gamma0OriginWidth }}
@@ -346,7 +349,7 @@ ApparentHorizons:
     InitialGuess:
       LMax: *LMax
       Radius: {{ ExcisionRadiusA * 1.5 }}
-      Center: [*XCoordA, 0.0, 0.0]
+      Center: [*XCoordA, *YOffset, *ZOffset]
     FastFlow: &DefaultFastFlow
       Flow: Fast
       Alpha: 1.0
@@ -361,7 +364,7 @@ ApparentHorizons:
     InitialGuess:
       LMax: *LMax
       Radius: {{ ExcisionRadiusB * 1.5 }}
-      Center: [*XCoordB, 0.0, 0.0]
+      Center: [*XCoordB, *YOffset, *ZOffset]
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
   ObservationAhC:
@@ -384,12 +387,12 @@ InterpolationTargets:
     AngularOrdering: Cce
   ObservationExcisionBoundaryA: &ExBdryA
     LMax: *LMax
-    Center: [*XCoordA, 0., 0.]
+    Center: [*XCoordA, *YOffset, *ZOffset]
     Radius: *ExcisionRadiusA
     AngularOrdering: "Strahlkorper"
   ObservationExcisionBoundaryB: &ExBdryB
     LMax: *LMax
-    Center: [*XCoordB, 0., 0.]
+    Center: [*XCoordB, *YOffset, *ZOffset]
     Radius: *ExcisionRadiusB
     AngularOrdering: "Strahlkorper"
   ControlSystemCharSpeedExcisionA: *ExBdryA

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -58,6 +58,7 @@ DomainCreator:
       Interior:
         ExciseWithBoundaryCondition: Worldtube
       UseLogarithmicMap: false
+    CenterOfMassOffset: [0., 0.]
     Envelope:
       RadialDistribution: Linear
       Radius: 50.

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -47,6 +47,7 @@ DomainCreator:
       XCoord: -7.683
       ExciseInterior: true
       UseLogarithmicMap: true
+    CenterOfMassOffset: [0., 0.]
     Envelope:
       Radius: 100.0
       RadialDistribution: Linear

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -41,6 +41,7 @@ DomainCreator:
       CartesianCubeAtXCoord: &XCoordA 20
     ObjectB:
       CartesianCubeAtXCoord: &XCoordB -20
+    CenterOfMassOffset: [0., 0.]
     Envelope:
       Radius: 100.0
       RadialDistribution: Linear

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -79,6 +79,7 @@ ResourceInfo:
 Background: &background
   Binary:
     XCoords: [&x_left -8., &x_right 8.]
+    CenterOfMassOffset: [&y_offset 0., &z_offset 0.]
     ObjectLeft: &kerr_left
       KerrSchild:
         Mass: 0.4229
@@ -109,7 +110,7 @@ DomainCreator:
       Interior:
         ExciseWithBoundaryCondition:
           ApparentHorizon:
-            Center: [*x_right, 0., 0.]
+            Center: [*x_right, *y_offset, *z_offset]
             Rotation: [0., 0., 0.]
             Lapse: *kerr_right
             NegativeExpansion: *kerr_right
@@ -121,11 +122,12 @@ DomainCreator:
       Interior:
         ExciseWithBoundaryCondition:
           ApparentHorizon:
-            Center: [*x_left, 0., 0.]
+            Center: [*x_left, *y_offset, *z_offset]
             Rotation: [0., 0., 0.]
             Lapse: *kerr_left
             NegativeExpansion: *kerr_left
       UseLogarithmicMap: True
+    CenterOfMassOffset: [*y_offset, *z_offset]
     Envelope:
       Radius: &outer_shell_inner_radius 60.
       RadialDistribution: Projective

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -19,6 +19,7 @@ ResourceInfo:
 Background: &background
   Binary:
     XCoords: [&x_left -20., &x_right 20.]
+    CenterOfMassOffset: [&y_offset 0., &z_offset 0.]
     ObjectLeft: &star_left
       TovStar:
         # Values taken from Sec. V.C and Fig. 8 in
@@ -54,6 +55,7 @@ DomainCreator:
       XCoord: *x_left
       Interior: Auto
       UseLogarithmicMap: False
+    CenterOfMassOffset: [*y_offset, *z_offset]
     Envelope:
       Radius: &outer_shell_inner_radius 120.
       RadialDistribution: Projective

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -99,6 +99,9 @@ void test_connectivity() {
   constexpr double outer_radius_objectB = 1.0;
   constexpr double xcoord_objectB = -3.0;
 
+  // Center of mass offset:
+  constexpr std::array<double, 2> center_of_mass_offset{{0.1, 0.2}};
+
   // Envelope:
   constexpr double envelope_radius = 25.5;
 
@@ -157,6 +160,7 @@ void test_connectivity() {
                                           : nullptr})
                                 : std::nullopt,
                false},
+        center_of_mass_offset,
         envelope_radius,
         outer_radius,
         refinement,
@@ -234,28 +238,30 @@ void test_connectivity() {
     if (excise_interiorA) {
       expected_excision_spheres.emplace(
           "ExcisionSphereA",
-          ExcisionSphere<3>{
-              inner_radius_objectA,
-              tnsr::I<double, 3, Frame::Grid>{{xcoord_objectA, 0.0, 0.0}},
-              {{0, Direction<3>::lower_zeta()},
-               {1, Direction<3>::lower_zeta()},
-               {2, Direction<3>::lower_zeta()},
-               {3, Direction<3>::lower_zeta()},
-               {4, Direction<3>::lower_zeta()},
-               {5, Direction<3>::lower_zeta()}}});
+          ExcisionSphere<3>{inner_radius_objectA,
+                            tnsr::I<double, 3, Frame::Grid>{
+                                {xcoord_objectA, center_of_mass_offset[0],
+                                 center_of_mass_offset[1]}},
+                            {{0, Direction<3>::lower_zeta()},
+                             {1, Direction<3>::lower_zeta()},
+                             {2, Direction<3>::lower_zeta()},
+                             {3, Direction<3>::lower_zeta()},
+                             {4, Direction<3>::lower_zeta()},
+                             {5, Direction<3>::lower_zeta()}}});
     }
     if (excise_interiorB) {
       expected_excision_spheres.emplace(
           "ExcisionSphereB",
-          ExcisionSphere<3>{
-              inner_radius_objectB,
-              tnsr::I<double, 3, Frame::Grid>{{xcoord_objectB, 0.0, 0.0}},
-              {{12, Direction<3>::lower_zeta()},
-               {13, Direction<3>::lower_zeta()},
-               {14, Direction<3>::lower_zeta()},
-               {15, Direction<3>::lower_zeta()},
-               {16, Direction<3>::lower_zeta()},
-               {17, Direction<3>::lower_zeta()}}});
+          ExcisionSphere<3>{inner_radius_objectB,
+                            tnsr::I<double, 3, Frame::Grid>{
+                                {xcoord_objectB, center_of_mass_offset[0],
+                                 center_of_mass_offset[1]}},
+                            {{12, Direction<3>::lower_zeta()},
+                             {13, Direction<3>::lower_zeta()},
+                             {14, Direction<3>::lower_zeta()},
+                             {15, Direction<3>::lower_zeta()},
+                             {16, Direction<3>::lower_zeta()},
+                             {17, Direction<3>::lower_zeta()}}});
     }
     CHECK(domain.excision_spheres() == expected_excision_spheres);
 
@@ -275,8 +281,8 @@ void test_connectivity() {
                                          create_inner_boundary_condition()})
                                    : std::nullopt,
                   false},
-              envelope_radius, outer_radius, refinement, grid_points,
-              use_equiangular_map, radial_distribution_envelope,
+              center_of_mass_offset, envelope_radius, outer_radius, refinement,
+              grid_points, use_equiangular_map, radial_distribution_envelope,
               radial_distribution_outer_shell, opening_angle, std::nullopt,
               std::make_unique<PeriodicBc>(),
               Options::Context{false, {}, 1, 1}),
@@ -298,10 +304,10 @@ void test_connectivity() {
                                               std::make_unique<PeriodicBc>()})
                                         : std::nullopt,
                        false},
-                envelope_radius, outer_radius, refinement, grid_points,
-                use_equiangular_map, radial_distribution_envelope,
-                radial_distribution_outer_shell, opening_angle, std::nullopt,
-                create_outer_boundary_condition(),
+                center_of_mass_offset, envelope_radius, outer_radius,
+                refinement, grid_points, use_equiangular_map,
+                radial_distribution_envelope, radial_distribution_outer_shell,
+                opening_angle, std::nullopt, create_outer_boundary_condition(),
                 Options::Context{false, {}, 1, 1}),
             Catch::Matchers::ContainsSubstring(
                 "Cannot have periodic boundary "
@@ -320,10 +326,11 @@ void test_connectivity() {
                                            create_inner_boundary_condition()})
                                      : std::nullopt,
                     false},
-                envelope_radius, outer_radius, refinement, grid_points,
-                use_equiangular_map, radial_distribution_envelope,
-                radial_distribution_outer_shell, opening_angle, std::nullopt,
-                nullptr, Options::Context{false, {}, 1, 1}),
+                center_of_mass_offset, envelope_radius, outer_radius,
+                refinement, grid_points, use_equiangular_map,
+                radial_distribution_envelope, radial_distribution_outer_shell,
+                opening_angle, std::nullopt, nullptr,
+                Options::Context{false, {}, 1, 1}),
             Catch::Matchers::ContainsSubstring(
                 "Must specify either both inner and outer boundary "
                 "conditions or neither."));
@@ -339,10 +346,10 @@ void test_connectivity() {
                        excise_interiorB ? std::make_optional(Excision{nullptr})
                                         : std::nullopt,
                        false},
-                envelope_radius, outer_radius, refinement, grid_points,
-                use_equiangular_map, radial_distribution_envelope,
-                radial_distribution_outer_shell, opening_angle, std::nullopt,
-                create_outer_boundary_condition(),
+                center_of_mass_offset, envelope_radius, outer_radius,
+                refinement, grid_points, use_equiangular_map,
+                radial_distribution_envelope, radial_distribution_outer_shell,
+                opening_angle, std::nullopt, create_outer_boundary_condition(),
                 Options::Context{false, {}, 1, 1}),
             Catch::Matchers::ContainsSubstring(
                 "Must specify either both inner and outer boundary "
@@ -427,6 +434,7 @@ std::string create_option_string(
          interior_B +
          "    UseLogarithmicMap: " + stringize(use_logarithmic_map_AB) +
          "\n"
+         "  CenterOfMassOffset: [0.1, 0.2]\n"
          "  Envelope:\n"
          "    Radius: 22.0\n"
          "    RadialDistribution: Projective\n"
@@ -465,6 +473,9 @@ void test_bns_domain_with_cubes() {
   // ObjectB:
   constexpr double xcoord_objectB = -3.0;
 
+  // CoM offset:
+  constexpr std::array<double, 2> center_of_mass_offset{{0.1, 0.2}};
+
   // Envelope:
   constexpr double envelope_radius = 25.5;
   constexpr auto radial_distribution_envelope = Distribution::Projective;
@@ -487,6 +498,7 @@ void test_bns_domain_with_cubes() {
   const domain::creators::BinaryCompactObject binary_compact_object{
       CartesianCubeAtXCoord{xcoord_objectA},
       CartesianCubeAtXCoord{xcoord_objectB},
+      center_of_mass_offset,
       envelope_radius,
       outer_radius,
       refinement,
@@ -574,7 +586,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
   expected_excision_spheres.emplace(
       "ExcisionSphereA",
       ExcisionSphere<3>{1.0,
-                        tnsr::I<double, 3, Frame::Grid>{{3.0, 0.0, 0.0}},
+                        tnsr::I<double, 3, Frame::Grid>{{3.0, 0.1, 0.2}},
                         {{0, Direction<3>::lower_zeta()},
                          {1, Direction<3>::lower_zeta()},
                          {2, Direction<3>::lower_zeta()},
@@ -591,7 +603,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
     expected_excision_spheres.emplace(
         "ExcisionSphereB",
         ExcisionSphere<3>{0.2,
-                          tnsr::I<double, 3, Frame::Grid>{{-2.0, 0.0, 0.0}},
+                          tnsr::I<double, 3, Frame::Grid>{{-2.0, 0.1, 0.2}},
                           {{12, Direction<3>::lower_zeta()},
                            {13, Direction<3>::lower_zeta()},
                            {14, Direction<3>::lower_zeta()},
@@ -683,8 +695,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, 2_st, 6_st, true, Distribution::Projective,
-          Distribution::Linear, 120.0, std::nullopt,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st, 6_st, true,
+          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of ObjectA's center is expected to be positive."));
@@ -692,8 +704,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, 2_st, 6_st, true, Distribution::Projective,
-          Distribution::Linear, 120.0, std::nullopt,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st, 6_st, true,
+          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of ObjectB's center is expected to be negative."));
@@ -701,8 +713,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, 2_st, 6_st, true, Distribution::Projective,
-          Distribution::Linear, 120.0, std::nullopt,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st, 6_st, true,
+          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius for the enveloping cube is too "
@@ -711,8 +723,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, 2_st, 6_st, true, Distribution::Projective,
-          Distribution::Linear, 120.0, std::nullopt,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st, 6_st, true,
+          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "ObjectB's inner radius must be less than its outer radius."));
@@ -720,18 +732,18 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, 2_st, 6_st, true, Distribution::Projective,
-          Distribution::Linear, 120.0, std::nullopt,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st, 6_st, true,
+          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "ObjectA's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.5, 1.0, -1.0, std::nullopt, true}, 25.5, 32.4, 2_st, 6_st,
-          true, Distribution::Projective, Distribution::Linear, 120.0,
-          std::nullopt, create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          Object{0.5, 1.0, -1.0, std::nullopt, true},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st, 6_st, true,
+          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Using a logarithmically spaced radial grid in the "
           "part of Layer 1 enveloping Object B requires excising the interior "
@@ -740,8 +752,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 1.0, std::nullopt, true},
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, 2_st, 6_st, true, Distribution::Projective,
-          Distribution::Linear, 120.0, std::nullopt,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st, 6_st, true,
+          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Using a logarithmically spaced radial grid in the "
@@ -751,7 +763,8 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, std::vector<std::array<size_t, 3>>{}, 6_st, true,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4,
+          std::vector<std::array<size_t, 3>>{}, 6_st, true,
           Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("Invalid 'InitialRefinement'"));
@@ -759,8 +772,9 @@ void test_parse_errors() {
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          25.5, 32.4, 2_st, std::vector<std::array<size_t, 3>>{}, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 2_st,
+          std::vector<std::array<size_t, 3>>{}, true, Distribution::Projective,
+          Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("Invalid 'InitialGridPoints'"));
   // Note: the boundary condition-related parse errors are checked in the
@@ -780,9 +794,12 @@ void test_kerr_horizon_conforming() {
   const double inner_radius_B = 0.89 * r_plus_B;
   const double x_pos_A = 8;
   const double x_pos_B = -8;
+  const double y_offset = 0.1;
+  const double z_offset = 0.2;
   domain::creators::BinaryCompactObject domain_creator{
       Object{inner_radius_A, 4., x_pos_A, true, true},
       Object{inner_radius_B, 4., x_pos_B, true, true},
+      std::array<double, 2>{{0.1, 0.2}},
       40.,
       200.,
       0_st,
@@ -826,12 +843,14 @@ void test_kerr_horizon_conforming() {
   tnsr::I<DataVector, 3> x_B{};
   get<0>(x_A) =
       x_pos_A + radius_A * sin(get<0>(theta_phi)) * cos(get<1>(theta_phi));
-  get<1>(x_A) = radius_A * sin(get<0>(theta_phi)) * sin(get<1>(theta_phi));
-  get<2>(x_A) = radius_A * cos(get<0>(theta_phi));
+  get<1>(x_A) =
+      y_offset + radius_A * sin(get<0>(theta_phi)) * sin(get<1>(theta_phi));
+  get<2>(x_A) = z_offset + radius_A * cos(get<0>(theta_phi));
   get<0>(x_B) =
       x_pos_B + radius_B * sin(get<0>(theta_phi)) * cos(get<1>(theta_phi));
-  get<1>(x_B) = radius_B * sin(get<0>(theta_phi)) * sin(get<1>(theta_phi));
-  get<2>(x_B) = radius_B * cos(get<0>(theta_phi));
+  get<1>(x_B) =
+      y_offset + radius_B * sin(get<0>(theta_phi)) * sin(get<1>(theta_phi));
+  get<2>(x_B) = z_offset + radius_B * cos(get<0>(theta_phi));
   // Map the coordinates through the domain. They should lie at the lower zeta
   // boundary of their block.
   const auto x_logical_A =

--- a/tests/Unit/Domain/Creators/Test_Tags.cpp
+++ b/tests/Unit/Domain/Creators/Test_Tags.cpp
@@ -43,15 +43,15 @@ void test_center_tags() {
   const std::unique_ptr<DomainCreator<3>> domain_creator =
       std::make_unique<domain::creators::BinaryCompactObject>(
           Object{0.2, 5.0, 8.0, true, true}, Object{0.6, 4.0, -5.5, true, true},
-          100.0, 500.0, 1_st, 5_st);
+          std::array<double, 2>{{0.1, 0.2}}, 100.0, 500.0, 1_st, 5_st);
 
   const auto grid_center_A =
       Tags::ObjectCenter<ObjectLabel::A>::create_from_options(domain_creator);
   const auto grid_center_B =
       Tags::ObjectCenter<ObjectLabel::B>::create_from_options(domain_creator);
 
-  CHECK(grid_center_A == tnsr::I<double, 3, Frame::Grid>{{8.0, 0.0, 0.0}});
-  CHECK(grid_center_B == tnsr::I<double, 3, Frame::Grid>{{-5.5, 0.0, 0.0}});
+  CHECK(grid_center_A == tnsr::I<double, 3, Frame::Grid>{{8.0, 0.1, 0.2}});
+  CHECK(grid_center_B == tnsr::I<double, 3, Frame::Grid>{{-5.5, 0.1, 0.2}});
 
   const std::unique_ptr<DomainCreator<3>> creator_no_excision =
       std::make_unique<domain::creators::Brick>(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
@@ -122,6 +122,7 @@ SPECTRE_TEST_CASE(
             std::make_optional(
                 domain::creators::BinaryCompactObject::Excision{nullptr}),
             false},
+        std::array<double, 2>{{0.1, 0.2}},
         30.,
         50.,
         initial_refinement,

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -46,6 +46,7 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "      ExciseWithBoundaryCondition:\n"
       "        None\n"
       "    UseLogarithmicMap: false\n"
+      "  CenterOfMassOffset: [0., 0.]\n"
       "  Envelope:\n"
       "    Radius: 30.0\n"
       "    RadialDistribution: Linear\n"

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -278,7 +278,8 @@ void test_interpolate_on_element(
         using BCO = domain::creators::BinaryCompactObject;
         return std::make_unique<BCO>(
             BCO::Object{0.9, 2.9, 4.0, true, true},
-            BCO::Object{0.9, 2.9, -4.0, true, true}, 20.0, 100.0,
+            BCO::Object{0.9, 2.9, -4.0, true, true},
+            std::array<double, 2>{{0.1, 0.2}}, 20.0, 100.0,
             // Only object B needs to have the refinement for this test
             std::unordered_map<std::string, std::array<size_t, 3>>{
                 {"ObjectAShell", std::array{0_st, 0_st, 0_st}},

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -100,6 +100,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
     const domain::creators::BinaryCompactObject domain_creator{
         Object{1., 4., 8., true, true},
         Object{0.8, 2.5, -6., true, true},
+        std::array<double, 2>{{0., 0.}},
         60.,
         300.,
         0_st,

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -18,6 +18,7 @@ SourceDomainCreator:
       XCoord: &x_left -7.683
       ExciseInterior: True
       UseLogarithmicMap: True
+    CenterOfMassOffset: [0., 0.]
     Envelope:
       Radius: 60.
       RadialDistribution: Projective
@@ -44,6 +45,7 @@ TargetDomainCreator:
       XCoord: *x_left
       ExciseInterior: True
       UseLogarithmicMap: true
+    CenterOfMassOffset: [0., 0.]
     Envelope:
       Radius: 100.
       RadialDistribution: Projective

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Binary.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Binary.py
@@ -3,7 +3,9 @@
 
 import numpy as np
 
-centers = [-5.0, 6.0]
+x_coords = [-5.0, 6.0]
+y_offset = 0.1
+z_offset = 0.2
 masses = [1.1, 0.43]
 angular_velocity = 0.02
 radial_velocity = 0.01
@@ -40,8 +42,16 @@ def longitudinal_shift_background_bbh_isotropic(x):
 
 
 def conformal_factor_minus_one_bbh_isotropic(x):
-    r1 = np.sqrt((x[0] - centers[0]) ** 2 + x[1] ** 2 + x[2] ** 2)
-    r2 = np.sqrt((x[0] - centers[1]) ** 2 + x[1] ** 2 + x[2] ** 2)
+    r1 = np.sqrt(
+        (x[0] - x_coords[0]) ** 2
+        + (x[1] - y_offset) ** 2
+        + (x[2] - z_offset) ** 2
+    )
+    r2 = np.sqrt(
+        (x[0] - x_coords[1]) ** 2
+        + (x[1] - y_offset) ** 2
+        + (x[2] - z_offset) ** 2
+    )
     return 0.5 * (
         np.exp(-(r1**2) / falloff_widths[0] ** 2) * masses[0] / r1
         + np.exp(-(r2**2) / falloff_widths[1] ** 2) * masses[1] / r2

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_Binary.cpp
@@ -64,6 +64,7 @@ struct Metavariables {
 };
 
 void test_data(const std::array<double, 2>& x_coords,
+               const std::array<double, 2>& center_of_mass_offset,
                const double angular_velocity, const double expansion,
                const std::array<double, 3> linear_velocity,
                const std::optional<std::array<double, 2>>& falloff_widths,
@@ -86,6 +87,8 @@ void test_data(const std::array<double, 2>& x_coords,
   {
     INFO("Properties");
     CHECK(binary.x_coords() == x_coords);
+    CHECK(binary.y_offset() == center_of_mass_offset[0]);
+    CHECK(binary.z_offset() == center_of_mass_offset[1]);
     CHECK(binary.angular_velocity() == angular_velocity);
     CHECK(binary.expansion() == expansion);
     CHECK(binary.linear_velocity() == linear_velocity);
@@ -123,10 +126,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.Xcts.Binary",
                   "[PointwiseFunctions][Unit]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticData/Xcts"};
-  test_data({{-5., 6.}}, 0.02, 0.01, {{0.1, 0.2, 0.3}}, {{7., 8.}},
-            {{1.1, 0.43}}, "bbh_isotropic",
+  test_data({{-5., 6.}}, {{0.1, 0.2}}, 0.02, 0.01, {{0.1, 0.2, 0.3}},
+            {{7., 8.}}, {{1.1, 0.43}}, "bbh_isotropic",
             "Binary:\n"
             "  XCoords: [-5., 6.]\n"
+            "  CenterOfMassOffset: [0.1, 0.2]\n"
             "  ObjectLeft:\n"
             "    Schwarzschild:\n"
             "      Mass: 1.1\n"

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -33,6 +33,8 @@ class TestInitialData(unittest.TestCase):
             mass_b=0.4,
             dimensionless_spin_a=[0.1, 0.2, 0.3],
             dimensionless_spin_b=[0.4, 0.5, 0.6],
+            center_of_mass_offset=[0.1, 0.2, 0.3],
+            linear_velocity=[0.1, 0.2, 0.3],
             separation=20.0,
             orbital_angular_velocity=0.01,
             radial_expansion_velocity=-1.0e-5,
@@ -41,8 +43,16 @@ class TestInitialData(unittest.TestCase):
         )
         self.assertEqual(params["MassRight"], 0.6)
         self.assertEqual(params["MassLeft"], 0.4)
-        self.assertEqual(params["XRight"], 8.0)
-        self.assertEqual(params["XLeft"], -12.0)
+        self.assertEqual(params["XRight"], 8.0 + 0.1)
+        self.assertEqual(params["XLeft"], -12.0 + 0.1)
+        self.assertEqual(
+            [params[f"CenterOfMassOffset_{yz}"] for yz in "yz"],
+            [0.2, 0.3],
+        )
+        self.assertEqual(
+            [params[f"LinearVelocity_{xyz}"] for xyz in "xyz"],
+            [0.1, 0.2, 0.3],
+        )
         self.assertAlmostEqual(params["ExcisionRadiusRight"], 1.07546791205)
         self.assertAlmostEqual(params["ExcisionRadiusLeft"], 0.5504049327)
         self.assertEqual(params["OrbitalAngularVelocity"], 0.01)
@@ -67,10 +77,10 @@ class TestInitialData(unittest.TestCase):
         self.assertAlmostEqual(params["FalloffWidthLeft"], 5.520327410332324)
         self.assertEqual(params["L"], 1)
         self.assertEqual(params["P"], 5)
-        # COM is zero
+        # Newtonian center of mass (without offset) is zero
         self.assertAlmostEqual(
-            params["MassRight"] * params["XRight"]
-            + params["MassLeft"] * params["XLeft"],
+            params["MassRight"] * (params["XRight"] - 0.1)
+            + params["MassLeft"] * (params["XLeft"] - 0.1),
             0.0,
         )
 
@@ -142,6 +152,12 @@ class TestInitialData(unittest.TestCase):
                     "control": True,
                     "control_refinement_level": 1,
                     "control_polynomial_order": 5,
+                    "control_params": {
+                        "mass_A": 0.6,
+                        "mass_B": 0.4,
+                        "spin_A": [0.1, 0.2, 0.3],
+                        "spin_B": [0.4, 0.5, 0.6],
+                    },
                     "evolve": True,
                     "scheduler": "None",
                     "copy_executable": "None",


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR extends the control loop in initial data to adjust the center of mass and ADM linear momentum.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

This PR changes `BinaryCompactObject`, which is used in multiple parts of the code. Now, the constructor expects the argument `std::array<double, 2> center_of_mass_offset`.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
