### PR TITLE
Extend sphere and wedge transition

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -26,9 +26,14 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * r_{\text{max}}
  * \f}
  *
- * If the `reverse` flag is set to `true`, then the function falls off from 0 at
+ * If \p reverse is set to `true`, then the function falls off from 0 at
  * `r_min` to 1 at `r_max`. To do this, the coefficients are modified as
  * $a \rightarrow -a$ and $b \rightarrow 1-b$.
+ *
+ * The function can be called beyond `r_min` and `r_max`. Within `r_min` the
+ * value is 1, and outside `r_max` the value is 0. This is reversed if \p
+ * reverse is true. However, the gradient function cannot be called with a point
+ * beyond `r_min` and `r_max`.
  */
 class SphereTransition final : public ShapeMapTransitionFunction {
  public:
@@ -68,7 +73,7 @@ class SphereTransition final : public ShapeMapTransitionFunction {
 
   // checks that the magnitudes are all between `r_min_` and `r_max_`
   template <typename T>
-  void check_magnitudes(const T& mag) const;
+  void check_magnitudes(const T& mag, bool check_bounds) const;
 
   double r_min_{};
   double r_max_{};

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -37,6 +37,16 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * \label{eq:distance}
  * \end{equation}
  *
+ * \note If \p reverse is true, then the functional form of the transition is
+ * actually
+ * \begin{equation}
+ * f(r, \theta, \phi) = 1 - \frac{D_{\text{out}}(r, \theta, \phi) -
+ * r}{D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)} =
+ * \frac{r - \frac{D_{\text{in}}(r, \theta, \phi)}
+ * {D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)}.
+ * \label{eq:transition_func_reverse}
+ * \end{equation}
+ *
  * Here, $s$ is the sphericity of the surface which goes from 0 (flat) to 1
  * (spherical), $R$ is the radius of the spherical surface, $\text{out}$ is the
  * outer surface, and $\text{in}$ is the inner surface. If the sphericity is 1,
@@ -224,6 +234,14 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * the radius, we can use $\tilde{\vec x}$ in Eq. $\ref{eq:x_0_vector}$ instead
  * of $\vec x$.
  *
+ * \parblock
+ *
+ * \note If \p reverse is true, then the value multiplying $\Sigma$ in the
+ * numerator is now $-|\vec x_0 - \vec P|$ and in the denomintor $\Sigma$ picks
+ * up a minus sign factor.
+ *
+ * \endparblock
+ *
  * ## Gradient
  *
  * The cartesian gradient of the transition function is
@@ -236,6 +254,8 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * \frac{\partial |\vec x_0 - \vec P|}{\partial x_i} \right)}{\left(|\vec x_1 -
  * \vec P| - |\vec x_0 - \vec P|\right)^2}.
  * \end{equation}
+ *
+ * \note If \p reverse is true, the gradient picks up an overall factor of -1.0.
  *
  * Therefore, we need to compute the gradients of $\vec x_0$ and $\vec x_1$.
  *

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -47,6 +47,12 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * \label{eq:transition_func_reverse}
  * \end{equation}
  *
+ * The function is also defined beyond $D_{\text{in}}(r, \theta, \phi)$ and
+ * $D_{\text{out}}(r, \theta, \phi)$, but slighly differently. Within
+ * $D_{\text{in}}(r, \theta, \phi)$, $f(r, \theta, \phi) = 1$ and beyond
+ * $D_{\text{out}}(r, \theta, \phi)$, $f(r, \theta, \phi) = 0$. If \p reverse is
+ * true, this logic is flipped.
+ *
  * Here, $s$ is the sphericity of the surface which goes from 0 (flat) to 1
  * (spherical), $R$ is the radius of the spherical surface, $\text{out}$ is the
  * outer surface, and $\text{in}$ is the inner surface. If the sphericity is 1,
@@ -242,6 +248,18 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  *
  * \endparblock
  *
+ * \parblock
+ *
+ * \note If we are inside the inner surface, then this simplifies to
+ * \begin{equation}
+ * \frac{r}{\tilde{r}} = 1 + \frac{\Sigma(\theta, \phi)}{\tilde{r}}
+ * \end{equation}
+ * because $f(r, \theta, \phi) = 1$. If we are outside the outer surface, then
+ * $r/\tilde{r} = 1$ because $f(r, \theta, \phi) = 0$. If \p reverse is true,
+ * this logic is reversed.
+ *
+ * \endparblock
+ *
  * ## Gradient
  *
  * The cartesian gradient of the transition function is
@@ -256,6 +274,13 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * \end{equation}
  *
  * \note If \p reverse is true, the gradient picks up an overall factor of -1.0.
+ *
+ * \parblock
+ *
+ * \note The gradient is not supported if points lie beyond the inner or outer
+ * surface.
+ *
+ * \endparblock
  *
  * Therefore, we need to compute the gradients of $\vec x_0$ and $\vec x_1$.
  *
