### PR TITLE
Conform BNS ID domain to star surfaces

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -297,7 +297,7 @@ class Shape {
       gsl::not_null<tnsr::Ij<T, 3, Frame::NoFrame>*> result,
       const ylm::Spherepack::InterpolationInfo<T>& interpolation_info,
       const DataVector& extended_coefs, const std::array<T, 3>& centered_coords,
-      const T& distorted_radii, const T& one_over_radius,
+      const T& radial_distortion, const T& one_over_radius,
       const T& transition_func_over_radius) const;
 
   void check_size(const gsl::not_null<DataVector*>& coefs,

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
@@ -25,10 +25,11 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * from the mapped radius. The mapped radius \f$\tilde{r}\f$ is related to the
  * original \f$r\f$ radius by:
  * \f{equation}{\label{eq:shape_map_radius}
- *  \tilde{r} = r (1 - f(r,\theta,\phi) \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta,
- *  \phi)),
+ *  \tilde{r} = r (1 - \frac{f(r,\theta,\phi)}{r}
+ *    \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta,\phi)),
  *  \f}
- * where \f$f(r,\theta,\phi)\f$ is the transition function. Depending
+ * where $f(r,\theta,\phi) \in [0, 1]$ is the transition function (see docs of
+ * domain::CoordinateMaps::TimeDependent::Shape map). Depending
  * on the format of the transition function, it should be possible to
  * analytically derive this map's inverse because it preserves angles and shifts
  * only the radius of each point. Otherwise the inverse has to be computed
