### PR TITLE
AlignedLattice: boundary condition per direction

### DIFF
--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -23,38 +23,33 @@
 namespace domain::creators {
 
 using ::operator<<;
-template <size_t VolumeDim>
+template <size_t Dim>
 std::ostream& operator<<(std::ostream& /*s*/,
-                         const RefinementRegion<VolumeDim>& /*unused*/) {
+                         const RefinementRegion<Dim>& /*unused*/) {
   ERROR(
       "RefinementRegion stream operator is only for option parsing and "
       "should never be called.");
 }
 
-template <size_t VolumeDim>
-AlignedLattice<VolumeDim>::AlignedLattice(
-    const typename BlockBounds::type block_bounds,
-    const typename InitialLevels::type initial_refinement_levels,
-    const typename InitialGridPoints::type initial_number_of_grid_points,
-    typename RefinedLevels::type refined_refinement,
-    typename RefinedGridPoints::type refined_grid_points,
-    typename BlocksToExclude::type blocks_to_exclude,
-    const typename IsPeriodicIn::type is_periodic_in,
-    const Options::Context& context)
-    // clang-tidy: trivially copyable
-    : block_bounds_(std::move(block_bounds)),         // NOLINT
-      is_periodic_in_(std::move(is_periodic_in)),     // NOLINT
-      initial_refinement_levels_(                     // NOLINT
-          std::move(initial_refinement_levels)),      // NOLINT
-      initial_number_of_grid_points_(                 // NOLINT
-          std::move(initial_number_of_grid_points)),  // NOLINT
+template <size_t Dim>
+AlignedLattice<Dim>::AlignedLattice(
+    std::array<std::vector<double>, Dim> block_bounds,
+    std::array<size_t, Dim> initial_refinement_levels,
+    std::array<size_t, Dim> initial_number_of_grid_points,
+    std::vector<RefinementRegion<Dim>> refined_refinement,
+    std::vector<RefinementRegion<Dim>> refined_grid_points,
+    std::vector<std::array<size_t, Dim>> blocks_to_exclude,
+    std::array<bool, Dim> is_periodic_in, const Options::Context& context)
+    : block_bounds_(std::move(block_bounds)),
+      is_periodic_in_(is_periodic_in),
+      initial_refinement_levels_(initial_refinement_levels),
+      initial_number_of_grid_points_(initial_number_of_grid_points),
       refined_refinement_(std::move(refined_refinement)),
       refined_grid_points_(std::move(refined_grid_points)),
       blocks_to_exclude_(std::move(blocks_to_exclude)),
-      number_of_blocks_by_dim_{
-          map_array(block_bounds_,
-                    [](const std::vector<double>& v) { return v.size() - 1; })},
-      boundary_condition_(nullptr) {
+      number_of_blocks_by_dim_{map_array(
+          block_bounds_,
+          [](const std::vector<double>& v) { return v.size() - 1; })} {
   if (not blocks_to_exclude_.empty() and
       alg::any_of(is_periodic_in_, [](const bool t) { return t; })) {
     PARSE_ERROR(context,
@@ -62,7 +57,7 @@ AlignedLattice<VolumeDim>::AlignedLattice(
                 "conditions!");
   }
   for (const auto& refinement_region : refined_grid_points_) {
-    for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t i = 0; i < Dim; ++i) {
       if (gsl::at(refinement_region.upper_corner_index, i) >=
           gsl::at(block_bounds_, i).size()) {
         PARSE_ERROR(context, "Refinement region extends to "
@@ -72,7 +67,7 @@ AlignedLattice<VolumeDim>::AlignedLattice(
     }
   }
   for (const auto& refinement_region : refined_refinement_) {
-    for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t i = 0; i < Dim; ++i) {
       if (gsl::at(refinement_region.upper_corner_index, i) >=
           gsl::at(block_bounds_, i).size()) {
         PARSE_ERROR(context, "Refinement region extends to "
@@ -83,44 +78,47 @@ AlignedLattice<VolumeDim>::AlignedLattice(
   }
 }
 
-template <size_t VolumeDim>
-AlignedLattice<VolumeDim>::AlignedLattice(
-    const typename BlockBounds::type block_bounds,
-    const typename InitialLevels::type initial_refinement_levels,
-    const typename InitialGridPoints::type initial_number_of_grid_points,
-    typename RefinedLevels::type refined_refinement,
-    typename RefinedGridPoints::type refined_grid_points,
-    typename BlocksToExclude::type blocks_to_exclude,
-    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        boundary_condition,
+template <size_t Dim>
+AlignedLattice<Dim>::AlignedLattice(
+    std::array<std::vector<double>, Dim> block_bounds,
+    std::array<size_t, Dim> initial_refinement_levels,
+    std::array<size_t, Dim> initial_number_of_grid_points,
+    std::vector<RefinementRegion<Dim>> refined_refinement,
+    std::vector<RefinementRegion<Dim>> refined_grid_points,
+    std::vector<std::array<size_t, Dim>> blocks_to_exclude,
+    std::array<
+        std::array<
+            std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>, 2>,
+        Dim>
+        boundary_conditions,
     const Options::Context& context)
-    // clang-tidy: trivially copyable
-    : block_bounds_(std::move(block_bounds)),  // NOLINT
-      is_periodic_in_(make_array<VolumeDim>(false)),
-      initial_refinement_levels_(                     // NOLINT
-          std::move(initial_refinement_levels)),      // NOLINT
-      initial_number_of_grid_points_(                 // NOLINT
-          std::move(initial_number_of_grid_points)),  // NOLINT
-      refined_refinement_(std::move(refined_refinement)),
-      refined_grid_points_(std::move(refined_grid_points)),
-      blocks_to_exclude_(std::move(blocks_to_exclude)),
-      number_of_blocks_by_dim_{
-          map_array(block_bounds_,
-                    [](const std::vector<double>& v) { return v.size() - 1; })},
-      boundary_condition_(std::move(boundary_condition)) {
+    : AlignedLattice(
+          std::move(block_bounds), initial_refinement_levels,
+          initial_number_of_grid_points, std::move(refined_refinement),
+          std::move(refined_grid_points), std::move(blocks_to_exclude),
+          make_array<Dim>(false), context) {
+  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+  boundary_conditions_ = std::move(boundary_conditions);
   using domain::BoundaryConditions::is_none;
-  if (is_none(boundary_condition_)) {
-    PARSE_ERROR(
-        context,
-        "None boundary condition is not supported. If you would like an "
-        "outflow-type boundary condition, you must use that.");
-  }
   using domain::BoundaryConditions::is_periodic;
-  if (is_periodic(boundary_condition_)) {
-    is_periodic_in_[0] = true;
-    is_periodic_in_[1] = true;
-    is_periodic_in_[2] = true;
-    boundary_condition_ = nullptr;
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto& [lower_bc, upper_bc] = gsl::at(boundary_conditions_, d);
+    ASSERT(lower_bc != nullptr and upper_bc != nullptr,
+           "None of the boundary conditions can be nullptr.");
+    if (is_none(lower_bc) or is_none(upper_bc)) {
+      PARSE_ERROR(
+          context,
+          "None boundary condition is not supported. If you would like an "
+          "outflow-type boundary condition, you must use that.");
+    }
+    if (is_periodic(lower_bc) != is_periodic(upper_bc)) {
+      PARSE_ERROR(context,
+                  "Periodic boundary conditions must be applied for both "
+                  "upper and lower direction in a dimension.");
+    }
+    if (is_periodic(lower_bc) and is_periodic(upper_bc)) {
+      gsl::at(is_periodic_in_, d) = true;
+    }
   }
   if (not blocks_to_exclude_.empty() and
       alg::any_of(is_periodic_in_, [](const bool t) { return t; })) {
@@ -129,7 +127,7 @@ AlignedLattice<VolumeDim>::AlignedLattice(
                 "conditions!");
   }
   for (const auto& refinement_region : refined_grid_points_) {
-    for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t i = 0; i < Dim; ++i) {
       if (gsl::at(refinement_region.upper_corner_index, i) >=
           gsl::at(block_bounds_, i).size()) {
         PARSE_ERROR(context, "Refinement region extends to "
@@ -139,7 +137,7 @@ AlignedLattice<VolumeDim>::AlignedLattice(
     }
   }
   for (const auto& refinement_region : refined_refinement_) {
-    for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t i = 0; i < Dim; ++i) {
       if (gsl::at(refinement_region.upper_corner_index, i) >=
           gsl::at(block_bounds_, i).size()) {
         PARSE_ERROR(context, "Refinement region extends to "
@@ -150,20 +148,27 @@ AlignedLattice<VolumeDim>::AlignedLattice(
   }
 }
 
-template <size_t VolumeDim>
-Domain<VolumeDim> AlignedLattice<VolumeDim>::create_domain() const {
-  return rectilinear_domain<VolumeDim>(
+template <size_t Dim>
+Domain<Dim> AlignedLattice<Dim>::create_domain() const {
+  return rectilinear_domain<Dim>(
       number_of_blocks_by_dim_, block_bounds_,
-      {std::vector<Index<VolumeDim>>(blocks_to_exclude_.begin(),
-                                     blocks_to_exclude_.end())},
+      {std::vector<Index<Dim>>(blocks_to_exclude_.begin(),
+                               blocks_to_exclude_.end())},
       {}, is_periodic_in_, {}, false);
 }
 
-template <size_t VolumeDim>
+template <size_t Dim>
 std::vector<DirectionMap<
-    VolumeDim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-AlignedLattice<VolumeDim>::external_boundary_conditions() const {
-  if (boundary_condition_ == nullptr) {
+    Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+AlignedLattice<Dim>::external_boundary_conditions() const {
+  if (boundary_conditions_[0][0] == nullptr) {
+#ifdef SPECTRE_DEBUG
+    for (size_t d = 0; d < Dim; ++d) {
+      ASSERT(gsl::at(boundary_conditions_, d)[0] == nullptr and
+                 gsl::at(boundary_conditions_, d)[1] == nullptr,
+             "Boundary conditions must be set for all directions or none.");
+    }
+#endif  // SPECTRE_DEBUG
     return {};
   }
   // Set boundary conditions by using the computed domain's external
@@ -171,34 +176,35 @@ AlignedLattice<VolumeDim>::external_boundary_conditions() const {
   const auto domain = create_domain();
   const auto& blocks = domain.blocks();
   std::vector<DirectionMap<
-      VolumeDim,
-      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+      Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions{blocks.size()};
   for (size_t i = 0; i < blocks.size(); ++i) {
-    for (const Direction<VolumeDim>& external_direction :
+    for (const Direction<Dim>& external_direction :
          blocks[i].external_boundaries()) {
       boundary_conditions[i][external_direction] =
-          boundary_condition_->get_clone();
+          gsl::at(gsl::at(boundary_conditions_, external_direction.dimension()),
+                  external_direction.side() == Side::Lower ? 0 : 1)
+              ->get_clone();
     }
   }
   return boundary_conditions;
 }
 
 namespace {
-template <size_t VolumeDim>
-std::vector<std::array<size_t, VolumeDim>> apply_refinement_regions(
-    const Index<VolumeDim>& number_of_blocks_by_dim,
-    const std::vector<std::array<size_t, VolumeDim>>& blocks_to_exclude,
-    const std::array<size_t, VolumeDim>& default_refinement,
-    const std::vector<RefinementRegion<VolumeDim>>& refinement_regions) {
-  std::vector<std::array<size_t, VolumeDim>> result;
+template <size_t Dim>
+std::vector<std::array<size_t, Dim>> apply_refinement_regions(
+    const Index<Dim>& number_of_blocks_by_dim,
+    const std::vector<std::array<size_t, Dim>>& blocks_to_exclude,
+    const std::array<size_t, Dim>& default_refinement,
+    const std::vector<RefinementRegion<Dim>>& refinement_regions) {
+  std::vector<std::array<size_t, Dim>> result;
   for (const auto& block_index : indices_for_rectilinear_domains(
            number_of_blocks_by_dim,
-           std::vector<Index<VolumeDim>>(blocks_to_exclude.begin(),
-                                         blocks_to_exclude.end()))) {
-    std::array<size_t, VolumeDim> block_result = default_refinement;
+           std::vector<Index<Dim>>(blocks_to_exclude.begin(),
+                                   blocks_to_exclude.end()))) {
+    std::array<size_t, Dim> block_result = default_refinement;
     for (const auto& refinement_region : refinement_regions) {
-      for (size_t d = 0; d < VolumeDim; ++d) {
+      for (size_t d = 0; d < Dim; ++d) {
         if (block_index[d] < gsl::at(refinement_region.lower_corner_index, d) or
             block_index[d] >=
                 gsl::at(refinement_region.upper_corner_index, d)) {
@@ -214,17 +220,17 @@ std::vector<std::array<size_t, VolumeDim>> apply_refinement_regions(
 }
 }  // namespace
 
-template <size_t VolumeDim>
-std::vector<std::array<size_t, VolumeDim>>
-AlignedLattice<VolumeDim>::initial_extents() const {
+template <size_t Dim>
+std::vector<std::array<size_t, Dim>> AlignedLattice<Dim>::initial_extents()
+    const {
   return apply_refinement_regions(number_of_blocks_by_dim_, blocks_to_exclude_,
                                   initial_number_of_grid_points_,
                                   refined_grid_points_);
 }
 
-template <size_t VolumeDim>
-std::vector<std::array<size_t, VolumeDim>>
-AlignedLattice<VolumeDim>::initial_refinement_levels() const {
+template <size_t Dim>
+std::vector<std::array<size_t, Dim>>
+AlignedLattice<Dim>::initial_refinement_levels() const {
   return apply_refinement_regions(number_of_blocks_by_dim_, blocks_to_exclude_,
                                   initial_refinement_levels_,
                                   refined_refinement_);

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -247,11 +247,10 @@ class Rectilinear : public DomainCreator<Dim> {
 
   std::vector<std::string> block_names() const override { return block_names_; }
 
- private:
   // Transforms from option-created boundary conditions to the type used in the
   // constructor
   template <typename BoundaryConditionsBase>
-  auto transform_boundary_conditions(
+  static auto transform_boundary_conditions(
       std::array<
           std::variant<std::unique_ptr<BoundaryConditionsBase>,
                        LowerUpperBoundaryCondition<BoundaryConditionsBase>>,
@@ -263,6 +262,7 @@ class Rectilinear : public DomainCreator<Dim> {
               2>,
           Dim>;
 
+ private:
   std::array<double, Dim> lower_bounds_{};
   std::array<double, Dim> upper_bounds_{};
   std::array<CoordinateMaps::DistributionAndSingularityPosition, Dim>

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -970,6 +970,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
       //  [oooo|ooo|ooo]-> xi
       //  ^    ^   ^   ^
       // -2    0   1   2
+      const auto dirichlet_bc = make_boundary_condition<system>(
+          elliptic::BoundaryConditionType::Dirichlet);
       const domain::creators::AlignedLattice<1> domain_creator{
           {{{-2., 0., 2.}}},
           {{0}},
@@ -977,8 +979,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           {{{{1}}, {{2}}, {{1}}}},  // Refine once in block 1
           {{{{0}}, {{1}}, {{4}}}},  // Increase num points in block 0
           {},
-          make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Dirichlet)};
+          {{{{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}}}}};
       test_subdomain_operator<system>(domain_creator);
     }
     {
@@ -999,6 +1000,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
       //    |ooo |ooo|
       //  2 +----+---+
       //    v eta
+      const auto dirichlet_bc = make_boundary_condition<system>(
+          elliptic::BoundaryConditionType::Dirichlet);
       const domain::creators::AlignedLattice<2> domain_creator{
           // Start with 4 unrefined blocks
           {{{-2., 0., 2.}, {-2., 0., 2.}}},
@@ -1009,13 +1012,15 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           // Increase num points in xi in upper-left block in sketch above
           {{{{0, 0}}, {{1, 1}}, {{4, 3}}}},
           {},
-          make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Dirichlet)};
+          {{{{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}},
+            {{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}}}}};
       test_subdomain_operator<system>(domain_creator);
     }
     {
       INFO("3D");
       using system = Poisson::FirstOrderSystem<3, Poisson::Geometry::Curved>;
+      const auto dirichlet_bc = make_boundary_condition<system>(
+          elliptic::BoundaryConditionType::Dirichlet);
       const domain::creators::AlignedLattice<3> domain_creator{
           {{{-2., 0., 2.}, {-2., 0., 2.}, {-2., 0., 2.}}},
           {{0, 0, 0}},
@@ -1023,8 +1028,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           {{{{1, 0, 0}}, {{2, 1, 1}}, {{0, 1, 1}}}},
           {{{{0, 0, 0}}, {{1, 1, 1}}, {{4, 3, 2}}}},
           {},
-          make_boundary_condition<system>(
-              elliptic::BoundaryConditionType::Dirichlet)};
+          {{{{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}},
+            {{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}},
+            {{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}}}}};
       test_subdomain_operator<system>(domain_creator);
     }
   }

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -977,6 +977,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
       // +-+ |
       // | | |
       // +-+-+
+      const auto dirichlet_bc =
+          elliptic::BoundaryConditions::AnalyticSolution<system>{
+              analytic_solution.get_clone(),
+              elliptic::BoundaryConditionType::Dirichlet};
       const domain::creators::AlignedLattice<2> domain_creator{
           // Start with 2 unrefined blocks
           {{{0., 0.25, 0.5}, {0., 0.5}}},
@@ -986,10 +990,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
           {{{{0, 0}}, {{1, 1}}, {{0, 1}}}},
           {},
           {},
-          std::make_unique<
-              elliptic::BoundaryConditions::AnalyticSolution<system>>(
-              analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet)};
+          {{{{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}},
+            {{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}}}}};
       const ElementId<2> lowerleft_id{0, {{{0, 0}, {1, 0}}}};
       const ElementId<2> upperleft_id{0, {{{0, 0}, {1, 1}}}};
       const ElementId<2> right_id{1, {{{0, 0}, {0, 0}}}};
@@ -1065,6 +1067,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
     }
     {
       INFO("Higher-resolution analytic-solution tests");
+      const auto dirichlet_bc =
+          elliptic::BoundaryConditions::AnalyticSolution<system>{
+              analytic_solution.get_clone(),
+              elliptic::BoundaryConditionType::Dirichlet};
       const domain::creators::AlignedLattice<2> domain_creator{
           {{{0., 0.25, 0.5}, {0., 0.5}}},
           {{1, 1}},
@@ -1072,10 +1078,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
           {{{{0, 0}}, {{1, 1}}, {{1, 2}}}},
           {},
           {},
-          std::make_unique<
-              elliptic::BoundaryConditions::AnalyticSolution<system>>(
-              analytic_solution.get_clone(),
-              elliptic::BoundaryConditionType::Dirichlet)};
+          {{{{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}},
+            {{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}}}}};
       Approx analytic_solution_aux_approx =
           Approx::custom().epsilon(1.e-11).scale(M_PI);
       Approx analytic_solution_operator_approx =


### PR DESCRIPTION
## Proposed changes

Allows to specify a different boundary condition in each direction of the AlignedLattice, just like the rectilinear domains (Interval/Rectangle/Brick).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
