### PR TITLE
Add protection against negative pressure in `HybridEos`

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.tpp
@@ -140,9 +140,11 @@ class FunctionOfMu {
       eps_min = equation_of_state_.specific_internal_energy_lower_bound(
           rest_mass_density_times_lorentz_factor_ / lorentz_max,
           electron_fraction_);
-    } else {
+    } else if constexpr (EosType::thermodynamic_dim == 2) {
       eps_min = equation_of_state_.specific_internal_energy_lower_bound(
           rest_mass_density_times_lorentz_factor_ / lorentz_max);
+    } else {
+      eps_min = equation_of_state_.specific_internal_energy_lower_bound();
     }
     q_ = tau / rest_mass_density_times_lorentz_factor;
     if constexpr (EnforcePhysicality) {
@@ -295,11 +297,16 @@ Primitives FunctionOfMu<EnforcePhysicality, EosType>::primitives(
                        rho_hat, electron_fraction_),
                    equation_of_state_.specific_internal_energy_upper_bound(
                        rho_hat, electron_fraction_));
-  } else {
+  } else if constexpr (EosType::thermodynamic_dim == 2) {
     epsilon_hat = std::clamp(
         epsilon_hat,
         equation_of_state_.specific_internal_energy_lower_bound(rho_hat),
         equation_of_state_.specific_internal_energy_upper_bound(rho_hat));
+  } else {
+    epsilon_hat = std::clamp(
+        epsilon_hat,
+        equation_of_state_.specific_internal_energy_lower_bound(),
+        equation_of_state_.specific_internal_energy_upper_bound());
   }
   // Pressure from EOS
   double p_hat = std::numeric_limits<double>::signaling_NaN();

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAlHydro.tpp
@@ -57,9 +57,12 @@ class FunctionOfZ {
     if constexpr (EosType::thermodynamic_dim == 3) {
       eps_min = equation_of_state_.specific_internal_energy_lower_bound(
           rho_min, electron_fraction);
-    } else {
+    } else if constexpr (EosType::thermodynamic_dim == 2) {
       eps_min =
           equation_of_state_.specific_internal_energy_lower_bound(rho_min);
+    } else {
+      eps_min =
+          equation_of_state_.specific_internal_energy_lower_bound();
     }
 
     if constexpr (EnforcePhysicality) {
@@ -134,11 +137,16 @@ Primitives FunctionOfZ<EosType, EnforcePhysicality>::primitives(
                        rho_hat, electron_fraction_),
                    equation_of_state_.specific_internal_energy_upper_bound(
                        rho_hat, electron_fraction_));
-  } else {
+  } else if constexpr (EosType::thermodynamic_dim == 2) {
     epsilon_hat = std::clamp(
         epsilon_hat,
         equation_of_state_.specific_internal_energy_lower_bound(rho_hat),
         equation_of_state_.specific_internal_energy_upper_bound(rho_hat));
+  } else {
+    epsilon_hat = std::clamp(
+        epsilon_hat,
+        equation_of_state_.specific_internal_energy_lower_bound(),
+        equation_of_state_.specific_internal_energy_upper_bound());
   }
 
   // Pressure from EOS

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp
@@ -142,17 +142,15 @@ class Barotropic2D : public EquationOfState<ColdEos::is_relativistic, 2> {
   /// The lower bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$ and electron fraction \f$Y_e\f$
   double specific_internal_energy_lower_bound(
-      const double rest_mass_density) const override {
-    return underlying_eos_.specific_internal_energy_lower_bound(
-        rest_mass_density);
+      const double /*rest_mass_density*/) const override {
+    return underlying_eos_.specific_internal_energy_lower_bound();
   }
 
   /// The upper bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$
   double specific_internal_energy_upper_bound(
-      const double rest_mass_density) const override {
-    return underlying_eos_.specific_internal_energy_upper_bound(
-        rest_mass_density);
+      const double /*rest_mass_density*/) const override {
+    return underlying_eos_.specific_internal_energy_upper_bound();
   }
 
   /// The lower bound of the specific enthalpy that is valid for this EOS

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
@@ -147,19 +147,17 @@ class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {
   /// The lower bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$ and electron fraction \f$Y_e\f$
   double specific_internal_energy_lower_bound(
-      const double rest_mass_density,
+      const double /*rest_mass_density*/,
       const double /*electron_fraction*/) const override {
-    return underlying_eos_.specific_internal_energy_lower_bound(
-        rest_mass_density);
+    return underlying_eos_.specific_internal_energy_lower_bound();
   }
 
   /// The upper bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$
   double specific_internal_energy_upper_bound(
-      const double rest_mass_density,
+      const double /*rest_mass_density*/,
       const double /*electron_fraction*/) const override {
-    return underlying_eos_.specific_internal_energy_upper_bound(
-        rest_mass_density);
+    return underlying_eos_.specific_internal_energy_upper_bound();
   }
 
   /// The lower bound of the specific enthalpy that is valid for this EOS

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.hpp
@@ -248,22 +248,16 @@ class Enthalpy : public EquationOfState<true, 1> {
     return std::numeric_limits<double>::max();
   }
 
-  /// The lower bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_lower_bound(
-      const double /* rest_mass_density */) const override {
-    return 0.0;
-  }
-
-  /// The upper bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_upper_bound(
-      const double /* rest_mass_density */) const override {
-    return std::numeric_limits<double>::max();
-  }
-
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override { return 1.0; }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_upper_bound() const override {
+    return std::numeric_limits<double>::max();
+  }
 
   /// The vacuum baryon mass for this EoS
   double baryon_mass() const override { return low_density_eos_.baryon_mass(); }

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -308,15 +308,14 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
   virtual double temperature_upper_bound() const {
     return std::numeric_limits<double>::max();
   };
