### PR TITLE
Add equatorial compression option for spherical torus map 

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/SphericalTorus.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/SphericalTorus.cpp
@@ -7,20 +7,24 @@
 
 #include "Options/ParseError.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Functional.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"
 
 namespace grmhd::AnalyticData {
 
 SphericalTorus::SphericalTorus(const double r_min, const double r_max,
                                const double min_polar_angle,
                                const double fraction_of_torus,
+                               const double compression_level,
                                const Options::Context& context)
     : r_min_(r_min),
       r_max_(r_max),
       pi_over_2_minus_theta_min_(M_PI_2 - min_polar_angle),
-      fraction_of_torus_(fraction_of_torus) {
+      fraction_of_torus_(fraction_of_torus),
+      compression_level_(compression_level) {
   if (r_min_ <= 0.0) {
     PARSE_ERROR(context, "Minimum radius must be positive.");
   }
@@ -39,14 +43,23 @@ SphericalTorus::SphericalTorus(const double r_min, const double r_max,
   if (fraction_of_torus_ > 1.0) {
     PARSE_ERROR(context, "Fraction of torus included must be at most 1.");
   }
+  if (compression_level_ < 0.0) {
+    PARSE_ERROR(context, "Compression level must be non-negative.");
+  }
+  // a = 1 can lead to 1/0 when computing inv_jacobian so we simply
+  // avoid this issue by restricting to a <1.
+  if (compression_level_ >= 1.0) {
+    PARSE_ERROR(context, "Compression level must be less than 1.");
+  }
 }
 
 SphericalTorus::SphericalTorus(const std::array<double, 2>& radial_range,
                                const double min_polar_angle,
                                const double fraction_of_torus,
+                               const double compression_level,
                                const Options::Context& context)
     : SphericalTorus(radial_range[0], radial_range[1], min_polar_angle,
-                     fraction_of_torus, context) {}
+                     fraction_of_torus, compression_level, context) {}
 
 //
 //  * r       : radius
@@ -58,9 +71,9 @@ tnsr::I<T, 3> SphericalTorus::operator()(
     const tnsr::I<T, 3>& source_coords) const {
   tnsr::I<T, 3> result;
   const auto r = radius(get<0>(source_coords));
-  const auto theta =
-      M_PI_2 - (pi_over_2_minus_theta_min_ * get<1>(source_coords));
-  const auto phi = M_PI * fraction_of_torus_ * get<2>(source_coords);
+  const T theta = M_PI_2 - (pi_over_2_minus_theta_min_ *
+                            cubic_compression(get<1>(source_coords)));
+  const T phi = M_PI * fraction_of_torus_ * get<2>(source_coords);
   get<0>(result) = r * sin(theta) * cos(phi);
   get<1>(result) = r * sin(theta) * sin(phi);
   get<2>(result) = r * cos(theta);
@@ -77,7 +90,13 @@ tnsr::I<double, 3> SphericalTorus::inverse(
                  get<2>(target_coords));
   const double phi = std::atan2(get<1>(target_coords), get<0>(target_coords));
   get<0>(result) = radius_inverse(r);
+
   get<1>(result) = (M_PI_2 - theta) / pi_over_2_minus_theta_min_;
+  // if we are using compression (compression_level_ !=0), there is an extra
+  // step of inverting back to original eta before the cubic compression map.
+  if (compression_level_ != 0.0) {
+    get<1>(result) = cubic_inversion(get<1>(result));
+  }
   get<2>(result) = phi / (M_PI * fraction_of_torus_);
   return result;
 }
@@ -94,8 +113,9 @@ Jacobian<T, 3, Frame::BlockLogical, Frame::Inertial> SphericalTorus::jacobian(
 
   auto& sin_theta = get<2, 1>(jacobian);
   auto& cos_theta = get<2, 0>(jacobian);
-  get<2, 2>(jacobian) =
-      M_PI_2 - (pi_over_2_minus_theta_min_ * get<1>(source_coords));
+
+  get<2, 2>(jacobian) = M_PI_2 - (pi_over_2_minus_theta_min_ *
+                                  cubic_compression(get<1>(source_coords)));
   sin_theta = sin(get<2, 2>(jacobian));
   cos_theta = cos(get<2, 2>(jacobian));
 
@@ -118,8 +138,16 @@ Jacobian<T, 3, Frame::BlockLogical, Frame::Inertial> SphericalTorus::jacobian(
   get<1, 2>(jacobian) = M_PI * fraction_of_torus_ * r * sin_theta * cos_phi;
   get<2, 0>(jacobian) = 0.5 * (r_max_ - r_min_) * cos_theta;
   get<2, 1>(jacobian) = pi_over_2_minus_theta_min_ * r * sin_theta;
-  get<2, 2>(jacobian) = 0.0;
 
+  // an extra factor of partial deriv. from equatorial compression map
+  get<2, 2>(jacobian) =
+      3.0 * compression_level_ * pow<2>(get<1>(source_coords)) +
+      (1.0 - compression_level_);
+  get<0, 1>(jacobian) *= get<2, 2>(jacobian);
+  get<1, 1>(jacobian) *= get<2, 2>(jacobian);
+  get<2, 1>(jacobian) *= get<2, 2>(jacobian);
+  // Set it back to 0
+  get<2, 2>(jacobian) = 0.0;
   return jacobian;
 }
 
@@ -135,8 +163,9 @@ SphericalTorus::inv_jacobian(const tnsr::I<T, 3>& source_coords) const {
 
   auto& sin_theta = get<1, 2>(inv_jacobian);
   auto& cos_theta = get<0, 2>(inv_jacobian);
-  get<2, 2>(inv_jacobian) =
-      M_PI_2 - (pi_over_2_minus_theta_min_ * get<1>(source_coords));
+
+  get<2, 2>(inv_jacobian) = M_PI_2 - (pi_over_2_minus_theta_min_ *
+                                      cubic_compression(get<1>(source_coords)));
   cos_theta = cos(get<2, 2>(inv_jacobian));
   sin_theta = sin(get<2, 2>(inv_jacobian));
 
@@ -163,6 +192,16 @@ SphericalTorus::inv_jacobian(const tnsr::I<T, 3>& source_coords) const {
       (1.0 / (M_PI * fraction_of_torus_)) * cos_phi / (r * sin_theta);
   get<0, 2>(inv_jacobian) = 2.0 / (r_max_ - r_min_) * cos_theta;
   get<1, 2>(inv_jacobian) = (1.0 / pi_over_2_minus_theta_min_) * sin_theta / r;
+
+  // an extra factor of partial deriv. from equatorial compression map.
+  get<2, 2>(inv_jacobian) =
+      (3.0 * compression_level_ * pow<2>(get<1>(source_coords)) +
+       (1.0 - compression_level_));
+  get<1, 0>(inv_jacobian) /= get<2, 2>(inv_jacobian);
+  get<1, 1>(inv_jacobian) /= get<2, 2>(inv_jacobian);
+  get<1, 2>(inv_jacobian) /= get<2, 2>(inv_jacobian);
+
+  // set it back to 0.
   get<2, 2>(inv_jacobian) = 0.0;
 
   return inv_jacobian;
@@ -177,16 +216,24 @@ tnsr::Ijj<T, 3, Frame::NoFrame> SphericalTorus::hessian(
   // In order to reduce number of memory allocations we use some slots of
   // hessian for storing temp variables as below.
 
+  const double theta_factor = pi_over_2_minus_theta_min_;
+  const double phi_factor = M_PI * fraction_of_torus_;
+
   // these two slots are zeros (not used)
-  auto& theta_factor = get<2, 0, 0>(hessian);
-  auto& phi_factor = get<2, 0, 2>(hessian);
-  phi_factor = M_PI * fraction_of_torus_;
-  theta_factor = pi_over_2_minus_theta_min_;
+  // These two correspond to the derivative and double derivative of the
+  // cubic function we use for the equatorial compression.
+  auto& eta_prime = get<2, 0, 0>(hessian);
+  auto& eta_double_prime = get<2, 0, 2>(hessian);
+  eta_prime = 3 * compression_level_ * pow<2>(get<1>(source_coords)) + 1 -
+              compression_level_;
+  eta_double_prime = 6.0 * compression_level_ * get<1>(source_coords);
 
   // these two slots are zeros (not used)
   auto& cos_theta = get<2, 1, 2>(hessian);
   auto& sin_theta = get<2, 2, 2>(hessian);
-  get<0, 0, 0>(hessian) = M_PI_2 - (theta_factor * get<1>(source_coords));
+
+  get<0, 0, 0>(hessian) =
+      M_PI_2 - (theta_factor * cubic_compression(get<1>(source_coords)));
   cos_theta = cos(get<0, 0, 0>(hessian));
   sin_theta = sin(get<0, 0, 0>(hessian));
 
@@ -204,18 +251,27 @@ tnsr::Ijj<T, 3, Frame::NoFrame> SphericalTorus::hessian(
   radius(make_not_null(&r), get<0>(source_coords));
 
   // Note : execution order matters here
-  get<0, 0, 1>(hessian) = -r_factor * theta_factor * cos_theta * cos_phi;
+  get<0, 0, 1>(hessian) =
+      -r_factor * theta_factor * cos_theta * cos_phi * eta_prime;
   get<0, 0, 2>(hessian) = -r_factor * phi_factor * sin_theta * sin_phi;
-  get<0, 1, 1>(hessian) = -square(theta_factor) * r * sin_theta * cos_phi;
-  get<0, 1, 2>(hessian) = phi_factor * theta_factor * r * cos_theta * sin_phi;
+  get<0, 1, 1>(hessian) =
+      -square(theta_factor * eta_prime) * r * sin_theta * cos_phi -
+      theta_factor * r * cos_theta * cos_phi * eta_double_prime;
+  get<0, 1, 2>(hessian) =
+      phi_factor * theta_factor * r * cos_theta * sin_phi * eta_prime;
   get<0, 2, 2>(hessian) = -square(phi_factor) * r * sin_theta * cos_phi;
-  get<1, 0, 1>(hessian) = -r_factor * theta_factor * cos_theta * sin_phi;
+  get<1, 0, 1>(hessian) =
+      -r_factor * theta_factor * cos_theta * sin_phi * eta_prime;
   get<1, 0, 2>(hessian) = r_factor * phi_factor * sin_theta * cos_phi;
-  get<1, 1, 1>(hessian) = -square(theta_factor) * r * sin_theta * sin_phi;
-  get<1, 1, 2>(hessian) = -phi_factor * theta_factor * r * cos_theta * cos_phi;
+  get<1, 1, 1>(hessian) =
+      -square(theta_factor * eta_prime) * r * sin_theta * sin_phi -
+      theta_factor * r * cos_theta * sin_phi * eta_double_prime;
+  get<1, 1, 2>(hessian) =
+      -phi_factor * theta_factor * r * cos_theta * cos_phi * eta_prime;
   get<1, 2, 2>(hessian) = -square(phi_factor) * r * sin_theta * sin_phi;
-  get<2, 0, 1>(hessian) = r_factor * theta_factor * sin_theta;
-  get<2, 1, 1>(hessian) = -square(theta_factor) * r * cos_theta;
+  get<2, 0, 1>(hessian) = r_factor * theta_factor * sin_theta * eta_prime;
+  get<2, 1, 1>(hessian) = -square(theta_factor * eta_prime) * r * cos_theta +
+                          theta_factor * r * sin_theta * eta_double_prime;
 
   // remove temp vars and restore to zero
   get<0, 0, 0>(hessian) = 0.0;
@@ -237,6 +293,9 @@ tnsr::Ijk<T, 3, Frame::NoFrame> SphericalTorus::derivative_of_inv_jacobian(
   // In order to reduce number of memory allocations we use some slots of
   // `result` for storing temp variables as below.
 
+  const double theta_factor = pi_over_2_minus_theta_min_;
+  const double phi_factor = M_PI * fraction_of_torus_;
+
   auto& cos_phi = get<1, 2, 2>(result);
   auto& sin_phi = get<2, 2, 0>(result);
   get<0, 0, 0>(result) = M_PI * fraction_of_torus_ * get<2>(source_coords);
@@ -245,46 +304,60 @@ tnsr::Ijk<T, 3, Frame::NoFrame> SphericalTorus::derivative_of_inv_jacobian(
 
   auto& cos_theta = get<2, 2, 1>(result);
   auto& sin_theta = get<2, 2, 2>(result);
-  get<0, 0, 0>(result) =
-      M_PI_2 - (pi_over_2_minus_theta_min_ * get<1>(source_coords));
+
+  get<0, 0, 0>(result) = M_PI_2 - (pi_over_2_minus_theta_min_ *
+                                   cubic_compression(get<1>(source_coords)));
   cos_theta = cos(get<0, 0, 0>(result));
   sin_theta = sin(get<0, 0, 0>(result));
 
-  auto& theta_factor = get<0, 2, 0>(result);
-  auto& phi_factor = get<0, 2, 2>(result);
-  phi_factor = M_PI * fraction_of_torus_;
-  theta_factor = pi_over_2_minus_theta_min_;
+  // These two correspond to the derivative and double derivative of the
+  // cubic function we use for the equatorial compression.
+  auto& eta_prime = get<0, 2, 0>(result);
+  auto& eta_double_prime = get<0, 2, 2>(result);
+  eta_prime = 3.0 * compression_level_ * pow<2>(get<1>(source_coords)) + 1.0 -
+              compression_level_;
+  eta_double_prime = 6.0 * compression_level_ * get<1>(source_coords);
 
   auto& r = get<0, 0, 0>(result);
   auto& r_factor = get<0, 1, 0>(result);
   radius(make_not_null(&r), get<0>(source_coords));
   r_factor = 0.5 * (r_max_ - r_min_);
 
-  get<0, 0, 1>(result) = -theta_factor / r_factor * cos_theta * cos_phi;
+  get<0, 0, 1>(result) =
+      -theta_factor / r_factor * cos_theta * cos_phi * eta_prime;
   get<0, 0, 2>(result) = -phi_factor / r_factor * sin_theta * sin_phi;
-  get<0, 1, 1>(result) = -theta_factor / r_factor * cos_theta * sin_phi;
+  get<0, 1, 1>(result) =
+      -theta_factor / r_factor * cos_theta * sin_phi * eta_prime;
   get<0, 1, 2>(result) = phi_factor / r_factor * sin_theta * cos_phi;
-  get<0, 2, 1>(result) = theta_factor / r_factor * sin_theta;
+  get<0, 2, 1>(result) = theta_factor / r_factor * sin_theta * eta_prime;
   get<1, 0, 0>(result) =
-      r_factor / theta_factor * cos_theta * cos_phi / square(r);
-  get<1, 0, 1>(result) = -sin_theta * cos_phi / r;
-  get<1, 0, 2>(result) = phi_factor / theta_factor * cos_theta * sin_phi / r;
+      r_factor / theta_factor * cos_theta * cos_phi / (square(r) * eta_prime);
+  get<1, 0, 1>(result) =
+      (-cos_phi / r) * ((sin_theta) - ((cos_theta * eta_double_prime) /
+                                       (square(eta_prime) * theta_factor)));
+  get<1, 0, 2>(result) =
+      phi_factor / theta_factor * cos_theta * sin_phi / (r * eta_prime);
   get<1, 1, 0>(result) =
-      r_factor / theta_factor * cos_theta * sin_phi / square(r);
-  get<1, 1, 1>(result) = -sin_theta * sin_phi / r;
-  get<1, 1, 2>(result) = -phi_factor / theta_factor * cos_theta * cos_phi / r;
-  get<1, 2, 0>(result) = -r_factor / theta_factor * sin_theta / square(r);
-  get<1, 2, 1>(result) = -cos_theta / r;
+      r_factor / theta_factor * cos_theta * sin_phi / (square(r) * eta_prime);
+  get<1, 1, 1>(result) =
+      (-sin_phi / r) * ((sin_theta) - ((cos_theta * eta_double_prime) /
+                                       (square(eta_prime) * theta_factor)));
+  get<1, 1, 2>(result) =
+      -phi_factor / theta_factor * cos_theta * cos_phi / (r * eta_prime);
+  get<1, 2, 0>(result) =
+      -r_factor / theta_factor * sin_theta / (square(r) * eta_prime);
+  get<1, 2, 1>(result) =
+      (-1.0 / r) * (cos_theta + (sin_theta * eta_double_prime /
+                                 (square(eta_prime) * theta_factor)));
   get<2, 0, 0>(result) =
       r_factor / phi_factor * sin_phi / (square(r) * sin_theta);
-  get<2, 0, 1>(result) = -theta_factor / phi_factor * cos_theta * sin_phi /
-                         (r * square(sin_theta));
+  get<2, 0, 1>(result) = -theta_factor / phi_factor * cos_theta * sin_phi *
+                         eta_prime / (r * square(sin_theta));
   get<2, 0, 2>(result) = -cos_phi / (r * sin_theta);
-
   get<2, 1, 0>(result) =
       -r_factor / phi_factor * cos_phi / (square(r) * sin_theta);
-  get<2, 1, 1>(result) =
-      theta_factor / phi_factor * cos_theta * cos_phi / (r * square(sin_theta));
+  get<2, 1, 1>(result) = theta_factor / phi_factor * cos_theta * cos_phi *
+                         eta_prime / (r * square(sin_theta));
   get<2, 1, 2>(result) = -sin_phi / (r * sin_theta);
 
   // remove temp vars and restore to zero
@@ -301,16 +374,19 @@ tnsr::Ijk<T, 3, Frame::NoFrame> SphericalTorus::derivative_of_inv_jacobian(
 }
 
 void SphericalTorus::pup(PUP::er& p) {
-  size_t version = 0;
+  size_t version = 1;
   p | version;
   // Remember to increment the version number when making changes to this
   // function. Retain support for unpacking data written by previous versions
   // whenever possible. See `Domain` docs for details.
-  if (version >= 0) {
-    p | r_min_;
-    p | r_max_;
-    p | pi_over_2_minus_theta_min_;
-    p | fraction_of_torus_;
+  p | r_min_;
+  p | r_max_;
+  p | pi_over_2_minus_theta_min_;
+  p | fraction_of_torus_;
+  if (version > 0) {
+    p | compression_level_;
+  } else {
+    compression_level_ = 0;
   }
 }
 
@@ -333,6 +409,25 @@ bool operator==(const SphericalTorus& lhs, const SphericalTorus& rhs) {
   return lhs.r_min_ == rhs.r_min_ and lhs.r_max_ == rhs.r_max_ and
          lhs.pi_over_2_minus_theta_min_ == rhs.pi_over_2_minus_theta_min_ and
          lhs.fraction_of_torus_ == rhs.fraction_of_torus_;
+}
+
+template <typename T>
+T SphericalTorus::cubic_compression(const T& x) const {
+  return compression_level_ * pow<3>(x) + (1.0 - compression_level_) * x;
+}
+
+double SphericalTorus::cubic_inversion(const double x) const {
+  using std::abs;
+  // using p.228 of Numerical Recipe (cubic equation)
+  const double q = (compression_level_ - 1.0) / (3.0 * compression_level_);
+  const double r = -0.5 * x / (compression_level_);
+  const double a =
+      -sgn(r) * pow(abs(r) + sqrt(square(r) - pow<3>(q)), 1.0 / 3.0);
+  double b = 0.0;
+  if (a != 0.0) {
+    b = q / a;
+  }
+  return a + b;
 }
 
 bool operator!=(const SphericalTorus& lhs, const SphericalTorus& rhs) {

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_PolarMagnetizedFmDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_PolarMagnetizedFmDisk.cpp
@@ -53,28 +53,30 @@ void test_create_from_options() {
           "  TorusParameters:\n"
           "    RadialRange: [2.5, 3.6]\n"
           "    MinPolarAngle: 0.9\n"
-          "    FractionOfTorus: 0.7\n")
+          "    FractionOfTorus: 0.7\n"
+          "    CompressionLevel: 0.0\n")
           ->get_clone();
   const auto deserialized_option_solution =
       serialize_and_deserialize(option_solution);
   const auto& disk =
       dynamic_cast<const grmhd::AnalyticData::PolarMagnetizedFmDisk&>(
           *deserialized_option_solution);
-  CHECK(disk == grmhd::AnalyticData::PolarMagnetizedFmDisk(
-                    grmhd::AnalyticData::MagnetizedFmDisk(
-                        1.3, 0.345, 6.123, 14.2, 0.065, 1.654, 0.42, 85.0, 4),
-                    grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7)));
+  CHECK(disk ==
+        grmhd::AnalyticData::PolarMagnetizedFmDisk(
+            grmhd::AnalyticData::MagnetizedFmDisk(1.3, 0.345, 6.123, 14.2,
+                                                  0.065, 1.654, 0.42, 85.0, 4),
+            grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7, 0.0)));
 }
 
 void test_move() {
   grmhd::AnalyticData::PolarMagnetizedFmDisk disk(
       grmhd::AnalyticData::MagnetizedFmDisk(1.3, 0.345, 6.123, 14.2, 0.065,
                                             1.654, 0.42, 85.0, 4),
-      grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7));
+      grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7, 0.0));
   grmhd::AnalyticData::PolarMagnetizedFmDisk disk_copy(
       grmhd::AnalyticData::MagnetizedFmDisk(1.3, 0.345, 6.123, 14.2, 0.065,
                                             1.654, 0.42, 85.0, 4),
-      grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7));
+      grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7, 0.0));
   test_move_semantics(std::move(disk), disk_copy);
 }
 
@@ -82,7 +84,7 @@ void test_serialize() {
   grmhd::AnalyticData::PolarMagnetizedFmDisk disk(
       grmhd::AnalyticData::MagnetizedFmDisk(1.3, 0.345, 6.123, 14.2, 0.065,
                                             1.654, 0.42, 85.0, 4),
-      grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7));
+      grmhd::AnalyticData::SphericalTorus(2.5, 3.6, 0.9, 0.7, 0.0));
   test_serialization(disk);
 }
 
@@ -112,7 +114,7 @@ void test_variables(const DataType& used_for_size) {
           bh_mass, bh_dimless_spin, inner_edge_radius, max_pressure_radius,
           polytropic_constant, polytropic_exponent, threshold_density,
           inverse_plasma_beta, b_field_normalization),
-      grmhd::AnalyticData::SphericalTorus(3.0, 20.0, 1.0, 0.3));
+      grmhd::AnalyticData::SphericalTorus(3.0, 20.0, 1.0, 0.3, 0.0));
 
   const auto coords = make_with_value<tnsr::I<DataType, 3>>(used_for_size, 0.5);
 


### PR DESCRIPTION


## Proposed changes

Add an equatorial compression option for the spherical torus map using a simple cubic function. This is for PolarMagFmDisk runs which use spherical torus.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
