### PR TITLE
Fetch Kokkos if requested

### DIFF
--- a/cmake/AddSpectreExecutable.cmake
+++ b/cmake/AddSpectreExecutable.cmake
@@ -32,9 +32,12 @@ function(add_spectre_executable TARGET_NAME)
   if(SPECTRE_KOKKOS)
     # We need to make sure we don't drop the Kokkos link wrapper
     get_target_property(
-      SPECTRE_KOKKOS_LAUNCHER
+      _RULE_LAUNCH_LINK
       ${TARGET_NAME}
       RULE_LAUNCH_LINK)
+    if (_RULE_LAUNCH_LINK)
+      set(SPECTRE_KOKKOS_LAUNCHER ${_RULE_LAUNCH_LINK})
+    endif()
   endif()
   set_target_properties(
     ${TARGET_NAME}

--- a/cmake/SetupKokkos.cmake
+++ b/cmake/SetupKokkos.cmake
@@ -25,7 +25,23 @@ if(SPECTRE_KOKKOS)
       "Enable lambda expressions in CUDA")
   endif()
 
-  find_package(Kokkos REQUIRED)
+  find_package(Kokkos)
+
+  if (NOT Kokkos_FOUND)
+    if (NOT SPECTRE_FETCH_MISSING_DEPS)
+      message(FATAL_ERROR "Could not find Kokkos. If you want to fetch "
+        "missing dependencies automatically, set SPECTRE_FETCH_MISSING_DEPS=ON.")
+    endif()
+    message(STATUS "Fetching Kokkos")
+    include(FetchContent)
+    FetchContent_Declare(Kokkos
+      GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+      GIT_TAG 4.4.00
+      GIT_SHALLOW TRUE
+      ${SPECTRE_FETCHCONTENT_BASE_ARGS}
+    )
+    FetchContent_MakeAvailable(Kokkos)
+  endif()
 
   if (TARGET Kokkos::kokkos
       AND Kokkos_ENABLE_CUDA

--- a/cmake/SpectreAddLibraries.cmake
+++ b/cmake/SpectreAddLibraries.cmake
@@ -45,9 +45,12 @@ function(ADD_SPECTRE_LIBRARY LIBRARY_NAME)
     if(SPECTRE_KOKKOS)
       # We need to make sure we don't drop the Kokkos link wrapper
       get_target_property(
-        SPECTRE_KOKKOS_LAUNCHER
+        _RULE_LAUNCH_LINK
         ${LIBRARY_NAME}
         RULE_LAUNCH_LINK)
+      if (_RULE_LAUNCH_LINK)
+        set(SPECTRE_KOKKOS_LAUNCHER ${_RULE_LAUNCH_LINK})
+      endif()
     endif()
     set_target_properties(
       ${LIBRARY_NAME}


### PR DESCRIPTION
## Proposed changes

With this I can compile with Kokkos on my machine simply by setting `cmake -D SPECTRE_KOKKOS=ON -D SPECTRE_FETCH_MISSING_DEPS=ON .` in the build directory.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