+
   /// The lower bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  virtual double specific_internal_energy_lower_bound(
-      double rest_mass_density) const = 0;
+  virtual double specific_internal_energy_lower_bound() const { return 0.0; };
 
   /// The upper bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  virtual double specific_internal_energy_upper_bound(
-      double rest_mass_density) const = 0;
+  virtual double specific_internal_energy_upper_bound() const {
+    return std::numeric_limits<double>::max();
+  };
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
   virtual double specific_enthalpy_lower_bound() const = 0;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
@@ -81,12 +81,14 @@ Scalar<DataType>
 HybridEos<ColdEquationOfState>::pressure_from_density_and_energy_impl(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy) const {
+  using std::max;
   return Scalar<DataType>{
       get(cold_eos_.pressure_from_density(rest_mass_density)) +
       get(rest_mass_density) * (thermal_adiabatic_index_ - 1.0) *
-          (get(specific_internal_energy) -
-           get(cold_eos_.specific_internal_energy_from_density(
-               rest_mass_density)))};
+          max((get(specific_internal_energy) -
+               get(cold_eos_.specific_internal_energy_from_density(
+                   rest_mass_density))),
+              0.0)};
 }
 
 template <typename ColdEquationOfState>
@@ -95,21 +97,22 @@ Scalar<DataType>
 HybridEos<ColdEquationOfState>::pressure_from_density_and_enthalpy_impl(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_enthalpy) const {
+  using std::max;
   if constexpr (ColdEquationOfState::is_relativistic) {
     return Scalar<DataType>{
         (get(cold_eos_.pressure_from_density(rest_mass_density)) +
          get(rest_mass_density) * (thermal_adiabatic_index_ - 1.0) *
-             (get(specific_enthalpy) - 1.0 -
-              get(cold_eos_.specific_internal_energy_from_density(
-                  rest_mass_density)))) /
+             max((get(specific_enthalpy) - 1.0 -
+                  get(cold_eos_.specific_internal_energy_from_density(
+                      rest_mass_density))), 0.0)) /
         thermal_adiabatic_index_};
   } else {
     return Scalar<DataType>{
         (get(cold_eos_.pressure_from_density(rest_mass_density)) +
          get(rest_mass_density) * (thermal_adiabatic_index_ - 1.0) *
-             (get(specific_enthalpy) -
-              get(cold_eos_.specific_internal_energy_from_density(
-                  rest_mass_density)))) /
+             max((get(specific_enthalpy) -
+                  get(cold_eos_.specific_internal_energy_from_density(
+                      rest_mass_density))), 0.0)) /
         thermal_adiabatic_index_};
   }
 }
