### PR TITLE
Fix FPEs occurring when density is zero in MC

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/ImplicitMonteCarloCorrections.tpp
+++ b/src/Evolution/Particles/MonteCarlo/ImplicitMonteCarloCorrections.tpp
@@ -155,11 +155,13 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
     // We have all we need to calculate beta here. We take the largest of the
     // two variations
     get(beta)[i] = fabs(get(neutrino_energy_1)[i] - get(neutrino_energy_0)[i]) /
-                   fabs(get(fluid_energy_1)[i] - get(fluid_energy_0)[i]);
+                   (fabs(get(fluid_energy_1)[i] - get(fluid_energy_0)[i]) +
+                    1.e-16);
     const double beta_lepton =
         fabs(get(neutrino_lepton_number_1)[i] -
              get(neutrino_lepton_number_0)[i]) /
-        fabs(get(fluid_lepton_number_1)[i] - get(fluid_lepton_number_0)[i]);
+        (fabs(get(fluid_lepton_number_1)[i] - get(fluid_lepton_number_0)[i]) +
+         1.e-16);
     get(beta)[i] =
         std::max(get(beta)[i], beta_lepton);
   }

--- a/src/Evolution/Particles/MonteCarlo/NeutrinoInteractionTable.cpp
+++ b/src/Evolution/Particles/MonteCarlo/NeutrinoInteractionTable.cpp
@@ -309,9 +309,12 @@ void NeutrinoInteractionTable<EnergyBins, NeutrinoSpecies>::
   double ye = 0.0;
   double log_rho = 0.0;
   double log_temp = 0.0;
+  const double minimum_density = exp(table_log_density[0]);
   for (size_t p = 0; p < get(electron_fraction).size(); p++) {
     ye = get(electron_fraction)[p];
-    log_rho = log(get(rest_mass_density)[p]);
+    log_rho = get(rest_mass_density)[p] > minimum_density
+                  ? log(get(rest_mass_density)[p])
+                  : log(minimum_density);
     log_temp = get(temperature)[p] > minimum_temperature
                    ? log(get(temperature)[p])
                    : log(minimum_temperature);
@@ -351,6 +354,12 @@ void NeutrinoInteractionTable<EnergyBins, NeutrinoSpecies>::
             square(square(temperature_correction_factor));
         gsl::at(gsl::at(*scattering_opacity, ns), ng)[p] *=
             square(square(temperature_correction_factor));
+        gsl::at(gsl::at(*absorption_opacity, ns), ng)[p] =
+            std::clamp(gsl::at(gsl::at(*absorption_opacity, ns), ng)[p],
+                       min_kappa, max_kappa);
+        gsl::at(gsl::at(*scattering_opacity, ns), ng)[p] =
+            std::clamp(gsl::at(gsl::at(*scattering_opacity, ns), ng)[p],
+                       min_kappa, max_kappa);
       }
     }
   }

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
@@ -20,13 +20,7 @@
 
 namespace{
 
-void test_flat_space_time_step(const bool skip) {
-  CHECK(true);
-  // This test FPEs because the ghost zone handling is broken.
-  if (skip) {
-    return;
-  }
-
+void test_flat_space_time_step() {
   const Mesh<3> mesh(2, Spectral::Basis::FiniteDifference,
                      Spectral::Quadrature::CellCentered);
 
@@ -270,5 +264,5 @@ void test_flat_space_time_step(const bool skip) {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarloTakeTimeStep",
                   "[Unit][Evolution]") {
-  test_flat_space_time_step(true);
+  test_flat_space_time_step();
 }

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_TimeStepAction.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_TimeStepAction.cpp
@@ -119,12 +119,7 @@ struct Metavariables {
                  Particles::MonteCarlo::Tags::InteractionRatesTable<4, 3>>;
 };
 
-void test_advance_packets(const bool skip) {
-  CHECK(true);
-  // This test FPEs because the ghost zone handling is broken.
-  if (skip) {
-    return;
-  }
+void test_advance_packets() {
 
   MAKE_GENERATOR(generator);
   const size_t Dim = 3;
@@ -202,7 +197,8 @@ void test_advance_packets(const bool skip) {
 
   // Fluid variables
   Scalar<DataVector> rest_mass_density(zero_dv);
-  Scalar<DataVector> lorentz_factor(zero_dv);
+  Scalar<DataVector> lorentz_factor =
+    make_with_value<Scalar<DataVector>>(lapse, 1.0);;
   Scalar<DataVector> electron_fraction(zero_dv);
   Scalar<DataVector> temperature(zero_dv);
   tnsr::i<DataVector, 3, Frame::Inertial> lower_spatial_four_velocity =
@@ -343,5 +339,5 @@ void test_advance_packets(const bool skip) {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarloTimeStepAction",
                   "[Unit][Evolution]") {
-  test_advance_packets(true);
+  test_advance_packets();
 }


### PR DESCRIPTION
## Proposed changes

Make two fixes to unsafe part of the MC code when a zero density is provided to the neutrino interaction table; this allows us to restore 1/2 failing MC tests.

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
