### PR TITLE
TransformVolumeData.py: support instance methods as kernels

### DIFF
--- a/tests/Unit/Visualization/Python/Test_TransformVolumeData.py
+++ b/tests/Unit/Visualization/Python/Test_TransformVolumeData.py
@@ -20,6 +20,7 @@ from spectre.PointwiseFunctions.Punctures import adm_mass_integrand
 from spectre.Spectral import Mesh
 from spectre.Visualization.TransformVolumeData import (
     Kernel,
+    parse_kernels,
     parse_pybind11_signatures,
     snake_case_to_camel_case,
     transform_volume_data,
@@ -225,6 +226,17 @@ class TestTransformVolumeData(unittest.TestCase):
         # The domain has pretty low resolution so the integral is not
         # particularly precise
         npt.assert_allclose(integrals["Sinusoid"], 64.0, rtol=1e-2)
+
+    def test_parse_kernels(self):
+        (mesh_kernel,) = list(
+            parse_kernels(
+                ["spectre.Spectral.Mesh3D:number_of_grid_points"],
+                exec_files=[],
+                map_input_names={},
+                interactive=False,
+            )
+        )
+        self.assertEqual(mesh_kernel.callable, Mesh[3].number_of_grid_points)
 
     def test_cli(self):
         runner = CliRunner()


### PR DESCRIPTION
## Proposed changes

Useful to look at mesh.extents() in ParaView without having to write a kernel file.

Just do this:

```py
spectre transform-vol path/to/volfiles*.h5 -k spectre.Spectral.Mesh3D:extents
```

Then run generate-xdmf and open in ParaView.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
