### PR TITLE
Add nodegroup support to SW and GH execs

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -124,12 +124,12 @@ void retrieve_boundary_data_spsc(
             it != current_inbox.end()) {
           auto& [volume_mesh_of_ghost_cell_data, face_mesh, ghost_cell_data,
                  boundary_data, boundary_data_validity_range,
-                 boundary_tci_status] = data;
+                 boundary_tci_status, boundary_integration_order] = data;
           (void)ghost_cell_data;
           auto& [current_volume_mesh_of_ghost_cell_data, current_face_mesh,
                  current_ghost_cell_data, current_boundary_data,
-                 current_boundary_data_validity_range, current_tci_status] =
-              it->second;
+                 current_boundary_data_validity_range, current_tci_status,
+                 current_integration_order] = it->second;
           // Need to use when optimizing subcell
           (void)current_volume_mesh_of_ghost_cell_data;
           // We have already received some data at this time. Receiving
@@ -175,6 +175,7 @@ void retrieve_boundary_data_spsc(
           current_boundary_data = std::move(boundary_data);
           current_boundary_data_validity_range = boundary_data_validity_range;
           current_tci_status = boundary_tci_status;
+          current_integration_order = boundary_integration_order;
         } else {
           // We have not received ghost cells or fluxes at this time.
           if (not current_inbox

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -74,6 +74,9 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/ArrayCollection/DgElementCollection.hpp"
+#include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
+#include "Parallel/ArrayCollection/SimpleActionOnElement.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
@@ -664,8 +667,14 @@ struct EvolutionMetavars {
             Parallel::get_parallel_component<component>(cache));
       });
 
-      Parallel::simple_action<deadlock::PrintElementInfo>(
-          Parallel::get_parallel_component<gh_dg_element_array>(cache));
+      if constexpr (Parallel::is_dg_element_collection_v<gh_dg_element_array>) {
+        Parallel::threaded_action<Parallel::Actions::SimpleActionOnElement<
+            deadlock::PrintElementInfo, true>>(
+            Parallel::get_parallel_component<gh_dg_element_array>(cache));
+      } else {
+        Parallel::simple_action<deadlock::PrintElementInfo>(
+            Parallel::get_parallel_component<gh_dg_element_array>(cache));
+      }
     }
   }
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -11,11 +11,13 @@
 #include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
+#include "Parallel/ArrayCollection/DgElementCollection.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
 #include "Parallel/PhaseControl/PhaseControlTags.hpp"
 #include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "Time/Actions/SelfStartActions.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
 #include "Time/ChangeSlabSize/Tags.hpp"
 #include "Time/Tags/StepperErrors.hpp"
@@ -70,7 +72,7 @@ struct EvolutionMetavars
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
+              tmpl::list<::evolution::Actions::RunEventsAndTriggers,
                          Actions::ChangeSlabSize, step_actions,
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -29,6 +29,7 @@
 #include "Options/FactoryHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
+#include "Parallel/ArrayCollection/DgElementCollection.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/MemoryMonitor/MemoryMonitor.hpp"
@@ -316,8 +317,14 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
             Parallel::get_parallel_component<component>(cache));
       });
 
-      Parallel::simple_action<deadlock::PrintElementInfo>(
-          Parallel::get_parallel_component<gh_dg_element_array>(cache));
+      if constexpr (Parallel::is_dg_element_collection_v<gh_dg_element_array>) {
+        Parallel::threaded_action<Parallel::Actions::SimpleActionOnElement<
+            deadlock::PrintElementInfo, true>>(
+            Parallel::get_parallel_component<gh_dg_element_array>(cache));
+      } else {
+        Parallel::simple_action<deadlock::PrintElementInfo>(
+            Parallel::get_parallel_component<gh_dg_element_array>(cache));
+      }
     }
   }
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -129,7 +129,6 @@
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
-#include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -41,6 +41,7 @@
 #include "NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
+#include "Parallel/ArrayCollection/DgElementCollection.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp"

