### PR TITLE
Allow multiple callbacks on same component

### DIFF
--- a/src/Parallel/Callback.hpp
+++ b/src/Parallel/Callback.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <pup.h>
 #include <tuple>
 #include <utility>
@@ -64,6 +65,7 @@ class Callback : public PUP::able {
    */
   virtual bool is_equal_to(const Callback& rhs) const = 0;
   virtual std::string name() const = 0;
+  virtual std::unique_ptr<Callback> get_clone() = 0;
 };
 
 /// Wraps a call to a simple action and its arguments.
@@ -115,6 +117,11 @@ class SimpleActionCallback : public Callback {
            "," + pretty_type::name<Proxy>() + ")";
   }
 
+  std::unique_ptr<Callback> get_clone() override {
+    return std::make_unique<SimpleActionCallback<SimpleAction, Proxy, Args...>>(
+        *this);
+  }
+
  private:
   std::decay_t<Proxy> proxy_{};
   std::tuple<std::decay_t<Args>...> args_{};
@@ -154,6 +161,10 @@ class SimpleActionCallback<SimpleAction, Proxy> : public Callback {
     // likely be really long with the template parameters which is unnecessary
     return "SimpleActionCallback(" + pretty_type::get_name<SimpleAction>() +
            "," + pretty_type::name<Proxy>() + ")";
+  }
+
+  std::unique_ptr<Callback> get_clone() override {
+    return std::make_unique<SimpleActionCallback<SimpleAction, Proxy>>(*this);
   }
 
  private:
@@ -210,6 +221,11 @@ class ThreadedActionCallback : public Callback {
            "," + pretty_type::name<Proxy>() + ")";
   }
 
+  std::unique_ptr<Callback> get_clone() override {
+    return std::make_unique<
+        ThreadedActionCallback<ThreadedAction, Proxy, Args...>>(*this);
+  }
+
  private:
   std::decay_t<Proxy> proxy_{};
   std::tuple<std::decay_t<Args>...> args_{};
@@ -252,6 +268,11 @@ class ThreadedActionCallback<ThreadedAction, Proxy> : public Callback {
            "," + pretty_type::name<Proxy>() + ")";
   }
 
+  std::unique_ptr<Callback> get_clone() override {
+    return std::make_unique<ThreadedActionCallback<ThreadedAction, Proxy>>(
+        *this);
+  }
+
  private:
   std::decay_t<Proxy> proxy_{};
 };
@@ -288,6 +309,10 @@ class PerformAlgorithmCallback : public Callback {
     // Only use pretty_type::name for proxy because it'll likely be really long
     // with the template parameters which is unnecessary
     return "PerformAlgorithmCallback(" + pretty_type::name<Proxy>() + ")";
+  }
+
+  std::unique_ptr<Callback> get_clone() override {
+    return std::make_unique<PerformAlgorithmCallback<Proxy>>(*this);
   }
 
  private:

