### PR TITLE
Mark formaline objects noexecstack

### DIFF
--- a/tools/Formaline.sh
+++ b/tools/Formaline.sh
@@ -25,7 +25,8 @@ fi
 popd >/dev/null
 
 pushd @CMAKE_BINARY_DIR@/tmp >/dev/null
-ld -r -b binary -o ${formaline_archive_name}.o ${formaline_archive_name}.tar.gz
+ld -r -z noexecstack -b binary -o ${formaline_archive_name}.o \
+   ${formaline_archive_name}.tar.gz
 rm ${formaline_dir}/${formaline_archive_name}.tar.gz
 popd >/dev/null
 # Set the formaline object file output name


### PR DESCRIPTION
Depending on linker settings, the lack of marking could cause warnings and executable stack in the final binaries.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