--- a/src/Parallel/ArrayCollection/CreateElementCollection.hpp
+++ b/src/Parallel/ArrayCollection/CreateElementCollection.hpp
@@ -156,7 +156,9 @@ struct CreateElementCollection {
           const auto serialized_initialization_items =
               serialize(initialization_items);
           *element_locations_ptr = std::move(node_of_elements);
-          for (const auto& [element_id, core] : my_elements_and_cores) {
+          for (const auto& element_id_and_core : my_elements_and_cores) {
+            const auto& element_id = element_id_and_core.first;
+            const auto core = element_id_and_core.second;
             if (not collection_ptr
                         ->emplace(
                             std::piecewise_construct,

--- a/src/Parallel/ArrayCollection/DgElementArrayMember.hpp
+++ b/src/Parallel/ArrayCollection/DgElementArrayMember.hpp
@@ -436,10 +436,12 @@ bool DgElementArrayMember<Dim, Metavariables,
   }
 #endif  // SPECTRE_CHARM_PROJECTIONS
 
-  const auto& [requested_execution, next_action_step] = ThisAction::apply(
-      box_, inboxes_, *Parallel::local_branch(global_cache_proxy_),
-      std::as_const(this->element_id_), actions_list{},
-      std::add_pointer_t<ParallelComponent>{});
+  const auto& [requested_execution_return, next_action_step] =
+      ThisAction::apply(box_, inboxes_,
+                        *Parallel::local_branch(global_cache_proxy_),
+                        std::as_const(this->element_id_), actions_list{},
+                        std::add_pointer_t<ParallelComponent>{});
+  const auto& requested_execution = requested_execution_return;
 
   if (next_action_step.has_value()) {
     ASSERT(

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -24,6 +24,7 @@
 #include "IO/Logging/Tags.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Phase.hpp"
@@ -83,185 +84,193 @@ struct AdjustDomain {
   static void apply(db::DataBox<DbTagList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ElementId<Metavariables::volume_dim>& element_id) {
-    constexpr size_t volume_dim = Metavariables::volume_dim;
-    using amr_projectors = typename Metavariables::amr::projectors;
-    static_assert(
-        tmpl::all<
-            amr_projectors,
-            tt::assert_conforms_to<tmpl::_1, amr::protocols::Projector>>::value,
-        "All AMR projectors must conform to 'amr::protocols::Projector'.");
+    if constexpr (Parallel::is_dg_element_collection_v<ParallelComponent>) {
+      ERROR("Can't adjust the domain for DG elements running on nodegroups.");
+    } else {
+      constexpr size_t volume_dim = Metavariables::volume_dim;
+      using amr_projectors = typename Metavariables::amr::projectors;
+      static_assert(
+          tmpl::all<amr_projectors,
+                    tt::assert_conforms_to<tmpl::_1,
+                                           amr::protocols::Projector>>::value,
+          "All AMR projectors must conform to 'amr::protocols::Projector'.");
 
-    // To prevent bugs when new mutable items are added to a DataBox, we require
-    // that all mutable_item_creation_tags of box are either:
-    // - mutated by one of the projectors in Metavariables::amr::projectors
-    // - in the list of distributed_object_tags
-    // - or in the list of tags mutated by this action
-    using distributed_object_tags =
-        typename ::Parallel::Tags::distributed_object_tags<
-            Metavariables, ElementId<volume_dim>>;
-    using tags_mutated_by_this_action = tmpl::list<
-        ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>,
-        ::domain::Tags::NeighborMesh<volume_dim>, amr::Tags::Info<volume_dim>,
-        amr::Tags::NeighborInfo<volume_dim>>;
-    using mutated_tags =
-        tmpl::append<distributed_object_tags, tags_mutated_by_this_action,
-                     typename detail::GetMutatedTags<amr_projectors>::type>;
-    using mutable_tags =
-        typename db::DataBox<DbTagList>::mutable_item_creation_tags;
-    using mutable_tags_not_mutated =
-        tmpl::list_difference<mutable_tags, mutated_tags>;
-    static_assert(std::is_same_v<mutable_tags_not_mutated, tmpl::list<>>,
-                  "All mutable tags in the DataBox must be explicitly mutated "
-                  "by an amr::projector.  Default initialized objects can use "
-                  "amr::projector::DefaultInitialize.");
+      // To prevent bugs when new mutable items are added to a DataBox, we
+      // require that all mutable_item_creation_tags of box are either:
+      // - mutated by one of the projectors in Metavariables::amr::projectors
+      // - in the list of distributed_object_tags
+      // - or in the list of tags mutated by this action
+      using distributed_object_tags =
+          typename ::Parallel::Tags::distributed_object_tags<
+              Metavariables, ElementId<volume_dim>>;
+      using tags_mutated_by_this_action = tmpl::list<
+          ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>,
+          ::domain::Tags::NeighborMesh<volume_dim>, amr::Tags::Info<volume_dim>,
+          amr::Tags::NeighborInfo<volume_dim>>;
+      using mutated_tags =
+          tmpl::append<distributed_object_tags, tags_mutated_by_this_action,
+                       typename detail::GetMutatedTags<amr_projectors>::type>;
+      using mutable_tags =
+          typename db::DataBox<DbTagList>::mutable_item_creation_tags;
+      using mutable_tags_not_mutated =
+          tmpl::list_difference<mutable_tags, mutated_tags>;
+      static_assert(
+          std::is_same_v<mutable_tags_not_mutated, tmpl::list<>>,
+          "All mutable tags in the DataBox must be explicitly mutated "
+          "by an amr::projector.  Default initialized objects can use "
+          "amr::projector::DefaultInitialize.");
 
-    const auto& my_amr_info = db::get<amr::Tags::Info<volume_dim>>(box);
-    const auto& my_amr_flags = my_amr_info.flags;
-    auto& element_array =
-        Parallel::get_parallel_component<ParallelComponent>(cache);
-    const auto& phase_bookmarks =
-        Parallel::local(element_array[element_id])->phase_bookmarks();
-    const auto& verbosity =
-        db::get<logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>(box);
+      const auto& my_amr_info = db::get<amr::Tags::Info<volume_dim>>(box);
+      const auto& my_amr_flags = my_amr_info.flags;
+      auto& element_array =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      const auto& phase_bookmarks =
+          Parallel::local(element_array[element_id])->phase_bookmarks();
+      const auto& verbosity =
+          db::get<logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>(box);
 
-    if (alg::all_of(my_amr_flags, [](amr::Flag flag) {
-          return flag == amr::Flag::Undefined;
-        })) {
-      // AMR flags are undefined. This state can be reached when the AMR
-      // component broadcasts the `AdjustDomain` simple action to the entire
-      // element array, then some of those elements run the simple action and
-      // create new child elements, and then the broadcast also arrives at these
-      // new elements for some reason (seems like a Charm++ bug). The AMR flags
-      // will be undefined in this case, so we just ignore the broadcast and
-      // return early here.
-      return;
-    } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
-                 return flag == amr::Flag::Split;
-               })) {
-      // h-refinement
-      using ::operator<<;
-      ASSERT(alg::count(my_amr_flags, amr::Flag::Join) == 0,
-             "Element " << element_id
-                        << " cannot both split and join, but had AMR flags "
-                        << my_amr_flags << "\n");
-      auto children_ids = amr::ids_of_children(element_id, my_amr_flags);
-      auto& amr_component =
-          Parallel::get_parallel_component<amr::Component<Metavariables>>(
-              cache);
-      if (verbosity >= Verbosity::Debug) {
-        Parallel::printf("Splitting element %s into %zu: %s\n", element_id,
-                         children_ids.size(), children_ids);
-      }
-      Parallel::simple_action<CreateChild>(amr_component, element_array,
-                                           element_id, children_ids, 0_st,
-                                           phase_bookmarks);
-
-    } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
-                 return flag == amr::Flag::Join;
-               })) {
-      // h-coarsening
-      // Only one element should create the new parent
-      if (amr::is_child_that_creates_parent(element_id, my_amr_flags)) {
-        auto parent_id = amr::id_of_parent(element_id, my_amr_flags);
-        const auto& element = db::get<::domain::Tags::Element<volume_dim>>(box);
-        auto ids_to_join = amr::ids_of_joining_neighbors(element, my_amr_flags);
+      if (alg::all_of(my_amr_flags, [](amr::Flag flag) {
+            return flag == amr::Flag::Undefined;
+          })) {
+        // AMR flags are undefined. This state can be reached when the AMR
+        // component broadcasts the `AdjustDomain` simple action to the entire
+        // element array, then some of those elements run the simple action and
+        // create new child elements, and then the broadcast also arrives at
+        // these new elements for some reason (seems like a Charm++ bug). The
+        // AMR flags will be undefined in this case, so we just ignore the
+        // broadcast and return early here.
+        return;
+      } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+                   return flag == amr::Flag::Split;
+                 })) {
+        // h-refinement
+        using ::operator<<;
+        ASSERT(alg::count(my_amr_flags, amr::Flag::Join) == 0,
+               "Element " << element_id
+                          << " cannot both split and join, but had AMR flags "
+                          << my_amr_flags << "\n");
+        auto children_ids = amr::ids_of_children(element_id, my_amr_flags);
         auto& amr_component =
             Parallel::get_parallel_component<amr::Component<Metavariables>>(
                 cache);
         if (verbosity >= Verbosity::Debug) {
-          Parallel::printf("Joining %zu elements: %s -> %s\n",
-                           ids_to_join.size(), ids_to_join, parent_id);
+          Parallel::printf("Splitting element %s into %zu: %s\n", element_id,
+                           children_ids.size(), children_ids);
         }
-        Parallel::simple_action<CreateParent>(
-            amr_component, element_array, std::move(parent_id), element_id,
-            std::move(ids_to_join), phase_bookmarks);
-      }
+        Parallel::simple_action<CreateChild>(amr_component, element_array,
+                                             element_id, children_ids, 0_st,
+                                             phase_bookmarks);
 
-    } else {
-      // Neither h-refinement nor h-coarsening. This element will remain.
-      const auto old_mesh_and_element =
-          std::make_pair(db::get<::domain::Tags::Mesh<volume_dim>>(box),
-                         db::get<::domain::Tags::Element<volume_dim>>(box));
-      const auto& old_mesh = old_mesh_and_element.first;
+      } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+                   return flag == amr::Flag::Join;
+                 })) {
+        // h-coarsening
+        // Only one element should create the new parent
+        if (amr::is_child_that_creates_parent(element_id, my_amr_flags)) {
+          auto parent_id = amr::id_of_parent(element_id, my_amr_flags);
+          const auto& element =
+              db::get<::domain::Tags::Element<volume_dim>>(box);
+          auto ids_to_join =
+              amr::ids_of_joining_neighbors(element, my_amr_flags);
+          auto& amr_component =
+              Parallel::get_parallel_component<amr::Component<Metavariables>>(
+                  cache);
+          if (verbosity >= Verbosity::Debug) {
+            Parallel::printf("Joining %zu elements: %s -> %s\n",
+                             ids_to_join.size(), ids_to_join, parent_id);
+          }
+          Parallel::simple_action<CreateParent>(
+              amr_component, element_array, std::move(parent_id), element_id,
+              std::move(ids_to_join), phase_bookmarks);
+        }
 
-      // Determine new neighbors and update the Element
-      {  // avoid shadowing when mutating flags below
-        using NeighborMeshType =
-            DirectionalIdMap<volume_dim, ::Mesh<volume_dim>>;
-        const auto& amr_info_of_neighbors =
-            db::get<amr::Tags::NeighborInfo<volume_dim>>(box);
-        db::mutate<::domain::Tags::Element<volume_dim>,
-                   ::domain::Tags::NeighborMesh<volume_dim>>(
-            [&element_id, &amr_info_of_neighbors](
-                const gsl::not_null<Element<volume_dim>*> element,
-                const gsl::not_null<NeighborMeshType*> neighbor_meshes) {
-              auto new_neighbors = element->neighbors();
-              neighbor_meshes->clear();
-              for (auto& [direction, neighbors] : new_neighbors) {
-                const auto new_neighbor_ids_and_meshes = amr::new_neighbor_ids(
-                    element_id, direction, neighbors, amr_info_of_neighbors);
-                std::unordered_set<ElementId<volume_dim>> new_neighbor_ids;
-                for (const auto& [id, mesh] : new_neighbor_ids_and_meshes) {
-                  neighbor_meshes->insert({{direction, id}, mesh});
-                  new_neighbor_ids.insert(id);
+      } else {
+        // Neither h-refinement nor h-coarsening. This element will remain.
+        const auto old_mesh_and_element =
+            std::make_pair(db::get<::domain::Tags::Mesh<volume_dim>>(box),
+                           db::get<::domain::Tags::Element<volume_dim>>(box));
+        const auto& old_mesh = old_mesh_and_element.first;
+
+        // Determine new neighbors and update the Element
+        {  // avoid shadowing when mutating flags below
+          using NeighborMeshType =
+              DirectionalIdMap<volume_dim, ::Mesh<volume_dim>>;
+          const auto& amr_info_of_neighbors =
+              db::get<amr::Tags::NeighborInfo<volume_dim>>(box);
+          db::mutate<::domain::Tags::Element<volume_dim>,
+                     ::domain::Tags::NeighborMesh<volume_dim>>(
+              [&element_id, &amr_info_of_neighbors](
+                  const gsl::not_null<Element<volume_dim>*> element,
+                  const gsl::not_null<NeighborMeshType*> neighbor_meshes) {
+                auto new_neighbors = element->neighbors();
+                neighbor_meshes->clear();
+                for (auto& [direction, neighbors] : new_neighbors) {
+                  const auto new_neighbor_ids_and_meshes =
+                      amr::new_neighbor_ids(element_id, direction, neighbors,
+                                            amr_info_of_neighbors);
+                  std::unordered_set<ElementId<volume_dim>> new_neighbor_ids;
+                  for (const auto& [id, mesh] : new_neighbor_ids_and_meshes) {
+                    neighbor_meshes->insert({{direction, id}, mesh});
+                    new_neighbor_ids.insert(id);
+                  }
+                  neighbors.set_ids_to(new_neighbor_ids);
                 }
-                neighbors.set_ids_to(new_neighbor_ids);
-              }
-              *element =
-                  Element<volume_dim>(element_id, std::move(new_neighbors));
-            },
-            make_not_null(&box));
-      }
-
-      // Check for p-refinement
-      if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
-            return (flag == amr::Flag::IncreaseResolution or
-                    flag == amr::Flag::DecreaseResolution);
-          })) {
-        db::mutate<::domain::Tags::Mesh<volume_dim>>(
-            [&old_mesh,
-             &my_amr_flags](const gsl::not_null<Mesh<volume_dim>*> mesh) {
-              *mesh = amr::projectors::mesh(old_mesh, my_amr_flags);
-            },
-            make_not_null(&box));
-
-        if (verbosity >= Verbosity::Debug) {
-          Parallel::printf(
-              "Increasing order of element %s: %s -> %s\n", element_id,
-              old_mesh.extents(),
-              db::get<::domain::Tags::Mesh<volume_dim>>(box).extents());
+                *element =
+                    Element<volume_dim>(element_id, std::move(new_neighbors));
+              },
+              make_not_null(&box));
         }
+
+        // Check for p-refinement
+        if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+              return (flag == amr::Flag::IncreaseResolution or
+                      flag == amr::Flag::DecreaseResolution);
+            })) {
+          db::mutate<::domain::Tags::Mesh<volume_dim>>(
+              [&old_mesh,
+               &my_amr_flags](const gsl::not_null<Mesh<volume_dim>*> mesh) {
+                *mesh = amr::projectors::mesh(old_mesh, my_amr_flags);
+              },
+              make_not_null(&box));
+
+          if (verbosity >= Verbosity::Debug) {
+            Parallel::printf(
+                "Increasing order of element %s: %s -> %s\n", element_id,
+                old_mesh.extents(),
+                db::get<::domain::Tags::Mesh<volume_dim>>(box).extents());
+          }
+        }
+
+        // Run the projectors on all elements, even if they did no h-refinement.
+        // This allows projectors to update mutable items that depend upon the
+        // neighbors of the element.
+        tmpl::for_each<amr_projectors>(
+            [&box, &old_mesh_and_element](auto projector_v) {
+              using projector = typename decltype(projector_v)::type;
+              try {
+                db::mutate_apply<projector>(make_not_null(&box),
+                                            old_mesh_and_element);
+              } catch (std::exception& e) {
+                ERROR("Error in AMR projector '"
+                      << pretty_type::get_name<projector>() << "':\n"
+                      << e.what());
+              }
+            });
+
+        // Reset the AMR flags
+        db::mutate<amr::Tags::Info<volume_dim>,
+                   amr::Tags::NeighborInfo<volume_dim>>(
+            [](const gsl::not_null<amr::Info<volume_dim>*> amr_info,
+               const gsl::not_null<std::unordered_map<ElementId<volume_dim>,
+                                                      amr::Info<volume_dim>>*>
+                   amr_info_of_neighbors) {
+              amr_info_of_neighbors->clear();
+              for (size_t d = 0; d < volume_dim; ++d) {
+                amr_info->flags[d] = amr::Flag::Undefined;
+              }
+            },
+            make_not_null(&box));
       }