--- a/src/Parallel/Callback.hpp
+++ b/src/Parallel/Callback.hpp
@@ -11,10 +11,39 @@
 #include <utility>
 
 #include "Parallel/Invoke.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TypeTraits/HasEquivalence.hpp"
 
 namespace Parallel {
+namespace detail {
+// Not all tuple arguments are guaranteed to have operator==, so we check the
+// ones we can.
+template <typename... Args>
+bool tuple_equal(const std::tuple<Args...>& tuple_1,
+                 const std::tuple<Args...>& tuple_2) {
+  bool result = true;
+  tmpl::for_each<tmpl::make_sequence<tmpl::size_t<0>,
+                                     tmpl::size<tmpl::list<Args...>>::value>>(
+      [&](const auto index_v) {
+        constexpr size_t index = tmpl::type_from<decltype(index_v)>::value;
+
+        if (not result) {
+          return;
+        }
+
+        if constexpr (tt::has_equivalence_v<decltype(std::get<index>(
+                          tuple_1))>) {
+          result =
+              result and std::get<index>(tuple_1) == std::get<index>(tuple_2);
+        }
+      });
+
+  return result;
+}
+}  // namespace detail
+
 /// An abstract base class, whose derived class holds a function that
 /// can be invoked at a later time.  The function is intended to be
 /// invoked only once.
@@ -30,6 +59,11 @@ class Callback : public PUP::able {
   explicit Callback(CkMigrateMessage* msg) : PUP::able(msg) {}
   virtual void invoke() = 0;
   virtual void register_with_charm() = 0;
+  /*!
+   * \brief Returns if this callback is equal to the one passed in.
+   */
+  virtual bool is_equal_to(const Callback& rhs) const = 0;
+  virtual std::string name() const = 0;
 };
 
 /// Wraps a call to a simple action and its arguments.
@@ -65,6 +99,22 @@ class SimpleActionCallback : public Callback {
     register_classes_with_charm<SimpleActionCallback>();
   }
 
+  bool is_equal_to(const Callback& rhs) const override {
+    const auto* downcast_ptr = dynamic_cast<const SimpleActionCallback*>(&rhs);
+    if (downcast_ptr == nullptr) {
+      return false;
+    }
+    return detail::tuple_equal(args_, downcast_ptr->args_);
+  }
+
+  std::string name() const override {
+    // Use pretty_type::get_name with the action since we want to differentiate
+    // template paremeters. Only use pretty_type::name for proxy because it'll
+    // likely be really long with the template parameters which is unnecessary
+    return "SimpleActionCallback(" + pretty_type::get_name<SimpleAction>() +
+           "," + pretty_type::name<Proxy>() + ")";
+  }
+
  private:
   std::decay_t<Proxy> proxy_{};
   std::tuple<std::decay_t<Args>...> args_{};
@@ -91,6 +141,19 @@ class SimpleActionCallback<SimpleAction, Proxy> : public Callback {
     }
     done_registration = true;
     register_classes_with_charm<SimpleActionCallback>();
+  }
+
+  bool is_equal_to(const Callback& rhs) const override {
+    const auto* downcast_ptr = dynamic_cast<const SimpleActionCallback*>(&rhs);
+    return downcast_ptr != nullptr;
+  }
+
+  std::string name() const override {
+    // Use pretty_type::get_name with the action since we want to differentiate
+    // template paremeters. Only use pretty_type::name for proxy because it'll
+    // likely be really long with the template parameters which is unnecessary
+    return "SimpleActionCallback(" + pretty_type::get_name<SimpleAction>() +
+           "," + pretty_type::name<Proxy>() + ")";
   }
 
  private:
@@ -130,6 +193,23 @@ class ThreadedActionCallback : public Callback {
     register_classes_with_charm<ThreadedActionCallback>();
   }
 
+  bool is_equal_to(const Callback& rhs) const override {
+    const auto* downcast_ptr =
+        dynamic_cast<const ThreadedActionCallback*>(&rhs);
+    if (downcast_ptr == nullptr) {
+      return false;
+    }
+    return detail::tuple_equal(args_, downcast_ptr->args_);
+  }
+
+  std::string name() const override {
+    // Use pretty_type::get_name with the action since we want to differentiate
+    // template paremeters. Only use pretty_type::name for proxy because it'll
+    // likely be really long with the template parameters which is unnecessary
+    return "ThreadedActionCallback(" + pretty_type::get_name<ThreadedAction>() +
+           "," + pretty_type::name<Proxy>() + ")";
+  }
+
  private:
   std::decay_t<Proxy> proxy_{};
   std::tuple<std::decay_t<Args>...> args_{};
@@ -158,6 +238,20 @@ class ThreadedActionCallback<ThreadedAction, Proxy> : public Callback {
     register_classes_with_charm<ThreadedActionCallback>();
   }
 
+  bool is_equal_to(const Callback& rhs) const override {
+    const auto* downcast_ptr =
+        dynamic_cast<const ThreadedActionCallback*>(&rhs);
+    return downcast_ptr != nullptr;
+  }
+
+  std::string name() const override {
+    // Use pretty_type::get_name with the action since we want to differentiate
+    // template paremeters. Only use pretty_type::name for proxy because it'll
+    // likely be really long with the template parameters which is unnecessary
+    return "ThreadedActionCallback(" + pretty_type::get_name<ThreadedAction>() +
+           "," + pretty_type::name<Proxy>() + ")";
+  }
+
  private:
   std::decay_t<Proxy> proxy_{};
 };
