### PR TITLE
Add Christoffel symbol and trace to `BackgroundQuantities`

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.cpp
@@ -18,9 +18,12 @@ void UpdateAcceleration::apply(
                              ::Tags::dt<Tags::EvolvedVelocity<Dim>>>>*>
         dt_evolved_vars,
     const std::array<tnsr::I<double, Dim>, 2>& pos_vel,
-    const tuples::TaggedTuple<gr::Tags::SpacetimeMetric<double, Dim>,
-                              gr::Tags::InverseSpacetimeMetric<double, Dim>,
-                              Tags::TimeDilationFactor>& background,
+    const tuples::TaggedTuple<
+        gr::Tags::SpacetimeMetric<double, Dim>,
+        gr::Tags::InverseSpacetimeMetric<double, Dim>,
+        gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>,
+        gr::Tags::TraceSpacetimeChristoffelSecondKind<double, Dim>,
+        Tags::TimeDilationFactor>& background,
     const tnsr::I<double, Dim, Frame::Inertial>& geodesic_acc,
     const Scalar<double>& dt_psi_monopole,
     const tnsr::i<double, Dim, Frame::Inertial>& psi_dipole,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.hpp
@@ -46,9 +46,12 @@ struct UpdateAcceleration {
                                ::Tags::dt<Tags::EvolvedVelocity<Dim>>>>*>
           dt_evolved_vars,
       const std::array<tnsr::I<double, Dim>, 2>& pos_vel,
-      const tuples::TaggedTuple<gr::Tags::SpacetimeMetric<double, Dim>,
-                                gr::Tags::InverseSpacetimeMetric<double, Dim>,
-                                Tags::TimeDilationFactor>& background,
+      const tuples::TaggedTuple<
+          gr::Tags::SpacetimeMetric<double, Dim>,
+          gr::Tags::InverseSpacetimeMetric<double, Dim>,
+          gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>,
+          gr::Tags::TraceSpacetimeChristoffelSecondKind<double, Dim>,
+          Tags::TimeDilationFactor>& background,
       const tnsr::I<double, Dim, Frame::Inertial>& geodesic_acc,
       const Scalar<double>& dt_psi_monopole,
       const tnsr::i<double, Dim, Frame::Inertial>& psi_dipole, double charge,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -423,19 +423,23 @@ struct TimeDilationFactor : db::SimpleTag {
  */
 template <size_t Dim>
 struct BackgroundQuantities : db::SimpleTag {
-  using type =
-      tuples::TaggedTuple<gr::Tags::SpacetimeMetric<double, Dim>,
-                          gr::Tags::InverseSpacetimeMetric<double, Dim>,
-                          Tags::TimeDilationFactor>;
+  using type = tuples::TaggedTuple<
+      gr::Tags::SpacetimeMetric<double, Dim>,
+      gr::Tags::InverseSpacetimeMetric<double, Dim>,
+      gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>,
+      gr::Tags::TraceSpacetimeChristoffelSecondKind<double, Dim>,
+      Tags::TimeDilationFactor>;
 };
 
 template <size_t Dim>
 struct BackgroundQuantitiesCompute : BackgroundQuantities<Dim>, db::ComputeTag {
   using base = BackgroundQuantities<Dim>;
-  using return_type =
-      tuples::TaggedTuple<gr::Tags::SpacetimeMetric<double, Dim>,
-                          gr::Tags::InverseSpacetimeMetric<double, Dim>,
-                          Tags::TimeDilationFactor>;
+  using return_type = tuples::TaggedTuple<
+      gr::Tags::SpacetimeMetric<double, Dim>,
+      gr::Tags::InverseSpacetimeMetric<double, Dim>,
+      gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>,
+      gr::Tags::TraceSpacetimeChristoffelSecondKind<double, Dim>,
+      Tags::TimeDilationFactor>;
 
   using argument_tags = tmpl::list<
       ParticlePositionVelocity<Dim>,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -254,9 +254,12 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
         initial_refinements, quadrature, shell_domain, excision_sphere);
 
     // these are all unused
-    tuples::TaggedTuple<gr::Tags::SpacetimeMetric<double, Dim>,
-                        gr::Tags::InverseSpacetimeMetric<double, Dim>,
-                        Tags::TimeDilationFactor>
+    tuples::TaggedTuple<
+        gr::Tags::SpacetimeMetric<double, Dim>,
+        gr::Tags::InverseSpacetimeMetric<double, Dim>,
+        gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>,
+        gr::Tags::TraceSpacetimeChristoffelSecondKind<double, Dim>,
+        Tags::TimeDilationFactor>
         background_quantities{};
     MockWorldtubeSingleton<MockMetavariables<Dim>>::dt_variables_tag::type
         dt_variables{};

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
@@ -48,10 +48,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.UpdateAcceleration",
       make_not_null(&gen), dist, 1);
   const auto inverse_metric = make_with_random_values<tnsr::AA<double, Dim>>(
       make_not_null(&gen), dist, 1);
+  const auto christoffel = make_with_random_values<tnsr::Abb<double, Dim>>(
+      make_not_null(&gen), dist, 1);
+  const auto trace_christoffel = make_with_random_values<tnsr::A<double, Dim>>(
+      make_not_null(&gen), dist, 1);
   const auto dilation =
       make_with_random_values<Scalar<double>>(make_not_null(&gen), dist, 1);
   const Tags::BackgroundQuantities<Dim>::type background_quantities{
-      metric, inverse_metric, dilation};
+      metric, inverse_metric, christoffel, trace_christoffel, dilation};
   const auto dt_psi_monopole =
       make_with_random_values<Scalar<double>>(make_not_null(&gen), dist, 1);
   const auto psi_dipole = make_with_random_values<tnsr::i<double, Dim>>(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -436,7 +436,8 @@ void test_background_quantities_compute() {
       random_position, 0.,
       tmpl::list<gr::Tags::Lapse<double>, gr::Tags::Shift<double, Dim>,
                  gr::Tags::SpatialMetric<double, Dim>,
-                 gr::Tags::InverseSpatialMetric<double, Dim>>{});
+                 gr::Tags::InverseSpatialMetric<double, Dim>,
+                 gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>>{});
   const auto expected_metric = gr::spacetime_metric(
       get<gr::Tags::Lapse<double>>(kerr_schild_quantities),
       get<gr::Tags::Shift<double, Dim>>(kerr_schild_quantities),
@@ -445,6 +446,12 @@ void test_background_quantities_compute() {
       get<gr::Tags::Lapse<double>>(kerr_schild_quantities),
       get<gr::Tags::Shift<double, Dim>>(kerr_schild_quantities),
       get<gr::Tags::InverseSpatialMetric<double, Dim>>(kerr_schild_quantities));
+  const auto& expected_christoffel =
+      get<gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>>(
+          kerr_schild_quantities);
+  const auto expected_trace_christoffel =
+      tenex::evaluate<ti::C>(expected_inverse_metric(ti::A, ti::B) *
+                             expected_christoffel(ti::C, ti::a, ti::b));
 
   const auto& background_quantities =
       db::get<Tags::BackgroundQuantities<Dim>>(box);
@@ -453,9 +460,17 @@ void test_background_quantities_compute() {
       get<gr::Tags::SpacetimeMetric<double, Dim>>(background_quantities);
   const auto& inverse_metric =
       get<gr::Tags::InverseSpacetimeMetric<double, Dim>>(background_quantities);
+  const auto& christoffel =
+      get<gr::Tags::SpacetimeChristoffelSecondKind<double, Dim>>(
+          background_quantities);
+  const auto& trace_christoffel =
+      get<gr::Tags::TraceSpacetimeChristoffelSecondKind<double, Dim>>(
+          background_quantities);
 
   CHECK_ITERABLE_APPROX(metric, expected_metric);
   CHECK_ITERABLE_APPROX(inverse_metric, expected_inverse_metric);
+  CHECK_ITERABLE_APPROX(christoffel, expected_christoffel);
+  CHECK_ITERABLE_APPROX(trace_christoffel, expected_trace_christoffel);
 
   const double dilation_factor =
       get(get<Tags::TimeDilationFactor>(background_quantities));


### PR DESCRIPTION
Adds the Christoffel symbol of the second kind as well as its trace to the `BackgroundQuantities` tag.