### PR TITLE
Fix communication race bug in interpolation framework

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp
@@ -4,8 +4,10 @@
 #pragma once
 
 #include <algorithm>
+#include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -16,36 +18,33 @@
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
-namespace intrp {
-
-namespace Actions {
+namespace intrp::Actions {
 /// \ingroup ActionsGroup
-/// \brief Adds `temporal_id`s on which this InterpolationTarget
+/// \brief Adds a `temporal_id` on which this InterpolationTarget
 /// should be triggered.
 ///
 /// Invoked on an InterpolationTarget.
 ///
 /// In more detail, does the following:
-/// - Adds the passed-in `temporal_id`s to PendingTemporalIds.
-/// - If the InterpolationTarget is sequential
-///   - If TemporalIds and PendingTemporalIds were both initially empty,
-///     invokes Actions::VerifyTemporalIdsAndSendPoints. (Otherwise there
-///     is an interpolation in progress and nothing needs to be done.)
-/// - If the InterpolationTarget is not sequential
-///   - Invokes Actions::SendPointsToInterpolator on all TemporalIds
-///   - Invokes Actions::VerifyTemporalIdsAndSendPoints if PendingTemporalIds
-///     is non-empty.
+/// - Adds the passed-in `temporal_id` to PendingTemporalIds.
+/// - If all the following conditions are met:
+///    - CurrentTemporalId doesn't have a value
+///    - PendingTemporalIds is not empty,
+///    - The temporal id is a LinkedMessageId or PendingTemporalIds was empty
+///      upon entry
+///   call Actions::VerifyTemporalIdsAndSendPoints. (Otherwise there
+///   is an interpolation in progress and nothing needs to be done.)
 ///
 /// Uses:
 /// - DataBox:
-///   - `Tags::TemporalIds<TemporalId>`
+///   - `Tags::CurrentTemporalId<TemporalId>`
 ///   - `Tags::CompletedTemporalIds<TemporalId>`
 ///
 /// DataBox changes:
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies:
-///   - `Tags::TemporalIds<TemporalId>`
+///   - `Tags::PendingTemporalIds<TemporalId>`
 template <typename InterpolationTargetTag>
 struct AddTemporalIdsToInterpolationTarget {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
@@ -59,34 +58,32 @@ struct AddTemporalIdsToInterpolationTarget {
         "Actions::AddTemporalIdsToInterpolationTarget can be used only with "
         "sequential targets.");
 
-    // - If Tags::TemporalIds is non-empty, then there is an
-    //   interpolation in progress, so do nothing here.  (If there's
-    //   an interpolation in progress, then a later interpolation
-    //   will be started as soon as the earlier one finishes (in
-    //   InterpolationTargetReceiveVars)).
-    // - If not pending_temporal_ids_was_empty_on_entry, then
-    //   there are pending temporal_ids waiting inside a
-    //   VerifyTemporalIdsAndSendPoints callback, so do nothing here.
-    //   (A later interpolation will be started on the callback).
-    // - If Tags::PendingTemporalIds is empty, then we didn't actually
-    //   add any pending temporal_ids above, so do nothing here.
-    // - Otherwise, there is no interpolation in progress and there
-    //   is no pending_temporal_ids waiting. So initiate waiting and
-    //   interpolation on the pending_temporal_ids.
-
     const bool pending_temporal_ids_was_empty_on_entry =
         db::get<Tags::PendingTemporalIds<TemporalId>>(box).empty();
     InterpolationTarget_detail::flag_temporal_id_as_pending<
         InterpolationTargetTag>(make_not_null(&box), temporal_id);
 
-    if (db::get<Tags::TemporalIds<TemporalId>>(box).empty() and
-        pending_temporal_ids_was_empty_on_entry and
-        not db::get<Tags::PendingTemporalIds<TemporalId>>(box).empty()) {
+    // - If Tags::CurrentTemporalIds has a value, then there is an
+    //   interpolation in progress, so do nothing here.  (If there's
+    //   an interpolation in progress, then a later interpolation
+    //   will be started as soon as the earlier one finishes (in
+    //   InterpolationTargetReceiveVars)).
+    // - If Tags::PendingTemporalIds is empty, then we didn't actually
+    //   add any pending temporal_ids above, so do nothing here.
+    // - After we check if TemporalIds is empty and PendingIds isn't, if this is
+    //   not a LinkedMessageId, then our indication for sending points was
+    //   whether the pending ids was empty at the beginning of this action. But
+    //   if this is a LinkedMessageId, it doesn't matter if pending was empty on
+    //   entry because of receiving messages out of order. We have to check the
+    //   pending id regardless
+    if (not db::get<Tags::CurrentTemporalId<TemporalId>>(box).has_value() and
+        not db::get<Tags::PendingTemporalIds<TemporalId>>(box).empty() and
+        (std::is_same_v<LinkedMessageId<double>, TemporalId> or
+         pending_temporal_ids_was_empty_on_entry)) {
       // Call directly
       Actions::VerifyTemporalIdsAndSendPoints<InterpolationTargetTag>::
           template apply<ParallelComponent>(box, cache, array_index);
     }
   }
 };
-}  // namespace Actions
-}  // namespace intrp
+}  // namespace intrp::Actions

--- a/src/ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp
@@ -27,10 +27,8 @@ class GlobalCache;
 }  // namespace Parallel
 /// \endcond
 
-namespace intrp {
-
 /// Holds Actions for Interpolator and InterpolationTarget.
-namespace Actions {
+namespace intrp::Actions {
 
 // The purpose of the metafunctions in this namespace is to allow
 // InterpolationTarget::compute_target_points to omit an initialize
@@ -55,7 +53,8 @@ CREATE_IS_CALLABLE_V(initialize)
 ///   - `Tags::IndicesOfFilledInterpPoints<TemporalId>`
 ///   - `Tags::IndicesOfInvalidInterpPoints<TemporalId>`
 ///   - `Tags::PendingTemporalIds<TemporalId>`
-///   - `Tags::TemporalIds<TemporalId>`
+///   - `Tags::TemporalIds<TemporalId>` if target is non-sequential
+///     `Tags::CurrentTemporalId<TemporalId>` if target is sequential
 ///   - `Tags::CompletedTemporalIds<TemporalId>`
 ///   - `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`
 ///   - `::Tags::Variables<typename
@@ -66,11 +65,16 @@ CREATE_IS_CALLABLE_V(initialize)
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename Metavariables, typename InterpolationTargetTag>
 struct InitializeInterpolationTarget {
+  using is_sequential =
+      typename InterpolationTargetTag::compute_target_points::is_sequential;
   using TemporalId = typename InterpolationTargetTag::temporal_id::type;
   using return_tag_list_initial = tmpl::list<
       Tags::IndicesOfFilledInterpPoints<TemporalId>,
       Tags::IndicesOfInvalidInterpPoints<TemporalId>,
-      Tags::PendingTemporalIds<TemporalId>, Tags::TemporalIds<TemporalId>,
+      Tags::PendingTemporalIds<TemporalId>,
+      tmpl::conditional_t<is_sequential::value,
+                          Tags::CurrentTemporalId<TemporalId>,
+                          Tags::TemporalIds<TemporalId>>,
       Tags::CompletedTemporalIds<TemporalId>,
       Tags::InterpolatedVars<InterpolationTargetTag, TemporalId>,
       ::Tags::Variables<
@@ -106,5 +110,4 @@ struct InitializeInterpolationTarget {
   }
 };
 
-}  // namespace Actions
-}  // namespace intrp
+}  // namespace intrp::Actions

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
@@ -173,20 +173,15 @@ struct InterpolationTargetReceiveVars {
         // one.
         const auto& temporal_ids = db::get<Tags::TemporalIds<TemporalId>>(box);
         if (not temporal_ids.empty()) {
-          auto& my_proxy = Parallel::get_parallel_component<
-              InterpolationTarget<Metavariables, InterpolationTargetTag>>(
-              cache);
-          Parallel::simple_action<
-              SendPointsToInterpolator<InterpolationTargetTag>>(
-              my_proxy, temporal_ids.front());
+          // Call directly
+          Actions::SendPointsToInterpolator<InterpolationTargetTag>::
+              template apply<ParallelComponent>(box, cache, array_index,
+                                                temporal_ids.front());
         } else if (not db::get<Tags::PendingTemporalIds<TemporalId>>(box)
                            .empty()) {
-          auto& my_proxy = Parallel::get_parallel_component<
-              InterpolationTarget<Metavariables, InterpolationTargetTag>>(
-              cache);
-          Parallel::simple_action<
-              Actions::VerifyTemporalIdsAndSendPoints<InterpolationTargetTag>>(
-              my_proxy);
+          // Call directly
+          Actions::VerifyTemporalIdsAndSendPoints<InterpolationTargetTag>::
+              template apply<ParallelComponent>(box, cache, array_index);
         }
       }
     }

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp
@@ -6,11 +6,13 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
@@ -18,6 +20,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Requires.hpp"
@@ -29,22 +32,19 @@
 namespace domain::Tags {
 struct FunctionsOfTime;
 }  // namespace domain::Tags
-namespace intrp {
-namespace Tags {
+namespace intrp::Tags {
 template <typename TemporalId>
 struct CompletedTemporalIds;
 template <typename TemporalId>
 struct PendingTemporalIds;
 template <typename TemporalId>
 struct TemporalIds;
-}  // namespace Tags
-}  // namespace intrp
+}  // namespace intrp::Tags
 template <typename TagsList>
 struct Variables;
 /// \endcond
 
