### PR TITLE
Add transformation to tortoise radius

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -29,6 +29,7 @@ spectre_target_sources(
   SpatialMetric.cpp
   TimeDerivativeOfSpacetimeMetric.cpp
   TimeDerivativeOfSpatialMetric.cpp
+  TortoiseCoordinates.cpp
   WeylElectric.cpp
   WeylMagnetic.cpp
   WeylPropagating.cpp
@@ -63,6 +64,7 @@ spectre_target_headers(
   TagsDeclarations.hpp
   TimeDerivativeOfSpacetimeMetric.hpp
   TimeDerivativeOfSpatialMetric.hpp
+  TortoiseCoordinates.hpp
   WeylElectric.hpp
   WeylMagnetic.hpp
   WeylPropagating.hpp
@@ -75,6 +77,8 @@ target_link_libraries(
   DataStructures
   Domain
   Utilities
+  PRIVATE
+  RootFinding
   INTERFACE
   ErrorHandling
   )

--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -23,6 +23,7 @@
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
@@ -294,5 +295,19 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
         py::arg("spatial_ricci"), py::arg("extrinsic_curvature"),
         py::arg("cov_deriv_extrinsic_curvature"), py::arg("spatial_metric"),
         py::arg("inverse_spatial_metric"), py::arg("inertial_coords"));
+  m.def("tortoise_radius_from_boyer_lindquist_minus_r_plus",
+        &::gr::tortoise_radius_from_boyer_lindquist_minus_r_plus<double>,
+        py::arg("r_minus_r_plus"), py::arg("mass"),
+        py::arg("dimensionless_spin"));
+  m.def("tortoise_radius_from_boyer_lindquist_minus_r_plus",
+        &::gr::tortoise_radius_from_boyer_lindquist_minus_r_plus<DataVector>,
+        py::arg("r_minus_r_plus"), py::arg("mass"),
+        py::arg("dimensionless_spin"));
+  m.def("boyer_lindquist_radius_minus_r_plus_from_tortoise",
+        &::gr::boyer_lindquist_radius_minus_r_plus_from_tortoise<double>,
+        py::arg("r_star"), py::arg("mass"), py::arg("dimensionless_spin"));
+  m.def("boyer_lindquist_radius_minus_r_plus_from_tortoise",
+        &::gr::boyer_lindquist_radius_minus_r_plus_from_tortoise<DataVector>,
+        py::arg("r_star"), py::arg("mass"), py::arg("dimensionless_spin"));
 }
 }  // namespace GeneralRelativity::py_bindings

