### PR TITLE
Use PostNewtonian.jl for initial orbital parameters

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -730,6 +730,14 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         working-directory: build
         run: |
           make -j${NUMBER_OF_CORES} unit-tests
+      - name: Precompile Julia packages
+        working-directory: build
+        # This happens the first time the `sxs` package is imported. Do it here
+        # to avoid the delay when running the tests. The CI container should
+        # already have the Julia packages precompiled, so this step should only
+        # take a few seconds.
+        run: |
+          ./python-spectre -c "from sxs import julia"
       - name: Run unit tests
         if: matrix.unit_tests != 'OFF' && matrix.COVERAGE != 'ON'
         working-directory: build
@@ -964,7 +972,8 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.
       SPECTRE_BREW_DEPS: >-  # Line breaks are spaces, no trailing newline
-        autoconf automake boost catch2 ccache cmake gsl hdf5 openblas yaml-cpp
+        autoconf automake boost catch2 ccache cmake fftw gsl hdf5 openblas
+        yaml-cpp
       # We install these packages with Spack and cache them. The full specs are
       # listed below. This list is only needed to create the cache.
       SPECTRE_SPACK_DEPS: blaze charmpp libxsmm
@@ -1151,6 +1160,12 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       - name: Diagnose ccache
         run: |
           ccache -s
+      - name: Precompile Julia packages
+        working-directory: build
+        # This happens the first time the `sxs` package is imported. Do it here
+        # to avoid the delay when running the tests.
+        run: |
+          ./python-spectre -c "from sxs import julia"
       - name: Run unit tests
         working-directory: build
         run: |

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -53,6 +53,18 @@ set(PYTHON_EXEC_ENV_VARS "")
 # if(PARAVIEW_PYTHON_ENV_VARS)
 #   string(APPEND PYTHON_EXEC_ENV_VARS " ${PARAVIEW_PYTHON_ENV_VARS}")
 # endif()
+#
+# Place the Julia environment for the `sxs` package in the build directory.
+# The `sxs` package uses Julia for a PN implementation, which can be imported as
+# `from sxs import julia` (see https://moble.github.io/PostNewtonian.jl/dev/interface/python/).
+# This uses [juliapkg](https://github.com/JuliaPy/pyjuliapkg) to manage a Julia
+# environment. On a shared cluster the Julia environment can't be created in the
+# shared Python environment because even just reading/checking the environment
+# causes a permissions error (see issue https://github.com/sxs-collaboration/sxs/issues/155).
+# Therefore we configure juliapkg to create the environment in the build
+# directory.
+string(APPEND PYTHON_EXEC_ENV_VARS
+  " PYTHON_JULIAPKG_PROJECT=${CMAKE_BINARY_DIR}/julia_env")
 configure_file(
   "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
   "${CMAKE_BINARY_DIR}/tmp/spectre")
