### PR TITLE
Allow three extra refinement levels for an ElementId

### DIFF
--- a/src/Domain/Structure/ElementId.cpp
+++ b/src/Domain/Structure/ElementId.cpp
@@ -3,29 +3,32 @@
 
 #include "Domain/Structure/ElementId.hpp"
 
-#include <boost/functional/hash.hpp>
-#include <exception>
-#include <limits>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
 #include <ostream>
-#include <pup.h>
-#include <pup_stl.h>
 #include <regex>
 #include <string>
+#include <type_traits>
 
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Side.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
-#include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
-#include "Utilities/MakeArray.hpp"
-#include "Utilities/Numeric.hpp"
 #include "Utilities/StdHelpers.hpp"
+#include "Utilities/StdHelpers/Bit.hpp"
 
 // The `static_assert`s verify that `ElementId` satisfies the constraints
 // imposed by Charm++ to make `ElementId` able to act as an index into Charm++'s
 // arrays. These constraints are:
 // - `ElementId` must satisfy `std::is_standard_layout` and `std::is_trivial`
-// - `ElementId` must not be larger than the size of three `int`s, i.e.
-//   `sizeof(ElementId) <= 3 * sizeof(int)`
+// - `ElementId` is the size of two `int`s`
 static_assert(std::is_standard_layout_v<ElementId<1>> and
               std::is_trivial_v<ElementId<1>>);
 static_assert(std::is_standard_layout_v<ElementId<2>> and
@@ -40,17 +43,83 @@ static_assert(sizeof(ElementId<2>) == 2 * sizeof(int),
 static_assert(sizeof(ElementId<3>) == 2 * sizeof(int),
               "Wrong size for ElementId<3>");
 
+// IMPLEMENTATION DETAILS:
+// We use a compact representation of a SegmentId as a uint16_t.
+// This allows 16 refinement levels from the coarsest level 0 thorugh 15
+// Labeling the 16 bits of the uint16_t from right (0) to left (15), the
+// position of the bit of the leading 1 (also known as the most significant bit)
+// determines the refinement level of the SegmentId, while masking that bit
+// (i.e. setting it to zero) of the uint16_t will determine the index of the
+// SegmentId.
+// We reserve 0 as representing an undefined SegmentId
+// Thus using the string representation of a SegmentId as LlIi with l and i
+// as the refinement level and index respectively we have:
+// 0000000000000000 undefined
+// 0000000000000001 L0I0
+// 0000000000000010 L1I0
+// 0000000000000011 L1I1
+// 0000000000000100 L2I0
+// ...
+// 1111111111111111 L15I32767
+namespace {
+uint16_t make_compact_segment_id(const SegmentId& segment_id) {
+  return (uint16_t{1} << segment_id.refinement_level()) +
+         static_cast<uint16_t>(segment_id.index());
+}
+
+size_t get_refinement_level(const uint16_t compact_segment_id) {
+  ASSERT(compact_segment_id > 0, "Undefined compact segment id");
+  return 15_st - static_cast<size_t>(std::countl_zero(compact_segment_id));
+}
+
+size_t get_index(const uint16_t compact_segment_id) {
+  ASSERT(compact_segment_id > 0, "Undefined compact segment id");
+  return static_cast<size_t>(compact_segment_id -
+                             std::bit_floor(compact_segment_id));
+}
+
+SegmentId make_segment_id(const uint16_t compact_segment_id) {
+  ASSERT(compact_segment_id > 0, "Undefined compact segment id");
+  return SegmentId{get_refinement_level(compact_segment_id),
+                   get_index(compact_segment_id)};
+}
+
+bool is_on_lower_block_boundary(const uint16_t compact_segment_id) {
+  ASSERT(compact_segment_id > 0, "Undefined compact segment id");
+  // true if index is zero, which means only a single bit is a one
+  return std::has_single_bit(compact_segment_id);
+}
+
+bool is_on_upper_block_boundary(const uint16_t compact_segment_id) {
+  ASSERT(compact_segment_id > 0, "Undefined compact segment id");
+  // true if all bits after the leading one are also one
+  return 16 == (std::countl_zero(compact_segment_id) +
+                std::countr_one(compact_segment_id));
+}
+}  // namespace
+
 template <size_t VolumeDim>
-ElementId<VolumeDim>::ElementId(const size_t block_id, const size_t grid_index)
+ElementId<VolumeDim>::ElementId(const uint8_t block_id,
+                                const uint8_t grid_index,
+                                const uint8_t direction,
+                                const uint16_t compact_segment_id_xi,
+                                const uint16_t compact_segment_id_eta,
+                                const uint16_t compact_segment_id_zeta)
     : block_id_(block_id),
       grid_index_(grid_index),
-      direction_{Direction<VolumeDim>::self().bits()},
-      index_xi_{0},
-      refinement_level_xi_{0},
-      index_eta_{0},
-      refinement_level_eta_{0},
-      index_zeta_{0},
-      refinement_level_zeta_{0} {
+      direction_(direction),
+      compact_segment_id_xi_(compact_segment_id_xi),
+      compact_segment_id_eta_(compact_segment_id_eta),
+      compact_segment_id_zeta_(compact_segment_id_zeta) {}
+
+template <size_t VolumeDim>
+ElementId<VolumeDim>::ElementId(const size_t block_id, const size_t grid_index)
+    : block_id_(static_cast<uint8_t>(block_id)),
+      grid_index_(static_cast<uint8_t>(grid_index)),
+      direction_(Direction<VolumeDim>::self().bits()),
+      compact_segment_id_xi_(uint16_t{1}),
+      compact_segment_id_eta_(VolumeDim > 1 ? uint16_t{1} : uint16_t{0}),
+      compact_segment_id_zeta_(VolumeDim > 2 ? uint16_t{1} : uint16_t{0}) {
   ASSERT(block_id < two_to_the(block_id_bits),
          "Block id out of bounds: " << block_id << "\nMaximum value is: "
                                     << two_to_the(block_id_bits) - 1);
@@ -59,45 +128,58 @@ ElementId<VolumeDim>::ElementId(const size_t block_id, const size_t grid_index)
                                       << two_to_the(grid_index_bits) - 1);
 }
 
-template <size_t VolumeDim>
-ElementId<VolumeDim>::ElementId(const size_t block_id,
-                                std::array<SegmentId, VolumeDim> segment_ids,
-                                const size_t grid_index)
-    : block_id_(block_id),
-      grid_index_(grid_index),
-      direction_{Direction<VolumeDim>::self().bits()} {
+template <>
+ElementId<1>::ElementId(const size_t block_id,
+                        const std::array<SegmentId, 1>& segment_ids,
+                        const size_t grid_index)
+    : block_id_(static_cast<uint8_t>(block_id)),
+      grid_index_(static_cast<uint8_t>(grid_index)),
+      direction_(Direction<3>::self().bits()),
+      compact_segment_id_xi_(make_compact_segment_id(segment_ids[0])),
+      compact_segment_id_eta_(uint16_t{0}),
+      compact_segment_id_zeta_(uint16_t{0}) {
   ASSERT(block_id < two_to_the(block_id_bits),
          "Block id out of bounds: " << block_id << "\nMaximum value is: "
                                     << two_to_the(block_id_bits) - 1);
   ASSERT(grid_index < two_to_the(grid_index_bits),
          "Grid index out of bounds: " << grid_index << "\nMaximum value is: "
                                       << two_to_the(grid_index_bits) - 1);
-  const auto check_refinement_level = [](const size_t refinement_level) {
-    ASSERT(refinement_level <= max_refinement_level,
-           "Refinement level out of bounds: " << refinement_level
-                                              << "\nMaximum value is: "
-                                              << max_refinement_level);
-    return refinement_level;
-  };
-  index_xi_ = segment_ids[0].index();
-  refinement_level_xi_ =
-      check_refinement_level(segment_ids[0].refinement_level());
-  if constexpr (VolumeDim > 1) {
-    index_eta_ = segment_ids[1].index();
-    refinement_level_eta_ =
-        check_refinement_level(segment_ids[1].refinement_level());
-  } else {
-    index_eta_ = 0;
-    refinement_level_eta_ = 0;
-  }
-  if constexpr (VolumeDim > 2) {
-    index_zeta_ = segment_ids[2].index();
-    refinement_level_zeta_ =
-        check_refinement_level(segment_ids[2].refinement_level());
-  } else {
-    index_zeta_ = 0;
-    refinement_level_zeta_ = 0;
-  }
+}
+
+template <>
+ElementId<2>::ElementId(const size_t block_id,
+                        const std::array<SegmentId, 2>& segment_ids,
+                        const size_t grid_index)
+    : block_id_(static_cast<uint8_t>(block_id)),
+      grid_index_(static_cast<uint8_t>(grid_index)),
+      direction_(Direction<3>::self().bits()),
+      compact_segment_id_xi_(make_compact_segment_id(segment_ids[0])),
+      compact_segment_id_eta_(make_compact_segment_id(segment_ids[1])),
+      compact_segment_id_zeta_(uint16_t{0}) {
+  ASSERT(block_id < two_to_the(block_id_bits),
+         "Block id out of bounds: " << block_id << "\nMaximum value is: "
+                                    << two_to_the(block_id_bits) - 1);
+  ASSERT(grid_index < two_to_the(grid_index_bits),
+         "Grid index out of bounds: " << grid_index << "\nMaximum value is: "
+                                      << two_to_the(grid_index_bits) - 1);
+}
+
+template <>
+ElementId<3>::ElementId(const size_t block_id,
+                        const std::array<SegmentId, 3>& segment_ids,
+                        const size_t grid_index)
+    : block_id_(static_cast<uint8_t>(block_id)),
+      grid_index_(static_cast<uint8_t>(grid_index)),
+      direction_(Direction<3>::self().bits()),
+      compact_segment_id_xi_(make_compact_segment_id(segment_ids[0])),
+      compact_segment_id_eta_(make_compact_segment_id(segment_ids[1])),
+      compact_segment_id_zeta_(make_compact_segment_id(segment_ids[2])) {
+  ASSERT(block_id < two_to_the(block_id_bits),
+         "Block id out of bounds: " << block_id << "\nMaximum value is: "
+                                    << two_to_the(block_id_bits) - 1);
+  ASSERT(grid_index < two_to_the(grid_index_bits),
+         "Grid index out of bounds: " << grid_index << "\nMaximum value is: "
+                                      << two_to_the(grid_index_bits) - 1);
 }
 
 template <size_t VolumeDim>
@@ -105,14 +187,10 @@ ElementId<VolumeDim>::ElementId(const Direction<VolumeDim>& direction,
                                 const ElementId<VolumeDim>& element_id)
     : block_id_(element_id.block_id_),
       grid_index_(element_id.grid_index_),
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       direction_(direction.bits()),
-      index_xi_{element_id.index_xi_},
-      refinement_level_xi_{element_id.refinement_level_xi_},
-      index_eta_{element_id.index_eta_},
-      refinement_level_eta_{element_id.refinement_level_eta_},
-      index_zeta_{element_id.index_zeta_},
-      refinement_level_zeta_{element_id.refinement_level_zeta_} {}
+      compact_segment_id_xi_(element_id.compact_segment_id_xi_),
+      compact_segment_id_eta_(element_id.compact_segment_id_eta_),
+      compact_segment_id_zeta_(element_id.compact_segment_id_zeta_) {}
 
 template <size_t VolumeDim>
 ElementId<VolumeDim>::ElementId(const std::string& grid_name)
@@ -136,31 +214,34 @@ ElementId<VolumeDim>::ElementId(const std::string& grid_name)
   const auto to_size_t = [](const std::ssub_match& s) {
     return static_cast<size_t>(std::stoi(s.str()));
   };
-  const auto check_refinement_level =
-      [&grid_name](const size_t refinement_level) {
-        ASSERT(refinement_level <= ElementId<VolumeDim>::max_refinement_level,
-               "Refinement level '"
-                   << refinement_level << "' out of bounds for element ID '"
-                   << grid_name << "'. Maximum value is: "
-                   << ElementId<VolumeDim>::max_refinement_level);
-        return refinement_level;
-      };
   block_id_ = to_size_t(match[1]);
-  refinement_level_xi_ = check_refinement_level(to_size_t(match[2]));
-  index_xi_ = to_size_t(match[3]);
+  const auto make_compact_segment_id = [](const size_t refinement_level,
+                                          const size_t index,
+                                          const std::string& name) {
+    ASSERT(refinement_level <= max_refinement_level,
+           "Refinement level '"
+               << refinement_level << "' out of bounds for element ID '" << name
+               << "'. Maximum value is: " << max_refinement_level);
+    ASSERT(index < two_to_the(refinement_level),
+           "Index '" << index << "' out of bounds for element ID '" << name
+                     << "'. Maximum value is: "
+                     << two_to_the(refinement_level) - 1);
+    return (uint16_t{1} << refinement_level) + static_cast<uint16_t>(index);
+  };
+
+  compact_segment_id_xi_ = make_compact_segment_id(
+      to_size_t(match[2]), to_size_t(match[3]), grid_name);
   if constexpr (VolumeDim > 1) {
-    refinement_level_eta_ = check_refinement_level(to_size_t(match[4]));
-    index_eta_ = to_size_t(match[5]);
+    compact_segment_id_eta_ = make_compact_segment_id(
+        to_size_t(match[4]), to_size_t(match[5]), grid_name);
   } else {
-    refinement_level_eta_ = 0;
-    index_eta_ = 0;
+    compact_segment_id_eta_ = 0;
   }
   if constexpr (VolumeDim > 2) {
-    refinement_level_zeta_ = check_refinement_level(to_size_t(match[6]));
-    index_zeta_ = to_size_t(match[7]);
+    compact_segment_id_zeta_ = make_compact_segment_id(
+        to_size_t(match[6]), to_size_t(match[7]), grid_name);
   } else {
-    refinement_level_zeta_ = 0;
-    index_zeta_ = 0;
+    compact_segment_id_zeta_ = 0;
   }
   if (match[1                // Full matched string
             + 1              // Block ID
@@ -183,18 +264,67 @@ ElementId<VolumeDim>::ElementId(const std::string& grid_name)
 template <size_t VolumeDim>
 ElementId<VolumeDim> ElementId<VolumeDim>::id_of_child(const size_t dim,
                                                        const Side side) const {
-  std::array<SegmentId, VolumeDim> new_segment_ids = segment_ids();
-  gsl::at(new_segment_ids, dim) =
-      gsl::at(new_segment_ids, dim).id_of_child(side);
-  return {block_id(), new_segment_ids, grid_index()};
+  ASSERT(dim < VolumeDim,
+         "Dimension must be smaller than " << VolumeDim << ", but is: " << dim);
+  ElementId<VolumeDim> result = this->without_direction();
+  switch (dim) {
+    case 0:
+      ASSERT(get_refinement_level(result.compact_segment_id_xi_) !=
+                 max_refinement_level,
+             "Cannot get child of element on max refinement level");
+      result.compact_segment_id_xi_ = result.compact_segment_id_xi_ << 1;
+      if (side == Side::Upper) {
+        ++result.compact_segment_id_xi_;
+      }
+      return result;
+    case 1:
+      ASSERT(get_refinement_level(result.compact_segment_id_eta_) !=
+                 max_refinement_level,
+             "Cannot get child of element on max refinement level");
+      result.compact_segment_id_eta_ = result.compact_segment_id_eta_ << 1;
+      if (side == Side::Upper) {
+        ++result.compact_segment_id_eta_;
+      }
+      return result;
+    case 2:
+      ASSERT(get_refinement_level(result.compact_segment_id_zeta_) !=
+                 max_refinement_level,
+             "Cannot get child of element on max refinement level");
+      result.compact_segment_id_zeta_ = result.compact_segment_id_zeta_ << 1;
+      if (side == Side::Upper) {
+        ++result.compact_segment_id_zeta_;
+      }
+      return result;
+    default:
+      ERROR("Invalid dimension: " << dim);
+  }
 }
 
 template <size_t VolumeDim>
 ElementId<VolumeDim> ElementId<VolumeDim>::id_of_parent(
     const size_t dim) const {
-  std::array<SegmentId, VolumeDim> new_segment_ids = segment_ids();
-  gsl::at(new_segment_ids, dim) = gsl::at(new_segment_ids, dim).id_of_parent();
-  return {block_id(), new_segment_ids, grid_index()};
+  ASSERT(dim < VolumeDim,
+         "Dimension must be smaller than " << VolumeDim << ", but is: " << dim);
+  ElementId<VolumeDim> result = this->without_direction();
+  switch (dim) {
+    case 0:
+      ASSERT(get_refinement_level(result.compact_segment_id_xi_) != 0,
+             "Cannot get parent of element on refinement level 0");
+      result.compact_segment_id_xi_ = result.compact_segment_id_xi_ >> 1;
+      return result;
+    case 1:
+      ASSERT(get_refinement_level(result.compact_segment_id_xi_) != 0,
+             "Cannot get parent of element on refinement level 0");
+      result.compact_segment_id_eta_ = result.compact_segment_id_eta_ >> 1;
+      return result;
+    case 2:
+      ASSERT(get_refinement_level(result.compact_segment_id_xi_) != 0,
+             "Cannot get parent of element on refinement level 0");
+      result.compact_segment_id_zeta_ = result.compact_segment_id_zeta_ >> 1;
+      return result;
+    default:
+      ERROR("Invalid dimension: " << dim);
+  }
 }
 
 template <size_t VolumeDim>
@@ -207,26 +337,28 @@ Direction<VolumeDim> ElementId<VolumeDim>::direction() const {
 template <size_t VolumeDim>
 std::array<size_t, VolumeDim> ElementId<VolumeDim>::refinement_levels() const {
   if constexpr (VolumeDim == 1) {
-    return {{refinement_level_xi_}};
+    return {{get_refinement_level(compact_segment_id_xi_)}};
   } else if constexpr (VolumeDim == 2) {
-    return {{refinement_level_xi_, refinement_level_eta_}};
+    return {{get_refinement_level(compact_segment_id_xi_),
+             get_refinement_level(compact_segment_id_eta_)}};
   } else if constexpr (VolumeDim == 3) {
-    return {
-        {refinement_level_xi_, refinement_level_eta_, refinement_level_zeta_}};
+    return {{get_refinement_level(compact_segment_id_xi_),
+             get_refinement_level(compact_segment_id_eta_),
+             get_refinement_level(compact_segment_id_zeta_)}};
   }
 }
 
 template <size_t VolumeDim>
 std::array<SegmentId, VolumeDim> ElementId<VolumeDim>::segment_ids() const {
   if constexpr (VolumeDim == 1) {
-    return {{SegmentId{refinement_level_xi_, index_xi_}}};
+    return {{make_segment_id(compact_segment_id_xi_)}};
   } else if constexpr (VolumeDim == 2) {
-    return {{SegmentId{refinement_level_xi_, index_xi_},
-             SegmentId{refinement_level_eta_, index_eta_}}};
+    return {{make_segment_id(compact_segment_id_xi_),
+             make_segment_id(compact_segment_id_eta_)}};
   } else if constexpr (VolumeDim == 3) {
-    return {{SegmentId{refinement_level_xi_, index_xi_},
-             SegmentId{refinement_level_eta_, index_eta_},
-             SegmentId{refinement_level_zeta_, index_zeta_}}};
+    return {{make_segment_id(compact_segment_id_xi_),
+             make_segment_id(compact_segment_id_eta_),
+             make_segment_id(compact_segment_id_zeta_)}};
   }
 }
 
@@ -236,11 +368,11 @@ SegmentId ElementId<VolumeDim>::segment_id(const size_t dim) const {
          "Dimension must be smaller than " << VolumeDim << ", but is: " << dim);
   switch (dim) {
     case 0:
-      return {refinement_level_xi_, index_xi_};
+      return make_segment_id(compact_segment_id_xi_);
     case 1:
-      return {refinement_level_eta_, index_eta_};
+      return make_segment_id(compact_segment_id_eta_);
     case 2:
-      return {refinement_level_zeta_, index_zeta_};
+      return make_segment_id(compact_segment_id_zeta_);
     default:
       ERROR("Invalid dimension: " << dim);
   }
@@ -248,14 +380,10 @@ SegmentId ElementId<VolumeDim>::segment_id(const size_t dim) const {
 
 template <size_t VolumeDim>
 ElementId<VolumeDim> ElementId<VolumeDim>::external_boundary_id() {
-  // We use the maximum possible value that can be stored in `block_id_bits` and
-  // the maximum refinement level to signal an external boundary. While in
-  // theory this could cause a problem if we have an element at the highest
-  // refinement level in the largest block (by id), in practice it is very
-  // unlikely we will ever get to that large of a refinement.
-  return ElementId<VolumeDim>(
-      two_to_the(ElementId::block_id_bits) - 1,
-      make_array<VolumeDim>(SegmentId(ElementId::max_refinement_level - 1, 0)));
+  // In order to distinguish this from an uninitialized ElementId, we use the
+  // maximum possible value that can be stored in `block_id_bits`
+  static_assert(ElementId::block_id_bits == 8);
+  return ElementId{255, 0, 0, 0, 0, 0};
 }
 
 template <size_t VolumeDim>
@@ -267,28 +395,20 @@ ElementId<VolumeDim> ElementId<VolumeDim>::without_direction() const {
 
 template <size_t VolumeDim>
 size_t ElementId<VolumeDim>::number_of_block_boundaries() const {
-  return (index_xi_ == 0 ? (refinement_level_xi_ == 0 ? 2 : 1)
-          : (index_xi_ ==
-             two_to_the(static_cast<unsigned short>(refinement_level_xi_)) - 1)
-              ? 1_st
-              : 0_st) +
+  return (is_on_lower_block_boundary(compact_segment_id_xi_) ? 1_st : 0_st) +
+         (is_on_upper_block_boundary(compact_segment_id_xi_) ? 1_st : 0_st) +
          (VolumeDim > 1
-              ? (index_eta_ == 0
-                     ? (refinement_level_eta_ == 0 ? 2 : 1)
-                     : ((index_eta_ == two_to_the(static_cast<unsigned short>(
-                                           refinement_level_eta_)) -
-                                           1)
-                            ? 1_st
-                            : 0_st))
+              ? (is_on_lower_block_boundary(compact_segment_id_eta_) ? 1_st
+                                                                     : 0_st) +
+                    (is_on_upper_block_boundary(compact_segment_id_eta_) ? 1_st
+                                                                         : 0_st)
               : 0_st) +
          (VolumeDim > 2
-              ? (index_zeta_ == 0
-                     ? (refinement_level_zeta_ == 0 ? 2 : 1)
-                     : ((index_zeta_ == two_to_the(static_cast<unsigned short>(
-                                            refinement_level_zeta_)) -
-                                            1)
-                            ? 1_st
-                            : 0_st))
+              ? (is_on_lower_block_boundary(compact_segment_id_zeta_) ? 1_st
+                                                                      : 0_st) +
+                    (is_on_upper_block_boundary(compact_segment_id_zeta_)
+                         ? 1_st
+                         : 0_st)
               : 0_st);
 }
 
@@ -305,20 +425,23 @@ std::ostream& operator<<(std::ostream& os, const ElementId<VolumeDim>& id) {
 template <size_t VolumeDim>
 bool operator<(const ElementId<VolumeDim>& lhs,
                const ElementId<VolumeDim>& rhs) {
-  if (lhs.grid_index() != rhs.grid_index()) {
-    return lhs.grid_index() < rhs.grid_index();
+  if (lhs.grid_index_ != rhs.grid_index_) {
+    return lhs.grid_index_ < rhs.grid_index_;
   }
-  if (lhs.block_id() != rhs.block_id()) {
-    return lhs.block_id() < rhs.block_id();
+  if (lhs.block_id_ != rhs.block_id_) {
+    return lhs.block_id_ < rhs.block_id_;
   }
-  for (size_t d = 0; d < VolumeDim; ++d) {
-    if (lhs.segment_id(d).refinement_level() !=
-        rhs.segment_id(d).refinement_level()) {
-      return lhs.segment_id(d).refinement_level() <
-             rhs.segment_id(d).refinement_level();
+  if (lhs.compact_segment_id_xi_ != rhs.compact_segment_id_xi_) {
+    return lhs.compact_segment_id_xi_ < rhs.compact_segment_id_xi_;
+  }
+  if constexpr (VolumeDim > 1) {
+    if (lhs.compact_segment_id_eta_ != rhs.compact_segment_id_eta_) {
+      return lhs.compact_segment_id_eta_ < rhs.compact_segment_id_eta_;
     }
-    if (lhs.segment_id(d).index() != rhs.segment_id(d).index()) {
-      return lhs.segment_id(d).index() < rhs.segment_id(d).index();
+  }
+  if constexpr (VolumeDim > 2) {
+    if (lhs.compact_segment_id_zeta_ != rhs.compact_segment_id_zeta_) {
+      return lhs.compact_segment_id_zeta_ < rhs.compact_segment_id_zeta_;
     }
   }
   return false;
@@ -327,15 +450,22 @@ bool operator<(const ElementId<VolumeDim>& lhs,
 template <size_t Dim>
 bool is_zeroth_element(const ElementId<Dim>& id,
                        const std::optional<size_t>& grid_index) {
-  const bool base_checks =
-      id.block_id() == 0 and
-      alg::accumulate(id.segment_ids(), 0_st,
-                      [](const size_t current, const auto& segment_id) {
-                        return current + segment_id.index();
-                      }) == 0;
-  return grid_index.has_value()
-             ? base_checks and id.grid_index() == grid_index.value()
-             : base_checks;
+  if (id.block_id_ != 0) {
+    return false;
+  }
+  if (not is_on_lower_block_boundary(id.compact_segment_id_xi_)) {
+    return false;
+  }
+  if (Dim > 1 and not is_on_lower_block_boundary(id.compact_segment_id_eta_)) {
+    return false;
+  }
+  if (Dim > 2 and not is_on_lower_block_boundary(id.compact_segment_id_zeta_)) {
+    return false;
+  }
+  if (grid_index.has_value()) {
+    return id.grid_index_ == grid_index.value();
+  }
+  return true;
 }
 
 template <size_t Dim>
@@ -354,8 +484,8 @@ size_t hash_value(const ElementId<VolumeDim>& id) {
          (compl ElementId<VolumeDim>::direction_mask);
 }
 
-// clang-tidy: do not modify namespace std
-namespace std {  // NOLINT
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+namespace std {
 template <size_t VolumeDim>
 size_t hash<ElementId<VolumeDim>>::operator()(
     const ElementId<VolumeDim>& id) const {

--- a/src/Domain/Structure/SegmentId.cpp
+++ b/src/Domain/Structure/SegmentId.cpp
@@ -3,7 +3,9 @@
 
 #include "Domain/Structure/SegmentId.hpp"
 
-#include <boost/functional/hash.hpp>
+#include <boost/container_hash/hash.hpp>
+#include <cstddef>
+#include <functional>
 #include <ostream>
 #include <pup.h>
 
@@ -12,8 +14,6 @@
 
 SegmentId::SegmentId(const size_t refinement_level, const size_t index)
     : refinement_level_(refinement_level), index_(index) {
-  ASSERT(refinement_level < max_refinement_level,
-         "Refinement level out of bounds: " << refinement_level);
   ASSERT(index < two_to_the(refinement_level),
          "index = " << index << ", refinement_level = " << refinement_level);
 }

--- a/src/Domain/Structure/SegmentId.hpp
+++ b/src/Domain/Structure/SegmentId.hpp
@@ -91,7 +91,6 @@ class SegmentId {
   void pup(PUP::er& p);
 
  private:
-  static constexpr size_t max_refinement_level = 16;
   size_t refinement_level_;
   size_t index_;
 };
@@ -105,9 +104,9 @@ bool operator==(const SegmentId& lhs, const SegmentId& rhs);
 /// Inequivalence operator for SegmentId.
 bool operator!=(const SegmentId& lhs, const SegmentId& rhs);
 
-//##############################################################################
-// INLINE DEFINITIONS
-//##############################################################################
+// #############################################################################
+//  INLINE DEFINITIONS
+// #############################################################################
 
 inline SegmentId SegmentId::id_of_parent() const {
   ASSERT(0 != refinement_level_,

--- a/src/Utilities/StdHelpers/Bit.hpp
+++ b/src/Utilities/StdHelpers/Bit.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <bit>
+
+#if defined(__cpp_lib_int_pow2) && __cpp_lib_int_pow2 >= 202002L
+// std::bit_floor and std::has_single_bit are defined in <bit>
+#else
+// std::bit_floor and std::has_single_bit are not defined in <bit> and
+// therefore we provide the definitions
+#include <cstdint>
+#include <limits>
+
+#include "Utilities/Requires.hpp"
+
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+namespace std {
+template <typename T,
+          Requires<std::is_same_v<T, uint8_t> or std::is_same_v<T, uint16_t> or
+                   std::is_same_v<T, uint32_t> or std::is_same_v<T, uint64_t> or
+                   std::is_same_v<T, size_t> > = nullptr>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+constexpr T bit_floor(T x) noexcept {
+  if (x != 0) {
+    return T(1) << (std::numeric_limits<T>::digits - std::countl_zero(x) - 1);
+  }
+  return 0;
+}
+
+template <typename T,
+          Requires<std::is_same_v<T, uint8_t> or std::is_same_v<T, uint16_t> or
+                   std::is_same_v<T, uint32_t> or std::is_same_v<T, uint64_t> or
+                   std::is_same_v<T, size_t> > = nullptr>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+constexpr bool has_single_bit(T x) noexcept {
+  return std::popcount(x) == 1;
+}
+}  // namespace std
+#endif

--- a/src/Utilities/StdHelpers/CMakeLists.txt
+++ b/src/Utilities/StdHelpers/CMakeLists.txt
@@ -9,5 +9,6 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Bit.hpp
   RetrieveUniquePtr.hpp
   )

--- a/tests/Unit/Domain/Structure/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Structure/Test_ElementId.cpp
@@ -5,11 +5,14 @@
 
 #include <array>
 #include <cstddef>
-#include <limits>
+#include <cstring>
+#include <functional>
+#include <pup.h>
 #include <random>
 #include <string>
 #include <vector>
 
+#include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Domain/Structure/SegmentId.hpp"
@@ -18,10 +21,8 @@
 #include "Parallel/ArrayIndex.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GetOutput.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
+#include "Utilities/Literals.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
-#include "Utilities/StdHelpers.hpp"
 
 namespace {
 template <size_t Dim>
@@ -205,22 +206,20 @@ void test_element_id() {
 
   CHECK(ElementId<3>::external_boundary_id().block_id() ==
         two_to_the(ElementId<3>::block_id_bits) - 1);
-  CHECK(ElementId<3>::external_boundary_id().segment_ids() ==
-        make_array<3>(SegmentId(ElementId<3>::max_refinement_level - 1, 0)));
   CHECK(ElementId<3>::external_boundary_id().grid_index() == 0);
 
-  ElementId<3> element1(0);
-  ElementId<3> element2{0, 1};
-  ElementId<3> element3(1);
-  ElementId<3> element4{1, 1};
-  ElementId<3> element5{0, {{{1, 0}, {2, 0}, {1, 0}}}};
-  ElementId<3> element6{0, {{{1, 0}, {2, 0}, {1, 0}}}, 1};
-  ElementId<3> element7{0, {{{1, 0}, {2, 1}, {1, 0}}}};
-  ElementId<3> element8{0, {{{1, 0}, {2, 1}, {1, 0}}}, 1};
-  ElementId<3> element9{1, {{{1, 0}, {2, 0}, {1, 0}}}};
-  ElementId<3> element10{1, {{{1, 0}, {2, 0}, {1, 0}}}, 1};
-  ElementId<3> element11{1, {{{1, 0}, {2, 1}, {1, 0}}}};
-  ElementId<3> element12{1, {{{1, 0}, {2, 1}, {1, 0}}}, 1};
+  const ElementId<3> element1(0);
+  const ElementId<3> element2{0, 1};
+  const ElementId<3> element3(1);
+  const ElementId<3> element4{1, 1};
+  const ElementId<3> element5{0, {{{1, 0}, {2, 0}, {1, 0}}}};
+  const ElementId<3> element6{0, {{{1, 0}, {2, 0}, {1, 0}}}, 1};
+  const ElementId<3> element7{0, {{{1, 0}, {2, 1}, {1, 0}}}};
+  const ElementId<3> element8{0, {{{1, 0}, {2, 1}, {1, 0}}}, 1};
+  const ElementId<3> element9{1, {{{1, 0}, {2, 0}, {1, 0}}}};
+  const ElementId<3> element10{1, {{{1, 0}, {2, 0}, {1, 0}}}, 1};
+  const ElementId<3> element11{1, {{{1, 0}, {2, 1}, {1, 0}}}};
+  const ElementId<3> element12{1, {{{1, 0}, {2, 1}, {1, 0}}}, 1};
 
   CHECK(is_zeroth_element(element1));
   CHECK_FALSE(is_zeroth_element(element1, {1}));

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -626,6 +626,7 @@ standard_checks+=(enable_if)
 # Check for noexcept
 noexcept() {
     whitelist "$1" \
+              "src/Utilities/StdHelpers/Bit.hpp" \
               'src/Parallel/StaticSpscQueue.hpp' \
               "src/Parallel/NodeLock..pp$" \
               "src/Evolution/DiscontinuousGalerkin/\


### PR DESCRIPTION
This is done by using a compact representation of a SegmentId. Also fix some clang-tidy errors.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
