### PR TITLE
Add epsilon when reading NumericInitialData

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
@@ -54,9 +54,11 @@ void initial_gh_variables_from_adm(
 NumericInitialData::NumericInitialData(
     std::string file_glob, std::string subfile_name,
     std::variant<double, importers::ObservationSelector> observation_value,
-    bool enable_interpolation, std::variant<AdmVars, GhVars> selected_variables)
-    : importer_options_(std::move(file_glob), std::move(subfile_name),
-                        observation_value, enable_interpolation),
+    std::optional<double> observation_value_epsilon, bool enable_interpolation,
+    std::variant<AdmVars, GhVars> selected_variables)
+    : importer_options_(
+          std::move(file_glob), std::move(subfile_name), observation_value,
+          observation_value_epsilon.value_or(1.0e-12), enable_interpolation),
       selected_variables_(std::move(selected_variables)) {}
 
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
@@ -131,10 +131,7 @@ class NumericInitialData : public evolution::initial_data::InitialData {
   };
 
   using options =
-      tmpl::list<importers::OptionTags::FileGlob,
-                 importers::OptionTags::Subgroup,
-                 importers::OptionTags::ObservationValue,
-                 importers::OptionTags::EnableInterpolation, Variables>;
+      tmpl::push_back<importers::ImporterOptions::tags_list, Variables>;
 
   static constexpr Options::String help =
       "Numeric initial data loaded from volume data files";