@@ -492,7 +517,8 @@ class Wedge final : public ShapeMapTransitionFunction {
   template <typename T>
   void check_distances(const T& inner_distance, const T& outer_distance,
                        const T& centered_coords_magnitude,
-                       const std::array<T, 3>& source_coords) const;
+                       const std::array<T, 3>& source_coords,
+                       bool check_bounds) const;
 
   Surface inner_surface_{};
   Surface outer_surface_{};

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -5,49 +5,66 @@
 
 #include <array>
 #include <limits>
+#include <memory>
+#include <vector>
 
+#include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
                   "[Domain][Unit]") {
   constexpr double eps = std::numeric_limits<double>::epsilon() * 100;
+  const size_t l_max = 4;
+  const size_t num_coefs = 2 * square(l_max + 1);
+  const double time = 1.3;
+
+  domain::FunctionsOfTimeMap functions_of_time{};
+  functions_of_time["Shape"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          0.0, std::array{DataVector{num_coefs, 1.e-3}}, 10.0);
+
   {
     INFO("Sphere transition");
     const SphereTransition sphere_transition{2., 4.};
-    const std::array<double, 3> lower_bound{{2., 0., 0.}};
-    CHECK(sphere_transition(lower_bound) == approx(1.0));
-    const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
-    CHECK(sphere_transition(lower_bound_eps) == approx(1.0));
-    const std::array<double, 3> inside_lower_bound{{1., 0., 0.}};
-    CHECK(sphere_transition(inside_lower_bound) == 1.0);
-    const std::array<double, 3> midpoint{{3., 0., 0.}};
-    CHECK(sphere_transition(midpoint) == approx(0.5));
-    const std::array<double, 3> upper_bound{{4., 0., 0.}};
-    CHECK(sphere_transition(upper_bound) == approx(0.));
-    const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
-    CHECK(sphere_transition(upper_bound_eps) == approx(0.));
-    const std::array<double, 3> outside_upper_bound{{5., 0., 0.}};
-    CHECK(sphere_transition(outside_upper_bound) == 0.0);
+    const domain::CoordinateMaps::TimeDependent::Shape shape_map{
+        std::array{0.0, 0.0, 0.0}, l_max, l_max,
+        std::make_unique<SphereTransition>(sphere_transition), "Shape"};
+
+    const std::vector<std::array<double, 3>> test_points{
+        {2., 0., 0.}, {2. - eps, 0., 0.}, {1., 0., 0.}, {3., 0., 0.},
+        {4., 0., 0.}, {4. + eps, 0., 0.}, {5., 0., 0.}};
+    const std::vector<double> function_values{1.0, 1.0, 1.0, 0.5,
+                                              0.0, 0.0, 0.0};
+
+    for (size_t i = 0; i < test_points.size(); i++) {
+      CHECK(sphere_transition(test_points[i]) == approx(function_values[i]));
+      test_inverse_map(shape_map, test_points[i], time, functions_of_time);
+    }
   }
   {
     INFO("Reverse sphere transition");
     const SphereTransition sphere_transition{2., 4., true};
-    const std::array<double, 3> lower_bound{{2., 0., 0.}};
-    CHECK(sphere_transition(lower_bound) == approx(0.0));
-    const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
-    CHECK(sphere_transition(lower_bound_eps) == approx(0.0));
-    const std::array<double, 3> inside_lower_bound{{1., 0., 0.}};
-    CHECK(sphere_transition(inside_lower_bound) == 0.0);
-    const std::array<double, 3> midpoint{{3., 0., 0.}};
-    CHECK(sphere_transition(midpoint) == approx(0.5));
-    const std::array<double, 3> upper_bound{{4., 0., 0.}};
-    CHECK(sphere_transition(upper_bound) == approx(1.0));
-    const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
-    CHECK(sphere_transition(upper_bound_eps) == approx(1.0));
-    const std::array<double, 3> outside_upper_bound{{5., 0., 0.}};
-    CHECK(sphere_transition(outside_upper_bound) == 1.0);
+
+    const domain::CoordinateMaps::TimeDependent::Shape shape_map{
+        std::array{0.0, 0.0, 0.0}, 4, 4,
+        std::make_unique<SphereTransition>(sphere_transition), "Shape"};
+
+    const std::vector<std::array<double, 3>> test_points{
+        {2., 0., 0.}, {2. - eps, 0., 0.}, {1., 0., 0.}, {3., 0., 0.},
+        {4., 0., 0.}, {4. + eps, 0., 0.}, {5., 0., 0.}};
+    const std::vector<double> function_values{0.0, 0.0, 0.0, 0.5,
+                                              1.0, 1.0, 1.0};
+
+    for (size_t i = 0; i < test_points.size(); i++) {
+      CHECK(sphere_transition(test_points[i]) == approx(function_values[i]));
+      test_inverse_map(shape_map, test_points[i], time, functions_of_time);
+    }
   }
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -20,12 +20,16 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
     CHECK(sphere_transition(lower_bound) == approx(1.0));
     const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
     CHECK(sphere_transition(lower_bound_eps) == approx(1.0));
+    const std::array<double, 3> inside_lower_bound{{1., 0., 0.}};
+    CHECK(sphere_transition(inside_lower_bound) == 1.0);
     const std::array<double, 3> midpoint{{3., 0., 0.}};
     CHECK(sphere_transition(midpoint) == approx(0.5));
     const std::array<double, 3> upper_bound{{4., 0., 0.}};
     CHECK(sphere_transition(upper_bound) == approx(0.));
     const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
     CHECK(sphere_transition(upper_bound_eps) == approx(0.));
+    const std::array<double, 3> outside_upper_bound{{5., 0., 0.}};
+    CHECK(sphere_transition(outside_upper_bound) == 0.0);
   }
   {
     INFO("Reverse sphere transition");
@@ -34,12 +38,16 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
     CHECK(sphere_transition(lower_bound) == approx(0.0));
     const std::array<double, 3> lower_bound_eps{{2. - eps, 0., 0.}};
     CHECK(sphere_transition(lower_bound_eps) == approx(0.0));
+    const std::array<double, 3> inside_lower_bound{{1., 0., 0.}};
+    CHECK(sphere_transition(inside_lower_bound) == 0.0);
     const std::array<double, 3> midpoint{{3., 0., 0.}};
     CHECK(sphere_transition(midpoint) == approx(0.5));
     const std::array<double, 3> upper_bound{{4., 0., 0.}};
     CHECK(sphere_transition(upper_bound) == approx(1.0));
     const std::array<double, 3> upper_bound_eps{{4. + eps, 0., 0.}};
     CHECK(sphere_transition(upper_bound_eps) == approx(1.0));
+    const std::array<double, 3> outside_upper_bound{{5., 0., 0.}};
+    CHECK(sphere_transition(outside_upper_bound) == 1.0);
   }
 }
 

