### PR TITLE
Add logical_divergence function, elliptic StrongLogical DG formulation

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -626,7 +626,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
         // This is the sign flip that makes the operator _minus_ the Laplacian
         // for a Poisson system
         *operator_applied_to_vars *= -1.;
-      } else {
+      } else if (formulation == ::dg::Formulation::WeakInertial) {
         // Compute weak divergence:
         //   F^i \partial_i \phi = 1/w_p \sum_q
         //     (D^T_\hat{i})_pq (w det(J) J^\hat{i}_i F^i)_q
@@ -635,6 +635,10 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
         if (not massive) {
           *operator_applied_to_vars *= get(det_inv_jacobian);
         }
+      } else {
+        ERROR("Unsupported DG formulation: "
+              << formulation
+              << "\nSupported formulations are: StrongInertial, WeakInertial.");
       }
       if constexpr (not std::is_same_v<SourcesComputer, void>) {
         Variables<tmpl::list<OperatorTags...>> sources{num_points, 0.};

--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
@@ -263,7 +263,12 @@ void volume_terms(
              "when using the weak form.");
       (*div_fluxes) *= get(*det_inverse_jacobian);
     } else {
-      ERROR("Unsupported DG formulation: " << dg_formulation);
+      // Note: when adding support for other DG formulations here, also check
+      // that the implementations of `BoundaryCorrection` classes support the
+      // added formulation.
+      ERROR("Unsupported DG formulation: "
+            << dg_formulation
+            << "\nSupported formulations are: StrongInertial, WeakInertial.");
     }
     tmpl::for_each<flux_variables>(
         [&dg_formulation, &dt_vars_ptr, &div_fluxes](auto var_tag_v) {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -239,8 +239,6 @@ struct EvolutionMetavars {
   static constexpr size_t volume_dim = 3;
   static constexpr bool use_damped_harmonic_rollon = false;
   using system = gh::System<volume_dim>;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
   using temporal_id = Tags::TimeStepId;
   using TimeStepperBase = LtsTimeStepper;
 

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -211,8 +211,6 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       UseParametrizedDeleptonization;
   static constexpr bool use_dg_subcell = true;
   static constexpr size_t volume_dim = 3;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
   using initial_data_list =
       grmhd::ValenciaDivClean::InitialData::initial_data_list;
 

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -133,8 +133,6 @@ struct EvolutionMetavars {
   // The use_dg_subcell flag controls whether to use "standard" limiting (false)
   // or a DG-FD hybrid scheme (true).
   static constexpr bool use_dg_subcell = true;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
 
   using system = NewtonianEuler::System<Dim>;
 

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -102,8 +102,6 @@ class CProxy_GlobalCache;
 
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = 3;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
 
   // To switch which initial data is evolved you only need to change the
   // line `using initial_data = ...;` and include the header file for the

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -108,8 +108,6 @@ class CProxy_GlobalCache;
 template <size_t Dim, typename InitialData>
 struct EvolutionMetavars {
   static constexpr size_t volume_dim = Dim;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
 
   using initial_data = InitialData;
   static_assert(

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -131,8 +131,6 @@ struct EvolutionMetavars {
   using initial_data_list = ScalarWave::Solutions::all_solutions<Dim>;
 
   using system = ScalarWave::System<Dim>;
-  static constexpr dg::Formulation dg_formulation =
-      dg::Formulation::StrongInertial;
   using temporal_id = Tags::TimeStepId;
   using TimeStepperBase = TimeStepper;
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.cpp
@@ -16,6 +16,8 @@ std::ostream& operator<<(std::ostream& os, const Formulation t) {
       return os << "StrongInertial";
     case Formulation::WeakInertial:
       return os << "WeakInertial";
+    case Formulation::StrongLogical:
+      return os << "StrongLogical";
     default:
       ERROR("Unknown DG formulation.");
   }
@@ -30,9 +32,12 @@ dg::Formulation Options::create_from_yaml<dg::Formulation>::create<void>(
     return dg::Formulation::StrongInertial;
   } else if ("WeakInertial" == type_read) {
     return dg::Formulation::WeakInertial;
+  } else if ("StrongLogical" == type_read) {
+    return dg::Formulation::StrongLogical;
   }
-  PARSE_ERROR(options.context(), "Failed to convert \""
-                                     << type_read
-                                     << "\" to dg::Formulation. Must be one "
-                                        "of StrongInertial or WeakInertial.");
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read
+                  << "\" to dg::Formulation. Must be one of "
+                     "StrongInertial, WeakInertial, or StrongLogical.");
 }

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp
@@ -30,8 +30,28 @@ namespace dg {
  *   the "weak" part refers to the fact that the boundary correction terms are
  *   non-zero even if the solution is continuous at the interfaces.
  *   See \cite Teukolsky2015ega for an overview.
+ * - The `StrongLogical` formulation is also known as the transform then
+ *   integrate formulation. The "logical" part of the name refers to the fact
+ *   that the integration is done over the logical coordinates, while the
+ *   "strong" part refers to the fact that the boundary correction terms are
+ *   zero if the solution is continuous at the interfaces. This formulation
+ *   arises from the `StrongInertial` formulation by moving the Jacobians that
+ *   appear when computing the divergence of fluxes into the divergence so the
+ *   divergence is computed in logical coordinates:
+ *   \begin{equation}
+ *     \partial_i F^i = \frac{1}{J} \partial_\hat{\imath} J F^\hat{\imath}
+ *   \end{equation}
+ *   where $J$ is the Jacobian determinant and $\hat{\imath}$ are the logical
+ *   coordinates. This is possible because of the "metric identities"
+ *   \begin{equation}
+ *    \partial_\hat{\imath} \left(J \frac{\partial \xi^\hat{\imath}}
+ *    {\partial x^i}\right) = 0.
+ *   \end{equation}
+ *   See also `dg::metric_identity_det_jac_times_inv_jac` for details and for
+ *   functions that compute the Jacobians so they satisfy the metric identities
+ *   numerically (which may or may not be useful or necessary).
  */
-enum class Formulation { StrongInertial, WeakInertial };
+enum class Formulation { StrongInertial, WeakInertial, StrongLogical };
 
 std::ostream& operator<<(std::ostream& os, Formulation t);
 }  // namespace dg

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -89,6 +89,29 @@ void divergence(gsl::not_null<Scalar<DataType>*> div_input,
                                       DerivativeFrame>& inverse_jacobian);
 /// @}
 
+/// @{
+/*!
+ * \brief Compute the divergence of fluxes in logical coordinates
+ *
+ * Applies the logical differentiation matrix to the fluxes in each dimension
+ * and sums over dimensions.
+ *
+ * \see divergence
+ */
+template <typename ResultTensor, typename FluxTensor, size_t Dim>
+void logical_divergence(gsl::not_null<ResultTensor*> div_flux,
+                        const FluxTensor& flux, const Mesh<Dim>& mesh);
+
+template <typename FluxTags, size_t Dim>
+auto logical_divergence(const Variables<FluxTags>& flux, const Mesh<Dim>& mesh)
+    -> Variables<db::wrap_tags_in<Tags::div, FluxTags>>;
+
+template <typename... DivTags, typename... FluxTags, size_t Dim>
+void logical_divergence(
+    gsl::not_null<Variables<tmpl::list<DivTags...>>*> div_flux,
+    const Variables<tmpl::list<FluxTags...>>& flux, const Mesh<Dim>& mesh);
+/// @}
+
 namespace Tags {
 /*!
  * \ingroup DataBoxTagsGroup

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_DgOperator.cpp
   Test_Penalty.cpp
   Test_Tags.cpp
+  Test_LargeOuterRadius.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_LargeOuterRadius.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_LargeOuterRadius.cpp
@@ -1,0 +1,184 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceLogicalCoordinates.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Elliptic/DiscontinuousGalerkin/DgOperator.hpp"
+#include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/Poisson/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/WeakDivergence.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp"
+#include "Utilities/TMPL.hpp"
+
+SPECTRE_TEST_CASE("Unit.Elliptic.DG.LargeOuterRadius", "[Unit][Elliptic]") {
+  // This test works for the StrongLogical and WeakInertial formulations, but
+  // breaks for the StrongInertial formulation.
+  const ::dg::Formulation formulation = ::dg::Formulation::StrongLogical;
+  // The test also breaks if the constant is set to 1. _and_ the numeric first
+  // derivative is used. It works fine if the analytic first derivative is used
+  // or if the constant is set to 0.
+  const Poisson::Solutions::Lorentzian<3> solution{/* plus_constant */ 1.};
+  const bool use_numeric_first_deriv = false;
+  // Set up the grid
+  using Wedge3D = domain::CoordinateMaps::Wedge<3>;
+  const double inner_radius = 1e2;
+  CAPTURE(inner_radius);
+  const double outer_radius = 1e9;
+  CAPTURE(outer_radius);
+  auto block_map =
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Wedge3D{inner_radius, outer_radius, 1., 1.,
+                  OrientationMap<3>::create_aligned(), true,
+                  Wedge3D::WedgeHalves::Both,
+                  domain::CoordinateMaps::Distribution::Inverse});
+  const ElementId<3> element_id{0, {{{2, 0}, {2, 0}, {0, 0}}}};
+  CAPTURE(element_id);
+  const Mesh<3> mesh{12, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  CAPTURE(mesh);
+
+  // Quantify grid stretching by looking at the midpoint of the element
+  const ElementMap<3, Frame::Inertial> element_map{element_id,
+                                                   std::move(block_map)};
+  const auto midpoint_radius = magnitude(
+      element_map(tnsr::I<double, 3, Frame::ElementLogical>{{{0., 0., 0.}}}));
+  CAPTURE(midpoint_radius);
+  Approx custom_approx = Approx::custom().epsilon(1.0e-6).scale(1.0);
+  const size_t num_points = mesh.number_of_grid_points();
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto inertial_coords = element_map(logical_coords);
+  const auto inv_jacobian = element_map.inv_jacobian(logical_coords);
+  const auto det_jacobian = determinant(element_map.jacobian(logical_coords));
+
+  // Take first derivative
+  using Field = Poisson::Tags::Field;
+  using FieldDeriv =
+      ::Tags::deriv<Poisson::Tags::Field, tmpl::size_t<3>, Frame::Inertial>;
+  using Flux =
+      ::Tags::Flux<Poisson::Tags::Field, tmpl::size_t<3>, Frame::Inertial>;
+  using FixedSource = ::Tags::FixedSource<Field>;
+  const auto vars = solution.variables(
+      inertial_coords, tmpl::list<Field, FieldDeriv, FixedSource>{});
+  const auto& u = get<Field>(vars);
+  const auto& du_analytic = get<FieldDeriv>(vars);
+  const auto& f = get<FixedSource>(vars);
+  const auto du_numeric = partial_derivative(u, mesh, inv_jacobian);
+  CHECK_ITERABLE_CUSTOM_APPROX(du_numeric, du_analytic, custom_approx);
+
+  // Take second derivative
+  CAPTURE(formulation);
+  const bool massive = true;
+  CAPTURE(massive);
+  tnsr::I<DataVector, 3> flux{num_points};
+  Poisson::flat_cartesian_fluxes(
+      make_not_null(&flux), use_numeric_first_deriv ? du_numeric : du_analytic);
+  if (formulation == ::dg::Formulation::StrongInertial) {
+    Scalar<DataVector> ddu{num_points, 0.};
+    divergence(make_not_null(&ddu), flux, mesh, inv_jacobian);
+    DataVector lhs = -get(ddu);
+    DataVector rhs = get(f);
+    // Massive scheme multiplies by Jacobian determinant
+    if (massive) {
+      lhs *= get(det_jacobian);
+      rhs *= get(det_jacobian);
+    }
+    CHECK_ITERABLE_CUSTOM_APPROX(lhs, rhs, custom_approx);
+  } else if (formulation == ::dg::Formulation::StrongLogical) {
+    Scalar<DataVector> ddu{num_points, 0.};
+    tnsr::I<DataVector, 3, Frame::ElementLogical> logical_flux =
+        transform::first_index_to_different_frame(flux, inv_jacobian);
+    for (size_t d = 0; d < 3; ++d) {
+      logical_flux.get(d) *= get(det_jacobian);
+    }
+    logical_divergence(make_not_null(&ddu), logical_flux, mesh);
+    DataVector lhs = -get(ddu);
+    DataVector rhs = get(f);
+    // Massive scheme multiplies by Jacobian determinant
+    if (massive) {
+      ::dg::apply_mass_matrix(make_not_null(&lhs), mesh);
+      ::dg::apply_mass_matrix(make_not_null(&rhs), mesh);
+      rhs *= get(det_jacobian);
+    } else {
+      lhs /= get(det_jacobian);
+    }
+    CHECK_ITERABLE_CUSTOM_APPROX(lhs, rhs, custom_approx);
+  } else {
+    auto det_times_inv_jacobian = inv_jacobian;
+    for (auto& component : det_times_inv_jacobian) {
+      component *= get(det_jacobian);
+    }
+    Variables<tmpl::list<Flux>> fluxes{mesh.number_of_grid_points()};
+    get<Flux>(fluxes) = flux;
+    Variables<tmpl::list<Field>> lhs{mesh.number_of_grid_points()};
+    weak_divergence(make_not_null(&lhs), fluxes, mesh, det_times_inv_jacobian);
+    DataVector rhs = get(f);
+    if (massive) {
+      ::dg::apply_mass_matrix(make_not_null(&lhs), mesh);
+      ::dg::apply_mass_matrix(make_not_null(&rhs), mesh);
+      rhs *= get(det_jacobian);
+    } else {
+      lhs /= get(det_jacobian);
+    }
+    // Add boundary corrections
+    for (const auto direction : Direction<3>::all_directions()) {
+      CAPTURE(direction);
+      // Compute face geometry
+      const auto face_mesh = mesh.slice_away(direction.dimension());
+      const size_t face_num_points = face_mesh.number_of_grid_points();
+      const auto face_logical_coords =
+          interface_logical_coordinates(face_mesh, direction);
+      const auto face_inertial_coords = element_map(face_logical_coords);
+      auto face_normal =
+          unnormalized_face_normal(face_mesh, element_map, direction);
+      const auto face_normal_magnitude = magnitude(face_normal);
+      for (size_t d = 0; d < 3; ++d) {
+        face_normal.get(d) /= get(face_normal_magnitude);
+      }
+      auto face_jacobian = face_normal_magnitude;
+      const auto det_jacobian_face =
+          determinant(element_map.jacobian(face_logical_coords));
+      get(face_jacobian) *= get(det_jacobian_face);
+      // Compute boundary correction
+      const auto vars_on_face =
+          solution.variables(face_inertial_coords, tmpl::list<FieldDeriv>{});
+      const auto& du_on_face = get<FieldDeriv>(vars_on_face);
+      Variables<tmpl::list<Flux>> fluxes_on_face{face_num_points};
+      Poisson::flat_cartesian_fluxes(make_not_null(&get<Flux>(fluxes_on_face)),
+                                     du_on_face);
+      auto boundary_correction =
+          normal_dot_flux<tmpl::list<Field>>(face_normal, fluxes_on_face);
+      ASSERT(massive, "Only massive scheme supported here");
+      ::dg::apply_mass_matrix(make_not_null(&boundary_correction), face_mesh);
+      boundary_correction *= get(face_jacobian);
+      boundary_correction *= -1.;
+      if (mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto) {
+        add_slice_to_data(make_not_null(&lhs), boundary_correction,
+                          mesh.extents(), direction.dimension(),
+                          index_to_slice_at(mesh.extents(), direction));
+      } else {
+        ::dg::lift_boundary_terms_gauss_points(
+            make_not_null(&lhs), boundary_correction, mesh, direction);
+      }
+    }
+    CHECK_ITERABLE_CUSTOM_APPROX(get(get<Field>(lhs)), rhs, custom_approx);
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Test_Formulation.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Tags/Test_Formulation.cpp
@@ -17,4 +17,6 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Tags.Formulation",
             "StrongInertial") == dg::Formulation::StrongInertial);
   CHECK(TestHelpers::test_option_tag<dg::OptionTags::Formulation>(
             "WeakInertial") == dg::Formulation::WeakInertial);
+  CHECK(TestHelpers::test_option_tag<dg::OptionTags::Formulation>(
+            "StrongLogical") == dg::Formulation::StrongLogical);
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Formulation.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_Formulation.cpp
@@ -12,4 +12,5 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Formulation",
                   "[Unit][NumericalAlgorithms]") {
   CHECK(get_output(dg::Formulation::StrongInertial) == "StrongInertial");
   CHECK(get_output(dg::Formulation::WeakInertial) == "WeakInertial");
+  CHECK(get_output(dg::Formulation::StrongInertial) == "StrongInertial");
 }


### PR DESCRIPTION
## Proposed changes

This variant of the elliptic DG formulation moves the Jacobian into the divergence like this:

$$
\partial_i F^i = \frac{1}{J} \partial_\hat{\imath} J {J^{-1}}^{\hat{\imath}}_j F^j
$$

This formulation makes the strong scheme work as well as the weak scheme for extremely stretched grids (initial data with large outer boundaries).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
