### PR TITLE
Add serial numeric initial data loading

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -58,6 +58,20 @@ target_link_libraries(
   SpectreWarnNoNoexceptType
   )
 
+# GCC versions below 13 don't respect 'GCC diagnostic' pragmas to disable
+# warnings by the preprocessor:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
+# So we disable the warning about unknown pragmas because we can't silence it.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
+  create_cxx_flag_target("-Wno-unknown-pragmas" SpectreWarnNoUnknownPragmas)
+  target_link_libraries(
+    SpectreWarnings
+    INTERFACE
+    SpectreWarnNoUnknownPragmas
+    )
+endif()
+
 target_link_libraries(
   SpectreFlags
   INTERFACE

--- a/src/Elliptic/Executables/Elasticity/CMakeLists.txt
+++ b/src/Elliptic/Executables/Elasticity/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   FunctionsOfTime
   Informer
+  InitialDataUtilities
   LinearOperators
   Observer
   Options

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -48,6 +48,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -94,9 +95,13 @@ struct Metavariables {
                    Elasticity::BoundaryConditions::standard_boundary_conditions<
                        system>>,
         tmpl::pair<elliptic::analytic_data::Background,
-                   Elasticity::Solutions::all_analytic_solutions<volume_dim>>,
+                   tmpl::push_back<Elasticity::Solutions::
+                                       all_analytic_solutions<volume_dim>,
+                                   elliptic::analytic_data::NumericData>>,
         tmpl::pair<elliptic::analytic_data::InitialGuess,
-                   Elasticity::Solutions::all_analytic_solutions<volume_dim>>,
+                   tmpl::push_back<Elasticity::Solutions::
+                                       all_analytic_solutions<volume_dim>,
+                                   elliptic::analytic_data::NumericData>>,
         tmpl::pair<elliptic::analytic_data::AnalyticSolution,
                    Elasticity::Solutions::all_analytic_solutions<volume_dim>>,
         tmpl::pair<
@@ -107,17 +112,17 @@ struct Metavariables {
                    ::amr::Criteria::standard_criteria<
                        volume_dim,
                        tmpl::list<Elasticity::Tags::Displacement<volume_dim>>>>,
-        tmpl::pair<
-            Event,
-            tmpl::flatten<tmpl::list<
-                Events::Completion,
-                dg::Events::field_observations<
-                    volume_dim, observe_fields, observer_compute_tags,
-                    LinearSolver::multigrid::Tags::IsFinestGrid>,
-                // Observation per material layer
-                ::Events::ObserveNorms<observe_fields, observer_compute_tags,
-                                       Elasticity::Tags::MaterialLayerName,
-                                       ObserveNormsPerLayer>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, observer_compute_tags,
+                           LinearSolver::multigrid::Tags::IsFinestGrid>,
+                       // Observation per material layer
+                       ::Events::ObserveNorms<
+                           observe_fields, observer_compute_tags,
+                           Elasticity::Tags::MaterialLayerName,
+                           ObserveNormsPerLayer>>>>,
         tmpl::pair<Trigger, elliptic::Triggers::all_triggers<
                                 ::amr::OptionTags::AmrGroup>>,
         tmpl::pair<

--- a/src/Elliptic/Executables/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Executables/Poisson/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   FunctionsOfTime
   Informer
+  InitialDataUtilities
   LinearOperators
   MathFunctions
   Observer

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -43,6 +43,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -85,9 +86,13 @@ struct Metavariables {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<elliptic::analytic_data::Background,
-                   Poisson::Solutions::all_analytic_solutions<volume_dim>>,
+                   tmpl::push_back<
+                       Poisson::Solutions::all_analytic_solutions<volume_dim>,
+                       elliptic::analytic_data::NumericData>>,
         tmpl::pair<elliptic::analytic_data::InitialGuess,
-                   Poisson::Solutions::all_analytic_solutions<volume_dim>>,
+                   tmpl::push_back<
+                       Poisson::Solutions::all_analytic_solutions<volume_dim>,
+                       elliptic::analytic_data::NumericData>>,
         tmpl::pair<elliptic::analytic_data::AnalyticSolution,
                    Poisson::Solutions::all_analytic_solutions<volume_dim>>,
         tmpl::pair<

--- a/src/Elliptic/Executables/Punctures/CMakeLists.txt
+++ b/src/Elliptic/Executables/Punctures/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   EventsAndTriggers
   FunctionsOfTime
   Informer
+  InitialDataUtilities
   Initialization
   LinearOperators
   MathFunctions

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
@@ -43,6 +43,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
 #include "PointwiseFunctions/Punctures/AdmIntegrals.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -73,9 +74,11 @@ struct Metavariables {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<elliptic::analytic_data::Background,
-                   tmpl::list<Punctures::AnalyticData::MultiplePunctures>>,
+                   tmpl::list<Punctures::AnalyticData::MultiplePunctures,
+                              elliptic::analytic_data::NumericData>>,
         tmpl::pair<elliptic::analytic_data::InitialGuess,
-                   tmpl::list<Punctures::Solutions::Flatness>>,
+                   tmpl::list<Punctures::Solutions::Flatness,
+                              elliptic::analytic_data::NumericData>>,
         tmpl::pair<elliptic::analytic_data::AnalyticSolution, tmpl::list<>>,
         tmpl::pair<elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
                    tmpl::list<Punctures::BoundaryConditions::Flatness>>,

--- a/src/Elliptic/Executables/Xcts/CMakeLists.txt
+++ b/src/Elliptic/Executables/Xcts/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
   FunctionsOfTime
   Hydro
   Informer
+  InitialDataUtilities
   Initialization
   LinearOperators
   MathFunctions

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -49,6 +49,7 @@
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
 #include "PointwiseFunctions/Xcts/SpacetimeQuantities.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -116,7 +117,8 @@ struct Metavariables {
     using analytic_solutions_and_data = tmpl::push_back<
         Xcts::Solutions::all_analytic_solutions,
         Xcts::AnalyticData::Binary<elliptic::analytic_data::AnalyticSolution,
-                                   Xcts::Solutions::all_analytic_solutions>>;
+                                   Xcts::Solutions::all_analytic_solutions>,
+        elliptic::analytic_data::NumericData>;
 
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBS_TO_LINK
   EventsAndTriggers
   Evolution
   Informer
+  InitialDataUtilities
   LinearOperators
   MathFunctions
   ScalarWave

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -86,6 +86,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/AdvanceTime.hpp"
@@ -187,7 +188,9 @@ struct EvolutionMetavars {
                        dg::Events::field_observations<
                            volume_dim, observe_fields, non_tensor_compute_tags>,
                        Events::time_events<system>>>>,
-        tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
+        tmpl::pair<evolution::initial_data::InitialData,
+                   tmpl::push_back<initial_data_list,
+                                   evolution::initial_data::NumericData>>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,
                    MathFunctions::all_math_functions<1, Frame::Inertial>>,

--- a/src/IO/Exporter/CMakeLists.txt
+++ b/src/IO/Exporter/CMakeLists.txt
@@ -22,11 +22,13 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Exporter.hpp
+  InterpolateToPoints.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  DataStructures
   Domain
   DomainCreators
   FunctionsOfTime

--- a/src/IO/Exporter/InterpolateToPoints.hpp
+++ b/src/IO/Exporter/InterpolateToPoints.hpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "IO/Exporter/Exporter.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace spectre::Exporter {
+
+/*!
+ * \brief Interpolates data in volume files to target points
+ *
+ * This is an overload of the `interpolate_to_points` function that works with
+ * Tensor types and tags, rather than the raw C++ types that are used in the
+ * other overload so it can be used by external programs.
+ *
+ * The `Tags` template parameter is a typelist of tags that should be read from
+ * the volume files. The dataset names to read are constructed from the tag
+ * names. Here is an example of how to use this function:
+ *
+ * \snippet Test_Exporter.cpp interpolate_tensors_to_points_example
+ */
+template <typename Tags, typename DataType, size_t Dim>
+tuples::tagged_tuple_from_typelist<Tags> interpolate_to_points(
+    const std::variant<std::vector<std::string>, std::string>&
+        volume_files_or_glob,
+    const std::string& subfile_name,
+    const std::variant<ObservationId, ObservationStep>& observation,
+    const tnsr::I<DataType, Dim>& target_points,
+    bool extrapolate_into_excisions = false,
+    std::optional<size_t> num_threads = std::nullopt) {
+  // Convert target_points to an array of vectors
+  // Possible performance optimization: avoid copying the data by allowing
+  // interpolate_to_points to accept pointers or spans.
+  const size_t num_points = target_points.begin()->size();
+  std::array<std::vector<double>, Dim> target_points_array{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(target_points_array, d).resize(num_points);
+    for (size_t i = 0; i < num_points; ++i) {
+      gsl::at(target_points_array, d)[i] = target_points.get(d)[i];
+    }
+  }
+  // Collect tensor component names
+  std::vector<std::string> tensor_components{};
+  tmpl::for_each<Tags>([&tensor_components](auto tag_v) {
+    using tensor_tag = tmpl::type_from<decltype(tag_v)>;
+    using TensorType = typename tensor_tag::type;
+    const std::string tag_name = db::tag_name<tensor_tag>();
+    for (size_t i = 0; i < TensorType::size(); ++i) {
+      const std::string component_name =
+          tag_name + TensorType::component_suffix(i);
+      tensor_components.push_back(component_name);
+    }
+  });
+  // Interpolate!
+  const auto interpolated_data = interpolate_to_points(
+      volume_files_or_glob, subfile_name, observation, tensor_components,
+      target_points_array, extrapolate_into_excisions, num_threads);
+  // Convert the interpolated data to a tagged_tuple
+  tuples::tagged_tuple_from_typelist<Tags> result{};
+  size_t component_index = 0;
+  tmpl::for_each<Tags>(
+      [&component_index, &interpolated_data, &result](auto tag_v) {
+        using tensor_tag = tmpl::type_from<decltype(tag_v)>;
+        using TensorType = typename tensor_tag::type;
+        for (size_t i = 0; i < TensorType::size(); ++i) {
+          const auto& component_data = interpolated_data[component_index];
+          get<tensor_tag>(result)[i] = DataVector(component_data);
+          ++component_index;
+        }
+      });
+  return result;
+}
+
+}  // namespace spectre::Exporter

--- a/src/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
+++ b/src/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 set(LIBRARY InitialDataUtilities)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  NumericData.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
@@ -13,12 +19,17 @@ spectre_target_headers(
   Background.hpp
   InitialData.hpp
   InitialGuess.hpp
+  NumericData.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PUBLIC
+  DataStructures
+  Exporter
+  Options
   Serialization
+  Spectral
   )
 
 add_subdirectory(Tags)

--- a/src/PointwiseFunctions/InitialDataUtilities/NumericData.cpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/NumericData.cpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <utility>
+
+NumericData::NumericData(std::string file_glob, std::string subgroup,
+                         int observation_step, bool extrapolate_into_excisions)
+    : file_glob_(std::move(file_glob)),
+      subgroup_(std::move(subgroup)),
+      observation_step_(observation_step),
+      extrapolate_into_excisions_(extrapolate_into_excisions) {}
+
+bool operator==(const NumericData& lhs, const NumericData& rhs) {
+  return lhs.file_glob() == rhs.file_glob() and
+         lhs.subgroup() == rhs.subgroup() and
+         lhs.observation_step() == rhs.observation_step() and
+         lhs.extrapolate_into_excisions() == rhs.extrapolate_into_excisions();
+}
+
+bool operator!=(const NumericData& lhs, const NumericData& rhs) {
+  return not(lhs == rhs);
+}
+
+void NumericData::pup(PUP::er& p) {
+  p | file_glob_;
+  p | subgroup_;
+  p | observation_step_;
+  p | extrapolate_into_excisions_;
+}
+
+namespace elliptic::analytic_data {
+
+NumericData::NumericData(CkMigrateMessage* m)
+    : elliptic::analytic_data::Background(m),
+      elliptic::analytic_data::InitialGuess(m) {}
+
+void NumericData::pup(PUP::er& p) {
+  elliptic::analytic_data::Background::pup(p);
+  elliptic::analytic_data::InitialGuess::pup(p);
+  ::NumericData::pup(p);
+}
+
+bool operator==(const NumericData& lhs, const NumericData& rhs) {
+  return static_cast<const ::NumericData&>(lhs) ==
+         static_cast<const ::NumericData&>(rhs);
+}
+
+bool operator!=(const NumericData& lhs, const NumericData& rhs) {
+  return not(lhs == rhs);
+}
+
+PUP::able::PUP_ID NumericData::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace elliptic::analytic_data
+
+namespace evolution::initial_data {
+
+NumericData::NumericData(CkMigrateMessage* m)
+    : evolution::initial_data::InitialData(m) {}
+
+std::unique_ptr<evolution::initial_data::InitialData> NumericData::get_clone()
+    const {
+  return std::make_unique<NumericData>(*this);
+}
+
+void NumericData::pup(PUP::er& p) {
+  evolution::initial_data::InitialData::pup(p);
+  ::NumericData::pup(p);
+}
+
+bool operator==(const NumericData& lhs, const NumericData& rhs) {
+  return static_cast<const ::NumericData&>(lhs) ==
+         static_cast<const ::NumericData&>(rhs);
+}
+
+bool operator!=(const NumericData& lhs, const NumericData& rhs) {
+  return not(lhs == rhs);
+}
+
+PUP::able::PUP_ID NumericData::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace evolution::initial_data

--- a/src/PointwiseFunctions/InitialDataUtilities/NumericData.hpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/NumericData.hpp
@@ -1,0 +1,199 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "IO/Exporter/InterpolateToPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/*!
+ * \brief Load numeric data from volume data files
+ *
+ * This class loads all requested tags from volume data files using
+ * `spectre::Exporter::interpolate_to_points`. This is an easy and useful
+ * alternative to `importers::ElementDataReader` to load numeric data with the
+ * following advantages:
+ *
+ * - No need to work with parallel components, actions, or phases to load
+ *   numeric data. Also, no need to parse numeric data options separately from
+ *   analytic data options. Just include this class in the list of analytic data
+ *   classes for the executable.
+ * - The data is interpolated and returned in serial, just like analytic data.
+ * - The data can be re-interpolated to any set of points on request, which is
+ *   an easy way to handle AMR or other domain changes.
+ *
+ * However, it also comes with the following caveats:
+ *
+ * - The volume data files must have datasets with the same names as the tags
+ *   being loaded. For example, if the tag being loaded is `gr::Tags::Shift`,
+ *   then the volume data files must have datasets named `Shift_x`, `Shift_y`,
+ *   and `Shift_z`. If you need processing of the data before it can be used,
+ *   e.g. to load some datasets and compute other derived quantities from them,
+ *   then consider writing a custom class or use `importers::ElementDataReader`.
+ * - Reading in data on the same grid that it was written on may not give you
+ *   the same data back, at least not on Gauss-Lobatto grids. This is because
+ *   grid points on element boundaries are disambiguated by
+ *   `block_logical_coordinates` and `element_logical_coordinates`, so a
+ *   boundary point may be written by one element but read back in from its
+ *   neighbor. To avoid this, consider using `importers::ElementDataReader`
+ *   which has functionality to read in data on the same grid that it was
+ *   written on. This is not possible with this class because it is not aware of
+ *   the element structure (it operates in a pointwise manner).
+ * - Large datasets may not fit in memory. Each element will open the H5 files
+ *   and interpolate data from them, so this may not fit in memory if the
+ *   datasets are large and/or many elements are doing this at the same time. To
+ *   avoid this, consider using `importers::ElementDataReader` which reads one
+ *   H5 file at a time on the node level.
+ */
+class NumericData {
+ public:
+  struct FileGlob {
+    static constexpr Options::String help =
+        "Path or glob pattern to the data file";
+    using type = std::string;
+  };
+  struct Subgroup {
+    static constexpr Options::String help = {
+        "The subgroup within the file, excluding extensions"};
+    using type = std::string;
+  };
+  struct ObservationStep {
+    static constexpr Options::String help =
+        "The observation step at which to read data";
+    using type = int;
+  };
+  struct ExtrapolateIntoExcisions {
+    static constexpr Options::String help = {
+        "Whether to extrapolate data into excised regions"};
+    using type = bool;
+  };
+  using options =
+      tmpl::list<FileGlob, Subgroup, ObservationStep, ExtrapolateIntoExcisions>;
+  static constexpr Options::String help =
+      "Numeric data loaded from volume data files";
+
+  NumericData() = default;
+  NumericData(const NumericData&) = default;
+  NumericData& operator=(const NumericData&) = default;
+  NumericData(NumericData&&) = default;
+  NumericData& operator=(NumericData&&) = default;
+  ~NumericData() = default;
+
+  NumericData(std::string file_glob, std::string subgroup, int observation_step,
+              bool extrapolate_into_excisions);
+
+  const std::string& file_glob() const { return file_glob_; }
+
+  const std::string& subgroup() const { return subgroup_; }
+
+  int observation_step() const { return observation_step_; }
+
+  bool extrapolate_into_excisions() const {
+    return extrapolate_into_excisions_;
+  }
+
+  template <typename DataType, size_t Dim, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, Dim>& x,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    return spectre::Exporter::interpolate_to_points<
+        tmpl::list<RequestedTags...>>(
+        file_glob_, subgroup_,
+        spectre::Exporter::ObservationStep{observation_step_}, x,
+        extrapolate_into_excisions_);
+  }
+
+  template <size_t Dim, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    return variables(x, tmpl::list<RequestedTags...>{});
+  }
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p);
+
+ protected:
+  std::string file_glob_{};
+  std::string subgroup_{};
+  int observation_step_{};
+  bool extrapolate_into_excisions_{};
+};
+
+bool operator==(const NumericData& lhs, const NumericData& rhs);
+bool operator!=(const NumericData& lhs, const NumericData& rhs);
+
+namespace elliptic::analytic_data {
+
+/*!
+ * \brief Load numeric data from volume data files
+ *
+ * \see ::NumericData
+ */
+class NumericData : public elliptic::analytic_data::Background,
+                    public elliptic::analytic_data::InitialGuess,
+                    public ::NumericData {
+ public:
+  using ::NumericData::NumericData;
+
+  explicit NumericData(CkMigrateMessage* m);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(NumericData);
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p) override;
+};
+
+bool operator==(const NumericData& lhs, const NumericData& rhs);
+bool operator!=(const NumericData& lhs, const NumericData& rhs);
+
+}  // namespace elliptic::analytic_data
+
+namespace evolution::initial_data {
+
+/*!
+ * \brief Load numeric data from volume data files
+ *
+ * \see ::NumericData
+ */
+class NumericData : public evolution::initial_data::InitialData,
+                    public ::NumericData {
+ public:
+  using ::NumericData::NumericData;
+
+  explicit NumericData(CkMigrateMessage* m);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(NumericData);
+
+  std::unique_ptr<evolution::initial_data::InitialData> get_clone()
+      const override;
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p) override;
+};
+
+bool operator==(const NumericData& lhs, const NumericData& rhs);
+bool operator!=(const NumericData& lhs, const NumericData& rhs);
+
+}  // namespace evolution::initial_data

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -18,7 +18,9 @@
 #include "Domain/Creators/Rectilinear.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "IO/Exporter/Exporter.hpp"
+#include "IO/Exporter/InterpolateToPoints.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/TensorData.hpp"
 #include "IO/H5/VolumeData.hpp"
@@ -45,6 +47,26 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
     CHECK(psi[1] == approx(0.7869554122196492));
     CHECK(psi[2] == approx(0.9876185584100299));
     const auto& phi_y = interpolated_data[2];
+    CHECK(phi_y[0] == approx(1.0569673471948728));
+    CHECK(phi_y[1] == approx(0.6741524090220188));
+    CHECK(phi_y[2] == approx(0.2629752479142838));
+  }
+  {
+    INFO("Tensor interface");
+    // [interpolate_tensors_to_points_example]
+    const tnsr::I<DataVector, 3> target_points{
+        {{{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 0.0}}}};
+    const auto interpolated_data = interpolate_to_points<
+        tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Phi<3>>>(
+        unit_test_src_path() + "/Visualization/Python/VolTestData*.h5",
+        "element_data", ObservationStep{0}, target_points);
+    const auto& psi = get(get<ScalarWave::Tags::Psi>(interpolated_data));
+    // [interpolate_tensors_to_points_example]
+    CHECK(psi[0] == approx(-0.07059806932542323));
+    CHECK(psi[1] == approx(0.7869554122196492));
+    CHECK(psi[2] == approx(0.9876185584100299));
+    const auto& phi_y =
+        get<1>(get<ScalarWave::Tags::Phi<3>>(interpolated_data));
     CHECK(phi_y[0] == approx(1.0569673471948728));
     CHECK(phi_y[1] == approx(0.6741524090220188));
     CHECK(phi_y[2] == approx(0.2629752479142838));

--- a/tests/Unit/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Test_InitialDataUtilities)
 
 set(LIBRARY_SOURCES
   Tags/Test_InitialData.cpp
+  Test_NumericData.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
@@ -12,5 +13,6 @@ add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  InitialDataUtilities
   Parallel
   )

