### PR TITLE
Support sources fetching from const_global_cache.

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -193,6 +193,7 @@ struct SubdomainOperator
   // when evaluating neighbors
   using args_tags_from_center = tmpl::remove_duplicates<tmpl::push_back<
       elliptic::get_fluxes_const_global_cache_tags<System, linearized>,
+      elliptic::get_sources_const_global_cache_tags<System, linearized>,
       elliptic::dg::Tags::Massive, elliptic::dg::Tags::Formulation>>;
 
   // Data on neighbors is stored in the central element's DataBox in

--- a/src/Elliptic/Protocols/FirstOrderSystem.hpp
+++ b/src/Elliptic/Protocols/FirstOrderSystem.hpp
@@ -152,7 +152,12 @@ struct test_fields_and_fluxes<Dim, tmpl::list<PrimalFields...>,
  *   4. The `primal_fluxes`
  *
  *   The function is expected to _add_ the sources \f$S_\alpha\f$ to the
- *   output buffers.
+ *   output buffers. It must also have the following alias:
+ *
+ * - `const_global_cache_tags`: the subset of `argument_tags` that can be
+ *     retrieved from _any_ element's DataBox, because they are stored in the
+ *     global cache.
+ *
  *   The `sources_computer` may also be `void`, in which case \f$S_\alpha=0\f$.
  *
  * - `boundary_conditions_base`: A base class representing the supported

--- a/src/Elliptic/Systems/BnsInitialData/Equations.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/Equations.hpp
@@ -100,6 +100,7 @@ struct Sources {
   using argument_tags = tmpl::list<
       Tags::DerivLogLapseTimesDensityOverSpecificEnthalpy<DataVector>,
       gr::Tags::SpatialChristoffelSecondKindContracted<DataVector, 3>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(gsl::not_null<Scalar<DataVector>*> equation_for_potential,
                     const tnsr::i<DataVector, 3>&
                         log_deriv_lapse_times_density_over_specific_enthalpy,

--- a/src/Elliptic/Systems/GetSourcesComputer.hpp
+++ b/src/Elliptic/Systems/GetSourcesComputer.hpp
@@ -20,6 +20,7 @@ struct sources_computer_linearized<
 };
 struct NoSourcesComputer {
   using argument_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
 };
 }  // namespace detail
 
@@ -40,4 +41,13 @@ using get_sources_argument_tags = typename tmpl::conditional_t<
     std::is_same_v<get_sources_computer<System, Linearized>, void>,
     detail::NoSourcesComputer,
     get_sources_computer<System, Linearized>>::argument_tags;
