### PR TITLE
Fix interpolation stencil misalignment in `RotatingStar`

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
@@ -77,13 +77,23 @@ SPECTRE_TEST_CASE(
   // and update the path to the `dat` file in order to figure out what the
   // central rest mass density is.
   // RelativisticEuler::Solutions::detail::CstSolution cst_solution(
-  //     "/path/to/InitialData.dat", 100);
+  //     "/path/to/InitialData.dat", true, 100);
   // std::cout << cst_solution.interpolate(0.0, 0.0, true) << "\n\n";
 
   // The tolerance depends on the resolution that the RotNS file used. In order
   // to avoid storing very large files in the repo, we accept a larger
   // tolerance. However, Nils Deppe verified on Jan. 5, 2022 that increasing the
   // RotNS code resolution allows for a stricter tolerance.
+
+  const RelativisticEuler::Solutions::detail::CstSolution cst_solution(
+      unit_test_src_path() +
+          "/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/"
+          "RotatingStarId.dat",
+      true, 100.);
+  // The following line would fail under the original stencil construction due
+  // to rounding errors.
+  cst_solution.interpolate(5.85, 0.64999999999, true);
+
   register_classes_with_charm<RelativisticEuler::Solutions::RotatingStar>();
   const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
       TestHelpers::test_option_tag_factory_creation<


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

In `RotatingStar`, the setup of the stencils for the interpolation of the `RotNS` data was slightly offset. This resulted in rare edge cases where the target point could fall outside of the stencil if the rounding behaved unfavorably, especially at high resolutions. However, even when the target point fell inside the stencil, it would likely be closer to its upper edge.

This PR both fixes the rounding issue that resulted in the target point falling outside of the stencil and improves on the stencil construction overall. Now, if the stencil size is an even number, the target point will always be placed between the middle two points of the stencil, and if the stencil size is an odd number, the target point will be closest to the central point in the stencil.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
