### PR TITLE
Add ability to take a consistent LTS step in a region

### DIFF
--- a/src/Time/StepChoosers/ByBlock.hpp
+++ b/src/Time/StepChoosers/ByBlock.hpp
@@ -29,6 +29,10 @@ class er;
 
 namespace StepChoosers {
 /// Sets a goal specified per-block.
+///
+/// \note This debugging StepChooser is not included in the
+/// `standard_step_choosers` list, but can be added to the
+/// `factory_creation` struct in the metavariables.
 template <size_t Dim>
 class ByBlock : public StepChooser<StepChooserUse::Slab>,
                 public StepChooser<StepChooserUse::LtsStep> {

--- a/src/Time/StepChoosers/CMakeLists.txt
+++ b/src/Time/StepChoosers/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   ByBlock.cpp
   Constant.cpp
+  FixedLtsRatio.cpp
   LimitIncrease.cpp
   Maximum.cpp
   PreventRapidIncrease.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   ElementSizeCfl.hpp
   ErrorControl.hpp
   Factory.hpp
+  FixedLtsRatio.hpp
   LimitIncrease.hpp
   Maximum.hpp
   PreventRapidIncrease.hpp

--- a/src/Time/StepChoosers/FixedLtsRatio.cpp
+++ b/src/Time/StepChoosers/FixedLtsRatio.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/StepChoosers/FixedLtsRatio.hpp"
+
+#include <memory>
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+#include <vector>
+
+#include "Time/StepChoosers/StepChooser.hpp"
+
+namespace StepChoosers {
+FixedLtsRatio::FixedLtsRatio(
+    std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>
+        step_choosers)
+    : step_choosers_(std::move(step_choosers)) {}
+
+bool FixedLtsRatio::uses_local_data() const { return true; }
+bool FixedLtsRatio::can_be_delayed() const { return true; }
+
+void FixedLtsRatio::pup(PUP::er& p) {
+  StepChooser<StepChooserUse::Slab>::pup(p);
+  p | step_choosers_;
+}
+
+PUP::able::PUP_ID FixedLtsRatio::my_PUP_ID = 0;  // NOLINT
+}  // namespace StepChoosers

--- a/src/Time/StepChoosers/FixedLtsRatio.hpp
+++ b/src/Time/StepChoosers/FixedLtsRatio.hpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Options/String.hpp"
+#include "Time/EvolutionOrdering.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/TimeStepRequest.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Tags {
+struct FixedLtsRatio;
+struct TimeStep;
+}  // namespace Tags
+/// \endcond
+
+namespace StepChoosers {
+/// Requests a slab size based on the desired step in regions with a
+/// fixed slab fraction.
+///
+/// \note This StepChooser is not included in the
+/// `standard_step_choosers` list.  Executables using the feature must
+/// include it explicitly in the `factory_creation` struct and add the
+/// `::Tags::FixedLtsRatio` tag to the element DataBox.
+class FixedLtsRatio : public StepChooser<StepChooserUse::Slab> {
+ public:
+  /// \cond
+  FixedLtsRatio() = default;
+  explicit FixedLtsRatio(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(FixedLtsRatio);  // NOLINT
+  /// \endcond
+
+  struct StepChoosers {
+    using type =
+        std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>;
+    static constexpr Options::String help{"LTS step choosers to test"};
+  };
+
+  static constexpr Options::String help{
+      "Requests a slab size based on the desired step in regions with a fixed "
+      "slab fraction."};
+  using options = tmpl::list<StepChoosers>;
+
+  explicit FixedLtsRatio(
+      std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>
+          step_choosers);
+
+  using argument_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTags>
+  std::pair<TimeStepRequest, bool> operator()(
+      const db::DataBox<DbTags>& box, const double /*last_step*/) const {
+    const auto& step_ratio = db::get<::Tags::FixedLtsRatio>(box);
+    if (not step_ratio.has_value()) {
+      return {{}, true};
+    }
+
+    const auto& current_step = db::get<::Tags::TimeStep>(box);
+    const evolution_less<double> less{current_step.is_positive()};
+
+    std::optional<double> size_goal{};
+    std::optional<double> size{};
+    for (const auto& step_chooser : step_choosers_) {
+      const auto step_request =
+          step_chooser->desired_step(current_step.value(), box).first;
+
+      if (step_request.size_goal.has_value()) {
+        if (size_goal.has_value()) {
+          *size_goal = std::min(*size_goal, *step_request.size_goal, less);
+        } else {
+          size_goal = step_request.size_goal;
+        }
+      }
+      if (step_request.size.has_value()) {
+        if (size.has_value()) {
+          *size = std::min(*size, *step_request.size, less);
+        } else {
+          size = step_request.size;
+        }
+      }
+
+      // As of writing (Oct. 2024), no StepChooserUse::LtsStep chooser
+      // sets these.
+      ASSERT(not(step_request.end.has_value() or
+                 step_request.size_hard_limit.has_value() or
+                 step_request.end_hard_limit.has_value()),
+             "Unhandled field set by StepChooser.  Please file a bug "
+             "containing the options passed to FixedLtsRatio.");
+    }
+
+    if (size_goal.has_value()) {
+      *size_goal *= *step_ratio;
+    }
+    if (size.has_value()) {
+      *size *= *step_ratio;
+      if (size_goal.has_value() and less(*size_goal, *size)) {
+        // Not allowed to request a goal and a bigger step.
+        size.reset();
+      }
+    }
+
+    return {{.size_goal = size_goal, .size = size}, true};
+  }
+
+  bool uses_local_data() const override;
+  bool can_be_delayed() const override;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>
+      step_choosers_;
+};
+}  // namespace StepChoosers

--- a/src/Time/StepChoosers/Random.hpp
+++ b/src/Time/StepChoosers/Random.hpp
@@ -31,6 +31,10 @@ struct Element;
 namespace StepChoosers {
 /// Changes the step size pseudo-randomly.  Values are distributed
 /// uniformly in $\log(dt)$.  The current step is always accepted.
+///
+/// \note This debugging StepChooser is not included in the
+/// `standard_step_choosers` list, but can be added to the
+/// `factory_creation` struct in the metavariables.
 template <size_t VolumeDim>
 class Random : public StepChooser<StepChooserUse::Slab>,
                public StepChooser<StepChooserUse::LtsStep> {

--- a/src/Time/Tags/CMakeLists.txt
+++ b/src/Time/Tags/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   AdaptiveSteppingDiagnostics.hpp
+  FixedLtsRatio.hpp
   HistoryEvolvedVariables.hpp
   IsUsingTimeSteppingErrorControl.hpp
   MinimumTimeStep.hpp

--- a/src/Time/Tags/FixedLtsRatio.hpp
+++ b/src/Time/Tags/FixedLtsRatio.hpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataBox/Tag.hpp"
+
+namespace Tags {
+/// \ingroup TimeGroup
+/// \brief Tag forcing a constant step size over a region in an LTS evolution.
+struct FixedLtsRatio : db::SimpleTag {
+  using type = std::optional<size_t>;
+};
+}  // namespace Tags

--- a/tests/Unit/Time/StepChoosers/CMakeLists.txt
+++ b/tests/Unit/Time/StepChoosers/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   StepChoosers/Test_Constant.cpp
   StepChoosers/Test_ElementSizeCfl.cpp
   StepChoosers/Test_ErrorControl.cpp
+  StepChoosers/Test_FixedLtsRatio.cpp
   StepChoosers/Test_LimitIncrease.cpp
   StepChoosers/Test_Maximum.cpp
   StepChoosers/Test_PreventRapidIncrease.cpp

--- a/tests/Unit/Time/StepChoosers/Test_FixedLtsRatio.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_FixedLtsRatio.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Options/String.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "Time/Slab.hpp"
+#include "Time/StepChoosers/Constant.hpp"
+#include "Time/StepChoosers/FixedLtsRatio.hpp"
+#include "Time/StepChoosers/LimitIncrease.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/Tags/FixedLtsRatio.hpp"
+#include "Time/Tags/TimeStep.hpp"
+#include "Time/TimeStepRequest.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+class ErrorChooser : public StepChooser<StepChooserUse::LtsStep> {
+ public:
+  ErrorChooser() = default;
+  explicit ErrorChooser(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+  WRAPPED_PUPable_decl_template(ErrorChooser);  // NOLINT
+#pragma GCC diagnostic pop
+
+  static constexpr Options::String help{""};
+  using options = tmpl::list<>;
+
+  using argument_tags = tmpl::list<>;
+
+  std::pair<TimeStepRequest, bool> operator()(double /*last_step*/) const {
+    ERROR("StepChooser should not be called in fixed LTS region");
+  }
+
+  bool uses_local_data() const override { return false; }
+  bool can_be_delayed() const override { return true; }
+};
+
+PUP::able::PUP_ID ErrorChooser::my_PUP_ID = 0;  // NOLINT
+
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                   tmpl::list<StepChoosers::Constant,
+                              StepChoosers::LimitIncrease, ErrorChooser>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                   tmpl::list<StepChoosers::FixedLtsRatio>>>;
+  };
+};
+
+void test(const std::optional<double>& expected_goal,
+          const std::optional<double>& expected_size,
+          const std::optional<size_t>& fixed_ratio,
+          const std::string& lts_choosers) {
+  CAPTURE(lts_choosers);
+  const Slab slab(2.0, 6.0);
+  const auto time_step = slab.duration() / 2;
+
+  for (const auto& time_sign : {1, -1}) {
+    CAPTURE(time_sign);
+    auto box = db::create<
+        db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
+                          Tags::TimeStep, Tags::FixedLtsRatio>>(
+        Metavariables{}, time_sign * time_step, fixed_ratio);
+
+    const auto chooser = TestHelpers::test_creation<
+        std::unique_ptr<StepChooser<StepChooserUse::Slab>>, Metavariables>(
+        "FixedLtsRatio:\n"
+        "  StepChoosers:\n" +
+        lts_choosers);
+
+    const auto set_sign = [&](const std::optional<double>& opt) {
+      if (opt.has_value()) {
+        return std::optional<double>(time_sign * *opt);
+      } else {
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 10
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+        return std::optional<double>{};
+#if defined(__GNUC__) and not defined(__clang__) and __GNUC__ < 10
+#pragma GCC diagnostic pop
+#endif
+      }
+    };
+
+    const double current_step = time_sign * slab.duration().value();
+    const std::pair<TimeStepRequest, bool> expected{
+        {.size_goal = set_sign(expected_goal), .size = set_sign(expected_size)},
+        true};
+    CHECK(chooser->desired_step(current_step, box) == expected);
+    CHECK(serialize_and_deserialize(chooser)->desired_step(current_step, box) ==
+          expected);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.StepChoosers.FixedLtsRatio", "[Unit][Time]") {
+  register_factory_classes_with_charm<Metavariables>();
+
+  test({}, {}, {}, "    - ErrorChooser");
+  test({}, {}, {8}, "");
+  test({40.0}, {}, {8},
+       "    - Constant: 5.0\n"
+       "    - Constant: 7.0");
+  // Initial step size used in test is 2.0
+  test({}, {64.0}, {8},
+       "    - LimitIncrease:\n"
+       "        Factor: 4.0\n"
+       "    - LimitIncrease:\n"
+       "        Factor: 9.0");
+  test({40.0}, {32.0}, {8},
+       "    - Constant: 5.0\n"
+       "    - LimitIncrease:\n"
+       "        Factor: 2.0");
+  // Should never give a limit larger than the goal.
+  test({40.0}, {}, {8},
+       "    - Constant: 5.0\n"
+       "    - LimitIncrease:\n"
+       "        Factor: 4.0");
+
+  CHECK(StepChoosers::FixedLtsRatio{}.uses_local_data());
+  CHECK(StepChoosers::FixedLtsRatio{}.can_be_delayed());
+}

--- a/tests/Unit/Time/Tags/CMakeLists.txt
+++ b/tests/Unit/Time/Tags/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Tags/Test_AdaptiveSteppingDiagnostics.cpp
+  Tags/Test_FixedLtsRatio.cpp
   Tags/Test_HistoryEvolvedVariables.cpp
   Tags/Test_IsUsingTimeSteppingErrorControl.cpp
   Tags/Test_MinimumTimeStep.cpp

--- a/tests/Unit/Time/Tags/Test_FixedLtsRatio.cpp
+++ b/tests/Unit/Time/Tags/Test_FixedLtsRatio.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Time/Tags/FixedLtsRatio.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.Tags.FixedLtsRatio", "[Unit][Time]") {
+  TestHelpers::db::test_simple_tag<Tags::FixedLtsRatio>("FixedLtsRatio");
+}


### PR DESCRIPTION
This is early work for supporting LTS in the wave zone of evolutions using subcell.  This PR does not contain initialization code to enable to new feature, as determining the region to enable this in depends on the details of the problem.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
