### PR TITLE
Add Transition to Ringdown Script

### DIFF
--- a/src/Evolution/Ringdown/CMakeLists.txt
+++ b/src/Evolution/Ringdown/CMakeLists.txt
@@ -31,3 +31,5 @@ target_link_libraries(
   SphericalHarmonicsIO
   Utilities
   )
+
+add_subdirectory(Python)

--- a/src/Evolution/Ringdown/Python/Bindings.cpp
+++ b/src/Evolution/Ringdown/Python/Bindings.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace py = pybind11;
+
+namespace evolution::Ringdown::py_bindings {  // NOLINT
+// Silence warning about no previous declaration
+void bind_strahlkorper_coefs_in_ringdown_distorted_frame(py::module& m);
+
+void bind_strahlkorper_coefs_in_ringdown_distorted_frame(py::module& m) {
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  m.def("strahlkorper_coefs_in_ringdown_distorted_frame",
+        &evolution::Ringdown::strahlkorper_coefs_in_ringdown_distorted_frame,
+        py::arg("path_to_horizons_h5"), py::arg("surface_subfile_name"),
+        py::arg("requested_number_of_times_from_end"), py::arg("match_time"),
+        py::arg("settling_timescale"), py::arg("exp_func_and_2_derivs"),
+        py::arg("exp_outer_bdry_func_and_2_derivs"),
+        py::arg("rot_func_and_2_derivs"));
+}
+}  // namespace evolution::Ringdown::py_bindings
+
+PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
+  enable_segfault_handler();
+  // So return types are converted to DataVectors
+  py::module_::import("spectre.DataStructures");
+  evolution::Ringdown::py_bindings::
+      bind_strahlkorper_coefs_in_ringdown_distorted_frame(m);
+}

--- a/src/Evolution/Ringdown/Python/CMakeLists.txt
+++ b/src/Evolution/Ringdown/Python/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyRingdown")
+
+spectre_python_add_module(
+    Ringdown
+    LIBRARY_NAME ${LIBRARY}
+    MODULE_PATH "Evolution"
+    SOURCES
+    Bindings.cpp
+    PYTHON_FILES
+    __init__.py
+    ComputeAhCCoefsInRingdownDistortedFrame.py
+    FunctionsOfTimeFromVolume.py
+)
+
+spectre_python_headers(
+    ${LIBRARY}
+    INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+    HEADERS
+)
+
+spectre_python_link_libraries(
+    ${LIBRARY}
+    PRIVATE
+    Boost::boost
+    CoordinateMaps
+    DataStructures
+    Domain
+    DomainCreators
+    DomainStructure
+    ErrorHandling
+    Options
+    ParallelInterpolation
+    Ringdown
+    Serialization
+    Spectral
+    SphericalHarmonics
+    SphericalHarmonicsIO
+    Utilities
+    pybind11::module
+)
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyDataStructures
+  PyH5
+  PySpectral
+  PyTensor
+  )