-
-      // Run the projectors on all elements, even if they did no h-refinement.
-      // This allows projectors to update mutable items that depend upon the
-      // neighbors of the element.
-      tmpl::for_each<amr_projectors>(
-          [&box, &old_mesh_and_element](auto projector_v) {
-            using projector = typename decltype(projector_v)::type;
-            try {
-              db::mutate_apply<projector>(make_not_null(&box),
-                                          old_mesh_and_element);
-            } catch (std::exception& e) {
-              ERROR("Error in AMR projector '"
-                    << pretty_type::get_name<projector>() << "':\n"
-                    << e.what());
-            }
-          });
-
-      // Reset the AMR flags
-      db::mutate<amr::Tags::Info<volume_dim>,
-                 amr::Tags::NeighborInfo<volume_dim>>(
-          [](const gsl::not_null<amr::Info<volume_dim>*> amr_info,
-             const gsl::not_null<std::unordered_map<ElementId<volume_dim>,
-                                                    amr::Info<volume_dim>>*>
-                 amr_info_of_neighbors) {
-            amr_info_of_neighbors->clear();
-            for (size_t d = 0; d < volume_dim; ++d) {
-              amr_info->flags[d] = amr::Flag::Undefined;
-            }
-          },
-          make_not_null(&box));
     }
   }
 };


### PR DESCRIPTION
## Proposed changes

There's no runtime switch for using nodegroups so this will continue to use the array until we switch over in the metavariables.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