--- a/src/PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Simd/Simd.hpp"
+
+namespace gr {
+
+template <typename DataType>
+DataType tortoise_radius_from_boyer_lindquist_minus_r_plus(
+    const DataType& r_minus_r_plus, const double mass,
+    const double dimensionless_spin) {
+  const double r_plus = 1.0 + sqrt(1.0 - square(dimensionless_spin));
+  return r_minus_r_plus + r_plus * mass +
+         (r_plus * log(0.5 * r_minus_r_plus / mass) +
+          (r_plus - 2.0) * log(0.5 * r_minus_r_plus / mass + r_plus - 1.0)) *
+             mass / (r_plus - 1.0);
+}
+
+template <typename DataType>
+DataType boyer_lindquist_radius_minus_r_plus_from_tortoise(
+    const DataType& r_star, const double mass,
+    const double dimensionless_spin) {
+  const auto residual = [&r_star, &mass, &dimensionless_spin](
+                            const auto r_minus_r_plus, const size_t i = 0) {
+    if constexpr (simd::is_batch<
+                      std::decay_t<decltype(r_minus_r_plus)>>::value) {
+      return tortoise_radius_from_boyer_lindquist_minus_r_plus(
+                 r_minus_r_plus, 1.0, dimensionless_spin) -
+             simd::load_unaligned(&(get_element(r_star, i))) / mass;
+    } else {
+      return tortoise_radius_from_boyer_lindquist_minus_r_plus(
+                 r_minus_r_plus, 1.0, dimensionless_spin) -
+             get_element(r_star, i) / mass;
+    }
+  };
+  // Possible performance optimization: tighten these bounds, e.g. by treating
+  // small and large tortoise radii separately.
+  const auto lower_bound = make_with_value<DataType>(r_star, 1e-14);
+  DataType upper_bound = blaze::max(r_star / mass, 5.0);
+  upper_bound =
+      RootFinder::toms748(residual, lower_bound, upper_bound, 0.0, 1e-14) *
+      mass;
+  return upper_bound;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template DTYPE(data) tortoise_radius_from_boyer_lindquist_minus_r_plus( \
+      const DTYPE(data) & r_minus_r_plus, double mass,                    \
+      double dimensionless_spin);                                         \
+  template DTYPE(data) boyer_lindquist_radius_minus_r_plus_from_tortoise( \
+      const DTYPE(data) & r_star, double mass, double dimensionless_spin);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace gr {
+
+/*!
+ * \brief Computes the tortoise coordinates radius from the Boyer-Lindquist
+ * radius.
+ *
+ * This function evaluates the transformation from tortoise coordinates $r_*$ to
+ * Boyer-Lindquist radius $r$:
+ * \begin{equation}
+ * r_* = r + \frac{2 M}{r_+ - r_-}\left(
+ *   r_+ \ln(\frac{r - r_+}{2 M}) - r_- \ln(\frac{r - r_-}{2 M}) \right)
+ * \end{equation}
+ * where $r_\pm = M \pm \sqrt{M^2 - a^2}$.
+ *
+ * \param r_minus_r_plus Boyer-Lindquist radius minus $r_+$: $r - r_+$.
+ * \param mass Kerr mass parameter $M$.
+ * \param dimensionless_spin Kerr dimensionless spin parameter $\chi=a/M$.
+ * \return Tortoise coordinates radius $r_*$.
+ */
+template <typename DataType>
+DataType tortoise_radius_from_boyer_lindquist_minus_r_plus(
+    const DataType& r_minus_r_plus, double mass, double dimensionless_spin);
+
+/*!
+ * \brief Computes the Boyer-Lindquist radius from tortoise coordinates.
+ *
+ * This function inverts the transformation from tortoise coordinates radius
+ * $r_*$ to Boyer-Lindquist radius $r$:
+ * \begin{equation}
+ * r_* = r + \frac{2 M}{r_+ - r_-}\left(
+ *   r_+ \ln(\frac{r - r_+}{2 M}) - r_- \ln(\frac{r - r_-}{2 M}) \right)
+ * \end{equation}
+ * where $r_\pm = M \pm \sqrt{M^2 - a^2}$.
+ *
+ * It performs a numerical rootfind to invert the above equation.
+ *
+ * \param r_star Tortoise coordinate $r_*$.
+ * \param mass Kerr mass parameter $M$.
+ * \param dimensionless_spin Kerr dimensionless spin parameter $\chi=a/M$.
+ * \return Boyer-Lindquist radius minus $r_+$: $r - r_+$.
+ */
+template <typename DataType>
+DataType boyer_lindquist_radius_minus_r_plus_from_tortoise(
+    const DataType& r_star, double mass, double dimensionless_spin);
+
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Test_Ricci.cpp
   Test_SpacetimeDerivativeOfGothG.cpp
   Test_Tags.cpp
+  Test_TortoiseCoordinates.cpp
   Test_WeylElectric.cpp
   Test_WeylMagnetic.cpp
   Test_WeylPropagating.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -213,6 +213,20 @@ class TestBindings(unittest.TestCase):
         )
         npt.assert_allclose(t_deriv_of_spatial_metric_test, 0)
 
+    def test_tortoise_coordinates(self):
+        npt.assert_allclose(
+            tortoise_radius_from_boyer_lindquist_minus_r_plus(
+                0.55692908552214748, 1.0, 0.0
+            ),
+            0.0,
+            atol=1e-14,
+        )
+        npt.assert_allclose(
+            boyer_lindquist_radius_minus_r_plus_from_tortoise(0.0, 1.0, 0.0),
+            0.55692908552214748,
+            atol=1e-14,
+        )
+
     def test_weyl_electric(self):
         spatial_ricci = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)
         extrinsic_curvature = tnsr.ii[DataVector, 3](num_points=1, fill=0.0)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_TortoiseCoordinates.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_TortoiseCoordinates.cpp
@@ -1,0 +1,59 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.hpp"
+
+namespace gr {
+
+SPECTRE_TEST_CASE("Unit.GeneralRelativity.TortoiseCoordinates",
+                  "[Unit][PointwiseFunctions]") {
+  MAKE_GENERATOR(generator);
+  {
+    INFO("Random values");
+    const pypp::SetupLocalPythonEnvironment local_python_env(
+        "PointwiseFunctions/GeneralRelativity");
+    pypp::check_with_random_values<3>(
+        tortoise_radius_from_boyer_lindquist_minus_r_plus<DataVector>,
+        "TortoiseCoordinates",
+        "tortoise_radius_from_boyer_lindquist_minus_r_plus",
+        {{{0.3, 10.0}, {0.3, 1.0}, {0.3, 1.0}}}, DataVector(5));
+  }
+  {
+    INFO("Inverse");
+    const size_t num_samples = 100;
+    std::uniform_real_distribution<> dist_mass(0.1, 2.0);
+    std::uniform_real_distribution<> dist_spin(0.0, 1.0);
+    std::uniform_real_distribution<> dist_tortoise(-50.0, 100.0);
+    const double mass = dist_mass(generator);
+    const double dimensionless_spin = dist_spin(generator);
+    const DataVector r_star = make_with_random_values<DataVector>(
+                                  make_not_null(&generator),
+                                  make_not_null(&dist_tortoise), num_samples) *
+                              mass;
+    CAPTURE(mass);
+    CAPTURE(dimensionless_spin);
+    CAPTURE(r_star);
+    const auto r_minus_r_plus =
+        boyer_lindquist_radius_minus_r_plus_from_tortoise(r_star, mass,
+                                                          dimensionless_spin);
+    CHECK_ITERABLE_APPROX(tortoise_radius_from_boyer_lindquist_minus_r_plus(
+                              r_minus_r_plus, mass, dimensionless_spin),
+                          r_star);
+  }
+  {
+    INFO("Specific values");
+    CHECK(boyer_lindquist_radius_minus_r_plus_from_tortoise(0.0, 1.0, 0.0) ==
+          approx(0.55692908552214748));
+  }
+}
+
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.py
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def tortoise_radius_from_boyer_lindquist_minus_r_plus(
+    r_minus_r_plus, mass, dimensionless_spin
+):
+    r_plus = mass * (1.0 + np.sqrt(1.0 - dimensionless_spin**2))
+    r_minus = mass * (1.0 - np.sqrt(1.0 - dimensionless_spin**2))
+    r = r_minus_r_plus + r_plus
+    return r + 2 * mass / (r_plus - r_minus) * (
+        r_plus * np.log(r_minus_r_plus / (2 * mass))
+        - r_minus * np.log((r - r_minus) / (2 * mass))
+    )


### PR DESCRIPTION
## Proposed changes

Bundles some root-finding code from https://github.com/tosburn3/KerrGeodesicsC to transform between Boyer-Lindquist and tortoise radius. The bundled code has figured out good initial guesses and a robust method for the root find.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
