### PR TITLE
Change the GaugePlaneWave implementations for SO-CCZ4 in development.

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.cpp
@@ -23,9 +23,9 @@ GaugePlaneWave<Dim>::GaugePlaneWave(CkMigrateMessage* /*msg*/) {}
 
 template <size_t Dim>
 GaugePlaneWave<Dim>::GaugePlaneWave(
-    std::array<double, Dim> wave_vector,
+    const std::array<double, Dim>& wave_vector,
     std::unique_ptr<MathFunction<1, Frame::Inertial>> profile)
-    : wave_vector_(std::move(wave_vector)),
+    : wave_vector_(wave_vector),
       profile_(std::move(profile)),
       omega_(magnitude(wave_vector_)) {}
 
@@ -64,6 +64,7 @@ GaugePlaneWave<Dim>::IntermediateVars<DataType>::IntermediateVars(
   }
   h = profile->operator()(u);
   du_h = profile->first_deriv(u);
+  du_du_h = profile->second_deriv(u);
   det_gamma = 1.0 + h * square(omega);
   lapse = 1.0 / sqrt(det_gamma);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Change the GaugePlaneWave implementations for SO-CCZ4 in development. The struct IntermediateVars is moved to public so one can easily construct the h function and its derivatives.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