--- a/tools/CheckOutputFiles.py
+++ b/tools/CheckOutputFiles.py
@@ -115,22 +115,55 @@ class H5Check:
                         ),
                     )
                     if test_data.dtype == float or test_data.dtype == complex:
-                        npt.assert_allclose(
-                            test_data[:, column_mask],
-                            expected_data[:, column_mask],
-                            rtol=self.relative_tolerance,
-                            atol=self.absolute_tolerance,
-                        )
+                        # numpy testing doesn't print the full array nor does it
+                        # print to full precision during a test, so we capture
+                        # the error and print the arrays to full precision
+                        try:
+                            npt.assert_allclose(
+                                test_data[:, column_mask],
+                                expected_data[:, column_mask],
+                                rtol=self.relative_tolerance,
+                                atol=self.absolute_tolerance,
+                            )
+                        except AssertionError as e:
+                            np.set_printoptions(precision=16)
+                            print(
+                                "DESIRED:"
+                                f" {np.array(expected_data[:, column_mask])}"
+                            )
+                            print(
+                                f"ACTUAL: {np.array(test_data[:, column_mask])}"
+                            )
+                            raise AssertionError(
+                                "Test data is not equal to the expected data"
+                            ) from e
                     else:
                         self.unit_test.assertEqual(test_data, expected_data)
                 else:
                     if test_data.dtype == float or test_data.dtype == complex:
-                        npt.assert_allclose(
-                            test_data[:, column_mask],
-                            self.expected_data or 0.0,
-                            rtol=self.relative_tolerance,
-                            atol=self.absolute_tolerance,
-                        )
+                        # numpy testing doesn't print the full array nor does it
+                        # print to full precision during a test, so we capture
+                        # the error and print the arrays to full precision
+                        try:
+                            npt.assert_allclose(
+                                test_data[:, column_mask],
+                                self.expected_data or 0.0,
+                                rtol=self.relative_tolerance,
+                                atol=self.absolute_tolerance,
+                            )
+                        except AssertionError as e:
+                            np.set_printoptions(precision=16)
+                            print(f"DESIRED: {np.array(self.expected_data)}")
+                            if self.expected_data:
+                                print(
+                                    "ACTUAL:"
+                                    f" {np.array(test_data[:, column_mask])}"
+                                )
+                            else:
+                                print("ACTUAL: 0.0")
+                            raise AssertionError(
+                                "Test data is not equal to the expected data"
+                            ) from e
                     else:
                         self.assertTrue(
                             False,


### PR DESCRIPTION
## Proposed changes

Allows the sphere and wedge shape map transition function to be extended outside the inner and outer radii/surfaces. This will be needed for BBH ringdown transition and also for extrapolating into excision spheres.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