@@ -120,11 +123,12 @@ Scalar<DataType> HybridEos<ColdEquationOfState>::
     specific_internal_energy_from_density_and_pressure_impl(
         const Scalar<DataType>& rest_mass_density,
         const Scalar<DataType>& pressure) const {
+  using std::max;
   return Scalar<DataType>{
       get(cold_eos_.specific_internal_energy_from_density(rest_mass_density)) +
       1.0 / (thermal_adiabatic_index_ - 1.0) *
-          (get(pressure) -
-           get(cold_eos_.pressure_from_density(rest_mass_density))) /
+          max((get(pressure) -
+               get(cold_eos_.pressure_from_density(rest_mass_density))), 0.0) /
           get(rest_mass_density)};
 }
 
@@ -134,10 +138,11 @@ Scalar<DataType>
 HybridEos<ColdEquationOfState>::temperature_from_density_and_energy_impl(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy) const {
+  using std::max;
   return Scalar<DataType>{(thermal_adiabatic_index_ - 1.0) *
-                          (get(specific_internal_energy) -
+                          max((get(specific_internal_energy) -
                            get(cold_eos_.specific_internal_energy_from_density(
-                               rest_mass_density)))};
+                               rest_mass_density))), 0.0)};
 }
 
 template <typename ColdEquationOfState>
@@ -173,14 +178,15 @@ Scalar<DataType> HybridEos<ColdEquationOfState>::
     kappa_times_p_over_rho_squared_from_density_and_energy_impl(
         const Scalar<DataType>& rest_mass_density,
         const Scalar<DataType>& specific_internal_energy) const {
+  using std::max;
   return Scalar<DataType>{
       (thermal_adiabatic_index_ - 1.0) *
           get(cold_eos_.pressure_from_density(rest_mass_density)) /
           get(rest_mass_density) +
       square(thermal_adiabatic_index_ - 1.0) *
-          (get(specific_internal_energy) -
-           get(cold_eos_.specific_internal_energy_from_density(
-               rest_mass_density)))};
+          max((get(specific_internal_energy) -
+               get(cold_eos_.specific_internal_energy_from_density(
+                   rest_mass_density))), 0.0)};
 }
 }  // namespace EquationsOfState
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -141,7 +141,8 @@ class HybridEos
   /// at the given rest mass density \f$\rho\f$
   double specific_internal_energy_lower_bound(
       const double rest_mass_density) const override {
-    return cold_eos_.specific_internal_energy_lower_bound(rest_mass_density);
+    return get(cold_eos_.specific_internal_energy_from_density(
+        Scalar<double>{rest_mass_density}));
   }
 
   /// The upper bound of the specific internal energy that is valid for this EOS

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.cpp
@@ -302,6 +302,24 @@ double PiecewisePolytropicFluid<IsRelativistic>::rest_mass_density_upper_bound()
   }
   return std::numeric_limits<double>::max();
 }
+
+template <bool IsRelativistic>
+double PiecewisePolytropicFluid<
+    IsRelativistic>::specific_internal_energy_upper_bound() const {
+  // this bound comes from the dominant energy condition which implies
+  // that the pressure is bounded by the total energy density,
+  // i.e. p < e = rho * (1 + eps)
+  if (IsRelativistic and polytropic_exponent_hi_ > 2.0) {
+    const double eint_boundary_constant =
+        (polytropic_exponent_hi_ - polytropic_exponent_lo_) *
+        polytropic_constant_lo_ /
+        ((polytropic_exponent_hi_ - 1.0) * (polytropic_exponent_lo_ - 1.0)) *
+        pow(transition_density_, polytropic_exponent_lo_ - 1.0);
+    return (1.0 + (polytropic_exponent_hi_ - 1.0) * eint_boundary_constant) /
+           (polytropic_exponent_hi_ - 2.0);
+  }
+  return std::numeric_limits<double>::max();
+}
 }  // namespace EquationsOfState
 
 template class EquationsOfState::PiecewisePolytropicFluid<true>;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
