### PR TITLE
Adds worldtube functions of time to `BinaryCompactObject`

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -64,11 +64,13 @@ create_grid_anchors(const std::array<double, 3>& center_a,
 }
 }  // namespace bco
 
-bool BinaryCompactObject::Object::is_excised() const {
+template <bool UseWorldtube>
+bool BinaryCompactObject<UseWorldtube>::Object::is_excised() const {
   return inner_boundary_condition.has_value();
 }
 
-BinaryCompactObject::BinaryCompactObject(
+template <bool UseWorldtube>
+BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
     typename ObjectA::type object_A, typename ObjectB::type object_B,
     std::array<double, 2> center_of_mass_offset, const double envelope_radius,
     const double outer_radius,
@@ -336,7 +338,8 @@ BinaryCompactObject::BinaryCompactObject(
   }
 }
 
-Domain<3> BinaryCompactObject::create_domain() const {
+template <bool UseWorldtube>
+Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
   const double inner_sphericity_A = is_excised_a_ ? 1.0 : 0.0;
   const double inner_sphericity_B = is_excised_b_ ? 1.0 : 0.0;
 
@@ -728,9 +731,10 @@ Domain<3> BinaryCompactObject::create_domain() const {
   return domain;
 }
 
+template <bool UseWorldtube>
 std::vector<DirectionMap<
     3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-BinaryCompactObject::external_boundary_conditions() const {
+BinaryCompactObject<UseWorldtube>::external_boundary_conditions() const {
   if (outer_boundary_condition_ == nullptr) {
     return {};
   }
@@ -766,16 +770,20 @@ BinaryCompactObject::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
+template <bool UseWorldtube>
 std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-BinaryCompactObject::functions_of_time(
+BinaryCompactObject<UseWorldtube>::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
   return time_dependent_options_.has_value()
-             ? time_dependent_options_->create_functions_of_time(
+             ? time_dependent_options_->create_functions_of_time<UseWorldtube>(
                    initial_expiration_times)
              : std::unordered_map<
                    std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{};
 }
+
+template class BinaryCompactObject<true>;
+template class BinaryCompactObject<false>;
 }  // namespace domain::creators

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -144,7 +144,12 @@ create_grid_anchors(const std::array<double, 3>& center_a,
  * `domain::creators::bco::TimeDependentMapOptions`. This class must pass a
  * template parameter of `false` to
  * `domain::creators::bco::TimeDependentMapOptions`.
+ *
+ * The `UseWorldtube` template parameter is set to false by default. When set to
+ * true, some of the functions of time will be `IntegratedFunctionOfTime` used
+ * to control the orbit of the worldtube.
  */
+template <bool UseWorldtube = false>
 class BinaryCompactObject : public DomainCreator<3> {
  private:
   // Time-independent maps

--- a/src/Domain/Creators/Factory3D.hpp
+++ b/src/Domain/Creators/Factory3D.hpp
@@ -21,8 +21,8 @@ template <>
 struct domain_creators<3> {
   using type =
       tmpl::list<domain::creators::AlignedLattice<3>,
-                 domain::creators::BinaryCompactObject, domain::creators::Brick,
-                 domain::creators::Cylinder,
+                 domain::creators::BinaryCompactObject<false>,
+                 domain::creators::Brick, domain::creators::Cylinder,
                  domain::creators::CylindricalBinaryCompactObject,
                  domain::creators::FrustalCloak,
                  domain::creators::RotatedBricks, domain::creators::Sphere>;

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
@@ -277,7 +277,17 @@ struct TimeDependentMapOptions {
    * - Translation: `PiecewisePolynomial<3>`
    * - SizeA/B: `PiecewisePolynomial<3>`
    * - ShapeA/B: `PiecewisePolynomial<2>`
+   *
+   *  When `UseWorldtube` is set to true, they are
+   *
+   * - Expansion: `IntegratedFunctionOfTime`
+   * - ExpansionOuterBoundary: `FixedSpeedCubic`
+   * - Rotation: `IntegratedFunctionOfTime`
+   * - Translation: None
+   * - SizeA/B: IntegratedFunctionOfTime
+   * - ShapeA/B: `PiecewisePolynomial<2>`
    */
+  template <bool UseWorldtube = false>
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
   create_functions_of_time(const std::unordered_map<std::string, double>&
@@ -398,5 +408,10 @@ struct TimeDependentMapOptions {
       tmpl::conditional_t<IsCylindrical, std::array<std::optional<Shape>, 2>,
                           std::array<std::array<std::optional<Shape>, 6>, 2>>;
   ShapeMapType shape_maps_{};
+
+  // helper function that creates the functions of time used by the worldtube
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+  create_worldtube_functions_of_time() const;
 };
 }  // namespace domain::creators::bco

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include <vector>
 
-#include "Domain/Creators/Factory3D.hpp"
+#include "Domain/Creators/BinaryCompactObject.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/ElementDistribution.hpp"
@@ -208,7 +208,8 @@ struct EvolutionMetavars {
                     standard_boundary_conditions<volume_dim>,
                 CurvedScalarWave::BoundaryConditions::Worldtube<volume_dim>>>>,
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
-        tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
+        tmpl::pair<DomainCreator<volume_dim>,
+                   tmpl::list<domain::creators::BinaryCompactObject<false>>>,
         tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -451,7 +451,7 @@ struct EvolutionMetavars {
                        DenseTriggers::standard_dense_triggers>>>,
         tmpl::pair<
             DomainCreator<volume_dim>,
-            tmpl::list<::domain::creators::BinaryCompactObject,
+            tmpl::list<::domain::creators::BinaryCompactObject<false>,
                        ::domain::creators::CylindricalBinaryCompactObject>>,
         tmpl::pair<
             Event,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -586,13 +586,14 @@ struct GhValenciaDivCleanTemplateBase<
                    tmpl::append<DenseTriggers::standard_dense_triggers,
                                 control_system::control_system_triggers<
                                     control_systems>>>,
-        tmpl::pair<DomainCreator<volume_dim>,
-                   // Currently control systems can only be used with BCO
-                   // domains
-                   tmpl::conditional_t<
-                       use_control_systems,
-                       tmpl::list<::domain::creators::BinaryCompactObject>,
-                       domain_creators<volume_dim>>>,
+        tmpl::pair<
+            DomainCreator<volume_dim>,
+            // Currently control systems can only be used with BCO
+            // domains
+            tmpl::conditional_t<
+                use_control_systems,
+                tmpl::list<::domain::creators::BinaryCompactObject<false>>,
+                domain_creators<volume_dim>>>,
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
                        Events::Completion,

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -52,10 +52,10 @@ class FunctionOfTime;
 
 namespace {
 using ExpirationTimeMap = std::unordered_map<std::string, double>;
-using Object = domain::creators::BinaryCompactObject::Object;
+using Object = domain::creators::BinaryCompactObject<false>::Object;
 using CartesianCubeAtXCoord =
-    domain::creators::BinaryCompactObject::CartesianCubeAtXCoord;
-using Excision = domain::creators::BinaryCompactObject::Excision;
+    domain::creators::BinaryCompactObject<false>::CartesianCubeAtXCoord;
+using Excision = domain::creators::BinaryCompactObject<false>::Excision;
 using Distribution = domain::CoordinateMaps::Distribution;
 
 template <size_t Dim, bool WithBoundaryConditions>
@@ -67,8 +67,9 @@ struct Metavariables {
                                          SystemWithoutBoundaryConditions<Dim>>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<tmpl::pair<
-        DomainCreator<3>, tmpl::list<::domain::creators::BinaryCompactObject>>>;
+    using factory_classes = tmpl::map<
+        tmpl::pair<DomainCreator<3>,
+                   tmpl::list<::domain::creators::BinaryCompactObject<false>>>>;
   };
 };
 
@@ -275,7 +276,7 @@ void test_connectivity() {
                                             create_inner_boundary_condition()})
                                       : std::nullopt,
                      false},
-              domain::creators::BinaryCompactObject::Object{
+              domain::creators::BinaryCompactObject<false>::Object{
                   inner_radius_objectB, outer_radius_objectB, xcoord_objectB,
                   excise_interiorB ? std::make_optional(Excision{
                                          create_inner_boundary_condition()})

--- a/tests/Unit/Domain/Creators/Test_Tags.cpp
+++ b/tests/Unit/Domain/Creators/Test_Tags.cpp
@@ -38,10 +38,10 @@ void test_center_tags() {
   TestHelpers::db::test_simple_tag<Tags::ObjectCenter<ObjectLabel::B>>(
       "ObjectCenterB");
 
-  using Object = domain::creators::BinaryCompactObject::Object;
+  using Object = domain::creators::BinaryCompactObject<false>::Object;
 
   const std::unique_ptr<DomainCreator<3>> domain_creator =
-      std::make_unique<domain::creators::BinaryCompactObject>(
+      std::make_unique<domain::creators::BinaryCompactObject<false>>(
           Object{0.2, 5.0, 8.0, true, true}, Object{0.6, 4.0, -5.5, true, true},
           std::array<double, 2>{{0.1, 0.2}}, 100.0, 500.0, 1_st, 5_st);
 

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
@@ -14,6 +14,7 @@
 #include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/IntegratedFunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
@@ -637,6 +638,98 @@ void test_errors() {
 #endif
 }
 
+void test_worldtube_fots() {
+  const std::array<double, 3> size_a_opts{{1.3, 1.2, 1.1}};
+  const std::array<double, 3> size_b_opts{{1.4, 1.5, 1.6}};
+  const double initial_time = 0.0;
+
+  const double initial_expansion = 1.2;
+  const double initial_expansion_deriv = 2.2;
+
+  const TimeDependentMapOptions<false> worldtube_options{
+      initial_time,
+      ExpMapOptions<false>{
+          {initial_expansion, initial_expansion_deriv}, 1., 1.},
+      RotMapOptions<false>{{0.0, 0.0, 1.0}},
+      std::nullopt,
+      ShapeMapAOptions<false>{2, {}, std::make_optional(size_a_opts)},
+      ShapeMapBOptions<false>{2, {}, std::make_optional(size_b_opts)}};
+  const auto fots = worldtube_options.create_functions_of_time<true>({});
+  CHECK(not fots.contains("Translation"));
+
+  CHECK(fots.contains("Rotation"));
+  const auto& rotation_fot = fots.at("Rotation");
+  CHECK(dynamic_cast<domain::FunctionsOfTime::IntegratedFunctionOfTime*>(
+      &*rotation_fot));
+  CHECK(rotation_fot->time_bounds() ==
+        std::array<double, 2>{{initial_time, initial_time + 1e-10}});
+  const DataVector rotation_value{1., 0., 0., 0.};
+  const DataVector rotation_deriv_value{0., 0., 0., 0.5};
+  CHECK_ITERABLE_APPROX(rotation_fot->func(initial_time)[0], rotation_value);
+  CHECK_ITERABLE_APPROX(rotation_fot->func_and_deriv(initial_time)[1],
+                        rotation_deriv_value);
+
+  CHECK(fots.contains("Expansion"));
+  const auto& expansion_fot = fots.at("Expansion");
+  CHECK(dynamic_cast<domain::FunctionsOfTime::IntegratedFunctionOfTime*>(
+      &*expansion_fot));
+  CHECK(expansion_fot->time_bounds() ==
+        std::array<double, 2>{{initial_time, initial_time + 1e-10}});
+  const DataVector expansion_value{initial_expansion};
+  const DataVector expansion_deriv_value{initial_expansion_deriv};
+  CHECK_ITERABLE_APPROX(expansion_fot->func(initial_time)[0], expansion_value);
+  CHECK_ITERABLE_APPROX(expansion_fot->func_and_deriv(initial_time)[1],
+                        expansion_deriv_value);
+
+  CHECK(fots.contains("ExpansionOuterBoundary"));
+  const auto& boundary_expansion = fots.at("ExpansionOuterBoundary");
+  CHECK(dynamic_cast<domain::FunctionsOfTime::FixedSpeedCubic*>(
+      &*boundary_expansion));
+  CHECK(boundary_expansion->time_bounds() ==
+        std::array<double, 2>{
+            {initial_time, std::numeric_limits<double>::infinity()}});
+
+  CHECK(fots.contains("SizeA"));
+  const auto& size_a_fot = fots.at("SizeA");
+  CHECK(dynamic_cast<domain::FunctionsOfTime::IntegratedFunctionOfTime*>(
+      &*size_a_fot));
+  CHECK(size_a_fot->time_bounds() ==
+        std::array<double, 2>{{initial_time, initial_time + 1e-10}});
+  const DataVector size_a_value{size_a_opts[0]};
+  const DataVector size_a_deriv_value{size_a_opts[1]};
+  CHECK_ITERABLE_APPROX(size_a_fot->func(initial_time)[0], size_a_value);
+  CHECK_ITERABLE_APPROX(size_a_fot->func_and_deriv(initial_time)[1],
+                        size_a_deriv_value);
+
+  CHECK(fots.contains("SizeB"));
+  const auto& size_b_fot = fots.at("SizeB");
+  CHECK(dynamic_cast<domain::FunctionsOfTime::IntegratedFunctionOfTime*>(
+      &*size_b_fot));
+  CHECK(size_b_fot->time_bounds() ==
+        std::array<double, 2>{{initial_time, initial_time + 1e-10}});
+  const DataVector size_b_value{size_b_opts[0]};
+  const DataVector size_b_deriv_value{size_b_opts[1]};
+  CHECK_ITERABLE_APPROX(size_b_fot->func(initial_time)[0], size_b_value);
+  CHECK_ITERABLE_APPROX(size_b_fot->func_and_deriv(initial_time)[1],
+                        size_b_deriv_value);
+
+  CHECK(fots.contains("ShapeA"));
+  const auto& shape_a_fot = fots.at("ShapeA");
+  CHECK(dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+      &*shape_a_fot));
+  CHECK(shape_a_fot->time_bounds() ==
+        std::array<double, 2>{
+            {initial_time, std::numeric_limits<double>::infinity()}});
+
+  CHECK(fots.contains("ShapeB"));
+  const auto& shape_b_fot = fots.at("ShapeB");
+  CHECK(dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+      &*shape_b_fot));
+  CHECK(shape_b_fot->time_bounds() ==
+        std::array<double, 2>{
+            {initial_time, std::numeric_limits<double>::infinity()}});
+}
+
 }  // namespace
 
 // [[TimeOut, 45]]
@@ -657,5 +750,6 @@ SPECTRE_TEST_CASE(
   check_names<false>();
   test_errors<true>();
   test_errors<false>();
+  test_worldtube_fots();
 }
 }  // namespace domain::creators::bco

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -1117,7 +1117,7 @@ Domain<3> create_serialized_domain() {
   const ExpandOverBlocks<std::array<size_t, 3>> expand_over_blocks{
       block_names, block_groups};
 
-  using BCO = creators::BinaryCompactObject;
+  using BCO = creators::BinaryCompactObject<false>;
 
   const BCO::InitialRefinement::type initial_refinement_variant{1_st};
   const BCO::InitialGridPoints::type initial_grid_points_variant{3_st};
@@ -1139,10 +1139,10 @@ Domain<3> create_serialized_domain() {
   using Identity2D = CoordinateMaps::Identity<2>;
   using Translation = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>;
 
-  creators::BinaryCompactObject::Object object_A{0.45825, 6., 7.683, true,
-                                                 true};
-  creators::BinaryCompactObject::Object object_B{0.45825, 6., -7.683, true,
-                                                 true};
+  const creators::BinaryCompactObject<false>::Object object_A{
+      0.45825, 6., 7.683, true, true};
+  const creators::BinaryCompactObject<false>::Object object_B{
+      0.45825, 6., -7.683, true, true};
 
   const double x_coord_a = object_A.x_coord;
   const double x_coord_b = object_B.x_coord;
@@ -1167,10 +1167,9 @@ Domain<3> create_serialized_domain() {
 
   Maps maps_center_A =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
-          sph_wedge_coordinate_maps(object_A.inner_radius,
-                                    object_A.outer_radius, inner_sphericity_A,
-                                    1.0, use_equiangular_map, false, {},
-                                    radial_distribution),
+          sph_wedge_coordinate_maps(
+              object_A.inner_radius, object_A.outer_radius, inner_sphericity_A,
+              1.0, use_equiangular_map, false, {}, radial_distribution),
           translation_A);
   Maps maps_cube_A =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
@@ -1184,10 +1183,9 @@ Domain<3> create_serialized_domain() {
 
   Maps maps_center_B =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
-          sph_wedge_coordinate_maps(object_B.inner_radius,
-                                    object_B.outer_radius, inner_sphericity_B,
-                                    1.0, use_equiangular_map, false, {},
-                                    radial_distribution),
+          sph_wedge_coordinate_maps(
+              object_B.inner_radius, object_B.outer_radius, inner_sphericity_B,
+              1.0, use_equiangular_map, false, {}, radial_distribution),
           translation_B);
   Maps maps_cube_B =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
@@ -111,16 +111,16 @@ SPECTRE_TEST_CASE(
                                                   quadrature);
 
     INFO("Testing BinaryCompactObject");
-    const domain::creators::BinaryCompactObject binary_compact_object{
-        domain::creators::BinaryCompactObject::Object{
+    const domain::creators::BinaryCompactObject<true> binary_compact_object{
+        domain::creators::BinaryCompactObject<true>::Object{
             0.5, 3., 8.,
             std::make_optional(
-                domain::creators::BinaryCompactObject::Excision{nullptr}),
+                domain::creators::BinaryCompactObject<true>::Excision{nullptr}),
             false},
-        domain::creators::BinaryCompactObject::Object{
+        domain::creators::BinaryCompactObject<true>::Object{
             1.5, 3., -5.,
             std::make_optional(
-                domain::creators::BinaryCompactObject::Excision{nullptr}),
+                domain::creators::BinaryCompactObject<true>::Excision{nullptr}),
             false},
         std::array<double, 2>{{0.1, 0.2}},
         30.,

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.hpp
@@ -20,8 +20,11 @@ struct Metavariables {
       TestHelpers::domain::BoundaryConditions::SystemWithBoundaryConditions<3>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<tmpl::pair<
-        DomainCreator<3>, tmpl::list<::domain::creators::BinaryCompactObject>>>;
+    // we set `UseWorldtube` to `false` here so the functions of time are valid
+    // which simplifies testing.
+    using factory_classes = tmpl::map<
+        tmpl::pair<DomainCreator<3>,
+                   tmpl::list<::domain::creators::BinaryCompactObject<false>>>>;
   };
 };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -275,7 +275,7 @@ void test_interpolate_on_element(
               0.0, 0.0, 0.1, 0.0));
     } else {
       if constexpr (OffCenter) {
-        using BCO = domain::creators::BinaryCompactObject;
+        using BCO = domain::creators::BinaryCompactObject<false>;
         return std::make_unique<BCO>(
             BCO::Object{0.9, 2.9, 4.0, true, true},
             BCO::Object{0.9, 2.9, -4.0, true, true},

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -96,7 +96,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
   }
   {
     INFO("Extrapolation into BBH excisions");
-    using Object = domain::creators::BinaryCompactObject::Object;
+    using Object = domain::creators::BinaryCompactObject<false>::Object;
     const domain::creators::BinaryCompactObject domain_creator{
         Object{1., 4., 8., true, true},
         Object{0.8, 2.5, -6., true, true},


### PR DESCRIPTION
This PR allows the `BinaryCompactObject` domain creator to return the functions of time needed by the worldtube evolution.

This required either adding a Worldtube argument that could be determined in the input file at runtime or templating the class on a bool. @knelli2 and I decided it is best to use the latter approach, as a `UseWorldtube` option in the input file might be confusing to 99 % of users who would not need it. The template parameter is defaulted to `false` and only this instantiation is added to the Factory so it should be very hard for a user to use the wrong one by accident.