### PR TITLE
Fix clang-tidy errors in PiMonteCarlo example

### DIFF
--- a/src/Executables/Examples/PiMonteCarlo/PiMonteCarlo.cpp
+++ b/src/Executables/Examples/PiMonteCarlo/PiMonteCarlo.cpp
@@ -169,7 +169,8 @@ struct ThrowDarts {
             cache)[array_index];
 
     // Tutorial STEP 2.3: contribute hits to reduction data
-    Parallel::ReductionData<Parallel::ReductionDatum<size_t, funcl::Plus<>>>
+    const Parallel::ReductionData<
+        Parallel::ReductionDatum<size_t, funcl::Plus<>>>
         hits_to_send{hits};
     Parallel::contribute_to_reduction<Actions::ProcessHitsAndThrows>(
         hits_to_send, dart_thrower_element_proxy, pi_estimator_proxy);
@@ -194,7 +195,7 @@ struct ProcessHitsAndThrows {
                     const Parallel::GlobalCache<Metavars>& cache,
                     const ArrayIndex& /*array_index*/, const size_t new_hits) {
     // TUTORIAL STEP 2.4: get number of processors from the cache
-    const size_t num_procs = Parallel::number_of_procs<size_t>(cache);
+    const auto num_procs = Parallel::number_of_procs<size_t>(cache);
 
     // TUTORIAL STEP 2.5: get number of darts thrown each iteration
     // from the DataBox
@@ -266,7 +267,7 @@ struct PiEstimator {
       tmpl::list<Tags::HitsAllProcs, Tags::ThrowsAllProcs,
                  Tags::DartsPerIteration, Tags::AccuracyGoal>;
   static void execute_next_phase(
-      const Parallel::Phase next_phase,
+      Parallel::Phase next_phase,
       const Parallel::CProxy_GlobalCache<Metavars>& global_cache);
 };
 
@@ -309,7 +310,7 @@ struct DartThrower {
   using array_allocation_tags = tmpl::list<>;
 
   static void execute_next_phase(
-      const Parallel::Phase next_phase,
+      Parallel::Phase next_phase,
       const Parallel::CProxy_GlobalCache<Metavars>& global_cache);
   static void allocate_array(
       Parallel::CProxy_GlobalCache<Metavars>& global_cache,
@@ -358,7 +359,7 @@ void DartThrower<Metavars>::allocate_array(
       Parallel::get_parallel_component<DartThrower<Metavars>>(local_cache);
 
   size_t which_proc = 0;
-  const size_t num_procs = Parallel::number_of_procs<size_t>(local_cache);
+  const auto num_procs = Parallel::number_of_procs<size_t>(local_cache);
   const size_t number_of_elements = num_procs;
 
   for (size_t i = 0; i < number_of_elements; ++i) {

--- a/src/Executables/Examples/PiMonteCarlo/PiMonteCarloTutorial.cpp
+++ b/src/Executables/Examples/PiMonteCarlo/PiMonteCarloTutorial.cpp
@@ -114,9 +114,12 @@ struct ThrowDarts {
       const ParallelComponent* const /*meta*/
   ) {
     // TUTORIAL STEP 2.0: get how many darts to throw from the DataBox
+    (void)box;  // remove this line
 
     // TUTORIAL STEP 2.1: throw N darts at the unit square, seeing how many
     // hit the quarter circle
+    (void)cache;        // remove this line
+    (void)array_index;  // remove this line
 
     // Get a proxy (an object that might live on another compute node)
     // for each ParallelComponent. The PiEstimator Singleton component


### PR DESCRIPTION
## Proposed changes

Addresses a small part of #6188

See [here](https://github.com/sxs-collaboration/spectre/pull/6189/files) to see the clang-tidy errors that this PR addresses

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
