### PR TITLE
Fix bugs in RefineMesh Event

### DIFF
--- a/docs/DevGuide/Amr.md
+++ b/docs/DevGuide/Amr.md
@@ -343,13 +343,16 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 ```
 
 Note that the values `Auto` for the Limits options choose the default
-limits set by the code.
+limits set by the code. Also note that if a criterion tries to refine beyond the
+limits, whether or not the code should error is controlled by
+`ErrorBeyondLimits`.
 
-"When" AMR happens is contolled by specifying a Trigger and a list of
+"When" AMR happens is controlled by specifying a Trigger and a list of
 `PhaseChanges` in the top-level option `PhaseChangesAndTriggers`.  For
 example:
 ```

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.hpp
@@ -31,6 +31,9 @@ namespace amr {
 ///   their bounds, the Flag is changed to DoNothing.  Note that the minimum
 ///   resolution is Basis and Quadrature dependent, so may be higher than the
 ///   given amr_policies.refinement_limits().minimum_resolution()
+/// - If an `amr_decision` tried to go beyond the `amr::Limits` in any
+///   direction, this function will error if
+///   `amr::Limits::error_beyond_limits()` is true.
 template <size_t Dim>
 void enforce_policies(gsl::not_null<std::array<Flag, Dim>*> amr_decision,
                       const amr::Policies& amr_policies,

--- a/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
@@ -21,7 +21,7 @@ Limits::Limits()
 Limits::Limits(
     const std::optional<std::array<size_t, 2>>& refinement_level_bounds,
     const std::optional<std::array<size_t, 2>>& resolution_bounds,
-    const Options::Context& context)
+    const bool error_beyond_limits, const Options::Context& context)
     : minimum_refinement_level_(refinement_level_bounds.has_value()
                                     ? refinement_level_bounds.value()[0]
                                     : 0),
@@ -33,7 +33,8 @@ Limits::Limits(
       maximum_resolution_(
           resolution_bounds.has_value()
               ? resolution_bounds.value()[1]
-              : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {
+              : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>),
+      error_beyond_limits_(error_beyond_limits) {
   if (minimum_refinement_level_ > ElementId<1>::max_refinement_level) {
     PARSE_ERROR(context,
                 "RefinementLevel lower bound '" +
@@ -116,17 +117,18 @@ void Limits::pup(PUP::er& p) {
   p | maximum_refinement_level_;
   p | minimum_resolution_;
   p | maximum_resolution_;
+  p | error_beyond_limits_;
 }
 
 bool operator==(const Limits& lhs, const Limits& rhs) {
   return lhs.minimum_refinement_level() == rhs.minimum_refinement_level() and
          lhs.maximum_refinement_level() == rhs.maximum_refinement_level() and
          lhs.minimum_resolution() == rhs.minimum_resolution() and
-         lhs.maximum_resolution() == rhs.maximum_resolution();
+         lhs.maximum_resolution() == rhs.maximum_resolution() and
+         lhs.error_beyond_limits() == rhs.error_beyond_limits();
 }
 
 bool operator!=(const Limits& lhs, const Limits& rhs) {
   return not(lhs == rhs);
 }
-
 }  // namespace amr

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -162,6 +162,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -246,6 +246,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -182,6 +182,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -119,6 +119,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -153,6 +153,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -170,6 +170,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -28,6 +28,7 @@ Amr:
     Limits:
       RefinementLevel: [0, 8]
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 
 DomainCreator:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -27,6 +27,7 @@ Amr:
     Limits:
       RefinementLevel: [0, 4]
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -22,6 +22,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -22,6 +22,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -23,6 +23,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -138,6 +138,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -34,6 +34,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -35,6 +35,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -57,6 +57,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -59,6 +59,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 2
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -96,6 +96,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 3
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -122,6 +122,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -126,6 +126,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -83,6 +83,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 2
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -37,6 +37,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -39,6 +39,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -40,6 +40,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -34,6 +34,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -32,6 +32,7 @@ Amr:
     Limits:
       RefinementLevel: Auto
       NumGridPoints: Auto
+      ErrorBeyondLimits: False
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -165,6 +165,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -233,6 +233,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -123,6 +123,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 2
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -168,6 +168,7 @@ Amr:
     Limits:
       NumGridPoints: Auto
       RefinementLevel: Auto
+      ErrorBeyondLimits: False
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 
+#include "Domain/Amr/Flag.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -14,13 +15,19 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Events/RefineMesh.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -34,8 +41,8 @@ struct ElementComponent {
   using const_global_cache_tags =
       tmpl::list<amr::Criteria::Tags::Criteria,
                  logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>;
-  using simple_tags =
-      tmpl::list<domain::Tags::Element<1>, domain::Tags::Mesh<1>>;
+  using simple_tags = tmpl::list<domain::Tags::Element<1>,
+                                 domain::Tags::Mesh<1>, amr::Tags::Policies>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
@@ -49,7 +56,8 @@ struct Metavariables {
     using factory_classes =
         tmpl::map<tmpl::pair<Event, tmpl::list<amr::Events::RefineMesh>>,
                   tmpl::pair<amr::Criterion,
-                             tmpl::list<amr::Criteria::IncreaseResolution<1>>>>;
+                             tmpl::list<amr::Criteria::IncreaseResolution<1>,
+                                        amr::Criteria::DriveToTarget<1>>>>;
   };
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
@@ -62,34 +70,99 @@ struct Metavariables {
 };
 
 void test(const Event& event) {
-  CHECK(event.needs_evolved_variables());
-  std::vector<std::unique_ptr<amr::Criterion>> criteria;
-  criteria.emplace_back(
-      std::make_unique<amr::Criteria::IncreaseResolution<1>>());
-  ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {std::move(criteria), ::Verbosity::Debug}};
   using element_component = ElementComponent<Metavariables>;
+
+  CHECK(event.needs_evolved_variables());
+
   const ElementId<1> element_id{0};
   const Element<1> element{element_id, DirectionMap<1, Neighbors<1>>{}};
   const Mesh<1> mesh{std::array{3_st}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
-  ActionTesting::emplace_component_and_initialize<element_component>(
-      &runner, element_id, {element, mesh});
-  auto& box = ActionTesting::get_databox<element_component>(
-      make_not_null(&runner), element_id);
-  auto obs_box = make_observation_box<tmpl::list<>>(make_not_null(&box));
-  event.run(make_not_null(&obs_box),
-            ActionTesting::cache<element_component>(runner, element_id),
-            element_id, std::add_pointer_t<element_component>{},
-            {"Unused", -1.0});
-  const Mesh<1> expected_mesh{std::array{4_st}, Spectral::Basis::Legendre,
-                              Spectral::Quadrature::GaussLobatto};
-  CHECK(
-      ActionTesting::get_databox_tag<element_component, domain::Tags::Mesh<1>>(
-          runner, element_id) == expected_mesh);
-  CHECK(ActionTesting::get_databox_tag<element_component,
-                                       domain::Tags::Element<1>>(
-            runner, element_id) == element);
+  const amr::Policies policies{amr::Isotropy::Anisotropic,
+                               amr::Limits{0, 0, 3, 5}, true};
+
+  {
+    INFO("Basic function");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria{};
+    criteria.emplace_back(
+        std::make_unique<amr::Criteria::IncreaseResolution<1>>());
+    ActionTesting::MockRuntimeSystem<Metavariables> runner{
+        {std::move(criteria), ::Verbosity::Debug}};
+
+    ActionTesting::emplace_component_and_initialize<element_component>(
+        &runner, element_id, {element, mesh, policies});
+    auto& box = ActionTesting::get_databox<element_component>(
+        make_not_null(&runner), element_id);
+    auto obs_box = make_observation_box<tmpl::list<>>(make_not_null(&box));
+
+    event.run(make_not_null(&obs_box),
+              ActionTesting::cache<element_component>(runner, element_id),
+              element_id, std::add_pointer_t<element_component>{},
+              {"Unused", -1.0});
+
+    const Mesh<1> expected_mesh{std::array{4_st}, Spectral::Basis::Legendre,
+                                Spectral::Quadrature::GaussLobatto};
+    CHECK(ActionTesting::get_databox_tag<element_component,
+                                         domain::Tags::Mesh<1>>(
+              runner, element_id) == expected_mesh);
+    CHECK(ActionTesting::get_databox_tag<element_component,
+                                         domain::Tags::Element<1>>(
+              runner, element_id) == element);
+  }
+
+  {
+    INFO("Obey policies");
+    // Try to drive to smaller number of grid points than we allow
+    std::vector<std::unique_ptr<amr::Criterion>> criteria{};
+    criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
+        std::array{1_st}, std::array{0_st}, std::array{amr::Flag::DoNothing}));
+    ActionTesting::MockRuntimeSystem<Metavariables> runner{
+        {std::move(criteria), ::Verbosity::Debug}};
+
+    ActionTesting::emplace_component_and_initialize<element_component>(
+        &runner, element_id, {element, mesh, policies});
+    auto& box = ActionTesting::get_databox<element_component>(
+        make_not_null(&runner), element_id);
+    auto obs_box = make_observation_box<tmpl::list<>>(make_not_null(&box));
+
+    event.run(make_not_null(&obs_box),
+              ActionTesting::cache<element_component>(runner, element_id),
+              element_id, std::add_pointer_t<element_component>{},
+              {"Unused", -1.0});
+
+    const Mesh<1> expected_mesh = mesh;
+    CHECK(ActionTesting::get_databox_tag<element_component,
+                                         domain::Tags::Mesh<1>>(
+              runner, element_id) == expected_mesh);
+    CHECK(ActionTesting::get_databox_tag<element_component,
+                                         domain::Tags::Element<1>>(
+              runner, element_id) == element);
+  }
+
+  {
+    INFO("Test h-refinement error");
+    // Try to drive to larger refinement which isn't allowed for this event
+    std::vector<std::unique_ptr<amr::Criterion>> criteria{};
+    criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
+        std::array{3_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
+    ActionTesting::MockRuntimeSystem<Metavariables> runner{
+        {std::move(criteria), ::Verbosity::Debug}};
+
+    ActionTesting::emplace_component_and_initialize<element_component>(
+        &runner, element_id, {element, mesh, policies});
+    auto& box = ActionTesting::get_databox<element_component>(
+        make_not_null(&runner), element_id);
+    auto obs_box = make_observation_box<tmpl::list<>>(make_not_null(&box));
+
+    CHECK_THROWS_WITH(
+        (event.run(make_not_null(&obs_box),
+                   ActionTesting::cache<element_component>(runner, element_id),
+                   element_id, std::add_pointer_t<element_component>{},
+                   {"Unused", -1.0})),
+        Catch::Matchers::ContainsSubstring(
+            "requested h-refinement, but RefineMesh only works for "
+            "p-refinement"));
+  }
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
@@ -31,27 +31,30 @@ void test_pup() {
 void test_option_parsing() {
   INFO("Option Parsing creation");
   {
-    std::string creation_string_1 =
+    const std::string creation_string_1 =
         "RefinementLevel: [0, 3]\n"
-        "NumGridPoints: [1, 5]\n";
+        "NumGridPoints: [1, 5]\n"
+        "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_1);
     CHECK(limits == amr::Limits{0, 3, 1, 5});
   }
 
   {
-    std::string creation_string_2 =
+    const std::string creation_string_2 =
         "RefinementLevel: Auto\n"
-        "NumGridPoints: [1, 5]\n";
+        "NumGridPoints: [1, 5]\n"
+        "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_2);
     CHECK(limits == amr::Limits{0, ElementId<1>::max_refinement_level, 1, 5});
   }
 
   {
-    std::string creation_string_3 =
+    const std::string creation_string_3 =
         "RefinementLevel: [0, 3]\n"
-        "NumGridPoints: Auto\n";
+        "NumGridPoints: Auto\n"
+        "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_3);
     CHECK(limits ==
@@ -61,57 +64,74 @@ void test_option_parsing() {
   }
 
   {
-    std::string creation_string_4 =
+    const std::string creation_string_4 =
         "RefinementLevel: Auto\n"
-        "NumGridPoints: Auto\n";
+        "NumGridPoints: Auto\n"
+        "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_4);
     CHECK(limits == amr::Limits{});
   }
 
-  std::string bad_creation_string_1 =
+  {
+    const std::string creation_string_5 =
+        "RefinementLevel: [0, 3]\n"
+        "NumGridPoints: [1, 5]\n"
+        "ErrorBeyondLimits: True\n";
+    const auto limits =
+        TestHelpers::test_creation<amr::Limits>(creation_string_5);
+    CHECK(limits == amr::Limits{{{0, 3}}, {{1, 5}}, true});
+  }
+
+  const std::string bad_creation_string_1 =
       "RefinementLevel: [255, 3]\n"
-      "NumGridPoints: [1, 5]\n";
+      "NumGridPoints: [1, 5]\n"
+      "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_1),
       Catch::Matchers::ContainsSubstring(
           "RefinementLevel lower bound '255' cannot be larger than '"));
 
-  std::string bad_creation_string_2 =
+  const std::string bad_creation_string_2 =
       "RefinementLevel: [1, 255]\n"
-      "NumGridPoints: [1, 5]\n";
+      "NumGridPoints: [1, 5]\n"
+      "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_2),
       Catch::Matchers::ContainsSubstring(
           "RefinementLevel upper bound '255' cannot be larger than '"));
 
-  std::string bad_creation_string_3 =
+  const std::string bad_creation_string_3 =
       "RefinementLevel: [0, 3]\n"
-      "NumGridPoints: [0, 5]\n";
+      "NumGridPoints: [0, 5]\n"
+      "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_3),
       Catch::Matchers::ContainsSubstring(
           "NumGridPoints lower bound '0' cannot be smaller than '1'."));
 
-  std::string bad_creation_string_4 =
+  const std::string bad_creation_string_4 =
       "RefinementLevel: [1, 3]\n"
-      "NumGridPoints: [255, 5]\n";
+      "NumGridPoints: [255, 5]\n"
+      "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_4),
       Catch::Matchers::ContainsSubstring(
           "NumGridPoints lower bound '255' cannot be larger than '"));
 
-  std::string bad_creation_string_5 =
+  const std::string bad_creation_string_5 =
       "RefinementLevel: [1, 3]\n"
-      "NumGridPoints: [1, 0]\n";
+      "NumGridPoints: [1, 0]\n"
+      "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_5),
       Catch::Matchers::ContainsSubstring(
           "NumGridPoints upper bound '0' cannot be smaller than '1'."));
 
-  std::string bad_creation_string_6 =
+  const std::string bad_creation_string_6 =
       "RefinementLevel: [1, 3]\n"
-      "NumGridPoints: [1, 255]\n";
+      "NumGridPoints: [1, 255]\n"
+      "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_6),
       Catch::Matchers::ContainsSubstring(

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
@@ -45,7 +45,8 @@ void test_option_parsing() {
         creation_string << "Isotropy: " << isotropy << "\n";
         creation_string << "Limits:\n"
                         << "  RefinementLevel: [1, 5]\n"
-                        << "  NumGridPoints: [3, 7]\n";
+                        << "  NumGridPoints: [3, 7]\n"
+                        << "  ErrorBeyondLimits: False\n";
         creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
                         << std::boolalpha << enforce_two_to_one << "\n";
         const auto policies =
@@ -59,7 +60,8 @@ void test_option_parsing() {
         creation_string << "Isotropy: " << isotropy << "\n";
         creation_string << "Limits:\n"
                         << "  RefinementLevel: Auto\n"
-                        << "  NumGridPoints: Auto\n";
+                        << "  NumGridPoints: Auto\n"
+                        << "  ErrorBeyondLimits: False\n";
         creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
                         << std::boolalpha << enforce_two_to_one << "\n";
         const auto policies =


### PR DESCRIPTION
## Proposed changes

Also adds an option in the input file to choose whether the code should error if it tries to refine beyond the limits (but is stopped by enforcing the limits) since this could be an indicator of something going wrong. Currently, I set it to *not* error in all the executables to keep the original behavior. If we decide this is something we want to turn on in certain executables, we can do so later.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Must add a new option `ErrorBeyondLimits: False` to the AMR limits section, i.e.

```yaml
Amr:
  ...
  Policies:
    ...
    Limits:
      ...
      ErrorBeyondLimits: False
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
