### PR TITLE
Add event to observe AMR criteria

### DIFF
--- a/src/DataStructures/FloatingPointType.hpp
+++ b/src/DataStructures/FloatingPointType.hpp
@@ -20,7 +20,7 @@ struct create_from_yaml;
 /// data is written to disk, since most simulations will not have full double
 /// precision accuracy on volume data and we don't need all digits to visualize
 /// the data.
-enum FloatingPointType { Float, Double };
+enum class FloatingPointType { Float, Double };
 
 std::ostream& operator<<(std::ostream& os, const FloatingPointType& t);
 

--- a/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.hpp
+++ b/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.hpp
@@ -43,6 +43,8 @@ class RefineAtPunctures : public amr::Criterion {
   WRAPPED_PUPable_decl_template(RefineAtPunctures);  // NOLINT
   /// \endcond
 
+  std::string observation_name() override { return "RefineAtPunctures"; }
+
   using argument_tags = tmpl::list<
       elliptic::Tags::Background<elliptic::analytic_data::Background>,
       domain::Tags::Domain<3>>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -66,6 +66,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Events/RefineMesh.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
@@ -186,6 +187,7 @@ struct EvolutionMetavars {
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
                        Events::Completion, amr::Events::RefineMesh,
+                       amr::Events::ObserveAmrCriteria<EvolutionMetavars>,
                        dg::Events::field_observations<
                            volume_dim, observe_fields, non_tensor_compute_tags>,
                        Events::time_events<system>>>>,

--- a/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
@@ -159,6 +159,8 @@ class Constraints : public Criterion {
                              Events::Tags::ObserverJacobianCompute<
                                  Dim, Frame::ElementLogical, Frame::Inertial>>>;
 
+  std::string observation_name() override { return "Constraints"; }
+
   using argument_tags = tmpl::list<::Tags::ObservationBox>;
 
   template <typename ComputeTagsList, typename DataBoxType,

--- a/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
@@ -54,6 +54,8 @@ class Criterion : public PUP::able {
 
   WRAPPED_PUPable_abstract(Criterion);  // NOLINT
 
+  virtual std::string observation_name() = 0;
+
   /// Evaluates the AMR criteria by selecting the appropriate derived class
   /// and forwarding its `argument_tags` from the ObservationBox (along with the
   /// GlobalCache and ArrayIndex) to the call operator of the derived class

--- a/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
@@ -78,6 +78,8 @@ class DriveToTarget : public Criterion {
   WRAPPED_PUPable_decl_template(DriveToTarget);  // NOLINT
   /// \endcond
 
+  std::string observation_name() override { return "DriveToTarget"; }
+
   using compute_tags_for_observation_box = tmpl::list<>;
 
   using argument_tags = tmpl::list<::domain::Tags::Mesh<Dim>>;

--- a/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
@@ -35,6 +35,8 @@ class IncreaseResolution : public Criterion {
   WRAPPED_PUPable_decl_template(IncreaseResolution);  // NOLINT
   /// \endcond
 
+  std::string observation_name() override { return "IncreaseResolution"; }
+
   using compute_tags_for_observation_box = tmpl::list<>;
   using argument_tags = tmpl::list<>;
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
@@ -177,6 +177,8 @@ class Loehner : public Criterion {
   WRAPPED_PUPable_decl_template(Loehner);  // NOLINT
   /// \endcond
 
+  std::string observation_name() override { return "Loehner"; }
+
   using compute_tags_for_observation_box = tmpl::list<>;
 
   using argument_tags = tmpl::list<::Tags::DataBox>;

--- a/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
@@ -141,6 +141,8 @@ class Persson : public Criterion {
   WRAPPED_PUPable_decl_template(Persson);  // NOLINT
   /// \endcond
 
+  std::string observation_name() override { return "Persson"; }
+
   using compute_tags_for_observation_box = tmpl::list<>;
 
   using argument_tags = tmpl::list<::Tags::DataBox>;

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
@@ -61,6 +61,8 @@ class Random : public Criterion {
   WRAPPED_PUPable_decl_template(Random);  // NOLINT
   /// \endcond
 
+  std::string observation_name() override { return "Random"; }
+
   using compute_tags_for_observation_box = tmpl::list<>;
 
   using argument_tags = tmpl::list<>;

--- a/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
@@ -110,6 +110,8 @@ class TruncationError : public Criterion {
   WRAPPED_PUPable_decl_template(TruncationError);  // NOLINT
   /// \endcond
 
+  std::string observation_name() override { return "TruncationError"; }
+
   using compute_tags_for_observation_box = tmpl::list<>;
 
   using argument_tags = tmpl::list<::Tags::DataBox>;

--- a/src/ParallelAlgorithms/Amr/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Events/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Events.hpp
+  ObserveAmrCriteria.hpp
   RefineMesh.hpp
   )
 

--- a/src/ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/FloatingPointType.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class Domain;
+template <size_t VolumeDim>
+class ElementId;
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+namespace Tags {
+template <size_t VolumeDim>
+struct Domain;
+struct FunctionsOfTime;
+}  // namespace Tags
+}  // namespace domain
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace Tags {
+struct Time;
+struct TimeStep;
+}  // namespace Tags
+/// \endcond
+
+namespace amr::Events {
+namespace detail {
+template <typename Criterion>
+struct get_compute_tags {
+  using type = typename Criterion::compute_tags_for_observation_box;
+};
+}  // namespace detail
+
+/// \brief Observe the desired decisions of AMR criteria
+///
+/// \details The event will return a vector of decisions (an independent choice
+/// in each logical dimension) for each of the AMR criteria.  These are the raw
+/// choices made by each AMR critera, not taking into account any AMR policies.
+/// Each element is output as a single cell with two points per dimension and
+/// the observation constant on all those points.  The decisions are converted
+/// to values as follows (in each logical dimension):
+/// - -2.0 is for join with sibling (if possible)
+/// - -1.0 is for decrease number of grid points
+/// - 0.0 is for no change
+/// - 1.0 is for increase number of grid points
+/// - 2.0 is for splitting the element
+template <typename Metavariables>
+class ObserveAmrCriteria
+    : public dg::Events::ObserveConstantsPerElement<Metavariables::volume_dim> {
+ public:
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  /// \cond
+  explicit ObserveAmrCriteria(CkMigrateMessage* m)
+      : dg::Events::ObserveConstantsPerElement<volume_dim>(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveAmrCriteria);  // NOLINT
+  /// \endcond
+
+  static constexpr Options::String help =
+      "Observe the desired decisions of AMR criteria in the volume.";
+
+  ObserveAmrCriteria() = default;
+
+  ObserveAmrCriteria(const std::string& subfile_name,
+                     ::FloatingPointType coordinates_floating_point_type,
+                     ::FloatingPointType floating_point_type)
+      : dg::Events::ObserveConstantsPerElement<volume_dim>(
+            subfile_name, coordinates_floating_point_type,
+            floating_point_type) {}
+
+  using compute_tags_for_observation_box =
+      tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+          tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                   Criterion>,
+          detail::get_compute_tags<tmpl::_1>>>>;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<::Tags::ObservationBox>;
+
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename ParallelComponent>
+  void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<Metavariables::volume_dim>& element_id,
+                  const ParallelComponent* const component,
+                  const Event::ObservationValue& observation_value) const {
+    const auto& refinement_criteria = get<amr::Criteria::Tags::Criteria>(box);
+    const double time = get<::Tags::Time>(box);
+    const auto& functions_of_time = get<::domain::Tags::FunctionsOfTime>(box);
+    const Domain<volume_dim>& domain =
+        get<::domain::Tags::Domain<volume_dim>>(box);
+
+    std::vector<TensorComponent> components = this->allocate_and_insert_coords(
+        volume_dim * refinement_criteria.size(), time, functions_of_time,
+        domain, element_id);
+
+    for (const auto& criterion : refinement_criteria) {
+      const auto decision = criterion->evaluate(box, cache, element_id);
+      for (size_t d = 0; d < volume_dim; ++d) {
+        this->add_constant(
+            make_not_null(&components),
+            criterion->observation_name() +
+                tnsr::i<double, volume_dim,
+                        Frame::ElementLogical>::component_suffix(d),
+            static_cast<double>(gsl::at(decision, d)) - 3.0);
+      }
+    }
+
+    this->observe(components, cache, element_id, component, observation_value);
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+  void pup(PUP::er& p) override {
+    dg::Events::ObserveConstantsPerElement<volume_dim>::pup(p);
+  }
+};
+
+/// \cond
+template <typename Metavariables>
+PUP::able::PUP_ID ObserveAmrCriteria<Metavariables>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace amr::Events

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ObserveAdaptiveSteppingDiagnostics.cpp
+  ObserveConstantsPerElement.cpp
   ObserveDataBox.cpp
   ObserveNorms.cpp
   ObserveTimeStepVolume.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   Factory.hpp
   MonitorMemory.hpp
   ObserveAdaptiveSteppingDiagnostics.hpp
+  ObserveConstantsPerElement.hpp
   ObserveDataBox.hpp
   ObserveAtExtremum.hpp
   ObserveFields.hpp

--- a/src/ParallelAlgorithms/Events/ObserveConstantsPerElement.cpp
+++ b/src/ParallelAlgorithms/Events/ObserveConstantsPerElement.cpp
@@ -1,0 +1,173 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/FloatingPointType.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace dg::Events {
+template <size_t VolumeDim>
+ObserveConstantsPerElement<VolumeDim>::ObserveConstantsPerElement(
+    const std::string& subfile_name,
+    const ::FloatingPointType coordinates_floating_point_type,
+    const ::FloatingPointType floating_point_type)
+    : subfile_path_("/" + subfile_name),
+      coordinates_floating_point_type_(coordinates_floating_point_type),
+      floating_point_type_(floating_point_type) {}
+
+template <size_t VolumeDim>
+ObserveConstantsPerElement<VolumeDim>::ObserveConstantsPerElement(
+    CkMigrateMessage* msg)
+    : Event(msg) {}
+
+template <size_t VolumeDim>
+std::optional<
+    std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+ObserveConstantsPerElement<
+    VolumeDim>::get_observation_type_and_key_for_registration() const {
+  return {{observers::TypeOfObservation::Volume,
+           observers::ObservationKey{subfile_path_ + ".vol"}}};
+}
+
+template <size_t VolumeDim>
+void ObserveConstantsPerElement<VolumeDim>::pup(PUP::er& p) {
+  Event::pup(p);
+  p | subfile_path_;
+  p | coordinates_floating_point_type_;
+  p | floating_point_type_;
+}
+
+namespace {
+template <typename T, size_t VolumeDim>
+void map_corners(const gsl::not_null<std::vector<TensorComponent>*> components,
+                 const double time,
+                 const domain::FunctionsOfTimeMap& functions_of_time,
+                 const Domain<VolumeDim>& domain,
+                 const ElementId<VolumeDim>& element_id) {
+  // Get the name from the tag even though we don't fetch it to make
+  // sure it's consistent with other observers.
+  using coordinates_tag =
+      ::domain::Tags::Coordinates<VolumeDim, Frame::Inertial>;
+  const std::string coordinates_name = db::tag_name<coordinates_tag>();
+
+  const ElementMap<VolumeDim, Frame::Inertial> map(
+      element_id, domain.blocks()[element_id.block_id()]);
+
+  auto corners = make_array<VolumeDim, T>(two_to_the(VolumeDim));
+  size_t index = 0;
+
+  const auto add_point =
+      [&](const tnsr::I<double, VolumeDim, Frame::ElementLogical>& point) {
+        const tnsr::I<double, VolumeDim, Frame::Inertial> mapped =
+            map(point, time, functions_of_time);
+        for (size_t i = 0; i < VolumeDim; ++i) {
+          gsl::at(corners, i)[index] = mapped.get(i);
+        }
+        ++index;
+      };
+
+  if constexpr (VolumeDim == 1) {
+    for (auto xi : {-1.0, 1.0}) {
+      add_point(tnsr::I<double, 1, Frame::ElementLogical>{{xi}});
+    }
+  } else if constexpr (VolumeDim == 2) {
+    for (auto eta : {-1.0, 1.0}) {
+      for (auto xi : {-1.0, 1.0}) {
+        add_point(tnsr::I<double, 2, Frame::ElementLogical>{{xi, eta}});
+      }
+    }
+  } else {
+    static_assert(VolumeDim == 3);
+    for (auto zeta : {-1.0, 1.0}) {
+      for (auto eta : {-1.0, 1.0}) {
+        for (auto xi : {-1.0, 1.0}) {
+          add_point(tnsr::I<double, 3, Frame::ElementLogical>{{xi, eta, zeta}});
+        }
+      }
+    }
+  }
+
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    const std::string component_name =
+        coordinates_name + coordinates_tag::type::component_suffix(i);
+    components->emplace_back(component_name, std::move(gsl::at(corners, i)));
+  }
+}
+}  // namespace
+
+template <size_t VolumeDim>
+std::vector<TensorComponent>
+ObserveConstantsPerElement<VolumeDim>::allocate_and_insert_coords(
+    const size_t number_of_constants, const double time,
+    const domain::FunctionsOfTimeMap& functions_of_time,
+    const Domain<VolumeDim>& domain,
+    const ElementId<VolumeDim>& element_id) const {
+  std::vector<TensorComponent> components{};
+  components.reserve(VolumeDim + number_of_constants);
+
+  if (coordinates_floating_point_type_ == ::FloatingPointType::Float) {
+    map_corners<std::vector<float>>(&components, time, functions_of_time,
+                                    domain, element_id);
+  } else {
+    map_corners<DataVector>(&components, time, functions_of_time, domain,
+                            element_id);
+  }
+
+  return components;
+}
+
+template <size_t VolumeDim>
+void ObserveConstantsPerElement<VolumeDim>::add_constant(
+    const gsl::not_null<std::vector<TensorComponent>*> components,
+    std::string name, const double value) const {
+  // We could save some space by using cell-centered data instead of
+  // the same value at each corner, but that would require also adding
+  // support to the rest of our visualization tools, and we'd still
+  // need the coordinates at the corners which would be most of the
+  // data.
+  constexpr auto num_corners = two_to_the(VolumeDim);
+
+  if (floating_point_type_ == ::FloatingPointType::Float) {
+    components->emplace_back(
+        std::move(name),
+        std::vector<float>(num_corners, static_cast<float>(value)));
+  } else {
+    components->emplace_back(std::move(name), DataVector(num_corners, value));
+  }
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) \
+  template class ObserveConstantsPerElement<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace dg::Events

--- a/src/ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp
@@ -1,0 +1,191 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/FloatingPointType.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Options/String.hpp"
+#include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/TypeTraits.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class Domain;
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+namespace observers {
+class ObservationKey;
+enum class TypeOfObservation;
+}  // namespace observers
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace dg::Events {
+/// \brief Base class for Observers that write data that is constant within an
+/// Element
+template <size_t VolumeDim>
+class ObserveConstantsPerElement : public Event {
+ public:
+  /// The name of the subfile inside the HDF5 file
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "The name of the subfile inside the HDF5 file without an extension and "
+        "without a preceding '/'."};
+  };
+
+  /// The floating point type/precision with which to write the data to disk.
+  struct FloatingPointType {
+    static constexpr Options::String help =
+        "The floating point type/precision with which to write the data to "
+        "disk.";
+    using type = ::FloatingPointType;
+  };
+
+  /// The floating point type/precision with which to write the coordinates to
+  /// disk.
+  struct CoordinatesFloatingPointType {
+    static constexpr Options::String help =
+        "The floating point type/precision with which to write the coordinates "
+        "to disk.";
+    using type = ::FloatingPointType;
+  };
+
+  using options =
+      tmpl::list<SubfileName, CoordinatesFloatingPointType, FloatingPointType>;
+
+  ObserveConstantsPerElement() = default;
+
+  ObserveConstantsPerElement(
+      const std::string& subfile_name,
+      ::FloatingPointType coordinates_floating_point_type,
+      ::FloatingPointType floating_point_type);
+
+  /// \cond
+  explicit ObserveConstantsPerElement(CkMigrateMessage* /*unused*/);
+  /// \endcond
+
+  using observation_registration_tags = tmpl::list<>;
+
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration() const;
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  void pup(PUP::er& p) override;
+
+ protected:
+  /// \brief Creates the vector of tensor components that will be observed
+  /// and starts to fill it with the inertial coordinates
+  ///
+  /// \details number_of_constants is the number of additional tensor components
+  /// that will be observed.  These are added by calling add_constant
+  std::vector<TensorComponent> allocate_and_insert_coords(
+      size_t number_of_constants, double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const Domain<VolumeDim>& domain,
+      const ElementId<VolumeDim>& element_id) const;
+
+  /// \brief Adds a TensorComponent to components with the given name and the
+  /// given value.
+  ///
+  /// \details Should be called after allocate_and_insert_coords
+  void add_constant(gsl::not_null<std::vector<TensorComponent>*> components,
+                    std::string name, double value) const;
+
+  /// Observes the components as volume data
+  template <typename Metavariables, typename ParallelComponent>
+  void observe(std::vector<TensorComponent> components,
+               Parallel::GlobalCache<Metavariables>& cache,
+               const ElementId<VolumeDim>& element_id,
+               const ParallelComponent* /*component*/,
+               const ObservationValue& observation_value) const;
+private:
+  std::string subfile_path_;
+  ::FloatingPointType coordinates_floating_point_type_ =
+      ::FloatingPointType::Double;
+  ::FloatingPointType floating_point_type_ = ::FloatingPointType::Double;
+};
+
+template <size_t VolumeDim>
+template <typename Metavariables, typename ParallelComponent>
+void ObserveConstantsPerElement<VolumeDim>::observe(
+    std::vector<TensorComponent> components,
+    Parallel::GlobalCache<Metavariables>& cache,
+    const ElementId<VolumeDim>& element_id,
+    const ParallelComponent* const /*component*/,
+    const ObservationValue& observation_value) const {
+  const Mesh<VolumeDim> single_cell_mesh(2, Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto);
+  const Parallel::ArrayComponentId array_component_id{
+      std::add_pointer_t<ParallelComponent>{nullptr},
+      Parallel::ArrayIndex<ElementId<VolumeDim>>{element_id}};
+  ElementVolumeData element_volume_data{element_id, std::move(components),
+                                        single_cell_mesh};
+  observers::ObservationId observation_id{observation_value.value,
+                                          subfile_path_ + ".vol"};
+
+  auto& local_observer = *Parallel::local_branch(
+      Parallel::get_parallel_component<
+          tmpl::conditional_t<Parallel::is_nodegroup_v<ParallelComponent>,
+                              observers::ObserverWriter<Metavariables>,
+                              observers::Observer<Metavariables>>>(cache));
+
+  if constexpr (Parallel::is_nodegroup_v<ParallelComponent>) {
+    // Send data to reduction observer writer (nodegroup)
+    std::unordered_map<Parallel::ArrayComponentId,
+                       std::vector<ElementVolumeData>>
+        data_to_send{};
+    data_to_send[array_component_id] =
+        std::vector{std::move(element_volume_data)};
+    Parallel::threaded_action<
+        observers::ThreadedActions::ContributeVolumeDataToWriter>(
+        local_observer, std::move(observation_id), array_component_id,
+        subfile_path_, std::move(data_to_send));
+  } else {
+    // Send data to volume observer
+    Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+        local_observer, std::move(observation_id), subfile_path_,
+        array_component_id, std::move(element_volume_data));
+  }
+}
+
+}  // namespace dg::Events

--- a/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.cpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.cpp
@@ -4,34 +4,27 @@
 #include "ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp"
 
 #include <cstddef>
-#include <optional>
+#include <memory>
 #include <pup.h>
-#include <pup_stl.h>
 #include <string>
-#include <utility>
+#include <unordered_map>
 #include <vector>
 
-#include "DataStructures/DataBox/TagName.hpp"
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/FloatingPointType.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/ElementMap.hpp"
-#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
-#include "Domain/Tags.hpp"
 #include "IO/H5/TensorData.hpp"
-#include "IO/Observer/ObservationId.hpp"
-#include "IO/Observer/TypeOfObservation.hpp"
+#include "ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Time/Time.hpp"
-#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
 
-namespace Frame {
-struct ElementLogical;
-struct Inertial;
-}  // namespace Frame
+template <size_t VolumeDim>
+class Domain;
+template <size_t VolumeDim>
+class ElementId;
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
 
 namespace dg::Events {
 template <size_t VolumeDim>
@@ -39,18 +32,12 @@ ObserveTimeStepVolume<VolumeDim>::ObserveTimeStepVolume(
     const std::string& subfile_name,
     const ::FloatingPointType coordinates_floating_point_type,
     const ::FloatingPointType floating_point_type)
-    : subfile_path_("/" + subfile_name),
-      coordinates_floating_point_type_(coordinates_floating_point_type),
-      floating_point_type_(floating_point_type) {}
+    : ObserveConstantsPerElement<VolumeDim>(
+          subfile_name, coordinates_floating_point_type, floating_point_type) {}
 
 template <size_t VolumeDim>
-std::optional<
-    std::pair<observers::TypeOfObservation, observers::ObservationKey>>
-ObserveTimeStepVolume<
-    VolumeDim>::get_observation_type_and_key_for_registration() const {
-  return {{observers::TypeOfObservation::Volume,
-           observers::ObservationKey{subfile_path_ + ".vol"}}};
-}
+ObserveTimeStepVolume<VolumeDim>::ObserveTimeStepVolume(CkMigrateMessage* m)
+    : ObserveConstantsPerElement<VolumeDim>(m) {}
 
 template <size_t VolumeDim>
 bool ObserveTimeStepVolume<VolumeDim>::needs_evolved_variables() const {
@@ -59,105 +46,25 @@ bool ObserveTimeStepVolume<VolumeDim>::needs_evolved_variables() const {
 
 template <size_t VolumeDim>
 void ObserveTimeStepVolume<VolumeDim>::pup(PUP::er& p) {
-  Event::pup(p);
-  p | subfile_path_;
-  p | coordinates_floating_point_type_;
-  p | floating_point_type_;
+  ObserveConstantsPerElement<VolumeDim>::pup(p);
 }
-
-namespace {
-template <typename T, size_t VolumeDim>
-void map_corners(const gsl::not_null<std::vector<TensorComponent>*> components,
-                 const double time,
-                 const domain::FunctionsOfTimeMap& functions_of_time,
-                 const Domain<VolumeDim>& domain,
-                 const ElementId<VolumeDim>& element_id) {
-  // Get the name from the tag even though we don't fetch it to make
-  // sure it's consistent with other observers.
-  using coordinates_tag =
-      ::domain::Tags::Coordinates<VolumeDim, Frame::Inertial>;
-  const std::string coordinates_name = db::tag_name<coordinates_tag>();
-
-  const ElementMap<VolumeDim, Frame::Inertial> map(
-      element_id, domain.blocks()[element_id.block_id()]);
-
-  auto corners = make_array<VolumeDim, T>(two_to_the(VolumeDim));
-  size_t index = 0;
-
-  const auto add_point =
-      [&](const tnsr::I<double, VolumeDim, Frame::ElementLogical>& point) {
-        const tnsr::I<double, VolumeDim, Frame::Inertial> mapped =
-            map(point, time, functions_of_time);
-        for (size_t i = 0; i < VolumeDim; ++i) {
-          gsl::at(corners, i)[index] = mapped.get(i);
-        }
-        ++index;
-      };
-
-  if constexpr (VolumeDim == 1) {
-    for (auto xi : {-1.0, 1.0}) {
-      add_point(tnsr::I<double, 1, Frame::ElementLogical>{{xi}});
-    }
-  } else if constexpr (VolumeDim == 2) {
-    for (auto eta : {-1.0, 1.0}) {
-      for (auto xi : {-1.0, 1.0}) {
-        add_point(tnsr::I<double, 2, Frame::ElementLogical>{{xi, eta}});
-      }
-    }
-  } else {
-    static_assert(VolumeDim == 3);
-    for (auto zeta : {-1.0, 1.0}) {
-      for (auto eta : {-1.0, 1.0}) {
-        for (auto xi : {-1.0, 1.0}) {
-          add_point(tnsr::I<double, 3, Frame::ElementLogical>{{xi, eta, zeta}});
-        }
-      }
-    }
-  }
-
-  for (size_t i = 0; i < VolumeDim; ++i) {
-    const std::string component_name =
-        coordinates_name + coordinates_tag::type::component_suffix(i);
-    components->emplace_back(component_name, std::move(gsl::at(corners, i)));
-  }
-}
-}  // namespace
 
 template <size_t VolumeDim>
 std::vector<TensorComponent> ObserveTimeStepVolume<VolumeDim>::assemble_data(
-    const double time, const domain::FunctionsOfTimeMap& functions_of_time,
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
     const Domain<VolumeDim>& domain, const ElementId<VolumeDim>& element_id,
     const TimeDelta& time_step, const double minimum_grid_spacing) const {
-  constexpr auto num_corners = two_to_the(VolumeDim);
-
-  std::vector<TensorComponent> components{};
-  components.reserve(VolumeDim + 2);
-
-  if (coordinates_floating_point_type_ == ::FloatingPointType::Float) {
-    map_corners<std::vector<float>>(&components, time, functions_of_time,
-                                    domain, element_id);
-  } else {
-    map_corners<DataVector>(&components, time, functions_of_time, domain,
-                            element_id);
-  }
-
-  // We could save some space by using cell-centered data instead of
-  // the same value at each corner, but that would require also adding
-  // support to the rest of our visualization tools, and we'd still
-  // need the coordinates at the corners which would be most of the
-  // data.
-  const auto add_constant = [&](std::string name, const double value) {
-    if (floating_point_type_ == ::FloatingPointType::Float) {
-      components.emplace_back(
-          std::move(name),
-          std::vector<float>(num_corners, static_cast<float>(value)));
-    } else {
-      components.emplace_back(std::move(name), DataVector(num_corners, value));
-    }
-  };
-  add_constant("Time step", time_step.value());
-  add_constant("Slab fraction", time_step.fraction().value());
-  add_constant("Minimum grid spacing", minimum_grid_spacing);
+  std::vector<TensorComponent> components = this->allocate_and_insert_coords(
+      3, time, functions_of_time, domain, element_id);
+  this->add_constant(make_not_null(&components), "Time step",
+                     time_step.value());
+  this->add_constant(make_not_null(&components), "Slab fraction",
+                     time_step.fraction().value());
+  this->add_constant(make_not_null(&components), "Minimum grid spacing",
+                     minimum_grid_spacing);
 
   return components;
 }

--- a/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp
@@ -59,6 +59,7 @@ namespace dg::Events {
  * - InertialCoordinates (only element corners)
  * - Time step
  * - Slab fraction
+ * - Minimum grid spacing
  */
 template <size_t VolumeDim>
 class ObserveTimeStepVolume : public ObserveConstantsPerElement<VolumeDim> {

--- a/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp
@@ -4,41 +4,40 @@
 #pragma once
 
 #include <cstddef>
-#include <optional>
+#include <memory>
 #include <string>
-#include <type_traits>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
-#include "DataStructures/FloatingPointType.hpp"
-#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
-#include "Domain/MinimumGridSpacing.hpp"
-#include "Domain/Structure/ElementId.hpp"
-#include "Domain/Tags.hpp"
 #include "IO/H5/TensorData.hpp"
-#include "IO/Observer/ObservationId.hpp"
-#include "IO/Observer/ObserverComponent.hpp"
-#include "IO/Observer/TypeOfObservation.hpp"
-#include "IO/Observer/VolumeActions.hpp"
-#include "NumericalAlgorithms/Spectral/Basis.hpp"
-#include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/String.hpp"
-#include "Parallel/ArrayComponentId.hpp"
-#include "Parallel/ArrayIndex.hpp"
-#include "Parallel/GlobalCache.hpp"
-#include "Parallel/Invoke.hpp"
-#include "Parallel/Local.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+enum class FloatingPointType;
 template <size_t VolumeDim>
 class Domain;
+template <size_t VolumeDim>
+class ElementId;
 class TimeDelta;
+namespace domain {
+namespace FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace FunctionsOfTime
+namespace Tags {
+template <size_t VolumeDim>
+struct Domain;
+struct FunctionsOfTime;
+template <size_t VolumeDim, typename Frame>
+struct MinimumGridSpacing;
+}  // namespace Tags
+}  // namespace domain
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -46,11 +45,6 @@ namespace Tags {
 struct Time;
 struct TimeStep;
 }  // namespace Tags
-namespace domain::Tags {
-template <size_t VolumeDim>
-struct Domain;
-struct FunctionsOfTime;
-}  // namespace domain::Tags
 /// \endcond
 
 namespace dg::Events {
@@ -67,41 +61,13 @@ namespace dg::Events {
  * - Slab fraction
  */
 template <size_t VolumeDim>
-class ObserveTimeStepVolume : public Event {
+class ObserveTimeStepVolume : public ObserveConstantsPerElement<VolumeDim> {
  public:
-  /// The name of the subfile inside the HDF5 file
-  struct SubfileName {
-    using type = std::string;
-    static constexpr Options::String help = {
-        "The name of the subfile inside the HDF5 file without an extension and "
-        "without a preceding '/'."};
-  };
-
   /// \cond
-  explicit ObserveTimeStepVolume(CkMigrateMessage* /*unused*/) {}
+  explicit ObserveTimeStepVolume(CkMigrateMessage* m);
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(ObserveTimeStepVolume);  // NOLINT
   /// \endcond
-
-  /// The floating point type/precision with which to write the data to disk.
-  struct FloatingPointType {
-    static constexpr Options::String help =
-        "The floating point type/precision with which to write the data to "
-        "disk.";
-    using type = ::FloatingPointType;
-  };
-
-  /// The floating point type/precision with which to write the coordinates to
-  /// disk.
-  struct CoordinatesFloatingPointType {
-    static constexpr Options::String help =
-        "The floating point type/precision with which to write the coordinates "
-        "to disk.";
-    using type = ::FloatingPointType;
-  };
-
-  using options =
-      tmpl::list<SubfileName, CoordinatesFloatingPointType, FloatingPointType>;
 
   static constexpr Options::String help =
       "Observe the time step in the volume.";
@@ -122,65 +88,21 @@ class ObserveTimeStepVolume : public Event {
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(const double time,
-                  const domain::FunctionsOfTimeMap& functions_of_time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time,
                   const Domain<VolumeDim>& domain, const TimeDelta& time_step,
                   const double minimum_grid_spacing,
                   Parallel::GlobalCache<Metavariables>& cache,
                   const ElementId<VolumeDim>& element_id,
-                  const ParallelComponent* const /*component*/,
-                  const ObservationValue& observation_value) const {
+                  const ParallelComponent* const component,
+                  const Event::ObservationValue& observation_value) const {
     std::vector<TensorComponent> components =
         assemble_data(time, functions_of_time, domain, element_id, time_step,
                       minimum_grid_spacing);
 
-    const Mesh<VolumeDim> single_cell_mesh(2, Spectral::Basis::Legendre,
-                                           Spectral::Quadrature::GaussLobatto);
-    const Parallel::ArrayComponentId array_component_id{
-        std::add_pointer_t<ParallelComponent>{nullptr},
-        Parallel::ArrayIndex<ElementId<VolumeDim>>{element_id}};
-    ElementVolumeData element_volume_data{element_id, std::move(components),
-                                          single_cell_mesh};
-    observers::ObservationId observation_id{observation_value.value,
-                                            subfile_path_ + ".vol"};
-
-    auto& local_observer = *Parallel::local_branch(
-        Parallel::get_parallel_component<
-            tmpl::conditional_t<Parallel::is_nodegroup_v<ParallelComponent>,
-                                observers::ObserverWriter<Metavariables>,
-                                observers::Observer<Metavariables>>>(cache));
-
-    if constexpr (Parallel::is_nodegroup_v<ParallelComponent>) {
-      // Send data to reduction observer writer (nodegroup)
-      std::unordered_map<Parallel::ArrayComponentId,
-                         std::vector<ElementVolumeData>>
-          data_to_send{};
-      data_to_send[array_component_id] =
-          std::vector{std::move(element_volume_data)};
-      Parallel::threaded_action<
-          observers::ThreadedActions::ContributeVolumeDataToWriter>(
-          local_observer, std::move(observation_id), array_component_id,
-          subfile_path_, std::move(data_to_send));
-    } else {
-      // Send data to volume observer
-      Parallel::simple_action<observers::Actions::ContributeVolumeData>(
-          local_observer, std::move(observation_id), subfile_path_,
-          array_component_id, std::move(element_volume_data));
-    }
-  }
-
-  using observation_registration_tags = tmpl::list<>;
-
-  std::optional<
-      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
-  get_observation_type_and_key_for_registration() const;
-
-  using is_ready_argument_tags = tmpl::list<>;
-
-  template <typename Metavariables, typename ArrayIndex, typename Component>
-  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
-                const ArrayIndex& /*array_index*/,
-                const Component* const /*meta*/) const {
-    return true;
+    this->observe(components, cache, element_id, component, observation_value);
   }
 
   bool needs_evolved_variables() const override;
@@ -192,10 +114,5 @@ class ObserveTimeStepVolume : public Event {
       double time, const domain::FunctionsOfTimeMap& functions_of_time,
       const Domain<VolumeDim>& domain, const ElementId<VolumeDim>& element_id,
       const TimeDelta& time_step, double minimum_grid_spacing) const;
-
-  std::string subfile_path_;
-  ::FloatingPointType coordinates_floating_point_type_ =
-      ::FloatingPointType::Double;
-  ::FloatingPointType floating_point_type_ = ::FloatingPointType::Double;
 };
 }  // namespace dg::Events

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -965,12 +965,14 @@ void test_impl(const Spectral::Quadrature quadrature,
       mortar_id_ptr = &mortar_id;
       compute_correction_coupling(mortar_data.local(), mortar_data.neighbor());
     }
+    Approx custom_approx = Approx::custom().epsilon(5.e-11);
     tmpl::for_each<dt_variables_tags>(
-        [&expected_dt_variables_volume, &runner, &self_id](auto tag_v) {
+        [&custom_approx, &expected_dt_variables_volume, &runner,
+         &self_id](auto tag_v) {
           using tag = tmpl::type_from<decltype(tag_v)>;
-          CHECK_ITERABLE_APPROX(
+          CHECK_ITERABLE_CUSTOM_APPROX(
               get<tag>(get_tag<dt_variables_tag>(runner, self_id)),
-              get<tag>(expected_dt_variables_volume));
+              get<tag>(expected_dt_variables_volume), custom_approx);
         });
     CHECK(expected_evolved_variables ==
           get_tag<variables_tag>(runner, self_id));

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -84,7 +84,7 @@ struct ElementComponent {
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
-  using array_index = ElementId<Metavariables::system::volume_dim>;
+  using array_index = ElementId<Metavariables::volume_dim>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
 };
@@ -106,6 +106,7 @@ struct MockObserverComponent {
 template <typename System, bool HasAnalyticSolution>
 struct Metavariables {
   using system = System;
+  static constexpr size_t volume_dim = system::volume_dim;
   using component_list = tmpl::list<ElementComponent<Metavariables>,
                                     MockObserverComponent<Metavariables>>;
   using const_global_cache_tags =

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Persson.cpp
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
+  Events/Test_ObserveAmrCriteria.cpp
   Events/Test_RefineMesh.cpp
   Policies/Test_EnforcePolicies.cpp
   Policies/Test_Isotropy.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
@@ -66,6 +66,8 @@ class CriterionOne : public amr::Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(CriterionOne);  // NOLINT
 
+  std::string observation_name() override { return "CriterionOne"; }
+
   using compute_tags_for_observartion_box = tmpl::list<>;
   using argument_tags = tmpl::list<FieldOne>;
 
@@ -107,6 +109,8 @@ class CriterionTwo : public amr::Criterion {
   explicit CriterionTwo(CkMigrateMessage* /*msg*/) {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(CriterionTwo);  // NOLINT
+
+  std::string observation_name() override { return "CriterionTwo"; }
 
   using compute_tags_for_observartion_box = tmpl::list<ConstraintCompute>;
   using argument_tags = tmpl::list<Constraint>;

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
@@ -1,0 +1,182 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/MakeVector.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+namespace LocalTags {
+struct FunctionsOfTime : domain::Tags::FunctionsOfTime, db::SimpleTag {
+  using type = domain::FunctionsOfTimeMap;
+};
+}  // namespace LocalTags
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 1;
+  using component_list = tmpl::list<
+      TestHelpers::dg::Events::ObserveFields::ElementComponent<Metavariables>,
+      TestHelpers::dg::Events::ObserveFields::MockObserverComponent<
+          Metavariables>>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion, tmpl::list<amr::Criteria::DriveToTarget<1>>>,
+        tmpl::pair<Event,
+                   tmpl::list<amr::Events::ObserveAmrCriteria<Metavariables>>>>;
+  };
+};
+
+void test() {
+  std::vector<std::unique_ptr<amr::Criterion>> criteria;
+  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
+      std::array{4_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
+      std::array{3_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
+      std::array{5_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
+      std::array{4_st}, std::array{0_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
+      std::array{4_st}, std::array{2_st}, std::array{amr::Flag::DoNothing}));
+  const size_t number_of_criteria = criteria.size();
+  const std::vector<double> expected_values{0.0, -1.0, 1.0, -2.0, 2.0};
+  register_factory_classes_with_charm<Metavariables>();
+  using element_component =
+      TestHelpers::dg::Events::ObserveFields::ElementComponent<Metavariables>;
+  using observer_component =
+      TestHelpers::dg::Events::ObserveFields::MockObserverComponent<
+          Metavariables>;
+  element_component* const element_component_p = nullptr;
+
+  const ElementId<1> element_id(0, make_array<1>(SegmentId(1, 0)));
+  const Mesh<1> mesh{4_st, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_component<element_component>(make_not_null(&runner),
+                                                      element_id);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
+  auto& cache = ActionTesting::cache<element_component>(runner, element_id);
+
+  const auto event =
+      TestHelpers::test_creation<std::unique_ptr<Event>, Metavariables>(
+          "ObserveAmrCriteria:\n"
+          "  SubfileName: amr_criteria\n"
+          "  CoordinatesFloatingPointType: Double\n"
+          "  FloatingPointType: Float");
+  const double time = 3.0;
+  Domain domain(make_vector(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<1>{})));
+  domain.inject_time_dependent_map_for_block(
+      0, domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+             domain::CoordinateMaps::TimeDependent::Translation<1>(
+                 "translation")));
+
+  domain::FunctionsOfTimeMap functions_of_time{};
+  functions_of_time.emplace(
+      "translation",
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<1>>(
+          1.0, std::array{DataVector(1, 2.0), DataVector(1, 5.0)}, 4.0));
+  const double expected_offset = 2.0 + (time - 1.0) * 5.0;
+
+  auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
+                        Tags::Time, LocalTags::FunctionsOfTime,
+                        domain::Tags::Domain<1>, domain::Tags::Mesh<1>,
+                        amr::Criteria::Tags::Criteria, amr::Tags::Policies>>(
+      Metavariables{}, time, std::move(functions_of_time), std::move(domain),
+      mesh, std::move(criteria),
+      amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true});
+
+  const double observation_value = 1.23;
+
+  auto observation_box =
+      make_observation_box<typename amr::Events::ObserveAmrCriteria<
+          Metavariables>::compute_tags_for_observation_box>(
+          make_not_null(&box));
+
+  event->run(make_not_null(&observation_box), cache, element_id,
+             element_component_p, {"value_name", observation_value});
+
+  runner.template invoke_queued_simple_action<observer_component>(0);
+  CHECK(runner.template is_simple_action_queue_empty<observer_component>(0));
+
+  const auto& results =
+      TestHelpers::dg::Events::ObserveFields::MockContributeVolumeData::results;
+  CHECK(results.observation_id.value() == observation_value);
+  CHECK(results.observation_id.observation_key().tag() == "/amr_criteria.vol");
+  CHECK(results.subfile_name == "/amr_criteria");
+  CHECK(results.array_component_id ==
+        Parallel::make_array_component_id<element_component>(element_id));
+  CHECK(results.received_volume_data.element_name == get_output(element_id));
+  CHECK(results.received_volume_data.extents == std::vector<size_t>(1, 2));
+  const auto& components = results.received_volume_data.tensor_components;
+  REQUIRE(components.size() == 1 + number_of_criteria);
+  for (const auto& component : components) {
+    std::visit([](const auto& data) { CHECK(data.size() == 2); },
+               component.data);
+  }
+  CHECK(components[0].name == "InertialCoordinates_x");
+  std::visit(
+      [&](const auto& data) {
+        for (size_t i = 0; i < data.size(); ++i) {
+          CHECK(data[i] ==
+                (i % 2 < 1 ? -1.0 + expected_offset : expected_offset));
+        }
+      },
+      components[0].data);
+  for (size_t i = 0; i < number_of_criteria; ++i) {
+    CHECK(components[i + 1].name == "DriveToTarget_x");
+    std::visit(
+        [&](const auto& data) {
+          for (size_t j = 0; j < data.size(); ++j) {
+            CHECK(data[j] == expected_values[i]);
+          }
+        },
+        components[i + 1].data);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Events.ObserveAmrCriteria",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}
+}  // namespace

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
@@ -61,13 +61,8 @@ struct FunctionsOfTime : domain::Tags::FunctionsOfTime, db::SimpleTag {
 }  // namespace LocalTags
 
 template <size_t VolumeDim>
-struct System {
-  static constexpr size_t volume_dim = VolumeDim;
-};
-
-template <size_t VolumeDim>
 struct Metavariables {
-  using system = System<VolumeDim>;
+  static constexpr size_t volume_dim = VolumeDim;
   using component_list = tmpl::list<
       TestHelpers::dg::Events::ObserveFields::ElementComponent<Metavariables>,
       TestHelpers::dg::Events::ObserveFields::MockObserverComponent<

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
@@ -23,6 +23,7 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/MinimumGridSpacing.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/SegmentId.hpp"
 #include "Domain/Tags.hpp"


### PR DESCRIPTION
## Proposed changes

This adds an event to observe the decisions of AMR criteria.  It can be used independently of actually refining the grid.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
