### PR TITLE
Add ability to RunEventsAndTriggers at steps within a slab for local time-stepping

### DIFF
--- a/src/Elliptic/Actions/RunEventsAndTriggers.hpp
+++ b/src/Elliptic/Actions/RunEventsAndTriggers.hpp
@@ -8,6 +8,7 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -28,7 +29,8 @@ namespace elliptic::Actions {
 /// - Modifies: nothing
 template <typename ObservationId>
 struct RunEventsAndTriggers {
-  using const_global_cache_tags = tmpl::list<Tags::EventsAndTriggers>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtIterations>>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -38,10 +40,11 @@ struct RunEventsAndTriggers {
       Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const component) {
-    Parallel::get<Tags::EventsAndTriggers>(cache).run_events(
-        make_not_null(&box), cache, array_index, component,
-        {db::tag_name<ObservationId>(),
-         static_cast<double>(db::get<ObservationId>(box))});
+    Parallel::get<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtIterations>>(
+        cache)
+        .run_events(make_not_null(&box), cache, array_index, component,
+                    {db::tag_name<ObservationId>(),
+                     static_cast<double>(db::get<ObservationId>(box))});
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/Evolution/Actions/RunEventsAndTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndTriggers.hpp
@@ -25,6 +25,37 @@ struct TimeStepId;
 /// \endcond
 
 namespace evolution::Actions {
+namespace detail {
+template <typename DbTags, typename Metavariables, typename ArrayIndex,
+          typename ParallelComponent, typename EventsAndTriggers_t>
+void run_events_and_triggers(db::DataBox<DbTags>& box,
+                             Parallel::GlobalCache<Metavariables>& cache,
+                             const ArrayIndex& array_index,
+                             const ParallelComponent* const component,
+                             const EventsAndTriggers_t& events_and_triggers,
+                             const TimeStepId& time_step_id) {
+  if (time_step_id.substep() == 0) {
+    events_and_triggers.run_events(
+        make_not_null(&box), cache, array_index, component,
+        {db::tag_name<::Tags::Time>(), db::get<::Tags::Time>(box)});
+  } else {
+    const double substep_offset = 1.0e6;
+    const double observation_value =
+        time_step_id.step_time().value() +
+        substep_offset * static_cast<double>(time_step_id.substep());
+    events_and_triggers.run_events(
+        make_not_null(&box), cache, array_index, component,
+        {db::tag_name<::Tags::Time>(), observation_value},
+        [&box](const Trigger& trigger) {
+          const auto* substep_trigger =
+              dynamic_cast<const ::Triggers::OnSubsteps*>(&trigger);
+          return substep_trigger != nullptr and
+                 substep_trigger->is_triggered(box);
+        });
+  }
+}
+}  // namespace detail
+
 /// \ingroup ActionsGroup
 /// \ingroup EventsAndTriggersGroup
 /// \brief Run the events and triggers
@@ -41,9 +72,14 @@ namespace evolution::Actions {
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies: nothing
+template <bool LocalTimeStepping>
 struct RunEventsAndTriggers {
-  using const_global_cache_tags =
-      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>;
+  static constexpr bool local_time_stepping = LocalTimeStepping;
+  using const_global_cache_tags = tmpl::conditional_t<
+      local_time_stepping,
+      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
+                 ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSteps>>,
+      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -54,31 +90,26 @@ struct RunEventsAndTriggers {
       const ArrayIndex& array_index, const ActionList /*meta*/,
       const ParallelComponent* const component) {
     const auto time_step_id = db::get<::Tags::TimeStepId>(box);
-    if (SelfStart::is_self_starting(time_step_id) or
-        not time_step_id.step_time().is_at_slab_boundary()) {
+    if (SelfStart::is_self_starting(time_step_id)) {
       return {Parallel::AlgorithmExecution::Continue, std::nullopt};
     }
-    const auto& events_and_triggers_at_slabs = Parallel::get<
-        ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(cache);
-    if (time_step_id.substep() == 0) {
-      events_and_triggers_at_slabs.run_events(
-          make_not_null(&box), cache, array_index, component,
-          {db::tag_name<::Tags::Time>(), db::get<::Tags::Time>(box)});
-    } else {
-      const double substep_offset = 1.0e6;
-      const double observation_value = time_step_id.step_time().value() +
-                                       substep_offset * time_step_id.substep();
-      events_and_triggers_at_slabs.run_events(
-          make_not_null(&box), cache, array_index, component,
-          {db::tag_name<::Tags::Time>(), observation_value},
-          [&box](const Trigger& trigger) {
-            const auto* substep_trigger =
-                dynamic_cast<const ::Triggers::OnSubsteps*>(&trigger);
-            return substep_trigger != nullptr and
-                   substep_trigger->is_triggered(box);
-          });
+
+    if constexpr (local_time_stepping) {
+      const auto& events_and_triggers_at_steps = Parallel::get<
+          ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSteps>>(cache);
+      detail::run_events_and_triggers(box, cache, array_index, component,
+                                      events_and_triggers_at_steps,
+                                      time_step_id);
     }
 
+    if (not time_step_id.step_time().is_at_slab_boundary()) {
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+
+    const auto& events_and_triggers_at_slabs = Parallel::get<
+        ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(cache);
+    detail::run_events_and_triggers(box, cache, array_index, component,
+                                    events_and_triggers_at_slabs, time_step_id);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -333,10 +333,10 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -304,10 +304,10 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -329,10 +329,10 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -259,10 +259,11 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, dg_step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, dg_step_actions,
+                  Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -616,7 +616,7 @@ struct EvolutionMetavars {
               Parallel::Phase::Evolve,
               tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  evolution::Actions::RunEventsAndTriggers,
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -74,7 +74,8 @@ struct EvolutionMetavars
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<::evolution::Actions::RunEventsAndTriggers,
+              tmpl::list<::evolution::Actions::RunEventsAndTriggers<
+                             local_time_stepping>,
                          Actions::ChangeSlabSize, step_actions,
                          Actions::AdvanceTime,
                          PhaseControl::Actions::ExecutePhaseChange>>>>>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -80,6 +80,7 @@
 
 template <bool UseLts>
 struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
+  static constexpr bool local_time_stepping = UseLts;
   static constexpr size_t volume_dim = 3;
   using gh_base = GeneralizedHarmonicTemplateBase<volume_dim, UseLts>;
   using typename gh_base::initialize_initial_data_dependent_quantities_actions;
@@ -260,7 +261,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
               Parallel::Phase::Evolve,
               tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  evolution::Actions::RunEventsAndTriggers,
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -866,7 +866,7 @@ struct GhValenciaDivCleanTemplateBase<
                   VariableFixing::Actions::FixVariables<
                       VariableFixing::LimitLorentzFactor>,
                   Actions::UpdateConservatives,
-                  evolution::Actions::RunEventsAndTriggers,
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
                   PhaseControl::Actions::ExecutePhaseChange>>,
           Parallel::PhaseActions<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -580,28 +580,29 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
 
   using dg_element_array_component = DgElementArray<
       EvolutionMetavars,
-      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                        initialization_actions>,
+      tmpl::list<
+          Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                 initialization_actions>,
 
-                 Parallel::PhaseActions<
-                     Parallel::Phase::InitializeTimeStepperHistory,
-                     SelfStart::self_start_procedure<step_actions, system>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::InitializeTimeStepperHistory,
+              SelfStart::self_start_procedure<step_actions, system>>,
 
-                 Parallel::PhaseActions<
-                     Parallel::Phase::Register,
-                     tmpl::push_back<dg_registration_list,
-                                     Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::Register,
+              tmpl::push_back<dg_registration_list,
+                              Parallel::Actions::TerminatePhase>>,
 
-                 Parallel::PhaseActions<
-                     Parallel::Phase::Evolve,
-                     tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                                Actions::ChangeSlabSize, step_actions,
-                                Actions::AdvanceTime,
-                                PhaseControl::Actions::ExecutePhaseChange>>,
-                 Parallel::PhaseActions<
-                     Parallel::Phase::PostFailureCleanup,
-                     tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
-                                Parallel::Actions::TerminatePhase>>>>;
+          Parallel::PhaseActions<
+              Parallel::Phase::Evolve,
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::PostFailureCleanup,
+              tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
+                         Parallel::Actions::TerminatePhase>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -389,10 +389,10 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -259,10 +259,10 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -269,13 +269,13 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<VariableFixing::Actions::FixVariables<
-                             VariableFixing::FixToAtmosphere<volume_dim>>,
-                         Actions::UpdateConservatives,
-                         evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  VariableFixing::Actions::FixVariables<
+                      VariableFixing::FixToAtmosphere<volume_dim>>,
+                  Actions::UpdateConservatives,
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
+++ b/src/Evolution/Executables/RelativisticEuler/Valencia/EvolveValencia.hpp
@@ -135,8 +135,7 @@ struct EvolutionMetavars {
   using analytic_variables_tags =
       typename system::primitive_variables_tag::tags_list;
 
-  using equation_of_state_tag =
-      hydro::Tags::EquationOfState<equation_of_state_type>;
+  using equation_of_state_tag = hydro::Tags::EquationOfState<true, 2>;
 
   using limiter = Tags::Limiter<Limiters::Minmod<
       Dim, tmpl::list<RelativisticEuler::Valencia::Tags::TildeD,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -359,10 +359,10 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -215,7 +215,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
               Parallel::Phase::Evolve,
               tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  evolution::Actions::RunEventsAndTriggers,
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -295,10 +295,10 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -204,7 +204,8 @@ struct CharacteristicEvolution {
           CharacteristicEvolution<Metavariables>>,
       ::Actions::Label<CceEvolutionLabelTag>,
       tmpl::conditional_t<evolve_ccm, tmpl::list<>,
-                          evolution::Actions::RunEventsAndTriggers>,
+                          evolution::Actions::RunEventsAndTriggers<
+                              Metavariables::local_time_stepping>>,
       Actions::ReceiveWorldtubeData<
           Metavariables,
           typename Metavariables::cce_boundary_communication_tags>,
@@ -231,8 +232,8 @@ struct CharacteristicEvolution {
       Actions::RequestNextBoundaryData<
           typename Metavariables::cce_boundary_component,
           CharacteristicEvolution<Metavariables>>,
-      ::Actions::AdvanceTime,
-      Actions::ExitIfEndTimeReached, ::Actions::Goto<CceEvolutionLabelTag>>;
+      ::Actions::AdvanceTime, Actions::ExitIfEndTimeReached,
+      ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -123,7 +123,8 @@ struct KleinGordonCharacteristicEvolution
           KleinGordonCharacteristicEvolution<Metavariables>>,
       ::Actions::Label<CceEvolutionLabelTag>,
       tmpl::conditional_t<evolve_ccm, tmpl::list<>,
-                          evolution::Actions::RunEventsAndTriggers>,
+                          evolution::Actions::RunEventsAndTriggers<
+                              Metavariables::local_time_stepping>>,
       Actions::ReceiveWorldtubeData<
           Metavariables,
           typename Metavariables::cce_boundary_communication_tags>,
@@ -161,8 +162,8 @@ struct KleinGordonCharacteristicEvolution
       Actions::RequestNextBoundaryData<
           typename Metavariables::cce_boundary_component,
           KleinGordonCharacteristicEvolution<Metavariables>>,
-      ::Actions::AdvanceTime,
-      Actions::ExitIfEndTimeReached, ::Actions::Goto<CceEvolutionLabelTag>>;
+      ::Actions::AdvanceTime, Actions::ExitIfEndTimeReached,
+      ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -333,10 +333,11 @@ struct Metavariables {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Execute,
-              tmpl::list<Actions::AdvanceTime, Actions::ExportCoordinates<Dim>,
-                         Actions::FindGlobalMinimumGridSpacing,
-                         evolution::Actions::RunEventsAndTriggers,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>;
+              tmpl::list<
+                  Actions::AdvanceTime, Actions::ExportCoordinates<Dim>,
+                  Actions::FindGlobalMinimumGridSpacing,
+                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;

--- a/src/IO/Observer/Actions/RegisterEvents.hpp
+++ b/src/IO/Observer/Actions/RegisterEvents.hpp
@@ -20,6 +20,7 @@
 #include "Parallel/TypeTraits.hpp"
 #include "ParallelAlgorithms/EventsAndDenseTriggers/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -135,9 +136,30 @@ struct RegisterEventsWithObservers
     (void)collect_observations;
 #endif  // defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 10
 
-    if constexpr (db::tag_is_retrievable_v<::Tags::EventsAndTriggers,
-                                           db::DataBox<DbTagList>>) {
-      const auto& triggers_and_events = db::get<::Tags::EventsAndTriggers>(box);
+    if constexpr (db::tag_is_retrievable_v<
+                      ::Tags::EventsAndTriggers<
+                          Triggers::WhenToCheck::AtIterations>,
+                      db::DataBox<DbTagList>>) {
+      const auto& triggers_and_events = db::get<
+          ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtIterations>>(box);
+      triggers_and_events.for_each_event(collect_observations);
+    }
+
+    if constexpr (db::tag_is_retrievable_v<
+                      ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
+                      db::DataBox<DbTagList>>) {
+      const auto& triggers_and_events =
+          db::get<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
+              box);
+      triggers_and_events.for_each_event(collect_observations);
+    }
+
+    if constexpr (db::tag_is_retrievable_v<
+                      ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSteps>,
+                      db::DataBox<DbTagList>>) {
+      const auto& triggers_and_events =
+          db::get<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSteps>>(
+              box);
       triggers_and_events.for_each_event(collect_observations);
     }
 

--- a/src/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
+++ b/src/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Completion.cpp
   EventsAndTriggers.cpp
   LogicalTriggers.cpp
+  WhenToCheck.cpp
   )
 
 spectre_target_headers(
@@ -23,6 +24,7 @@ spectre_target_headers(
   LogicalTriggers.hpp
   Tags.hpp
   Trigger.hpp
+  WhenToCheck.hpp
   )
 
 target_link_libraries(

--- a/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Tags.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -22,7 +23,7 @@ namespace OptionTags {
 ///
 /// In yaml this is specified as a map of triggers to lists of events:
 /// \code{.yaml}
-/// EventsAndTriggers:
+/// EventsAndTriggersAtSlabs:
 ///   ? TriggerA:
 ///       OptionsForTriggerA
 ///   : - Event1:
@@ -36,6 +37,7 @@ namespace OptionTags {
 ///     - Event4:
 ///         OptionsForEvent4
 /// \endcode
+template <Triggers::WhenToCheck WhenToCheck>
 struct EventsAndTriggers {
   using type = ::EventsAndTriggers;
   static constexpr Options::String help = "Events to run at triggers";
@@ -45,7 +47,9 @@ struct EventsAndTriggers {
   // OptionParser run-time error saying that an option name is greater
   // than 21 characters.  Adding the name() function below bypasses
   // pretty_type::short_name().
-  static std::string name() { return "EventsAndTriggers"; }
+  static std::string name() {
+    return "EventsAndTriggers" + get_output(WhenToCheck);
+  }
 };
 
 namespace EventsRunAtCleanup {
@@ -80,13 +84,17 @@ struct ObservationValue {
 namespace Tags {
 /// \ingroup EventsAndTriggersGroup
 /// Contains the events and triggers
+template <Triggers::WhenToCheck WhenToCheck>
 struct EventsAndTriggers : db::SimpleTag {
   using type = ::EventsAndTriggers;
-  using option_tags = tmpl::list<::OptionTags::EventsAndTriggers>;
+  using option_tags = tmpl::list<::OptionTags::EventsAndTriggers<WhenToCheck>>;
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& events_and_triggers) {
     return deserialize<type>(serialize<type>(events_and_triggers).data());
+  }
+  static std::string name() {
+    return "EventsAndTriggers" + get_output(WhenToCheck);
   }
 };
 

--- a/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.cpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
+
+#include <ostream>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace Triggers {
+
+std::ostream& operator<<(std::ostream& os, const WhenToCheck& when_to_check) {
+  switch (when_to_check) {
+    case WhenToCheck::AtIterations:
+      os << "AtIterations";
+      break;
+    case WhenToCheck::AtSlabs:
+      os << "AtSlabs";
+      break;
+    case WhenToCheck::AtSteps:
+      os << "AtSteps";
+      break;
+    default:
+      ERROR("An unknown check was passed to the stream operator. "
+            << static_cast<int>(when_to_check));
+  }
+  return os;
+}
+}  // namespace Triggers

--- a/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines enum class Triggers::WhenToCheck.
+
+#pragma once
+
+#include <cstdint>
+#include <iosfwd>
+
+namespace Triggers {
+
+/// \ingroup EventsAndTriggersGroup
+/// \brief Frequency at which Events and Triggers are checked
+enum class WhenToCheck : uint8_t {
+  AtIterations, /**< checked at iterations e.g. of an elliptic solve */
+  AtSlabs,      /**< checked at time Slab boundaries */
+  AtSteps,      /**< checked at time step boundaries */
+};
+
+/// Output operator for a WhenToCheck.
+std::ostream& operator<<(std::ostream& os, const WhenToCheck& when_to_check);
+}  // namespace Triggers

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -17,6 +18,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
 #include "Time/ChangeSlabSize/Event.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepperErrorTolerances.hpp"
@@ -31,6 +33,7 @@
 
 /// \cond
 namespace Tags {
+template <Triggers::WhenToCheck WhenToCheck>
 struct EventsAndTriggers;
 template <bool LocalTimeStepping>
 struct IsUsingTimeSteppingErrorControlCompute;
@@ -280,9 +283,9 @@ struct IsUsingTimeSteppingErrorControlCompute
     IsUsingTimeSteppingErrorControl {
   using base = IsUsingTimeSteppingErrorControl;
   using return_type = type;
-  using argument_tags =
-      tmpl::conditional_t<LocalTimeStepping, tmpl::list<::Tags::StepChoosers>,
-                          tmpl::list<::Tags::EventsAndTriggers>>;
+  using argument_tags = tmpl::conditional_t<
+      LocalTimeStepping, tmpl::list<::Tags::StepChoosers>,
+      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 
   // local time stepping
   static void function(
@@ -340,9 +343,9 @@ struct StepperErrorTolerancesCompute
       StepperErrorTolerances<EvolvedVariableTag> {
   using base = StepperErrorTolerances<EvolvedVariableTag>;
   using return_type = typename base::type;
-  using argument_tags =
-      tmpl::conditional_t<LocalTimeStepping, tmpl::list<::Tags::StepChoosers>,
-                          tmpl::list<::Tags::EventsAndTriggers>>;
+  using argument_tags = tmpl::conditional_t<
+      LocalTimeStepping, tmpl::list<::Tags::StepChoosers>,
+      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 
   // local time stepping
   static void function(

--- a/src/Visualization/Python/ReadInputFile.py
+++ b/src/Visualization/Python/ReadInputFile.py
@@ -20,16 +20,19 @@ files.
 """
 
 
-def find_event(event_name: str, input_file: dict) -> dict:
-    """Find a particular event in the "EventsAndTriggers" of the input file.
+def find_event(
+    event_name: str, events_and_triggers_name: str, input_file: dict
+) -> dict:
+    """Find a particular event in the given list of events of the input file.
 
     Arguments:
       event_name: The name of an event like "ObserveTimeSteps".
+      events_and_triggers_name: The name of a list of events.
       input_file: The input file read in as a dictionary.
 
     Returns: The event as a dictionary, or None if the event wasn't found.
     """
-    for trigger_and_events in input_file["EventsAndTriggers"]:
+    for trigger_and_events in input_file[events_and_triggers_name]:
         try:
             for event in trigger_and_events["Events"]:
                 if isinstance(event, str):

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -231,7 +231,7 @@ RadiallyCompressedCoordinates:
   OuterRadius: *outer_radius
   Compression: *outer_shell_distribution
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveFields:

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -372,6 +372,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
   # BondiSachs output needs to be often enough for CCE to run properly. An
   # interval of 0.1 was found to work well in SpEC.

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -155,7 +155,7 @@ Evolution:
   MinimumTimeStep: 1e-7
   # This is the smallest interval we'd need to observe time step/constraints. If
   # you need it smaller you can edit it, but make sure to change the slab
-  # intervals in the EventsAndTriggers
+  # intervals in the EventsAndTriggersAtSlabs
   InitialSlabSize: 0.1
   StepChoosers:
     - LimitIncrease:
@@ -261,7 +261,7 @@ PhaseChangeAndTriggers:
       - CheckpointAndExitAfterWallclock:
           WallclockHours: 23.5
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   # Observe time step and cheap constraints every slab
   - Trigger:
       Slabs:

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -93,7 +93,7 @@ def postprocess_id(
     excision_radius_B = id_domain[f"ObjectB"]["InnerRadius"]
     volfile_name = id_input_file["Observers"]["VolumeFileName"]
     id_subfile_name = find_event(
-        "ObserveFields", "EventsAndTriggers", id_input_file
+        "ObserveFields", "EventsAndTriggersAtIterations", id_input_file
     )["SubfileName"]
 
     # Find latest observation in output data

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -92,7 +92,9 @@ def postprocess_id(
     excision_radius_A = id_domain[f"ObjectA"]["InnerRadius"]
     excision_radius_B = id_domain[f"ObjectB"]["InnerRadius"]
     volfile_name = id_input_file["Observers"]["VolumeFileName"]
-    id_subfile_name = find_event("ObserveFields", id_input_file)["SubfileName"]
+    id_subfile_name = find_event(
+        "ObserveFields", "EventsAndTriggers", id_input_file
+    )["SubfileName"]
 
     # Find latest observation in output data
     if id_run_dir is None:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -266,6 +266,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
   # BondiSachs output needs to be often enough for CCE to run properly. An
   # interval of 0.1 was found to work well in SpEC.

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -196,7 +196,7 @@ PhaseChangeAndTriggers:
       - CheckpointAndExitAfterWallclock:
           WallclockHours: 23.5
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -69,7 +69,7 @@ SpatialDiscretization:
   SubcellSolver:
     Reconstructor: MonotonisedCentral
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger: Always
     Events:
       - ChangeSlabSize:

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -47,6 +47,8 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: false
 
+EventsAndTriggersAtSteps:
+
 Cce:
   Evolution:
     TimeStepper:

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -36,7 +36,7 @@ Observers:
   VolumeFileName: "CharacteristicExtractUnusedVolume"
   ReductionFileName: "CharacteristicExtractReduction"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -47,6 +47,8 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: false
 
+EventsAndTriggersAtSteps:
+
 Cce:
   Evolution:
     TimeStepper:

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -36,7 +36,7 @@ Observers:
   VolumeFileName: "CharacteristicExtractUnusedVolume"
   ReductionFileName: "CharacteristicExtractReduction"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -47,6 +47,8 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: false
 
+EventsAndTriggersAtSteps:
+
 Cce:
   Evolution:
     TimeStepper:

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -36,7 +36,7 @@ Observers:
   VolumeFileName: "CharacteristicExtractUnusedVolume"
   ReductionFileName: "CharacteristicExtractReduction"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -47,6 +47,8 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: false
 
+EventsAndTriggersAtSteps:
+
 Cce:
   Evolution:
     TimeStepper:

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -36,7 +36,7 @@ Observers:
   VolumeFileName: "CharacteristicExtractUnusedVolume"
   ReductionFileName: "CharacteristicExtractReduction"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -47,6 +47,8 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: false
 
+EventsAndTriggersAtSteps:
+
 Cce:
   Evolution:
     TimeStepper:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -36,7 +36,7 @@ Observers:
   VolumeFileName: "CharacteristicExtractUnusedVolume"
   ReductionFileName: "CharacteristicExtractReduction"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -47,6 +47,8 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: false
 
+EventsAndTriggersAtSteps:
+
 Cce:
   Evolution:
     TimeStepper:

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -36,7 +36,7 @@ Observers:
   VolumeFileName: "CharacteristicExtractUnusedVolume"
   ReductionFileName: "CharacteristicExtractReduction"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -31,7 +31,7 @@ Observers:
   # ExtractionRadius specified below.
   ReductionFileName: "CharacteristicExtractReduction"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   # Write the CCE time step every Slab. A Slab is a fixed length of simulation
   # time and is not influenced by the dynamically adjusted step size.
   - Trigger:

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -46,6 +46,8 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: true
 
+EventsAndTriggersAtSteps:
+
 Cce:
   Evolution:
     TimeStepper:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -75,6 +75,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -67,7 +67,7 @@ Filtering:
     Enable: false
     BlocksToFilter: All
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -75,6 +75,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -67,7 +67,7 @@ Filtering:
     Enable: false
     BlocksToFilter: All
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -82,7 +82,7 @@ Filtering:
     Enable: false
     BlocksToFilter: All
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -134,6 +134,8 @@ EventsAndTriggersAtSlabs:
               NormType: L2Norm
               Components: Individual
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 InterpolationTargets:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -97,7 +97,7 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -91,7 +91,7 @@ LinearSolver:
         WriteMatrixToFile: None
     ObservePerCoreReductions: False
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -117,7 +117,7 @@ LinearSolver:
             BoundaryConditions: Auto
     ObservePerCoreReductions: False
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -132,7 +132,7 @@ LinearSolver:
             BoundaryConditions: Auto
     ObservePerCoreReductions: False
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveNorms: &error_norms

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -52,7 +52,7 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Quadrature: GaussLobatto
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:
         Comparison: GreaterThanOrEqualTo

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -47,7 +47,7 @@ SpatialDiscretization:
   DiscontinuousGalerkin:
     Quadrature: GaussLobatto
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:
         Comparison: GreaterThanOrEqualTo

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -54,7 +54,7 @@ Evolution:
     AdamsBashforth:
       Order: 1
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:
         Comparison: GreaterThanOrEqualTo

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -99,7 +99,7 @@ Evolution:
     AdamsBashforth:
       Order: 1
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:
         Comparison: GreaterThanOrEqualTo

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -72,7 +72,7 @@ Observers:
   VolumeFileName: "ForceFreeFastWaveVolume"
   ReductionFileName: "ForceFreeFastWaveReductions"
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -235,6 +235,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 Observers:
   VolumeFileName: "GhBinaryBlackHoleVolumeData"
   ReductionFileName: "GhBinaryBlackHoleReductionData"

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -167,7 +167,7 @@ Filtering:
     BlocksToFilter: All
 
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -110,7 +110,7 @@ SpatialDiscretization:
   BoundaryCorrection:
     UpwindPenalty:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -102,7 +102,7 @@ SpatialDiscretization:
   BoundaryCorrection:
     UpwindPenalty:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -139,7 +139,7 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -212,6 +212,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -197,7 +197,7 @@ Filtering:
     Enable: true
     BlocksToFilter: All
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   # Set time step at t=0
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -136,7 +136,7 @@ SpatialDiscretization:
       UpwindPenalty:
       Rusanov:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -169,7 +169,7 @@ Filtering:
     BlocksToFilter: All
 
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -128,7 +128,7 @@ Observers:
 Interpolator:
   DumpVolumeDataOnFailure: false
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -138,7 +138,7 @@ PrimitiveFromConservative:
   DensityWhenSkippingInversion: *MinimumD
   KastaunMaxLorentzFactor: 10.0
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -82,7 +82,7 @@ EvolutionSystem:
   SourceTerm:
     NoSource:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:
         Comparison: GreaterThanOrEqualTo

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -85,7 +85,7 @@ EvolutionSystem:
   SourceTerm:
     NoSource:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -89,7 +89,7 @@ EvolutionSystem:
   SourceTerm:
     NoSource:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -114,7 +114,7 @@ RadiallyCompressedCoordinates:
   OuterRadius: *outer_radius
   Compression: *outer_shell_distribution
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: Always
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -155,7 +155,7 @@ LinearSolver:
 
 RadiallyCompressedCoordinates: None
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: Always
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -96,7 +96,7 @@ LinearSolver:
 
 RadiallyCompressedCoordinates: None
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -100,7 +100,7 @@ LinearSolver:
 
 RadiallyCompressedCoordinates: None
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -158,7 +158,7 @@ LinearSolver:
 
 RadiallyCompressedCoordinates: None
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: Always
     Events:
       - ObserveFields:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -62,7 +62,7 @@ Limiter:
     TvbConstant: 0.0
     DisableForDebugging: false
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -65,7 +65,7 @@ SpatialDiscretization:
 InitialData:
   Krivodonova:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -66,7 +66,7 @@ SpatialDiscretization:
 InitialData:
   Kuzmin:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -65,7 +65,7 @@ SpatialDiscretization:
 InitialData:
   Sinusoid:
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -196,6 +196,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - SphericalSurface
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -126,7 +126,7 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:
         Comparison: GreaterThan

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -90,7 +90,7 @@ SpatialDiscretization:
 #     Enable: false
 #     BlocksToFilter: All
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -81,7 +81,7 @@ SpatialDiscretization:
 EventsAndDenseTriggers:
 
 # [multiple_events]
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         EvenlySpaced:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -111,7 +111,7 @@ EventsAndDenseTriggers:
               NormType: L2Norm
               Components: Sum
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -74,7 +74,7 @@ Filtering:
     Enable: true
     BlocksToFilter: All
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -70,7 +70,7 @@ SpatialDiscretization:
 #     Enable: false
 #     BlocksToFilter: All
 
-EventsAndTriggers:
+EventsAndTriggersAtSlabs:
   - Trigger:
       Times:
         Specified:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -234,7 +234,7 @@ RadiallyCompressedCoordinates:
   OuterRadius: *outer_radius
   Compression: *outer_shell_distribution
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: Always
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -173,7 +173,7 @@ RadiallyCompressedCoordinates:
   OuterRadius: *outer_radius
   Compression: *outer_shell_distribution
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -201,7 +201,7 @@ LinearSolver:
 
 RadiallyCompressedCoordinates: None
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: Always
     Events:
       - ObserveNorms:

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -120,7 +120,7 @@ LinearSolver:
 
 RadiallyCompressedCoordinates: None
 
-EventsAndTriggers:
+EventsAndTriggersAtIterations:
   - Trigger: HasConverged
     Events:
       - ObserveNorms:

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -27,6 +27,8 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -86,7 +88,8 @@ struct Component {
   using component_being_mocked = void;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tags = tmpl::list<Tags::EventsAndTriggers>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Testing,
       tmpl::list<observers::Actions::RegisterEventsWithObservers>>>;

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_EventsAndTriggers.cpp
   Test_RunEventsOnFailure.cpp
   Test_Tags.cpp
+  Test_WhenToCheck.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_Tags.cpp
@@ -7,11 +7,19 @@
 
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.EventsAndTriggers.Tags",
                   "[Unit][ParallelAlgorithms]") {
-  TestHelpers::db::test_simple_tag<Tags::EventsAndTriggers>(
-      "EventsAndTriggers");
+  TestHelpers::db::test_simple_tag<
+      Tags::EventsAndTriggers<Triggers::WhenToCheck::AtIterations>>(
+      "EventsAndTriggersAtIterations");
+  TestHelpers::db::test_simple_tag<
+      Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
+      "EventsAndTriggersAtSlabs");
+  TestHelpers::db::test_simple_tag<
+      Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSteps>>(
+      "EventsAndTriggersAtSteps");
   TestHelpers::db::test_simple_tag<Tags::EventsRunAtCleanup>(
       "EventsRunAtCleanup");
   TestHelpers::db::test_simple_tag<Tags::EventsRunAtCleanupObservationValue>(

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_WhenToCheck.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_WhenToCheck.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.EventsAndTriggers.WhenToCheck",
+                  "[Unit][ParallelAlgorithms]") {
+  CHECK(get_output(Triggers::WhenToCheck::AtIterations) == "AtIterations");
+  CHECK(get_output(Triggers::WhenToCheck::AtSlabs) == "AtSlabs");
+  CHECK(get_output(Triggers::WhenToCheck::AtSteps) == "AtSteps");
+}

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -26,6 +26,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
 #include "Time/ChangeSlabSize/Event.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/Constant.hpp"
@@ -415,15 +416,16 @@ void test_tags() {
   {
     INFO("Compute tag GTS test");
     auto box = db::create<
-        db::AddSimpleTags<Tags::EventsAndTriggers>,
+        db::AddSimpleTags<
+            Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>,
         db::AddComputeTags<
             Tags::IsUsingTimeSteppingErrorControlCompute<false>,
             Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag, false>,
             Tags::StepperErrorTolerancesCompute<AltEvolvedVariablesTag,
                                                 false>>>();
-    db::mutate<Tags::EventsAndTriggers>(
-        [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
-          *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
+    db::mutate<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
+        [](const gsl::not_null<EventsAndTriggers*> events) {
+          *events = TestHelpers::test_creation<EventsAndTriggers,
                                                Metavariables<true, true>>(
               "- Trigger: Always\n"
               "  Events:\n"
@@ -451,9 +453,9 @@ void test_tags() {
     CHECK(not db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box)
                   .has_value());
 
-    db::mutate<Tags::EventsAndTriggers>(
-        [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
-          *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
+    db::mutate<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
+        [](const gsl::not_null<EventsAndTriggers*> events) {
+          *events = TestHelpers::test_creation<EventsAndTriggers,
                                                Metavariables<true, true>>(
               "- Trigger: Always\n"
               "  Events:\n"
@@ -475,9 +477,9 @@ void test_tags() {
     CHECK(not db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box)
                   .has_value());
 
-    db::mutate<Tags::EventsAndTriggers>(
-        [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
-          *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
+    db::mutate<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
+        [](const gsl::not_null<EventsAndTriggers*> events) {
+          *events = TestHelpers::test_creation<EventsAndTriggers,
                                                Metavariables<true, true>>(
               "- Trigger: Always\n"
               "  Events:\n"
@@ -493,9 +495,9 @@ void test_tags() {
     CHECK(not db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box)
                   .has_value());
 
-    db::mutate<Tags::EventsAndTriggers>(
-        [](const gsl::not_null<Tags::EventsAndTriggers::type*> events) {
-          *events = TestHelpers::test_creation<Tags::EventsAndTriggers::type,
+    db::mutate<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
+        [](const gsl::not_null<EventsAndTriggers*> events) {
+          *events = TestHelpers::test_creation<EventsAndTriggers,
                                                Metavariables<true, true>>("");
         },
         make_not_null(&box));

--- a/tests/Unit/Visualization/Python/Test_ReadInputFile.py
+++ b/tests/Unit/Visualization/Python/Test_ReadInputFile.py
@@ -20,8 +20,12 @@ class TestReadInputFile(unittest.TestCase):
     def test_find_event(self):
         with self.input_file.open() as open_input_file:
             _, input_file = yaml.safe_load_all(open_input_file)
-        self.assertEqual(find_event("Completion", input_file), {})
-        self.assertIsNone(find_event("NonexistentEvent", input_file))
+        self.assertEqual(
+            find_event("Completion", "EventsAndTriggers", input_file), {}
+        )
+        self.assertIsNone(
+            find_event("NonexistentEvent", "EventsAndTriggers", input_file)
+        )
 
     def test_find_phase_change(self):
         with self.input_file.open() as open_input_file:

--- a/tests/Unit/Visualization/Python/Test_ReadInputFile.py
+++ b/tests/Unit/Visualization/Python/Test_ReadInputFile.py
@@ -21,10 +21,12 @@ class TestReadInputFile(unittest.TestCase):
         with self.input_file.open() as open_input_file:
             _, input_file = yaml.safe_load_all(open_input_file)
         self.assertEqual(
-            find_event("Completion", "EventsAndTriggers", input_file), {}
+            find_event("Completion", "EventsAndTriggersAtSlabs", input_file), {}
         )
         self.assertIsNone(
-            find_event("NonexistentEvent", "EventsAndTriggers", input_file)
+            find_event(
+                "NonexistentEvent", "EventsAndTriggersAtSlabs", input_file
+            )
         )
 
     def test_find_phase_change(self):

--- a/tools/Status/ExecutableStatus/ExecutableStatus.py
+++ b/tools/Status/ExecutableStatus/ExecutableStatus.py
@@ -140,7 +140,9 @@ class EvolutionStatus(ExecutableStatus):
         assert (
             avg_num_slabs >= 2
         ), "Need at least 'avg_num_slabs >= 2' to estimate simulation speed."
-        observe_time_event = find_event("ObserveTimeStep", input_file)
+        observe_time_event = find_event(
+            "ObserveTimeStep", "EventsAndTriggers", input_file
+        )
         if observe_time_event is None:
             return {}
         subfile_name = observe_time_event["SubfileName"] + ".dat"
@@ -208,7 +210,9 @@ class EvolutionStatus(ExecutableStatus):
         import plotly.express as px
         import streamlit as st
 
-        observe_time_event = find_event("ObserveTimeStep", input_file)
+        observe_time_event = find_event(
+            "ObserveTimeStep", "EventsAndTriggers", input_file
+        )
         if observe_time_event is None:
             st.warning("No 'ObserveTimeStep' event found in input file.")
             return


### PR DESCRIPTION
## Proposed changes

- Add enum Triggers::WhenToCheck to use as a template parameter for Tags that label EventsAndTriggers
- Template RunEventsAndTriggers on whether or not LocalTimeStepping is being used
- Rename input file options EventsAndTriggers to EventsAndTriggersAtIterations for the elliptic executables, and to EventsAndTriggersAtSlabs for evolution executables

### Upgrade instructions
<!-- UPGRADE INSTRUCTIONS -->
- In elliptic input files, rename EventsAndTriggers to EventsAndTriggersAtIterations
- In evolution input files, rename EventsAndTriggers to EventsAndTriggersAtSlabs
- In evolution input files using local time stepping, add a new option EventsAndTriggersAtSteps
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