+
+/// The `const_global_cache_tags` of either the `System::sources_computer` or
+/// the `System::sources_computer_linearized`, depending on the `Linearized`
+/// parameter, or an empty list if the sources computer is `void`.
+template <typename System, bool Linearized>
+using get_sources_const_global_cache_tags = typename tmpl::conditional_t<
+    std::is_same_v<get_sources_computer<System, Linearized>, void>,
+    detail::NoSourcesComputer,
+    get_sources_computer<System, Linearized>>::const_global_cache_tags;
 }  // namespace elliptic

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -127,6 +127,7 @@ template <size_t Dim, typename DataType>
 struct Sources<Dim, Geometry::Curved, DataType> {
   using argument_tags = tmpl::list<
       gr::Tags::SpatialChristoffelSecondKindContracted<DataVector, Dim>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(gsl::not_null<Scalar<DataType>*> equation_for_field,
                     const tnsr::i<DataVector, Dim>& christoffel_contracted,
                     const Scalar<DataType>& field,

--- a/src/Elliptic/Systems/Punctures/Sources.hpp
+++ b/src/Elliptic/Systems/Punctures/Sources.hpp
@@ -49,6 +49,7 @@ void add_linearized_sources(
 /// \see elliptic::protocols::FirstOrderSystem
 struct Sources {
   using argument_tags = tmpl::list<Tags::Alpha, Tags::Beta>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(gsl::not_null<Scalar<DataVector>*> puncture_equation,
                     const Scalar<DataVector>& alpha,
                     const Scalar<DataVector>& beta,
@@ -62,6 +63,7 @@ struct Sources {
 /// \see elliptic::protocols::FirstOrderSystem
 struct LinearizedSources {
   using argument_tags = tmpl::list<Tags::Alpha, Tags::Beta, Tags::Field>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_puncture_equation,
       const Scalar<DataVector>& alpha, const Scalar<DataVector>& beta,

--- a/src/Elliptic/Systems/ScalarGaussBonnet/Equations.hpp
+++ b/src/Elliptic/Systems/ScalarGaussBonnet/Equations.hpp
@@ -128,6 +128,7 @@ struct Sources {
                     Frame::Inertial>,
       Tags::Epsilon2, Tags::Epsilon4, gr::Tags::WeylElectricScalar<DataVector>,
       gr::Tags::WeylMagneticScalar<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> equation_for_field,
       const tnsr::i<DataVector, 3>& conformal_christoffel_contracted,
@@ -157,6 +158,7 @@ struct LinearizedSources {
                  ::CurvedScalarWave::Tags::Psi, Tags::Epsilon2, Tags::Epsilon4,
                  gr::Tags::WeylElectricScalar<DataVector>,
                  gr::Tags::WeylMagneticScalar<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_equation_for_field,
       const tnsr::i<DataVector, 3>& conformal_christoffel_contracted,

--- a/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
+++ b/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
@@ -235,6 +235,7 @@ struct Sources<Equations::Hamiltonian, Geometry::Curved, ConformalMatterScale> {
                        ConformalMatterScale>::argument_tags,
       Tags::ConformalChristoffelContracted<DataVector, 3, Frame::Inertial>,
       Tags::ConformalRicciScalar<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
       const Scalar<DataVector>& conformal_energy_density,
@@ -259,6 +260,7 @@ struct Sources<Equations::HamiltonianAndLapse, Geometry::FlatCartesian,
       ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>,
       Tags::LongitudinalShiftMinusDtConformalMetricSquare<DataVector>,
       Tags::ShiftDotDerivExtrinsicCurvatureTrace<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> lapse_equation,
@@ -283,6 +285,7 @@ struct Sources<Equations::HamiltonianAndLapse, Geometry::Curved,
                        ConformalMatterScale>::argument_tags,
       Tags::ConformalChristoffelContracted<DataVector, 3, Frame::Inertial>,
       Tags::ConformalRicciScalar<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> lapse_equation,
@@ -320,6 +323,7 @@ struct Sources<Equations::HamiltonianLapseAndShift, Geometry::FlatCartesian,
                                                               Frame::Inertial>,
       ::Tags::div<Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
           DataVector, 3, Frame::Inertial>>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> lapse_equation,
@@ -356,6 +360,7 @@ struct Sources<Equations::HamiltonianLapseAndShift, Geometry::Curved,
       Tags::ConformalChristoffelSecondKind<DataVector, 3, Frame::Inertial>,
       Tags::ConformalChristoffelContracted<DataVector, 3, Frame::Inertial>,
       Tags::ConformalRicciScalar<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> lapse_equation,
@@ -402,6 +407,7 @@ struct LinearizedSources<Equations::Hamiltonian, Geometry::FlatCartesian,
       typename Sources<Equations::Hamiltonian, Geometry::FlatCartesian,
                        ConformalMatterScale>::argument_tags,
       Tags::ConformalFactorMinusOne<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
       const Scalar<DataVector>& conformal_energy_density,
@@ -421,6 +427,7 @@ struct LinearizedSources<Equations::Hamiltonian, Geometry::Curved,
       tmpl::push_back<typename Sources<Equations::Hamiltonian, Geometry::Curved,
                                        ConformalMatterScale>::argument_tags,
                       Tags::ConformalFactorMinusOne<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
       const Scalar<DataVector>& conformal_energy_density,
@@ -442,6 +449,7 @@ struct LinearizedSources<Equations::HamiltonianAndLapse,
                        ConformalMatterScale>::argument_tags,
       Tags::ConformalFactorMinusOne<DataVector>,
       Tags::LapseTimesConformalFactorMinusOne<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
@@ -469,6 +477,7 @@ struct LinearizedSources<Equations::HamiltonianAndLapse, Geometry::Curved,
                        ConformalMatterScale>::argument_tags,
       Tags::ConformalFactorMinusOne<DataVector>,
       Tags::LapseTimesConformalFactorMinusOne<DataVector>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
@@ -505,6 +514,7 @@ struct LinearizedSources<Equations::HamiltonianLapseAndShift,
       ::Tags::Flux<Tags::LapseTimesConformalFactorMinusOne<DataVector>,
                    tmpl::size_t<3>, Frame::Inertial>,
       Tags::LongitudinalShiftExcess<DataVector, 3, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,
@@ -549,6 +559,7 @@ struct LinearizedSources<Equations::HamiltonianLapseAndShift, Geometry::Curved,
       ::Tags::Flux<Tags::LapseTimesConformalFactorMinusOne<DataVector>,
                    tmpl::size_t<3>, Frame::Inertial>,
       Tags::LongitudinalShiftExcess<DataVector, 3, Frame::Inertial>>;
+  using const_global_cache_tags = tmpl::list<>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> linearized_hamiltonian_constraint,
       gsl::not_null<Scalar<DataVector>*> linearized_lapse_equation,


### PR DESCRIPTION
## Proposed changes

Allows a subset of `argument_tags` for the `SourcesComputer` to be fetched from the `const_global_cache`. This isn't used for anything right now, but will be used in an upcoming system.

### Upgrade instructions

All `Sources` and `LinearizedSources` classes must now define the alias `const_global_cache_tags`.

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