@@ -145,24 +145,16 @@ class PiecewisePolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   /// The upper bound of the rest mass density that is valid for this EOS
   double rest_mass_density_upper_bound() const override;
 
-  /// The lower bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_lower_bound(
-      const double /* rest_mass_density */) const override {
-    return 0.0;
-  }
-
-  /// The upper bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_upper_bound(
-      const double /* rest_mass_density */) const override {
-    return std::numeric_limits<double>::max();
-  }
-
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override {
     return IsRelativistic ? 1.0 : 0.0;
   }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_upper_bound() const override;
 
   /// The vacuum baryon mass for this EoS
   double baryon_mass() const override {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.cpp
@@ -144,6 +144,18 @@ double PolytropicFluid<IsRelativistic>::rest_mass_density_upper_bound() const {
   }
   return std::numeric_limits<double>::max();
 }
+
+template <bool IsRelativistic>
+double PolytropicFluid<IsRelativistic>::specific_internal_energy_upper_bound()
+    const {
+  // this bound comes from the dominant energy condition which implies
+  // that the pressure is bounded by the total energy density,
+  // i.e. p < e = rho * (1 + eps)
+  if (IsRelativistic and polytropic_exponent_ > 2.0) {
+    return 1.0 / (polytropic_exponent_ - 2.0);
+  }
+  return std::numeric_limits<double>::max();
+}
 }  // namespace EquationsOfState
 
 template class EquationsOfState::PolytropicFluid<true>;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -104,24 +104,16 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   /// The upper bound of the rest mass density that is valid for this EOS
   double rest_mass_density_upper_bound() const override;
 
