### PR TITLE
Increase default l_max for the horizon finder.

### DIFF
--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 def postprocess_id(
     id_input_file_path: Union[str, Path],
     id_run_dir: Optional[Union[str, Path]] = None,
-    horizon_l_max: int = 12,
+    horizon_l_max: int = 16,
     horizons_file: Optional[Union[str, Path]] = None,
     control: bool = True,
     control_residual_tolerance: float = DEFAULT_RESIDUAL_TOLERANCE,
@@ -207,7 +207,7 @@ def postprocess_id(
     "--horizon-l-max",
     type=click.IntRange(0, None),
     help="Maximum l-mode for the horizon search.",
-    default=12,
+    default=16,
     show_default=True,
 )
 @click.option(


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

While comparing SpECTRE's new initial data parameter control with the one in SPEC, we found that the initial horizon quantities were limited by the default maximum L-mode for the horizon search. The image below shows convergence plots that support this conclusion. For the high-resolution run (L=0, P=15), we reach an accuracy floor around `l_max=16`, which is the new default value set in this PR to make sure we are not limited by this. Future runs with higher resolution should take this into consideration. 

![horizon_finder_resolution](https://github.com/user-attachments/assets/f7bad8a5-723d-49da-9d85-b9909be3cc49)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
