### PR TITLE
Support linearised fluxes.

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/IndexToSliceAt.hpp"
 #include "Elliptic/Protocols/FirstOrderSystem.hpp"
+#include "Elliptic/Systems/GetFluxesComputer.hpp"
 #include "Elliptic/Systems/GetSourcesComputer.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
@@ -222,7 +223,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
       tt::assert_conforms_to_v<System, elliptic::protocols::FirstOrderSystem>);
 
   static constexpr size_t Dim = System::volume_dim;
-  using FluxesComputer = typename System::fluxes_computer;
+  using FluxesComputer = elliptic::get_fluxes_computer<System, Linearized>;
   using SourcesComputer = elliptic::get_sources_computer<System, Linearized>;
 
   struct AllDirections {
@@ -511,7 +512,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
         all_mortar_data->at(mortar_id).remote_insert(temporal_id,
                                                      std::move(boundary_data));
       }  // if (is_internal)
-    }    // loop directions
+    }  // loop directions
   }
 
   // --- This is essentially a break to communicate the mortar data ---

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
@@ -37,6 +37,7 @@
 #include "Domain/Tags/NeighborMesh.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Initialization.hpp"
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/Tags.hpp"
+#include "Elliptic/Systems/GetFluxesComputer.hpp"
 #include "Elliptic/Utilities/ApplyAt.hpp"
 #include "Elliptic/Utilities/GetAnalyticData.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
@@ -160,10 +161,10 @@ struct InitializeSubdomain {
   // necessary for the DG operator, i.e. the background fields in the
   // System::fluxes_computer::argument_tags
   using fluxes_non_background_args =
-      tmpl::list_difference<typename System::fluxes_computer::argument_tags,
+      tmpl::list_difference<elliptic::get_fluxes_argument_tags<System, true>,
                             typename System::background_fields>;
   using background_fields_internal =
-      tmpl::list_difference<typename System::fluxes_computer::argument_tags,
+      tmpl::list_difference<elliptic::get_fluxes_argument_tags<System, true>,
                             fluxes_non_background_args>;
   // Slice all background fields to external boundaries for use in boundary
   // conditions
@@ -245,7 +246,7 @@ struct InitializeSubdomain {
         // Faces on the other side of the overlapped element's mortars
         initialize_remote_faces(make_not_null(&box), overlap_id);
       }  // neighbors in direction
-    }    // directions
+    }  // directions
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 
@@ -382,7 +383,7 @@ struct InitializeSubdomain {
               box, std::make_tuple(overlap_id, mortar_id));
         }
       }  // neighbors
-    }    // internal directions
+    }  // internal directions
   }
 };
 

--- a/src/Elliptic/Protocols/FirstOrderSystem.hpp
+++ b/src/Elliptic/Protocols/FirstOrderSystem.hpp
@@ -178,8 +178,8 @@ struct FirstOrderSystem {
 
     using fluxes_computer = typename ConformingType::fluxes_computer;
     using sources_computer = typename ConformingType::sources_computer;
-    using fluxes_argument_tags = typename fluxes_computer::argument_tags;
-    static_assert(tt::is_a_v<tmpl::list, fluxes_argument_tags>);
+    static_assert(
+        tt::is_a_v<tmpl::list, typename fluxes_computer::argument_tags>);
 
     using boundary_conditions_base =
         typename ConformingType::boundary_conditions_base;

--- a/src/Elliptic/Systems/CMakeLists.txt
+++ b/src/Elliptic/Systems/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  GetFluxesComputer.hpp
   GetSourcesComputer.hpp
   )
 

--- a/src/Elliptic/Systems/GetFluxesComputer.hpp
+++ b/src/Elliptic/Systems/GetFluxesComputer.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "Utilities/TMPL.hpp"
+
+namespace elliptic {
+namespace detail {
+template <typename System, typename = std::void_t<>>
+struct fluxes_computer_linearized {
+  using type = typename System::fluxes_computer;
+};
+template <typename System>
+struct fluxes_computer_linearized<
+    System, std::void_t<typename System::fluxes_computer_linearized>> {
+  using type = typename System::fluxes_computer_linearized;
+};
+}  // namespace detail
+
+/// The `System::fluxes_computer` or the `System::fluxes_computer_linearized`,
+/// depending on the `Linearized` parameter. If the system has no
+/// `fluxes_computer_linearized` alias it is assumed that the linear flux is
+/// functionally identical to the non-linear flux, so the
+/// `System::fluxes_computer` is returned either way.
+template <typename System, bool Linearized>
+using get_fluxes_computer = tmpl::conditional_t<
+    Linearized, typename detail::fluxes_computer_linearized<System>::type,
+    typename System::fluxes_computer>;
+
+/// The `argument_tags` of either the `System::fluxes_computer` or the
+/// `System::fluxes_computer_linearized`, depending on the `Linearized`
+/// parameter.
+template <typename System, bool Linearized>
+using get_fluxes_argument_tags =
+    typename get_fluxes_computer<System, Linearized>::argument_tags;
+
+/// The `volume_tags` of either the `System::fluxes_computer` or the
+/// `System::fluxes_computer_linearized`, depending on the `Linearized`
+/// parameter.
+template <typename System, bool Linearized>
+using get_fluxes_volume_tags =
+    typename get_fluxes_computer<System, Linearized>::volume_tags;
+
+/// The `const_global_cache_tags` of either the `System::fluxes_computer` or the
+/// `System::fluxes_computer_linearized`, depending on the `Linearized`
+/// parameter.
+template <typename System, bool Linearized>
+using get_fluxes_const_global_cache_tags =
+    typename get_fluxes_computer<System, Linearized>::const_global_cache_tags;
+}  // namespace elliptic


### PR DESCRIPTION
## Proposed changes

Adds support for non-linear systems with linearised fluxes that are not functionally identical to their non-linear counterpart. Currently none of the systems require this, but this will be needed in the future.

### Upgrade instructions

To have a system with different fluxes and linearised fluxes, one just needs to add an alias for `fluxes_computer_linearized` to the systems `FirstOrderSystem`, similar to what is done for `sources_computer` and `sources_computer_linearized`. An example system will be in upcoming PR's.
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
