### PR TITLE
Deprecate the Metric worldtube format in CCE

### DIFF
--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -340,6 +340,14 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
                                                           extraction_radius),
           l_max, number_of_lookahead_times, interpolator->get_clone());
     } else {
+      Parallel::printf(
+          "\nDEPRECATION WARNING: Reading worldtube H5 files that are in the "
+          "Metric data format (i.e. cartesian components of the metric and "
+          "derivs expressed in modal coefficients) is deprecated. Convert your "
+          "data to the Bondi modal format using the 'ReduceCceWorldtube' "
+          "executable. See https://spectre-code.org/tutorial_cce.html for "
+          "details. Support for reading the Metric data format will be "
+          "dropped in January 2025.\n");
       return std::make_unique<MetricWorldtubeDataManager>(
           std::make_unique<MetricWorldtubeH5BufferUpdater>(filename,
                                                            extraction_radius),


### PR DESCRIPTION
## Proposed changes

We will be making it so that the CCE executable can only read Bondi modal data. In order to get your data into that format, all transitional functionality is moving to the `ReduceCceWorldtube` executable.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Not sure if this was the best place for it, but there's already a warning in this option tag so I figured it'd be the best place and wouldn't be printed many times.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
