### PR TITLE
Fix clang-tidy quirk

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,7 +55,7 @@ Checks: '*,
 -llvm-qualified-auto,
 # We are not developing LLVM libc,
 -llvmlibc-*,
-# Triggers when 'l' is used because it's "too similar" to 'I'
+# Triggers when "l" is used because it's "too similar" to "I",
 -misc-confusable-identifiers,
 # thinks constexpr variables in header files cause ODR violations,
 -misc-definitions-in-headers,


### PR DESCRIPTION
## Proposed changes

My bad for missing this. It's causing clang-tidy to fail on all PRs that have been rebased.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
