### PR TITLE
Limit ADM integrals observer to the finest grid.

### DIFF
--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -134,7 +134,9 @@ struct Metavariables {
                        volume_dim, typename system::primal_fields>>,
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
-                       Events::Completion, Events::ObserveAdmIntegrals,
+                       Events::Completion,
+                       Events::ObserveAdmIntegrals<
+                           LinearSolver::multigrid::Tags::IsFinestGrid>,
                        dg::Events::field_observations<
                            volume_dim, observe_fields, observer_compute_tags,
                            LinearSolver::multigrid::Tags::IsFinestGrid>>>>,

--- a/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.cpp
+++ b/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.cpp
@@ -148,6 +148,4 @@ void local_adm_integrals(
   }
 }
 
-PUP::able::PUP_ID ObserveAdmIntegrals::my_PUP_ID = 0;  // NOLINT
-
 }  // namespace Events


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Before this PR, the ADM integrals observer was summing over all grids, which becomes a problem when using multigrid for the linear solver. With this PR, we limit the reduction to only the finest grid.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