-  /// The lower bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_lower_bound(
-      const double /* rest_mass_density */) const override {
-    return 0.0;
-  }
-
-  /// The upper bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_upper_bound(
-      const double /* rest_mass_density */) const override {
-    return std::numeric_limits<double>::max();
-  }
-
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override {
     return IsRelativistic ? 1.0 : 0.0;
   }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_upper_bound() const override;
 
   /// The vacuum baryon mass for this EoS
   double baryon_mass() const override {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.hpp
@@ -128,22 +128,16 @@ class Spectral : public EquationOfState<true, 1> {
     return std::numeric_limits<double>::max();
   }
 
-  /// The lower bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_lower_bound(
-      const double /* rest_mass_density */) const override {
-    return 0.0;
-  }
-
-  /// The upper bound of the specific internal energy that is valid for this EOS
-  /// at the given rest mass density \f$\rho\f$
-  double specific_internal_energy_upper_bound(
-      const double /* rest_mass_density */) const override {
-    return std::numeric_limits<double>::max();
-  }
-
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override { return 1.0; }
+
+  /// The lower bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_lower_bound() const override { return 0.0; }
+
+  /// The upper bound of the specific internal energy that is valid for this EOS
+  double specific_internal_energy_upper_bound() const override {
+    return std::numeric_limits<double>::max();
+  }
 
   /// The vacuum baryon mass for this EoS
   double baryon_mass() const override {

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.py
@@ -20,9 +20,9 @@ def hybrid_polytrope_pressure_from_density_and_energy(
     eps_c = polytropic_specific_internal_energy_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
     )
-    return p_c + rest_mass_density * (specific_internal_energy - eps_c) * (
-        thermal_adiabatic_index - 1.0
-    )
+    return p_c + rest_mass_density * max(
+        (specific_internal_energy - eps_c), 0.0
+    ) * (thermal_adiabatic_index - 1.0)
 
 
 def hybrid_polytrope_rel_pressure_from_density_and_enthalpy(
@@ -40,7 +40,7 @@ def hybrid_polytrope_rel_pressure_from_density_and_enthalpy(
     )
     return p_c / thermal_adiabatic_index + (
         rest_mass_density
-        * (specific_enthalpy - 1.0 - eps_c)
+        * max((specific_enthalpy - 1.0 - eps_c), 0.0)
         * (thermal_adiabatic_index - 1.0)
         / thermal_adiabatic_index
     )
@@ -56,7 +56,9 @@ def hybrid_polytrope_temperature_from_density_and_energy(
     eps_c = polytropic_specific_internal_energy_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
     )
-    return (thermal_adiabatic_index - 1.0) * (specific_internal_energy - eps_c)
+    return (thermal_adiabatic_index - 1.0) * max(
+        (specific_internal_energy - eps_c), 0.0
+    )
 
 
 def hybrid_polytrope_newt_pressure_from_density_and_enthalpy(
@@ -74,7 +76,7 @@ def hybrid_polytrope_newt_pressure_from_density_and_enthalpy(
     )
     return p_c / thermal_adiabatic_index + (
         rest_mass_density
-        * (specific_enthalpy - eps_c)
+        * max((specific_enthalpy - eps_c), 0.0)
         * (thermal_adiabatic_index - 1.0)
         / thermal_adiabatic_index
     )
@@ -97,7 +99,7 @@ def hybrid_polytrope_rel_specific_enthalpy_from_density_and_energy(
         1.0
         + eps_c
         + p_c / rest_mass_density
-        + thermal_adiabatic_index * (specific_internal_energy - eps_c)
+        + thermal_adiabatic_index * max((specific_internal_energy - eps_c), 0.0)
     )
 
 
@@ -117,7 +119,7 @@ def hybrid_polytrope_newt_specific_enthalpy_from_density_and_energy(
     return (
         eps_c
         + p_c / rest_mass_density
-        + thermal_adiabatic_index * (specific_internal_energy - eps_c)
+        + thermal_adiabatic_index * max((specific_internal_energy - eps_c), 0.0)
     )
 
 
@@ -136,7 +138,9 @@ def hybrid_polytrope_specific_internal_energy_from_density_and_pressure(
     )
     return (
         eps_c
-        + (pressure - p_c) / (thermal_adiabatic_index - 1.0) / rest_mass_density
+        + max((pressure - p_c), 0.0)
+        / (thermal_adiabatic_index - 1.0)
+        / rest_mass_density
     )
 
 
@@ -171,6 +175,6 @@ def hybrid_polytrope_kappa_times_p_over_rho_squared_from_density_and_energy(
     eps_c = polytropic_specific_internal_energy_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
     )
-    return (thermal_adiabatic_index - 1.0) * p_c / rest_mass_density + (
-        specific_internal_energy - eps_c
+    return (thermal_adiabatic_index - 1.0) * p_c / rest_mass_density + max(
+        (specific_internal_energy - eps_c), 0.0
     ) * (thermal_adiabatic_index - 1.0) ** 2

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Enthalpy.cpp
@@ -204,11 +204,11 @@ void check_exact() {
   }
   // Test bounds
   CHECK(0.0 == eos.rest_mass_density_lower_bound());
-  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(0.0 == eos.specific_internal_energy_lower_bound());
   CHECK(1.0 == eos.specific_enthalpy_lower_bound());
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
-  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(max_double == eos.specific_internal_energy_upper_bound());
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
@@ -77,21 +77,21 @@ void check_exact_polytrope() {
   CHECK(*eos.promote_to_3d_eos() ==
         EquationsOfState::Equilibrium3D<EquationsOfState::HybridEos<
             EquationsOfState::PolytropicFluid<IsRelativistic>>>(eos));
-  const Scalar<double> eps{5.0};
+  const Scalar<double> eps{18.0};
   const auto p = eos.pressure_from_density_and_energy(rho, eps);
-  CHECK(get(p) == 34.0);
+  CHECK(get(p) == 60.0);
   const auto h = IsRelativistic
                      ? hydro::relativistic_specific_enthalpy(rho, eps, p)
                      : Scalar<double>{get(eps) + get(p) / get(rho)};
-  CHECK(get(h) == (IsRelativistic ? 14.5 : 13.5));
-  CHECK(get(eos.pressure_from_density_and_enthalpy(rho, h)) == 34.0);
+  CHECK(get(h) == (IsRelativistic ? 34.0 : 33.0));
+  CHECK(get(eos.pressure_from_density_and_enthalpy(rho, h)) == 60.0);
   CHECK(get(eos.specific_internal_energy_from_density_and_pressure(rho, p)) ==
-        5.0);
+        get(eps));
   const auto chi = eos.chi_from_density_and_energy(rho, eps);
-  CHECK(get(chi) == 14.5);
+  CHECK(get(chi) == 21.0);
   const auto p_kappa_over_rho_sq =
       eos.kappa_times_p_over_rho_squared_from_density_and_energy(rho, eps);
-  CHECK(get(p_kappa_over_rho_sq) == 4.25);
+  CHECK(get(p_kappa_over_rho_sq) == 7.5);
   CHECK(not eos.is_barotropic());
 }
 

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
@@ -103,7 +103,7 @@ void check_bounds() {
       EquationsOfState::PolytropicFluid<IsRelativistic>>
       eos{cold_eos, 1.5};
   CHECK(0.0 == eos.rest_mass_density_lower_bound());
-  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(200.0 == eos.specific_internal_energy_lower_bound(1.0));
   if constexpr (IsRelativistic) {
     CHECK(1.0 == eos.specific_enthalpy_lower_bound());
   } else {

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PiecewisePolytropicFluid.cpp
@@ -280,7 +280,7 @@ void check_bounds() {
       transition_density, 0.5 * polytropic_constant, 0.5 * polytropic_exponent,
       1.0 * polytropic_exponent};
   CHECK(0.0 == eos.rest_mass_density_lower_bound());
-  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(0.0 == eos.specific_internal_energy_lower_bound());
   if constexpr (IsRelativistic) {
     CHECK(1.0 == eos.specific_enthalpy_lower_bound());
   } else {
@@ -288,7 +288,7 @@ void check_bounds() {
   }
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
-  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(max_double == eos.specific_internal_energy_upper_bound());
 
   const auto eos_high_gamma =
       EquationsOfState::PiecewisePolytropicFluid<IsRelativistic>{

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_PolytropicFluid.cpp
@@ -49,7 +49,7 @@ void check_bounds() {
   const auto eos =
       EquationsOfState::PolytropicFluid<IsRelativistic>{100.0, 1.5};
   CHECK(0.0 == eos.rest_mass_density_lower_bound());
-  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(0.0 == eos.specific_internal_energy_lower_bound());
   if constexpr (IsRelativistic) {
     CHECK(1.0 == eos.specific_enthalpy_lower_bound());
   } else {
@@ -57,7 +57,7 @@ void check_bounds() {
   }
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
-  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(max_double == eos.specific_internal_energy_upper_bound());
   CHECK(eos.baryon_mass() ==
         approx(hydro::units::geometric::default_baryon_mass));
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_SpectralEoS.cpp
@@ -100,11 +100,11 @@ void check_exact() {
   }
   // Test bounds
   CHECK(0.0 == eos.rest_mass_density_lower_bound());
-  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(0.0 == eos.specific_internal_energy_lower_bound());
   CHECK(1.0 == eos.specific_enthalpy_lower_bound());
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
-  CHECK(max_double == eos.specific_internal_energy_upper_bound(1.0));
+  CHECK(max_double == eos.specific_internal_energy_upper_bound());
   CHECK(eos.baryon_mass() ==
         approx(hydro::units::geometric::default_baryon_mass));
 }


### PR DESCRIPTION
## Proposed changes

Floating point issues can lead to negative pressures in `HybridEos`. This quick PR puts a safeguard against this.

Edit: delving into fixing the unit-tests has revealed another related issue, so I've split the PR into two commits. For the first commit, the `specific_internal_energy_lower_bound` and `specific_internal_energy_upper_bound` functions in 1D EoSs are supposed to provide these bounds as a function of rest mass density. Since in the case of a 1D EoS the internal energy is not a free parameter when density is known, these bounds can only be the exact specific internal energy returned by the 1D EoS.
The second commit deals with the original floating point problem with `HybridEos`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
