### PR TITLE
Fix PCH issue

### DIFF
--- a/cmake/SetupBlaze.cmake
+++ b/cmake/SetupBlaze.cmake
@@ -143,9 +143,10 @@ target_compile_definitions(Blaze
   BLAZE_USE_ALWAYS_INLINE=${_BLAZE_USE_ALWAYS_INLINE}
   )
 
-target_compile_options(Blaze
+target_precompile_headers(Blaze
   INTERFACE
-  "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-include ${CMAKE_SOURCE_DIR}/tools/BlazeExceptions.hpp>")
+  ${CMAKE_SOURCE_DIR}/tools/BlazeExceptions.hpp
+  )
 
 add_interface_lib_headers(
   TARGET Blaze

--- a/src/IO/Exporter/CMakeLists.txt
+++ b/src/IO/Exporter/CMakeLists.txt
@@ -55,6 +55,9 @@ add_subdirectory(Python)
 # - The `TARGET_OBJECTS` generator expression links in the objects from the
 #   Exporter library, because otherwise they wouldn't be used and therefore
 #   wouldn't be linked in.
+#   Note that `TARGET_OBJECTS` also includes precompiled headers. LLVM's lld
+#   is smart enough to ignore them, but GNU's ld isn't, so we have to filter
+#   them out (see https://gitlab.kitware.com/cmake/cmake/-/issues/22832).
 # - The `EXPORTER_LINKED_LIBS` are needed to resolve the symbols for the
 #   `TARGET_OBJECTS`, just like in the Exporter library (of which this library
 #   is basically an extended copy).
@@ -67,7 +70,7 @@ get_target_property(EXPORTER_LINKED_LIBS ${LIBRARY} LINK_LIBRARIES)
 target_link_libraries(
   ${BUNDLED_EXPORTER_LIB}
   PRIVATE
-  $<TARGET_OBJECTS:${LIBRARY}>
+  $<FILTER:$<TARGET_OBJECTS:${LIBRARY}>,EXCLUDE,.*\\.gch>
   ${EXPORTER_LINKED_LIBS}
   Informer
   CharmModuleInit


### PR DESCRIPTION
I got warnings from clang saying the PCH was ignored because the BlazeExceptions.hpp header appeared first as an `-include`. This happened after #6203. This change fixed it.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
