### PR TITLE
Combine Shape map calls

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -82,6 +82,7 @@ Checks: '*,
 # We have lots of "x", "p", & "os" variable names,
 -readability-identifier-length,
 -readability-magic-numbers,
+-misc-confusable-identifiers
 # Same as llvm-qualified-auto above.,
 -readability-qualified-auto,
 # Access specifiers can be useful to structure code,

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -33,6 +33,136 @@ std::array<T, 2> cartesian_to_spherical(const std::array<T, 3>& cartesian) {
   const auto& [x, y, z] = cartesian;
   return {atan2(hypot(x, y), z), atan2(y, x)};
 }
+template <typename T>
+void cartesian_to_spherical(gsl::not_null<std::array<T, 2>*> result,
+                            const std::array<T, 3>& cartesian) {
+  const auto& [x, y, z] = cartesian;
+  gsl::at(*result, 0) = atan2(hypot(x, y), z);
+  gsl::at(*result, 1) = atan2(y, x);
+}
+
+template <typename T>
+void Shape::jacobian_helper(
+    gsl::not_null<tnsr::Ij<T, 3, Frame::NoFrame>*> result,
+    const ylm::Spherepack::InterpolationInfo<T>& interpolation_info,
+    const DataVector& extended_coefs, const std::array<T, 3>& centered_coords,
+    const T& distorted_radii, const T& one_over_radius,
+    const T& transition_func_over_radius) const {
+  const auto angular_gradient =
+      extended_ylm_.gradient_from_coefs(extended_coefs);
+
+  tnsr::i<DataVector, 3, Frame::Inertial> cartesian_gradient(
+      extended_ylm_.physical_size());
+
+  std::array<DataVector, 2> collocation_theta_phis{};
+  collocation_theta_phis[0].set_data_ref(&get<2>(cartesian_gradient));
+  collocation_theta_phis[1].set_data_ref(&get<1>(cartesian_gradient));
+  collocation_theta_phis = extended_ylm_.theta_phi_points();
+
+  const auto& col_thetas = collocation_theta_phis[0];
+  const auto& col_phis = collocation_theta_phis[1];
+
+  // The Cartesian derivative is the Pfaffian derivative multiplied by the
+  // inverse Jacobian matrix. Some optimizations here may be possible by
+  // introducing temporaries for some of the sin/cos which are computed twice,
+  // if the compiler CSE doesn't take care of it.
+  get<0>(cartesian_gradient) =
+      (cos(col_thetas) * cos(col_phis) * get<0>(angular_gradient) -
+       sin(col_phis) * get<1>(angular_gradient));
+
+  get<1>(cartesian_gradient) =
+      (cos(col_thetas) * sin(col_phis) * get<0>(angular_gradient) +
+       cos(col_phis) * get<1>(angular_gradient));
+
+  get<2>(cartesian_gradient) = -sin(col_thetas) * get<0>(angular_gradient);
+
+  // re-use allocation
+  auto& target_gradient_x = get<2, 0>(*result);
+  auto& target_gradient_y = get<2, 1>(*result);
+  auto& target_gradient_z = get<2, 2>(*result);
+
+  // interpolate the cartesian gradient to the thetas and phis of the
+  // `source_coords`
+  extended_ylm_.interpolate(make_not_null(&target_gradient_x),
+                            get<0>(cartesian_gradient).data(),
+                            interpolation_info);
+  extended_ylm_.interpolate(make_not_null(&target_gradient_y),
+                            get<1>(cartesian_gradient).data(),
+                            interpolation_info);
+  extended_ylm_.interpolate(make_not_null(&target_gradient_z),
+                            get<2>(cartesian_gradient).data(),
+                            interpolation_info);
+
+  auto transition_func_over_square_radius =
+      transition_func_over_radius * one_over_radius;
+  auto transition_func_over_cube_radius =
+      transition_func_over_square_radius * one_over_radius;
+  auto transition_func_gradient_over_radius =
+      transition_func_->gradient(centered_coords) * one_over_radius;
+
+  auto& target_gradient_x_times_spatial_part = target_gradient_x;
+  auto& target_gradient_y_times_spatial_part = target_gradient_y;
+  auto& target_gradient_z_times_spatial_part = target_gradient_z;
+  target_gradient_x_times_spatial_part *= transition_func_over_square_radius;
+  target_gradient_y_times_spatial_part *= transition_func_over_square_radius;
+  target_gradient_z_times_spatial_part *= transition_func_over_square_radius;
+
+  const auto& [x_transition_gradient_over_radius,
+               y_transition_gradient_over_radius,
+               z_transition_gradient_over_radius] =
+      transition_func_gradient_over_radius;
+  const auto& [x_centered, y_centered, z_centered] = centered_coords;
+
+  get<0, 0>(*result) =
+      -x_centered * ((x_transition_gradient_over_radius -
+                      x_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_x_times_spatial_part);
+  get<0, 1>(*result) =
+      -x_centered * ((y_transition_gradient_over_radius -
+                      y_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_y_times_spatial_part);
+  get<0, 2>(*result) =
+      -x_centered * ((z_transition_gradient_over_radius -
+                      z_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_z_times_spatial_part);
+  get<1, 0>(*result) =
+      -y_centered * ((x_transition_gradient_over_radius -
+                      x_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_x_times_spatial_part);
+  get<1, 1>(*result) =
+      -y_centered * ((y_transition_gradient_over_radius -
+                      y_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_y_times_spatial_part);
+  get<1, 2>(*result) =
+      -y_centered * ((z_transition_gradient_over_radius -
+                      z_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_z_times_spatial_part);
+  get<2, 0>(*result) =
+      -z_centered * ((x_transition_gradient_over_radius -
+                      x_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_x_times_spatial_part);
+  get<2, 1>(*result) =
+      -z_centered * ((y_transition_gradient_over_radius -
+                      y_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_y_times_spatial_part);
+  get<2, 2>(*result) =
+      -z_centered * ((z_transition_gradient_over_radius -
+                      z_centered * transition_func_over_cube_radius) *
+                         distorted_radii +
+                     target_gradient_z_times_spatial_part);
+
+  get<0, 0>(*result) += 1. - distorted_radii * transition_func_over_radius;
+  get<1, 1>(*result) += 1. - distorted_radii * transition_func_over_radius;
+  get<2, 2>(*result) += 1. - distorted_radii * transition_func_over_radius;
+}
 
 Shape::Shape(
     const std::array<double, 3>& center, const size_t l_max, const size_t m_max,
@@ -188,143 +318,24 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
       extended_coefs[extended_iter()] = coefs[iter()];
     }
   }
-
   check_size(make_not_null(&extended_coefs), functions_of_time, time, false);
 
   // Re-use allocation
   auto& distorted_radii = get<0>(theta_phis);
   extended_ylm_.interpolate_from_coefs(make_not_null(&distorted_radii),
                                        extended_coefs, interpolation_info);
-  // Calculates the Pfaffian derivative at the internal collocation points of
-  // YlmSpherePack. We can't interpolate these directly as they are not smooth
-  // across the poles, so we convert them to the Cartesian gradients first,
-  // which are smooth.
-  const auto angular_gradient =
-      extended_ylm_.gradient_from_coefs(extended_coefs);
 
-  tnsr::i<DataVector, 3, Frame::Inertial> cartesian_gradient(
-      extended_ylm_.physical_size());
-
-  // Re-use allocations
-  std::array<DataVector, 2> collocation_theta_phis{};
-  collocation_theta_phis[0].set_data_ref(&get<2>(cartesian_gradient));
-  collocation_theta_phis[1].set_data_ref(&get<1>(cartesian_gradient));
-  collocation_theta_phis = extended_ylm_.theta_phi_points();
-
-  const auto& col_thetas = collocation_theta_phis[0];
-  const auto& col_phis = collocation_theta_phis[1];
-
-  // The Cartesian derivative is the Pfaffian derivative multiplied by the
-  // inverse Jacobian matrix. Some optimizations here may be possible by
-  // introducing temporaries for some of the sin/cos which are computed twice,
-  // if the compiler CSE doesn't take care of it.
-  get<0>(cartesian_gradient) =
-      (cos(col_thetas) * cos(col_phis) * get<0>(angular_gradient) -
-       sin(col_phis) * get<1>(angular_gradient));
-
-  get<1>(cartesian_gradient) =
-      (cos(col_thetas) * sin(col_phis) * get<0>(angular_gradient) +
-       cos(col_phis) * get<1>(angular_gradient));
-
-  get<2>(cartesian_gradient) = -sin(col_thetas) * get<0>(angular_gradient);
-
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> result(
-      get_size(centered_coords[0]));
-
-  // re-use allocation
-  auto& target_gradient_x = get<2, 0>(result);
-  auto& target_gradient_y = get<2, 1>(result);
-  auto& target_gradient_z = get<2, 2>(result);
-
-  // interpolate the cartesian gradient to the thetas and phis of the
-  // `source_coords`
-  extended_ylm_.interpolate(make_not_null(&target_gradient_x),
-                            get<0>(cartesian_gradient).data(),
-                            interpolation_info);
-  extended_ylm_.interpolate(make_not_null(&target_gradient_y),
-                            get<1>(cartesian_gradient).data(),
-                            interpolation_info);
-  extended_ylm_.interpolate(make_not_null(&target_gradient_z),
-                            get<2>(cartesian_gradient).data(),
-                            interpolation_info);
-
-  // No auto here to avoid DVExpressions
   using ReturnType = tt::remove_cvref_wrap_t<T>;
   const ReturnType one_over_radius =
       check_and_compute_one_over_radius(centered_coords);
   const ReturnType transition_func_over_radius =
       transition_func_->operator()(centered_coords) * one_over_radius;
-  const ReturnType transition_func_over_square_radius =
-      transition_func_over_radius * one_over_radius;
-  const ReturnType transition_func_over_cube_radius =
-      transition_func_over_square_radius * one_over_radius;
-  const std::array<ReturnType, 3> transition_func_gradient_over_radius =
-      transition_func_->gradient(centered_coords) * one_over_radius;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> result(
+      get_size(centered_coords[0]));
 
-  // re-use allocation
-  auto& target_gradient_x_times_spatial_part = target_gradient_x;
-  auto& target_gradient_y_times_spatial_part = target_gradient_y;
-  auto& target_gradient_z_times_spatial_part = target_gradient_z;
-  target_gradient_x_times_spatial_part *= transition_func_over_square_radius;
-  target_gradient_y_times_spatial_part *= transition_func_over_square_radius;
-  target_gradient_z_times_spatial_part *= transition_func_over_square_radius;
-
-  const auto& [x_transition_gradient_over_radius,
-               y_transition_gradient_over_radius,
-               z_transition_gradient_over_radius] =
-      transition_func_gradient_over_radius;
-  const auto& [x_centered, y_centered, z_centered] = centered_coords;
-
-  get<0, 0>(result) =
-      -x_centered * ((x_transition_gradient_over_radius -
-                      x_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_x_times_spatial_part);
-  get<0, 1>(result) =
-      -x_centered * ((y_transition_gradient_over_radius -
-                      y_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_y_times_spatial_part);
-  get<0, 2>(result) =
-      -x_centered * ((z_transition_gradient_over_radius -
-                      z_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_z_times_spatial_part);
-  get<1, 0>(result) =
-      -y_centered * ((x_transition_gradient_over_radius -
-                      x_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_x_times_spatial_part);
-  get<1, 1>(result) =
-      -y_centered * ((y_transition_gradient_over_radius -
-                      y_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_y_times_spatial_part);
-  get<1, 2>(result) =
-      -y_centered * ((z_transition_gradient_over_radius -
-                      z_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_z_times_spatial_part);
-  get<2, 0>(result) =
-      -z_centered * ((x_transition_gradient_over_radius -
-                      x_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_x_times_spatial_part);
-  get<2, 1>(result) =
-      -z_centered * ((y_transition_gradient_over_radius -
-                      y_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_y_times_spatial_part);
-  get<2, 2>(result) =
-      -z_centered * ((z_transition_gradient_over_radius -
-                      z_centered * transition_func_over_cube_radius) *
-                         distorted_radii +
-                     target_gradient_z_times_spatial_part);
-
-  get<0, 0>(result) += 1. - distorted_radii * transition_func_over_radius;
-  get<1, 1>(result) += 1. - distorted_radii * transition_func_over_radius;
-  get<2, 2>(result) += 1. - distorted_radii * transition_func_over_radius;
-
+  jacobian_helper(make_not_null(&result), interpolation_info, extended_coefs,
+                  centered_coords, distorted_radii, one_over_radius,
+                  transition_func_over_radius);
   return result;
 }
 

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -269,6 +269,23 @@ class Shape {
             coords[2] - center_[2]};
   }
 
+  template <typename T>
+  void center_coordinates(
+      gsl::not_null<std::array<tt::remove_cvref_wrap_t<T>, 3>*> result,
+      const std::array<T, 3>& coords) const {
+    for (size_t i = 0; i < 3; ++i) {
+      gsl::at(*result, i) = gsl::at(coords, i) - gsl::at(center_, i);
+    }
+  }
+
+  template <typename T>
+  void jacobian_helper(
+      gsl::not_null<tnsr::Ij<T, 3, Frame::NoFrame>*> result,
+      const ylm::Spherepack::InterpolationInfo<T>& interpolation_info,
+      const DataVector& extended_coefs, const std::array<T, 3>& centered_coords,
+      const T& distorted_radii, const T& one_over_radius,
+      const T& transition_func_over_radius) const;
+
   void check_size(const gsl::not_null<DataVector*>& coefs,
                   const FunctionsOfTimeMap& functions_of_time, double time,
                   bool use_deriv) const;

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -241,6 +241,20 @@ class Shape {
       const std::array<T, 3>& source_coords, double time,
       const FunctionsOfTimeMap& functions_of_time) const;
 
+  /*!
+   * \brief An optimized call that computes the target coordinates, frame
+   * velocity and jacobian at once to avoid duplicate calculations.
+   *
+   * \details The first argument `source_and_target_coords` should contain
+   * the source coordinates and will be overwritten in place with the target
+   * coordinates.
+   */
+  void coords_frame_velocity_jacobian(
+      gsl::not_null<std::array<DataVector, 3>*> source_and_target_coords,
+      gsl::not_null<std::array<DataVector, 3>*> frame_vel,
+      gsl::not_null<tnsr::Ij<DataVector, 3, Frame::NoFrame>*> jac, double time,
+      const FunctionsOfTimeMap& functions_of_time) const;
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
   static bool is_identity() { return false; }

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -258,6 +258,7 @@ class Shape {
   size_t l_max_ = 2;
   size_t m_max_ = 2;
   ylm::Spherepack ylm_{2, 2};
+  ylm::Spherepack extended_ylm_{3, 3};
   std::unique_ptr<ShapeMapTransitionFunctions::ShapeMapTransitionFunction>
       transition_func_;
 

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -100,7 +100,7 @@ DomainCreator:
     TimeDependentMaps:
       Shape:
         InitialTime: 0.
-        LMax: 20
+        LMax: 18
         Mass: *KerrMass
         Spin: *KerrSpin
         Center: *KerrCenter

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -31,6 +31,7 @@
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
@@ -1472,9 +1473,11 @@ void test_coords_frame_velocity_jacobians() {
               cubic_scale_jac.get(2, 1) * velocity_affine_map_frame[1] +
               cubic_scale_jac.get(2, 2) * velocity_affine_map_frame[2]}}};
 
-    CHECK(std::get<3>(composed_map_3d.coords_frame_velocity_jacobians(
-              tnsr::I<double, 3, Frame::BlockLogical>{source_pt}, time,
-              functions_of_time)) == expected_velocity);
+    CHECK_ITERABLE_APPROX(
+        (std::get<3>(composed_map_3d.coords_frame_velocity_jacobians(
+            tnsr::I<double, 3, Frame::BlockLogical>{source_pt}, time,
+            functions_of_time))),
+        expected_velocity);
   }
   {
     MAKE_GENERATOR(generator);
@@ -1522,5 +1525,10 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMap", "[Domain][Unit]") {
   test_push_back();
   test_jacobian_is_time_dependent();
   test_coords_frame_velocity_jacobians();
+  static_assert(CoordinateMap_detail::has_combined_coords_frame_velocity_jacs_v<
+                3, domain::CoordinateMaps::TimeDependent::Shape>);
+  static_assert(
+      not CoordinateMap_detail::has_combined_coords_frame_velocity_jacs_v<
+          3, domain::CoordinateMaps::TimeDependent::Translation<3>>);
 }
 }  // namespace domain


### PR DESCRIPTION
Currently, the shape map computes the coordinates, frame velocity and jacobians separately which duplicates a lot of work such as computing the spherical harmonic expansion.

This PR adds a combined call to these three quantities. I found that this speeds up simulations between 16 % and 27% (when combined with #6223)

depends on #6223 


![image](https://github.com/user-attachments/assets/86da46c7-bb3f-420d-bf83-7e937b157836)

