### PR TITLE
Communicate volume mesh in boundary data

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -30,6 +30,7 @@
 #include "Evolution/DgSubcell/Tags/Interpolators.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/MeshForGhostData.hpp"
 #include "Evolution/DgSubcell/Tags/ReconstructionOrder.hpp"
 #include "Evolution/DgSubcell/Tags/StepsSinceTciCall.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
@@ -68,6 +69,7 @@ namespace evolution::dg::subcell::Actions {
  *   - `System::variables_tag`
  * - Adds:
  *   - `subcell::Tags::Mesh<Dim>`
+ *   - `subcell::Tags::MeshForGhostData<Dim>`
  *   - `subcell::Tags::ActiveGrid`
  *   - `subcell::Tags::DidRollback`
  *   - `subcell::Tags::TciGridHistory`
@@ -94,6 +96,7 @@ struct SetSubcellGrid {
   using simple_tags = tmpl::list<
       Tags::ActiveGrid, Tags::DidRollback, Tags::TciGridHistory,
       Tags::TciCallsSinceRollback, Tags::StepsSinceTciCall,
+      evolution::dg::subcell::Tags::MeshForGhostData<Dim>,
       Tags::GhostDataForReconstruction<Dim>, Tags::TciDecision,
       Tags::NeighborTciDecisions<Dim>, Tags::DataForRdmpTci,
       subcell::Tags::CellCenteredFlux<typename System::flux_variables, Dim>,

--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -22,7 +22,6 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
-#include "Domain/Tags/NeighborMesh.hpp"
 #include "Evolution/DgSubcell/Actions/Labels.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
@@ -38,6 +37,7 @@
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Interpolators.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/MeshForGhostData.hpp"
 #include "Evolution/DgSubcell/Tags/Reconstructor.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
@@ -261,7 +261,8 @@ struct TciAndRollback {
           // method, since we need to lift G+D instead of the ingredients
           // that go into G+D, which is what we would be projecting here.
         },
-        make_not_null(&box), db::get<domain::Tags::NeighborMesh<Dim>>(box),
+        make_not_null(&box),
+        db::get<evolution::dg::subcell::Tags::MeshForGhostData<Dim>>(box),
         db::get<evolution::dg::subcell::Tags::Reconstructor>(box)
             .ghost_zone_size(),
         db::get<

--- a/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.tpp
+++ b/src/Evolution/DgSubcell/NeighborReconstructedFaceSolution.tpp
@@ -21,6 +21,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/MeshForGhostData.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Time/TimeStepId.hpp"
@@ -35,9 +36,11 @@ void neighbor_reconstructed_face_solution(
         TimeStepId,
         DirectionalIdMap<VolumeDim, evolution::dg::BoundaryData<VolumeDim>>>*>
         received_temporal_id_and_data) {
-  db::mutate<subcell::Tags::GhostDataForReconstruction<VolumeDim>,
+  db::mutate<subcell::Tags::MeshForGhostData<VolumeDim>,
+             subcell::Tags::GhostDataForReconstruction<VolumeDim>,
              subcell::Tags::DataForRdmpTci>(
-      [&received_temporal_id_and_data](const auto subcell_ghost_data_ptr,
+      [&received_temporal_id_and_data](const auto mesh_for_ghost_data_ptr,
+                                       const auto subcell_ghost_data_ptr,
                                        const auto rdmp_tci_data_ptr) {
         const size_t number_of_evolved_vars =
             rdmp_tci_data_ptr->max_variables_values.size();
@@ -48,6 +51,9 @@ void neighbor_reconstructed_face_solution(
                  "The subcell mortar data was not sent at TimeStepId "
                      << received_temporal_id_and_data->first
                      << " with mortar id " << mortar_id);
+          mesh_for_ghost_data_ptr->insert_or_assign(
+              mortar_id,
+              received_mortar_data.second.volume_mesh_ghost_cell_data.value());
           const DataVector& neighbor_ghost_and_subcell_data =
               received_mortar_data.second.ghost_cell_data.value();
           // Compute min and max over neighbors

--- a/src/Evolution/DgSubcell/PrepareNeighborData.hpp
+++ b/src/Evolution/DgSubcell/PrepareNeighborData.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -62,7 +63,7 @@ template <typename Metavariables, typename DbTagsList, size_t Dim>
 void prepare_neighbor_data(
     const gsl::not_null<DirectionMap<Dim, DataVector>*>
         all_neighbor_data_for_reconstruction,
-    const gsl::not_null<Mesh<Dim>*> ghost_data_mesh,
+    const gsl::not_null<std::optional<Mesh<Dim>>*> ghost_data_mesh,
     const gsl::not_null<db::DataBox<DbTagsList>*> box,
     [[maybe_unused]] const Variables<db::wrap_tags_in<
         ::Tags::Flux, typename Metavariables::system::flux_variables,

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   Interpolators.hpp
   Jacobians.hpp
   Mesh.hpp
+  MeshForGhostData.hpp
   MethodOrder.hpp
   ObserverCoordinates.hpp
   ObserverMesh.hpp

--- a/src/Evolution/DgSubcell/Tags/MeshForGhostData.hpp
+++ b/src/Evolution/DgSubcell/Tags/MeshForGhostData.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+
+/// \cond
+template <size_t Dim, typename T>
+class DirectionalIdMap;
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace evolution::dg::subcell::Tags {
+/*!
+ * \brief Holds the volume Mesh used by each neighbor for communicating subcell
+ * ghost data.
+ *
+ * \details This will be the subcell Mesh unless an Element doing DG has only
+ * neighbors also doing DG
+ */
+template <size_t Dim>
+struct MeshForGhostData : db::SimpleTag {
+  using type = DirectionalIdMap<Dim, ::Mesh<Dim>>;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -123,14 +123,14 @@ void retrieve_boundary_data_spsc(
         auto& current_inbox = (*boundary_data_ptr)[time_step_id];
         if (auto it = current_inbox.find(directional_element_id);
             it != current_inbox.end()) {
-          auto& [volume_mesh_of_ghost_cell_data, face_mesh, ghost_cell_data,
-                 boundary_data, boundary_data_validity_range,
+          auto& [volume_mesh, volume_mesh_of_ghost_cell_data, face_mesh,
+                 ghost_cell_data, boundary_data, boundary_data_validity_range,
                  boundary_tci_status, boundary_integration_order] = data;
           (void)ghost_cell_data;
-          auto& [current_volume_mesh_of_ghost_cell_data, current_face_mesh,
-                 current_ghost_cell_data, current_boundary_data,
-                 current_boundary_data_validity_range, current_tci_status,
-                 current_integration_order] = it->second;
+          auto& [current_volume_mesh, current_volume_mesh_of_ghost_cell_data,
+                 current_face_mesh, current_ghost_cell_data,
+                 current_boundary_data, current_boundary_data_validity_range,
+                 current_tci_status, current_integration_order] = it->second;
           // Need to use when optimizing subcell
           (void)current_volume_mesh_of_ghost_cell_data;
           // We have already received some data at this time. Receiving
@@ -326,8 +326,7 @@ bool receive_boundary_data_global_time_stepping(
              received_temporal_id_and_data.second) {
           const auto& mortar_id = received_mortar_data.first;
           neighbor_mesh->insert_or_assign(
-              mortar_id,
-              received_mortar_data.second.volume_mesh_ghost_cell_data);
+              mortar_id, received_mortar_data.second.volume_mesh);
           mortar_next_time_step_id->at(mortar_id) =
               received_mortar_data.second.validity_range;
           ASSERT(using_subcell_v<Metavariables> or
@@ -466,8 +465,7 @@ bool receive_boundary_data_local_time_stepping(
                        << mortar_id
                        << "\nTimeStepId: " << mortar_next_time_step_id);
             neighbor_mesh->insert_or_assign(
-                mortar_id,
-                received_mortar_data->second.volume_mesh_ghost_cell_data);
+                mortar_id, received_mortar_data->second.volume_mesh);
             neighbor_mortar_data.face_mesh =
                 received_mortar_data->second.interface_mesh;
             neighbor_mortar_data.mortar_mesh = mortar_meshes.at(mortar_id);

--- a/src/Evolution/DiscontinuousGalerkin/BoundaryData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryData.cpp
@@ -13,6 +13,7 @@
 namespace evolution::dg {
 template <size_t Dim>
 void BoundaryData<Dim>::pup(PUP::er& p) {
+  p | volume_mesh;
   p | volume_mesh_ghost_cell_data;
   p | interface_mesh;
   p | ghost_cell_data;
@@ -24,7 +25,8 @@ void BoundaryData<Dim>::pup(PUP::er& p) {
 
 template <size_t Dim>
 bool operator==(const BoundaryData<Dim>& lhs, const BoundaryData<Dim>& rhs) {
-  return lhs.volume_mesh_ghost_cell_data == rhs.volume_mesh_ghost_cell_data and
+  return lhs.volume_mesh == rhs.volume_mesh and
+         lhs.volume_mesh_ghost_cell_data == rhs.volume_mesh_ghost_cell_data and
          lhs.interface_mesh == rhs.interface_mesh and
          lhs.ghost_cell_data == rhs.ghost_cell_data and
          lhs.boundary_correction_data == rhs.boundary_correction_data and
@@ -40,7 +42,8 @@ bool operator!=(const BoundaryData<Dim>& lhs, const BoundaryData<Dim>& rhs) {
 
 template <size_t Dim>
 std::ostream& operator<<(std::ostream& os, const BoundaryData<Dim>& value) {
-  return os << "Ghost mesh: " << value.volume_mesh_ghost_cell_data << '\n'
+  return os << "Volume mesh: " << value.volume_mesh << '\n'
+            << "Ghost mesh: " << value.volume_mesh_ghost_cell_data << '\n'
             << "Interface mesh: " << value.interface_mesh << '\n'
             << "Ghost cell data: " << value.ghost_cell_data << '\n'
             << "Boundary correction: " << value.boundary_correction_data << '\n'

--- a/src/Evolution/DiscontinuousGalerkin/BoundaryData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryData.hpp
@@ -17,25 +17,27 @@ namespace evolution::dg {
  *
  * The stored data consists of the following:
  *
- * 1. the mesh of the ghost cell data we received. This allows eliding
+ * 1. the volume mesh of the element.
+ * 2. the volume mesh corresponding to the ghost cell data. This allows eliding
  *    projection when all neighboring elements are doing DG.
- * 2. the mesh of the neighboring element's face (not the mortar mesh!)
- * 3. the variables at the ghost zone cells for finite difference/volume
+ * 3. the mesh of the neighboring element's face (not the mortar mesh!)
+ * 4. the variables at the ghost zone cells for finite difference/volume
  *    reconstruction
- * 4. the data on the mortar needed for computing the boundary corrections (e.g.
+ * 5. the data on the mortar needed for computing the boundary corrections (e.g.
  *    fluxes, characteristic speeds, conserved variables)
- * 5. the TimeStepId beyond which the boundary terms are no longer valid, when
+ * 6. the TimeStepId beyond which the boundary terms are no longer valid, when
  *    using local time stepping.
- * 6. the troubled cell indicator status used for determining halos around
+ * 7. the troubled cell indicator status used for determining halos around
  *    troubled cells.
- * 7. the integration order of the time-stepper
+ * 8. the integration order of the time-stepper
  */
 template <size_t Dim>
 struct BoundaryData {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 
-  Mesh<Dim> volume_mesh_ghost_cell_data{};
+  Mesh<Dim> volume_mesh{};
+  std::optional<Mesh<Dim>> volume_mesh_ghost_cell_data{};
   Mesh<Dim - 1> interface_mesh{};
   std::optional<DataVector> ghost_cell_data{};
   std::optional<DataVector> boundary_correction_data{};

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -41,18 +41,19 @@ namespace evolution::dg::Tags {
  *
  * The stored data consists of the following:
  *
- * 1. the mesh of the ghost cell data we received. This allows eliding
+ * 1. the volume mesh of the element.
+ * 2. the volume mesh corresponding to the ghost cell data. This allows eliding
  *    projection when all neighboring elements are doing DG.
- * 2. the mesh of the neighboring element's face (not the mortar mesh!)
- * 3. the variables at the ghost zone cells for finite difference/volume
+ * 3. the mesh of the neighboring element's face (not the mortar mesh!)
+ * 4. the variables at the ghost zone cells for finite difference/volume
  *    reconstruction
- * 4. the data on the mortar needed for computing the boundary corrections (e.g.
+ * 5. the data on the mortar needed for computing the boundary corrections (e.g.
  *    fluxes, characteristic speeds, conserved variables)
- * 5. the TimeStepId beyond which the boundary terms are no longer valid, when
+ * 6. the TimeStepId beyond which the boundary terms are no longer valid, when
  *    using local time stepping.
- * 6. the troublade cell indicator status using for determining halos around
+ * 7. the troublade cell indicator status using for determining halos around
  *    troubled cells.
- * 7. the integration order of the time-stepper.
+ * 8. the integration order of the time-stepper.
  *
  * The TimeStepId is the neighboring element's next time step. When using local
  * time stepping, the neighbor's boundary data is valid up until this time,
@@ -60,13 +61,13 @@ namespace evolution::dg::Tags {
  * neighbor time step, the local element knows whether or not it should remove
  * boundary data and expect new data to be sent from the neighbor.
  *
- * The ghost cell data (second element of the tuple) will be valid whenever a
- * DG-subcell scheme is being used. Whenever a DG-subcell scheme is being used,
- * elements using DG and not FD/FV always send both the ghost cells and boundary
- * correction data together. Elements using FD/FV send the ghost cells first
- * followed by the boundary correction data once the element has received all
- * neighbor ghost cell data. Note that the second send/receive only modifies the
- * flux and the TimeStepId used for the flux validity range.
+ * The ghost cell data will be valid whenever a DG-subcell scheme is being used.
+ * Whenever a DG-subcell scheme is being used, elements using DG and not FD/FV
+ * always send both the ghost cells and boundary correction data together.
+ * Elements using FD/FV send the ghost cells first followed by the boundary
+ * correction data once the element has received all neighbor ghost cell data.
+ * Note that the second send/receive only modifies the flux and the TimeStepId
+ * used for the flux validity range.
  *
  * When only a DG scheme (not a DG-subcell scheme) is used the ghost cell data
  * will never be valid.
@@ -177,12 +178,12 @@ struct BoundaryCorrectionAndGhostCellsInbox {
                                   ReceiveDataType&& data) {
     auto& current_inbox = (*inbox)[time_step_id];
     if (auto it = current_inbox.find(data.first); it != current_inbox.end()) {
-      auto& [volume_mesh_of_ghost_cell_data, face_mesh, ghost_cell_data,
-             boundary_data, boundary_data_validity_range, boundary_tci_status,
-             integration_order] = data.second;
+      auto& [volume_mesh, volume_mesh_of_ghost_cell_data, face_mesh,
+             ghost_cell_data, boundary_data, boundary_data_validity_range,
+             boundary_tci_status, integration_order] = data.second;
       (void)ghost_cell_data;
-      auto& [current_volume_mesh_of_ghost_cell_data, current_face_mesh,
-             current_ghost_cell_data, current_boundary_data,
+      auto& [current_volume_mesh, current_volume_mesh_of_ghost_cell_data,
+             current_face_mesh, current_ghost_cell_data, current_boundary_data,
              current_boundary_data_validity_range, current_tci_status,
              current_integration_order] = it->second;
       (void)current_volume_mesh_of_ghost_cell_data;  // Need to use when

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -24,7 +24,6 @@
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
-#include "Domain/Tags/NeighborMesh.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndRollback.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
@@ -37,6 +36,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/MeshForGhostData.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/TciGridHistory.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
@@ -106,7 +106,8 @@ struct component {
           evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>,
           evolution::dg::subcell::Tags::TciDecision,
           evolution::dg::subcell::Tags::DataForRdmpTci,
-          domain::Tags::NeighborMesh<Dim>, ::Tags::Variables<tmpl::list<Var1>>,
+          evolution::dg::subcell::Tags::MeshForGhostData<Dim>,
+          ::Tags::Variables<tmpl::list<Var1>>,
           ::Tags::HistoryEvolvedVariables<::Tags::Variables<tmpl::list<Var1>>>,
           SelfStart::Tags::InitialValue<::Tags::Variables<tmpl::list<Var1>>>,
           evolution::dg::subcell::Tags::NeighborTciDecisions<Dim>,

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Test_JacobianCompute.cpp
   Test_Matrices.cpp
   Test_Mesh.cpp
+  Test_MeshForGhostData.cpp
   Test_NeighborRdmpAndVolumeData.cpp
   Test_NeighborReconstructedFaceSolution.cpp
   Test_NeighborTciDecision.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_MeshForGhostData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_MeshForGhostData.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/DgSubcell/Tags/MeshForGhostData.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.Tags.MeshForGhostData",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::MeshForGhostData<1>>("MeshForGhostData");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::MeshForGhostData<2>>("MeshForGhostData");
+  TestHelpers::db::test_simple_tag<
+      evolution::dg::subcell::Tags::MeshForGhostData<3>>("MeshForGhostData");
+}

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <iterator>
+#include <optional>
 #include <unordered_set>
 #include <utility>
 
@@ -256,13 +257,13 @@ void test(const bool all_neighbors_are_doing_dg,
       subcell_options, fd_to_fd_neighbor_interpolants,
       dg_to_fd_neighbor_interpolants);
 
-  Mesh<Dim> ghost_data_mesh{};
+  std::optional<Mesh<Dim>> ghost_data_mesh{std::nullopt};
   DirectionMap<Dim, DataVector> data_for_neighbors{};
   evolution::dg::subcell::prepare_neighbor_data<Metavariables<Dim>>(
       make_not_null(&data_for_neighbors), make_not_null(&ghost_data_mesh),
       make_not_null(&box), volume_fluxes);
 
-  CHECK(ghost_data_mesh ==
+  CHECK(ghost_data_mesh.value() ==
         (all_neighbors_are_doing_dg ? dg_mesh : subcell_mesh));
 
   const auto& rdmp_tci_data =

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -685,7 +685,8 @@ void test_impl(const Spectral::Quadrature quadrature,
                     10 * static_cast<unsigned long>(direction.side()) +
                     100 * count);
       evolution::dg::BoundaryData<Dim> data{
-          mesh,    face_mesh, {}, {flux_data}, {neighbor_next_time_step_id},
+          mesh,    std::nullopt, face_mesh,
+          {},      {flux_data},  {neighbor_next_time_step_id},
           decision};
       neighbor_decision.insert(std::pair{mortar_id, decision});
       ++decision;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryData.cpp
@@ -22,47 +22,57 @@ void test() {
   CAPTURE(Dim);
   const Mesh<Dim> volume_mesh{5, Spectral::Basis::Legendre,
                               Spectral::Quadrature::Gauss};
+  const Mesh<Dim> ghost_data_mesh{9, Spectral::Basis::FiniteDifference,
+                              Spectral::Quadrature::CellCentered};
   const Mesh<Dim - 1> interface_mesh = volume_mesh.slice_away(0);
   const Time time{{0.0, 1.0}, {0, 1}};
   const BoundaryData<Dim> data0{volume_mesh,
+                                ghost_data_mesh,
                                 interface_mesh,
                                 DataVector{2, 2.3},
                                 DataVector{1, 4.4},
                                 TimeStepId{true, 1, time},
                                 7,
                                 3};
-  CHECK(data0 == BoundaryData<Dim>{volume_mesh, interface_mesh,
+  CHECK(data0 == BoundaryData<Dim>{volume_mesh, ghost_data_mesh, interface_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
                                    TimeStepId{true, 1, time}, 7, 3});
   CHECK(data0 != BoundaryData<Dim>{Mesh<Dim>{6, Spectral::Basis::Legendre,
                                              Spectral::Quadrature::Gauss},
-                                   interface_mesh, DataVector{2, 2.3},
-                                   DataVector{1, 4.4},
+                                   ghost_data_mesh, interface_mesh,
+                                   DataVector{2, 2.3}, DataVector{1, 4.4},
                                    TimeStepId{true, 1, time}, 7, 3});
+  CHECK(data0 !=
+        BoundaryData<Dim>{volume_mesh,
+                          Mesh<Dim>{11, Spectral::Basis::FiniteDifference,
+                                    Spectral::Quadrature::CellCentered},
+                          interface_mesh, DataVector{2, 2.3},
+                          DataVector{1, 4.4}, TimeStepId{true, 1, time}, 7, 3});
   if constexpr (Dim > 1) {
-    CHECK(data0 != BoundaryData<Dim>{volume_mesh,
+    CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh,
                                      Mesh<Dim - 1>{2, Spectral::Basis::Legendre,
                                                    Spectral::Quadrature::Gauss},
                                      DataVector{2, 2.3}, DataVector{1, 4.4},
                                      TimeStepId{true, 1, time}, 7, 3});
   }
-  CHECK(data0 != BoundaryData<Dim>{volume_mesh, interface_mesh,
+  CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, interface_mesh,
                                    DataVector{9, 2.3}, DataVector{1, 4.4},
                                    TimeStepId{true, 1, time}, 7, 3});
-  CHECK(data0 != BoundaryData<Dim>{volume_mesh, interface_mesh,
+  CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, interface_mesh,
                                    DataVector{2, 2.3}, DataVector{6, 4.4},
                                    TimeStepId{true, 1, time}, 7, 3});
-  CHECK(data0 != BoundaryData<Dim>{volume_mesh, interface_mesh,
+  CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, interface_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
                                    TimeStepId{true, 2, time}, 7, 3});
-  CHECK(data0 != BoundaryData<Dim>{volume_mesh, interface_mesh,
+  CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, interface_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
                                    TimeStepId{true, 1, time}, 9, 3});
-  CHECK(data0 != BoundaryData<Dim>{volume_mesh, interface_mesh,
+  CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, interface_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
                                    TimeStepId{true, 2, time}, 7, 5});
   CHECK(get_output(data0) ==
-        std::string("Ghost mesh: " + get_output(volume_mesh) +
+        std::string("Volume mesh: " + get_output(volume_mesh) +
+                    "\nGhost mesh: " + get_output(ghost_data_mesh) +
                     "\nInterface mesh: " + get_output(interface_mesh) +
                     "\nGhost cell data: " + get_output(DataVector{2, 2.3}) +
                     "\nBoundary correction: " + get_output(DataVector{1, 4.4}) +

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -575,7 +575,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
   }
 }
 
-// [[Timeout, 60]]
+// [[Timeout, 90]]
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {
   const size_t n0 =


### PR DESCRIPTION
## Proposed changes

- Adds tag `evolution::dg::subcell::Tags::MeshForGhostData` which holds the volume mesh used by each neighbor for communicating subcell ghost data.  This information was previously held by `domain::Tags::NeighborMesh<Dim>` which will now always hold the mesh of the neighbor.
- Add the volume mesh to what is communicated via `BoundaryData`.  This is needed for reactive adaptive mesh refinement. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
