### PR TITLE
Allow observing only some blocks in ObserveFields

### DIFF
--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -247,6 +247,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
       - ObserveAdmIntegrals
 
 RandomizeInitialGuess: None

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -328,6 +328,7 @@ EventsAndTriggers:
           # for visualization.
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
+          BlocksToObserve: All
   # Try to find common horizon at small separation
   - Trigger:
       SeparationLessThan:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -191,6 +191,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
       - ApparentHorizon
       - ExcisionBoundary
   # Never terminate... run until something fails!

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -100,6 +100,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         EvenlySpaced:
@@ -116,6 +117,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -112,6 +112,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -108,6 +108,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 Amr:
   Verbosity: Quiet

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -142,6 +142,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 Amr:
   Verbosity: Quiet

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -159,6 +159,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
+          BlocksToObserve: All
 
 Amr:
   Verbosity: Quiet

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -205,6 +205,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -145,6 +145,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -138,6 +138,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -195,6 +195,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -311,6 +311,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
+          BlocksToObserve: All
   - Trigger:
       TimeCompares:
         Comparison: GreaterThan
@@ -362,6 +363,7 @@ EventsRunAtCleanup:
         InterpolateToMesh: None
         CoordinatesFloatingPointType: Double
         FloatingPointTypes: [Double]
+        BlocksToObserve: All
 
 # Control systems are disabled by default
 ControlSystems:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -206,6 +206,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -239,6 +239,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -132,6 +132,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -169,6 +169,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 BuildMatrix:
   MatrixSubfileName: Matrix

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -111,6 +111,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 Amr:
   Verbosity: Quiet

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -115,6 +115,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 Amr:
   Verbosity: Quiet

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -169,6 +169,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
       - ObserveNorms:
           SubfileName: VolumeIntegrals
           TensorsToObserve:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -84,6 +84,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
+          BlocksToObserve: All
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -85,6 +85,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
+          BlocksToObserve: All
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -84,6 +84,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
+          BlocksToObserve: All
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -173,6 +173,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
+          BlocksToObserve: All
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -93,6 +93,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
       - ObserveNorms:
           SubfileName: Errors
           TensorsToObserve:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -129,6 +129,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Float, Float]
+          BlocksToObserve: All
 # [observe_event_trigger]
 
 Observers:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -269,3 +269,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -222,6 +222,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 Amr:
   Verbosity: Quiet

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -242,3 +242,4 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+          BlocksToObserve: All

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -157,6 +157,7 @@ EventsAndTriggers:
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
+          BlocksToObserve: All
 
 Amr:
   Verbosity: Quiet

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -224,14 +224,18 @@ struct ScalarSystem {
       "  CoordinatesFloatingPointType: Double\n"
       "  VariablesToObserve: [Scalar, ScalarVarTimesTwo, ScalarVarTimesThree, "
       "Error(Scalar)]\n"
-      "  FloatingPointTypes: [Double]\n";
+      "  FloatingPointTypes: [Double]\n"
+      "  BlocksToObserve: All\n";
   static ObserveEvent make_test_object(
-      const std::optional<Mesh<volume_dim>>& interpolating_mesh) {
+      const std::optional<Mesh<volume_dim>>& interpolating_mesh,
+      std::optional<std::vector<std::string>> active_block_or_block_groups =
+          std::nullopt) {
     return ObserveEvent{
         "element_data",
         FloatingPointType::Double,
         {FloatingPointType::Double},
         {"Scalar", "ScalarVarTimesTwo", "ScalarVarTimesThree", "Error(Scalar)"},
+        std::move(active_block_or_block_groups),
         interpolating_mesh};
   }
 };
@@ -346,10 +350,13 @@ struct ComplicatedSystem {
       "                       Vector, Tensor, Tensor2,"
       "                       Error(Vector), Error(Tensor2)]\n"
       "  FloatingPointTypes: [Double, Double, Double, Double, Float, Float,"
-      "                       Double, Float]\n";
+      "                       Double, Float]\n"
+      "  BlocksToObserve: All\n";
 
   static ObserveEvent make_test_object(
-      const std::optional<Mesh<volume_dim>>& interpolating_mesh) {
+      const std::optional<Mesh<volume_dim>>& interpolating_mesh,
+      std::optional<std::vector<std::string>> active_block_or_block_groups =
+          std::nullopt) {
     return ObserveEvent(
         "element_data", FloatingPointType::Double,
         {FloatingPointType::Double, FloatingPointType::Double,
@@ -358,7 +365,7 @@ struct ComplicatedSystem {
          FloatingPointType::Double, FloatingPointType::Float},
         {"Scalar", "ScalarVarTimesTwo", "ScalarVarTimesThree", "Vector",
          "Tensor", "Tensor2", "Error(Vector)", "Error(Tensor2)"},
-        interpolating_mesh);
+        std::move(active_block_or_block_groups), interpolating_mesh);
   }
 };
 }  // namespace TestHelpers::dg::Events::ObserveFields


### PR DESCRIPTION
## Proposed changes

This is useful for visualizations, e.g. in a BNS simulation we only care about the stars, not the matter in the wave zone.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
