### PR TITLE
TransformVolumeData.py: support ElementId in kernels

### DIFF
--- a/src/Domain/Python/ElementId.cpp
+++ b/src/Domain/Python/ElementId.cpp
@@ -29,6 +29,9 @@ void bind_element_id_impl(py::module& m) {  // NOLINT
            py::arg("segment_ids"))
       .def(py::init<const std::string&>(), py::arg("grid_name"))
       .def_property("block_id", &ElementId<Dim>::block_id, nullptr)
+      .def_property("grid_index", &ElementId<Dim>::grid_index, nullptr)
+      .def_property("refinement_levels", &ElementId<Dim>::refinement_levels,
+                    nullptr)
       .def_property("segment_ids", &ElementId<Dim>::segment_ids, nullptr)
       .def_static("external_boundary_id", &ElementId<Dim>::external_boundary_id)
       .def("id_of_child", &ElementId<Dim>::id_of_child, py::arg("dim"),

--- a/src/IO/Exporter/Python/__init__.py
+++ b/src/IO/Exporter/Python/__init__.py
@@ -46,4 +46,4 @@ def interpolate_tensors_to_points(
         for i in range(tensor.size):
             tensor[i] = DataVector(data[j])
             j += 1
-    return tensors.values()
+    return list(tensors.values())

--- a/src/Visualization/Python/TransformVolumeData.py
+++ b/src/Visualization/Python/TransformVolumeData.py
@@ -24,6 +24,7 @@ from spectre.DataStructures.Tensor import (
     Tensor,
     tnsr,
 )
+from spectre.Domain import ElementId
 from spectre.IO.H5.IterElements import Element, iter_elements
 from spectre.NumericalAlgorithms.LinearOperators import definite_integral
 from spectre.Spectral import Mesh
@@ -167,6 +168,7 @@ def parse_kernel_arg(
     arguments are supported:
 
     - Mesh: Annotate the argument with a 'Mesh' type.
+    - ElementId: Annotate the argument with an 'ElementId' type.
     - Coordinates: Annotate the argument with a 'tnsr.I' type and name it
         "logical_coords" / "logical_coordinates" or "inertial_coords" /
         "inertial_coordinates" / "x".
@@ -218,6 +220,8 @@ def parse_kernel_arg(
 
     if arg.annotation in Mesh.values():
         return ElementArg("mesh")
+    elif arg.annotation in ElementId.values():
+        return ElementArg("id")
     elif arg.name in ["logical_coords", "logical_coordinates"]:
         assert arg.annotation in [
             tnsr.I[DataVector, 1, Frame.ElementLogical],

--- a/tests/Unit/Domain/Python/Test_ElementId.py
+++ b/tests/Unit/Domain/Python/Test_ElementId.py
@@ -10,16 +10,21 @@ class TestElementId(unittest.TestCase):
     def test_construction(self):
         element_id = ElementId[1](block_id=1)
         self.assertEqual(element_id.block_id, 1)
+        self.assertEqual(element_id.grid_index, 0)
+        self.assertEqual(element_id.refinement_levels, [0])
         self.assertEqual(element_id.segment_ids, [SegmentId(0, 0)])
         element_id = ElementId[1](block_id=1, segment_ids=[SegmentId(1, 0)])
         self.assertEqual(element_id.block_id, 1)
+        self.assertEqual(element_id.grid_index, 0)
+        self.assertEqual(element_id.refinement_levels, [1])
         self.assertEqual(element_id.segment_ids, [SegmentId(1, 0)])
-        self.assertEqual(
-            ElementId[2]("[B2,(L0I0,L2I3)]"),
-            ElementId[2](
-                block_id=2, segment_ids=[SegmentId(0, 0), SegmentId(2, 3)]
-            ),
+        element_id = ElementId[2](
+            block_id=2, segment_ids=[SegmentId(0, 0), SegmentId(2, 3)]
         )
+        self.assertEqual(element_id.block_id, 2)
+        self.assertEqual(element_id.grid_index, 0)
+        self.assertEqual(element_id.refinement_levels, [0, 2])
+        self.assertEqual(ElementId[2]("[B2,(L0I0,L2I3)]"), element_id)
 
     def test_repr(self):
         self.assertEqual(repr(ElementId[1](0)), "[B0,(L0I0)]")


### PR DESCRIPTION
## Proposed changes

I used this to show the refinement level of each element in ParaView.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
