### PR TITLE
Fix shape map loaded from file

### DIFF
--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
@@ -217,7 +217,9 @@ struct ShapeMapOptions {
     static constexpr Options::String help = {
         "Initial value and two derivatives of the 00 coefficient. Specify "
         "'Auto' to use the 00 coefficient specified in the 'InitialValues' "
-        "option."};
+        "option. If you specify 'Auto', the deformed sphere will match the "
+        "'InitialValues' surface exactly, and the original radius will only "
+        "set the radius of the sphere in the grid frame (before deformation)."};
   };
 
   struct TransitionEndsAtCube {
@@ -262,5 +264,5 @@ template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
 std::pair<std::array<DataVector, 3>, std::array<DataVector, 4>>
 initial_shape_and_size_funcs(
     const ShapeMapOptions<IncludeTransitionEndsAtCube, Object>& shape_options,
-    double inner_radius);
+    double deformed_radius);
 }  // namespace domain::creators::time_dependent_options

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ShapeMap.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ShapeMap.cpp
@@ -377,12 +377,16 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
       for (size_t i = 0; i < shape_funcs.size(); i++) {
         CHECK(gsl::at(shape_funcs, i)[0] == 0.0);
       }
-      CHECK(size_funcs ==
-            std::array{DataVector{-1.0 * strahlkorpers[0].coefficients()[0] *
-                                  sqrt(0.5 * M_PI)},
-                       DataVector{-1.0 * strahlkorpers[1].coefficients()[0] *
-                                  sqrt(0.5 * M_PI)},
-                       DataVector{0.0}, DataVector{0.0}});
+      CHECK_ITERABLE_APPROX(
+          size_funcs,
+          (std::array{
+              DataVector{(inner_radius - ylm::Spherepack::average(
+                                             strahlkorpers[0].coefficients())) *
+                         2.0 * sqrt(M_PI)},
+              DataVector{(inner_radius - ylm::Spherepack::average(
+                                             strahlkorpers[1].coefficients())) *
+                         2.0 * sqrt(M_PI)},
+              DataVector{0.0}, DataVector{0.0}}));
     }
 
     if (file_system::check_if_file_exists(test_filename)) {


### PR DESCRIPTION
## Proposed changes

The size of the domain didn't match the Strahlkorper in the file because the loaded l=0, m=0 coefficient was interpreted as a deformation/scale. Fixed by subtracting the size of the original sphere.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
