### PR TITLE
Add a lower bound of zero for TildeTau in FixConservative for zero B

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.cpp
@@ -327,6 +327,15 @@ bool FixConservatives::operator()(
       }
     }
 
+    else {
+      auto zeroes = static_cast<SimdType>(0);
+      if (const auto tilde_tau_mask = tau_tilde < zeroes;
+          simd::any(tilde_tau_mask)) {
+        needed_fixing = true;
+        tau_tilde = simd::select(tilde_tau_mask, zeroes, tau_tilde);
+      }
+    }
+
     // Decrease momentum density if necessary
     auto s_tilde_squared = load(get(tilde_s_squared));
     // Equation B.24 of Foucart


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Add a lower bound of zero for TildeTau in FixConservative for zero B

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
