### PR TITLE
Constraint damping gaussian's amplitudes are exchanged

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -195,12 +195,12 @@ EvolutionSystem:
       TimeDependentTripleGaussian:
         Constant: {{ Gamma0Constant }}
         Gaussian1:
-          Amplitude: {{ Gamma0LeftAmplitude }}
-          Width: {{ Gamma0LeftWidth }}
+          Amplitude: {{ Gamma0RightAmplitude }}
+          Width: {{ Gamma0RightWidth }}
           Center: [*XCoordA, *YOffset, *ZOffset]
         Gaussian2:
-          Amplitude: {{ Gamma0RightAmplitude }}
-          Width:  {{ Gamma0RightWidth }}
+          Amplitude: {{ Gamma0LeftAmplitude }}
+          Width:  {{ Gamma0LeftWidth }}
           Center: [*XCoordB, *YOffset, *ZOffset]
         Gaussian3:
           Amplitude: {{ Gamma0OriginAmplitude }}


### PR DESCRIPTION
## Proposed changes

It seems to me that the amplitudes and widths for constraint damping are exchanged in the Inspiral yaml file. Object A should correspond to MassRight and viceversa. This will make a difference for unequal mass ratio evolutions.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