--- a/src/Evolution/Ringdown/Python/ComputeAhCCoefsInRingdownDistortedFrame.py
+++ b/src/Evolution/Ringdown/Python/ComputeAhCCoefsInRingdownDistortedFrame.py
@@ -1,0 +1,220 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import warnings
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+import numpy as np
+import yaml
+from rich.pretty import pretty_repr
+
+import spectre.Evolution.Ringdown as Ringdown
+import spectre.IO.H5 as spectre_h5
+from spectre.DataStructures import ModalVector
+from spectre.SphericalHarmonics import Strahlkorper, ylm_legend_and_data
+
+logger = logging.getLogger(__name__)
+
+
+def cubic(x, a, b, c, d):
+    return a * x**3 + b * x**2 + c * x + d
+
+
+def dt_cubic(x, a, b, c, d):
+    return 3 * a * x**2 + 2 * b * x + c
+
+
+def dt2_cubic(x, a, b, c, d):
+    return 6 * a * x + 2 * b
+
+
+# Cubic fit transformed coefs to get first and second time derivatives
+def fit_to_a_cubic(times, coefs, match_time, zero_coefs_eps):
+    fits = []
+    fit_ahc = []
+    fit_dt_ahc = []
+    fit_dt2_ahc = []
+    for j in np.arange(0, coefs.shape[-1], 1):
+        # Optionally, avoid fitting coefficients sufficiently close to zero by
+        # just setting these coefficients and their time derivatives to zero.
+        if (
+            zero_coefs_eps is not None
+            and sum(np.abs(coefs[:, j])) < zero_coefs_eps
+        ):
+            fits.append(np.zeros(4))
+            fit_ahc.append(0.0)
+            fit_dt_ahc.append(0.0)
+            fit_dt2_ahc.append(0.0)
+            continue
+        # Ignore RankWarnings suggesting the fit might not be good enough;
+        # for equal-mass non-spinning, sufficiently good fits for starting
+        # a ringdown, even though RankWarnings were triggered
+        with warnings.catch_warnings():
+            # In numpy 2.0+, RankWarning was moved to np.exceptions.RankWarning
+            try:
+                warnings.simplefilter("ignore", np.RankWarning)
+            except AttributeError:
+                warnings.simplefilter("ignore", np.exceptions.RankWarning)
+            fit = np.polyfit(times, coefs[:, j], 3)
+        fits.append(fit)
+        fit_ahc.append(cubic(match_time, *(fit)))
+        fit_dt_ahc.append(dt_cubic(match_time, *(fit)))
+        fit_dt2_ahc.append(dt2_cubic(match_time, *(fit)))
+
+    return fit_ahc, fit_dt_ahc, fit_dt2_ahc
+
+
+def compute_ahc_coefs_in_ringdown_distorted_frame(
+    ahc_reductions_path,
+    ahc_subfile,
+    exp_func_and_2_derivs,
+    exp_outer_bdry_func_and_2_derivs,
+    rot_func_and_2_derivs,
+    number_of_ahc_finds_for_fit,
+    match_time,
+    settling_timescale,
+    zero_coefs_eps,
+):
+    """Computes the AhC Ylm Coefficients in the Ringdown distorted frame
+    using the functions of time and the AhC coefficients in the Inspiral
+    inertial frame.
+
+    Arugments:
+    ahc_reductions_path: Path to reduction file where AhC Coefficients will be
+    written.
+    ahc_subfile: The subfile of the reductions file where AhC coefficients will
+    be placed.
+    expansion_func_and_2_derivs: Expansion functions of time from volume
+    data.
+    exp_outer_bdry_func_and_2_derivs: Outer boundary expansion function of time
+    from volume data
+    rot_func_and_2_derivs: Rotation function of time from volume data
+    number_of_ahc_finds_for_fit: The number of ahc finds that will be used in
+    the fit.
+    match_time: Time to match functions of time.
+    settling_timescale: Timescale for settle to constant functions of time.
+    zero_coefs_eps: Approximate limit to compare coefficients to 0.0
+
+    """
+
+    ahc_times = []
+    ahc_center = []
+    ahc_lmax = 0
+    with spectre_h5.H5File(ahc_reductions_path, "r") as h5file:
+        datfile = h5file.get_dat(ahc_subfile)
+        datfile_np = np.array(datfile.get_data())
+        ahc_times = datfile_np[:, 0]
+        ahc_center = [datfile_np[0][1], datfile_np[0][2], datfile_np[0][3]]
+        ahc_lmax = int(datfile_np[0][4])
+
+    # Transform AhC coefs to ringdown distorted frame and get other data
+    # needed to start a ringdown, such as initial values for functions of time
+    coefs_at_different_times = np.array(
+        Ringdown.strahlkorper_coefs_in_ringdown_distorted_frame(
+            ahc_reductions_path,
+            ahc_subfile,
+            number_of_ahc_finds_for_fit,
+            match_time,
+            settling_timescale,
+            exp_func_and_2_derivs,
+            exp_outer_bdry_func_and_2_derivs,
+            rot_func_and_2_derivs,
+        )
+    )
+
+    # Do not include AhCs at times greater than the match time. Errors tend
+    # to grow as time increases, so fit derivatives using the match time
+    # and earlier times, to get a more accurate fit.
+    ahc_times_for_fit_list = []
+    coefs_at_different_times_for_fit_list = []
+    for i, time in enumerate(ahc_times[-number_of_ahc_finds_for_fit:]):
+        if time <= match_time:
+            ahc_times_for_fit_list.append(time)
+            coefs_at_different_times_for_fit_list.append(
+                coefs_at_different_times[i]
+            )
+    ahc_times_for_fit = np.array(ahc_times_for_fit_list)
+    coefs_at_different_times_for_fit = np.array(
+        coefs_at_different_times_for_fit_list
+    )
+    if ahc_times_for_fit.shape[0] == 0:
+        logger.warning(
+            "No available AhC times before selected match time; using all"
+            " available AhC times, even though numerical errors are likely"
+            " larger after the match time"
+        )
+        ahc_times_for_fit = ahc_times[-number_of_ahc_finds_for_fit:]
+        coefs_at_different_times_for_fit = coefs_at_different_times[
+            -number_of_ahc_finds_for_fit:
+        ]
+
+    logger.info("AhC times available: " + str(ahc_times.shape[0]))
+    logger.info(
+        "AhC available time range: "
+        + str(np.min(ahc_times))
+        + " - "
+        + str(np.max(ahc_times))
+    )
+    logger.info("AhC times used: " + str(ahc_times_for_fit.shape[0]))
+    logger.info(
+        "AhC used time range: "
+        + str(np.min(ahc_times_for_fit))
+        + " - "
+        + str(np.max(ahc_times_for_fit))
+    )
+    logger.info(
+        "Coef times available: " + str(coefs_at_different_times.shape[0])
+    )
+    logger.info(
+        "Coef times used: " + str(coefs_at_different_times_for_fit.shape[0])
+    )
+
+    fit_ahc_coefs, fit_ahc_dt_coefs, fit_ahc_dt2_coefs = fit_to_a_cubic(
+        ahc_times_for_fit,
+        coefs_at_different_times_for_fit,
+        match_time,
+        zero_coefs_eps,
+    )
+
+    # Note: assumes no translation, so inertial and distorted centers are the
+    # same, i.e. both are at the origin. A future update will incorporate
+    # translation.
+
+    fit_ahc_coef_mv = ModalVector(fit_ahc_coefs)
+    fit_ahc_dt_coef_mv = ModalVector(fit_ahc_dt_coefs)
+    fit_ahc_dt2_coef_mv = ModalVector(fit_ahc_dt2_coefs)
+    fit_ahc_strahlkorper = Strahlkorper(
+        ahc_lmax, ahc_lmax, fit_ahc_coef_mv, ahc_center
+    )
+    fit_ahc_dt_strahlkorper = Strahlkorper(
+        ahc_lmax, ahc_lmax, fit_ahc_dt_coef_mv, ahc_center
+    )
+    fit_ahc_dt2_strahlkorper = Strahlkorper(
+        ahc_lmax, ahc_lmax, fit_ahc_dt2_coef_mv, ahc_center
+    )
+    legend_ahc, fit_ahc_ylm_coefs_to_write = ylm_legend_and_data(
+        fit_ahc_strahlkorper, match_time, ahc_lmax
+    )
+    legend_ahc_dt, fit_ahc_dt_ylm_coefs_to_write = ylm_legend_and_data(
+        fit_ahc_dt_strahlkorper, match_time, ahc_lmax
+    )
+    legend_ahc_dt2, fit_ahc_dt2_ylm_coefs_to_write = ylm_legend_and_data(
+        fit_ahc_dt2_strahlkorper, match_time, ahc_lmax
+    )
+
+    ringdown_ylm_coefs = [
+        fit_ahc_ylm_coefs_to_write,
+        fit_ahc_dt_ylm_coefs_to_write,
+        fit_ahc_dt2_ylm_coefs_to_write,
+    ]
+    ringdown_ylm_legend = [legend_ahc, legend_ahc_dt, legend_ahc_dt2]
+
+    for i in range(1, 4, 1):
+        legend_ahc[i] = legend_ahc[i].replace("Inertial", "Distorted")
+        legend_ahc_dt[i] = legend_ahc_dt[i].replace("Inertial", "Distorted")
+        legend_ahc_dt2[i] = legend_ahc_dt2[i].replace("Inertial", "Distorted")
+
+    return ringdown_ylm_coefs, ringdown_ylm_legend

--- a/src/Evolution/Ringdown/Python/FunctionsOfTimeFromVolume.py
+++ b/src/Evolution/Ringdown/Python/FunctionsOfTimeFromVolume.py
@@ -1,0 +1,63 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+import numpy as np
+import yaml
+from rich.pretty import pretty_repr
+
+import spectre.IO.H5 as spectre_h5
+from spectre.Domain import deserialize_functions_of_time
+
+logger = logging.getLogger(__name__)
+
+
+# Transform AhC coefs to ringdown distorted frame and get other data
+# needed to start a ringdown, such as initial values for functions of time
+def functions_of_time_from_volume(
+    fot_vol_h5_path, fot_vol_subfile, match_time, which_obs_id
+):
+    exp_func_and_2_derivs = []
+    exp_outer_bdry_func_and_2_derivs = []
+    rot_func_and_2_derivs = []
+
+    with spectre_h5.H5File(fot_vol_h5_path, "r") as h5file:
+        if fot_vol_subfile.split(".")[-1] == "vol":
+            fot_vol_subfile = fot_vol_subfile.split(".")[0]
+        volfile = h5file.get_vol("/" + fot_vol_subfile)
+        obs_ids = volfile.list_observation_ids()
+        logger.info("About to deserialize functions of time")
+        fot_times = list(map(volfile.get_observation_value, obs_ids))
+        serialized_fots = volfile.get_functions_of_time(obs_ids[which_obs_id])
+        functions_of_time = deserialize_functions_of_time(serialized_fots)
+        logger.info("Deserialized functions of time")
+
+        # The inspiral expansion map includes two functions of time:
+        # an expansion map allowing the black holes to move closer together in
+        # comoving coordinates, and an expansion map causing the outer boundary
+        # to move slightly inwards. The ringdown only requires the outer
+        # boundary expansion map, so set the other map to the identity.
+        exp_func_and_2_derivs = [1.0, 0.0, 0.0]
+
+        exp_outer_bdry_func_and_2_derivs = [
+            x[0]
+            for x in functions_of_time[
+                "ExpansionOuterBoundary"
+            ].func_and_2_derivs(fot_times[which_obs_id])
+        ]
+        rot_func_and_2_derivs_tuple = functions_of_time[
+            "Rotation"
+        ].func_and_2_derivs(fot_times[which_obs_id])
+        rot_func_and_2_derivs = [
+            [coef for coef in x] for x in rot_func_and_2_derivs_tuple
+        ]
+
+    return (
+        exp_func_and_2_derivs,
+        exp_outer_bdry_func_and_2_derivs,
+        rot_func_and_2_derivs,
+    )