@@ -160,6 +157,7 @@ class NumericInitialData : public evolution::initial_data::InitialData {
   NumericInitialData(
       std::string file_glob, std::string subfile_name,
       std::variant<double, importers::ObservationSelector> observation_value,
+      std::optional<double> observation_value_epsilon,
       bool enable_interpolation,
       std::variant<AdmVars, GhVars> selected_variables);
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp"
 
 #include <boost/functional/hash.hpp>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -13,15 +14,18 @@ namespace grmhd::GhValenciaDivClean {
 NumericInitialData::NumericInitialData(
     std::string file_glob, std::string subfile_name,
     std::variant<double, importers::ObservationSelector> observation_value,
+    std::optional<double> observation_value_epsilon,
     const bool enable_interpolation,
     typename GhNumericId::Variables::type gh_selected_variables,
     typename HydroNumericId::Variables::type hydro_selected_variables,
     const double density_cutoff)
     : gh_numeric_id_(file_glob, subfile_name, observation_value,
+                     observation_value_epsilon.value_or(1.0e-12),
                      enable_interpolation, std::move(gh_selected_variables)),
-      hydro_numeric_id_(std::move(file_glob), std::move(subfile_name),
-                        observation_value, enable_interpolation,
-                        std::move(hydro_selected_variables), density_cutoff) {}
+      hydro_numeric_id_(
+          std::move(file_glob), std::move(subfile_name), observation_value,
+          observation_value_epsilon.value_or(1.0e-12), enable_interpolation,
+          std::move(hydro_selected_variables), density_cutoff) {}
 
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
     : InitialData(msg) {}

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -72,11 +73,8 @@ class NumericInitialData : public evolution::initial_data::InitialData,
   struct HydroVariables : HydroNumericId::Variables {};
 
   using options =
-      tmpl::list<importers::OptionTags::FileGlob,
-                 importers::OptionTags::Subgroup,
-                 importers::OptionTags::ObservationValue,
-                 importers::OptionTags::EnableInterpolation, GhVariables,
-                 HydroVariables, HydroNumericId::DensityCutoff>;
+      tmpl::push_back<importers::ImporterOptions::tags_list, GhVariables,
+                      HydroVariables, HydroNumericId::DensityCutoff>;
 
   static constexpr Options::String help =
       "Numeric initial data loaded from volume data files";
@@ -102,6 +100,7 @@ class NumericInitialData : public evolution::initial_data::InitialData,
   NumericInitialData(
       std::string file_glob, std::string subfile_name,
       std::variant<double, importers::ObservationSelector> observation_value,
+      std::optional<double> observation_value_epsilon,
       bool enable_interpolation,
       typename GhNumericId::Variables::type gh_selected_variables,
       typename HydroNumericId::Variables::type hydro_selected_variables,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp"
 
 #include <boost/functional/hash.hpp>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -15,10 +16,12 @@ namespace grmhd::ValenciaDivClean {
 NumericInitialData::NumericInitialData(
     std::string file_glob, std::string subfile_name,
     std::variant<double, importers::ObservationSelector> observation_value,
+    std::optional<double> observation_value_epsilon,
     const bool enable_interpolation, PrimitiveVars selected_variables,
     const double density_cutoff)
-    : importer_options_(std::move(file_glob), std::move(subfile_name),
-                        observation_value, enable_interpolation),
+    : importer_options_(
+          std::move(file_glob), std::move(subfile_name), observation_value,
+          observation_value_epsilon.value_or(1.0e-12), enable_interpolation),
       selected_variables_(std::move(selected_variables)),
       density_cutoff_(density_cutoff) {}
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
@@ -108,10 +108,8 @@ class NumericInitialData : public evolution::initial_data::InitialData {
     static constexpr double lower_bound() { return 0.; }
   };
 
-  using options = tmpl::list<
-      importers::OptionTags::FileGlob, importers::OptionTags::Subgroup,
-      importers::OptionTags::ObservationValue,
-      importers::OptionTags::EnableInterpolation, Variables, DensityCutoff>;
+  using options = tmpl::push_back<importers::ImporterOptions::tags_list,
+                                  Variables, DensityCutoff>;
 
   static constexpr Options::String help =
       "Numeric initial data loaded from volume data files";
@@ -137,6 +135,7 @@ class NumericInitialData : public evolution::initial_data::InitialData {
   NumericInitialData(
       std::string file_glob, std::string subfile_name,
       std::variant<double, importers::ObservationSelector> observation_value,
+      std::optional<double> observation_value_epsilon,
       bool enable_interpolation, PrimitiveVars selected_variables,
       double density_cutoff);
 

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -13,7 +13,6 @@
 
 #include "IO/H5/Object.hpp"
 #include "IO/H5/OpenGroup.hpp"
-#include "Utilities/ErrorHandling/Error.hpp"
 
 /// \cond
 class DataVector;
@@ -146,15 +145,15 @@ class VolumeData : public h5::Object {
   double get_observation_value(size_t observation_id) const;
 
   /// Find the observation ID that matches the `observation_value`
-  size_t find_observation_id(const double observation_value) const {
-    for (auto& observation_id : list_observation_ids()) {
-      if (get_observation_value(observation_id) == observation_value) {
-        return observation_id;
-      }
-    }
-    ERROR_NO_TRACE("No observation with value " << observation_value
-                                                << " found in volume file.");
-  }
+  ///
+  /// \details An epsilon can be specified and the observation id that matches
+  /// within the epsilon of `observation_value` will be returned. If there is
+  /// more than one id that is within the epsilon, an error will occur. If no
+  /// epsilon is specified, this function will do exact comparison.
+  size_t find_observation_id(
+      double observation_value,
+      const std::optional<double>& observation_value_epsilon =
+          std::nullopt) const;
 
   /// List all the tensor components at observation id `observation_id`
   std::vector<std::string> list_tensor_components(size_t observation_id) const;

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -456,8 +456,11 @@ struct ReadAllVolumeDataAndDistribute {
       // Select observation ID
       const size_t observation_id = std::visit(
           Overloader{
-              [&volume_file](const double local_obs_value) {
-                return volume_file.find_observation_id(local_obs_value);
+              [&volume_file, &options](const double local_obs_value) {
+                const auto& observation_value_epsilon =
+                    get<OptionTags::ObservationValueEpsilon>(options);
+                return volume_file.find_observation_id(
+                    local_obs_value, observation_value_epsilon);
               },
               [&volume_file](const ObservationSelector local_obs_selector) {
                 const std::vector<size_t> all_observation_ids =

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "IO/Importers/ObservationSelector.hpp"
+#include "Options/Auto.hpp"
 #include "Options/String.hpp"
 #include "Parallel/ArrayComponentId.hpp"
 #include "Parallel/InboxInserters.hpp"
@@ -55,6 +56,15 @@ struct ObservationValue {
       "The observation value at which to read data";
 };
 
+struct ObservationValueEpsilon {
+  using type = Options::Auto<double>;
+  static constexpr Options::String help =
+      "Look for observations in the data within this epsilon of the "
+      "'ObservationValue'. Set to 'Auto' to use default of 1e-12. This option "
+      "is ignored if the 'ObservationValue' is a selector like 'First' or "
+      "'Last'.";
+};
+
 /*!
  * \brief Toggle interpolation of numeric data to the target domain
  */
@@ -77,6 +87,7 @@ struct EnableInterpolation {
 struct ImporterOptions
     : tuples::TaggedTuple<OptionTags::FileGlob, OptionTags::Subgroup,
                           OptionTags::ObservationValue,
+                          OptionTags::ObservationValueEpsilon,
                           OptionTags::EnableInterpolation> {
   using options = tags_list;
   static constexpr Options::String help = "The volume data to load.";

--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -5,6 +5,8 @@
 
 #include <optional>
 #include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
 #include <string>
 #include <utility>
 #include <variant>
@@ -46,6 +48,8 @@ class Auto {
   explicit Auto(T value) : value_(std::move(value)) {}
 
   // These lines are just to work around a spurious warning.
+  Auto(const Auto&) = default;
+  Auto& operator=(const Auto&) = default;
   Auto(Auto&&) = default;
   Auto& operator=(Auto&&) = default;
 #if defined(__GNUC__) and not defined(__clang__) and __GNUC__ >= 12 and \
@@ -64,6 +68,8 @@ class Auto {
   operator std::optional<U>() && {
     return std::move(value_);
   }
+
+  void pup(PUP::er& p) { p | value_; }
 
   // NOLINTNEXTLINE(google-explicit-constructor)
   operator const value_type&() const { return value_; }

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -31,6 +31,7 @@ InitialData:
     FileGlob: "{{ IdFileGlob }}"
     Subgroup: "VolumeData"
     ObservationValue: Last
+    ObservationValueEpsilon: Auto
     Interpolate: True
     Variables:
       Lapse: Lapse

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -17,6 +17,7 @@ InitialData:
     FileGlob: "{{ IdFileGlob }}"
     Subgroup: "VolumeData"
     ObservationValue: Last
+    ObservationValueEpsilon: Auto
     Interpolate: True
     Variables:
       SpacetimeMetric: SpacetimeMetric

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -411,6 +411,7 @@ InitialData:
     FileGlob: "/path/to/initial_data.h5"
     Subgroup: "VolumeData"
     ObservationValue: Last
+    ObservationValueEpsilon: Auto
     Interpolate: True
     Variables:
       Lapse: Lapse

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -427,6 +427,7 @@ InitialData:
     FileGlob: BnsVolume*.h5
     Subgroup: VolumeData
     ObservationValue: Last
+    ObservationValueEpsilon: Auto
     Interpolate: True
     GhVariables:
       Lapse: Lapse

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
@@ -287,26 +287,33 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
   register_factory_classes_with_charm<Metavariables>();
   test_set_initial_data(
       NumericInitialData{
-          "TestInitialData.h5", "VolumeData", 0., false,
+          "TestInitialData.h5",
+          "VolumeData",
+          0.,
+          {1.0e-9},
+          false,
           NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi"}},
       "NumericInitialData:\n"
       "  FileGlob: TestInitialData.h5\n"
       "  Subgroup: VolumeData\n"
       "  ObservationValue: 0.\n"
+      "  ObservationValueEpsilon: 1e-9\n"
       "  Interpolate: False\n"
       "  Variables:\n"
       "    SpacetimeMetric: CustomSpacetimeMetric\n"
       "    Pi: CustomPi\n",
       true);
   test_set_initial_data(
-      NumericInitialData{"TestInitialData.h5", "VolumeData", 0., false,
-                         NumericInitialData::AdmVars{
-                             "CustomSpatialMetric", "CustomLapse",
-                             "CustomShift", "CustomExtrinsicCurvature"}},
+      NumericInitialData{
+          "TestInitialData.h5", "VolumeData", 0., std::nullopt, false,
+          NumericInitialData::AdmVars{"CustomSpatialMetric", "CustomLapse",
+                                      "CustomShift",
+                                      "CustomExtrinsicCurvature"}},
       "NumericInitialData:\n"
       "  FileGlob: TestInitialData.h5\n"
       "  Subgroup: VolumeData\n"
       "  ObservationValue: 0.\n"
+      "  ObservationValueEpsilon: Auto\n"
       "  Interpolate: False\n"
       "  Variables:\n"
       "    SpatialMetric: CustomSpatialMetric\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
@@ -335,6 +335,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
             "TestInitialData.h5",
             "VolumeData",
             0.,
+            {1.0e-9},
             false,
             gh::NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi"},
             {"CustomRho", "CustomUi", "CustomYe", "CustomB"},
@@ -343,6 +344,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
         "  FileGlob: TestInitialData.h5\n"
         "  Subgroup: VolumeData\n"
         "  ObservationValue: 0.\n"
+        "  ObservationValueEpsilon: 1e-9\n"
         "  Interpolate: False\n"
         "  GhVariables:\n"
         "    SpacetimeMetric: CustomSpacetimeMetric\n"
@@ -358,6 +360,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
         NumericInitialData{"TestInitialData.h5",
                            "VolumeData",
                            0.,
+                           std::nullopt,
                            false,
                            gh::NumericInitialData::AdmVars{
                                "CustomSpatialMetric", "CustomLapse",
@@ -368,6 +371,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
         "  FileGlob: TestInitialData.h5\n"
         "  Subgroup: VolumeData\n"
         "  ObservationValue: 0.\n"
+        "  ObservationValueEpsilon: Auto\n"
         "  Interpolate: False\n"
         "  GhVariables:\n"
         "    SpatialMetric: CustomSpatialMetric\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/Test_NumericInitialData.cpp
@@ -245,6 +245,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
       NumericInitialData{"TestInitialData.h5",
                          "VolumeData",
                          0.,
+                         {1.0e-9},
                          false,
                          {"CustomRho", "CustomUi", "CustomYe", "CustomB"},
                          1.e-14},
@@ -252,6 +253,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
       "  FileGlob: TestInitialData.h5\n"
       "  Subgroup: VolumeData\n"
       "  ObservationValue: 0.\n"
+      "  ObservationValueEpsilon: 1e-9\n"
       "  Interpolate: False\n"
       "  Variables:\n"
       "    RestMassDensity: CustomRho\n"
@@ -263,6 +265,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
       NumericInitialData{"TestInitialData.h5",
                          "VolumeData",
                          0.,
+                         std::nullopt,
                          false,
                          {"CustomRho", "CustomUi", 0.15, 0.},
                          1.e-14},
@@ -270,6 +273,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
       "  FileGlob: TestInitialData.h5\n"
       "  Subgroup: VolumeData\n"
       "  ObservationValue: 0.\n"
+      "  ObservationValueEpsilon: Auto\n"
       "  Interpolate: False\n"
       "  Variables:\n"
       "    RestMassDensity: CustomRho\n"

--- a/tests/Unit/Helpers/IO/VolumeData.hpp
+++ b/tests/Unit/Helpers/IO/VolumeData.hpp
@@ -33,7 +33,8 @@ T multiply(const double obs_value, const T& component) {
 
 /// Helper function to check that volume data was written correctly.
 /// This function checks the following:
-///    0. That the provided observation_id is present in the file
+///    0. That the provided observation_id is present in the file (possibly
+///       within an epsilon)
 ///    1. That the grid_names provided are present in the file
 ///    2. That the provided bases and quadratures agree with the bases
 ///       and quadratures in the file.
@@ -50,6 +51,7 @@ void check_volume_data(
     const std::string& h5_file_name, const uint32_t version_number,
     const std::string& group_name, const size_t observation_id,
     const double observation_value,
+    const std::optional<double>& observation_value_epsilon,
     const std::vector<DataType>& tensor_components_and_coords,
     const std::vector<std::string>& grid_names,
     const std::vector<std::vector<Spectral::Basis>>& bases,

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -90,13 +90,26 @@ void test_strahlkorper() {
           observation_values[0]);
   }
 
+  // Check exact observation value
   TestHelpers::io::VolumeData::check_volume_data(
       h5_file_name, version_number, "element_data"s, observation_ids[0],
-      observation_values[0], tensor_and_coord_data, {{grid_name}}, {bases},
-      {quadratures}, {extents},
+      observation_values[0], std::nullopt, tensor_and_coord_data, {{grid_name}},
+      {bases}, {quadratures}, {extents},
       {"InertialCoordinates_x", "InertialCoordinates_y",
        "InertialCoordinates_z", "TestScalar"},
       {{0, 1, 2, 3}}, {}, observation_values[0]);
+
+  // Check observation value within epsilon
+  {
+    const std::optional<double> epsilon = 1.0e-8;
+    TestHelpers::io::VolumeData::check_volume_data(
+        h5_file_name, version_number, "element_data"s, observation_ids[0],
+        observation_values[0] + 0.1 * epsilon.value(), epsilon,
+        tensor_and_coord_data, {{grid_name}}, {bases}, {quadratures}, {extents},
+        {"InertialCoordinates_x", "InertialCoordinates_y",
+         "InertialCoordinates_z", "TestScalar"},
+        {{0, 1, 2, 3}}, {}, observation_values[0]);
+  }
 
   // Check pole connectivity
   DataVector connectivity_data{};
@@ -287,8 +300,8 @@ void test() {
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     TestHelpers::io::VolumeData::check_volume_data(
         h5_file_name, version_number, "element_data"s, observation_ids[i],
-        observation_values[i], tensor_components_and_coords, grid_names, bases,
-        quadratures, {{2, 2, 2}, {2, 2, 2}},
+        observation_values[i], std::nullopt, tensor_components_and_coords,
+        grid_names, bases, quadratures, {{2, 2, 2}, {2, 2, 2}},
         {"S", "x-coord", "y-coord", "z-coord", "T_x", "T_y", "T_z"},
         {{0, 1, 2, 3, 4, 5, 6}, {1, 0, 5, 3, 6, 4, 2}}, {},
         observation_values[i]);

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -38,6 +38,7 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
       "    FileGlob: File.name\n"
       "    Subgroup: data.group\n"
       "    ObservationValue: 1.\n"
+      "    ObservationValueEpsilon: 1e-9\n"
       "    Interpolate: True");
   const auto& options =
       opts.get<importers::Tags::ImporterOptions<ExampleVolumeData>>();
@@ -46,6 +47,10 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
   CHECK(get<importers::OptionTags::Subgroup>(options) == "data.group");
   CHECK(std::get<double>(
             get<importers::OptionTags::ObservationValue>(options)) == 1.);
+  const std::optional<double> obs_val_eps =
+      get<importers::OptionTags::ObservationValueEpsilon>(options);
+  CHECK(obs_val_eps.has_value());
+  CHECK(obs_val_eps.value() == 1.0e-9);
   CHECK(get<importers::OptionTags::EnableInterpolation>(options));
 
   CHECK(

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -117,7 +118,8 @@ void test_actions(const std::variant<double, importers::ObservationSelector>&
   using element_array = MockElementArray<metavars, AddSubcell>;
 
   ActionTesting::MockRuntimeSystem<metavars> runner{{importers::ImporterOptions{
-      "TestVolumeData*.h5", "element_data", observation_selection, false}}};
+      "TestVolumeData*.h5", "element_data", observation_selection,
+      Options::Auto<double>{}, false}}};
 
   // Setup mock data file reader
   ActionTesting::emplace_nodegroup_component<reader_component>(

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
@@ -32,6 +32,7 @@ Importers:
     FileGlob: "Test_DataImporterAlgorithm1D.h5"
     Subgroup: "TestData"
     ObservationValue: 1.
+    ObservationValueEpsilon: Auto
     Interpolate: True
 
 ResourceInfo:

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
@@ -21,6 +21,7 @@ Importers:
     FileGlob: "Test_DataImporterAlgorithm2D.h5"
     Subgroup: "TestData"
     ObservationValue: 2.
+    ObservationValueEpsilon: Auto
     Interpolate: False
 # [importer_options]
 

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -65,6 +65,7 @@ Importers:
     FileGlob: "Test_DataImporterAlgorithm3D.h5"
     Subgroup: "TestData"
     ObservationValue: 3.
+    ObservationValueEpsilon: Auto
     Interpolate: True
 
 ResourceInfo:

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -148,8 +148,8 @@ void check_write_volume_data(
     TestHelpers::io::VolumeData::check_volume_data(
         h5_write_volume_file_name + ".h5"s, 0, "element_data",
         write_vol_observation_id.hash(), write_vol_observation_id.value(),
-        h5_write_volume_expected_tensor_data, {h5_write_volume_element_name},
-        {h5_write_volume_expected_bases},
+        std::nullopt, h5_write_volume_expected_tensor_data,
+        {h5_write_volume_element_name}, {h5_write_volume_expected_bases},
         {h5_write_volume_expected_quadratures},
         {h5_write_volume_expected_extents}, expected_tensor_names,
         {{0, 1, 2, 5, 3, 4}}, {});

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -308,16 +308,16 @@ void check_surface_volume_data(const std::string& surfaces_file_prefix) {
   if constexpr (ValidPoints == InterpTargetTestHelpers::ValidPoints::None) {
     TestHelpers::io::VolumeData::check_volume_data(
         surfaces_file_prefix + ".h5"s, 0, grid_name, observation_id.hash(),
-        observation_id.value(), tensor_and_coord_data, {grid_name}, {bases},
-        {quadratures}, {extents},
+        observation_id.value(), std::nullopt, tensor_and_coord_data,
+        {grid_name}, {bases}, {quadratures}, {extents},
         {"InertialCoordinates_x"s, "InertialCoordinates_y"s,
          "InertialCoordinates_z"s, "Square"s},
         {{0, 1, 2, 3}}, 1.e-14, 1.0, {"Square"s});
   } else {
     TestHelpers::io::VolumeData::check_volume_data(
         surfaces_file_prefix + ".h5"s, 0, grid_name, observation_id.hash(),
-        observation_id.value(), tensor_and_coord_data, {grid_name}, {bases},
-        {quadratures}, {extents},
+        observation_id.value(), std::nullopt, tensor_and_coord_data,
+        {grid_name}, {bases}, {quadratures}, {extents},
         {"InertialCoordinates_x"s, "InertialCoordinates_y"s,
          "InertialCoordinates_z"s, "Square"s},
         {{0, 1, 2, 3}}, 1.e-2);  // loose tolerance because of low resolution


### PR DESCRIPTION
## Proposed changes

Part of #6278.

Now in the input file you don't need to know the full precision `double` of the observation value when you start. You can specify an epsilon for your value to be within.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Any executable that reads in numeric initial data must add the following option to the `NumericInitialData:` block
```yaml
NumericInitialData:
  ...
  ObservationValueEpsilon: Auto # <-- This defaults to 1e-12
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
