### PR TITLE
Update directory structure of ID parameter control

### DIFF
--- a/support/Pipelines/Bbh/ControlId.py
+++ b/support/Pipelines/Bbh/ControlId.py
@@ -149,7 +149,7 @@ def control_id(
     radial_expansion_velocity = binary_data["Expansion"]
 
     # File to write control diagnostic data
-    data_file = open(f"{id_run_dir}/ControlParamsData.txt", "w")
+    data_file = open(f"{id_run_dir}/../ControlParamsData.txt", "w")
 
     iteration = 0
     control_run_dir = id_run_dir
@@ -166,7 +166,7 @@ def control_id(
                 f" Control of BBH Parameters ({iteration}) "
                 "=========================================="
             )
-            control_run_dir = f"{id_run_dir}/ControlParams{iteration:02}"
+            control_run_dir = f"{id_run_dir}/../ControlParams_{iteration:03}"
 
             # Start with initial free data choices and update the ones being
             # controlled in `control_params` with the numeric value from `u`

--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -128,6 +128,7 @@ def generate_id(
     pipeline_dir: Optional[Union[str, Path]] = None,
     run_dir: Optional[Union[str, Path]] = None,
     segments_dir: Optional[Union[str, Path]] = None,
+    out_file_name: str = "spectre.out",
     **scheduler_kwargs,
 ):
     """Generate initial data for a BBH simulation.
@@ -169,6 +170,7 @@ def generate_id(
         subdirectory '001_InitialData'.
       run_dir: Directory where the initial data is generated. Mutually exclusive
         with 'pipeline_dir'.
+      out_file_name: Optional. Name of the log file. (Default: "spectre.out")
     """
     logger.warning(
         "The BBH pipeline is still experimental. Please review the"
@@ -196,6 +198,9 @@ def generate_id(
         )
     if pipeline_dir and not run_dir:
         run_dir = pipeline_dir / "001_InitialData"
+    if control:
+        run_dir = f"{run_dir}/ControlParams_000"
+        out_file_name = f"../{out_file_name}"
 
     # Determine initial data parameters from options
     id_params = id_parameters(
@@ -223,6 +228,7 @@ def generate_id(
         pipeline_dir=pipeline_dir,
         run_dir=run_dir,
         segments_dir=segments_dir,
+        out_file_name=out_file_name,
     )
 
 

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -123,7 +123,9 @@ class TestInitialData(unittest.TestCase):
             )
         except SystemExit as e:
             self.assertEqual(e.code, 0)
-        self.assertTrue((self.test_dir / "InitialData.yaml").exists())
+        self.assertTrue(
+            (self.test_dir / "ControlParams_000/InitialData.yaml").exists()
+        )
         # Test with pipeline directory
         try:
             generate_id_command(
@@ -138,7 +140,9 @@ class TestInitialData(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, 0)
         with open(
-            self.test_dir / "Pipeline/001_InitialData/InitialData.yaml", "r"
+            self.test_dir
+            / "Pipeline/001_InitialData/ControlParams_000/InitialData.yaml",
+            "r",
         ) as open_input_file:
             metadata = next(yaml.safe_load_all(open_input_file))
         self.assertEqual(


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR addresses issue #6328 by moving the 0th initial data run into the subdirectory `ControlParams00`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