@@ -184,6 +278,18 @@ class PerformAlgorithmCallback : public Callback {
     register_classes_with_charm<PerformAlgorithmCallback>();
   }
 
+  bool is_equal_to(const Callback& rhs) const override {
+    const auto* downcast_ptr =
+        dynamic_cast<const PerformAlgorithmCallback*>(&rhs);
+    return downcast_ptr != nullptr;
+  }
+
+  std::string name() const override {
+    // Only use pretty_type::name for proxy because it'll likely be really long
+    // with the template parameters which is unnecessary
+    return "PerformAlgorithmCallback(" + pretty_type::name<Proxy>() + ")";
+  }
+
  private:
   std::decay_t<Proxy> proxy_{};
 };
@@ -194,7 +300,7 @@ template <typename Proxy>
 PUP::able::PUP_ID PerformAlgorithmCallback<Proxy>::my_PUP_ID = 0;
 template <typename SimpleAction, typename Proxy, typename... Args>
 PUP::able::PUP_ID
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     SimpleActionCallback<SimpleAction, Proxy, Args...>::my_PUP_ID =
         0;  // NOLINT
 template <typename SimpleAction, typename Proxy>
@@ -203,7 +309,7 @@ PUP::able::PUP_ID SimpleActionCallback<SimpleAction, Proxy>::my_PUP_ID =
     0;  // NOLINT
 template <typename ThreadedAction, typename Proxy, typename... Args>
 PUP::able::PUP_ID
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     ThreadedActionCallback<ThreadedAction, Proxy, Args...>::my_PUP_ID =
         0;  // NOLINT
 template <typename ThreadedAction, typename Proxy>

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -191,9 +191,10 @@ struct MutexTag {
 template <typename Tag>
 struct MutableCacheTag {
   using tag = Tag;
-  using type = std::tuple<typename Tag::type,
-                          std::unordered_map<Parallel::ArrayComponentId,
-                                             std::unique_ptr<Callback>>>;
+  using type =
+      std::tuple<typename Tag::type,
+                 std::unordered_map<Parallel::ArrayComponentId,
+                                    std::vector<std::unique_ptr<Callback>>>>;
 };
 
 template <typename Tag>

--- a/tests/Unit/Parallel/Test_Callback.cpp
+++ b/tests/Unit/Parallel/Test_Callback.cpp
@@ -269,6 +269,12 @@ struct RunCallbacks {
     callback_3.invoke();
     callback_4.invoke();
     callback_5.invoke();
+    const auto callback_6 = callback_0.get_clone();
+    const auto callback_7 = callback_1.get_clone();
+    const auto callback_8 = callback_2.get_clone();
+    SPECTRE_PARALLEL_REQUIRE(callback_0.is_equal_to(*callback_6));
+    SPECTRE_PARALLEL_REQUIRE(callback_1.is_equal_to(*callback_7));
+    SPECTRE_PARALLEL_REQUIRE(callback_2.is_equal_to(*callback_8));
     std::vector<std::unique_ptr<Parallel::Callback>> callbacks;
     callbacks.emplace_back(
         std::make_unique<Parallel::PerformAlgorithmCallback<decltype(proxy_0)>>(

--- a/tests/Unit/Parallel/Test_Callback.cpp
+++ b/tests/Unit/Parallel/Test_Callback.cpp
@@ -247,12 +247,25 @@ struct RunCallbacks {
     Parallel::SimpleActionCallback<MultiplyValueByFactor, decltype(proxy_2),
                                    double>
         callback_2(proxy_2, 1.5);
+    SPECTRE_PARALLEL_REQUIRE(
+        callback_0.name().find("PerformAlgorithmCallback") !=
+        std::string::npos);
+    SPECTRE_PARALLEL_REQUIRE(
+        (callback_1.name().find("SimpleActionCallback") != std::string::npos and
+         callback_1.name().find("IncrementValue") != std::string::npos));
+    SPECTRE_PARALLEL_REQUIRE(
+        (callback_2.name().find("SimpleActionCallback") != std::string::npos and
+         callback_2.name().find("MultiplyValueByFactor") != std::string::npos));
     callback_0.invoke();
     callback_1.invoke();
     callback_2.invoke();
     auto callback_3 = serialize_and_deserialize(callback_0);
     auto callback_4 = serialize_and_deserialize(callback_1);
     auto callback_5 = serialize_and_deserialize(callback_2);
+    SPECTRE_PARALLEL_REQUIRE(callback_0.is_equal_to(callback_3));
+    SPECTRE_PARALLEL_REQUIRE_FALSE(callback_0.is_equal_to(callback_4));
+    SPECTRE_PARALLEL_REQUIRE(callback_1.is_equal_to(callback_4));
+    SPECTRE_PARALLEL_REQUIRE_FALSE(callback_1.is_equal_to(callback_5));
     callback_3.invoke();
     callback_4.invoke();
     callback_5.invoke();
@@ -267,6 +280,7 @@ struct RunCallbacks {
     callbacks.emplace_back(
         std::make_unique<Parallel::SimpleActionCallback<
             MultiplyValueByFactor, decltype(proxy_2), double>>(proxy_2, 2.0));
+    SPECTRE_PARALLEL_REQUIRE_FALSE(callback_2.is_equal_to(*callbacks.back()));
 
     auto& nodegroup_proxy =
         Parallel::get_parallel_component<TestNodegroup<Metavariables>>(cache);

--- a/tests/Unit/Parallel/Test_GlobalCache.ci
+++ b/tests/Unit/Parallel/Test_GlobalCache.ci
@@ -18,5 +18,6 @@ mainmodule Test_GlobalCache {
     entry void run_test_three();
     entry void run_test_four();
     entry void run_test_five();
+    entry void mutate_name();
   };
 }

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -152,7 +152,7 @@ struct modify_number_of_legs {
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tags = tmpl::list<name, age, height>;
+  using const_global_cache_tags = tmpl::list<age, height>;
   using mutable_global_cache_tags = tmpl::list<weight, animal>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
@@ -177,8 +177,8 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tags = tmpl::list<name>;
-  using mutable_global_cache_tags = tmpl::list<email>;
+  using const_global_cache_tags = tmpl::list<>;
+  using mutable_global_cache_tags = tmpl::list<email, name>;
   using metavariables = Metavariables;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
@@ -249,11 +249,24 @@ class UseCkCallbackAsCallback : public Parallel::Callback {
   size_t index_{};
 };
 
+size_t calls_to_test_one = 0;  // NOLINT
+
+template <typename Metavariables>
+void TestArrayChare<Metavariables>::mutate_name() {
+  auto& local_cache = *Parallel::local_branch(global_cache_proxy_);
+
+  // Turn Nobody into Somebody
+  Parallel::mutate<name, modify_value<std::string>>(local_cache,
+                                                    std::string("Somebody"));
+}
+
 template <typename Metavariables>
 void TestArrayChare<Metavariables>::run_test_one() {
   // Test that the values are what we think they should be.
   auto& local_cache = *Parallel::local_branch(global_cache_proxy_);
-  SPECTRE_PARALLEL_REQUIRE("Nobody" == Parallel::get<name>(local_cache));
+  const std::string expected_name =
+      calls_to_test_one == 0 ? "Nobody" : "Somebody";
+  SPECTRE_PARALLEL_REQUIRE(expected_name == Parallel::get<name>(local_cache));
   SPECTRE_PARALLEL_REQUIRE(178 == Parallel::get<age>(local_cache));
   SPECTRE_PARALLEL_REQUIRE(2.2 == Parallel::get<height>(local_cache));
   SPECTRE_PARALLEL_REQUIRE(
@@ -279,7 +292,7 @@ void TestArrayChare<Metavariables>::run_test_one() {
   serialize_and_deserialize(
       make_not_null(&serialized_and_deserialized_global_cache), local_cache);
   SPECTRE_PARALLEL_REQUIRE(
-      "Nobody" ==
+      expected_name ==
       Parallel::get<name>(serialized_and_deserialized_global_cache));
   SPECTRE_PARALLEL_REQUIRE(
       178 == Parallel::get<age>(serialized_and_deserialized_global_cache));
@@ -288,6 +301,57 @@ void TestArrayChare<Metavariables>::run_test_one() {
   SPECTRE_PARALLEL_REQUIRE(4 == Parallel::get<shape_of_nametag>(
                                     serialized_and_deserialized_global_cache)
                                     .number_of_sides());
+
+  // Only register callbacks on the first call to `run_test_one`
+  if (calls_to_test_one == 0) {
+    auto callback =
+        CkCallback(CkIndex_TestArrayChare<Metavariables>::run_test_one(),
+                   this->thisProxy[this->thisIndex]);
+    const auto array_component_id =
+        Parallel::make_array_component_id<TestArrayChare<Metavariables>>(
+            static_cast<int>(this->thisIndex));
+
+    const auto register_callback = [&](const size_t index) {
+      Parallel::mutable_cache_item_is_ready<name>(
+          local_cache, array_component_id,
+          [&callback, &index](const std::string& name_l)
+              -> std::unique_ptr<Parallel::Callback> {
+            return name_l == "Somebody"
+                       ? std::unique_ptr<Parallel::Callback>{}
+                       : std::unique_ptr<Parallel::Callback>(
+                             new UseCkCallbackAsCallback(callback, index));
+          });
+    };
+
+    // Register first callback for this function
+    register_callback(0);
+    // Register second callback for this function with different index to test
+    // that we can have two callbacks on the same element
+    register_callback(1);
+    // Try and register the first callback again. This shouldn't be registered
+    // and we should still only have two callbacks
+    register_callback(0);
+
+    // Do the mutate somehwere else so we can return here and have
+    // `run_test_one` be called again
+    this->thisProxy[0].mutate_name();
+
+    calls_to_test_one++;
+    return;
+  } else if (calls_to_test_one == 1) {
+    // Make sure we haven't mutated the weight yet, because that would move on
+    // to `run_test_two` then
+    SPECTRE_PARALLEL_REQUIRE(Parallel::get<weight>(local_cache) == 160.0);
+
+    calls_to_test_one++;
+    return;
+  } else {
+    // We have now called both registered callbacks
+    SPECTRE_PARALLEL_REQUIRE(calls_to_test_one == 2);
+
+    // The value will be checked in `run_test_two`
+    calls_to_test_one++;
+  }
 
   // Mutate the weight to 150.
   Parallel::mutate<weight, modify_value<double>>(local_cache, 150.0);
@@ -311,6 +375,9 @@ void TestArrayChare<Metavariables>::run_test_two() {
                        : std::unique_ptr<Parallel::Callback>(
                              new UseCkCallbackAsCallback(callback, 0));
           })) {
+    // One original call, and then two callbacks
+    SPECTRE_PARALLEL_REQUIRE(calls_to_test_one == 3);
+
     auto& local_cache = *Parallel::local_branch(global_cache_proxy_);
     SPECTRE_PARALLEL_REQUIRE(150 == Parallel::get<weight>(local_cache));
 
@@ -408,21 +475,21 @@ template <typename Metavariables>
 void Test_GlobalCache<Metavariables>::run_single_core_test() {
   using const_tag_list =
       typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-  static_assert(std::is_same_v<const_tag_list,
-                               tmpl::list<name, age, height, shape_of_nametag>>,
-                "Wrong const_tag_list in GlobalCache test");
+  static_assert(
+      std::is_same_v<const_tag_list, tmpl::list<age, height, shape_of_nametag>>,
+      "Wrong const_tag_list in GlobalCache test");
 
   using mutable_tag_list =
       typename Parallel::get_mutable_global_cache_tags<TestMetavariables>;
   static_assert(
-      std::is_same_v<mutable_tag_list, tmpl::list<weight, animal, email>>,
+      std::is_same_v<mutable_tag_list, tmpl::list<weight, animal, email, name>>,
       "Wrong mutable_tag_list in GlobalCache test");
 
   tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
-      "Nobody", 178, 2.2, std::make_unique<Square>());
+      178, 2.2, std::make_unique<Square>());
   tuples::tagged_tuple_from_typelist<mutable_tag_list>
       mutable_data_to_be_cached(160, std::make_unique<Arthropod>(6),
-                                "joe@somewhere.com");
+                                "joe@somewhere.com", "Nobody");
 
   Parallel::GlobalCache<TestMetavariables> cache(
       std::move(const_data_to_be_cached), std::move(mutable_data_to_be_cached));
@@ -477,7 +544,7 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
   using mutable_tag_list =
       typename Parallel::get_mutable_global_cache_tags<TestMetavariables>;
   static_assert(
-      std::is_same_v<mutable_tag_list, tmpl::list<weight, animal, email>>,
+      std::is_same_v<mutable_tag_list, tmpl::list<weight, animal, email, name>>,
       "Wrong mutable_tag_list in GlobalCache test");
   static_assert(
       Parallel::is_in_mutable_global_cache<TestMetavariables, animal>);
@@ -492,9 +559,9 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
 
   using const_tag_list =
       typename Parallel::get_const_global_cache_tags<TestMetavariables>;
-  static_assert(std::is_same_v<const_tag_list,
-                               tmpl::list<name, age, height, shape_of_nametag>>,
-                "Wrong const_tag_list in GlobalCache test");
+  static_assert(
+      std::is_same_v<const_tag_list, tmpl::list<age, height, shape_of_nametag>>,
+      "Wrong const_tag_list in GlobalCache test");
   static_assert(
       Parallel::is_in_const_global_cache<TestMetavariables, shape_of_nametag>);
   static_assert(
@@ -512,9 +579,9 @@ Test_GlobalCache<Metavariables>::Test_GlobalCache(CkArgMsg*
   // Arthropod begins as an insect.
   tuples::tagged_tuple_from_typelist<mutable_tag_list>
       mutable_data_to_be_cached(160, std::make_unique<Arthropod>(6),
-                                "joe@somewhere.com");
+                                "joe@somewhere.com", "Nobody");
   tuples::tagged_tuple_from_typelist<const_tag_list> const_data_to_be_cached(
-      "Nobody", 178, 2.2, std::make_unique<Square>());
+      178, 2.2, std::make_unique<Square>());
   global_cache_proxy_ = Parallel::CProxy_GlobalCache<TestMetavariables>::ckNew(
       std::move(const_data_to_be_cached), std::move(mutable_data_to_be_cached),
       std::nullopt);

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -240,6 +240,10 @@ class UseCkCallbackAsCallback : public Parallel::Callback {
     return "UseCkCallbackAsCallback" + std::to_string(index_);
   }
 
+  std::unique_ptr<Callback> get_clone() override {
+    return std::make_unique<UseCkCallbackAsCallback>(callback_, index_);
+  }
+
  private:
   CkCallback callback_;
   size_t index_{};

--- a/tests/Unit/Parallel/Test_GlobalCache.hpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.hpp
@@ -66,6 +66,7 @@ class TestArrayChare : public CBase_TestArrayChare<Metavariables> {
   void run_test_three();
   void run_test_four();
   void run_test_five();
+  void mutate_name();
 
  private:
   CProxy_Test_GlobalCache<Metavariables> main_proxy_;


### PR DESCRIPTION
## Proposed changes

It is possible for multiple unique callbacks to be registered to the same parallel component (size control system does this). Previously, we only took the first callback and discarded the rest (because the elements would register multiple identical callbacks and we only needed one). Now we still discard identical callbacks, but keep unique callbacks on the same component.

This was found while debugging the nodegroup implementation of our algorithm, but I believe this is also a bug on develop. I guess we just have been lucky and haven't hit this so far.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
