### PR TITLE
Increase a test timeout

### DIFF
--- a/tests/Unit/IO/H5/Test_CheckH5PropertiesMatch.cpp
+++ b/tests/Unit/IO/H5/Test_CheckH5PropertiesMatch.cpp
@@ -127,6 +127,7 @@ void test_check_observation_ids_match() {
 }
 }  // namespace
 
+// [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.IO.H5.CheckH5PropertiesMatch", "[Unit][IO][H5]") {
   test_check_src_files_match<DataVector>();
   test_check_src_files_match<std::vector<float>>();


### PR DESCRIPTION
## Proposed changes

Seen the `CheckH5PropertiesMatch` test time out a lot recently.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
