### PR TITLE
Fix `size_t` underflow in geodesic worldtube evolution

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
@@ -164,8 +164,8 @@ struct SendToWorldtube {
     Parallel::receive_data<Worldtube::Tags::SphericalHarmonicsInbox<Dim>>(
         worldtube_component, db::get<::Tags::TimeStepId>(box),
         std::make_pair(element_id, std::move(Ylm_coefs)));
-    if (db::get<Tags::CurrentIteration>(box) <
-        db::get<Tags::MaxIterations>(box) - 1) {
+    if (db::get<Tags::CurrentIteration>(box) + 1 <
+        db::get<Tags::MaxIterations>(box) ) {
       db::mutate<Tags::CurrentIteration>(
           [](const gsl::not_null<size_t*> current_iteration) {
             *current_iteration += 1;

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ReceiveElementData.hpp
@@ -128,8 +128,8 @@ struct ReceiveElementData {
         ylm::ylm_to_stf_0(dt_psi_ylm_l0), std::move(psi_stf_l1),
         std::move(dt_psi_stf_l1));
     inbox.erase(time_step_id);
-    if (db::get<Tags::CurrentIteration>(box) <
-        db::get<Tags::MaxIterations>(box) - 1) {
+    if (db::get<Tags::CurrentIteration>(box) + 1 <
+        db::get<Tags::MaxIterations>(box)) {
       db::mutate<Tags::CurrentIteration>(
           [](const gsl::not_null<size_t*> current_iteration) {
             *current_iteration += 1;

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
@@ -296,7 +296,7 @@ void test_iterations(const size_t max_iterations) {
           make_not_null(&runner), element_id));
     }
 
-    for (size_t current_iteration = 1; current_iteration <= max_iterations - 1;
+    for (size_t current_iteration = 1; current_iteration + 1 <= max_iterations;
          ++current_iteration) {
       CAPTURE(current_iteration);
       using inbox_tag = Tags::SphericalHarmonicsInbox<Dim>;
@@ -411,6 +411,7 @@ void test_iterations(const size_t max_iterations) {
 }
 
 SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.Iterations", "[Unit]") {
+  test_iterations(0);
   test_iterations(1);
   test_iterations(2);
   test_iterations(5);


### PR DESCRIPTION
For a geodesic evolution, the `MaxIterations` variable of type `size_t` is set to 0. However, the iteration termination condition in the code computes `MaxIterations - 1` which causes an underflow and an infinite loop. This PR fixes this and adds the neccessary test.