### PR TITLE
Change non-monotonic AM predictor coefficients

### DIFF
--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -396,26 +396,17 @@ void AdamsMoultonPc<Monotonic>::add_boundary_delta_impl(
   } else {
     adams_lts::AdamsScheme scheme{adams_lts::SchemeType::Implicit,
                                   current_order};
-    auto remote_scheme = scheme;
 
     if (local_times.number_of_substeps(local_times.size() - 1) == 1) {
       // Predictor
       scheme = {adams_lts::SchemeType::Explicit, current_order - 1};
       ASSERT(remote_times.back() <= local_times.back(),
              "Unexpected remote values available.");
-      // If the sides are not aligned, we use the predictor data
-      // available from the neighbor.  If they are, that data has not
-      // been received.
-      remote_scheme = {remote_times.back() == local_times.back()
-                           ? adams_lts::SchemeType::Explicit
-                           : adams_lts::SchemeType::Implicit,
-                       current_order - 1};
     }
 
     const auto lts_coefficients = adams_lts::lts_coefficients(
         local_times, remote_times, local_times.back().step_time(),
-        local_times.back().step_time() + time_step, scheme, remote_scheme,
-        scheme);
+        local_times.back().step_time() + time_step, scheme, scheme, scheme);
     adams_lts::apply_coefficients(result, lts_coefficients, coupling);
   }
 }


### PR DESCRIPTION
Either version works, but this version makes the analytic expressions nicer and is what will be in the paper.

Note that this does not affect the BBH paper, because that uses the monotonic method.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