--- a/tests/Unit/PointwiseFunctions/InitialDataUtilities/Test_NumericData.cpp
+++ b/tests/Unit/PointwiseFunctions/InitialDataUtilities/Test_NumericData.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
+
+template <typename Subclass>
+void test_numeric_data() {
+  const std::string file_name =
+      unit_test_src_path() + "/Visualization/Python/VolTestData*.h5";
+  const std::string option_string = "FileGlob: " + file_name +
+                                    "\nSubgroup: element_data\n"
+                                    "ObservationStep: -1\n"
+                                    "ExtrapolateIntoExcisions: False\n";
+  const auto created = TestHelpers::test_creation<Subclass>(option_string);
+  const elliptic::analytic_data::NumericData numeric_data{
+      file_name, "element_data", -1, false};
+  CHECK(created == numeric_data);
+  test_serialization(numeric_data);
+  test_copy_semantics(numeric_data);
+
+  const auto interpolated_data = numeric_data.variables(
+      tnsr::I<DataVector, 3>{
+          {{{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 0.0}}}},
+      tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Phi<3>>{});
+  const auto& psi = get(get<ScalarWave::Tags::Psi>(interpolated_data));
+  CHECK(psi[0] == approx(-0.07059806932542323));
+  CHECK(psi[1] == approx(0.7869554122196492));
+  CHECK(psi[2] == approx(0.9876185584100299));
+  const auto& phi_y = get<1>(get<ScalarWave::Tags::Phi<3>>(interpolated_data));
+  CHECK(phi_y[0] == approx(1.0569673471948728));
+  CHECK(phi_y[1] == approx(0.6741524090220188));
+  CHECK(phi_y[2] == approx(0.2629752479142838));
+}
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.InitialDataUtilities.NumericData",
+                  "[Unit][PointwiseFunctions]") {
+  test_numeric_data<elliptic::analytic_data::NumericData>();
+  test_numeric_data<evolution::initial_data::NumericData>();
+}


### PR DESCRIPTION
## Proposed changes

Adds a `NumericData` class that can be used in place of analytic data. It just loads the requested tags from numeric volume data files, just like the SpEC or FUKA initial data classes. It's an easy alternative to the parallel numeric data reader. See the docs in this PR for advantages and caveats.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
