### PR TITLE
Enable BBH ID control of CoM and Padm.

### DIFF
--- a/support/Pipelines/Bbh/ControlId.py
+++ b/support/Pipelines/Bbh/ControlId.py
@@ -15,7 +15,9 @@ from spectre.Visualization.ReadH5 import to_dataframe
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_RESIDUAL_TOLERANCE = 1.0e-6
+# The default tolerance is just below the effect of junk radiation on the
+# controlled paramaters, which  is about 1.0e-3.
+DEFAULT_RESIDUAL_TOLERANCE = 1.0e-4
 DEFAULT_MAX_ITERATIONS = 30
 
 # Initial data physical parameters that are supported in this control scheme

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -25,6 +25,8 @@ Next:
         - {{ DimensionlessSpinLeft_x }}
         - {{ DimensionlessSpinLeft_y }}
         - {{ DimensionlessSpinLeft_z }}
+      center_of_mass: [0., 0., 0.]
+      linear_momentum: [0., 0., 0.]
     evolve: {{ evolve }}
     scheduler: {{ scheduler | default("None") }}
     copy_executable: {{ copy_executable | default("None") }}

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -157,6 +157,8 @@ class TestInitialData(unittest.TestCase):
                         "mass_B": 0.4,
                         "spin_A": [0.1, 0.2, 0.3],
                         "spin_B": [0.4, 0.5, 0.6],
+                        "center_of_mass": [0.0, 0.0, 0.0],
+                        "linear_momentum": [0.0, 0.0, 0.0],
                     },
                     "evolve": True,
                     "scheduler": "None",


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

With recent changes to the calculation of the center of mass and linear momentum integrals, we are now ready to enable their control by default. We also take this opportunity to set the control residual tolerance to `1.e-4` instead of `1.e-6`, which makes more sense given that junk radiation effects are on the order of `1.e-3`.

For an equal-mass non-spinning case with default settings, the control loop currently reaches the residual tolerance in just 3 iterations. In human time, this takes ~17 minutes on 1 node of CaltechHPC.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
