### PR TITLE
Remove zeros after LtsCoefficients arithmetic

### DIFF
--- a/tests/Unit/Time/TimeSteppers/Test_AdamsLts.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsLts.cpp
@@ -175,6 +175,26 @@ void test_lts_coefficients_struct() {
               adams_lts::LtsCoefficients{{id1, id1, 1.0e-5}})
                  .empty());
   }
+
+  {
+    auto twice_coefs1 = coefs1;
+    twice_coefs1 += coefs1;
+    auto a = coefs1;
+    a += a;
+    CHECK(a == twice_coefs1);
+  }
+  {
+    auto a = coefs1;
+#if defined(__clang__) and __clang__ < 17
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
+    a -= a;
+#if defined(__clang__) and __clang__ < 17
+#pragma GCC diagnostic pop
+#endif
+    CHECK(a.empty());
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
## Proposed changes

Remove zeros after LtsCoefficients arithmetic.  These are the coefficients in a linear combination of Variables objects, so avoiding terms with zero coefficients is a worthwhile minor optimization.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
