### PR TITLE
Support filled sphere domain with shape map

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -153,7 +153,8 @@ bool operator==(const Block<VolumeDim>& lhs, const Block<VolumeDim>& rhs) {
       (lhs.id() == rhs.id() and lhs.neighbors() == rhs.neighbors() and
        lhs.external_boundaries() == rhs.external_boundaries() and
        lhs.name() == rhs.name() and
-       lhs.is_time_dependent() == rhs.is_time_dependent());
+       lhs.is_time_dependent() == rhs.is_time_dependent() and
+       lhs.has_distorted_frame() == rhs.has_distorted_frame());
 
   if (lhs.is_time_dependent() and not lhs.has_distorted_frame()) {
     blocks_are_equal =

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -93,23 +93,11 @@ class CoordinateMapBase : public PUP::able {
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   virtual tnsr::I<DataVector, Dim, TargetFrame> operator()(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   /// @}
 
   /// @{
@@ -125,13 +113,7 @@ class CoordinateMapBase : public PUP::able {
   virtual std::optional<tnsr::I<double, Dim, SourceFrame>> inverse(
       tnsr::I<double, Dim, TargetFrame> target_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   /// @}
 
   /// @{
@@ -140,24 +122,11 @@ class CoordinateMapBase : public PUP::able {
   virtual InverseJacobian<double, Dim, SourceFrame, TargetFrame> inv_jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   virtual InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>
-  inv_jacobian(
-      tnsr::I<DataVector, Dim, SourceFrame> source_point,
-      double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+  inv_jacobian(tnsr::I<DataVector, Dim, SourceFrame> source_point,
+               double time = std::numeric_limits<double>::signaling_NaN(),
+               const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   /// @}
 
   /// @{
@@ -165,23 +134,11 @@ class CoordinateMapBase : public PUP::able {
   virtual Jacobian<double, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   virtual Jacobian<DataVector, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   /// @}
 
   /// @{
@@ -194,13 +151,7 @@ class CoordinateMapBase : public PUP::able {
   coords_frame_velocity_jacobians(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   virtual std::tuple<tnsr::I<DataVector, Dim, TargetFrame>,
                      InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>,
                      Jacobian<DataVector, Dim, SourceFrame, TargetFrame>,
@@ -208,13 +159,7 @@ class CoordinateMapBase : public PUP::able {
   coords_frame_velocity_jacobians(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   /// @}
 
  private:
@@ -305,26 +250,14 @@ class CoordinateMap
   tnsr::I<double, dim, TargetFrame> operator()(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return call_impl(std::move(source_point), time, functions_of_time,
                      std::make_index_sequence<sizeof...(Maps)>{});
   }
   tnsr::I<DataVector, dim, TargetFrame> operator()(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return call_impl(std::move(source_point), time, functions_of_time,
                      std::make_index_sequence<sizeof...(Maps)>{});
   }
@@ -335,13 +268,7 @@ class CoordinateMap
   std::optional<tnsr::I<double, dim, SourceFrame>> inverse(
       tnsr::I<double, dim, TargetFrame> target_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return inverse_impl(std::move(target_point), time, functions_of_time,
                         std::make_index_sequence<sizeof...(Maps)>{});
   }
@@ -353,25 +280,13 @@ class CoordinateMap
   InverseJacobian<double, dim, SourceFrame, TargetFrame> inv_jacobian(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
   InverseJacobian<DataVector, dim, SourceFrame, TargetFrame> inv_jacobian(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
   /// @}
@@ -381,25 +296,13 @@ class CoordinateMap
   Jacobian<double, dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return jacobian_impl(std::move(source_point), time, functions_of_time);
   }
   Jacobian<DataVector, dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return jacobian_impl(std::move(source_point), time, functions_of_time);
   }
   /// @}
@@ -416,13 +319,7 @@ class CoordinateMap
   coords_frame_velocity_jacobians(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return coords_frame_velocity_jacobians_impl(std::move(source_point), time,
                                                 functions_of_time);
   }
@@ -433,13 +330,7 @@ class CoordinateMap
   coords_frame_velocity_jacobians(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time = std::unordered_map<
-              std::string,
-              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{})
-      const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return coords_frame_velocity_jacobians_impl(std::move(source_point), time,
                                                 functions_of_time);
   }
@@ -513,44 +404,29 @@ class CoordinateMap
   }
 
   void check_functions_of_time(
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time) const;
+      const FunctionsOfTimeMap& functions_of_time) const;
 
   template <typename T, size_t... Is>
   tnsr::I<T, dim, TargetFrame> call_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time,
+      const FunctionsOfTimeMap& functions_of_time,
       std::index_sequence<Is...> /*meta*/) const;
 
   template <typename T, size_t... Is>
   std::optional<tnsr::I<T, dim, SourceFrame>> inverse_impl(
       tnsr::I<T, dim, TargetFrame>&& target_point, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time,
+      const FunctionsOfTimeMap& functions_of_time,
       std::index_sequence<Is...> /*meta*/) const;
 
   template <typename T>
   InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jacobian_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time) const;
+      const FunctionsOfTimeMap& functions_of_time) const;
 
   template <typename T>
   Jacobian<T, dim, SourceFrame, TargetFrame> jacobian_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time) const;
+      const FunctionsOfTimeMap& functions_of_time) const;
 
   template <typename T>
   std::tuple<tnsr::I<T, dim, TargetFrame>,
@@ -559,10 +435,7 @@ class CoordinateMap
              tnsr::I<T, dim, TargetFrame>>
   coords_frame_velocity_jacobians_impl(
       tnsr::I<T, dim, SourceFrame> source_point, double time,
-      const std::unordered_map<
-          std::string,
-          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-          functions_of_time) const;
+      const FunctionsOfTimeMap& functions_of_time) const;
 
   std::tuple<Maps...> maps_;
   std::unordered_set<std::string> function_of_time_names_;

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
@@ -269,21 +269,21 @@ TimeDependentMapOptions<IsCylindrical>::create_functions_of_time(
       };
 
   if (shape_options_A_.has_value()) {
-    if (not inner_radii_[0].has_value()) {
+    if (not deformed_radii_[0].has_value()) {
       ERROR(
           "A shape map was specified for object A, but no inner radius is "
           "available. The object must be enclosed by a sphere.");
     }
-    build_shape_and_size_fot(shape_options_A_.value(), *inner_radii_[0],
+    build_shape_and_size_fot(shape_options_A_.value(), *deformed_radii_[0],
                              shape_names[0], size_names[0]);
   }
   if (shape_options_B_.has_value()) {
-    if (not inner_radii_[1].has_value()) {
+    if (not deformed_radii_[1].has_value()) {
       ERROR(
           "A shape map was specified for object B, but no inner radius is "
           "available. The object must be enclosed by a sphere.");
     }
-    build_shape_and_size_fot(shape_options_B_.value(), *inner_radii_[1],
+    build_shape_and_size_fot(shape_options_B_.value(), *deformed_radii_[1],
                              shape_names[1], size_names[1]);
   }
 
@@ -352,7 +352,7 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
     const auto& radii = radii_opt.value();
     const bool filled = i == 0 ? object_A_filled : object_B_filled;
     // Store the inner radii for creating functions of time
-    gsl::at(inner_radii_, i) = radii[0];
+    gsl::at(deformed_radii_, i) = filled ? radii[1] : radii[0];
 
     const size_t initial_l_max = i == 0 ? shape_options_A_.value().l_max
                                         : shape_options_B_.value().l_max;

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
@@ -412,7 +412,7 @@ struct TimeDependentMapOptions {
   std::optional<TranslationMapOptions> translation_map_options_{};
   std::optional<ShapeMapOptions<domain::ObjectLabel::A>> shape_options_A_{};
   std::optional<ShapeMapOptions<domain::ObjectLabel::B>> shape_options_B_{};
-  std::array<std::optional<double>, 2> inner_radii_{};
+  std::array<std::optional<double>, 2> deformed_radii_{};
 
   // Maps
   std::optional<Expansion> expansion_map_{};

--- a/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.cpp
+++ b/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.cpp
@@ -54,8 +54,9 @@ std::vector<DataVector> strahlkorper_coefs_in_ringdown_distorted_frame(
   const domain::creators::sphere::TimeDependentMapOptions::RotationMapOptions
       rotation_map_options{rot_func_and_2_derivs, settling_timescale};
   const domain::creators::sphere::TimeDependentMapOptions
-      time_dependent_map_options{match_time, std::nullopt, rotation_map_options,
-                                 expansion_map_options, std::nullopt};
+      time_dependent_map_options{match_time,           std::nullopt,
+                                 rotation_map_options, expansion_map_options,
+                                 std::nullopt,         true};
   const domain::creators::Sphere domain_creator{
       0.01,
       200.0,

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -82,6 +82,7 @@ DomainCreator:
         DecayTimescaleExpansionOuterBoundary: 1.0
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      TransitionRotScaleTrans: True
     OuterBoundaryCondition:
       ConstraintPreservingBjorhus:
         Type: ConstraintPreservingPhysical

--- a/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsInRingdownDistortedFrame.cpp
+++ b/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsInRingdownDistortedFrame.cpp
@@ -105,9 +105,9 @@ SPECTRE_TEST_CASE(
   const domain::creators::sphere::TimeDependentMapOptions::RotationMapOptions
       rotation_map_options{rot_func_and_2_derivs, settling_timescale};
   const domain::creators::sphere::TimeDependentMapOptions
-      time_dependent_map_options{match_time, shape_map_options,
+      time_dependent_map_options{match_time,           shape_map_options,
                                  rotation_map_options, expansion_map_options,
-                                 std::nullopt};
+                                 std::nullopt,         true};
 
   const domain::creators::Sphere domain_creator{
       0.01,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
@@ -108,8 +108,9 @@ void test() {
   domain::FunctionsOfTime::register_derived_with_charm();
 
   using TDMO = domain::creators::sphere::TimeDependentMapOptions;
-  TDMO time_dep_opts{0.0, TDMO::ShapeMapOptions{2, std::nullopt}, std::nullopt,
-                     std::nullopt, std::nullopt};
+  TDMO time_dep_opts{0.0,          TDMO::ShapeMapOptions{2, std::nullopt},
+                     std::nullopt, std::nullopt,
+                     std::nullopt, true};
 
   const auto domain_creator = domain::creators::Sphere(
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false, {},


### PR DESCRIPTION
## Proposed changes

Allows to deform a filled sphere domain with a shape map. Used for BNS initial data where we want to deform the sphere to conform to the star surface.

![Bildschirmfoto 2024-11-06 um 14 13 35](https://github.com/user-attachments/assets/7ddf56ea-8e45-4d5f-aa7b-29ce11e6b33c)

Here's another sphere domain that's possible now (deformed filled sphere, translated, enveloped by a region where the translation rolls off):

![Bildschirmfoto 2024-11-06 um 14 16 44](https://github.com/user-attachments/assets/c15ff40c-38bd-4328-8be6-7b694b09ec47)


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When constructing a Sphere domain with time-dependent maps, add the new option `TransitionRotScaleTrans` (boolean). Set it to `True` to keep the old behavior of transitioning the rotation, scaling, and translation maps to zero at the outer boundary (see second image in the PR description, used e.g. to impose boundary conditions in the BBH ringdown domain). Set it to `False` to disable the transition, e.g. to rigidly translate the sphere.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