@@ -67,8 +68,8 @@ class ShapeMapTransitionFunction : public PUP::able {
 
   /// @{
   /*!
-   * Evaluate the transition function at the Cartesian coordinates
-   *`source_coords`.
+   * Evaluate the transition function $f(r,\theta,\phi) \in [0, 1]$ at the
+   * Cartesian coordinates `source_coords`.
    */
   virtual double operator()(
       const std::array<double, 3>& source_coords) const = 0;
@@ -77,12 +78,23 @@ class ShapeMapTransitionFunction : public PUP::able {
   /// @}
 
   /*!
-   * Given the mapped coordinates `target_coords` and the corresponding
-   * spherical harmonic expansion \f$\sum_{lm} \lambda_{lm}(t)Y_{lm}\f$,
-   * `distorted_radius`, this method evaluates the original radius from the
-   * mapped radius by inverting the domain::CoordinateMaps::TimeDependent::Shape
-   * map. It also divides by the mapped radius to simplify calculations in the
-   * shape map.
+   * \brief The inverse of the transition function
+   *
+   * This method returns $r/\tilde{r}$ given the mapped coordinates
+   * $\tilde{x}^i$ (`target_coords`) and the spherical harmonic expansion
+   * $\Sigma(t, \theta, \phi) = \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta, \phi)$
+   * (`distorted_radius`). See domain::CoordinateMaps::TimeDependent::Shape for
+   * details on how this quantity is used to compute the inverse of the Shape
+   * map.
+   *
+   * To derive the expression for this inverse, solve Eq.
+   * (\f$\ref{eq:shape_map_radius}\f$) for $r$ after substituting
+   * $f(r,\theta,\phi)$.
+   *
+   * \param target_coords The mapped Cartesian coordinates $\tilde{x}^i$.
+   * \param distorted_radius The spherical harmonic expansion
+   * $\Sigma(t, \theta, \phi)$.
+   * \return The quantity $r/\tilde{r}$.
    */
   virtual std::optional<double> original_radius_over_radius(
       const std::array<double, 3>& target_coords,

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
@@ -83,7 +83,7 @@ class ShapeMapTransitionFunction : public PUP::able {
    * This method returns $r/\tilde{r}$ given the mapped coordinates
    * $\tilde{x}^i$ (`target_coords`) and the spherical harmonic expansion
    * $\Sigma(t, \theta, \phi) = \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta, \phi)$
-   * (`distorted_radius`). See domain::CoordinateMaps::TimeDependent::Shape for
+   * (`radial_distortion`). See domain::CoordinateMaps::TimeDependent::Shape for
    * details on how this quantity is used to compute the inverse of the Shape
    * map.
    *
@@ -92,13 +92,13 @@ class ShapeMapTransitionFunction : public PUP::able {
    * $f(r,\theta,\phi)$.
    *
    * \param target_coords The mapped Cartesian coordinates $\tilde{x}^i$.
-   * \param distorted_radius The spherical harmonic expansion
+   * \param radial_distortion The spherical harmonic expansion
    * $\Sigma(t, \theta, \phi)$.
    * \return The quantity $r/\tilde{r}$.
    */
   virtual std::optional<double> original_radius_over_radius(
       const std::array<double, 3>& target_coords,
-      double distorted_radius) const = 0;
+      double radial_distortion) const = 0;
 
   /*!
    * Evaluate the gradient of the transition function with respect to the

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
@@ -15,7 +15,8 @@
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
-SphereTransition::SphereTransition(const double r_min, const double r_max)
+SphereTransition::SphereTransition(const double r_min, const double r_max,
+                                   const bool reverse)
     : r_min_(r_min), r_max_(r_max) {
   if (r_min <= 0.) {
     ERROR("The minimum radius must be greater than 0 but is " << r_min);
@@ -28,6 +29,10 @@ SphereTransition::SphereTransition(const double r_min, const double r_max)
   }
   a_ = -1.0 / (r_max - r_min);
   b_ = -a_ * r_max;
+  if (reverse) {
+    a_ *= -1.0;
+    b_ = 1.0 - b_;
+  }
 }
 
 double SphereTransition::operator()(

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
@@ -45,14 +45,15 @@ DataVector SphereTransition::operator()(
 }
 
 std::optional<double> SphereTransition::original_radius_over_radius(
-    const std::array<double, 3>& target_coords, double distorted_radius) const {
+    const std::array<double, 3>& target_coords,
+    double radial_distortion) const {
   const double mag = magnitude(target_coords);
-  const double denom = 1. - distorted_radius * a_;
+  const double denom = 1. - radial_distortion * a_;
   // prevent zero division
   if (equal_within_roundoff(mag, 0.) or equal_within_roundoff(denom, 0.)) {
     return std::nullopt;
   }
-  const double original_radius = (mag + distorted_radius * b_) / denom;
+  const double original_radius = (mag + radial_distortion * b_) / denom;
 
   return (original_radius + eps_) >= r_min_ and
                  (original_radius - eps_) <= r_max_

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -14,12 +14,10 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
 /*!
  * \ingroup CoordMapsTimeDependentGroup
- * \brief A transition function that falls off as $f(r) = g(r) / r$ where $g(r)
- * = ar + b$.
+ * \brief A transition function that falls off as $f(r) = ar + b$.
  *
- * \details The coefficients $a$ and $b$ are chosen so that the function $g(r) =
- * ar + b$ falls off linearly from 1 at `r_min` to 0 at `r_max`. This means that
- * $f(r)$ falls off from $1/r_{\text{min}}$ at `r_min` to 0 at `r_max`. The
+ * \details The coefficients $a$ and $b$ are chosen so that the function $f(r) =
+ * ar + b$ falls off linearly from 1 at `r_min` to 0 at `r_max`. The
  * coefficients are
  *
  * \f{align}{

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -25,11 +25,15 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * b &= \frac{r_{\text{max}}}{r_{\text{max}} - r_{\text{min}}} = -a
  * r_{\text{max}}
  * \f}
+ *
+ * If the `reverse` flag is set to `true`, then the function falls off from 0 at
+ * `r_min` to 1 at `r_max`. To do this, the coefficients are modified as
+ * $a \rightarrow -a$ and $b \rightarrow 1-b$.
  */
 class SphereTransition final : public ShapeMapTransitionFunction {
  public:
   explicit SphereTransition() = default;
-  SphereTransition(double r_min, double r_max);
+  SphereTransition(double r_min, double r_max, bool reverse = false);
 
   double operator()(const std::array<double, 3>& source_coords) const override;
   DataVector operator()(

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -41,7 +41,7 @@ class SphereTransition final : public ShapeMapTransitionFunction {
 
   std::optional<double> original_radius_over_radius(
       const std::array<double, 3>& target_coords,
-      double distorted_radius) const override;
+      double radial_distortion) const override;
 
   std::array<double, 3> gradient(
       const std::array<double, 3>& source_coords) const override;

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
@@ -352,17 +352,17 @@ T Wedge::call_impl(const std::array<T, 3>& source_coords) const {
 }
 
 std::optional<double> Wedge::original_radius_over_radius(
-    const std::array<double, 3>& target_coords, double distorted_radius) const {
+    const std::array<double, 3>& target_coords,
+    double radial_distortion) const {
   // The target coords are centered
   const double centered_coords_magnitude = magnitude(target_coords);
   CAPTURE_FOR_ERROR(target_coords);
-  CAPTURE_FOR_ERROR(distorted_radius);
+  CAPTURE_FOR_ERROR(radial_distortion);
   CAPTURE_FOR_ERROR(centered_coords_magnitude);
 
   // Couple protections that would make a point completely outside of the domain
   // of validity for any wedge
-  if (equal_within_roundoff(centered_coords_magnitude, 0.0) or
-      equal_within_roundoff(distorted_radius, 1.0) or distorted_radius > 1.0) {
+  if (equal_within_roundoff(centered_coords_magnitude, 0.0)) {
     return std::nullopt;
   }
 
@@ -392,7 +392,7 @@ std::optional<double> Wedge::original_radius_over_radius(
   // We do this check after we check if the point is beyond the outer distance
   // because if a point is outside the distorted frame, this function should
   // return nullopt.
-  if (equal_within_roundoff(distorted_radius, 0.0)) {
+  if (equal_within_roundoff(radial_distortion, 0.0)) {
     return std::optional{1.0};
   }
 
@@ -409,7 +409,7 @@ std::optional<double> Wedge::original_radius_over_radius(
   }
 
   const double denom = outer_distance - inner_distance +
-                       (reverse_ ? -1.0 : 1.0) * distorted_radius;
+                       (reverse_ ? -1.0 : 1.0) * radial_distortion;
   // prevent zero division
   if (equal_within_roundoff(denom, 0.)) {
     return std::nullopt;
@@ -417,7 +417,7 @@ std::optional<double> Wedge::original_radius_over_radius(
 
   const double original_radius_over_radius =
       (outer_distance - inner_distance +
-       (reverse_ ? -inner_distance : outer_distance) * distorted_radius /
+       (reverse_ ? -inner_distance : outer_distance) * radial_distortion /
            centered_coords_magnitude) /
       denom;
   const double original_radius =

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -201,7 +201,7 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  *
  * ## Original radius divided by mapped radius
  *
- * Given an already mapped point $\tilde{\vec x}$ and the distorted radius
+ * Given an already mapped point $\tilde{\vec x}$ and the radial distortion
  * $\Sigma(\theta, \phi) = \sum_{\ell,m}\lambda_{\ell m}Y_{\ell m}(\theta,
  * \phi)$, we can figure out the ratio of the original radius $r$ to the mapped
  * $\tilde{r} = |\tilde{\vec x}|$ by solving
@@ -405,7 +405,7 @@ class Wedge final : public ShapeMapTransitionFunction {
 
   std::optional<double> original_radius_over_radius(
       const std::array<double, 3>& target_coords,
-      double distorted_radius) const override;
+      double radial_distortion) const override;
 
   std::array<double, 3> gradient(
       const std::array<double, 3>& source_coords) const override;

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -389,10 +389,15 @@ class Wedge final : public ShapeMapTransitionFunction {
    * \param outer_radius Outermost radius of outermost wedge
    * \param outer_sphericity Sphericity of outermost surface of outermost wedge
    * \param axis The direction that this wedge is in.
+   * \param reverse If true, the transition function will be 0 at the inner
+   * boundary and 1 at the outer boundary (useful for deforming star surfaces).
+   * Otherwise, it will be 1 at the inner boundary and 0 at the outer boundary
+   * (useful for deforming black hole excision surfaces).
    */
   Wedge(const std::array<double, 3>& inner_center, double inner_radius,
         double inner_sphericity, const std::array<double, 3>& outer_center,
-        double outer_radius, double outer_sphericity, Axis axis);
+        double outer_radius, double outer_sphericity, Axis axis,
+        bool reverse = false);
 
   double operator()(const std::array<double, 3>& source_coords) const override;
   DataVector operator()(
@@ -473,6 +478,7 @@ class Wedge final : public ShapeMapTransitionFunction {
   Surface outer_surface_{};
   std::array<double, 3> projection_center_{};
   Axis axis_{};
+  bool reverse_{false};
 
   static constexpr double eps_ = std::numeric_limits<double>::epsilon() * 100;
 };

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -401,8 +401,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   // maps use piecewise functions for `Expansion` and `Translation`. This means
   // an inner common radius must be specified for the piecewise bounds.
   if (time_dependent_options_.has_value() and
-      not(include_inner_sphere_A and include_inner_sphere_B) and
-      not include_outer_sphere) {
+      not(include_inner_sphere_A and include_inner_sphere_B and
+          include_outer_sphere)) {
     PARSE_ERROR(context,
                 "To use the CylindricalBBH domain with time-dependent maps, "
                 "you must include the inner spheres for both objects and "
@@ -417,8 +417,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
         std::array{rotate_from_z_to_x_axis(center_A_),
                    rotate_from_z_to_x_axis(center_B_)},
         std::nullopt, std::nullopt, std::array{radius_A_, outer_radius_A_},
-        std::array{radius_B_, outer_radius_B_}, inner_common_radius,
-        outer_radius_);
+        std::array{radius_B_, outer_radius_B_}, false, false,
+        inner_common_radius, outer_radius_);
   }
 }
 

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
@@ -303,10 +303,21 @@ struct TimeDependentMapOptions {
    *
    * If the radii for an object are `std::nullopt`, this means that a Shape map
    * is not constructed for that object. An identity map will be used instead.
+   * This happens when the object is covered by a Cartesian cube, rather than a
+   * sphere.
    * If \p IsCylindrical is true, only pass two radii for the inner/outer radius
    * of the object sphere. If it is false, pass three radii corresponding to the
    * excision radius, the outer radius of the inner sphere, and the radius of
    * the surrounding cube.
+   *
+   * If a shape map is requested and the object is excised, then the shape map
+   * will deform the inner excision surface of the object. This deformation
+   * either extends to the outer radius of the sphere, or further to the edge of
+   * the cube that surrounds the sphere, depending on the `TransitionEndsAtCube`
+   * option.
+   * If the object is filled, then the shape map will deform the outer radius of
+   * the sphere that covers the object and the `TransitionEndsAtCube` option
+   * must be `true`.
    */
   void build_maps(
       const std::array<std::array<double, 3>, 2>& object_centers,
@@ -316,7 +327,8 @@ struct TimeDependentMapOptions {
           object_A_radii,
       const std::optional<std::array<double, IsCylindrical ? 2 : 3>>&
           object_B_radii,
-      double envelope_radius, double domain_outer_radius);
+      bool object_A_filled, bool object_B_filled, double envelope_radius,
+      double domain_outer_radius);
 
   /*!
    * \brief Check whether options were specified in the constructor for the
@@ -408,7 +420,7 @@ struct TimeDependentMapOptions {
   std::optional<std::pair<RotScaleTrans, RotScaleTrans>> rot_scale_trans_map_{};
   using ShapeMapType =
       tmpl::conditional_t<IsCylindrical, std::array<std::optional<Shape>, 2>,
-                          std::array<std::array<std::optional<Shape>, 6>, 2>>;
+                          std::array<std::array<std::optional<Shape>, 12>, 2>>;
   ShapeMapType shape_maps_{};
 
   // helper function that creates the functions of time used by the worldtube

--- a/src/ParallelAlgorithms/SurfaceFinder/Python/FindRadialSurface.py
+++ b/src/ParallelAlgorithms/SurfaceFinder/Python/FindRadialSurface.py
@@ -169,6 +169,7 @@ def find_radial_surface(
                         functions_of_time,
                     )
                 )[:, 0]
+                - initial_guess.expansion_center
             )
             filled[offset] = True
         if np.all(filled):

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -12,18 +12,35 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
                   "[Domain][Unit]") {
-  SphereTransition sphere_transition{2., 4.};
   constexpr double eps = std::numeric_limits<double>::epsilon() * 100;
-  const std::array<double, 3> lower_bound{{2., 0., 0.}};
-  CHECK(sphere_transition(lower_bound) == approx(1.0));
-  const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
-  CHECK(sphere_transition(lower_bound_eps) == approx(1.0));
-  const std::array<double, 3> midpoint{{3., 0., 0.}};
-  CHECK(sphere_transition(midpoint) == approx(0.5));
-  const std::array<double, 3> upper_bound{{4., 0., 0.}};
-  CHECK(sphere_transition(upper_bound) == approx(0.));
-  const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
-  CHECK(sphere_transition(upper_bound_eps) == approx(0.));
+  {
+    INFO("Sphere transition");
+    const SphereTransition sphere_transition{2., 4.};
+    const std::array<double, 3> lower_bound{{2., 0., 0.}};
+    CHECK(sphere_transition(lower_bound) == approx(1.0));
+    const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
+    CHECK(sphere_transition(lower_bound_eps) == approx(1.0));
+    const std::array<double, 3> midpoint{{3., 0., 0.}};
+    CHECK(sphere_transition(midpoint) == approx(0.5));
+    const std::array<double, 3> upper_bound{{4., 0., 0.}};
+    CHECK(sphere_transition(upper_bound) == approx(0.));
+    const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
+    CHECK(sphere_transition(upper_bound_eps) == approx(0.));
+  }
+  {
+    INFO("Reverse sphere transition");
+    const SphereTransition sphere_transition{2., 4., true};
+    const std::array<double, 3> lower_bound{{2., 0., 0.}};
+    CHECK(sphere_transition(lower_bound) == approx(0.0));
+    const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
+    CHECK(sphere_transition(lower_bound_eps) == approx(0.0));
+    const std::array<double, 3> midpoint{{3., 0., 0.}};
+    CHECK(sphere_transition(midpoint) == approx(0.5));
+    const std::array<double, 3> upper_bound{{4., 0., 0.}};
+    CHECK(sphere_transition(upper_bound) == approx(1.0));
+    const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
+    CHECK(sphere_transition(upper_bound_eps) == approx(1.0));
+  }
 }
 
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
@@ -186,11 +186,11 @@ void test_only_transition_no_offset() {
   std::optional<double> orig_rad_over_rad_reverse{};
   const auto set_orig_rad_over_rad =
       [&](const std::array<double, 3>& mapped_point,
-          const double distorted_radii) {
+          const double radial_distortion) {
         orig_rad_over_rad =
-            wedge.original_radius_over_radius(mapped_point, distorted_radii);
+            wedge.original_radius_over_radius(mapped_point, radial_distortion);
         orig_rad_over_rad_reverse = wedge_reverse.original_radius_over_radius(
-            mapped_point, distorted_radii);
+            mapped_point, radial_distortion);
       };
 
   // Test actual values
@@ -209,12 +209,6 @@ void test_only_transition_no_offset() {
         approx(4.0 / magnitude(point * (1.0 + 0.25 * function_value * 0.5))));
   // Hit some internal checks
   set_orig_rad_over_rad(point * 0.0, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  CHECK_FALSE(orig_rad_over_rad_reverse.has_value());
-  set_orig_rad_over_rad(point, 1.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  CHECK_FALSE(orig_rad_over_rad_reverse.has_value());
-  set_orig_rad_over_rad(point, 15.0);
   CHECK_FALSE(orig_rad_over_rad.has_value());
   CHECK_FALSE(orig_rad_over_rad_reverse.has_value());
   set_orig_rad_over_rad(point * 15.0, 0.0);
@@ -291,11 +285,11 @@ void test_only_transition_offset() {
   std::optional<double> orig_rad_over_rad_reverse{};
   const auto set_orig_rad_over_rad =
       [&](const std::array<double, 3>& mapped_point,
-          const double distorted_radii) {
+          const double radial_distortion) {
         orig_rad_over_rad =
-            wedge.original_radius_over_radius(mapped_point, distorted_radii);
+            wedge.original_radius_over_radius(mapped_point, radial_distortion);
         orig_rad_over_rad_reverse = wedge_reverse.original_radius_over_radius(
-            mapped_point, distorted_radii);
+            mapped_point, radial_distortion);
       };
 
   // Test actual values
@@ -335,12 +329,6 @@ void test_only_transition_offset() {
 
   // Hit some internal checks
   set_orig_rad_over_rad(centered_point * 0.0, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  CHECK_FALSE(orig_rad_over_rad_reverse.has_value());
-  set_orig_rad_over_rad(centered_point, 1.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  CHECK_FALSE(orig_rad_over_rad_reverse.has_value());
-  set_orig_rad_over_rad(centered_point, 15.0);
   CHECK_FALSE(orig_rad_over_rad.has_value());
   CHECK_FALSE(orig_rad_over_rad_reverse.has_value());
   set_orig_rad_over_rad(centered_point * 15.0, 0.0);

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -397,7 +397,7 @@ std::string create_option_string(
     const size_t additional_refinement_outer,
     const size_t additional_refinement_A, const size_t additional_refinement_B,
     const double opening_angle, const bool add_boundary_condition) {
-  const std::string cube_length =
+  const std::string cube_scale =
       (excise_A and excise_B and opening_angle == 90) ? "1.5" : "1.0";
   const std::string time_dependence{
       add_time_dependence
@@ -490,7 +490,7 @@ std::string create_option_string(
          std::to_string(1 + additional_refinement_outer) +
          "]\n"
          "  InitialGridPoints: 3\n" +
-         "  CubeScale: " + cube_length +
+         "  CubeScale: " + cube_scale +
          "\n"
          "  UseEquiangularMap: " +
          stringize(use_equiangular_map) + "\n" + time_dependence;
@@ -810,6 +810,13 @@ void test_parse_errors() {
           "Using a logarithmically spaced radial grid in the "
           "part of Layer 1 enveloping Object A requires excising the interior "
           "of Object A"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          Object{0.3, 1.0, 1.0, false, false},
+          Object{0.5, 1.0, -1.0, false, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.2, 2_st, 6_st),
+      Catch::Matchers::ContainsSubstring(
+          "A filled object cannot be offset within its cube."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},


### PR DESCRIPTION
## Proposed changes

Allows to deform the BNS initial data domain so a block boundary conforms to the star surfaces:

![domain-5](https://github.com/user-attachments/assets/95be6243-c925-4229-a2ec-de89ee8b9a8f)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
