### PR TITLE
Add function to combine H5 dat files

### DIFF
--- a/src/IO/H5/Cce.hpp
+++ b/src/IO/H5/Cce.hpp
@@ -102,11 +102,14 @@ class Cce : public h5::Object {
   /// @{
   /*!
    * \brief Return all currently stored data in the `h5::Cce` file in the form
-   * of a `Matrix` for each bondi variable
+   * of a `Matrix` or a `std::vector<std::vector<double>>` for each bondi
+   * variable
    */
-  std::unordered_map<std::string, Matrix> get_data() const;
+  template <typename T = Matrix>
+  std::unordered_map<std::string, T> get_data() const;
 
-  Matrix get_data(const std::string& bondi_variable_name) const;
+  template <typename T = Matrix>
+  T get_data(const std::string& bondi_variable_name) const;
   /// @}
 
   /// @{
@@ -119,13 +122,15 @@ class Cce : public h5::Object {
    * l_max that this file was constructed with. Also both the first and last row
    * requested must be less than or equal to the total number of rows.
    */
-  std::unordered_map<std::string, Matrix> get_data_subset(
+  template <typename T = Matrix>
+  std::unordered_map<std::string, T> get_data_subset(
       const std::vector<size_t>& these_ell, size_t first_row = 0,
       size_t num_rows = 1) const;
 
-  Matrix get_data_subset(const std::string& bondi_variable_name,
-                         const std::vector<size_t>& these_ell,
-                         size_t first_row = 0, size_t num_rows = 1) const;
+  template <typename T = Matrix>
+  T get_data_subset(const std::string& bondi_variable_name,
+                    const std::vector<size_t>& these_ell, size_t first_row = 0,
+                    size_t num_rows = 1) const;
   /// @}
 
   /*!

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -3,26 +3,34 @@
 
 #include "IO/H5/CombineH5.hpp"
 
-#include <boost/program_options.hpp>
+#include <array>
 #include <cstddef>
 #include <cstdlib>
 #include <iterator>
 #include <limits>
+#include <optional>
+#include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/Structure/BlockGroups.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/CheckH5PropertiesMatch.hpp"
+#include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/SourceArchive.hpp"
 #include "IO/H5/TensorData.hpp"
 #include "IO/H5/VolumeData.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "Parallel/Printf/Printf.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -278,6 +286,195 @@ void combine_h5_vol(
                                       serialized_domain,
                                       serialized_functions_of_time);
     new_file.close_current_object();
+  }
+}
+
+void combine_h5_dat(const std::vector<std::string>& h5_files_to_combine,
+                    const std::string& output_h5_filename,
+                    const Verbosity verbosity) {
+  if (h5_files_to_combine.empty()) {
+    ERROR_NO_TRACE("No H5 files to combine!");
+  }
+
+  std::vector<std::string> subfile_dat_names{};
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> file_to_combine{
+        h5_files_to_combine[0]};
+    subfile_dat_names = file_to_combine.all_files<h5::Dat>("/");
+
+    if (subfile_dat_names.empty()) {
+      ERROR_NO_TRACE("No dat files in H5 file " << h5_files_to_combine[0]
+                                                << "to combine!");
+    }
+  }
+
+  if (verbosity >= Verbosity::Quiet) {
+    Parallel::printf("Combining all dat files from %s into %s\n",
+                     h5_files_to_combine, output_h5_filename);
+  }
+
+  // We just copy if there's only 1 file. We could change this behavior to
+  // error, but that's less versatile when using globs
+  if (h5_files_to_combine.size() == 1) {
+    file_system::copy(h5_files_to_combine[0], output_h5_filename);
+    if (verbosity >= Verbosity::Quiet) {
+      Parallel::printf("Done!\n");
+    }
+    return;
+  }
+
+  // For each dat subfile, this holds the number of *sorted* times from each of
+  // the H5 files to combine so that we always use the latest times. The
+  // std::vector should be the same length as the number of H5 files to combine
+  std::unordered_map<std::string, std::vector<size_t>> num_time_map{};
+
+  // The outer loop is over dat files because we don't require different dat
+  // files to have the same times
+  for (const std::string& dat_filename : subfile_dat_names) {
+    num_time_map[dat_filename];
+    num_time_map.at(dat_filename).resize(h5_files_to_combine.size());
+
+    // The legend and version are sanity checks
+    std::optional<std::vector<std::string>> legend{};
+    std::optional<uint32_t> version{};
+    // Nullopt just means the first file we are looping over
+    std::optional<double> earliest_time{};
+    // We loop backwards to always ensure the "latest" time is used.
+    for (int i = static_cast<int>(h5_files_to_combine.size()) - 1; i >= 0;
+         i--) {
+      const auto index = static_cast<size_t>(i);
+      const std::string& filename = h5_files_to_combine[index];
+      const h5::H5File<h5::AccessType::ReadOnly> file_to_combine{filename};
+      const auto& dat_file = file_to_combine.get<h5::Dat>(dat_filename);
+      const auto dimensions = dat_file.get_dimensions();
+      if (not legend.has_value()) {
+        legend = dat_file.get_legend();
+        version = dat_file.get_version();
+      }
+
+      // Only grab the times for now
+      auto times = dat_file.get_data_subset<std::vector<std::vector<double>>>(
+          {0}, 0, dimensions[0]);
+      alg::sort(times,
+                [](const std::vector<double>& v1,
+                   const std::vector<double>& v2) { return v1[0] < v2[0]; });
+
+      // Makes things easier below.
+      if (UNLIKELY(times.empty())) {
+        ERROR_NO_TRACE("No times in dat file " << dat_filename << " in H5 file "
+                                               << filename);
+      }
+      if (UNLIKELY(legend.value() != dat_file.get_legend())) {
+        ERROR_NO_TRACE("Legend of dat file "
+                       << dat_filename << " in H5 file " << filename
+                       << " doesn't match other H5 files.");
+      }
+      if (UNLIKELY(version.value() != dat_file.get_version())) {
+        ERROR_NO_TRACE("Version of dat file "
+                       << dat_filename << " in H5 file " << filename
+                       << " doesn't match other H5 files.");
+      }
+
+      // This is the first (last) file. We can't make any decisions here so just
+      // store the number of times and the earliest time of this file
+      if (not earliest_time.has_value()) {
+        num_time_map.at(dat_filename)[index] = dimensions[0];
+        earliest_time = times[0][0];
+        continue;
+      }
+
+      // Check that the earliest time of the previous file (previous = later
+      // in the sequence of files since we are looping backward) is after the
+      // first time of this file. We require the files to be passed in
+      // increasing order by their first time.
+      if (UNLIKELY(times[0][0] >= earliest_time.value())) {
+        ERROR_NO_TRACE("The H5 files passed in "
+                       << h5_files_to_combine
+                       << " are not monotonically increasing in their first "
+                          "times for dat file "
+                       << dat_filename);
+      }
+
+      // Determine if the earliest time of the previous file is before any of
+      // the times in this file. If so, don't include those times.
+      size_t row = times.size() - 1;
+      while (times[row][0] >= earliest_time.value()) {
+        // Make sure we don't reach row 0 since that would mean the files are
+        // not ordered. We should've checked for this above, so this is an
+        // additional safety check.
+        if (UNLIKELY(row == 0)) {
+          ERROR_NO_TRACE("Internal consistency error. Please file an issue.");
+        }
+
+        row--;
+      }
+
+      // So long as this file contains some times that need to be combined,
+      // store the number of times and the first time in this file.
+      num_time_map.at(dat_filename)[index] = row + 1;
+      earliest_time = times[0][0];
+
+      file_to_combine.close_current_object();
+    }
+  }
+
+  if (verbosity >= Verbosity::Verbose) {
+    std::stringstream ss{};
+    ss << "Number of times selected to combine in each H5 file for each dat "
+          "subfile:\n";
+    for (const auto& [subfile_name, h5_files_num_times] : num_time_map) {
+      ss << " Dat Subfile " << subfile_name << ":\n";
+      for (size_t i = 0; i < h5_files_num_times.size(); i++) {
+        ss << "  H5 File " << h5_files_to_combine[i] << ": "
+           << h5_files_num_times[i] << "\n";
+      }
+    }
+
+    Parallel::printf("%s", ss.str());
+  }
+
+  // Now that we know the time indices for each dat file for each H5 file to
+  // combine, we open the output file and combine everything
+  h5::H5File<h5::AccessType::ReadWrite> output_h5_file{output_h5_filename};
+
+  // Now we loop over H5 files first to avoid unnecessary filesystem access
+  for (size_t i = 0; i < h5_files_to_combine.size(); i++) {
+    const std::string& filename = h5_files_to_combine[i];
+    const h5::H5File<h5::AccessType::ReadOnly> file_to_combine{filename};
+    for (const std::string& dat_filename : subfile_dat_names) {
+      const auto& input_dat_file = file_to_combine.get<h5::Dat>(dat_filename);
+      const std::vector<std::string>& legend = input_dat_file.get_legend();
+
+      // Avoid copying the legend around if we don't have to
+      h5::Dat* output_dat_file = nullptr;
+      if (output_h5_file.exists<h5::Dat>(dat_filename)) {
+        output_dat_file = &output_h5_file.get<h5::Dat>(dat_filename);
+      } else {
+        const uint32_t version = input_dat_file.get_version();
+        output_dat_file =
+            &output_h5_file.insert<h5::Dat>(dat_filename, legend, version);
+      }
+
+      const size_t num_times = num_time_map.at(dat_filename)[i];
+
+      // We must get all data first and sort it by times, because the number of
+      // times is only meaningful for the sorted data
+      auto data_to_append =
+          input_dat_file.get_data<std::vector<std::vector<double>>>();
+      alg::sort(data_to_append,
+                [](const std::vector<double>& v1,
+                   const std::vector<double>& v2) { return v1[0] < v2[0]; });
+      data_to_append.resize(num_times);
+
+      output_dat_file->append(data_to_append);
+
+      file_to_combine.close_current_object();
+      output_h5_file.close_current_object();
+    }
+  }
+
+  if (verbosity >= Verbosity::Quiet) {
+    Parallel::printf("Done!\n");
   }
 }
 }  // namespace h5

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -139,7 +139,7 @@ std::optional<std::unordered_set<size_t>> get_block_numbers_to_use(
 
 namespace h5 {
 
-void combine_h5(
+void combine_h5_vol(
     const std::vector<std::string>& file_names, const std::string& subfile_name,
     const std::string& output, const std::optional<double> start_value,
     const std::optional<double> stop_value,

--- a/src/IO/H5/CombineH5.hpp
+++ b/src/IO/H5/CombineH5.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "IO/Logging/Verbosity.hpp"
+
 namespace h5 {
 /*!
  * \brief Combine a volume subfile across different HDF5 files.
@@ -23,4 +25,40 @@ void combine_h5_vol(const std::vector<std::string>& file_names,
                     blocks_to_combine = std::nullopt,
                 bool check_src = true);
 
+/*!
+ * \brief Combine the `h5::Dat` subfiles of multiple `h5::H5File`s into a single
+ * H5 file.
+ *
+ * \details The times in each `h5::Dat` subfile can be unordered. The necessary
+ * sorting will be handled in this function. However, the \p h5_files_to_combine
+ * must be mononitcally increasing in time; meaning the earliest time in
+ * `File1.h5` must come before the earliest time in `File2.h5`.
+ *
+ * If there are overlapping times, the "latest" one is always used;
+ * meaning if you have data in `File1.h5` and `File2.h5` and if the earliest
+ * time in `File2.h5` is before some times in `File1.h5`, those times in
+ * `File1.h5` will be discarded and won't appear in the combined H5 file.
+ *
+ * If the H5 files in \p h5_files_to_combine have other types of subfiles, those
+ * will be ignored and will not appear in \p output_h5_filename.
+ *
+ * If \p h5_files_to_combine is empty, an error will occur.
+ *
+ * If there are no `h5::Dat` files in the \p h5_files_to_combine, an error will
+ * occur.
+ *
+ * If the legend or version of an `h5::Dat` is not the same in all of
+ * \p h5_files_to_combine, an error will occur.
+ *
+ * \param h5_files_to_combine Vector of H5 files to combine. They must all have
+ * the same `h5::Dat` filenames, and those `h5::Dat` subfiles must have the same
+ * legends and versions. If not, an error will occur.
+ * \param output_h5_filename Name of the combined H5 file. The `h5::Dat` subfile
+ * structure will be identical to the ones in \p h5_files_to_combine.
+ * \param verbosity Controls how much is printed to stdout. Defaults to no
+ * `Verbosity::Silent` or no output.
+ */
+void combine_h5_dat(const std::vector<std::string>& h5_files_to_combine,
+                    const std::string& output_h5_filename,
+                    Verbosity verbosity = Verbosity::Silent);
 }  // namespace h5

--- a/src/IO/H5/CombineH5.hpp
+++ b/src/IO/H5/CombineH5.hpp
@@ -15,7 +15,7 @@ namespace h5 {
  * should be combined. We ignore other blocks when combining the HDF5
  * files. This provides a way to filter volume data for easier visualization.
  */
-void combine_h5(const std::vector<std::string>& file_names,
+void combine_h5_vol(const std::vector<std::string>& file_names,
                 const std::string& subfile_name, const std::string& output,
                 std::optional<double> start_value = std::nullopt,
                 std::optional<double> stop_value = std::nullopt,

--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -8,6 +8,7 @@
 #include <iosfwd>
 #include <memory>
 #include <ostream>
+#include <vector>
 
 #include "DataStructures/Matrix.hpp"
 #include "IO/H5/CheckH5.hpp"
@@ -160,14 +161,24 @@ void Dat::append(const Matrix& data) {
                                 data.rows(), size_);
 }
 
-Matrix Dat::get_data() const {
-  return h5::retrieve_dataset(dataset_id_, size_);
+template <typename T>
+T Dat::get_data() const {
+  return h5::retrieve_dataset<T>(dataset_id_, size_);
 }
 
-Matrix Dat::get_data_subset(const std::vector<size_t>& these_columns,
-                            const size_t first_row,
-                            const size_t num_rows) const {
-  return retrieve_dataset_subset(dataset_id_, these_columns, first_row,
-                                 num_rows, size_);
+template <typename T>
+T Dat::get_data_subset(const std::vector<size_t>& these_columns,
+                       const size_t first_row, const size_t num_rows) const {
+  return retrieve_dataset_subset<T>(dataset_id_, these_columns, first_row,
+                                    num_rows, size_);
 }
+
+template Matrix Dat::get_data() const;
+template std::vector<std::vector<double>> Dat::get_data() const;
+template Matrix Dat::get_data_subset(const std::vector<size_t>& these_columns,
+                                     const size_t first_row,
+                                     const size_t num_rows) const;
+template std::vector<std::vector<double>> Dat::get_data_subset(
+    const std::vector<size_t>& these_columns, const size_t first_row,
+    const size_t num_rows) const;
 }  // namespace h5

--- a/src/IO/H5/Dat.hpp
+++ b/src/IO/H5/Dat.hpp
@@ -85,7 +85,8 @@ class Dat : public h5::Object {
    * \example
    * \snippet Test_Dat.cpp h5dat_get_data
    */
-  Matrix get_data() const;
+  template <typename T = Matrix>
+  T get_data() const;
 
   /*!
    * \brief Get only some columns over a range of rows
@@ -97,8 +98,9 @@ class Dat : public h5::Object {
    * \example
    * \snippet Test_Dat.cpp h5dat_get_subset
    */
-  Matrix get_data_subset(const std::vector<size_t>& these_columns,
-                         size_t first_row = 0, size_t num_rows = 1) const;
+  template <typename T = Matrix>
+  T get_data_subset(const std::vector<size_t>& these_columns,
+                    size_t first_row = 0, size_t num_rows = 1) const;
 
   /*!
    * \returns the number of rows (first index) and columns (second index)

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -133,14 +133,17 @@ std::array<hsize_t, 2> append_to_dataset(
 /// @{
 /*!
  * \ingroup HDF5Group
- * \brief Convert the data in a dataset to a Matrix
+ * \brief Convert the data in a dataset to a Matrix or a
+ * std::vector<std::vector<double>>
  */
-Matrix retrieve_dataset(hid_t file_id, const std::array<hsize_t, 2>& file_size);
+template <typename T>
+T retrieve_dataset(hid_t file_id, const std::array<hsize_t, 2>& file_size);
 
-Matrix retrieve_dataset_subset(hid_t file_id,
-                               const std::vector<size_t>& these_columns,
-                               size_t first_row, size_t num_rows,
-                               const std::array<hsize_t, 2>& file_size);
+template <typename T>
+T retrieve_dataset_subset(hid_t file_id,
+                          const std::vector<size_t>& these_columns,
+                          size_t first_row, size_t num_rows,
+                          const std::array<hsize_t, 2>& file_size);
 /// @}
 
 /*!

--- a/src/IO/H5/Python/Cce.cpp
+++ b/src/IO/H5/Python/Cce.cpp
@@ -20,18 +20,21 @@ void bind_h5cce(py::module& m) {
   py::class_<h5::Cce>(m, "H5Cce")
       .def("append", &h5::Cce::append, py::arg("data"))
       .def("get_legend", &h5::Cce::get_legend)
-      .def("get_data", py::overload_cast<>(&h5::Cce::get_data, py::const_))
-      .def(
-          "get_data",
-          py::overload_cast<const std::string&>(&h5::Cce::get_data, py::const_),
-          py::arg("bondi_variable_name"))
+      // Use the matrix overload because it all gets converted to numpy arrays
+      // anways
+      .def("get_data",
+           py::overload_cast<>(&h5::Cce::get_data<Matrix>, py::const_))
+      .def("get_data",
+           py::overload_cast<const std::string&>(&h5::Cce::get_data<Matrix>,
+                                                 py::const_),
+           py::arg("bondi_variable_name"))
       .def("get_data_subset",
            py::overload_cast<const std::vector<size_t>&, size_t, size_t>(
-               &h5::Cce::get_data_subset, py::const_),
+               &h5::Cce::get_data_subset<Matrix>, py::const_),
            py::arg("ell"), py::arg("first_row") = 0, py::arg("num_rows") = 1)
       .def("get_data_subset",
            py::overload_cast<const std::string&, const std::vector<size_t>&,
-                             size_t, size_t>(&h5::Cce::get_data_subset,
+                             size_t, size_t>(&h5::Cce::get_data_subset<Matrix>,
                                              py::const_),
            py::arg("bondi_variable_name"), py::arg("ell"),
            py::arg("first_row") = 0, py::arg("num_rows") = 1)

--- a/src/IO/H5/Python/CombineH5.cpp
+++ b/src/IO/H5/Python/CombineH5.cpp
@@ -18,7 +18,7 @@ void bind_h5combine(py::module& m) {
   domain::creators::register_derived_with_charm();
   domain::creators::time_dependence::register_derived_with_charm();
   // Wrapper for combining h5 files
-  m.def("combine_h5", &h5::combine_h5, py::arg("file_names"),
+  m.def("combine_h5_vol", &h5::combine_h5_vol, py::arg("file_names"),
         py::arg("subfile_name"), py::arg("output"), py::arg("start-time"),
         py::arg("stop-time"), py::arg("blocks_to_combine"),
         py::arg("check_src"));

--- a/src/IO/H5/Python/CombineH5.py
+++ b/src/IO/H5/Python/CombineH5.py
@@ -116,7 +116,7 @@ def combine_h5_vol_command(
     if not output.endswith(".h5"):
         output += ".h5"
 
-    spectre_h5.combine_h5(
+    spectre_h5.combine_h5_vol(
         h5files,
         subfile_name,
         output,

--- a/src/IO/H5/Python/Dat.cpp
+++ b/src/IO/H5/Python/Dat.cpp
@@ -29,9 +29,12 @@ void bind_h5dat(py::module& m) {
                const std::vector<std::vector<double>>&)>(&h5::Dat::append),
            py::arg("data"))
       .def("get_legend", &h5::Dat::get_legend)
-      .def("get_data", &h5::Dat::get_data)
-      .def("get_data_subset", &h5::Dat::get_data_subset, py::arg("columns"),
-           py::arg("first_row") = 0, py::arg("num_rows") = 1)
+      // Use the matrix overload because it all gets converted to numpy arrays
+      // anways
+      .def("get_data", &h5::Dat::get_data<Matrix>)
+      .def("get_data_subset", &h5::Dat::get_data_subset<Matrix>,
+           py::arg("columns"), py::arg("first_row") = 0,
+           py::arg("num_rows") = 1)
       .def("get_dimensions", &h5::Dat::get_dimensions)
       .def("get_header", &h5::Dat::get_header)
       .def("get_version", &h5::Dat::get_version);

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_H5")
 set(LIBRARY_SOURCES
   Test_Cce.cpp
   Test_CheckH5PropertiesMatch.cpp
+  Test_CombineH5.cpp
   Test_Dat.cpp
   Test_EosTable.cpp
   Test_H5.cpp

--- a/tests/Unit/IO/H5/Test_CombineH5.cpp
+++ b/tests/Unit/IO/H5/Test_CombineH5.cpp
@@ -1,0 +1,250 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Cce.hpp"
+#include "IO/H5/CombineH5.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "Utilities/FileSystem.hpp"
+
+namespace {
+void test_single_file() {
+  const std::string combined_filename{"CombinedSingle.h5"};
+  const std::string original_filename{"OriginalFileName.h5"};
+  if (file_system::check_if_file_exists(combined_filename)) {
+    file_system::rm(combined_filename, true);
+  }
+  if (file_system::check_if_file_exists(original_filename)) {
+    file_system::rm(original_filename, true);
+  }
+
+  const std::string subfile_name{"SubfileName"};
+  const Matrix data{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}};
+  const std::vector<std::string> legend{"Time", "Data"};
+  const uint32_t version = 4;
+
+  {
+    h5::H5File<h5::AccessType::ReadWrite> h5_file{original_filename};
+    auto& dat_file = h5_file.insert<h5::Dat>(subfile_name, legend, version);
+    dat_file.append(data);
+  }
+
+  h5::combine_h5_dat({original_filename}, combined_filename, Verbosity::Quiet);
+
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> h5_file{combined_filename};
+    const auto& dat_file = h5_file.get<h5::Dat>(subfile_name);
+    CHECK(dat_file.get_version() == version);
+    CHECK(dat_file.get_legend() == legend);
+    CHECK(dat_file.get_data() == data);
+  }
+
+  if (file_system::check_if_file_exists(combined_filename)) {
+    file_system::rm(combined_filename, true);
+  }
+  if (file_system::check_if_file_exists(original_filename)) {
+    file_system::rm(original_filename, true);
+  }
+}
+
+void test() {
+  const std::string combined_filename{"MightyMorphinPowerRangers.h5"};
+  if (file_system::check_if_file_exists(combined_filename)) {
+    file_system::rm(combined_filename, true);
+  }
+  const std::vector<std::string> individual_filenames{
+      "RedRanger.h5", "BlackRanger.h5", "BlueRanger.h5", "YellowRanger.h5"};
+  const std::vector<std::string> subfile_names{"Subfile1", "Subfile2"};
+  // All subfiles can just share the same legend. The data doesn't matter, only
+  // the times for this test.
+  const std::vector<std::string> legend{"Time", "Data"};
+  const std::vector<std::vector<std::vector<double>>> data{
+      // This file doesn't keep the last time
+      {{0.0, 0.0}, {1.0, 1.0}, {2.0, 0.0}},
+      // This file keeps all times, but is unordered
+      {{2.1, 3.0}, {1.5, 2.0}},
+      // This file only keeps the earliest time, but is unordered
+      {{4.1, 0.0}, {3.0, 4.0}, {4.5, 0.0}},
+      // This file keeps all times
+      {{4.0, 5.0}, {5.5, 6.0}, {6.0, 7.0}}};
+
+  const Matrix expected_data{{0.0, 0.0}, {1.0, 1.0}, {1.5, 2.0}, {2.1, 3.0},
+                             {3.0, 4.0}, {4.0, 5.0}, {5.5, 6.0}, {6.0, 7.0}};
+
+  // Write the individual files
+  {
+    for (size_t i = 0; i < individual_filenames.size(); i++) {
+      const std::string& filename = individual_filenames[i];
+      if (file_system::check_if_file_exists(filename)) {
+        file_system::rm(filename, true);
+      }
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{filename};
+      for (const std::string& subfile_name : subfile_names) {
+        auto& dat_file = h5_file.insert<h5::Dat>(subfile_name, legend);
+        dat_file.append(data[i]);
+        h5_file.close_current_object();
+      }
+    }
+  }
+
+  // Combine the H5 files
+  h5::combine_h5_dat(individual_filenames, combined_filename,
+                     Verbosity::Verbose);
+
+  REQUIRE(file_system::check_if_file_exists(combined_filename));
+
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> h5_file{combined_filename};
+    for (const std::string& subfile_name : subfile_names) {
+      CAPTURE(subfile_name);
+      const auto& dat_file = h5_file.get<h5::Dat>(subfile_name);
+      const Matrix dat_data = dat_file.get_data();
+      CHECK(expected_data == dat_data);
+      h5_file.close_current_object();
+    }
+  }
+
+  if (file_system::check_if_file_exists(combined_filename)) {
+    file_system::rm(combined_filename, true);
+  }
+
+  for (const std::string& filename : individual_filenames) {
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+  }
+}
+
+void test_errors() {
+  const std::string fake_file{"FakeFile.h5"};
+  const std::string error_filename_1{"CombineH5Error1.h5"};
+  const std::string error_filename_2{"CombineH5Error2.h5"};
+  CHECK_THROWS_WITH(
+      h5::combine_h5_dat({}, fake_file),
+      Catch::Matchers::ContainsSubstring("No H5 files to combine!"));
+
+  const auto delete_files = [&]() {
+    if (file_system::check_if_file_exists(error_filename_1)) {
+      file_system::rm(error_filename_1, true);
+    }
+    if (file_system::check_if_file_exists(error_filename_2)) {
+      file_system::rm(error_filename_2, true);
+    }
+    if (file_system::check_if_file_exists(fake_file)) {
+      file_system::rm(fake_file, true);
+    }
+  };
+
+  delete_files();
+
+  {
+    INFO("No dat files");
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_1};
+      h5_file.insert<h5::Cce>("CceSubfile", 4);
+    }
+    CHECK_THROWS_WITH(
+        h5::combine_h5_dat({error_filename_1}, fake_file),
+        Catch::Matchers::ContainsSubstring("No dat files in H5 file"));
+  }
+
+  {
+    INFO("No times in dat file");
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_1, true};
+      h5_file.insert<h5::Dat>("DatSubfile",
+                              std::vector<std::string>{"Time", "Blah"});
+    }
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_2, true};
+      h5_file.insert<h5::Dat>("DatSubfile",
+                              std::vector<std::string>{"Time", "Blah"});
+    }
+    CHECK_THROWS_WITH(
+        h5::combine_h5_dat({error_filename_1, error_filename_2}, fake_file),
+        Catch::Matchers::ContainsSubstring("No times in dat file"));
+  }
+
+  delete_files();
+
+  {
+    INFO("Legends don't match");
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_1, true};
+      auto& dat_file = h5_file.try_insert<h5::Dat>(
+          "DatSubfile", std::vector<std::string>{"Time", "Blah"});
+      dat_file.append(std::vector{0.0, 0.0});
+    }
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_2, true};
+      auto& dat_file = h5_file.try_insert<h5::Dat>(
+          "DatSubfile", std::vector<std::string>{"Time", "DifferentBlah"});
+      dat_file.append(std::vector{0.0, 0.0});
+    }
+    CHECK_THROWS_WITH(
+        h5::combine_h5_dat({error_filename_1, error_filename_2}, fake_file),
+        Catch::Matchers::ContainsSubstring("Legend of dat file") and
+            Catch::Matchers::ContainsSubstring("doesn't match other H5 files"));
+  }
+
+  delete_files();
+
+  {
+    INFO("Versions don't match");
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_1, true};
+      auto& dat_file = h5_file.try_insert<h5::Dat>(
+          "DatSubfile", std::vector<std::string>{"Time", "Blah"}, 0);
+      dat_file.append(std::vector{0.0, 0.0});
+    }
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_2, true};
+      auto& dat_file = h5_file.try_insert<h5::Dat>(
+          "DatSubfile", std::vector<std::string>{"Time", "Blah"}, 1);
+      dat_file.append(std::vector{0.0, 0.0});
+    }
+    CHECK_THROWS_WITH(
+        h5::combine_h5_dat({error_filename_1, error_filename_2}, fake_file),
+        Catch::Matchers::ContainsSubstring("Version of dat file") and
+            Catch::Matchers::ContainsSubstring("doesn't match other H5 files"));
+  }
+
+  delete_files();
+
+  {
+    INFO("Non monotonically increasing H5 files");
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_1, true};
+      auto& dat_file = h5_file.try_insert<h5::Dat>(
+          "DatSubfile", std::vector<std::string>{"Time", "Blah"}, 0);
+      dat_file.append(std::vector{1.0, 0.0});
+    }
+    {
+      h5::H5File<h5::AccessType::ReadWrite> h5_file{error_filename_2, true};
+      auto& dat_file = h5_file.try_insert<h5::Dat>(
+          "DatSubfile", std::vector<std::string>{"Time", "Blah"}, 0);
+      dat_file.append(std::vector{0.0, 0.0});
+    }
+    CHECK_THROWS_WITH(
+        h5::combine_h5_dat({error_filename_1, error_filename_2}, fake_file),
+        Catch::Matchers::ContainsSubstring(
+            "are not monotonically increasing in their first "
+            "times for dat file"));
+  }
+}
+}  // namespace
+
+// [[TimeOut, 15]]
+SPECTRE_TEST_CASE("Unit.IO.H5.CombineH5", "[Unit][IO][H5]") {
+  test_single_file();
+  test_errors();
+  test();
+}

--- a/tests/Unit/IO/H5/Test_CombineH5.py
+++ b/tests/Unit/IO/H5/Test_CombineH5.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 import spectre.IO.H5 as spectre_h5
 from spectre import Informer
 from spectre.DataStructures import DataVector
-from spectre.IO.H5 import ElementVolumeData, TensorComponent, combine_h5
+from spectre.IO.H5 import ElementVolumeData, TensorComponent, combine_h5_vol
 from spectre.IO.H5.CombineH5 import combine_h5_command
 from spectre.Spectral import Basis, Quadrature
 
@@ -152,7 +152,7 @@ class TestCombineH5(unittest.TestCase):
         # Run the combine_h5 command and check if any feature (for eg.
         # connectivity length has increased due to combining two files)
 
-        combine_h5(
+        combine_h5_vol(
             self.file_names,
             self.subfile_name,
             self.output_file,


### PR DESCRIPTION
## Proposed changes

Towards #6246.

This function is distinct from the existing CLI function `spectre combine-h5 dat` because this takes care of overlapping times in the dat subfiles (we could optionally replace the python function with this one if we bind this function). Also, this is a C++ function and not a python function because it will be used in the `ReduceCceWorldtube` executable which must be statically linked.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