@@ -319,6 +331,7 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS
   spectre_test_timeout(TIMEOUT PYTHON ${TIMEOUT})
 
   set(_PY_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
+  string(APPEND _PY_TEST_ENV_VARS " ${PYTHON_EXEC_ENV_VARS}")
 
   # The fail regular expression is what Python.unittest returns when no
   # tests are found to be run. We treat this as a test failure.

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -124,7 +124,7 @@ ARG TARGETARCH
 # Install add-apt-repository and basic tools
 RUN if [ ${UBUNTU_VERSION} = 18.04 ] && [ "$TARGETARCH" = "arm64" ]; then \
     echo "Cannot use Ubuntu 18.04 with ARM" && exit 1; fi && apt-get update -y \
-    && apt-get install -y software-properties-common wget git file \
+    && apt-get install -y software-properties-common curl wget git file \
     && if [ ${UBUNTU_VERSION} = 18.04 ]; then \
     add-apt-repository ppa:ubuntu-toolchain-r/test; fi
 
@@ -173,6 +173,7 @@ RUN apt-get update -y \
         libboost-thread-dev libboost-tools-dev libssl-dev \
         libhdf5-dev hdf5-tools \
         libarpack2-dev \
+        libfftw3-dev \
         libbenchmark-dev \
     && if [ ${UBUNTU_VERSION} = 18.04 ]; then \
     wget https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz \
@@ -196,17 +197,10 @@ RUN apt-get update -y \
     apt-get install -y libjemalloc2 libjemalloc-dev libyaml-cpp-dev; \
     fi
 
-# Install Python packages
-# We only install packages that are needed by the build system (e.g. to compile
-# Python bindings or build documentation) or used by Python code that is
-# unit-tested. Any other packages can be installed on-demand.
+# Install Python
 # - We use python-is-python3 because on Ubuntu 20.04 /usr/bin/python was removed
 #   to aid in tracking down anything that depends on python 2. However, many
 #   scripts use `/usr/bin/env python` to find python so restore it.
-# - We install h5py explicitly from binary so that cross compilation is quicker.
-COPY support/Python/requirements.txt requirements.txt
-COPY support/Python/dev_requirements.txt dev_requirements.txt
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y \
     && if [ ${UBUNTU_VERSION} = 18.04 ]; then \
     apt-get install -y zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
@@ -215,17 +209,41 @@ RUN apt-get update -y \
     && wget https://www.python.org/ftp/python/3.10.1/Python-3.10.1.tgz \
     && tar -xf Python-3.10.1.tgz && cd ./Python-3.10.1 \
     && ./configure --enable-optimizations && make ${PARALLEL_MAKE_ARG} \
-    && make altinstall && cd ../ \
-    && rm -rf ./Python-3.10.1.tgz ./Python-3.10.1 \
-    && python3.10 -m pip install --upgrade pip \
-    && pip3.10 --no-cache-dir install --only-binary=h5py -r requirements.txt \
-    -r dev_requirements.txt; \
+    && make install && cd ../ \
+    && rm -rf ./Python-3.10.1.tgz ./Python-3.10.1; \
     else \
-    apt-get install -y python3-pip python-is-python3 pkg-config \
-    && pip3 --no-cache-dir install --only-binary=h5py -r requirements.txt \
-    -r dev_requirements.txt; \
-    fi \
+    apt-get install -y python3-pip python-is-python3 pkg-config; \
+    fi
+
+# Install Python packages
+# We only install packages that are needed by the build system (e.g. to compile
+# Python bindings or build documentation) or used by Python code that is
+# unit-tested. Any other packages can be installed on-demand.
+# - Install h5py explicitly from binary so that cross compilation is quicker.
+COPY support/Python/requirements.txt requirements.txt
+COPY support/Python/dev_requirements.txt dev_requirements.txt
+ENV DEBIAN_FRONTEND noninteractive
+RUN python3 -m pip install --upgrade pip \
+    && pip3 --no-cache-dir install --only-binary=h5py \
+      -r requirements.txt -r dev_requirements.txt \
     && rm requirements.txt dev_requirements.txt
+
+# Install Julia for the SXS package
+# This is optional, as the SXS package will download Julia on first use.
+# However, installing Julia explicitly gives more control over the installation.
+# - Set a consistent path for precompiled Julia packages so they are found when
+#   CI runs as a different user
+ENV JULIA_DEPOT_PATH "/usr/local/julia"
+RUN if [ ${UBUNTU_VERSION} = 22.04 ]; then \
+    curl -fsSL https://install.julialang.org | sh -s -- \
+        -y --add-to-path=false \
+    ; fi
+ENV PATH="$PATH:$JULIA_DEPOT_PATH/bin"
+# Call the SXS package so it precompiles Julia packages on first use, see:
+# https://moble.github.io/PostNewtonian.jl/dev/interface/python/
+RUN if [ ${UBUNTU_VERSION} = 22.04 ]; then \
+    python3 -c "from sxs import julia" \
+    ; fi
 
 # Enable bash-completion by installing it and then adding it to the .bashrc file
 RUN apt-get update -y \
@@ -499,9 +517,8 @@ ARG PARALLEL_MAKE_ARG=-j4
 
 # vim and emacs for editing files
 # Also ffmpeg for making movies with paraview output pngs
-# paraview needs curl
 RUN apt-get update -y \
-    && apt-get install -y vim emacs-nox ffmpeg curl
+    && apt-get install -y vim emacs-nox ffmpeg
 
 # Install headless paraview so we can run pvserver in the container
 # Note: there is no arm64 linux binary of paraview available, so don't

--- a/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
+++ b/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
@@ -7,9 +7,52 @@ from typing import Optional, Sequence, Tuple
 import numpy as np
 from scipy.optimize import minimize
 
-from spectre.support.CheckSpecImport import check_spec_import
-
 logger = logging.getLogger(__name__)
+
+
+# The following two functions are modernized versions of those in SpEC's
+# `ZeroEccParamsFromPN.py`. They use higher PN orders (whichever are implemented
+# in the PostNewtonian module), are much faster, and avoid spurious output from
+# old Fortran code (LSODA) that was used in SpEC's `ZeroEccParamsFromPN.py`.
+# They are consistent with SpEC up to 2.5 PN order, as tested by Mike Boyle (see
+# https://github.com/moble/PostNewtonian.jl/issues/41).
+#
+# Since these functions use Julia through Python bindings, they will download
+# Julia and precompile the packages on first use, which may take a few minutes
+# (see https://moble.github.io/PostNewtonian.jl/dev/interface/python/).
+
+
+def omega_and_adot(r, q, chiA, chiB):
+    from sxs.julia import PostNewtonian
+
+    # The BBH system state vector is documented here:
+    # https://moble.github.io/PostNewtonian.jl/stable/internals/pn_systems/#PostNewtonian.BBH
+    # The 14 state variables are:
+    # M1, M2, chi1 (3 components), chi2 (3 components), R (4 components), v, Phi
+    # These state variables are documented here:
+    # https://moble.github.io/PostNewtonian.jl/stable/internals/fundamental_variables
+    pn = PostNewtonian.BBH(
+        np.array(
+            [q / (1.0 + q), 1.0 / (1.0 + q), *chiA, *chiB, 1, 0, 0, 0, 1, 0]
+        )
+    )
+    # Set velocity by computing it from separation and the rest of the state
+    # variables
+    pn.state[12] = PostNewtonian.separation_inverse(r, pn)
+    return PostNewtonian.Omega(pn), PostNewtonian.separation_dot(pn) / r
+
+
+def num_orbits_and_time_to_merger(q, chiA, chiB, omega0):
+    from sxs.julia import PNWaveform
+
+    pn_waveform = PNWaveform(
+        M1=q / (1.0 + q),
+        M2=1.0 / (1.0 + q),
+        chi1=chiA,
+        chi2=chiB,
+        Omega_i=omega0,
+    )
+    return 0.5 * pn_waveform.orbital_phase[-1] / np.pi, pn_waveform.time[-1]
 
 
 def initial_orbital_parameters(
@@ -27,9 +70,9 @@ def initial_orbital_parameters(
     The result can be used to start an eccentricity control procedure to tune
     the initial orbital parameters further.
 
-    Currently only zero eccentricity (circular orbits) are supported, and the
-    implementation uses functions from SpEC's ZeroEccParamsFromPN.py. This
-    should be generalized.
+    Currently only zero eccentricity (circular orbits) are supported, since the
+    implementation uses functions from 'sxs.julia.PostNewtonian' that currently
+    work only for zero eccentricity. Eccentric terms could be added there.
 
     Arguments:
       mass_ratio: Defined as q = M_A / M_B >= 1.
@@ -80,8 +123,9 @@ def initial_orbital_parameters(
             "If you specify a nonzero 'eccentricity' you must also specify a"
             " 'mean_anomaly_fraction'."
         )
-    # The functions from SpEC currently work only for zero eccentricity. We will
-    # need to generalize this for eccentric orbits.
+
+    # The functions from the PostNewtonian module currently work only for zero
+    # eccentricity. We will need to generalize this for eccentric orbits.
     assert eccentricity == 0.0, (
         "Initial orbital parameters can currently only be computed for zero"
         " eccentricity."
@@ -101,22 +145,16 @@ def initial_orbital_parameters(
         " 'time_to_merger'."
     )
 
-    # Import functions from SpEC until we have ported them over. These functions
-    # call old Fortran code (LSODA) through scipy.integrate.odeint, which leads
-    # to lots of noise in stdout. When porting these functions, we should
-    # modernize them to use scipy.integrate.solve_ivp.
-    check_spec_import()
-    from ZeroEccParamsFromPN import nOrbitsAndTotalTime, omegaAndAdot
-
     # Find an omega0 that gives the right number of orbits or time to merger
     if num_orbits is not None or time_to_merger is not None:
+        logger.info("Finding orbital angular velocity...")
         opt_result = minimize(
             lambda x: (
                 abs(
-                    nOrbitsAndTotalTime(
+                    num_orbits_and_time_to_merger(
                         q=mass_ratio,
-                        chiA0=dimensionless_spin_a,
-                        chiB0=dimensionless_spin_b,
+                        chiA=dimensionless_spin_a,
+                        chiB=dimensionless_spin_b,
                         omega0=x[0],
                     )[0 if num_orbits is not None else 1]
                     - (num_orbits if num_orbits is not None else time_to_merger)
@@ -138,14 +176,14 @@ def initial_orbital_parameters(
 
     # Find the separation that gives the desired orbital angular velocity
     if orbital_angular_velocity is not None:
+        logger.info("Finding separation...")
         opt_result = minimize(
             lambda x: abs(
-                omegaAndAdot(
+                omega_and_adot(
                     r=x[0],
                     q=mass_ratio,
                     chiA=dimensionless_spin_a,
                     chiB=dimensionless_spin_b,
-                    rPrime0=1.0,  # Choice also made in SpEC
                 )[0]
                 - orbital_angular_velocity
             ),
@@ -161,12 +199,11 @@ def initial_orbital_parameters(
         logger.debug(f"Found initial separation: {separation}")
 
     # Find the radial expansion velocity
-    new_orbital_angular_velocity, radial_expansion_velocity = omegaAndAdot(
+    new_orbital_angular_velocity, radial_expansion_velocity = omega_and_adot(
         r=separation,
         q=mass_ratio,
         chiA=dimensionless_spin_a,
         chiB=dimensionless_spin_b,
-        rPrime0=1.0,  # Choice also made in SpEC
     )
     if orbital_angular_velocity is None:
         orbital_angular_velocity = new_orbital_angular_velocity
@@ -179,10 +216,10 @@ def initial_orbital_parameters(
         )
 
     # Estimate number of orbits and time to merger
-    num_orbits, time_to_merger = nOrbitsAndTotalTime(
+    num_orbits, time_to_merger = num_orbits_and_time_to_merger(
         q=mass_ratio,
-        chiA0=dimensionless_spin_a,
-        chiB0=dimensionless_spin_b,
+        chiA=dimensionless_spin_a,
+        chiB=dimensionless_spin_b,
         omega0=orbital_angular_velocity,
     )
     logger.info(

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -32,3 +32,7 @@ pyyaml
 # Rich: to format CLI output and tracebacks
 rich >= 12.0.0
 scipy
+# SXS package: to work with SXS data, waveforms, etc. Also to evaluate some
+# post-Newtonian expressions, e.g. for low-eccentricity initial orbital
+# parameters.
+sxs >= 2024.0.3

--- a/tests/support/Pipelines/EccentricityControl/CMakeLists.txt
+++ b/tests/support/Pipelines/EccentricityControl/CMakeLists.txt
@@ -1,16 +1,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_add_python_bindings_test(
+  "support.Pipelines.EccentricityControl.InitialOrbitalParameters"
+  Test_InitialOrbitalParameters.py
+  "Python"
+  None
+  TIMEOUT 60)
+
 if (SpEC_FOUND)
   spectre_add_python_bindings_test(
     "support.Pipelines.EccentricityControl.EccentricityControlParams"
     Test_EccentricityControlParams.py
-    "Python"
-    None
-    TIMEOUT 60)
-  spectre_add_python_bindings_test(
-    "support.Pipelines.EccentricityControl.InitialOrbitalParameters"
-    Test_InitialOrbitalParameters.py
     "Python"
     None
     TIMEOUT 60)

--- a/tests/support/Pipelines/EccentricityControl/Test_InitialOrbitalParameters.py
+++ b/tests/support/Pipelines/EccentricityControl/Test_InitialOrbitalParameters.py
@@ -4,6 +4,7 @@
 import logging
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 from spectre.Pipelines.EccentricityControl.InitialOrbitalParameters import (
@@ -22,7 +23,7 @@ class TestInitialOrbitalParameters(unittest.TestCase):
             "DimensionlessSpinB": [0.0, 0.0, 0.0],
             "Eccentricity": 0.0,
         }
-        # Expected results are computed from SpEC's ZeroEccParamsFromPN.py
+        np.set_printoptions(precision=14)
         npt.assert_allclose(
             initial_orbital_parameters(
                 target_params,
@@ -37,33 +38,33 @@ class TestInitialOrbitalParameters(unittest.TestCase):
                 target_params,
                 separation=16.0,
             ),
-            [16.0, 0.014474280975952748, -4.117670632867514e-05],
+            [16.0, 0.014454484323416913, -4.236562633362394e-05],
         )
         npt.assert_allclose(
             initial_orbital_parameters(
                 target_params,
                 orbital_angular_velocity=0.015,
             ),
-            [15.6060791015625, 0.015, -4.541705362753467e-05],
+            [15.59033203125, 0.015, -4.696365029012517e-05],
         )
         npt.assert_allclose(
             initial_orbital_parameters(
                 target_params,
                 orbital_angular_velocity=0.015,
             ),
-            [15.6060791015625, 0.015, -4.541705362753467e-05],
+            [15.59033203125, 0.015, -4.696365029012517e-05],
         )
         npt.assert_allclose(
             initial_orbital_parameters(
                 {**target_params, "NumOrbits": 20},
             ),
-            [16.0421142578125, 0.014419921875000002, -4.0753460821644916e-05],
+            [15.71142578125, 0.014835205078125004, -4.554164727449197e-05],
         )
         npt.assert_allclose(
             initial_orbital_parameters(
                 {**target_params, "TimeToMerger": 6000},
             ),
-            [16.1357421875, 0.01430025219917298, -3.9831982447244026e-05],
+            [16.0909423828125, 0.01433787536621094, -4.14229775202535e-05],
         )
 
 


### PR DESCRIPTION
## Proposed changes

Replaces the dependence on SpEC to compute low-eccentricity initial orbital parameters with the `sxs` package. It provides the PN approximations at higher PN order than SpEC, is much faster, and avoids spurious output from old Fortran code (LSODA) that was used in SpEC.
The PN approximations are provided through the `PostNewtonian.jl` Julia package, so Julia will be downloaded on first use, which may take a few minutes.

See also https://github.com/moble/PostNewtonian.jl/issues/41, which made this possible.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To use low-eccentricity initial orbital parameters for BBH initial data, install the `sxs` package in your Python environment:

```sh
# In the build directory:
./bin/python-spectre -m pip install sxs
```

Now you can use `./bin/spectre bbh generate-id` with the `--eccentricity=0` option. You don't need SpEC for this anymore.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
