### PR TITLE
Cmake `yaml-cpp` package name fix

### DIFF
--- a/cmake/SetupYamlCpp.cmake
+++ b/cmake/SetupYamlCpp.cmake
@@ -1,9 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(yaml-cpp)
+find_package(YAML_CPP NAMES yaml-cpp)
 
-if (NOT yaml-cpp_FOUND)
+if (NOT YAML_CPP_FOUND)
   if (NOT SPECTRE_FETCH_MISSING_DEPS)
     message(FATAL_ERROR "Could not find yaml-cpp. If you want to fetch "
       "missing dependencies automatically, set SPECTRE_FETCH_MISSING_DEPS=ON.")


### PR DESCRIPTION

## Proposed changes

This PR changes the `cmake` name of the package in the build system from the default `yaml-cpp` to `YAML_CPP`, and sets it as an alias for  the original `yaml-cpp`.  

This ensures that an external installation of the library outside of the standard location can be found by `cmake`, through the default `cmake` env variable `YAML_CPP_ROOT`. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Currently, the package yaml-cpp is declared as itself in cmake setup files, with the hyphen.  While this doesn't cause any issues when the library is installed in standard locations, the hyphen in the cmake package name causes a failure for yaml-cpp to be found when installed in non-standard locations, translating to a failure at the configure stage:
```
CMake Warning at cmake/SetupYamlCpp.cmake:4 (find_package):
  By not providing "Findyaml-cpp.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by yaml-cpp,
  but CMake did not find one.

  Could not find a package configuration file provided by yaml-cpp with any
  of the following names:

    yaml-cppConfig.cmake
    yaml-cpp-config.cmake

  Add the installation prefix of "yaml-cpp" to CMAKE_PREFIX_PATH or set
  "yaml-cpp_DIR" to a directory containing one of the above files.  If
  "yaml-cpp" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:162 (include)


CMake Error at cmake/SetupYamlCpp.cmake:8 (message):
  Could not find yaml-cpp.  If you want to fetch missing dependencies
  automatically, set SPECTRE_FETCH_MISSING_DEPS=ON.
Call Stack (most recent call first):
  CMakeLists.txt:162 (include)

-- Configuring incomplete, errors occurred!
```

This is due to the fact that `cmake` looks in the path `<PackageName>_ROOT`, which for this package is `yaml-cpp_ROOT`. As per [IEEE Standards 1003.1-2001](https://standards.ieee.org/ieee/1003.1/1389/), this is not a valid environment variable, at least in UNIX and thus cannot be set.