-namespace intrp {
-namespace Actions {
+namespace intrp::Actions {
 /// \ingroup ActionsGroup
 /// \brief Receives interpolated variables from an `Interpolator` on a subset
 ///  of the target points.
@@ -57,13 +57,13 @@ namespace Actions {
 /// - Tells `Interpolator`s that the interpolation is complete
 ///  (by calling
 ///  `Actions::CleanUpInterpolator<InterpolationTargetTag>`)
-/// - Removes the first `temporal_id` from `Tags::TemporalIds<TemporalId>`
+/// - Removes the current id from `Tags::CurrentTemporalId<TemporalId>`
 /// - If there are more `temporal_id`s, begins interpolation at the next
-///  `temporal_id` (by calling `InterpolationTargetTag::compute_target_points`)
+///  `temporal_id` (by calling `Actions::VerifyTemporalIdsAndSendPoints`)
 ///
 /// Uses:
 /// - DataBox:
-///   - `Tags::TemporalIds<TemporalId>`
+///   - `Tags::CurrentTemporalId<TemporalId>`
 ///   - `Tags::IndicesOfFilledInterpPoints<TemporalId>`
 ///   - `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`
 ///
@@ -71,7 +71,7 @@ namespace Actions {
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies:
-///   - `Tags::TemporalIds<TemporalId>`
+///   - `Tags::CurrentTemporalId<TemporalId>`
 ///   - `Tags::CompletedTemporalIds<TemporalId>`
 ///   - `Tags::IndicesOfFilledInterpPoints<TemporalId>`
 ///   - `Tags::InterpolatedVars<InterpolationTargetTag,TemporalId>`
@@ -169,16 +169,16 @@ struct InterpolationTargetReceiveVars {
             Actions::CleanUpInterpolator<InterpolationTargetTag>>(
             interpolator_proxy, temporal_id);
 
-        // If there are further temporal_ids, begin interpolation for the next
-        // one.
-        const auto& temporal_ids = db::get<Tags::TemporalIds<TemporalId>>(box);
-        if (not temporal_ids.empty()) {
-          // Call directly
-          Actions::SendPointsToInterpolator<InterpolationTargetTag>::
-              template apply<ParallelComponent>(box, cache, array_index,
-                                                temporal_ids.front());
-        } else if (not db::get<Tags::PendingTemporalIds<TemporalId>>(box)
-                           .empty()) {
+        // If there are further pending_temporal_ids, begin interpolation for
+        // the next one.
+        const auto& current_id =
+            db::get<Tags::CurrentTemporalId<TemporalId>>(box);
+        using ::operator<<;
+        ASSERT(not current_id.has_value(),
+               "After a serial interpolation (horizon find) is finished, the "
+               "current temporal id shouldn't have a value, but it does "
+                   << current_id.value());
+        if (not db::get<Tags::PendingTemporalIds<TemporalId>>(box).empty()) {
           // Call directly
           Actions::VerifyTemporalIdsAndSendPoints<InterpolationTargetTag>::
               template apply<ParallelComponent>(box, cache, array_index);
@@ -187,5 +187,4 @@ struct InterpolationTargetReceiveVars {
     }
   }
 };
-}  // namespace Actions
-}  // namespace intrp
+}  // namespace intrp::Actions

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolationTargetVarsFromElement.hpp
@@ -134,10 +134,8 @@ struct InterpolationTargetVarsFromElement {
     // same temporal_id (by an invocation of InterpolationTargetVarsFromElement
     // by a different Element) and hence set_up_interpolation has already
     // been called.
-    if (not InterpolationTarget_detail::flag_temporal_ids_for_interpolation<
-                InterpolationTargetTag>(make_not_null(&box),
-                                        std::vector<TemporalId>{{temporal_id}})
-                .empty()) {
+    if (InterpolationTarget_detail::flag_temporal_id_for_interpolation<
+            InterpolationTargetTag>(make_not_null(&box), temporal_id)) {
       InterpolationTarget_detail::set_up_interpolation<InterpolationTargetTag>(
           make_not_null(&box), temporal_id, block_logical_coords);
     }

--- a/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/VerifyTemporalIdsAndSendPoints.hpp
@@ -7,12 +7,15 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Domain.hpp"
 #include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/Callback.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
@@ -23,193 +26,6 @@
 #include "Utilities/Gsl.hpp"
 
 namespace intrp::Actions {
-
-template <typename InterpolationTargetTag>
-struct VerifyTemporalIdsAndSendPoints;
-
-namespace detail {
-template <typename InterpolationTargetTag, typename ParallelComponent,
-          typename DbTags, typename Metavariables, typename ArrayIndex>
-void verify_temporal_ids_and_send_points_time_independent(
-    const gsl::not_null<db::DataBox<DbTags>*> box,
-    Parallel::GlobalCache<Metavariables>& cache,
-    const ArrayIndex& array_index) {
-  using TemporalId = typename InterpolationTargetTag::temporal_id::type;
-
-  // Move all PendingTemporalIds to TemporalIds, provided
-  // that they are not already there, and fill new_temporal_ids
-  // with the temporal_ids that were so moved.
-  std::vector<TemporalId> new_temporal_ids{};
-  db::mutate_apply<tmpl::list<Tags::TemporalIds<TemporalId>,
-                              Tags::PendingTemporalIds<TemporalId>>,
-                   tmpl::list<Tags::CompletedTemporalIds<TemporalId>>>(
-      [&new_temporal_ids](
-          const gsl::not_null<std::deque<TemporalId>*> ids,
-          const gsl::not_null<std::deque<TemporalId>*> pending_ids,
-          const std::deque<TemporalId>& completed_ids) {
-        // This sort is needed because the ordering of these ids and pending ids
-        // are not guaranteed. They aren't guaranteed because the elements must
-        // send a communication to the this target with the the temporal id. So
-        // it is possible that there are two interpolations that need to happen,
-        // the earlier temporal id is sent first and the later temporal id is
-        // sent second. But the later temporal id could arrive to this target
-        // first because of charm communication latency. If this was it, then
-        // there's nothing we could do and the later interpolation would happen
-        // before the earlier one (even for sequential targets). However, there
-        // is a scenario where this happens, except there is an interpolation in
-        // progress so it doesn't send points to the interpolator when it
-        // receives the later time first. In that case, we then receive the
-        // earlier time second, and sort them here so they are in temporal
-        // order. Note that this isn't a permanent actual fix, but so far works
-        // in practice.
-        alg::sort(*ids);
-        alg::sort(*pending_ids);
-        for (auto& id : *pending_ids) {
-          if (std::find(completed_ids.begin(), completed_ids.end(), id) ==
-                  completed_ids.end() and
-              std::find(ids->begin(), ids->end(), id) == ids->end()) {
-            ids->push_back(id);
-            new_temporal_ids.push_back(id);
-          }
-        }
-        pending_ids->clear();
-      },
-      box);
-
-  if (not new_temporal_ids.empty()) {
-    Actions::SendPointsToInterpolator<InterpolationTargetTag>::template apply<
-        ParallelComponent>(*box, cache, array_index, new_temporal_ids.front());
-  }
-}
-
-template <typename InterpolationTargetTag, typename ParallelComponent,
-          typename DbTags, typename Metavariables, typename ArrayIndex>
-void verify_temporal_ids_and_send_points_time_dependent(
-    const gsl::not_null<db::DataBox<DbTags>*> box,
-    Parallel::GlobalCache<Metavariables>& cache,
-    const ArrayIndex& array_index) {
-  using TemporalId = typename InterpolationTargetTag::temporal_id::type;
-
-  const auto& pending_temporal_ids =
-      db::get<Tags::PendingTemporalIds<TemporalId>>(*box);
-  if (pending_temporal_ids.empty()) {
-    return;  // Nothing to do if there are no pending temporal_ids.
-  }
-
-  auto& this_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
-  double min_expiration_time = std::numeric_limits<double>::max();
-  const Parallel::ArrayComponentId array_component_id =
-      Parallel::make_array_component_id<ParallelComponent>(array_index);
-  const bool at_least_one_pending_temporal_id_is_ready =
-      [&cache, &array_component_id, &this_proxy, &pending_temporal_ids,
-       &min_expiration_time]() {
-        if constexpr (Parallel::is_in_mutable_global_cache<
-                          Metavariables, domain::Tags::FunctionsOfTime>) {
-          return ::Parallel::mutable_cache_item_is_ready<
-              domain::Tags::FunctionsOfTime>(
-              cache, array_component_id,
-              [&this_proxy, &pending_temporal_ids, &min_expiration_time](
-                  const std::unordered_map<
-                      std::string,
-                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-                      functions_of_time)
-                  -> std::unique_ptr<Parallel::Callback> {
-                min_expiration_time =
-                    std::min_element(functions_of_time.begin(),
-                                     functions_of_time.end(),
-                                     [](const auto& a, const auto& b) {
-                                       return a.second->time_bounds()[1] <
-                                              b.second->time_bounds()[1];
-                                     })
-                        ->second->time_bounds()[1];
-                for (const auto& pending_id : pending_temporal_ids) {
-                  if (InterpolationTarget_detail::get_temporal_id_value(
-                          pending_id) <= min_expiration_time) {
-                    // Success: at least one pending_temporal_id is ok.
-                    return std::unique_ptr<Parallel::Callback>{};
-                  }
-                }
-                // Failure: none of the pending_temporal_ids are ok.
-                // Even though the GlobalCache docs say to only return a
-                // PerformAlgorithmCallback, we return a SimpleActionCallback
-                // here because it was already like this, and the effort to
-                // change it is too great right now. This is alright because
-                // this code should never be executed because the functions of
-                // time should always be valid for times sent to the
-                // interpolation target
-                return std::unique_ptr<Parallel::Callback>(
-                    new Parallel::SimpleActionCallback<
-                        VerifyTemporalIdsAndSendPoints<InterpolationTargetTag>,
-                        decltype(this_proxy)>(this_proxy));
-              });
-        } else {
-          (void)cache;
-          (void)array_component_id;
-          (void)this_proxy;
-          (void)pending_temporal_ids;
-          (void)min_expiration_time;
-          return true;
-        }
-      }();
-
-  if (not at_least_one_pending_temporal_id_is_ready) {
-    // A callback has been set so that VerifyTemporalIdsAndSendPoints will
-    // be called by the GlobalCache when domain::Tags::FunctionsOfTime is
-    // updated.  So we can exit now.
-    return;
-  }
-
-  // Move up-to-date PendingTemporalIds to TemporalIds, provided
-  // that they are not already there, and fill new_temporal_ids
-  // with the temporal_ids that were so moved.
-  std::vector<TemporalId> new_temporal_ids{};
-  db::mutate_apply<tmpl::list<Tags::TemporalIds<TemporalId>,
-                              Tags::PendingTemporalIds<TemporalId>>,
-                   tmpl::list<Tags::CompletedTemporalIds<TemporalId>>>(
-      [&min_expiration_time, &new_temporal_ids](
-          const gsl::not_null<std::deque<TemporalId>*> ids,
-          const gsl::not_null<std::deque<TemporalId>*> pending_ids,
-          const std::deque<TemporalId>& completed_ids) {
-        // This sort is needed because the ordering of these ids and pending ids
-        // are not guaranteed. They aren't guaranteed because the elements must
-        // send a communication to the this target with the the temporal id. So
-        // it is possible that there are two interpolations that need to happen,
-        // the earlier temporal id is sent first and the later temporal id is
-        // sent second. But the later temporal id could arrive to this target
-        // first because of charm communication latency. If this was it, then
-        // there's nothing we could do and the later interpolation would happen
-        // before the earlier one (even for sequential targets). However, there
-        // is a scenario where this happens, except there is an interpolation in
-        // progress so it doesn't send points to the interpolator when it
-        // receives the later time first. In that case, we then receive the
-        // earlier time second, and sort them here so they are in temporal
-        // order. Note that this isn't a permanent actual fix, but so far works
-        // in practice.
-        alg::sort(*ids);
-        alg::sort(*pending_ids);
-        for (auto it = pending_ids->begin(); it != pending_ids->end();) {
-          if (InterpolationTarget_detail::get_temporal_id_value(*it) <=
-                  min_expiration_time and
-              std::find(completed_ids.begin(), completed_ids.end(), *it) ==
-                  completed_ids.end() and
-              std::find(ids->begin(), ids->end(), *it) == ids->end()) {
-            ids->push_back(*it);
-            new_temporal_ids.push_back(*it);
-            it = pending_ids->erase(it);
-          } else {
-            ++it;
-          }
-        }
-      },
-      box);
-
-  if (not new_temporal_ids.empty()) {
-    Actions::SendPointsToInterpolator<InterpolationTargetTag>::template apply<
-        ParallelComponent>(*box, cache, array_index, new_temporal_ids.front());
-  }
-}
-}  // namespace detail
-
 /// \ingroup ActionsGroup
 /// \brief Sends points to an Interpolator for verified temporal_ids.
 ///
@@ -217,42 +33,36 @@ void verify_temporal_ids_and_send_points_time_dependent(
 ///
 /// In more detail, does the following:
 /// - If any map is time-dependent:
-///   - Moves verified PendingTemporalIds to TemporalIds, where
+///   - If there is a CurrentTemporalId or no PendingTemporalIds, does nothing
+///   - If any map is time-dependent:
+///     Moves first verified PendingTemporalId to CurrentTemporalId, where
 ///     verified means that the FunctionsOfTime in the GlobalCache
 ///     are up-to-date for that TemporalId.  If no PendingTemporalIds are
 ///     moved, then VerifyTemporalIdsAndSendPoints sets itself as a
 ///     callback in the GlobalCache so that it is called again when the
 ///     FunctionsOfTime are mutated.
-///   - If the InterpolationTarget is sequential, invokes
-///     intrp::Actions::SendPointsToInterpolator for the first TemporalId.
-///     (when interpolation is complete,
+///   - If maps are time-independent:
+///     Verified means just the first id in PendingTemporalIds
+///   - If the temporal id type is a LinkedMessageId, determines if this
+///     verified id is in order. If it isn't, then this just returns and does
+///     nothing
+///   - Calls intrp::Actions::SendPointsToInterpolator directly for this
+///     verified TemporalId. (when interpolation is complete,
 ///      intrp::Actions::InterpolationTargetReceiveVars will begin interpolation
-///     on the next TemporalId)
-///   - If the InterpolationTarget is not sequential, invokes
-///     intrp::Actions::SendPointsToInterpolator for all valid TemporalIds,
-///     and then if PendingTemporalIds is non-empty it invokes itself.
-///
-/// - If all maps are time-independent:
-///   - Moves all PendingTemporalIds to TemporalIds
-///   - If the InterpolationTarget is sequential, invokes
-///     intrp::Actions::SendPointsToInterpolator for the first TemporalId.
-///     (when interpolation is complete,
-///      intrp::Actions::InterpolationTargetReceiveVars will begin interpolation
-///     on the next TemporalId)
-///   - If the InterpolationTarget is not sequential, invokes
-///     intrp::Actions::SendPointsToInterpolator for all TemporalIds.
+///     on the next verified Id)
 ///
 /// Uses:
 /// - DataBox:
-///   - `intrp::Tags::PendingTeporalIds`
-///   - `intrp::Tags::TeporalIds`
+///   - `intrp::Tags::PendingTemporalIds`
+///   - `intrp::Tags::CompletedTemporalIds`
+///   - `intrp::Tags::CurrentTemporalId`
 ///
 /// DataBox changes:
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies:
-///   - `intrp::Tags::PendingTeporalIds`
-///   - `intrp::Tags::TeporalIds`
+///   - `intrp::Tags::PendingTemporalIds`
+///   - `intrp::Tags::CurrentTemporalId`
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag>
@@ -266,40 +76,132 @@ struct VerifyTemporalIdsAndSendPoints {
         InterpolationTargetTag::compute_target_points::is_sequential::value,
         "Actions::VerifyTemporalIdsAndSendPoints can be used only with "
         "sequential targets.");
-    if constexpr (std::is_same_v<typename InterpolationTargetTag::
-                                     compute_target_points::frame,
-                                 ::Frame::Grid>) {
-      detail::verify_temporal_ids_and_send_points_time_independent<
-          InterpolationTargetTag, ParallelComponent>(make_not_null(&box), cache,
-                                                     array_index);
-    } else {
-      const auto& domain =
-          get<domain::Tags::Domain<Metavariables::volume_dim>>(cache);
+
+    using TemporalId = typename InterpolationTargetTag::temporal_id::type;
+
+    const auto& pending_temporal_ids =
+        db::get<Tags::PendingTemporalIds<TemporalId>>(box);
+    // Nothing to do if there's an interpolation in progress or there are no
+    // pending temporal_ids.
+    if (db::get<Tags::CurrentTemporalId<TemporalId>>(box).has_value() or
+        pending_temporal_ids.empty()) {
+      return;
+    }
+
+    const auto& domain =
+        get<domain::Tags::Domain<Metavariables::volume_dim>>(cache);
+
+    // Account for time dependent maps. If the points are in the grid frame or
+    // if we don't have FunctionsOfTime in the cache, then we don't have to
+    // check the FunctionsOfTime.
+    if constexpr (not std::is_same_v<typename InterpolationTargetTag::
+                                         compute_target_points::frame,
+                                     ::Frame::Grid> and
+                  Parallel::is_in_global_cache<Metavariables,
+                                               domain::Tags::FunctionsOfTime>) {
       if (domain.is_time_dependent()) {
-        if constexpr (Parallel::is_in_global_cache<
-                          Metavariables, domain::Tags::FunctionsOfTime>) {
-          detail::verify_temporal_ids_and_send_points_time_dependent<
-              InterpolationTargetTag, ParallelComponent>(make_not_null(&box),
-                                                         cache, array_index);
-        } else {
-          // We error here because the maps are time-dependent, yet
-          // the cache does not contain FunctionsOfTime.  It would be
-          // nice to make this a compile-time error; however, we want
-          // the code to compile for the completely time-independent
-          // case where there are no FunctionsOfTime in the cache at
-          // all.  Unfortunately, checking whether the maps are
-          // time-dependent is currently not constexpr.
-          ERROR(
-              "There is a time-dependent CoordinateMap in at least one "
-              "of the Blocks, but FunctionsOfTime are not in the "
-              "GlobalCache.  If you intend to use a time-dependent "
-              "CoordinateMap, please add FunctionsOfTime to the GlobalCache.");
+        const auto& next_pending_id = pending_temporal_ids.front();
+
+        auto& this_proxy =
+            Parallel::get_parallel_component<ParallelComponent>(cache);
+        double min_expiration_time = std::numeric_limits<double>::max();
+        const Parallel::ArrayComponentId array_component_id =
+            Parallel::make_array_component_id<ParallelComponent>(array_index);
+        const bool next_pending_id_is_ready = [&cache, &array_component_id,
+                                               &this_proxy, &next_pending_id,
+                                               &min_expiration_time]() {
+          return ::Parallel::mutable_cache_item_is_ready<
+              domain::Tags::FunctionsOfTime>(
+              cache, array_component_id,
+              [&this_proxy, &next_pending_id, &min_expiration_time](
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time)
+                  -> std::unique_ptr<Parallel::Callback> {
+                min_expiration_time =
+                    std::min_element(functions_of_time.begin(),
+                                     functions_of_time.end(),
+                                     [](const auto& a, const auto& b) {
+                                       return a.second->time_bounds()[1] <
+                                              b.second->time_bounds()[1];
+                                     })
+                        ->second->time_bounds()[1];
+
+                // Success: the next pending_temporal_id is ok.
+                // Failure: the next pending_temporal_id is not ok.
+                return InterpolationTarget_detail::get_temporal_id_value(
+                           next_pending_id) <= min_expiration_time
+                           ? std::unique_ptr<Parallel::Callback>{}
+                           : std::unique_ptr<Parallel::Callback>(
+                                 new Parallel::SimpleActionCallback<
+                                     VerifyTemporalIdsAndSendPoints<
+                                         InterpolationTargetTag>,
+                                     decltype(this_proxy)>(this_proxy));
+              });
+        }();
+
+        if (not next_pending_id_is_ready) {
+          // A callback has been set so that VerifyTemporalIdsAndSendPoints will
+          // be called by the GlobalCache when domain::Tags::FunctionsOfTime is
+          // updated.  So we can exit now.
+          return;
         }
-      } else {
-        detail::verify_temporal_ids_and_send_points_time_independent<
-            InterpolationTargetTag, ParallelComponent>(make_not_null(&box),
-                                                       cache, array_index);
+      }  // if (domain.is_time_dependent())
+    } else if constexpr (not std::is_same_v<typename InterpolationTargetTag::
+                                                compute_target_points::frame,
+                                            ::Frame::Grid> and
+                         not Parallel::is_in_global_cache<
+                             Metavariables, domain::Tags::FunctionsOfTime>) {
+      if (domain.is_time_dependent()) {
+        // We error here because the maps are time-dependent, yet
+        // the cache does not contain FunctionsOfTime.  It would be
+        // nice to make this a compile-time error; however, we want
+        // the code to compile for the completely time-independent
+        // case where there are no FunctionsOfTime in the cache at
+        // all.  Unfortunately, checking whether the maps are
+        // time-dependent is currently not constexpr.
+        ERROR(
+            "There is a time-dependent CoordinateMap in at least one "
+            "of the Blocks, but FunctionsOfTime are not in the "
+            "GlobalCache.  If you intend to use a time-dependent "
+            "CoordinateMap, please add FunctionsOfTime to the GlobalCache.");
       }
+    }
+
+    // Move the most recent PendingTemporalId to CurrentTemporalId. If this is a
+    // LinkedMessageId, make sure this is the next id before sending points
+    db::mutate_apply<tmpl::list<Tags::CurrentTemporalId<TemporalId>,
+                                Tags::PendingTemporalIds<TemporalId>>,
+                     tmpl::list<Tags::CompletedTemporalIds<TemporalId>>>(
+        [](const gsl::not_null<std::optional<TemporalId>*> current_id,
+           const gsl::not_null<std::deque<TemporalId>*> pending_ids,
+           const std::deque<TemporalId>& completed_ids) {
+          auto& next_pending_id = pending_ids->front();
+          bool use_next_pending_id = true;
+
+          if constexpr (std::is_same_v<LinkedMessageId<double>, TemporalId>) {
+            // If completed ids is empty (and at this point so is temporal ids)
+            // then we must check if this is the first id.
+            use_next_pending_id = completed_ids.empty()
+                                      ? not next_pending_id.previous.has_value()
+                                      : next_pending_id.previous.value() ==
+                                            completed_ids.back().id;
+          }
+
+          if (use_next_pending_id) {
+            *current_id = next_pending_id;
+            pending_ids->pop_front();
+          }
+        },
+        make_not_null(&box));
+
+    // Send points to interpolator if the next id is ready
+    if (const auto& current_id =
+            db::get<Tags::CurrentTemporalId<TemporalId>>(box);
+        current_id.has_value()) {
+      Actions::SendPointsToInterpolator<InterpolationTargetTag>::template apply<
+          ParallelComponent>(box, cache, array_index, current_id.value());
     }
   }
 };

--- a/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -50,20 +50,18 @@ template <typename... Ts>
 auto make_legend(tmpl::list<Ts...> /* meta */) {
     std::vector<std::string> legend = {"Time"};
 
-    auto append_tags = [&legend](auto tag) {
-        using TagType = decltype(tag);
-        using ReturnType = typename TagType::type;
+    [[maybe_unused]] auto append_tags = [&legend](auto tag) {
+      using TagType = decltype(tag);
+      using ReturnType = typename TagType::type;
 
-        if constexpr (is_array_of_double<ReturnType>::value) {
-            constexpr std::array<const char*, 3> suffix = {"_x", "_y", "_z"};
-            for (size_t i = 0; i < std::tuple_size<ReturnType>::value; ++i) {
-                legend.push_back(db::tag_name<TagType>() + gsl::at(suffix, i));
-            }
+      if constexpr (is_array_of_double<ReturnType>::value) {
+        constexpr std::array<const char*, 3> suffix = {"_x", "_y", "_z"};
+        for (size_t i = 0; i < std::tuple_size<ReturnType>::value; ++i) {
+          legend.push_back(db::tag_name<TagType>() + gsl::at(suffix, i));
         }
-        else {
-            legend.push_back(db::tag_name<TagType>());
-        }
-
+      } else {
+        legend.push_back(db::tag_name<TagType>());
+      }
     };
 
     (append_tags(Ts{}), ...);

--- a/src/ParallelAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolate.hpp
@@ -78,7 +78,6 @@ void interpolate(
       InterpolationTarget<Metavariables, InterpolationTargetTag>>(cache);
   Parallel::simple_action<
       Actions::AddTemporalIdsToInterpolationTarget<InterpolationTargetTag>>(
-      target, std::vector<typename InterpolationTargetTag::temporal_id::type>{
-                  temporal_id});
+      target, temporal_id);
 }
 }  // namespace intrp

--- a/src/ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp
@@ -22,7 +22,9 @@ namespace intrp::protocols {
  *
  * - a type alias `is_sequential` that is either `std::true_type` or
  *   `std::false_type` which indicates if interpolations depend on previous
- *   interpolations' results
+ *   interpolations' results. It is assumed in the interpolation framework that
+ *   only horizon finds are sequential (e.y. anything that uses the
+ *   `intrp::Interpolator` component is a sequential horizon find).
  *
  * - a type alias `frame` that denotes the frame the target points are computed
  *   in

--- a/src/ParallelAlgorithms/Interpolation/Tags.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Tags.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <deque>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -86,7 +87,7 @@ struct IndicesOfInvalidInterpPoints : db::SimpleTag {
 };
 
 /// `temporal_id`s that have been flagged to interpolate on, but that
-/// have not yet been added to Tags::TemporalIds.  A `temporal_id` is
+/// have not yet been added to Tags::CurrentTemporalId.  A `temporal_id` is
 /// pending if the `FunctionOfTime`s are not up to date for the time
 /// associated with the `temporal_id`.
 template <typename TemporalId>
@@ -94,10 +95,21 @@ struct PendingTemporalIds : db::SimpleTag {
   using type = std::deque<TemporalId>;
 };
 
+/// `temporal_id` on which to interpolate.
+///
+/// \note This tag is only used in sequential targets because only one temporal
+/// id can be interpolated to at any given time
+template <typename TemporalId>
+struct CurrentTemporalId : db::SimpleTag {
+  using type = std::optional<TemporalId>;
+};
+
 /// `temporal_id`s on which to interpolate.
+///
+/// \note This tag is only used in non-sequential targets
 template <typename TemporalId>
 struct TemporalIds : db::SimpleTag {
-  using type = std::deque<TemporalId>;
+  using type = std::unordered_set<TemporalId>;
 };
 
 /// `temporal_id`s that we have already interpolated onto.

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -13,6 +13,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "Framework/MockDistributedObject.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/Examples.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/Examples.hpp
@@ -55,7 +55,7 @@ struct ExampleComputeTargetPoints
   // the global cache
   using const_global_cache_tags = tmpl::list<FakeCacheTag>;
 
-  using is_sequential = std::true_type;
+  using is_sequential = std::false_type;
 
   using frame = ::Frame::Grid;
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -5,6 +5,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cmath>
 #include <cstddef>
 #include <optional>
 #include <utility>
@@ -25,6 +26,7 @@
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
@@ -41,29 +43,12 @@ namespace Actions {
 template <typename InterpolationTargetTag>
 struct ReceivePoints;
 }  // namespace Actions
-}  // namespace intrp
-template <typename IdType, typename DataType>
-class IdPair;
-namespace Parallel {
-template <typename Metavariables>
-class GlobalCache;
-}  // namespace Parallel
-namespace db {
-template <typename TagsList>
-class DataBox;
-}  // namespace db
-namespace intrp {
 namespace Tags {
-template <typename TemporalId>
-struct IndicesOfFilledInterpPoints;
 template <typename TemporalId>
 struct InterpolatedVarsHolders;
 struct NumberOfElements;
 }  // namespace Tags
 }  // namespace intrp
-namespace domain {
-class BlockId;
-}  // namespace domain
 /// \endcond
 
 namespace InterpTargetTestHelpers {
@@ -81,8 +66,8 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
-      Parallel::get_const_global_cache_tags_from_actions<tmpl::list<
-          typename Metavariables::InterpolationTargetA::compute_target_points>>,
+      Parallel::get_const_global_cache_tags_from_actions<
+          tmpl::list<typename InterpolationTargetTag::compute_target_points>>,
       tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -149,109 +134,55 @@ struct mock_interpolator {
       MockReceivePoints<typename Metavariables::InterpolationTargetA>>;
 };
 
-template <typename MetaVariables, typename InterpolationTargetOptionTag,
-          typename DomainCreator, typename BlockCoordHolder>
+template <typename InterpolationTargetTag, size_t Dim>
+struct MockMetavars {
+  static constexpr size_t volume_dim = Dim;
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetTag>;
+
+  using component_list =
+      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
+          MockMetavars, InterpolationTargetTag>>;
+};
+
+template <typename InterpolationTargetTag, size_t Dim,
+          typename InterpolationTargetOptionTag, typename BlockCoordHolder>
 void test_interpolation_target(
-    const DomainCreator& domain_creator,
     typename InterpolationTargetOptionTag::type options,
     const BlockCoordHolder& expected_block_coord_holders) {
-  using metavars = MetaVariables;
-  using temporal_id_type =
-      typename metavars::InterpolationTargetA::temporal_id::type;
+  using metavars = MockMetavars<InterpolationTargetTag, Dim>;
   using target_component =
-      mock_interpolation_target<metavars,
-                                typename metavars::InterpolationTargetA>;
+      mock_interpolation_target<metavars, InterpolationTargetTag>;
   // Assert that all ComputeTargetPoints conform to the protocol
   static_assert(tt::assert_conforms_to_v<
-                typename metavars::InterpolationTargetA::compute_target_points,
+                typename InterpolationTargetTag::compute_target_points,
                 intrp::protocols::ComputeTargetPoints>);
-  using interp_component = mock_interpolator<metavars>;
 
   tuples::TaggedTuple<InterpolationTargetOptionTag,
-                      domain::Tags::Domain<MetaVariables::volume_dim>>
-      tuple_of_opts{std::move(options),
-                    std::move(domain_creator.create_domain())};
+                      domain::Tags::Domain<metavars::volume_dim>>
+      tuple_of_opts{std::move(options), Domain<metavars::volume_dim>{}};
+
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
-  ActionTesting::emplace_component<interp_component>(&runner, 0);
-  for (size_t i = 0; i < 2; ++i) {
-    ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
-  }
   ActionTesting::emplace_component<target_component>(&runner, 0);
   for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
-  Slab slab(0.0, 1.0);
-  TimeStepId temporal_id(true, 0, Time(slab, 0));
-  static_assert(
-      std::is_same_v<typename metavars::InterpolationTargetA::temporal_id::type,
-                     double> or
-          std::is_same_v<
-              typename metavars::InterpolationTargetA::temporal_id::type,
-              TimeStepId>,
-      "Unsupported temporal_id type");
-  if constexpr (std::is_same_v<temporal_id_type, double>) {
-    ActionTesting::simple_action<target_component,
-                                 intrp::Actions::SendPointsToInterpolator<
-                                     typename metavars::InterpolationTargetA>>(
-        make_not_null(&runner), 0, temporal_id.substep_time());
-  } else if constexpr (std::is_same_v<temporal_id_type, TimeStepId>) {
-    ActionTesting::simple_action<target_component,
-                                 intrp::Actions::SendPointsToInterpolator<
-                                     typename metavars::InterpolationTargetA>>(
-        make_not_null(&runner), 0, temporal_id);
-  }
+  auto& target_box =
+      ActionTesting::get_databox<target_component>(make_not_null(&runner), 0);
+  const auto& cache = ActionTesting::cache<target_component>(runner, 0_st);
 
-  // This should not have changed.
-  CHECK(ActionTesting::get_databox_tag<
-            target_component,
-            ::intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
-            runner, 0)
-            .empty());
+  Slab slab(0.0, 1.0);
+  TimeStepId temporal_id(true, 0, ::Time(slab, 0));
+
+  const auto block_coord_holders =
+      intrp::InterpolationTarget_detail::block_logical_coords<
+          InterpolationTargetTag>(target_box, cache, temporal_id);
 
   const size_t number_of_points = expected_block_coord_holders.size();
-  const auto& invalid_points = ActionTesting::get_databox_tag<
-      target_component,
-      ::intrp::Tags::IndicesOfInvalidInterpPoints<temporal_id_type>>(runner, 0);
-  if (invalid_points.count(temporal_id) > 0) {
-    if (number_of_points == invalid_points.at(temporal_id).size()) {
-      CHECK_FALSE(ActionTesting::is_simple_action_queue_empty<target_component>(
-          runner, 0));
-    } else {
-      CHECK(ActionTesting::is_simple_action_queue_empty<target_component>(
-          runner, 0));
-    }
-  }
-
-  // But there should be one in mock_interpolator
-
-  ActionTesting::invoke_queued_simple_action<interp_component>(
-      make_not_null(&runner), 0);
-
-  // Should be no more queued actions in mock_interpolator
-  CHECK(
-      ActionTesting::is_simple_action_queue_empty<mock_interpolator<metavars>>(
-          runner, 0));
-
-  const auto& vars_holders = ActionTesting::get_databox_tag<
-      interp_component, intrp::Tags::InterpolatedVarsHolders<metavars>>(runner,
-                                                                        0);
-  const auto& vars_infos =
-      get<intrp::Vars::HolderTag<typename metavars::InterpolationTargetA,
-                                 metavars>>(vars_holders)
-          .infos;
-  // Should be one entry in the vars_infos
-  CHECK(vars_infos.size() == 1);
-  const auto& info = vars_infos.at(temporal_id);
-  const auto& block_coord_holders = info.block_coord_holders;
-
-  // Check number of points and iteration
-  CHECK(block_coord_holders.size() == number_of_points);
-  CHECK(info.iteration == 0_st);
-
   for (size_t i = 0; i < number_of_points; ++i) {
     if (block_coord_holders[i].has_value()) {
       CHECK(block_coord_holders[i].value().id ==
@@ -260,30 +191,5 @@ void test_interpolation_target(
                             expected_block_coord_holders[i].value().data);
     }
   }
-
-  // Call again at a different temporal_id
-  TimeStepId new_temporal_id(true, 0, Time(slab, 1));
-  ActionTesting::simple_action<target_component,
-                               intrp::Actions::SendPointsToInterpolator<
-                                   typename metavars::InterpolationTargetA>>(
-      make_not_null(&runner), 0, new_temporal_id);
-  ActionTesting::invoke_queued_simple_action<interp_component>(
-      make_not_null(&runner), 0);
-
-  // Should be two entries in the vars_infos. Second should also have iteration
-  // 0
-  CHECK(vars_infos.size() == 2);
-  const auto& new_info = vars_infos.at(new_temporal_id);
-  const auto& new_block_coord_holders = new_info.block_coord_holders;
-  CHECK(new_info.iteration == 0_st);
-  for (size_t i = 0; i < number_of_points; ++i) {
-    if (new_block_coord_holders[i].has_value()) {
-      CHECK(new_block_coord_holders[i].value().id ==
-            expected_block_coord_holders[i].value().id);
-      CHECK_ITERABLE_APPROX(new_block_coord_holders[i].value().data,
-                            expected_block_coord_holders[i].value().data);
-    }
-  }
 }
-
 }  // namespace InterpTargetTestHelpers

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -87,8 +87,7 @@ struct MockReceivePoints {
   static void apply(
       db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
-      const typename Metavariables::InterpolationTargetA::temporal_id::type&
-          temporal_id,
+      const typename InterpolationTargetTag::temporal_id::type& temporal_id,
       std::vector<BlockLogicalCoords<VolumeDim>>&& block_coord_holders,
       const size_t iteration = 0_st) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -435,10 +435,12 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
 
   // Tell the InterpolationTargets that we want to interpolate at
   // two temporal_ids.
-  ActionTesting::simple_action<
-      target_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                            typename metavars::AhA>>(make_not_null(&runner), 0,
-                                                     temporal_ids);
+  for (const auto& temporal_id : temporal_ids) {
+    ActionTesting::simple_action<
+        target_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                              typename metavars::AhA>>(make_not_null(&runner),
+                                                       0, temporal_id);
+  }
 
   // Center of the analytic solution.
   const auto analytic_solution_center = []() -> std::array<double, 3> {

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
@@ -33,26 +33,13 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-struct MockMetavariables {
-  struct InterpolationTargetA
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::TimeStepId;
-    using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::Lapse<DataVector>>;
-    using compute_items_on_target = tmpl::list<>;
-    using compute_target_points =
-        ::intrp::TargetPoints::ApparentHorizon<InterpolationTargetA,
-                                               ::Frame::Inertial>;
-    using post_interpolation_callbacks = tmpl::list<>;
-  };
-  static constexpr size_t volume_dim = 3;
-  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
-  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-
-  using component_list =
-      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
-                     MockMetavariables, InterpolationTargetA>,
-                 InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+struct HorizonTag : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  using temporal_id = ::Tags::TimeStepId;
+  using vars_to_interpolate_to_target = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using compute_items_on_target = tmpl::list<>;
+  using compute_target_points =
+      ::intrp::TargetPoints::ApparentHorizon<HorizonTag, ::Frame::Inertial>;
+  using post_interpolation_callbacks = tmpl::list<>;
 };
 }  // namespace
 
@@ -131,14 +118,11 @@ SPECTRE_TEST_CASE(
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
 
-  TestHelpers::db::test_simple_tag<intrp::Tags::ApparentHorizon<
-      MockMetavariables::InterpolationTargetA, Frame::Inertial>>(
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::ApparentHorizon<HorizonTag, Frame::Inertial>>(
       "ApparentHorizon");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables,
-      intrp::Tags::ApparentHorizon<MockMetavariables::InterpolationTargetA,
-                                   Frame::Inertial>>(
-      domain_creator, std::move(apparent_horizon_opts),
-      expected_block_coord_holders);
+      HorizonTag, 3, intrp::Tags::ApparentHorizon<HorizonTag, Frame::Inertial>>(
+      apparent_horizon_opts, expected_block_coord_holders);
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -107,9 +107,8 @@ struct MockAddTemporalIdsToInterpolationTarget {
       db::DataBox<DbTags>& /*box*/,
       Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
-      std::vector<
-          typename Metavariables::InterpolatorTargetA::temporal_id::type>&&
-      /*temporal_ids*/) {
+      const typename Metavariables::InterpolatorTargetA::temporal_id::type&
+      /*temporal_id*/) {
     // We are not testing this Action here.
     // Do nothing except make sure it is called once.
     ++called_mock_add_temporal_ids_to_interpolation_target;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -44,26 +44,15 @@ domain::creators::Sphere make_sphere() {
   return {3.4, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false};
 }
 
-struct MockMetavariables {
-  struct InterpolationTargetA
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::TimeStepId;
-    using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::Lapse<DataVector>>;
-    using compute_items_on_target = tmpl::list<>;
-    using compute_target_points =
-        ::intrp::TargetPoints::KerrHorizon<InterpolationTargetA,
-                                           ::Frame::Inertial>;
-    using post_interpolation_callbacks = tmpl::list<>;
-  };
-  static constexpr size_t volume_dim = 3;
-  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
-  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-
-  using component_list =
-      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
-                     MockMetavariables, InterpolationTargetA>,
-                 InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+struct KerrHorizonTargetTag
+    : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  using temporal_id = ::Tags::TimeStepId;
+  using vars_to_interpolate_to_target = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using compute_items_on_target = tmpl::list<>;
+  using compute_target_points =
+      ::intrp::TargetPoints::KerrHorizon<KerrHorizonTargetTag,
+                                         ::Frame::Inertial>;
+  using post_interpolation_callbacks = tmpl::list<>;
 };
 
 template <InterpTargetTestHelpers::ValidPoints ValidPoints>
@@ -165,13 +154,11 @@ void test_interpolation_target_kerr_horizon(
   }();
 
   TestHelpers::db::test_simple_tag<
-      intrp::Tags::KerrHorizon<MockMetavariables::InterpolationTargetA>>(
-      "KerrHorizon");
+      intrp::Tags::KerrHorizon<KerrHorizonTargetTag>>("KerrHorizon");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables,
-      intrp::Tags::KerrHorizon<MockMetavariables::InterpolationTargetA>>(
-      domain_creator, kerr_horizon_opts, expected_block_coord_holders);
+      KerrHorizonTargetTag, 3, intrp::Tags::KerrHorizon<KerrHorizonTargetTag>>(
+      kerr_horizon_opts, expected_block_coord_holders);
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -39,25 +39,14 @@ domain::creators::Sphere make_sphere() {
 }
 
 template <typename Frame>
-struct MockMetavariables {
-  struct InterpolationTargetA
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::TimeStepId;
-    using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::Lapse<DataVector>>;
-    using compute_items_on_target = tmpl::list<>;
-    using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolationTargetA, 3, Frame>;
-    using post_interpolation_callbacks = tmpl::list<>;
-  };
-  static constexpr size_t volume_dim = 3;
-  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
-  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-
-  using component_list =
-      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
-                     MockMetavariables, InterpolationTargetA>,
-                 InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+struct LineSegmentTag
+    : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  using temporal_id = ::Tags::TimeStepId;
+  using vars_to_interpolate_to_target = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using compute_items_on_target = tmpl::list<>;
+  using compute_target_points =
+      ::intrp::TargetPoints::LineSegment<LineSegmentTag, 3, Frame>;
+  using post_interpolation_callbacks = tmpl::list<>;
 };
 
 template <InterpTargetTestHelpers::ValidPoints ValidPoints>
@@ -87,24 +76,20 @@ void test() {
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
 
-  TestHelpers::db::test_simple_tag<intrp::Tags::LineSegment<
-      MockMetavariables<Frame::Grid>::InterpolationTargetA, 3>>("LineSegment");
-  TestHelpers::db::test_simple_tag<intrp::Tags::LineSegment<
-      MockMetavariables<Frame::Inertial>::InterpolationTargetA, 3>>(
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::LineSegment<LineSegmentTag<Frame::Grid>, 3>>("LineSegment");
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::LineSegment<LineSegmentTag<Frame::Inertial>, 3>>(
       "LineSegment");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables<Frame::Grid>,
-      intrp::Tags::LineSegment<
-          MockMetavariables<Frame::Grid>::InterpolationTargetA, 3>>(
-      domain_creator, std::move(line_segment_opts),
-      expected_block_coord_holders);
+      LineSegmentTag<Frame::Grid>, 3,
+      intrp::Tags::LineSegment<LineSegmentTag<Frame::Grid>, 3>>(
+      line_segment_opts, expected_block_coord_holders);
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables<Frame::Inertial>,
-      intrp::Tags::LineSegment<
-          MockMetavariables<Frame::Inertial>::InterpolationTargetA, 3>>(
-      domain_creator, std::move(line_segment_opts),
-      expected_block_coord_holders);
+      LineSegmentTag<Frame::Inertial>, 3,
+      intrp::Tags::LineSegment<LineSegmentTag<Frame::Inertial>, 3>>(
+      line_segment_opts, expected_block_coord_holders);
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -28,11 +28,13 @@
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -72,40 +74,6 @@ struct CompletedTemporalIds;
 }  // namespace intrp::Tags
 
 namespace {
-
-// In the test, we don't care what SendPointsToInterpolator actually does;
-// we care only that SendPointsToInterpolator is called with the
-// correct arguments.
-template <typename InterpolationTargetTag>
-struct MockSendPointsToInterpolator {
-  template <typename ParallelComponent, typename DbTags, typename Metavariables,
-            typename ArrayIndex,
-            Requires<tmpl::list_contains_v<
-                DbTags, intrp::Tags::TemporalIds<
-                            typename Metavariables::InterpolationTargetA::
-                                temporal_id::type>>> = nullptr>
-  static void apply(
-      db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/,
-      const typename Metavariables::InterpolationTargetA::temporal_id::type&
-          temporal_id) {
-    using temporal_id_type =
-        typename Metavariables::InterpolationTargetA::temporal_id::type;
-    CHECK(temporal_id == 14.0 / 16.0);
-    // Increment IndicesOfFilledInterpPoints so we can check later
-    // whether this function was called.  This isn't the usual usage
-    // of IndicesOfFilledInterpPoints; this is done only for the test.
-    db::mutate<intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
-        [&temporal_id](
-            const gsl::not_null<std::unordered_map<temporal_id_type,
-                                                   std::unordered_set<size_t>>*>
-                indices) {
-          (*indices)[temporal_id].insert((*indices)[temporal_id].size() + 1);
-        },
-        make_not_null(&box));
-  }
-};
-
 template <typename Metavariables, typename InterpolationTargetTag>
 struct mock_interpolation_target {
   using metavariables = Metavariables;
@@ -127,10 +95,6 @@ struct mock_interpolation_target {
                                  simple_tags, typename InterpolationTargetTag::
                                                   compute_items_on_target>>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
-  using replace_these_simple_actions = tmpl::list<
-      intrp::Actions::SendPointsToInterpolator<InterpolationTargetTag>>;
-  using with_these_simple_actions =
-      tmpl::list<MockSendPointsToInterpolator<InterpolationTargetTag>>;
 };
 
 template <typename InterpolationTargetTag>
@@ -293,9 +257,13 @@ struct mock_interpolator {
   using component_being_mocked = intrp::Interpolator<Metavariables>;
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::CleanUpInterpolator<
-          typename Metavariables::InterpolationTargetA>>;
+                     typename Metavariables::InterpolationTargetA>,
+                 intrp::Actions::ReceivePoints<
+                     typename Metavariables::InterpolationTargetA>>;
   using with_these_simple_actions = tmpl::list<
-      MockCleanUpInterpolator<typename Metavariables::InterpolationTargetA>>;
+      MockCleanUpInterpolator<typename Metavariables::InterpolationTargetA>,
+      InterpTargetTestHelpers::MockReceivePoints<
+          typename Metavariables::InterpolationTargetA>>;
 };
 
 template <typename MockCallBackType, typename IsTimeDependent>
@@ -323,13 +291,14 @@ template <typename MockCallbackType, typename IsTimeDependent,
           size_t NumberOfExpectedCleanUpActions,
           size_t NumberOfInvalidPointsToAdd>
 void test_interpolation_target_receive_vars() {
+  CAPTURE(IsTimeDependent::value);
+  CAPTURE(NumberOfExpectedCleanUpActions);
+  CAPTURE(NumberOfInvalidPointsToAdd);
   using metavars = MockMetavariables<MockCallbackType, IsTimeDependent>;
-  using temporal_id_type =
-      typename metavars::InterpolationTargetA::temporal_id::type;
+  using target_tag = typename metavars::InterpolationTargetA;
+  using temporal_id_type = typename target_tag::temporal_id::type;
   using interp_component = mock_interpolator<metavars>;
-  using target_component =
-      mock_interpolation_target<metavars,
-                                typename metavars::InterpolationTargetA>;
+  using target_component = mock_interpolation_target<metavars, target_tag>;
 
   const size_t num_points = 10;
   const double first_time = 13.0 / 16.0;
@@ -378,8 +347,8 @@ void test_interpolation_target_receive_vars() {
   }
 
   // Type alias for better readability below.
-  using vars_type = Variables<
-      typename metavars::InterpolationTargetA::vars_to_interpolate_to_target>;
+  using vars_type =
+      Variables<typename target_tag::vars_to_interpolate_to_target>;
 
   ActionTesting::emplace_component<interp_component>(&runner, 0);
   for (size_t i = 0; i < 2; ++i) {
@@ -392,9 +361,9 @@ void test_interpolation_target_receive_vars() {
            invalid_indices},
        pending_temporal_ids, current_temporal_ids,
        std::deque<temporal_id_type>{},
-       std::unordered_map<temporal_id_type,
-                          Variables<typename metavars::InterpolationTargetA::
-                                        vars_to_interpolate_to_target>>{
+       std::unordered_map<
+           temporal_id_type,
+           Variables<typename target_tag::vars_to_interpolate_to_target>>{
            {first_time, vars_type{num_points + NumberOfInvalidPointsToAdd}}},
        // Default-constructed Variables cause problems, so below
        // we construct the Variables with a single point.
@@ -402,8 +371,8 @@ void test_interpolation_target_receive_vars() {
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
   // Now set up the vars.
-  std::vector<typename ::Variables<
-      typename metavars::InterpolationTargetA::vars_to_interpolate_to_target>>
+  std::vector<
+      typename ::Variables<typename target_tag::vars_to_interpolate_to_target>>
       vars_src;
   std::vector<std::vector<size_t>> global_offsets;
 
@@ -412,8 +381,8 @@ void test_interpolation_target_receive_vars() {
                              const std::vector<double>& lapse_vals,
                              const std::vector<size_t>& offset_vals) {
     vars_src.emplace_back(
-        ::Variables<typename metavars::InterpolationTargetA::
-                        vars_to_interpolate_to_target>{lapse_vals.size()});
+        ::Variables<typename target_tag::vars_to_interpolate_to_target>{
+            lapse_vals.size()});
     global_offsets.emplace_back(offset_vals);
     auto& lapse = get<gr::Tags::Lapse<DataVector>>(vars_src.back());
     for (size_t i = 0; i < lapse_vals.size(); ++i) {
@@ -424,9 +393,9 @@ void test_interpolation_target_receive_vars() {
   add_to_vars_src({{3.0, 6.0}}, {{3, 6}});
   add_to_vars_src({{2.0, 7.0}}, {{2, 7}});
 
-  ActionTesting::simple_action<target_component,
-                               intrp::Actions::InterpolationTargetReceiveVars<
-                                   typename metavars::InterpolationTargetA>>(
+  ActionTesting::simple_action<
+      target_component,
+      intrp::Actions::InterpolationTargetReceiveVars<target_tag>>(
       make_not_null(&runner), 0, vars_src, global_offsets, first_time);
 
   // It should have interpolated 4 points by now.
@@ -455,9 +424,9 @@ void test_interpolation_target_receive_vars() {
                   {{1, 6}});  // 6 is repeated, point will be ignored.
   add_to_vars_src({{8.0, 0.0, 4.0}}, {{8, 0, 4}});
 
-  ActionTesting::simple_action<target_component,
-                               intrp::Actions::InterpolationTargetReceiveVars<
-                                   typename metavars::InterpolationTargetA>>(
+  ActionTesting::simple_action<
+      target_component,
+      intrp::Actions::InterpolationTargetReceiveVars<target_tag>>(
       make_not_null(&runner), 0, vars_src, global_offsets, first_time);
 
   // It should have interpolated 8 points by now. (The ninth point had
@@ -489,9 +458,9 @@ void test_interpolation_target_receive_vars() {
 
   // This will try to call InterpolationTargetA::post_interpolation_callbacks
   // where we check that the points are correct.
-  ActionTesting::simple_action<target_component,
-                               intrp::Actions::InterpolationTargetReceiveVars<
-                                   typename metavars::InterpolationTargetA>>(
+  ActionTesting::simple_action<
+      target_component,
+      intrp::Actions::InterpolationTargetReceiveVars<target_tag>>(
       make_not_null(&runner), 0, vars_src, global_offsets, first_time);
 
   const auto check_zero_cleanup = [&runner, &first_time,
@@ -559,18 +528,17 @@ void test_interpolation_target_receive_vars() {
               runner, 0)
               .count(first_time) == 0);
 
-    // There should be a queued simple action on the target_component,
-    // which is either SendPointsToInterpolator or
-    // VerifyTemporalIdsAndSendPoints (depending on whether we are
-    // time-dependent)
-    CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
-              runner, 0) == 1);
+    // There should be a no simple actions on the target_component. Whether we
+    // directly called SendPointsToInterpolator or
+    // VerifyTemporalIdsAndSendPoints, they both result in a simple action
+    // (ReceivePoints) on the interpolator
+    CHECK(ActionTesting::is_simple_action_queue_empty<target_component>(runner,
+                                                                        0));
 
-    // There should be a queued simple action on the
-    // interp_component, which is CleanUpInterpolator, which here we
-    // mock.
+    // CleanUpInterpolator should always be queued on the interpolator. If we
+    // aren't time dependent, then we should also have ReceivePoints queued.
     CHECK(ActionTesting::number_of_queued_simple_actions<interp_component>(
-              runner, 0) == 1);
+              runner, 0) == (IsTimeDependent::value ? 1 : 2));
     ActionTesting::invoke_queued_simple_action<interp_component>(
         make_not_null(&runner), 0);
 
@@ -607,10 +575,6 @@ void test_interpolation_target_receive_vars() {
                 intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0)
                 .front() == second_time);
 
-      // Invoke the remaining simple action, VerifyTemporalIdsAndSendPoints.
-      ActionTesting::invoke_queued_simple_action<target_component>(
-          make_not_null(&runner), 0);
-
       // Now there should be no more simple actions, because the
       // FunctionsOfTime are not up to date for the pending
       // temporal_id.
@@ -635,17 +599,21 @@ void test_interpolation_target_receive_vars() {
       ActionTesting::invoke_queued_simple_action<target_component>(
           make_not_null(&runner), 0);
 
-      // Now there should be a single simple_action which is
-      // MockSendPointsToInterpolator.
-      CHECK(ActionTesting::number_of_queued_simple_actions<target_component>(
+      // Check that there is now MockReceivePoints queued on the interpolator
+      CHECK(ActionTesting::number_of_queued_simple_actions<interp_component>(
                 runner, 0) == 1);
-
-      // And PendingTemporalIds should be empty.
-      CHECK(ActionTesting::get_databox_tag<
-                target_component,
-                intrp::Tags::PendingTemporalIds<temporal_id_type>>(runner, 0)
-                .empty());
     }
+
+    // Call MockReceivePoints
+    ActionTesting::invoke_queued_simple_action<interp_component>(
+        make_not_null(&runner), 0);
+
+    // Check that ReceivePoints was called with the next id
+    CHECK(get<intrp::Vars::HolderTag<target_tag, metavars>>(
+              ActionTesting::get_databox_tag<
+                  interp_component,
+                  intrp::Tags::InterpolatedVarsHolders<metavars>>(runner, 0))
+              .infos.contains(second_time));
 
     // There should be only 1 TemporalId left.
     // And its value should be second_temporal_id.
@@ -657,30 +625,6 @@ void test_interpolation_target_receive_vars() {
               target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
               runner, 0)
               .front() == second_time);
-
-    // Check that MockSendPointsToInterpolator was not yet called.
-    // MockSendPointsToInterpolator sets a (fake) value of
-    // IndicesOfFilledInterpPoints for the express purpose of this
-    // check.
-    const auto& indices_to_check = ActionTesting::get_databox_tag<
-        target_component,
-        intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(runner, 0);
-    CHECK(indices_to_check.find(second_time) == indices_to_check.end());
-
-    // And there is yet one more simple action, SendPointsToInterpolator,
-    // which here we mock just to check that it is called.
-    ActionTesting::invoke_queued_simple_action<target_component>(
-        make_not_null(&runner), 0);
-
-    // Check that MockSendPointsToInterpolator was called.
-    // MockSendPointsToInterpolator sets a (fake) value of
-    // IndicesOfFilledInterpPoints for the express purpose of this check.
-    CHECK(ActionTesting::get_databox_tag<
-              target_component,
-              intrp::Tags::IndicesOfFilledInterpPoints<temporal_id_type>>(
-              runner, 0)
-              .at(second_time)
-              .size() == 1);
   }
 
   // There should be no more queued actions; verify this.

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
@@ -39,25 +39,14 @@ domain::creators::Interval make_interval() {
 }
 
 template <size_t Dim>
-struct MockMetavariables {
-  struct InterpolationTargetA
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::TimeStepId;
-    using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::Lapse<DataVector>>;
-    using compute_items_on_target = tmpl::list<>;
-    using compute_target_points =
-        ::intrp::TargetPoints::SpecifiedPoints<InterpolationTargetA, Dim>;
-    using post_interpolation_callbacks = tmpl::list<>;
-  };
-  static constexpr size_t volume_dim = Dim;
-  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
-  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-
-  using component_list = tmpl::list<
-      InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables<Dim>,
-                                                         InterpolationTargetA>,
-      InterpTargetTestHelpers::mock_interpolator<MockMetavariables<Dim>>>;
+struct SpecifiedPointsTag
+    : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  using temporal_id = ::Tags::TimeStepId;
+  using vars_to_interpolate_to_target = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using compute_items_on_target = tmpl::list<>;
+  using compute_target_points =
+      ::intrp::TargetPoints::SpecifiedPoints<SpecifiedPointsTag, Dim>;
+  using post_interpolation_callbacks = tmpl::list<>;
 };
 
 template <InterpTargetTestHelpers::ValidPoints ValidPoints>
@@ -81,13 +70,14 @@ void test_1d() {
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
 
-  TestHelpers::db::test_simple_tag<intrp::Tags::SpecifiedPoints<
-      MockMetavariables<1>::InterpolationTargetA, 1>>("SpecifiedPoints");
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::SpecifiedPoints<SpecifiedPointsTag<1>, 1>>(
+      "SpecifiedPoints");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables<1>, intrp::Tags::SpecifiedPoints<
-                                MockMetavariables<1>::InterpolationTargetA, 1>>(
-      domain_creator, std::move(points_opts), expected_block_coord_holders);
+      SpecifiedPointsTag<1>, 1,
+      intrp::Tags::SpecifiedPoints<SpecifiedPointsTag<1>, 1>>(
+      created_opts, expected_block_coord_holders);
 }
 
 void test_2d() {
@@ -113,13 +103,14 @@ void test_2d() {
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
 
-  TestHelpers::db::test_simple_tag<intrp::Tags::SpecifiedPoints<
-      MockMetavariables<2>::InterpolationTargetA, 2>>("SpecifiedPoints");
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::SpecifiedPoints<SpecifiedPointsTag<2>, 2>>(
+      "SpecifiedPoints");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables<2>, intrp::Tags::SpecifiedPoints<
-                                MockMetavariables<2>::InterpolationTargetA, 2>>(
-      domain_creator, std::move(points_opts), expected_block_coord_holders);
+      SpecifiedPointsTag<2>, 2,
+      intrp::Tags::SpecifiedPoints<SpecifiedPointsTag<2>, 2>>(
+      created_opts, expected_block_coord_holders);
 }
 
 void test_3d() {
@@ -150,13 +141,14 @@ void test_3d() {
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
 
-  TestHelpers::db::test_simple_tag<intrp::Tags::SpecifiedPoints<
-      MockMetavariables<3>::InterpolationTargetA, 3>>("SpecifiedPoints");
+  TestHelpers::db::test_simple_tag<
+      intrp::Tags::SpecifiedPoints<SpecifiedPointsTag<3>, 3>>(
+      "SpecifiedPoints");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables<3>, intrp::Tags::SpecifiedPoints<
-                                MockMetavariables<3>::InterpolationTargetA, 3>>(
-      domain_creator, std::move(points_opts), expected_block_coord_holders);
+      SpecifiedPointsTag<3>, 3,
+      intrp::Tags::SpecifiedPoints<SpecifiedPointsTag<3>, 3>>(
+      created_opts, expected_block_coord_holders);
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
@@ -48,25 +48,13 @@ domain::creators::Sphere make_sphere() {
   return {3.4, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false};
 }
 
-struct MockMetavariables {
-  struct InterpolationTargetA
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::TimeStepId;
-    using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::Lapse<DataVector>>;
-    using compute_items_on_target = tmpl::list<>;
-    using compute_target_points =
-        ::intrp::TargetPoints::Sphere<InterpolationTargetA, ::Frame::Inertial>;
-    using post_interpolation_callbacks = tmpl::list<>;
-  };
-  static constexpr size_t volume_dim = 3;
-  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
-  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-
-  using component_list =
-      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
-                     MockMetavariables, InterpolationTargetA>,
-                 InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+struct SphereTag : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  using temporal_id = ::Tags::TimeStepId;
+  using vars_to_interpolate_to_target = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using compute_items_on_target = tmpl::list<>;
+  using compute_target_points =
+      ::intrp::TargetPoints::Sphere<SphereTag, ::Frame::Inertial>;
+  using post_interpolation_callbacks = tmpl::list<>;
 };
 
 template <InterpTargetTestHelpers::ValidPoints ValidPoints, typename Generator>
@@ -129,8 +117,7 @@ void test_interpolation_target_sphere(
 
   const auto domain_creator = make_sphere<ValidPoints>();
 
-  TestHelpers::db::test_simple_tag<
-      intrp::Tags::Sphere<MockMetavariables::InterpolationTargetA>>("Sphere");
+  TestHelpers::db::test_simple_tag<intrp::Tags::Sphere<SphereTag>>("Sphere");
 
   const auto expected_block_coord_holders = [&domain_creator, &radii, &center,
                                              &angular_ordering,
@@ -186,10 +173,10 @@ void test_interpolation_target_sphere(
     }
     return block_logical_coordinates(domain_creator.create_domain(), points);
   }();
+
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables,
-      intrp::Tags::Sphere<MockMetavariables::InterpolationTargetA>>(
-      domain_creator, sphere_opts, expected_block_coord_holders);
+      SphereTag, 3, intrp::Tags::Sphere<SphereTag>>(
+      created_opts, expected_block_coord_holders);
 }
 
 void test_sphere_errors() {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -263,7 +263,7 @@ void test() {
       &runner, 0,
       {std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
        std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
-       std::deque<temporal_id_type>{}, std::deque<temporal_id_type>{},
+       std::deque<temporal_id_type>{}, std::unordered_set<temporal_id_type>{},
        std::deque<temporal_id_type>{},
        std::unordered_map<temporal_id_type,
                           Variables<typename metavars::InterpolationTargetA::
@@ -496,7 +496,7 @@ void test() {
   CHECK(ActionTesting::get_databox_tag<
             target_component, intrp::Tags::TemporalIds<temporal_id_type>>(
             runner, 0)
-            .front() == first_temporal_id);
+            .contains(first_temporal_id));
   // There should be 1 CompletedTemporalId, and its value
   // should be second_temporal_id.
   CHECK(ActionTesting::get_databox_tag<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -42,25 +42,14 @@ domain::creators::Sphere make_sphere() {
   return {3.4, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false};
 }
 
-struct MockMetavariables {
-  struct InterpolationTargetA
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::TimeStepId;
-    using vars_to_interpolate_to_target =
-        tmpl::list<gr::Tags::Lapse<DataVector>>;
-    using compute_items_on_target = tmpl::list<>;
-    using compute_target_points =
-        ::intrp::TargetPoints::WedgeSectionTorus<InterpolationTargetA>;
-    using post_interpolation_callbacks = tmpl::list<>;
-  };
-  static constexpr size_t volume_dim = 3;
-  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
-  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-
-  using component_list =
-      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
-                     MockMetavariables, InterpolationTargetA>,
-                 InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+struct WedgeTargetTag
+    : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  using temporal_id = ::Tags::TimeStepId;
+  using vars_to_interpolate_to_target = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using compute_items_on_target = tmpl::list<>;
+  using compute_target_points =
+      ::intrp::TargetPoints::WedgeSectionTorus<WedgeTargetTag>;
+  using post_interpolation_callbacks = tmpl::list<>;
 };
 
 template <InterpTargetTestHelpers::ValidPoints ValidPoints>
@@ -104,9 +93,8 @@ void test_r_theta_lgl() {
   }();
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables,
-      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
-      domain_creator, wedge_section_torus_opts, expected_block_coord_holders);
+      WedgeTargetTag, 3, intrp::Tags::WedgeSectionTorus<WedgeTargetTag>>(
+      wedge_section_torus_opts, expected_block_coord_holders);
 }
 
 template <InterpTargetTestHelpers::ValidPoints ValidPoints>
@@ -141,13 +129,11 @@ void test_r_theta_uniform() {
   }();
 
   TestHelpers::db::test_simple_tag<
-      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
-      "WedgeSectionTorus");
+      intrp::Tags::WedgeSectionTorus<WedgeTargetTag>>("WedgeSectionTorus");
 
   InterpTargetTestHelpers::test_interpolation_target<
-      MockMetavariables,
-      intrp::Tags::WedgeSectionTorus<MockMetavariables::InterpolationTargetA>>(
-      domain_creator, wedge_section_torus_opts, expected_block_coord_holders);
+      WedgeTargetTag, 3, intrp::Tags::WedgeSectionTorus<WedgeTargetTag>>(
+      wedge_section_torus_opts, expected_block_coord_holders);
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -344,12 +344,11 @@ void run_test(gsl::not_null<Generator*> generator,
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               typename metavars::LineA>>(
-      make_not_null(&runner), 0,
-      std::vector<double>{temporal_id.substep_time()});
+      make_not_null(&runner), 0, temporal_id.substep_time());
   ActionTesting::simple_action<
       target_b_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                              typename metavars::LineB>>(
-      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
+                              typename metavars::LineB>>(make_not_null(&runner),
+                                                         0, temporal_id);
 
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 0));
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 1));

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -160,6 +160,15 @@ struct MockInterpolator {
   using component_being_mocked = intrp::Interpolator<Metavariables>;
 };
 
+// This test was originally written with non-sequential targets, but an
+// infrastructure change made the interpolator only work with sequential
+// targets (horizon find). Rather than rewrite the whole test with horizon
+// finds, we just make new targets from the originals that are now sequential
+template <typename OriginalComputeTargetPoints>
+struct MockComputeTargetPoints : public OriginalComputeTargetPoints {
+  using is_sequential = std::true_type;
+};
+
 template <size_t Dim>
 struct MockMetavariables {
   static constexpr size_t volume_dim = Dim;
@@ -171,8 +180,8 @@ struct MockMetavariables {
                    gr::Tags::SpatialMetric<DataVector, volume_dim>,
                    domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
-    using compute_target_points =
-        intrp::TargetPoints::LineSegment<LineA, volume_dim, Frame::Inertial>;
+    using compute_target_points = MockComputeTargetPoints<
+        intrp::TargetPoints::LineSegment<LineA, volume_dim, Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveLineSegment<
             tmpl::append<vars_to_interpolate_to_target,
@@ -187,8 +196,8 @@ struct MockMetavariables {
                    gr::Tags::SpatialMetric<DataVector, volume_dim>,
                    domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
-    using compute_target_points =
-        intrp::TargetPoints::LineSegment<LineB, volume_dim, Frame::Inertial>;
+    using compute_target_points = MockComputeTargetPoints<
+        intrp::TargetPoints::LineSegment<LineB, volume_dim, Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveLineSegment<
             tmpl::append<vars_to_interpolate_to_target,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -419,6 +419,15 @@ struct MockInterpolator {
   using component_being_mocked = intrp::Interpolator<Metavariables>;
 };
 
+// This test was originally written with non-sequential targets, but an
+// infrastructure change made the interpolator only work with sequential
+// targets (horizon find). Rather than rewrite the whole test with horizon
+// finds, we just make new targets from the originals that are now sequential
+template <typename OriginalComputeTargetPoints>
+struct MockComputeTargetPoints : public OriginalComputeTargetPoints {
+  using is_sequential = std::true_type;
+};
+
 struct MockMetavariables {
   struct SurfaceA : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
@@ -429,8 +438,8 @@ struct MockMetavariables {
                    gr::surfaces::Tags::AreaElementCompute<Frame::Inertial>,
                    gr::surfaces::Tags::SurfaceIntegralCompute<
                        Tags::Square, ::Frame::Inertial>>;
-    using compute_target_points =
-        intrp::TargetPoints::KerrHorizon<SurfaceA, ::Frame::Inertial>;
+    using compute_target_points = MockComputeTargetPoints<
+        intrp::TargetPoints::KerrHorizon<SurfaceA, ::Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<gr::surfaces::Tags::SurfaceIntegral<Tags::Square,
@@ -448,8 +457,8 @@ struct MockMetavariables {
                                                               Frame::Inertial>,
                    gr::surfaces::Tags::SurfaceIntegralCompute<Tags::Negate,
                                                               Frame::Inertial>>;
-    using compute_target_points =
-        intrp::TargetPoints::KerrHorizon<SurfaceB, ::Frame::Inertial>;
+    using compute_target_points = MockComputeTargetPoints<
+        intrp::TargetPoints::KerrHorizon<SurfaceB, ::Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<gr::surfaces::Tags::SurfaceIntegral<Tags::Square,
@@ -467,8 +476,8 @@ struct MockMetavariables {
                    gr::surfaces::Tags::AreaElementCompute<Frame::Inertial>,
                    gr::surfaces::Tags::SurfaceIntegralCompute<
                        Tags::Negate, ::Frame::Inertial>>;
-    using compute_target_points =
-        intrp::TargetPoints::KerrHorizon<SurfaceC, ::Frame::Inertial>;
+    using compute_target_points = MockComputeTargetPoints<
+        intrp::TargetPoints::KerrHorizon<SurfaceC, ::Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<gr::surfaces::Tags::SurfaceIntegral<Tags::Negate,
@@ -485,8 +494,8 @@ struct MockMetavariables {
                    gr::surfaces::Tags::AreaElementCompute<Frame::Inertial>,
                    gr::surfaces::Tags::SurfaceIntegralCompute<
                        Tags::Square, ::Frame::Inertial>>;
-    using compute_target_points =
-        intrp::TargetPoints::KerrHorizon<SurfaceD, ::Frame::Inertial>;
+    using compute_target_points = MockComputeTargetPoints<
+        intrp::TargetPoints::KerrHorizon<SurfaceD, ::Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveSurfaceData<
             tmpl::list<Tags::Square>, SurfaceD, ::Frame::Inertial>>;
@@ -501,8 +510,8 @@ struct MockMetavariables {
                    gr::surfaces::Tags::AreaElementCompute<Frame::Inertial>,
                    gr::surfaces::Tags::SurfaceIntegralCompute<
                        Tags::Square, ::Frame::Inertial>>;
-    using compute_target_points =
-        intrp::TargetPoints::KerrHorizon<SurfaceE, ::Frame::Inertial>;
+    using compute_target_points = MockComputeTargetPoints<
+        intrp::TargetPoints::KerrHorizon<SurfaceE, ::Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveSurfaceData<
             tmpl::list<Tags::Square>, SurfaceE, ::Frame::Inertial>>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -698,26 +698,23 @@ void run_test() {
   ActionTesting::simple_action<
       target_a_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceA>>(
-      make_not_null(&runner), 0,
-      std::vector<double>{temporal_id.substep_time()});
+      make_not_null(&runner), 0, temporal_id.substep_time());
   ActionTesting::simple_action<
       target_b_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceB>>(
-      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
+      make_not_null(&runner), 0, temporal_id);
   ActionTesting::simple_action<
       target_c_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceC>>(
-      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
+      make_not_null(&runner), 0, temporal_id);
   ActionTesting::simple_action<
       target_d_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceD>>(
-      make_not_null(&runner), 0,
-      std::vector<double>{temporal_id.substep_time()});
+      make_not_null(&runner), 0, temporal_id.substep_time());
   ActionTesting::simple_action<
       target_e_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceE>>(
-      make_not_null(&runner), 0,
-      std::vector<double>{temporal_id.substep_time()});
+      make_not_null(&runner), 0, temporal_id.substep_time());
 
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 0));
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 1));

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -231,6 +231,15 @@ struct mock_interpolator {
   using component_being_mocked = intrp::Interpolator<Metavariables>;
 };
 
+// This test was originally written with non-sequential targets, but an
+// infrastructure change made the interpolator only work with sequential
+// targets (horizon find). Rather than rewrite the whole test with horizon
+// finds, we just make new targets from the originals that are now sequential
+template <typename OriginalComputeTargetPoints>
+struct MockComputeTargetPoints : public OriginalComputeTargetPoints {
+  using is_sequential = std::true_type;
+};
+
 struct MockMetavariables {
   struct InterpolationTargetA
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -239,8 +248,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        intrp::TargetPoints::LineSegment<InterpolationTargetA, 3,
-                                         Frame::Inertial>;
+        MockComputeTargetPoints<intrp::TargetPoints::LineSegment<
+            InterpolationTargetA, 3, Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<TestFunction<InterpolationTargetA, Tags::Square>>;
   };
@@ -251,8 +260,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<Tags::NegateCompute>;
     using compute_target_points =
-        intrp::TargetPoints::LineSegment<InterpolationTargetB, 3,
-                                         Frame::Inertial>;
+        MockComputeTargetPoints<intrp::TargetPoints::LineSegment<
+            InterpolationTargetB, 3, Frame::Inertial>>;
     using post_interpolation_callbacks =
         tmpl::list<TestFunction<InterpolationTargetB, Tags::Negate>>;
   };
@@ -262,8 +271,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::TestSolution>;
     using compute_items_on_target = tmpl::list<Tags::SquareCompute>;
     using compute_target_points =
-        intrp::TargetPoints::KerrHorizon<InterpolationTargetC,
-                                         ::Frame::Inertial>;
+        MockComputeTargetPoints<intrp::TargetPoints::KerrHorizon<
+            InterpolationTargetC, ::Frame::Inertial>>;
     using post_interpolation_callbacks = tmpl::list<TestKerrHorizonIntegral>;
   };
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -390,15 +390,15 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetA>>(
-      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
+      make_not_null(&runner), 0, temporal_id);
   ActionTesting::simple_action<
       target_b_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetB>>(
-      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
+      make_not_null(&runner), 0, temporal_id);
   ActionTesting::simple_action<
       target_c_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetC>>(
-      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
+      make_not_null(&runner), 0, temporal_id);
 
   // Create volume data and send it to the interpolator.
   for (const auto& element_id : element_ids) {
@@ -455,7 +455,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetA>>(
-      make_not_null(&runner), 0, std::vector<TimeStepId>{temporal_id});
+      make_not_null(&runner), 0, temporal_id);
   // ...so make sure it was ignored by checking that there isn't anything
   // else in the simple_action queue of the target or the interpolator.
   CHECK(ActionTesting::is_simple_action_queue_empty<target_a_component>(runner,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
@@ -89,6 +89,8 @@ SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
   TestHelpers::db::test_simple_tag<
       intrp::Tags::InterpolatedVars<InterpolationTargetTag, Metavars>>(
       "InterpolatedVars");
+  TestHelpers::db::test_simple_tag<intrp::Tags::CurrentTemporalId<Metavars>>(
+      "CurrentTemporalId");
   TestHelpers::db::test_simple_tag<intrp::Tags::TemporalIds<Metavars>>(
       "TemporalIds");
   TestHelpers::db::test_simple_tag<intrp::Tags::CompletedTemporalIds<Metavars>>(


### PR DESCRIPTION
## Proposed changes

We were not checking the order we received temporal IDs before sending points to the interpolator and this made some horizon finds happen out of order. I don't think this had a significant impact, but still best to fix it. In order to make some of the logic easier, I did a couple things

- Explicitly only allow sequential targets in the interpolator. This was already implicitly done because horizon finds are sequential and no other interpolation used the Interpolator. But best to make it explicit. (commit 2)
- There were multiple times I found where an action running on the target singleton would schedule another action on itself when it could just call it directly. So I did that. (commit 3)

I tested this branch on a BBH test case that I know to fail, and it has gotten significantly past the point of failure

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