--- a/src/Evolution/Ringdown/Python/__init__.py
+++ b/src/Evolution/Ringdown/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._Pybindings import *

--- a/support/Pipelines/Bbh/Ringdown.py
+++ b/support/Pipelines/Bbh/Ringdown.py
@@ -6,9 +6,19 @@ from pathlib import Path
 from typing import Optional, Union
 
 import click
+import numpy as np
 import yaml
 from rich.pretty import pretty_repr
 
+import spectre.IO.H5 as spectre_h5
+from spectre.Evolution.Ringdown.ComputeAhCCoefsInRingdownDistortedFrame import (
+    compute_ahc_coefs_in_ringdown_distorted_frame,
+)
+
+# next import out of order to avoid Unrecognized PUP::able::PUP_ID error
+from spectre.Evolution.Ringdown.FunctionsOfTimeFromVolume import (
+    functions_of_time_from_volume,
+)
 from spectre.support.Schedule import schedule, scheduler_options
 
 logger = logging.getLogger(__name__)
@@ -19,6 +29,7 @@ RINGDOWN_INPUT_FILE_TEMPLATE = Path(__file__).parent / "Ringdown.yaml"
 def ringdown_parameters(
     inspiral_input_file: dict,
     inspiral_run_dir: Union[str, Path],
+    fot_vol_subfile: str,
     refinement_level: int,
     polynomial_order: int,
 ) -> dict:
@@ -30,6 +41,7 @@ def ringdown_parameters(
       inspiral_input_file: Inspiral input file as a dictionary.
       id_run_dir: Directory of the inspiral run. Paths in the input file
         are relative to this directory.
+      fot_vol_subfile: Subfile in volume data used for Functions of Time.
       refinement_level: h-refinement level.
       polynomial_order: p-refinement level.
     """
@@ -39,6 +51,7 @@ def ringdown_parameters(
             Path(inspiral_run_dir).resolve()
             / (inspiral_input_file["Observers"]["VolumeFileName"] + "*.h5")
         ),
+        "IdFileGlobSubgroup": fot_vol_subfile,
         # Resolution
         "L": refinement_level,
         "P": polynomial_order,
@@ -46,10 +59,20 @@ def ringdown_parameters(
 
 
 def start_ringdown(
-    inspiral_input_file_path: Union[str, Path],
+    inspiral_run_dir: Union[str, Path],
+    number_of_ahc_finds_for_fit: int,
+    match_time: float,
+    settling_timescale: float,
+    zero_coefs_eps: float,
     refinement_level: int,
     polynomial_order: int,
-    inspiral_run_dir: Optional[Union[str, Path]] = None,
+    inspiral_input_file: Optional[Union[str, Path]] = None,
+    ahc_reductions_path: Optional[Union[str, Path]] = None,
+    ahc_subfile: str = "ObservationAhC_Ylm",
+    fot_vol_h5_path: Optional[Union[str, Path]] = None,
+    fot_vol_subfile: str = "ForContinuation",
+    path_to_output_h5: Optional[Union[str, Path]] = None,
+    output_subfile_prefix: str = "Distorted",
     ringdown_input_file_template: Union[
         str, Path
     ] = RINGDOWN_INPUT_FILE_TEMPLATE,
@@ -60,36 +83,200 @@ def start_ringdown(
 ):
     """Schedule a ringdown simulation from the inspiral.
 
-    Point the INSPIRAL_INPUT_FILE_PATH to the input file of the last inspiral
-    segment. Also specify 'inspiral_run_dir' if the simulation was run in a
-    different directory than where the input file is. Parameters for the
-    ringdown will be determined from the inspiral and inserted into the
+    Point the inspiral_run_dir to the last inspiral segment. Also specify
+    'inspiral_input_file' if the simulation was run in a different directory
+    than where the input file is. Parameters for the ringdown will be determined
+    from the inspiral and inserted into the
     'ringdown_input_file_template'. The remaining options are forwarded to the
     'schedule' command. See 'schedule' docs for details.
+
+    Here 'parameters for the ringdown' includes the information needed to
+    initialize the time-dependent maps, including the shape map. Common horizon
+    shape coefficients in the ringdown distorted frame will be written to
+    disk that the ringdown input file will point to.
+
+    Arguments:
+        inspiral_run_dir: Path to the last segment in the inspiral run
+        directory.
+        number_of_ahc_finds_for_fit: The number of ahc finds that will be used
+        in the fit.
+        match_time: The time to match the time dependent maps at.
+        settling_timescale: The settling timescale for the rotation and
+        expansion maps.
+        zero_coefs_eps: "If the sum of a given coefficient over all
+        'number_of_ahc_finds_for_fit' is less than 'zero_coefs_eps', set that
+        coefficient to 0.0 exactly."
+        refinement_level: The initial h refinement level for ringdown.
+        polynomial_order: The initial p refinement level for ringdown.
+        inspiral_input_file: The input file used for during the Inspiral,
+        defaults to the Inspiral.yaml inside the inspiral_run_dir.
+        ahc_reductions_path: The full path to the BbhReductions file that
+        contains AhC data, defaults to BbhReductions.h5 in the inspiral_run_dir.
+        ahc_subfile: Subfile containing reduction data at times of AhC finds,
+        defaults to 'ObservationAhC_Ylm'.
+        fot_vol_h5_path: The full path to any volume data containing the
+        functions of time at the time of AhC finds, defaults to BbhVolume0.h5 in
+        the inspiral_run_dir.
+        fot_vol_subfile: Subfile containing volume data where at times of AhC
+        finds, defaults to 'ForContinuation'.
+        path_to_output_h5: H5 file to output horizon coefficients needed for
+        Ringdown.
+        output_subfile_prefix: Subfile prefix for output data, defaults to
+        'Distorted'.
+        ringdown_input_file_template: Yaml to insert ringdown coefficients into.
     """
     logger.warning(
         "The BBH pipeline is still experimental. Please review the"
-        " generated input files."
+        " generated input files. In particular, the ringdown BBH pipline has"
+        " been tested for a q=1, spin=0 quasicircular inspiral but does not"
+        " yet support accounting for a nonzero translation map in the inspiral"
+        " (necessary for unequal-mass mergers.)"
     )
-
     # Determine ringdown parameters from inspiral
-    with open(inspiral_input_file_path, "r") as open_input_file:
+    # Resolve and set correct files/paths.
+    if inspiral_input_file is None:
+        inspiral_input_file = inspiral_run_dir / "Inspiral.yaml"
+
+    if ahc_reductions_path is None:
+        ahc_reductions_path = inspiral_run_dir / "BbhReductions.h5"
+
+    if fot_vol_h5_path is None:
+        fot_vol_h5_path = inspiral_run_dir / "BbhVolume0.h5"
+
+    with open(inspiral_input_file, "r") as open_input_file:
         _, inspiral_input_file = yaml.safe_load_all(open_input_file)
-    if inspiral_run_dir is None:
-        inspiral_run_dir = Path(inspiral_input_file_path).resolve().parent
-    ringdown_params = ringdown_parameters(
-        inspiral_input_file,
-        inspiral_run_dir,
-        refinement_level=refinement_level,
-        polynomial_order=polynomial_order,
-    )
-    logger.debug(f"Ringdown parameters: {pretty_repr(ringdown_params)}")
 
     # Resolve directories
     if pipeline_dir:
         pipeline_dir = Path(pipeline_dir).resolve()
     if pipeline_dir and not segments_dir and not run_dir:
         segments_dir = pipeline_dir / "003_Ringdown"
+
+    if path_to_output_h5 is None:
+        path_to_output_h5 = pipeline_dir / "RingdownDistortedCoefs.h5"
+
+    ringdown_params = ringdown_parameters(
+        inspiral_input_file,
+        inspiral_run_dir,
+        fot_vol_subfile,
+        refinement_level=refinement_level,
+        polynomial_order=polynomial_order,
+    )
+
+    # Compute ringdown shape coefficients and function of time info
+    # for ringdown
+    with spectre_h5.H5File(str(fot_vol_h5_path), "r") as h5file:
+        if fot_vol_subfile.split(".")[-1] == "vol":
+            fot_vol_subfile = fot_vol_subfile.split(".")[0]
+        volfile = h5file.get_vol("/" + fot_vol_subfile)
+        obs_ids = volfile.list_observation_ids()
+        fot_times = np.array(list(map(volfile.get_observation_value, obs_ids)))
+        which_obs_id = np.argmin(np.abs(fot_times - match_time))
+
+        logger.info("Desired match time: " + str(match_time))
+        logger.info("Selected ObservationID: " + str(which_obs_id))
+        logger.info("Selected match time: " + str(fot_times[which_obs_id]))
+
+    match_time = fot_times[which_obs_id]
+
+    (
+        expansion_func_with_2_derivs,
+        expansion_func_outer_boundary_with_2_derivs,
+        rotation_func_with_2_derivs,
+    ) = functions_of_time_from_volume(
+        str(fot_vol_h5_path), fot_vol_subfile, match_time, which_obs_id
+    )
+
+    ringdown_ylm_coefs, ringdown_ylm_legend = (
+        compute_ahc_coefs_in_ringdown_distorted_frame(
+            str(ahc_reductions_path),
+            ahc_subfile,
+            expansion_func_with_2_derivs,
+            expansion_func_outer_boundary_with_2_derivs,
+            rotation_func_with_2_derivs,
+            number_of_ahc_finds_for_fit,
+            match_time,
+            settling_timescale,
+            zero_coefs_eps,
+        )
+    )
+
+    # Setting up and writing the distorted coefficients output file.
+    output_subfile_ahc = output_subfile_prefix + "AhC_Ylm"
+    output_subfile_dt_ahc = output_subfile_prefix + "dtAhC_Ylm"
+    output_subfile_dt2_ahc = output_subfile_prefix + "dt2AhC_Ylm"
+
+    with spectre_h5.H5File(file_name=path_to_output_h5, mode="a") as h5file:
+        ahc_datfile = h5file.insert_dat(
+            path="/" + output_subfile_ahc,
+            legend=ringdown_ylm_legend[0],
+            version=0,
+        )
+        ahc_datfile.append(ringdown_ylm_coefs[0])
+        h5file.close_current_object()
+        ahc_dt_datfile = h5file.insert_dat(
+            path="/" + output_subfile_dt_ahc,
+            legend=ringdown_ylm_legend[1],
+            version=0,
+        )
+        ahc_dt_datfile.append(ringdown_ylm_coefs[1])
+        h5file.close_current_object()
+        ahc_dt2_datfile = h5file.insert_dat(
+            path="/" + output_subfile_dt2_ahc,
+            legend=ringdown_ylm_legend[2],
+            version=0,
+        )
+        ahc_dt2_datfile.append(ringdown_ylm_coefs[2])
+    logger.info("Obtained ringdown coefs")
+    # Print out coefficients for insertion into BBH domain
+    logger.info("Expansion: " + str(expansion_func_with_2_derivs))
+    logger.info(
+        "ExpansionOutrBdry: " + str(expansion_func_outer_boundary_with_2_derivs)
+    )
+    logger.info("Rotation: " + str(rotation_func_with_2_derivs))
+    logger.info("Match time: " + str(match_time))
+    logger.info("Settling timescale: " + str(settling_timescale))
+    logger.info("Lmax: " + str(int(ringdown_ylm_coefs[0][4])))
+
+    ringdown_params["MatchTime"] = match_time
+    ringdown_params["ShapeMapLMax"] = int(ringdown_ylm_coefs[0][4])
+    ringdown_params["PathToAhCCoefsH5File"] = path_to_output_h5
+    ringdown_params["AhCCoefsSubfilePrefix"] = output_subfile_prefix
+    ringdown_params["Rotation0"] = rotation_func_with_2_derivs[0][0]
+    ringdown_params["Rotation1"] = rotation_func_with_2_derivs[0][1]
+    ringdown_params["Rotation2"] = rotation_func_with_2_derivs[0][2]
+    ringdown_params["Rotation3"] = rotation_func_with_2_derivs[0][3]
+    ringdown_params["dtRotation0"] = rotation_func_with_2_derivs[1][0]
+    ringdown_params["dtRotation1"] = rotation_func_with_2_derivs[1][1]
+    ringdown_params["dtRotation2"] = rotation_func_with_2_derivs[1][2]
+    ringdown_params["dtRotation3"] = rotation_func_with_2_derivs[1][3]
+    ringdown_params["dt2Rotation0"] = rotation_func_with_2_derivs[2][0]
+    ringdown_params["dt2Rotation1"] = rotation_func_with_2_derivs[2][1]
+    ringdown_params["dt2Rotation2"] = rotation_func_with_2_derivs[2][2]
+    ringdown_params["dt2Rotation3"] = rotation_func_with_2_derivs[2][3]
+    ringdown_params["ExpansionOuterBdry"] = (
+        expansion_func_outer_boundary_with_2_derivs[0]
+    )
+    ringdown_params["dtExpansionOuterBdry"] = (
+        expansion_func_outer_boundary_with_2_derivs[1]
+    )
+    ringdown_params["dt2ExpansionOuterBdry"] = (
+        expansion_func_outer_boundary_with_2_derivs[2]
+    )
+    # To avoid interpolation errors, put outer boundary of ringdown domain
+    # slightly inside the outer boundary of the inspiral domain
+    ringdown_params["OuterBdryRadius"] = (
+        inspiral_input_file["DomainCreator"]["BinaryCompactObject"][
+            "OuterShell"
+        ]["Radius"]
+        - 1.0e-4
+    )
+    # Give the black hole 200M to relax, and then the light travel time
+    # to the outer boundary for the gravitational waves to leave the domain
+    ringdown_params["FinalTime"] = (
+        match_time + ringdown_params["OuterBdryRadius"] + 200.0
+    )
+    logger.info(f"Ringdown parameters: {pretty_repr(ringdown_params)}")
 
     # Schedule!
     return schedule(
@@ -104,18 +291,7 @@ def start_ringdown(
 
 @click.command(name="start-ringdown", help=start_ringdown.__doc__)
 @click.argument(
-    "inspiral_input_file_path",
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=False,
-        readable=True,
-        path_type=Path,
-    ),
-)
-@click.option(
-    "-i",
-    "--inspiral-run-dir",
+    "inspiral_run_dir",
     type=click.Path(
         exists=True,
         file_okay=False,
@@ -123,11 +299,132 @@ def start_ringdown(
         readable=True,
         path_type=Path,
     ),
-    help=(
-        "Directory of the last inspiral segment. Paths in the input file are"
-        " relative to this directory."
+)
+@click.option(
+    "-i",
+    "--inspiral-input-file",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
     ),
-    show_default="directory of the INSPIRAL_INPUT_FILE_PATH",
+    default=None,
+    help="Path to Inspiral yaml, defaults to Inspiral.yaml in directory given.",
+)
+@click.option(
+    "--ahc-reductions-path",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+    default=None,
+    help=(
+        "Path to reduction file containing AhC coefs, defualts to"
+        " 'BbhReductions.h5' in directory given."
+    ),
+)
+@click.option(
+    "--ahc-subfile",
+    type=str,
+    default="ObservationAhC_Ylm",
+    help=(
+        "Subfile path name in reduction data containing AhC coefs, defaults to"
+        " 'ObservationAhC_Ylm'"
+    ),
+)
+@click.option(
+    "--fot-vol-h5-path",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+    default=None,
+    help=(
+        "Path to volume data file containing functions of time, defaults to"
+        " 'BbhVolume0.h5' in directory given."
+    ),
+)
+@click.option(
+    "--fot-vol-subfile",
+    type=str,
+    default="ForContinuation",
+    help=(
+        "Subfile in volume data with functions of time at different times,"
+        " defaults to 'ForContinuation'."
+    ),
+)
+@click.option(
+    "--path-to-output-h5",
+    type=click.Path(
+        exists=False,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+    default=None,
+    help=(
+        "Output h5 file for shape coefs, defaults to directory where command"
+        "was run."
+    ),
+)
+@click.option(
+    "--output-subfile-prefix",
+    type=str,
+    default="Distorted",
+    help="Output subfile prefix for AhC coefs, defaults to 'Distorted'",
+)
+@click.option(
+    "--number-of-ahc-finds-for-fit",
+    type=int,
+    required=True,
+    help="Number of AhC finds that will be used for the fit.",
+)
+@click.option(
+    "--match-time",
+    required=True,
+    type=float,
+    help="Desired match time (volume data must contain data at this time)",
+)
+@click.option(
+    "--settling-timescale",
+    required=True,
+    type=float,
+    help="Damping timescale for settle to const",
+)
+@click.option(
+    "--zero-coefs-eps",
+    type=float,
+    default=None,
+    help=(
+        "Sets shape coefficients to exactly 0.0 if the sum over all"
+        " '--number-of-ahc-finds-for-fit' are within zero-coefs-eps close"
+        " to 0.0"
+    ),
+)
+@click.option(
+    "--refinement-level",
+    "-L",
+    type=int,
+    help="h-refinement level.",
+    default=2,
+    show_default=True,
+)
+@click.option(
+    "--polynomial-order",
+    "-P",
+    type=int,
+    help="p-refinement level.",
+    default=11,
+    show_default=True,
 )
 @click.option(
     "--ringdown-input-file-template",
@@ -140,22 +437,6 @@ def start_ringdown(
     ),
     default=RINGDOWN_INPUT_FILE_TEMPLATE,
     help="Input file template for the ringdown.",
-    show_default=True,
-)
-@click.option(
-    "--refinement-level",
-    "-L",
-    type=int,
-    help="h-refinement level.",
-    default=0,
-    show_default=True,
-)
-@click.option(
-    "--polynomial-order",
-    "-P",
-    type=int,
-    help="p-refinement level.",
-    default=5,
     show_default=True,
 )
 @click.option(

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -6,7 +6,7 @@ Executable: EvolveGhSingleBlackHole
 ---
 
 Parallelization:
-  ElementDistribution: NumGridPoints
+  ElementDistribution: NumGridPointsAndGridSpacing
 
 # Note: most of the parameters in this file are just made up. They should be
 # replaced with values that make sense once we have a better idea of the
@@ -15,8 +15,8 @@ Parallelization:
 InitialData:
   NumericInitialData:
     FileGlob: "{{ IdFileGlob }}"
-    Subgroup: "VolumeData"
-    ObservationValue: Last
+    Subgroup: "{{ IdFileGlobSubgroup }}"
+    ObservationValue: &InitialTime "{{ MatchTime }}"
     ObservationValueEpsilon: Auto
     Interpolate: True
     Variables:
@@ -25,28 +25,70 @@ InitialData:
 
 DomainCreator:
   Sphere:
-    InnerRadius: &InnerRadius 2.0
-    OuterRadius: 1000.0
+    # InnerRadius is not yet set automatically. The value of 1.45 works
+    # for equal-mass, zero spin, quasicircular.
+    InnerRadius: &InnerRadius 1.45
+    OuterRadius: "{{ OuterBdryRadius }}"
     Interior:
       ExciseWithBoundaryCondition:
         DemandOutgoingCharSpeeds:
     InitialRefinement:
-      Shell0: [{{ L }}, {{ L }}, {{ L }}]
-      Shell1: [{{ L }}, {{ L }}, {{ L + 2 }}]
+      Shell0: [{{ L }}, {{ L }}, {{ L + 2 }}]
+      Shell1: [{{ L - 1 }}, {{ L - 1 }}, {{ L + 3 }}]
     InitialGridPoints: {{ P + 1 }}
-    UseEquiangularMap: True
+    UseEquiangularMap: False
     EquatorialCompression: None
-    RadialPartitioning: [30.0]
+    # The radial partitioning split has been tested for
+    # equal-mass, zero spin, quasi-circular, but not
+    # yet for other cases.
+    RadialPartitioning: [50.0]
     RadialDistribution: [Logarithmic, Linear]
     WhichWedges: All
-    TimeDependentMaps: None
+    TimeDependentMaps:
+      InitialTime: *InitialTime
+      ShapeMap:
+        LMax: &MaximumL {{ ShapeMapLMax }}
+        InitialValues:
+          H5Filename: "{{ PathToAhCCoefsH5File }}"
+          SubfileNames: ["{{ AhCCoefsSubfilePrefix }}AhC_Ylm",
+                         "{{ AhCCoefsSubfilePrefix }}dtAhC_Ylm",
+                         "{{ AhCCoefsSubfilePrefix }}dt2AhC_Ylm"]
+          MatchTime: *InitialTime
+          MatchTimeEpsilon: 1.e-10
+          SetL1CoefsToZero: True
+          CheckFrame: True
+        # The excision surface initially has some outward velocity to avoid
+        # incoming char speeds. The size control system should catch the
+        # excision surface before it collides with the apparent horizon.
+        # This value works for equal-mass, nonspinning, quasicircular,
+        # and has not been tested for other configurations.
+        SizeInitialValues: [0.0, -1.0, 0.0]
+      RotationMap:
+        InitialValues:
+          - [{{ Rotation0 }}, {{ Rotation1 }}, {{ Rotation2 }}, {{ Rotation3 }}]
+          - [{{ dtRotation0 }}, {{ dtRotation1 }}, {{ dtRotation2 }},
+             {{ dtRotation3 }}]
+          - [{{ dt2Rotation0 }}, {{ dt2Rotation1 }}, {{ dt2Rotation2}},
+             {{ dt2Rotation3 }}]
+        DecayTimescaleRotation: 1.0
+      ExpansionMap:
+        # During the ringdown, only the outer boundary's expansion map is
+        # applied.
+        InitialValues: [1.0, 0.0, 0.0]
+        InitialValuesOuterBoundary: [{{ ExpansionOuterBdry }},
+                                     {{ dtExpansionOuterBdry }},
+                                     {{ dt2ExpansionOuterBdry }}]
+        DecayTimescaleExpansion: 1.0
+        DecayTimescaleExpansionOuterBoundary: 1.0
+      TranslationMap:
+        InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
     OuterBoundaryCondition:
       ConstraintPreservingBjorhus:
         Type: ConstraintPreservingPhysical
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0002
+  InitialTimeStep: 0.0001
   MinimumTimeStep: 1e-7
   # This is the smallest interval we'd need to observe time step/constraints. If
   # you would like more frequent output, consider using dense output.
@@ -54,17 +96,14 @@ Evolution:
   StepChoosers:
     - LimitIncrease:
         Factor: 2
-    - ElementSizeCfl:
-        SafetyFactor: 0.5
     - ErrorControl:
-        AbsoluteTolerance: 1e-10
-        RelativeTolerance: 1e-8
+        AbsoluteTolerance: 1e-8
+        RelativeTolerance: 1e-6
         MaxFactor: 2
         MinFactor: 0.25
         SafetyFactor: 0.95
-  # Found that order 4 offers a significant speedup compared to order 5
   TimeStepper:
-    AdamsBashforth:
+    AdamsMoultonPcMonotonic:
       Order: 4
 
 EvolutionSystem:
@@ -78,29 +117,49 @@ EvolutionSystem:
     # Einstein Code (SpEC). They should be suitable for evolutions of a
     # perturbation of a Kerr-Schild black hole.
     DampingFunctionGamma0:
-      GaussianPlusConstant:
+      # SpEC uses a sum of 2 gaussians. Here, the expansion func of time
+      # is just the identity, so TimeDependentTripleGaussian ought to work here
+      # as a time-independent triple Gaussian..
+      # The Gaussian amplitudes, widths, and centers are set according to what
+      # SpEC does ringdown for an equal-mass, zero-spin, circular inspiral.
+      TimeDependentTripleGaussian:
         Constant: 0.001
-        Amplitude: 3.0
-        Width: 11.313708499
-        Center: [0.0, 0.0, 0.0]
+        Gaussian1:
+          Amplitude: 7.0
+          Width: 2.5
+          Center: [0.0, 0.0, 0.0]
+        Gaussian2:
+          Amplitude: 0.1
+          Width: 100.0
+          Center: [0.0, 0.0, 0.0]
+        Gaussian3:
+          Amplitude: 0.0
+          Width: 100.0
+          Center: [0.0, 0.0, 0.0]
     DampingFunctionGamma1:
-      GaussianPlusConstant:
-        Constant: -1.0
-        Amplitude: 0.0
-        Width: 11.313708499
-        Center: [0.0, 0.0, 0.0]
+      Constant:
+        Value: -1.0
     DampingFunctionGamma2:
-      GaussianPlusConstant:
+      TimeDependentTripleGaussian:
         Constant: 0.001
-        Amplitude: 1.0
-        Width: 11.313708499
-        Center: [0.0, 0.0, 0.0]
+        Gaussian1:
+          Amplitude: 7.0
+          Width: 2.5
+          Center: [0.0, 0.0, 0.0]
+        Gaussian2:
+          Amplitude: 0.1
+          Width: 100.0
+          Center: [0.0, 0.0, 0.0]
+        Gaussian3:
+          Amplitude: 0.0
+          Width: 100.0
+          Center: [0.0, 0.0, 0.0]
 
 Filtering:
   ExpFilter0:
-    Alpha: 36.0
-    HalfPower: 24
-    Enable: false
+    Alpha: 64.0
+    HalfPower: 210
+    Enable: true
     BlocksToFilter: All
 
 SpatialDiscretization:
@@ -159,9 +218,6 @@ EventsAndTriggers:
           - Name: PointwiseL2Norm(ThreeIndexConstraint)
             NormType: L2Norm
             Components: Sum
-          - Name: PointwiseL2Norm(FourIndexConstraint)
-            NormType: L2Norm
-            Components: Sum
   - Trigger:
       Slabs:
         EvenlySpaced:
@@ -174,27 +230,40 @@ EventsAndTriggers:
   - Trigger:
       Slabs:
         EvenlySpaced:
-          Interval: 100
+          Interval: 1
           Offset: 0
     Events:
+      - ApparentHorizon
+      - ExcisionBoundary
+  - Trigger:
+      Times:
+        EvenlySpaced:
+          Interval: 10.0
+          Offset: 0.0
+    Events:
+      # SpatialRicciScalar and Psi4Real output for visualizations scripts.
       - ObserveFields:
           SubfileName: VolumeData
           VariablesToObserve:
             - SpacetimeMetric
-            - Pi
-            - Phi
-            - Lapse
-            - Shift
+            # For diagnostics:
+            - ConstraintEnergy
             - PointwiseL2Norm(GaugeConstraint)
             - PointwiseL2Norm(ThreeIndexConstraint)
-            - PointwiseL2Norm(FourIndexConstraint)
+            # For visualization:
+            - Lapse
+            - SpatialRicciScalar
+            - Psi4Real
           InterpolateToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
-      - ApparentHorizon
-      - ExcisionBoundary
-  # Never terminate... run until something fails!
+  - Trigger:
+      TimeCompares:
+        Comparison: GreaterThanOrEqualTo
+        Value: {{ FinalTime }}
+    Events:
+      - Completion
 
 EventsAndDenseTriggers:
   # BondiSachs output needs to be often enough for CCE to run properly. An
@@ -213,7 +282,7 @@ Interpolator:
 ApparentHorizons:
   ApparentHorizon: &Ah
     InitialGuess:
-      LMax: &LMax 4
+      LMax: *MaximumL
       Radius: 2.2
       Center: [0., 0., 0.]
     FastFlow:
@@ -221,11 +290,11 @@ ApparentHorizons:
       Alpha: 1.0
       Beta: 0.5
       AbsTol: 1e-12
-      TruncationTol: 1e-2
-      DivergenceTol: 1.2
+      TruncationTol: 1e-5
+      DivergenceTol: 5
       DivergenceIter: 5
       MaxIts: 100
-    Verbosity: Verbose
+    Verbosity: Quiet
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 
@@ -236,7 +305,7 @@ InterpolationTargets:
     Center: [0, 0, 0]
     AngularOrdering: Cce
   ExcisionBoundary: &ExBdry
-    LMax: *LMax
+    LMax: *MaximumL
     Center: [0., 0., 0.]
     Radius: *InnerRadius
     AngularOrdering: "Strahlkorper"
@@ -269,12 +338,14 @@ ControlSystems:
     IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
+      # This is different from inspiral but same as SpEC.
+      # See ComputePostMergerDataFromAhC.pl:2278
+      Average0thDeriv: true
     Controller:
-      UpdateFraction: 0.03
+      UpdateFraction: 0.3
     TimescaleTuner:
-      InitialTimescales: 0.2
-      MinTimescale: 1.0e-2
+      InitialTimescales: 0.04
+      MinTimescale: 1.0e-3
       MaxTimescale: 10.0
       IncreaseThreshold: 2.5e-4
       DecreaseThreshold: 1.0e-3
@@ -287,10 +358,10 @@ ControlSystems:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: true
     Controller:
-      UpdateFraction: 0.06
+      UpdateFraction: 0.1
     TimescaleTuner:
-      InitialTimescales: 0.2
-      MinTimescale: 1.0e-4
+      InitialTimescales: 0.008
+      MinTimescale: 1.0e-5
       MaxTimescale: 20.0
       IncreaseThreshold: 2.5e-4
       IncreaseFactor: 1.01
@@ -300,7 +371,7 @@ ControlSystems:
       DeltaRDriftOutwardOptions: None
       InitialState: DeltaR
       SmootherTuner:
-        InitialTimescales: [0.2]
+        InitialTimescales: [0.02]
         MinTimescale: 1.0e-4
         MaxTimescale: 20.0
         IncreaseThreshold: 2.5e-4

--- a/tests/Unit/Evolution/Ringdown/CMakeLists.txt
+++ b/tests/Unit/Evolution/Ringdown/CMakeLists.txt
@@ -23,3 +23,5 @@ target_link_libraries(
   SphericalHarmonicsIO
   Utilities
   )
+
+add_subdirectory(Python)

--- a/tests/Unit/Evolution/Ringdown/Python/CMakeLists.txt
+++ b/tests/Unit/Evolution/Ringdown/Python/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+    "Evolution.Ringdown.ComputeAhCCoefs"
+    Test_ComputeAhCCoefsInRingdownDistortedFrame.py
+    "Python"
+    None
+)

--- a/tests/Unit/Evolution/Ringdown/Python/Test_ComputeAhCCoefsInRingdownDistortedFrame.py
+++ b/tests/Unit/Evolution/Ringdown/Python/Test_ComputeAhCCoefsInRingdownDistortedFrame.py
@@ -1,0 +1,227 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import shutil
+import unittest
+from pathlib import Path
+
+import spectre.IO.H5 as spectre_h5
+from spectre import Spectral
+from spectre.DataStructures import DataVector, ModalVector
+from spectre.Evolution.Ringdown.ComputeAhCCoefsInRingdownDistortedFrame import (
+    compute_ahc_coefs_in_ringdown_distorted_frame,
+)
+from spectre.Informer import unit_test_build_path
+from spectre.SphericalHarmonics import Strahlkorper, ylm_legend_and_data
+from spectre.support.Logging import configure_logging
+
+
+class TestComputeAhCCoefs(unittest.TestCase):
+    def test_compute_ahc_coefs_in_ringdown_distorted_frame(self):
+        # Building a fake directory to hold fake reduction data
+        self.test_dir = Path(
+            unit_test_build_path(), "Unit/Evolution/Ringdown/Python/Ringdown"
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.inspiral_reduction_data = self.test_dir / "BbhReductions.h5"
+        shape_coefs = [5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        times = [4990.0, 4992.0, 4994.0, 4996.0, 4998.0, 5000.0]
+        time_to_match = 5000.0
+        ahc_center = [0.0, 0.0, 0.0]
+        ahc_lmax = 2
+        with spectre_h5.H5File(
+            str(self.inspiral_reduction_data.resolve()), "a"
+        ) as reduction_file:
+            legend = [
+                "Time",
+                "InertialExpansionCenter_x",
+                "InertialExpansionCenter_y",
+                "InertialExpansionCenter_z",
+                "Lmax",
+                "coef(0,0)",
+                "coef(1,-1)",
+                "coef(1,0)",
+                "coef(1,1)",
+                "coef(2,-2)",
+                "coef(2,-1)",
+                "coef(2,0)",
+                "coef(2,1)",
+                "coef(2,2)",
+            ]
+            reduction_dat = reduction_file.try_insert_dat(
+                "ObservationAhC_Ylm.dat", legend, 0
+            )
+            for x in range(0, 5):
+                reduction_dat.append(
+                    [
+                        [
+                            times[x],
+                            ahc_center[0],
+                            ahc_center[1],
+                            ahc_center[2],
+                            ahc_lmax,
+                            shape_coefs[x],
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                        ]
+                    ]
+                )
+            reduction_file.close_current_object()
+
+        exp_inner_func_with_2_derivs = [1.0, 0.0, 0.0]
+        exp_outer_boundary_func_with_2_derivs = [1.0, -1e-6, 0.0]
+        rot_func_with_2_derivs = [
+            [0.0, 0.0, 0.0, 1.0],
+            [0.15, 0.0, 0.0, 0.02],
+            [0.06, 0.0, 0.0, 0.03],
+        ]
+        ringdown_ylm_coefs, ringdown_ylm_legend = (
+            compute_ahc_coefs_in_ringdown_distorted_frame(
+                ahc_reductions_path=str(self.inspiral_reduction_data),
+                ahc_subfile="ObservationAhC_Ylm.dat",
+                exp_func_and_2_derivs=exp_inner_func_with_2_derivs,
+                exp_outer_bdry_func_and_2_derivs=(
+                    exp_outer_boundary_func_with_2_derivs
+                ),
+                rot_func_and_2_derivs=rot_func_with_2_derivs,
+                number_of_ahc_finds_for_fit=5,
+                match_time=time_to_match,
+                settling_timescale=10.0,
+                zero_coefs_eps=None,
+            )
+        )
+        # Expected fit should be a line
+        expected_fit_ahc_coefs = [
+            10,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        expected_fit_dt_ahc_coefs = [
+            0.5,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        expected_fit_dt2_ahc_coefs = [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        expected_fit_ahc_coefs_mv = ModalVector(expected_fit_ahc_coefs)
+        expected_fit_dt_ahc_coefs_mv = ModalVector(expected_fit_dt_ahc_coefs)
+        expected_fit_dt2_ahc_coefs_mv = ModalVector(expected_fit_dt2_ahc_coefs)
+        expected_ahc_strahlkorper = Strahlkorper(
+            ahc_lmax, ahc_lmax, expected_fit_ahc_coefs_mv, ahc_center
+        )
+        expected_dt_ahc_strahlkorper = Strahlkorper(
+            ahc_lmax, ahc_lmax, expected_fit_dt_ahc_coefs_mv, ahc_center
+        )
+        expected_dt2_ahc_strahlkorper = Strahlkorper(
+            ahc_lmax, ahc_lmax, expected_fit_dt2_ahc_coefs_mv, ahc_center
+        )
+        # These are bad legends because they say InertialExpansionCenter instead
+        # of Distorted.
+        bad_legend_ahc, expected_ahc_ylm_coefs = ylm_legend_and_data(
+            expected_ahc_strahlkorper, time_to_match, ahc_lmax
+        )
+        bad_legend_dt_ahc, expected_dt_ahc_ylm_coefs = ylm_legend_and_data(
+            expected_dt_ahc_strahlkorper, time_to_match, ahc_lmax
+        )
+        bad_legend_dt2_ahc, expected_dt2_ahc_ylm_coefs = ylm_legend_and_data(
+            expected_dt2_ahc_strahlkorper, time_to_match, ahc_lmax
+        )
+        expected_legends_ahc = [
+            "Time",
+            "DistortedExpansionCenter_x",
+            "DistortedExpansionCenter_y",
+            "DistortedExpansionCenter_z",
+            "Lmax",
+            "coef(0,0)",
+            "coef(1,-1)",
+            "coef(1,0)",
+            "coef(1,1)",
+            "coef(2,-2)",
+            "coef(2,-1)",
+            "coef(2,0)",
+            "coef(2,1)",
+            "coef(2,2)",
+        ]
+        for x in range(0, len(expected_ahc_ylm_coefs)):
+            self.assertAlmostEqual(
+                first=expected_ahc_ylm_coefs[x],
+                second=ringdown_ylm_coefs[0][x],
+                places=11,
+            )
+            self.assertAlmostEqual(
+                first=expected_dt_ahc_ylm_coefs[x],
+                second=ringdown_ylm_coefs[1][x],
+                places=11,
+            )
+            self.assertAlmostEqual(
+                first=expected_dt2_ahc_ylm_coefs[x],
+                second=ringdown_ylm_coefs[2][x],
+                places=11,
+            )
+        self.assertNotEqual(bad_legend_ahc, ringdown_ylm_legend[0])
+        self.assertNotEqual(bad_legend_dt_ahc, ringdown_ylm_legend[1])
+        self.assertNotEqual(bad_legend_dt2_ahc, ringdown_ylm_legend[2])
+        self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[0])
+        self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[1])
+        self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[2])
+
+
+if __name__ == "__main__":
+    configure_logging(log_level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -2,15 +2,25 @@
 # See LICENSE.txt for details.
 
 import logging
+import math
 import shutil
 import unittest
 from pathlib import Path
 
+import numpy as np
 import yaml
 from click.testing import CliRunner
 
 import spectre.IO.H5 as spectre_h5
+from spectre import Spectral
+from spectre.DataStructures import DataVector
+from spectre.Domain import (
+    PiecewisePolynomial3,
+    QuaternionFunctionOfTime,
+    serialize_functions_of_time,
+)
 from spectre.Informer import unit_test_build_path
+from spectre.IO.H5 import ElementVolumeData, TensorComponent
 from spectre.Pipelines.Bbh.InitialData import generate_id
 from spectre.Pipelines.Bbh.Inspiral import start_inspiral
 from spectre.Pipelines.Bbh.Ringdown import (
@@ -63,6 +73,99 @@ class TestInitialData(unittest.TestCase):
             executable=str(self.bin_dir / "EvolveGhBinaryBlackHole"),
         )
         self.inspiral_dir = self.test_dir / "Inspiral" / "Segment_0000"
+        # Making fake reduction data with simple derivative
+        self.inspiral_reduction_data = self.inspiral_dir / "BbhReductions.h5"
+        with spectre_h5.H5File(
+            str(self.inspiral_reduction_data.resolve()), "a"
+        ) as reduction_file:
+            legend = [
+                "Time",
+                "InertialExpansionCenter_x",
+                "InertialExpansionCenter_y",
+                "InertialExpansionCenter_z",
+                "Lmax",
+                "coef(0,0)",
+                "coef(1,-1)",
+                "coef(1,0)",
+                "coef(1,1)",
+                "coef(2,-2)",
+                "coef(2,-1)",
+                "coef(2,0)",
+                "coef(2,1)",
+                "coef(2,2)",
+            ]
+            shape_coefs = [5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+            times = [4990, 4992, 4994, 4996, 4998, 5000]
+            reduction_dat = reduction_file.try_insert_dat(
+                "ObservationAhC_Ylm.dat", legend, 0
+            )
+            for x in range(0, 5):
+                reduction_dat.append(
+                    [
+                        [
+                            times[x],
+                            0.0,
+                            0.0,
+                            0.0,
+                            2,
+                            shape_coefs[x],
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                        ]
+                    ]
+                )
+            reduction_file.close_current_object()
+
+        # Making volume data for functions of time to be extracted
+        rotation_fot = QuaternionFunctionOfTime(
+            0.0,
+            [DataVector(size=4, fill=1.0)],
+            4 * [DataVector(size=3, fill=0.0)],
+            math.inf,
+        )
+        expansion_fot = PiecewisePolynomial3(
+            0.0, 4 * [DataVector(size=1, fill=1.0)], math.inf
+        )
+        expansion_outer_fot = PiecewisePolynomial3(
+            0.0, 4 * [DataVector(size=1, fill=1.0)], math.inf
+        )
+        serialized_fots = serialize_functions_of_time(
+            {
+                "Expansion": expansion_fot,
+                "ExpansionOuterBoundary": expansion_outer_fot,
+                "Rotation": rotation_fot,
+            }
+        )
+        self.inspiral_volume_data = self.inspiral_dir / "BbhVolume0.h5"
+        obs_values = [4990.0, 4992.0, 4994.0, 4996.0, 4998.0, 5000.0]
+        with spectre_h5.H5File(self.inspiral_volume_data, "w") as volume_file:
+            volfile = volume_file.insert_vol("ForContinuation", version=0)
+            for x in range(0, 5):
+                volfile.write_volume_data(
+                    observation_id=x,
+                    observation_value=obs_values[x],
+                    elements=[
+                        ElementVolumeData(
+                            element_name="foo",
+                            components=[
+                                TensorComponent(
+                                    "bar",
+                                    np.random.rand(3),
+                                ),
+                            ],
+                            extents=[3],
+                            basis=[Spectral.Basis.Legendre],
+                            quadrature=[Spectral.Quadrature.GaussLobatto],
+                        )
+                    ],
+                    serialized_functions_of_time=serialized_fots,
+                )
 
     def tearDown(self):
         shutil.rmtree(self.test_dir, ignore_errors=True)
@@ -73,6 +176,7 @@ class TestInitialData(unittest.TestCase):
         params = ringdown_parameters(
             inspiral_input_file,
             self.inspiral_dir,
+            "ForContinuation",
             refinement_level=1,
             polynomial_order=5,
         )
@@ -89,22 +193,31 @@ class TestInitialData(unittest.TestCase):
         try:
             start_ringdown_command(
                 [
-                    str(self.inspiral_dir / "Inspiral.yaml"),
+                    str(self.inspiral_dir),
                     "--refinement-level",
                     "1",
                     "--polynomial-order",
                     "5",
                     "-O",
-                    str(self.test_dir / "Ringdown"),
-                    "--no-submit",
+                    str(self.test_dir),
+                    "--match-time",
+                    "5000.0",
+                    "--number-of-ahc-finds-for-fit",
+                    "5",
+                    "--settling-timescale",
+                    "10.0",
+                    "--path-to-output-h5",
+                    str(self.test_dir / "RingdownCoefs.h5"),
                     "-E",
                     str(self.bin_dir / "EvolveGhSingleBlackHole"),
+                    "--no-submit",
                 ]
             )
         except SystemExit as e:
             self.assertEqual(e.code, 0)
+        self.assertTrue((self.test_dir / "Segment_0000/Ringdown.yaml").exists())
         self.assertTrue(
-            (self.test_dir / "Ringdown/Segment_0000/Ringdown.yaml").exists()
+            (self.test_dir / "RingdownCoefs.h5").exists(),
         )
 
 


### PR DESCRIPTION
## Proposed changes

This is the first iteration of the transition to ringdown script for the BBH's. To use this script, you have to have a BBH that has reached common horizon and output reduction and volume data at the time of common horizon finds using the pipeline, then you can do something like

`spectre bbh start-ringdown path/to/final/segment/directory/from/inspiral --path-to-output-h5 Ringdown_Coefs.h5 --match-time 5000 --number-of-steps 10 --settling-timescale 10.0 -L 2 -P 9 -O Ringdown_9 --no-submit` 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
This script is still very experimental, if you try it out and things don't work or break, please let me know :)
