### PR TITLE
Convert M1Grey to use runtime initial data

### DIFF
--- a/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(EXECUTABLE EvolveM1GreyConstantM1)
+set(EXECUTABLE EvolveM1Grey)
 
 add_spectre_executable(
   ${EXECUTABLE}

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Initialize.hpp
@@ -13,6 +13,7 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -21,8 +22,10 @@
 namespace Frame {
 struct Inertial;
 }  // namespace Frame
+namespace evolution::initial_data::Tags {
+struct InitialData;
+}  // namespace evolution::initial_data::Tags
 namespace Tags {
-struct AnalyticSolutionOrData;
 struct Time;
 }  // namespace Tags
 namespace domain {
@@ -57,41 +60,46 @@ struct InitializeM1Tags {
   static Parallel::iterable_action_return_t apply(
       db::DataBox<DbTagsList>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& cache,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     using EvolvedVars = typename evolved_variables_tag::type;
     using HydroVars = typename hydro_variables_tag::type;
     using M1Vars = typename m1_variables_tag::type;
+    using derived_classes =
+        tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                 evolution::initial_data::InitialData>;
+    call_with_dynamic_type<void, derived_classes>(
+        &db::get<evolution::initial_data::Tags::InitialData>(box),
+        [&box](const auto* const data_or_solution) {
+          static constexpr size_t dim = System::volume_dim;
+          const double initial_time = db::get<::Tags::Time>(box);
+          const size_t num_grid_points =
+              db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
+          const auto& inertial_coords =
+              db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
 
-    static constexpr size_t dim = System::volume_dim;
-    const double initial_time = db::get<::Tags::Time>(box);
-    const size_t num_grid_points =
-        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
-    const auto& inertial_coords =
-        db::get<domain::Tags::Coordinates<dim, Frame::Inertial>>(box);
+          db::mutate<evolved_variables_tag>(
+              [initial_time, &inertial_coords, &data_or_solution](
+                  const gsl::not_null<EvolvedVars*> evolved_vars) {
+                evolved_vars->assign_subset(
+                    evolution::Initialization::initial_data(
+                        *data_or_solution, inertial_coords, initial_time,
+                        typename evolved_variables_tag::tags_list{}));
+              },
+              make_not_null(&box));
 
-    db::mutate<evolved_variables_tag>(
-        [&cache, initial_time,
-         &inertial_coords](const gsl::not_null<EvolvedVars*> evolved_vars) {
-          evolved_vars->assign_subset(evolution::Initialization::initial_data(
-              Parallel::get<::Tags::AnalyticSolutionOrData>(cache),
-              inertial_coords, initial_time,
-              typename evolved_variables_tag::tags_list{}));
-        },
-        make_not_null(&box));
+          // Get hydro variables
+          HydroVars hydro_variables{num_grid_points};
+          hydro_variables.assign_subset(evolution::Initialization::initial_data(
+              *data_or_solution, inertial_coords, initial_time,
+              typename hydro_variables_tag::tags_list{}));
 
-    // Get hydro variables
-    HydroVars hydro_variables{num_grid_points};
-    hydro_variables.assign_subset(evolution::Initialization::initial_data(
-        Parallel::get<::Tags::AnalyticSolutionOrData>(cache), inertial_coords,
-        initial_time, typename hydro_variables_tag::tags_list{}));
-
-    M1Vars m1_variables{num_grid_points, -1.};
-    Initialization::mutate_assign<simple_tags>(make_not_null(&box),
-                                               std::move(hydro_variables),
-                                               std::move(m1_variables));
-
+          M1Vars m1_variables{num_grid_points, -1.};
+          Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                                     std::move(hydro_variables),
+                                                     std::move(m1_variables));
+        });
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ConstantM1.hpp
+  Factory.hpp
   Solutions.hpp
   )
 

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
@@ -24,11 +24,21 @@ ConstantM1::ConstantM1(const std::array<double, 3>& mean_velocity,
       mean_velocity_(std::move(mean_velocity)),  // NOLINT
       comoving_energy_density_(comoving_energy_density) {}
 
+std::unique_ptr<evolution::initial_data::InitialData> ConstantM1::get_clone()
+    const {
+  return std::make_unique<ConstantM1>(*this);
+}
+
+ConstantM1::ConstantM1(CkMigrateMessage* msg) : InitialData(msg) {}
+
 void ConstantM1::pup(PUP::er& p) {
+  InitialData::pup(p);
   p | mean_velocity_;
   p | comoving_energy_density_;
   p | background_spacetime_;
 }
+
+PUP::able::PUP_ID ConstantM1::my_PUP_ID = 0;  // NOLINT
 
 // Variables templated on neutrino species.
 template <typename NeutrinoSpecies>

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <limits>
+#include <memory>
 #include <pup.h>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -13,6 +14,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -20,9 +22,7 @@
 class DataVector;
 /// \endcond
 
-namespace RadiationTransport {
-namespace M1Grey {
-namespace Solutions {
+namespace RadiationTransport::M1Grey::Solutions {
 
 /*!
  * \brief Constant solution to M1 equations in Minkowski spacetime.
@@ -34,7 +34,8 @@ namespace Solutions {
  * (i.e. comoving, with an isotropic pressure P=J/3)
  *
  */
-class ConstantM1 : public MarkAsAnalyticSolution {
+class ConstantM1 : public evolution::initial_data::InitialData,
+                   public MarkAsAnalyticSolution {
  public:
   /// The mean flow velocity.
   struct MeanVelocity {
@@ -55,8 +56,8 @@ class ConstantM1 : public MarkAsAnalyticSolution {
       "spacetime."};
 
   ConstantM1() = default;
-  ConstantM1(const ConstantM1& /*rhs*/) = delete;
-  ConstantM1& operator=(const ConstantM1& /*rhs*/) = delete;
+  ConstantM1(const ConstantM1& /*rhs*/) = default;
+  ConstantM1& operator=(const ConstantM1& /*rhs*/) = default;
   ConstantM1(ConstantM1&& /*rhs*/) = default;
   ConstantM1& operator=(ConstantM1&& /*rhs*/) = default;
   ~ConstantM1() = default;
@@ -64,7 +65,14 @@ class ConstantM1 : public MarkAsAnalyticSolution {
   ConstantM1(const std::array<double, 3>& mean_velocity,
              double comoving_energy_density);
 
-  explicit ConstantM1(CkMigrateMessage* /*unused*/) {}
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
+  /// \cond
+  explicit ConstantM1(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ConstantM1);
+  /// \endcond
 
   /// @{
   /// Retrieve fluid and neutrino variables at `(x, t)`
@@ -134,7 +142,7 @@ class ConstantM1 : public MarkAsAnalyticSolution {
   }
 
   // clang-tidy: no runtime references
-  void pup(PUP::er& /*p*/);  //  NOLINT
+  void pup(PUP::er& /*p*/) override;  //  NOLINT
 
  private:
   friend bool operator==(const ConstantM1& lhs, const ConstantM1& rhs);
@@ -149,6 +157,4 @@ class ConstantM1 : public MarkAsAnalyticSolution {
 };
 
 bool operator!=(const ConstantM1& lhs, const ConstantM1& rhs);
-}  // namespace Solutions
-}  // namespace M1Grey
-}  // namespace RadiationTransport
+}  // namespace RadiationTransport::M1Grey::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/Factory.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace RadiationTransport::M1Grey::Solutions {
+/// \brief List of all analytic solutions
+using all_solutions = tmpl::list<ConstantM1>;
+}  // namespace RadiationTransport::M1Grey::Solutions

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-Executable: EvolveM1GreyConstantM1
+Executable: EvolveM1Grey
 Testing:
   Timeout: 5
   Check: parse;execute
@@ -29,6 +29,11 @@ Evolution:
 
 PhaseChangeAndTriggers:
 
+InitialData: &InitialData
+  ConstantM1:
+    MeanVelocity: [0.1, 0.2, 0.15]
+    ComovingEnergyDensity: 1.0
+
 DomainCreator:
   Brick:
     LowerBound: [10.5, 0.0, 0.0]
@@ -38,14 +43,12 @@ DomainCreator:
     InitialGridPoints: [5, 5, 5]
     TimeDependence: None
     BoundaryConditions:
-      - DirichletAnalytic
-      - DirichletAnalytic
-      - DirichletAnalytic
-
-AnalyticSolution:
-  ConstantM1:
-    MeanVelocity: [0.1, 0.2, 0.15]
-    ComovingEnergyDensity: 1.0
+      - DirichletAnalytic:
+          AnalyticPrescription: *InitialData
+      - DirichletAnalytic:
+          AnalyticPrescription: *InitialData
+      - DirichletAnalytic:
+          AnalyticPrescription: *InitialData
 
 SpatialDiscretization:
   BoundaryCorrection:

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -13,16 +13,22 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 namespace helpers = TestHelpers::evolution::dg;
 
 namespace {
+using neutrino_species = tmpl::list<neutrinos::ElectronNeutrinos<1>,
+                                    neutrinos::ElectronAntiNeutrinos<1>>;
+
 struct ConvertConstantM1 {
   using unpacked_container = int;
   using packed_container = RadiationTransport::M1Grey::Solutions::ConstantM1;
@@ -51,15 +57,29 @@ struct ConvertConstantM1 {
   }
 };
 
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<RadiationTransport::M1Grey::BoundaryConditions::
+                       BoundaryCondition<neutrino_species>,
+                   tmpl::list<RadiationTransport::M1Grey::BoundaryConditions::
+                                  DirichletAnalytic<neutrino_species>>>,
+        tmpl::pair<
+            evolution::initial_data::InitialData,
+            tmpl::list<RadiationTransport::M1Grey::Solutions::ConstantM1>>>;
+  };
+};
+
 void test() {
+  register_classes_with_charm(
+      RadiationTransport::M1Grey::Solutions::all_solutions{});
   MAKE_GENERATOR(gen);
   const auto box_analytic_soln = db::create<db::AddSimpleTags<
       Tags::Time, Tags::AnalyticSolution<
                       RadiationTransport::M1Grey::Solutions::ConstantM1>>>(
       0.5, ConvertConstantM1::create_container());
 
-  using neutrino_species = tmpl::list<neutrinos::ElectronNeutrinos<1>,
-                                      neutrinos::ElectronAntiNeutrinos<1>>;
   using system = RadiationTransport::M1Grey::System<neutrino_species>;
   using boundary_condition =
       RadiationTransport::M1Grey::BoundaryConditions::BoundaryCondition<
@@ -83,7 +103,10 @@ void test() {
 
   helpers::test_boundary_condition_with_python<
       dirichlet_analytic, boundary_condition, system, tmpl::list<rusanov>,
-      tmpl::list<ConvertConstantM1>>(
+      tmpl::list<ConvertConstantM1>,
+      tmpl::list<Tags::AnalyticSolution<
+          RadiationTransport::M1Grey::Solutions::ConstantM1>>,
+      Metavariables>(
       make_not_null(&gen),
       "Evolution.Systems.RadiationTransport.M1Grey.BoundaryConditions."
       "DirichletAnalytic",
@@ -106,25 +129,22 @@ void test() {
           "soln_tilde_s_nue", "soln_tilde_s_bar_nue", "soln_flux_tilde_e_nue",
           "soln_flux_tilde_e_bar_nue", "soln_flux_tilde_s_nue",
           "soln_flux_tilde_s_bar_nue"},
-      "DirichletAnalytic:\n", Index<2>{5}, box_analytic_soln,
-      tuples::TaggedTuple<>{});
+      "DirichletAnalytic:\n"
+      "  AnalyticPrescription:\n"
+      "    ConstantM1:\n"
+      "      MeanVelocity: [0.1, 0.2, 0.3]\n"
+      "      ComovingEnergyDensity: 0.4\n",
+      Index<2>{5}, box_analytic_soln, tuples::TaggedTuple<>{});
 
   // Note: Currently there is no analytic data for the
-  // RadiationTransport::M1Grey system. When that is implemented, a test should
-  // be added.
+  // RadiationTransport::M1Grey system. When that is implemented, a test
+  // should be added.
 }
 }  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.RadiationTransport.M1Grey.BoundaryConditions.DirichletAnalytic",
     "[Unit][Evolution]") {
-  using neutrino_species = tmpl::list<neutrinos::ElectronNeutrinos<1>,
-                                      neutrinos::ElectronAntiNeutrinos<1>>;
-  using dirichlet_analytic =
-      RadiationTransport::M1Grey::BoundaryConditions::DirichletAnalytic<
-          neutrino_species>;
-  PUPable_reg(dirichlet_analytic);
-
   pypp::SetupLocalPythonEnvironment local_python_env{""};
   test();
 }


### PR DESCRIPTION
## Proposed changes

- Makes M1Grey solutions option creatable to be consistent with other code

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- New AnalyticSolutions for M1Grey should be added to `RadiationTransport::M1Grey::Solutions::all_solutions`
- Executable was renamed to EvolveM1Grey
- Input file needs updating (see tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml)
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
