### PR TITLE
Update Inspiral.yaml

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -147,8 +147,6 @@ Evolution:
     - LimitIncrease:
         Factor: 2
     - PreventRapidIncrease
-    - ElementSizeCfl:
-        SafetyFactor: 0.5
     - ErrorControl:
         AbsoluteTolerance: 1e-8
         RelativeTolerance: 1e-6
@@ -157,7 +155,7 @@ Evolution:
         SafetyFactor: 0.95
   # Found that order 4 offers a significant speedup compared to order 5
   TimeStepper:
-    AdamsBashforth:
+    AdamsMoultonPcMonotonic:
       Order: 4
 
 # Set gauge and constraint damping parameters.
@@ -247,6 +245,7 @@ PhaseChangeAndTriggers:
           WallclockHours: 23.5
 
 EventsAndTriggers:
+  # Observe time step and cheap constraints every slab
   - Trigger:
       Slabs:
         EvenlySpaced:
@@ -269,19 +268,14 @@ EventsAndTriggers:
           - Name: PointwiseL2Norm(ThreeIndexConstraint)
             NormType: L2Norm
             Components: Sum
-          - Name: PointwiseL2Norm(FourIndexConstraint)
-            NormType: L2Norm
-            Components: Sum
+  # Observe constraint energy more sparsely because it is expensive to compute.
+  # Also use it for ErrorIfDataTooBig so we only compute it once.
   - Trigger:
       Slabs:
-        # Trigger apparent horizon observations often enough so they find the
-        # next horizon based on the previous initial guess.
         EvenlySpaced:
-          Interval: 20
+          Interval: 100
           Offset: 0
     Events:
-      # Observe constraint energy while we need it for ErrorIfDataTooBig so we
-      # only compute it once
       - ObserveNorms:
           SubfileName: ConstraintEnergy
           TensorsToObserve:
@@ -294,35 +288,44 @@ EventsAndTriggers:
       - ErrorIfDataTooBig:
           Threshold: 100
           VariablesToCheck: [SpacetimeMetric]
+  # Observe apparent horizons often enough so they find the next horizon based
+  # on the previous initial guess. This is an issue with the AH finders not
+  # sharing initial guesses and needs to be fixed.
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 10
+          Offset: 0
+    Events:
       - ObservationAhA
       - ObservationAhB
       - ObservationExcisionBoundaryA
       - ObservationExcisionBoundaryB
+  # Observe volume data for visualization and debugging
   - Trigger:
       Slabs:
         EvenlySpaced:
           Interval: 100
           Offset: 0
     Events:
-      # SpatialRicciScalar is output for visualizations with Render3D/Bbh.py
-      # script
       - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - SpacetimeMetric
-            - Pi
-            - Phi
-            - Lapse
-            - Shift
-            - SpatialRicciScalar
+            # For diagnostics:
+            - ConstraintEnergy
             - PointwiseL2Norm(GaugeConstraint)
             - PointwiseL2Norm(ThreeIndexConstraint)
-            - PointwiseL2Norm(FourIndexConstraint)
+            # For visualization:
+            - Lapse
+            - SpatialRicciScalar
+            - Psi4Real
           InterpolateToMesh: None
           # Save disk space by saving single precision data. This is enough
           # for visualization.
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
+  # Try to find common horizon at small separation
   - Trigger:
       SeparationLessThan:
         Value: 2.5

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -661,7 +661,7 @@ void test_cylindrical_bbh() {
 }
 }  // namespace
 
-// [[TimeOut, 60]]
+// [[TimeOut, 80]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.CylindricalBinaryCompactObject",
                   "[Domain][Unit]") {
   test_cylindrical_bbh();


### PR DESCRIPTION
## Proposed changes

Small updates to the BBH Inspiral.yaml:
- Switches time stepper to AdamsMoulton because it's faster. 
- Trigger AH observations more often, but not constraint energy
- Observe fewer volume fields to save disk space

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
