### PR TITLE
Fix typo in BC test.

### DIFF
--- a/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/BoundaryConditions/Test_Robin.cpp
@@ -56,8 +56,7 @@ void apply_neumann_boundary_condition(
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Elasticity.BoundaryConditions.Robin",
-                  "[Unit][Elliptic]") {
+SPECTRE_TEST_CASE("Unit.Poisson.BoundaryConditions.Robin", "[Unit][Elliptic]") {
   // Test factory-creation
   const auto created = TestHelpers::test_factory_creation<
       elliptic::BoundaryConditions::BoundaryCondition<1>, Robin<1>>(


### PR DESCRIPTION
## Proposed changes

Just fixes a typo.

### Upgrade instructions

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
