### PR TITLE
Change TerminatePhase return value

### DIFF
--- a/src/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_headers(
   InitializeItems.hpp
   LimiterActions.hpp
   MutateApply.hpp
+  PausePhase.hpp
   RandomizeVariables.hpp
   SetData.hpp
   TerminatePhase.hpp

--- a/src/ParallelAlgorithms/Actions/PausePhase.hpp
+++ b/src/ParallelAlgorithms/Actions/PausePhase.hpp
@@ -22,10 +22,10 @@ namespace Parallel::Actions {
 
 /*!
  * \ingroup ActionsGroup
- * \brief Halt the algorithm and wait to proceed to the next phase by returning
- * `Parallel::AlgorithmExecution::Halt`
+ * \brief Pause the algorithm by returning
+ * `Parallel::AlgorithmExecution::Pause`.
  */
-struct TerminatePhase {
+struct PausePhase {
   template <typename DataBox, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -37,7 +37,7 @@ struct TerminatePhase {
       const ActionList /*meta*/,
       // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
       const ParallelComponent* const /*meta*/) {
-    return {Parallel::AlgorithmExecution::Halt, std::nullopt};
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
   }
 };
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -61,6 +61,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "ParallelAlgorithms/Actions/PausePhase.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
@@ -437,16 +438,16 @@ struct ElementArray {
                   Dim, subdomain_init_tags, DummyOptionsGroup, false,
                   TemporalIdTag>,
               init_subdomain_action, init_random_subdomain_data_action,
-              Parallel::Actions::TerminatePhase,
+              Parallel::Actions::PausePhase,
               // Full DG operator
               typename dg_operator::apply_actions,
-              Parallel::Actions::TerminatePhase,
+              Parallel::Actions::PausePhase,
               // Subdomain operator
               ApplySubdomainOperator<SubdomainOperator,
                                      typename fields_tag::tags_list>,
               TestSubdomainOperatorMatrix<SubdomainOperator,
                                           typename fields_tag::tags_list>,
-              Parallel::Actions::TerminatePhase>>>;
+              Parallel::Actions::PausePhase>>>;
 };
 
 template <typename Metavariables>
@@ -605,8 +606,7 @@ void test_subdomain_operator(
           {initial_ref_levs, initial_extents, SubdomainOperator{},
            typename subdomain_operator_applied_to_fields_tag::type{},
            override_boundary_conditions});
-      while (
-          not ActionTesting::get_terminate<element_array>(runner, element_id)) {
+      for (size_t i = 0; i < 4 + tmpl::size<ExtraInitActions>::value; i++) {
         ActionTesting::next_action<element_array>(make_not_null(&runner),
                                                   element_id);
       }

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -46,6 +46,7 @@
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/Goto.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "ParallelAlgorithms/Actions/PausePhase.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
@@ -156,7 +157,7 @@ struct ElementArray {
                              System, fixed_sources_tag>,
                      ::Actions::Label<ApplyOperatorStart>,
                      typename dg_operator::apply_actions, IncrementTemporalId,
-                     Parallel::Actions::TerminatePhase>>>;
+                     Parallel::Actions::PausePhase>>>;
 };
 
 template <typename Metavariables>

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -209,10 +209,10 @@ SPECTRE_TEST_CASE(
           std::make_unique<::TimeSteppers::DormandPrince5>()));
 
   // Run the initializations
-  for (size_t i = 0; i < 6; ++i) {
+  for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
-  for (size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
   }
   runner.set_phase(Parallel::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -257,10 +257,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
           false, false, std::optional<double>{}));
 
   // this should run the initializations
-  for (size_t i = 0; i < 5; ++i) {
+  for (size_t i = 0; i < 4; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
-  for (size_t i = 0; i < 2; ++i) {
+  for (size_t i = 0; i < 1; ++i) {
     ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -198,7 +198,7 @@ SPECTRE_TEST_CASE(
       target_step_size, scri_plus_interpolation_order);
 
   // this should run the initialization
-  for (size_t i = 0; i < 6; ++i) {
+  for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
@@ -183,7 +183,7 @@ void test_klein_gordon_cce_initialization(const gsl::not_null<Generator*> gen) {
       target_step_size, scri_plus_interpolation_order);
 
   // go through the action list
-  for (size_t i = 0; i < 7; ++i) {
+  for (size_t i = 0; i < 6; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -128,7 +128,7 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) {
           false, false, std::optional<double>{}));
 
   // this should run the initialization
-  for (size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);
@@ -177,7 +177,7 @@ void test_gh_initialization() {
       InterfaceManagers::GhLockstep{});
 
   // this should run the initialization
-  for (size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
   }
   runner.set_phase(Parallel::Phase::Evolve);
@@ -210,7 +210,7 @@ void test_analytic_initialization() {
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<::TimeSteppers::Rk3HesthavenSsp>()));
   // this should run the initialization
-  for (size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);
   }
   runner.set_phase(Parallel::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -289,7 +289,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::emplace_component<MockObserver<test_metavariables>>(&runner,
                                                                      0);
   // the initialization actions
-  for (size_t i = 0; i < 6; ++i) {
+  for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
   runner.set_phase(Parallel::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -236,10 +236,10 @@ void test_klein_gordon_h5_boundary_communication(
           std::optional<double>{}));
 
   // this should run the initializations
-  for (size_t i = 0; i < 6; ++i) {
+  for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
-  for (size_t i = 0; i < 2; ++i) {
+  for (size_t i = 0; i < 1; ++i) {
     ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
   }
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -222,10 +222,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
           false, false, std::optional<double>{}));
 
   // this should run the initializations
-  for (size_t i = 0; i < 5; ++i) {
+  for (size_t i = 0; i < 4; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
-  for(size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 2; ++i) {
     ActionTesting::next_action<worldtube_component>(make_not_null(&runner), 0);
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Evolve);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -204,7 +204,7 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
           std::optional<double>{}));
 
   // this should run the initializations
-  for (size_t i = 0; i < 6; ++i) {
+  for (size_t i = 0; i < 5; ++i) {
     ActionTesting::next_action<evolution_component>(make_not_null(&runner), 0);
   }
   for (size_t i = 0; i < 2; ++i) {

--- a/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Actions/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Goto.cpp
   Test_InitializeItems.cpp
   Test_MutateApply.cpp
+  Test_PausePhase.cpp
   Test_RandomizeVariables.cpp
   Test_SetData.cpp
   Test_TerminatePhase.cpp

--- a/tests/Unit/ParallelAlgorithms/Actions/Test_PausePhase.cpp
+++ b/tests/Unit/ParallelAlgorithms/Actions/Test_PausePhase.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
+#include "ParallelAlgorithms/Actions/PausePhase.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Testing, tmpl::list<Parallel::Actions::PausePhase>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.Actions.PausePhase",
+                  "[Unit][Parallel][Actions]") {
+  using component = Component<Metavariables>;
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}};
+  ActionTesting::emplace_component<component>(&runner, 0);
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  CHECK_FALSE(ActionTesting::get_terminate<component>(runner, 0));
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  CHECK(ActionTesting::get_terminate<component>(runner, 0));
+}


### PR DESCRIPTION
Now TerminatePhase returns `Parallel::AlgorithmExecution::Halt`. Also added a new action PausePhase which returns
`Parallel::AlgorithmExecution::Pause` if that is needed.

This changes how the algorithm ends at the end of a phase.

## Proposed changes

This is a fix for a bug in nodegroup parallization, but also a good thing to do. Once we get to the end of an PDAL (and we aren't looping), we shouldn't be allowed to restart as many phases are only intended to run once

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
