### PR TITLE
Add features to CCE worldtube buffer updaters

### DIFF
--- a/src/Evolution/Executables/Cce/CharacteristicExtract.cpp
+++ b/src/Evolution/Executables/Cce/CharacteristicExtract.cpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include "DataStructures/ComplexModalVector.hpp"
 #include "Evolution/Systems/Cce/Initialize/RegisterInitializeJWithCharm.hpp"
 #include "NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp"
 #include "NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp"
@@ -21,8 +22,8 @@ extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_init_node_and_proc(
       {&Cce::register_initialize_j_with_charm<
            metavariables::evolve_ccm, metavariables::cce_boundary_component>,
-       &register_derived_classes_with_charm<
-           Cce::WorldtubeBufferUpdater<Cce::cce_metric_input_tags>>,
+       &register_derived_classes_with_charm<Cce::WorldtubeBufferUpdater<
+           Cce::cce_metric_input_tags<ComplexModalVector>>>,
        &register_derived_classes_with_charm<Cce::WorldtubeBufferUpdater<
            Cce::Tags::worldtube_boundary_tags_for_writing<
                Spectral::Swsh::Tags::SwshTransform>>>,

--- a/src/Evolution/Executables/Cce/KleinGordonCharacteristicExtract.cpp
+++ b/src/Evolution/Executables/Cce/KleinGordonCharacteristicExtract.cpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include "DataStructures/ComplexModalVector.hpp"
 #include "Evolution/Systems/Cce/Initialize/RegisterInitializeJWithCharm.hpp"
 #include "Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp"
 #include "Evolution/Systems/Cce/WorldtubeDataManager.hpp"
@@ -23,8 +24,8 @@ extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_init_node_and_proc(
       {&Cce::register_initialize_j_with_charm<
            metavariables::evolve_ccm, metavariables::cce_boundary_component>,
-       &register_derived_classes_with_charm<
-           Cce::WorldtubeBufferUpdater<Cce::cce_metric_input_tags>>,
+       &register_derived_classes_with_charm<Cce::WorldtubeBufferUpdater<
+           Cce::cce_metric_input_tags<ComplexModalVector>>>,
        &register_derived_classes_with_charm<Cce::WorldtubeBufferUpdater<
            Cce::Tags::worldtube_boundary_tags_for_writing<
                Spectral::Swsh::Tags::SwshTransform>>>,

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -7,6 +7,8 @@
 #include <limits>
 #include <optional>
 
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
@@ -338,8 +340,8 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
             "clearer.\n");
       }
       return std::make_unique<BondiWorldtubeDataManager>(
-          std::make_unique<BondiWorldtubeH5BufferUpdater>(filename,
-                                                          extraction_radius),
+          std::make_unique<BondiWorldtubeH5BufferUpdater<ComplexModalVector>>(
+              filename, extraction_radius),
           l_max, number_of_lookahead_times, interpolator->get_clone());
     } else {
       Parallel::printf(
@@ -351,8 +353,8 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
           "details. Support for reading the Metric data format will be "
           "dropped in January 2025.\n");
       return std::make_unique<MetricWorldtubeDataManager>(
-          std::make_unique<MetricWorldtubeH5BufferUpdater>(filename,
-                                                           extraction_radius),
+          std::make_unique<MetricWorldtubeH5BufferUpdater<ComplexModalVector>>(
+              filename, extraction_radius),
           l_max, number_of_lookahead_times, interpolator->get_clone(),
           fix_spec_normalization);
     }
@@ -461,11 +463,13 @@ struct StartTimeFromFile : Tags::StartTime, db::SimpleTag {
       return *start_time;
     }
     if (is_bondi_data) {
-      BondiWorldtubeH5BufferUpdater h5_boundary_updater{filename};
+      BondiWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
+          filename};
       const auto& time_buffer = h5_boundary_updater.get_time_buffer();
       return time_buffer[0];
     } else {
-      MetricWorldtubeH5BufferUpdater h5_boundary_updater{filename};
+      MetricWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
+          filename};
       const auto& time_buffer = h5_boundary_updater.get_time_buffer();
       return time_buffer[0];
     }
@@ -510,11 +514,13 @@ struct EndTimeFromFile : Tags::EndTime, db::SimpleTag {
       return *end_time;
     }
     if (is_bondi_data) {
-      BondiWorldtubeH5BufferUpdater h5_boundary_updater{filename};
+      BondiWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
+          filename};
       const auto& time_buffer = h5_boundary_updater.get_time_buffer();
       return time_buffer[time_buffer.size() - 1];
     } else {
-      MetricWorldtubeH5BufferUpdater h5_boundary_updater{filename};
+      MetricWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
+          filename};
       const auto& time_buffer = h5_boundary_updater.get_time_buffer();
       return time_buffer[time_buffer.size() - 1];
     }

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -15,6 +16,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/Cce/ExtractionRadius.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
@@ -22,9 +24,13 @@
 #include "IO/H5/File.hpp"
 #include "IO/H5/Version.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Math.hpp"
@@ -76,7 +82,8 @@ std::pair<size_t, size_t> create_span_for_time_value(
 
 void set_time_buffer_and_lmax(const gsl::not_null<DataVector*> time_buffer,
                               size_t& l_max, const h5::Dat& data,
-                              const bool is_real) {
+                              const bool is_real, const bool is_modal_data,
+                              const bool is_complex) {
   const auto data_table_dimensions = data.get_dimensions();
   const Matrix time_matrix =
       data.get_data_subset(std::vector<size_t>{0}, 0, data_table_dimensions[0]);
@@ -86,80 +93,165 @@ void set_time_buffer_and_lmax(const gsl::not_null<DataVector*> time_buffer,
     (*time_buffer)[i] = time_matrix(i, 0);
   }
 
-  // If the quantitiy is real, then there's no way for us to do a check just
-  // from the number of columns alone. If not, then we expect an even number of
-  // total modes (both real and imaginary), so the number of columns should be
-  // odd with the addition of the time column
-  if (not is_real and data_table_dimensions[1] % 2 != 1) {
-    ERROR("Dimensions of subfile "
-          << data.subfile_path()
-          << " are incorrect. Was expecting an odd number of columns (because "
-             "of the time), but got "
-          << data_table_dimensions[1] << " instead.");
+  if (is_modal_data) {
+    // If the quantitiy is real, then there's no way for us to do a check just
+    // from the number of columns alone. If not, then we expect an even number
+    // of total modes (both real and imaginary), so the number of columns should
+    // be odd with the addition of the time column
+    if (not is_real and data_table_dimensions[1] % 2 != 1) {
+      ERROR("Dimensions of subfile "
+            << data.subfile_path()
+            << " for modal data are incorrect. Was expecting an odd number of "
+               "columns (because of the time), but got "
+            << data_table_dimensions[1] << " instead.");
+    }
+
+    // If it's real the number of columns is (l+1)^2. If it's not, then it's
+    // 2(l+1)^2
+    const size_t l_plus_one_squared =
+        (data_table_dimensions[1] - 1) / (is_real ? 1 : 2);
+    l_max =
+        static_cast<size_t>(sqrt(static_cast<double>(l_plus_one_squared)) - 1);
+  } else {
+    // Can only check number of columns for nodal data if it's complex
+    if (is_complex and data_table_dimensions[1] % 2 != 1) {
+      ERROR("Dimensions of subfile "
+            << data.subfile_path()
+            << " for nodal data are incorrect. Was expecting an odd number of "
+               "columns (because of the time), but got "
+            << data_table_dimensions[1] << " instead.");
+    }
+
+    // If number of real values N = (l+1)*(2l+1), then
+    // l = ( -3 + sqrt(9 + 8 * (N-1)) ) / 4. But the dimensions[1] includes time
+    // so we have to account for that by subtracting 1. Also, if this is complex
+    // nodal data, we have to do N=(dimensions[1]-1)/2 first
+    const size_t num_real_values = is_complex
+                                       ? (data_table_dimensions[1] - 1) / 2
+                                       : data_table_dimensions[1] - 1;
+    if (num_real_values == 0) {
+      ERROR("Not enough columns to read "
+            << (is_complex ? "complex" : "real")
+            << " nodal data from. Number of columns in file ("
+            << data_table_dimensions[1]
+            << "), number of columns without time column ("
+            << data_table_dimensions[1] << "), number of real valued columns ("
+            << num_real_values << ")");
+    }
+    const size_t discriminant = 9 + 8 * (num_real_values - 1);
+    l_max =
+        static_cast<size_t>((sqrt(static_cast<double>(discriminant)) - 3)) / 4;
   }
-  // Avoid compiler warning
-  const size_t l_plus_one_squared = (data_table_dimensions[1] - 1) / 2;
-  l_max =
-      static_cast<size_t>(sqrt(static_cast<double>(l_plus_one_squared)) - 1);
 }
 
-void update_buffer_with_modal_data(
-    const gsl::not_null<ComplexModalVector*> buffer_to_update,
-    const h5::Dat& read_data, const size_t computation_l_max,
-    const size_t l_max, const size_t time_span_start,
-    const size_t time_span_end, const bool is_real) {
+template <bool IsModal, int Spin, typename T>
+void update_buffer(const gsl::not_null<T*> buffer_to_update,
+                   const h5::Dat& read_data, const size_t computation_l_max,
+                   const size_t l_max, const size_t time_span_start,
+                   const size_t time_span_end,
+                   const bool time_varies_fastest = true) {
+  constexpr bool is_real = Spin == 0;
   size_t number_of_columns = read_data.get_dimensions()[1];
-  if (UNLIKELY(buffer_to_update->size() !=
-               square(computation_l_max + 1) *
-                   (time_span_end - time_span_start))) {
-    ERROR("Incorrect storage size for the data to be loaded in.");
+  const size_t result_l_max = std::min(l_max, computation_l_max);
+  // No x2 because the datatypes are std::complex
+  const size_t expected_size =
+      (time_span_end - time_span_start) *
+      (IsModal ? square(computation_l_max + 1)
+               : Spectral::Swsh::number_of_swsh_collocation_points(
+                     computation_l_max));
+
+  if (UNLIKELY(buffer_to_update->size() != expected_size)) {
+    ERROR("Incorrect storage size for the data to be loaded in. Expected "
+          << expected_size << ", but got " << buffer_to_update->size()
+          << " instead.");
   }
+
   std::vector<size_t> cols(number_of_columns - 1);
   std::iota(cols.begin(), cols.end(), 1);
   auto data_matrix =
       read_data.get_data_subset<std::vector<std::vector<double>>>(
           cols, time_span_start, time_span_end - time_span_start);
   *buffer_to_update = 0.0;
+
+  // For modal, only x2 if it's not real. If nodal, always x2
+  const size_t expected_dat_modal_size = (is_real ? 1 : 2) * square(l_max + 1);
+  const size_t expected_dat_nodal_size =
+      2 * Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  if (cols.size() !=
+      (IsModal ? expected_dat_modal_size : expected_dat_nodal_size)) {
+    ERROR("Incorrect number of columns in Dat file "
+          << read_data.subfile_path() << ". Expected (excluding time column) "
+          << (IsModal ? expected_dat_modal_size : expected_dat_nodal_size)
+          << ", but got " << cols.size());
+  }
+
   for (size_t time_row = 0; time_row < time_span_end - time_span_start;
        ++time_row) {
-    for (int l = 0; l <= static_cast<int>(std::min(computation_l_max, l_max));
-         ++l) {
-      for (int m = -l; m <= l; ++m) {
-        const size_t computation_goldber_index =
-            Spectral::Swsh::goldberg_mode_index(computation_l_max,
-                                                static_cast<size_t>(l), m) *
-                (time_span_end - time_span_start) +
-            time_row;
-        // NOLINTBEGIN
-        if (is_real) {
-          if (m == 0) {
-            (*buffer_to_update)[computation_goldber_index] =
-                std::complex<double>(
-                    data_matrix[time_row][static_cast<size_t>(square(l))], 0.0);
+    // For modal data we have to compute the correct goldberg mode indices for
+    // each l and m
+    if constexpr (IsModal) {
+      for (int l = 0; l <= static_cast<int>(result_l_max); ++l) {
+        for (int m = -l; m <= l; ++m) {
+          const size_t buffer_index =
+              time_varies_fastest
+                  ? Spectral::Swsh::goldberg_mode_index(
+                        computation_l_max, static_cast<size_t>(l), m) *
+                            (time_span_end - time_span_start) +
+                        time_row
+                  : time_row * square(computation_l_max + 1) +
+                        Spectral::Swsh::goldberg_mode_index(
+                            computation_l_max, static_cast<size_t>(l), m);
+          // NOLINTBEGIN
+          // If this quantity is real we don't expect to store the imaginary m=0
+          // modes in the H5 file so those have to be handled specially. Then
+          // for +/- and even/odd m-modes we have to have the correct sign for
+          // the coefficient.
+          if (is_real) {
+            if (m == 0) {
+              (*buffer_to_update)[buffer_index] = std::complex<double>(
+                  data_matrix[time_row][static_cast<size_t>(square(l))], 0.0);
+            } else {
+              const double factor = (m > 0 or abs(m) % 2 == 0) ? 1.0 : -1.0;
+              const size_t matrix_index =
+                  static_cast<size_t>(square(l) + 2 * abs(m));
+              (*buffer_to_update)[buffer_index] =
+                  factor * std::complex<double>(
+                               data_matrix[time_row][matrix_index - 1],
+                               sgn(m) * data_matrix[time_row][matrix_index]);
+            }
           } else {
-            const double factor = (m > 0 or abs(m) % 2 == 0) ? 1.0 : -1.0;
-            (*buffer_to_update)[computation_goldber_index] =
-                factor * std::complex<double>(
-                             data_matrix[time_row][static_cast<size_t>(
-                                 square(l) + 2 * abs(m) - 1)],
-                             sgn(m) * data_matrix[time_row][static_cast<size_t>(
-                                          square(l) + 2 * abs(m))]);
+            // If this quantity is complex, then it's straight forward to
+            // populate the buffer
+            const size_t matrix_goldberg_index =
+                Spectral::Swsh::goldberg_mode_index(l_max,
+                                                    static_cast<size_t>(l), m);
+            (*buffer_to_update)[buffer_index] = std::complex<double>(
+                data_matrix[time_row][2 * matrix_goldberg_index],
+                data_matrix[time_row][2 * matrix_goldberg_index + 1]);
           }
-        } else {
-          (*buffer_to_update)[computation_goldber_index] = std::complex<double>(
-              data_matrix[time_row][2 * Spectral::Swsh::goldberg_mode_index(
-                                            l_max, static_cast<size_t>(l), m)],
-              data_matrix[time_row][2 * Spectral::Swsh::goldberg_mode_index(
-                                            l_max, static_cast<size_t>(l), m) +
-                                    1]);
+          // NOLINTEND
         }
-        // NOLINTEND
+      }
+    } else {
+      (void)result_l_max;
+      // For nodal data, it must be complex so for each grid point we just read
+      // in the real and imaginary components
+      const size_t number_of_angular_points =
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+      for (size_t i = 0; i < number_of_angular_points; i++) {
+        const size_t buffer_index =
+            time_varies_fastest
+                ? i * (time_span_end - time_span_start) + time_row
+                : time_row * number_of_angular_points + i;
+        (*buffer_to_update)[buffer_index] = std::complex<double>(
+            data_matrix[time_row][2 * i], data_matrix[time_row][2 * i + 1]);
       }
     }
   }
 }
 
-template <typename InputTags>
+template <bool IsModal, typename InputTags>
 double update_buffers_for_time(
     const gsl::not_null<Variables<InputTags>*> buffers,
     const gsl::not_null<size_t*> time_span_start,
@@ -169,7 +261,17 @@ double update_buffers_for_time(
     const DataVector& time_buffer,
     const tuples::tagged_tuple_from_typelist<
         db::wrap_tags_in<Tags::detail::InputDataSet, InputTags>>& dataset_names,
-    const h5::H5File<h5::AccessType::ReadOnly>& cce_data_file) {
+    const h5::H5File<h5::AccessType::ReadOnly>& cce_data_file,
+    const bool time_varies_fastest = true) {
+  if (not IsModal and computation_l_max != l_max) {
+    ERROR(
+        "When reading in nodal data, the LMax that "
+        "the BufferUpdater was constructed with ("
+        << l_max
+        << ") must be the same as the computation LMax passed to the "
+           "update_buffers_for_time function ("
+        << computation_l_max << ").");
+  }
   if (*time_span_end >= time_buffer.size()) {
     return std::numeric_limits<double>::quiet_NaN();
   }
@@ -185,16 +287,14 @@ double update_buffers_for_time(
   *time_span_start = new_span_pair.first;
   *time_span_end = new_span_pair.second;
   // load the desired time spans into the buffers
-  tmpl::for_each<InputTags>([&buffers, &time_span_start, &time_span_end,
-                             &computation_l_max, &l_max, &cce_data_file,
-                             &dataset_names](auto tag_v) {
+  tmpl::for_each<InputTags>([&](auto tag_v) {
     using tag = typename decltype(tag_v)::type;
-    update_buffer_with_modal_data(
+    update_buffer<IsModal, tag::type::type::spin>(
         make_not_null(&get(get<tag>(*buffers)).data()),
         cce_data_file.get<h5::Dat>(
             "/" + get<Tags::detail::InputDataSet<tag>>(dataset_names)),
         computation_l_max, l_max, *time_span_start, *time_span_end,
-        tag::type::type::spin == 0);
+        time_varies_fastest);
     cce_data_file.close_current_object();
   });
   // the next time an update will be required
@@ -204,31 +304,33 @@ double update_buffers_for_time(
 
 }  // namespace detail
 
-MetricWorldtubeH5BufferUpdater::MetricWorldtubeH5BufferUpdater(
+template <typename T>
+MetricWorldtubeH5BufferUpdater<T>::MetricWorldtubeH5BufferUpdater(
     const std::string& cce_data_filename,
     const std::optional<double> extraction_radius, const bool file_is_from_spec)
     : cce_data_file_{cce_data_filename},
       filename_{cce_data_filename},
       file_is_from_spec_(file_is_from_spec) {
-  get<Tags::detail::InputDataSet<Tags::detail::SpatialMetric>>(dataset_names_) =
-      "/g";
+  get<Tags::detail::InputDataSet<Tags::detail::SpatialMetric<T>>>(
+      dataset_names_) = "/g";
   get<Tags::detail::InputDataSet<
-      Tags::detail::Dr<Tags::detail::SpatialMetric>>>(dataset_names_) = "/Drg";
-  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::SpatialMetric>>>(
+      Tags::detail::Dr<Tags::detail::SpatialMetric<T>>>>(dataset_names_) =
+      "/Drg";
+  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::SpatialMetric<T>>>>(
       dataset_names_) = "/Dtg";
 
-  get<Tags::detail::InputDataSet<Tags::detail::Shift>>(dataset_names_) =
+  get<Tags::detail::InputDataSet<Tags::detail::Shift<T>>>(dataset_names_) =
       "/Shift";
-  get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Shift>>>(
+  get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Shift<T>>>>(
       dataset_names_) = "/DrShift";
-  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Shift>>>(
+  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Shift<T>>>>(
       dataset_names_) = "/DtShift";
 
-  get<Tags::detail::InputDataSet<Tags::detail::Lapse>>(dataset_names_) =
+  get<Tags::detail::InputDataSet<Tags::detail::Lapse<T>>>(dataset_names_) =
       "/Lapse";
-  get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Lapse>>>(
+  get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Lapse<T>>>>(
       dataset_names_) = "/DrLapse";
-  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Lapse>>>(
+  get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Lapse<T>>>>(
       dataset_names_) = "/DtLapse";
 
   // 'VersionHist' is a feature written by SpEC to indicate the details of the
@@ -242,17 +344,29 @@ MetricWorldtubeH5BufferUpdater::MetricWorldtubeH5BufferUpdater(
           .value();
 
   detail::set_time_buffer_and_lmax(make_not_null(&time_buffer_), l_max_,
-                                   cce_data_file_.get<h5::Dat>("/Lapse"),
-                                   false);
+                                   cce_data_file_.get<h5::Dat>("/Lapse"), false,
+                                   is_modal, is_modal);
   cce_data_file_.close_current_object();
 }
 
-double MetricWorldtubeH5BufferUpdater::update_buffers_for_time(
-    const gsl::not_null<Variables<cce_metric_input_tags>*> buffers,
+template <typename T>
+double MetricWorldtubeH5BufferUpdater<T>::update_buffers_for_time(
+    const gsl::not_null<Variables<cce_metric_input_tags<T>>*> buffers,
     const gsl::not_null<size_t*> time_span_start,
     const gsl::not_null<size_t*> time_span_end, const double time,
     const size_t computation_l_max, const size_t interpolator_length,
-    const size_t buffer_depth) const {
+    const size_t buffer_depth, const bool time_varies_fastest) const {
+  // We require these to be the same for nodal data since we can't easily
+  // extend nodal data like we can modal data.
+  if (not is_modal and computation_l_max != l_max_) {
+    ERROR(
+        "When reading in nodal data, the LMax that "
+        "MetricWorldtubeH5BufferUpdater was constructed with ("
+        << l_max_
+        << ") must be the same as the computation LMax passed to the "
+           "update_buffers_for_time function ("
+        << computation_l_max << ").");
+  }
   if (*time_span_end >= time_buffer_.size()) {
     return std::numeric_limits<double>::quiet_NaN();
   }
@@ -271,48 +385,43 @@ double MetricWorldtubeH5BufferUpdater::update_buffers_for_time(
   // spatial metric
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = i; j < 3; ++j) {
-      tmpl::for_each<tmpl::list<Tags::detail::SpatialMetric,
-                                Tags::detail::Dr<Tags::detail::SpatialMetric>,
-                                ::Tags::dt<Tags::detail::SpatialMetric>>>(
-          [this, &i, &j, &buffers, &time_span_start, &time_span_end,
-           &computation_l_max](auto tag_v) {
+      tmpl::for_each<
+          Tags::detail::apply_derivs_t<Tags::detail::SpatialMetric<T>>>(
+          [&, this](auto tag_v) {
             using tag = typename decltype(tag_v)::type;
             this->update_buffer(
                 make_not_null(&get<tag>(*buffers).get(i, j)),
                 cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
                     get<Tags::detail::InputDataSet<tag>>(dataset_names_), i,
                     j)),
-                computation_l_max, *time_span_start, *time_span_end);
+                computation_l_max, *time_span_start, *time_span_end,
+                time_varies_fastest);
             cce_data_file_.close_current_object();
           });
     }
     // shift
-    tmpl::for_each<
-        tmpl::list<Tags::detail::Shift, Tags::detail::Dr<Tags::detail::Shift>,
-                   ::Tags::dt<Tags::detail::Shift>>>(
-        [this, &i, &buffers, &time_span_start, &time_span_end,
-         &computation_l_max](auto tag_v) {
+    tmpl::for_each<Tags::detail::apply_derivs_t<Tags::detail::Shift<T>>>(
+        [&, this](auto tag_v) {
           using tag = typename decltype(tag_v)::type;
           this->update_buffer(
               make_not_null(&get<tag>(*buffers).get(i)),
               cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
                   get<Tags::detail::InputDataSet<tag>>(dataset_names_), i)),
-              computation_l_max, *time_span_start, *time_span_end);
+              computation_l_max, *time_span_start, *time_span_end,
+              time_varies_fastest);
           cce_data_file_.close_current_object();
         });
   }
   // lapse
-  tmpl::for_each<
-      tmpl::list<Tags::detail::Lapse, Tags::detail::Dr<Tags::detail::Lapse>,
-                 ::Tags::dt<Tags::detail::Lapse>>>(
-      [this, &buffers, &time_span_start, &time_span_end,
-       &computation_l_max](auto tag_v) {
+  tmpl::for_each<Tags::detail::apply_derivs_t<Tags::detail::Lapse<T>>>(
+      [&, this](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
         this->update_buffer(
             make_not_null(&get(get<tag>(*buffers))),
             cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
                 get<Tags::detail::InputDataSet<tag>>(dataset_names_))),
-            computation_l_max, *time_span_start, *time_span_end);
+            computation_l_max, *time_span_start, *time_span_end,
+            time_varies_fastest);
         cce_data_file_.close_current_object();
       });
   // the next time an update will be required
@@ -320,18 +429,21 @@ double MetricWorldtubeH5BufferUpdater::update_buffers_for_time(
                                time_buffer_.size() - 1)];
 }
 
-std::unique_ptr<WorldtubeBufferUpdater<cce_metric_input_tags>>
-MetricWorldtubeH5BufferUpdater::get_clone() const {
+template <typename T>
+std::unique_ptr<WorldtubeBufferUpdater<cce_metric_input_tags<T>>>
+MetricWorldtubeH5BufferUpdater<T>::get_clone() const {
   return std::make_unique<MetricWorldtubeH5BufferUpdater>(
       MetricWorldtubeH5BufferUpdater{filename_});
 }
 
-bool MetricWorldtubeH5BufferUpdater::time_is_outside_range(
+template <typename T>
+bool MetricWorldtubeH5BufferUpdater<T>::time_is_outside_range(
     const double time) const {
   return time < time_buffer_[0] or time > time_buffer_[time_buffer_.size() - 1];
 }
 
-void MetricWorldtubeH5BufferUpdater::pup(PUP::er& p) {
+template <typename T>
+void MetricWorldtubeH5BufferUpdater<T>::pup(PUP::er& p) {
   p | time_buffer_;
   p | has_version_history_;
   p | filename_;
@@ -344,71 +456,109 @@ void MetricWorldtubeH5BufferUpdater::pup(PUP::er& p) {
   }
 }
 
-void MetricWorldtubeH5BufferUpdater::update_buffer(
-    const gsl::not_null<ComplexModalVector*> buffer_to_update,
-    const h5::Dat& read_data, const size_t computation_l_max,
-    const size_t time_span_start, const size_t time_span_end) const {
+template <typename T>
+void MetricWorldtubeH5BufferUpdater<T>::update_buffer(
+    const gsl::not_null<T*> buffer_to_update, const h5::Dat& read_data,
+    const size_t computation_l_max, const size_t time_span_start,
+    const size_t time_span_end, const bool time_varies_fastest) const {
   const size_t number_of_columns = read_data.get_dimensions()[1];
-  if (UNLIKELY(buffer_to_update->size() != (time_span_end - time_span_start) *
-                                               square(computation_l_max + 1))) {
-    ERROR("Incorrect storage size for the data to be loaded in.");
+  const size_t expected_size =
+      (time_span_end - time_span_start) *
+      (is_modal ? square(computation_l_max + 1)
+                : Spectral::Swsh::number_of_swsh_collocation_points(
+                      computation_l_max));
+  // We require these to be the same since for nodal data we can't easily extend
+  // nodal data like we can modal data.
+  if (not is_modal and computation_l_max != l_max_) {
+    ERROR(
+        "When reading in nodal data, the LMax that "
+        "MetricWorldtubeH5BufferUpdater was constructed with ("
+        << l_max_
+        << ") must be the same as the computation LMax passed to the "
+           "update_buffer functions ("
+        << computation_l_max << ").");
+  }
+  if (UNLIKELY(buffer_to_update->size() != expected_size)) {
+    ERROR(
+        "Incorrect " << (is_modal ? "modal" : "nodal")
+                     << " storage size for the data to be loaded in. Expected "
+                     << expected_size << " but got " << buffer_to_update->size()
+                     << ". Time span is " << time_span_end << "-"
+                     << time_span_start << "="
+                     << time_span_end - time_span_start);
   }
   auto cols = alg::iota(std::vector<size_t>(number_of_columns - 1), 1_st);
-  const auto data_matrix =
+  auto data_matrix =
       read_data.get_data_subset<std::vector<std::vector<double>>>(
           cols, time_span_start, time_span_end - time_span_start);
 
   *buffer_to_update = 0.0;
   for (size_t time_row = 0; time_row < time_span_end - time_span_start;
        ++time_row) {
-    for (int l = 0; l <= static_cast<int>(std::min(computation_l_max, l_max_));
-         ++l) {
-      for (int m = -l; m <= l; ++m) {
-        // -m because SpEC format is stored in decending m.
-        const int em = file_is_from_spec_ ? -m : m;
-        (*buffer_to_update)[Spectral::Swsh::goldberg_mode_index(
-                                computation_l_max, static_cast<size_t>(l), m) *
-                                (time_span_end - time_span_start) +
-                            time_row] =
-            std::complex<double>(
-                data_matrix[time_row]
-                           [2 * Spectral::Swsh::goldberg_mode_index(
-                                    l_max_, static_cast<size_t>(l), em)],
-                data_matrix[time_row]
-                           [2 * Spectral::Swsh::goldberg_mode_index(
-                                    l_max_, static_cast<size_t>(l), em) +
-                            1]);
+    // If we have modal data, we must construct the ComplexModalVector
+    if constexpr (is_modal) {
+      for (int l = 0;
+           l <= static_cast<int>(std::min(computation_l_max, l_max_)); ++l) {
+        for (int m = -l; m <= l; ++m) {
+          // -m because SpEC format is stored in decending m.
+          const int em = file_is_from_spec_ ? -m : m;
+          const size_t matrix_mode_index = Spectral::Swsh::goldberg_mode_index(
+              l_max_, static_cast<size_t>(l), em);
+          const size_t buffer_mode_index = Spectral::Swsh::goldberg_mode_index(
+              computation_l_max, static_cast<size_t>(l), m);
+          const size_t buffer_index =
+              time_varies_fastest
+                  ? buffer_mode_index * (time_span_end - time_span_start) +
+                        time_row
+                  : time_row * square(computation_l_max + 1) +
+                        buffer_mode_index;
+
+          (*buffer_to_update)[buffer_index] = std::complex<double>(
+              data_matrix[time_row][2 * matrix_mode_index],
+              data_matrix[time_row][2 * matrix_mode_index + 1]);
+        }
+      }
+    } else {
+      // Otherwise we just read the nodal data in as is
+      for (size_t i = 0; i < cols.size(); i++) {
+        const size_t buffer_index =
+            time_varies_fastest
+                ? i * (time_span_end - time_span_start) + time_row
+                : time_row * cols.size() + i;
+        (*buffer_to_update)[buffer_index] = data_matrix[time_row][i];
       }
     }
   }
 }
 
-BondiWorldtubeH5BufferUpdater::BondiWorldtubeH5BufferUpdater(
+namespace {
+// Convenience metafunction to return the correct tag depending on the template
+// parameter T
+template <typename T, typename Tag>
+struct name_tag {
+  using type = Tags::detail::InputDataSet<tmpl::conditional_t<
+      std::is_same_v<T, ComplexModalVector>,
+      Spectral::Swsh::Tags::SwshTransform<Tag>, Tags::BoundaryValue<Tag>>>;
+};
+
+template <typename T, typename Tag>
+using name_tag_t = typename name_tag<T, Tag>::type;
+}  // namespace
+
+template <typename T>
+BondiWorldtubeH5BufferUpdater<T>::BondiWorldtubeH5BufferUpdater(
     const std::string& cce_data_filename,
     const std::optional<double> extraction_radius)
     : cce_data_file_{cce_data_filename}, filename_{cce_data_filename} {
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::BondiBeta>>>(dataset_names_) =
-      "Beta";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::BondiU>>>(dataset_names_) = "U";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::BondiQ>>>(dataset_names_) = "Q";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::BondiW>>>(dataset_names_) = "W";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::BondiJ>>>(dataset_names_) = "J";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::Dr<Tags::BondiJ>>>>(
-      dataset_names_) = "DrJ";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::Du<Tags::BondiJ>>>>(
-      dataset_names_) = "H";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::BondiR>>>(dataset_names_) = "R";
-  get<Tags::detail::InputDataSet<
-      Spectral::Swsh::Tags::SwshTransform<Tags::Du<Tags::BondiR>>>>(
-      dataset_names_) = "DuR";
+  get<name_tag_t<T, Tags::BondiBeta>>(dataset_names_) = "Beta";
+  get<name_tag_t<T, Tags::BondiU>>(dataset_names_) = "U";
+  get<name_tag_t<T, Tags::BondiQ>>(dataset_names_) = "Q";
+  get<name_tag_t<T, Tags::BondiW>>(dataset_names_) = "W";
+  get<name_tag_t<T, Tags::BondiJ>>(dataset_names_) = "J";
+  get<name_tag_t<T, Tags::Dr<Tags::BondiJ>>>(dataset_names_) = "DrJ";
+  get<name_tag_t<T, Tags::Du<Tags::BondiJ>>>(dataset_names_) = "H";
+  get<name_tag_t<T, Tags::BondiR>>(dataset_names_) = "R";
+  get<name_tag_t<T, Tags::Du<Tags::BondiR>>>(dataset_names_) = "DuR";
 
   // the extraction radius is typically not used in the Bondi system, so we
   // don't error if it isn't parsed from the filename. Instead, we'll just error
@@ -418,27 +568,26 @@ BondiWorldtubeH5BufferUpdater::BondiWorldtubeH5BufferUpdater(
       Cce::get_extraction_radius(cce_data_filename, extraction_radius, false);
 
   detail::set_time_buffer_and_lmax(make_not_null(&time_buffer_), l_max_,
-                                   cce_data_file_.get<h5::Dat>("/U"), false);
+                                   cce_data_file_.get<h5::Dat>("/U"), false,
+                                   is_modal, true);
   cce_data_file_.close_current_object();
 }
 
-double BondiWorldtubeH5BufferUpdater::update_buffers_for_time(
-    const gsl::not_null<Variables<Tags::worldtube_boundary_tags_for_writing<
-        Spectral::Swsh::Tags::SwshTransform>>*>
-        buffers,
+template <typename T>
+double BondiWorldtubeH5BufferUpdater<T>::update_buffers_for_time(
+    const gsl::not_null<Variables<tags_for_writing>*> buffers,
     const gsl::not_null<size_t*> time_span_start,
     const gsl::not_null<size_t*> time_span_end, const double time,
     const size_t computation_l_max, const size_t interpolator_length,
-    const size_t buffer_depth) const {
-  return detail::update_buffers_for_time<
-      Tags::worldtube_boundary_tags_for_writing<
-          Spectral::Swsh::Tags::SwshTransform>>(
+    const size_t buffer_depth, const bool time_varies_fastest) const {
+  return detail::update_buffers_for_time<is_modal, tags_for_writing>(
       buffers, time_span_start, time_span_end, time, computation_l_max, l_max_,
       interpolator_length, buffer_depth, time_buffer_, dataset_names_,
-      cce_data_file_);
+      cce_data_file_, time_varies_fastest);
 }
 
-void BondiWorldtubeH5BufferUpdater::pup(PUP::er& p) {
+template <typename T>
+void BondiWorldtubeH5BufferUpdater<T>::pup(PUP::er& p) {
   p | time_buffer_;
   p | filename_;
   p | l_max_;
@@ -468,7 +617,8 @@ KleinGordonWorldtubeH5BufferUpdater::KleinGordonWorldtubeH5BufferUpdater(
       Cce::get_extraction_radius(cce_data_filename, extraction_radius, false);
 
   detail::set_time_buffer_and_lmax(make_not_null(&time_buffer_), l_max_,
-                                   cce_data_file_.get<h5::Dat>("/KGPsi"), true);
+                                   cce_data_file_.get<h5::Dat>("/KGPsi"), true,
+                                   true, true);
   cce_data_file_.close_current_object();
 }
 
@@ -477,8 +627,13 @@ double KleinGordonWorldtubeH5BufferUpdater::update_buffers_for_time(
     const gsl::not_null<size_t*> time_span_start,
     const gsl::not_null<size_t*> time_span_end, const double time,
     const size_t computation_l_max, const size_t interpolator_length,
-    const size_t buffer_depth) const {
-  return detail::update_buffers_for_time<klein_gordon_input_tags>(
+    const size_t buffer_depth, const bool time_varies_fastest) const {
+  if (UNLIKELY(not time_varies_fastest)) {
+    ERROR(
+        "KleinGordon worldtube data can only be read from H5 in "
+        "time-varies-fastest form.");
+  }
+  return detail::update_buffers_for_time<true, klein_gordon_input_tags>(
       buffers, time_span_start, time_span_end, time, computation_l_max, l_max_,
       interpolator_length, buffer_depth, time_buffer_, dataset_names_,
       cce_data_file_);
@@ -495,7 +650,33 @@ void KleinGordonWorldtubeH5BufferUpdater::pup(PUP::er& p) {
   }
 }
 
-PUP::able::PUP_ID MetricWorldtubeH5BufferUpdater::my_PUP_ID = 0;
-PUP::able::PUP_ID BondiWorldtubeH5BufferUpdater::my_PUP_ID = 0;
+template <typename T>
+PUP::able::PUP_ID MetricWorldtubeH5BufferUpdater<T>::my_PUP_ID = 0;  // NOLINT
+template <typename T>
+PUP::able::PUP_ID BondiWorldtubeH5BufferUpdater<T>::my_PUP_ID = 0;     // NOLINT
 PUP::able::PUP_ID KleinGordonWorldtubeH5BufferUpdater::my_PUP_ID = 0;  // NOLINT
+
+template class MetricWorldtubeH5BufferUpdater<ComplexModalVector>;
+template class MetricWorldtubeH5BufferUpdater<DataVector>;
+template class BondiWorldtubeH5BufferUpdater<ComplexModalVector>;
+template class BondiWorldtubeH5BufferUpdater<ComplexDataVector>;
+
+#define SPIN(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define IS_MODAL(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define VEC_TYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template void detail::update_buffer<IS_MODAL(data), SPIN(data)>( \
+      const gsl::not_null<VEC_TYPE(data)*> buffer_to_update,       \
+      const h5::Dat& read_data, const size_t computation_l_max,    \
+      const size_t l_max, const size_t time_span_start,            \
+      const size_t time_span_end, const bool time_varies_fastest);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2), (true, false),
+                        (ComplexModalVector, ComplexDataVector))
+
+#undef INSTANTIATE
+#undef VEC_TYPE
+#undef IS_MODAL
+#undef SPIN
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -17,6 +17,7 @@
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/SpecBoundaryData.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
+#include "Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp"
 #include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp"
@@ -162,8 +163,7 @@ void populate_hypersurface_boundary_data(
 }  // namespace detail
 
 MetricWorldtubeDataManager::MetricWorldtubeDataManager(
-    std::unique_ptr<WorldtubeBufferUpdater<cce_metric_input_tags>>
-        buffer_updater,
+    std::unique_ptr<WorldtubeBufferUpdater<input_tags>> buffer_updater,
     const size_t l_max, const size_t buffer_depth,
     std::unique_ptr<intrp::SpanInterpolator> interpolator,
     const bool fix_spec_normalization)
@@ -174,7 +174,7 @@ MetricWorldtubeDataManager::MetricWorldtubeDataManager(
           Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)},
       buffer_depth_{buffer_depth},
       interpolator_{std::move(interpolator)} {
-  detail::initialize_buffers<cce_metric_input_tags>(
+  detail::initialize_buffers<input_tags>(
       make_not_null(&buffer_depth_), make_not_null(&coefficients_buffers_),
       buffer_updater_->get_time_buffer().size(),
       interpolator_->required_number_of_points_before_and_after(), l_max);
@@ -240,9 +240,8 @@ bool MetricWorldtubeDataManager::populate_hypersurface_boundary_data(
        Spectral::Swsh::cached_coefficients_metadata(l_max_)) {
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = i; j < 3; ++j) {
-        tmpl::for_each<tmpl::list<Tags::detail::SpatialMetric,
-                                  Tags::detail::Dr<Tags::detail::SpatialMetric>,
-                                  ::Tags::dt<Tags::detail::SpatialMetric>>>(
+        tmpl::for_each<Tags::detail::apply_derivs_t<
+            Tags::detail::SpatialMetric<ComplexModalVector>>>(
             [this, &i, &j, &libsharp_mode, &interpolate_from_column,
              &spin_weighted_buffer](auto tag_v) {
               using tag = typename decltype(tag_v)::type;
@@ -263,9 +262,8 @@ bool MetricWorldtubeDataManager::populate_hypersurface_boundary_data(
                           -static_cast<int>(libsharp_mode.m))));
             });
       }
-      tmpl::for_each<
-          tmpl::list<Tags::detail::Shift, Tags::detail::Dr<Tags::detail::Shift>,
-                     ::Tags::dt<Tags::detail::Shift>>>(
+      tmpl::for_each<Tags::detail::apply_derivs_t<
+          Tags::detail::Shift<ComplexModalVector>>>(
           [this, &i, &libsharp_mode, &interpolate_from_column,
            &spin_weighted_buffer](auto tag_v) {
             using tag = typename decltype(tag_v)::type;
@@ -287,62 +285,52 @@ bool MetricWorldtubeDataManager::populate_hypersurface_boundary_data(
           });
     }
     tmpl::for_each<
-        tmpl::list<Tags::detail::Lapse, Tags::detail::Dr<Tags::detail::Lapse>,
-                   ::Tags::dt<Tags::detail::Lapse>>>([this, &libsharp_mode,
-                                                      &interpolate_from_column,
-                                                      &spin_weighted_buffer](
-                                                         auto tag_v) {
-      using tag = typename decltype(tag_v)::type;
-      spin_weighted_buffer.set_data_ref(
-          get(get<tag>(interpolated_coefficients_)).data(),
-          Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max_));
-      Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
-          libsharp_mode, make_not_null(&spin_weighted_buffer), 0,
-          interpolate_from_column(
-              get(get<tag>(coefficients_buffers_)).data(),
-              Spectral::Swsh::goldberg_mode_index(
-                  l_max_, libsharp_mode.l, static_cast<int>(libsharp_mode.m))),
-          interpolate_from_column(get(get<tag>(coefficients_buffers_)).data(),
-                                  Spectral::Swsh::goldberg_mode_index(
-                                      l_max_, libsharp_mode.l,
-                                      -static_cast<int>(libsharp_mode.m))));
-    });
+        Tags::detail::apply_derivs_t<Tags::detail::Lapse<ComplexModalVector>>>(
+        [this, &libsharp_mode, &interpolate_from_column,
+         &spin_weighted_buffer](auto tag_v) {
+          using tag = typename decltype(tag_v)::type;
+          spin_weighted_buffer.set_data_ref(
+              get(get<tag>(interpolated_coefficients_)).data(),
+              Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max_));
+          Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
+              libsharp_mode, make_not_null(&spin_weighted_buffer), 0,
+              interpolate_from_column(
+                  get(get<tag>(coefficients_buffers_)).data(),
+                  Spectral::Swsh::goldberg_mode_index(
+                      l_max_, libsharp_mode.l,
+                      static_cast<int>(libsharp_mode.m))),
+              interpolate_from_column(
+                  get(get<tag>(coefficients_buffers_)).data(),
+                  Spectral::Swsh::goldberg_mode_index(
+                      l_max_, libsharp_mode.l,
+                      -static_cast<int>(libsharp_mode.m))));
+        });
   }
+
   // At this point, we have a collection of 9 tensors of libsharp
   // coefficients. This is what the boundary data calculation utility takes
   // as an input, so we now hand off the control flow to the boundary and
   // gauge transform utility
-  if (not buffer_updater_->has_version_history() and fix_spec_normalization_) {
-    create_bondi_boundary_data_from_unnormalized_spec_modes(
-        boundary_data_variables,
-        get<Tags::detail::SpatialMetric>(interpolated_coefficients_),
-        get<::Tags::dt<Tags::detail::SpatialMetric>>(
-            interpolated_coefficients_),
-        get<Tags::detail::Dr<Tags::detail::SpatialMetric>>(
-            interpolated_coefficients_),
-        get<Tags::detail::Shift>(interpolated_coefficients_),
-        get<::Tags::dt<Tags::detail::Shift>>(interpolated_coefficients_),
-        get<Tags::detail::Dr<Tags::detail::Shift>>(interpolated_coefficients_),
-        get<Tags::detail::Lapse>(interpolated_coefficients_),
-        get<::Tags::dt<Tags::detail::Lapse>>(interpolated_coefficients_),
-        get<Tags::detail::Dr<Tags::detail::Lapse>>(interpolated_coefficients_),
-        buffer_updater_->get_extraction_radius(), l_max_);
-  } else {
-    create_bondi_boundary_data(
-        boundary_data_variables,
-        get<Tags::detail::SpatialMetric>(interpolated_coefficients_),
-        get<::Tags::dt<Tags::detail::SpatialMetric>>(
-            interpolated_coefficients_),
-        get<Tags::detail::Dr<Tags::detail::SpatialMetric>>(
-            interpolated_coefficients_),
-        get<Tags::detail::Shift>(interpolated_coefficients_),
-        get<::Tags::dt<Tags::detail::Shift>>(interpolated_coefficients_),
-        get<Tags::detail::Dr<Tags::detail::Shift>>(interpolated_coefficients_),
-        get<Tags::detail::Lapse>(interpolated_coefficients_),
-        get<::Tags::dt<Tags::detail::Lapse>>(interpolated_coefficients_),
-        get<Tags::detail::Dr<Tags::detail::Lapse>>(interpolated_coefficients_),
-        buffer_updater_->get_extraction_radius(), l_max_);
-  }
+  // This relies on the ordering of tags in the `input_tags` type alias
+  const auto create_boundary_data = [&](const auto&... tags) {
+    if (not buffer_updater_->has_version_history() and
+        fix_spec_normalization_) {
+      create_bondi_boundary_data_from_unnormalized_spec_modes(
+          boundary_data_variables,
+          get<tmpl::type_from<std::decay_t<decltype(tags)>>>(
+              interpolated_coefficients_)...,
+          buffer_updater_->get_extraction_radius(), l_max_);
+    } else {
+      create_bondi_boundary_data(
+          boundary_data_variables,
+          get<tmpl::type_from<std::decay_t<decltype(tags)>>>(
+              interpolated_coefficients_)...,
+          buffer_updater_->get_extraction_radius(), l_max_);
+    }
+  };
+
+  tmpl::as_pack<input_tags>(create_boundary_data);
+
   return true;
 }
 
@@ -367,7 +355,7 @@ void MetricWorldtubeDataManager::pup(PUP::er& p) {
   p | interpolator_;
   p | fix_spec_normalization_;
   if (p.isUnpacking()) {
-    detail::set_non_pupped_members<cce_metric_input_tags>(
+    detail::set_non_pupped_members<input_tags>(
         make_not_null(&time_span_start_), make_not_null(&time_span_end_),
         make_not_null(&coefficients_buffers_),
         make_not_null(&interpolated_coefficients_), buffer_depth_,
@@ -540,7 +528,7 @@ void KleinGordonWorldtubeDataManager::pup(PUP::er& p) {
   }
 }
 
-PUP::able::PUP_ID MetricWorldtubeDataManager::my_PUP_ID = 0;
-PUP::able::PUP_ID BondiWorldtubeDataManager::my_PUP_ID = 0;
+PUP::able::PUP_ID MetricWorldtubeDataManager::my_PUP_ID = 0;       // NOLINT
+PUP::able::PUP_ID BondiWorldtubeDataManager::my_PUP_ID = 0;        // NOLINT
 PUP::able::PUP_ID KleinGordonWorldtubeDataManager::my_PUP_ID = 0;  // NOLINT
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
@@ -114,13 +115,14 @@ class WorldtubeDataManager : public PUP::able {
 class MetricWorldtubeDataManager
     : public WorldtubeDataManager<
           Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>> {
+  using input_tags = cce_metric_input_tags<ComplexModalVector>;
+
  public:
   // charm needs an empty constructor.
   MetricWorldtubeDataManager() = default;
 
   MetricWorldtubeDataManager(
-      std::unique_ptr<WorldtubeBufferUpdater<cce_metric_input_tags>>
-          buffer_updater,
+      std::unique_ptr<WorldtubeBufferUpdater<input_tags>> buffer_updater,
       size_t l_max, size_t buffer_depth,
       std::unique_ptr<intrp::SpanInterpolator> interpolator,
       bool fix_spec_normalization);
@@ -166,8 +168,7 @@ class MetricWorldtubeDataManager
   void pup(PUP::er& p) override;  // NOLINT
 
  private:
-  std::unique_ptr<WorldtubeBufferUpdater<cce_metric_input_tags>>
-      buffer_updater_;
+  std::unique_ptr<WorldtubeBufferUpdater<input_tags>> buffer_updater_;
   // NOLINTNEXTLINE(spectre-mutable)
   mutable size_t time_span_start_ = 0;
   // NOLINTNEXTLINE(spectre-mutable)
@@ -178,11 +179,11 @@ class MetricWorldtubeDataManager
   // These buffers are just kept around to avoid allocations; they're
   // updated every time a time is requested
   // NOLINTNEXTLINE(spectre-mutable)
-  mutable Variables<cce_metric_input_tags> interpolated_coefficients_;
+  mutable Variables<input_tags> interpolated_coefficients_;
 
   // note: buffers store data in a 'time-varies-fastest' manner
   // NOLINTNEXTLINE(spectre-mutable)
-  mutable Variables<cce_metric_input_tags> coefficients_buffers_;
+  mutable Variables<input_tags> coefficients_buffers_;
 
   size_t buffer_depth_ = 0;
 

--- a/src/Executables/ReduceCceWorldtube/ReduceCceWorldtube.cpp
+++ b/src/Executables/ReduceCceWorldtube/ReduceCceWorldtube.cpp
@@ -35,124 +35,78 @@
 extern "C" void CkRegisterMainModule(void) {}
 
 namespace {
+using metric_input_tags = Cce::cce_metric_input_tags<ComplexModalVector>;
 // from a time-varies-fastest set of buffers provided by
 // `MetricWorldtubeH5BufferUpdater` extract the set of coefficients for a
 // particular time given by `buffer_time_offset` into the `time_span` size of
 // buffer.
 void slice_buffers_to_libsharp_modes(
-    const gsl::not_null<Variables<Cce::cce_metric_input_tags>*>
-        coefficients_set,
-    const Variables<Cce::cce_metric_input_tags>& coefficients_buffers,
+    const gsl::not_null<Variables<metric_input_tags>*> coefficients_set,
+    const Variables<metric_input_tags>& coefficients_buffers,
     const size_t time_span, const size_t buffer_time_offset, const size_t l_max,
     const size_t computation_l_max) {
   SpinWeighted<ComplexModalVector, 0> spin_weighted_buffer;
+
+  const auto convert_modes = [&](const ComplexModalVector& coefficients_buffer,
+                                 const auto& libsharp_mode) {
+    if (libsharp_mode.l > l_max) {
+      Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
+          libsharp_mode, make_not_null(&spin_weighted_buffer), 0, 0.0, 0.0);
+
+    } else {
+      Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
+          libsharp_mode, make_not_null(&spin_weighted_buffer), 0,
+          coefficients_buffer[time_span *
+                                  Spectral::Swsh::goldberg_mode_index(
+                                      l_max, libsharp_mode.l,
+                                      static_cast<int>(libsharp_mode.m)) +
+                              buffer_time_offset],
+          coefficients_buffer[time_span *
+                                  Spectral::Swsh::goldberg_mode_index(
+                                      l_max, libsharp_mode.l,
+                                      -static_cast<int>(libsharp_mode.m)) +
+                              buffer_time_offset]);
+    }
+  };
 
   for (const auto& libsharp_mode :
        Spectral::Swsh::cached_coefficients_metadata(computation_l_max)) {
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = i; j < 3; ++j) {
-        tmpl::for_each<
-            tmpl::list<Cce::Tags::detail::SpatialMetric,
-                       Cce::Tags::detail::Dr<Cce::Tags::detail::SpatialMetric>,
-                       Tags::dt<Cce::Tags::detail::SpatialMetric>>>(
-            [&i, &j, &libsharp_mode, &spin_weighted_buffer,
-             &coefficients_buffers, &coefficients_set, &l_max,
-             &computation_l_max, &time_span, &buffer_time_offset](auto tag_v) {
+        tmpl::for_each<Cce::Tags::detail::apply_derivs<
+            Cce::Tags::detail::SpatialMetric<ComplexModalVector>>>(
+            [&](auto tag_v) {
               using tag = typename decltype(tag_v)::type;
               spin_weighted_buffer.set_data_ref(
                   get<tag>(*coefficients_set).get(i, j).data(),
                   Spectral::Swsh::size_of_libsharp_coefficient_vector(
                       computation_l_max));
-              if (libsharp_mode.l > l_max) {
-                Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
-                    libsharp_mode, make_not_null(&spin_weighted_buffer), 0, 0.0,
-                    0.0);
 
-              } else {
-                Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
-                    libsharp_mode, make_not_null(&spin_weighted_buffer), 0,
-                    get<tag>(coefficients_buffers)
-                        .get(i, j)[time_span *
-                                       Spectral::Swsh::goldberg_mode_index(
-                                           l_max, libsharp_mode.l,
-                                           static_cast<int>(libsharp_mode.m)) +
-                                   buffer_time_offset],
-                    get<tag>(coefficients_buffers)
-                        .get(i, j)[time_span *
-                                       Spectral::Swsh::goldberg_mode_index(
-                                           l_max, libsharp_mode.l,
-                                           -static_cast<int>(libsharp_mode.m)) +
-                                   buffer_time_offset]);
-              }
+              convert_modes(get<tag>(coefficients_buffers).get(i, j),
+                            libsharp_mode);
             });
       }
-      tmpl::for_each<tmpl::list<Cce::Tags::detail::Shift,
-                                Cce::Tags::detail::Dr<Cce::Tags::detail::Shift>,
-                                Tags::dt<Cce::Tags::detail::Shift>>>(
-          [&i, &libsharp_mode, &spin_weighted_buffer, &coefficients_buffers,
-           &coefficients_set, &l_max, &computation_l_max, &time_span,
-           &buffer_time_offset](auto tag_v) {
-            using tag = typename decltype(tag_v)::type;
-            spin_weighted_buffer.set_data_ref(
-                get<tag>(*coefficients_set).get(i).data(),
-                Spectral::Swsh::size_of_libsharp_coefficient_vector(
-                    computation_l_max));
+      tmpl::for_each<Cce::Tags::detail::apply_derivs<
+          Cce::Tags::detail::Shift<ComplexModalVector>>>([&](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        spin_weighted_buffer.set_data_ref(
+            get<tag>(*coefficients_set).get(i).data(),
+            Spectral::Swsh::size_of_libsharp_coefficient_vector(
+                computation_l_max));
 
-            if (libsharp_mode.l > l_max) {
-              Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
-                  libsharp_mode, make_not_null(&spin_weighted_buffer), 0, 0.0,
-                  0.0);
-
-            } else {
-              Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
-                  libsharp_mode, make_not_null(&spin_weighted_buffer), 0,
-                  get<tag>(coefficients_buffers)
-                      .get(i)[time_span *
-                                  Spectral::Swsh::goldberg_mode_index(
-                                      l_max, libsharp_mode.l,
-                                      static_cast<int>(libsharp_mode.m)) +
-                              buffer_time_offset],
-                  get<tag>(coefficients_buffers)
-                      .get(i)[time_span *
-                                  Spectral::Swsh::goldberg_mode_index(
-                                      l_max, libsharp_mode.l,
-                                      -static_cast<int>(libsharp_mode.m)) +
-                              buffer_time_offset]);
-            }
-          });
+        convert_modes(get<tag>(coefficients_buffers).get(i), libsharp_mode);
+      });
     }
-    tmpl::for_each<tmpl::list<Cce::Tags::detail::Lapse,
-                              Cce::Tags::detail::Dr<Cce::Tags::detail::Lapse>,
-                              Tags::dt<Cce::Tags::detail::Lapse>>>(
-        [&libsharp_mode, &spin_weighted_buffer, &coefficients_buffers,
-         &coefficients_set, &l_max, &computation_l_max, &time_span,
-         &buffer_time_offset](auto tag_v) {
-          using tag = typename decltype(tag_v)::type;
-          spin_weighted_buffer.set_data_ref(
-              get(get<tag>(*coefficients_set)).data(),
-              Spectral::Swsh::size_of_libsharp_coefficient_vector(
-                  computation_l_max));
+    tmpl::for_each<Cce::Tags::detail::apply_derivs<
+        Cce::Tags::detail::Lapse<ComplexModalVector>>>([&](auto tag_v) {
+      using tag = typename decltype(tag_v)::type;
+      spin_weighted_buffer.set_data_ref(
+          get(get<tag>(*coefficients_set)).data(),
+          Spectral::Swsh::size_of_libsharp_coefficient_vector(
+              computation_l_max));
 
-          if (libsharp_mode.l > l_max) {
-            Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
-                libsharp_mode, make_not_null(&spin_weighted_buffer), 0, 0.0,
-                0.0);
-
-          } else {
-            Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
-                libsharp_mode, make_not_null(&spin_weighted_buffer), 0,
-                get(get<tag>(coefficients_buffers))
-                    [time_span * Spectral::Swsh::goldberg_mode_index(
-                                     l_max, libsharp_mode.l,
-                                     static_cast<int>(libsharp_mode.m)) +
-                     buffer_time_offset],
-                get(get<tag>(coefficients_buffers))
-                    [time_span * Spectral::Swsh::goldberg_mode_index(
-                                     l_max, libsharp_mode.l,
-                                     -static_cast<int>(libsharp_mode.m)) +
-                     buffer_time_offset]);
-          }
-        });
+      convert_modes(get(get<tag>(coefficients_buffers)), libsharp_mode);
+    });
   }
 }
 
@@ -163,7 +117,8 @@ void perform_cce_worldtube_reduction(
     const std::string& input_file, const std::string& output_file,
     const size_t buffer_depth, const size_t l_max_factor,
     const bool fix_spec_normalization = false) {
-  Cce::MetricWorldtubeH5BufferUpdater buffer_updater{input_file};
+  Cce::MetricWorldtubeH5BufferUpdater<ComplexModalVector> buffer_updater{
+      input_file};
   const size_t l_max = buffer_updater.get_l_max();
   // Perform the boundary computation to scalars at twice the input l_max to be
   // absolutely certain that there are no problems associated with aliasing.
@@ -174,8 +129,8 @@ void perform_cce_worldtube_reduction(
   const size_t size_of_buffer = square(l_max + 1) * (buffer_depth);
   const DataVector& time_buffer = buffer_updater.get_time_buffer();
 
-  Variables<Cce::cce_metric_input_tags> coefficients_buffers{size_of_buffer};
-  Variables<Cce::cce_metric_input_tags> coefficients_set{
+  Variables<metric_input_tags> coefficients_buffers{size_of_buffer};
+  Variables<metric_input_tags> coefficients_set{
       Spectral::Swsh::size_of_libsharp_coefficient_vector(computation_l_max)};
 
   Variables<Cce::Tags::characteristic_worldtube_boundary_tags<
@@ -200,39 +155,24 @@ void perform_cce_worldtube_reduction(
         time_span_end - time_span_start, i - time_span_start, l_max,
         computation_l_max);
 
-    if (not buffer_updater.has_version_history() and fix_spec_normalization) {
-      Cce::create_bondi_boundary_data_from_unnormalized_spec_modes(
-          make_not_null(&boundary_data_variables),
-          get<Cce::Tags::detail::SpatialMetric>(coefficients_set),
-          get<Tags::dt<Cce::Tags::detail::SpatialMetric>>(coefficients_set),
-          get<Cce::Tags::detail::Dr<Cce::Tags::detail::SpatialMetric>>(
-              coefficients_set),
-          get<Cce::Tags::detail::Shift>(coefficients_set),
-          get<Tags::dt<Cce::Tags::detail::Shift>>(coefficients_set),
-          get<Cce::Tags::detail::Dr<Cce::Tags::detail::Shift>>(
-              coefficients_set),
-          get<Cce::Tags::detail::Lapse>(coefficients_set),
-          get<Tags::dt<Cce::Tags::detail::Lapse>>(coefficients_set),
-          get<Cce::Tags::detail::Dr<Cce::Tags::detail::Lapse>>(
-              coefficients_set),
-          buffer_updater.get_extraction_radius(), computation_l_max);
-    } else {
-      Cce::create_bondi_boundary_data(
-          make_not_null(&boundary_data_variables),
-          get<Cce::Tags::detail::SpatialMetric>(coefficients_set),
-          get<Tags::dt<Cce::Tags::detail::SpatialMetric>>(coefficients_set),
-          get<Cce::Tags::detail::Dr<Cce::Tags::detail::SpatialMetric>>(
-              coefficients_set),
-          get<Cce::Tags::detail::Shift>(coefficients_set),
-          get<Tags::dt<Cce::Tags::detail::Shift>>(coefficients_set),
-          get<Cce::Tags::detail::Dr<Cce::Tags::detail::Shift>>(
-              coefficients_set),
-          get<Cce::Tags::detail::Lapse>(coefficients_set),
-          get<Tags::dt<Cce::Tags::detail::Lapse>>(coefficients_set),
-          get<Cce::Tags::detail::Dr<Cce::Tags::detail::Lapse>>(
-              coefficients_set),
-          buffer_updater.get_extraction_radius(), computation_l_max);
-    }
+    const auto create_boundary_data = [&](const auto&... tags) {
+      if (not buffer_updater.has_version_history() and fix_spec_normalization) {
+        Cce::create_bondi_boundary_data_from_unnormalized_spec_modes(
+            make_not_null(&boundary_data_variables),
+            get<tmpl::type_from<std::decay_t<decltype(tags)>>>(
+                coefficients_set)...,
+            buffer_updater.get_extraction_radius(), computation_l_max);
+      } else {
+        Cce::create_bondi_boundary_data(
+            make_not_null(&boundary_data_variables),
+            get<tmpl::type_from<std::decay_t<decltype(tags)>>>(
+                coefficients_set)...,
+            buffer_updater.get_extraction_radius(), computation_l_max);
+      }
+    };
+
+    tmpl::as_pack<metric_input_tags>(create_boundary_data);
+
     // loop over the tags that we want to dump.
     tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<>>(
         [&recorder, &boundary_data_variables, &computation_l_max,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -269,7 +269,7 @@ SPECTRE_TEST_CASE(
   Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-  TestHelpers::create_fake_time_varying_modal_data(
+  TestHelpers::create_fake_time_varying_data(
       make_not_null(&spatial_metric_coefficients),
       make_not_null(&dt_spatial_metric_coefficients),
       make_not_null(&dr_spatial_metric_coefficients),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -291,7 +291,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-  TestHelpers::create_fake_time_varying_modal_data(
+  TestHelpers::create_fake_time_varying_data(
       make_not_null(&spatial_metric_coefficients),
       make_not_null(&dt_spatial_metric_coefficients),
       make_not_null(&dr_spatial_metric_coefficients),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -281,7 +281,7 @@ void test_klein_gordon_h5_boundary_communication(
   Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-  TestHelpers::create_fake_time_varying_modal_data(
+  TestHelpers::create_fake_time_varying_data(
       make_not_null(&spatial_metric_coefficients),
       make_not_null(&dt_spatial_metric_coefficients),
       make_not_null(&dr_spatial_metric_coefficients),

--- a/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_GaugeTransformBoundaryData.cpp
@@ -156,7 +156,7 @@ void test_gauge_transforms_via_inverse_coordinate_map(
   Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-  TestHelpers::create_fake_time_varying_modal_data(
+  TestHelpers::create_fake_time_varying_data(
       make_not_null(&spatial_metric_coefficients),
       make_not_null(&dt_spatial_metric_coefficients),
       make_not_null(&dr_spatial_metric_coefficients),

--- a/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
@@ -44,7 +44,8 @@ class KleinGordonDummyBufferUpdater
       const gsl::not_null<size_t*> time_span_start,
       const gsl::not_null<size_t*> time_span_end, const double time,
       const size_t l_max, const size_t interpolator_length,
-      const size_t buffer_depth) const override {
+      const size_t buffer_depth,
+      const bool /*time_varies_fastest*/ = true) const override {
     if (*time_span_end > interpolator_length and
         time_buffer_[*time_span_end - interpolator_length + 1] > time) {
       // the next time an update will be required

--- a/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
@@ -175,7 +175,7 @@ void compute_psi0_of_bh_on_wt(const gsl::not_null<Generator*> gen) {
   Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
   Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-  TestHelpers::create_fake_time_varying_modal_data(
+  TestHelpers::create_fake_time_varying_data(
       make_not_null(&spatial_metric_coefficients),
       make_not_null(&dt_spatial_metric_coefficients),
       make_not_null(&dr_spatial_metric_coefficients),

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
@@ -57,12 +57,12 @@ void write_scalar_tensor_test_file(const AnalyticSolution& solution,
   }
   // scoped to close the file
   {
-    TestHelpers::WorldtubeModeRecorder recorder{filename, l_max};
+    TestHelpers::WorldtubeModeRecorder recorder{l_max, filename};
     // write times to file for several steps before and after the target time
     for (size_t t = 0; t < 30; ++t) {
       const double time = 0.1 * static_cast<double>(t) + target_time - 1.5;
       // create tensor data
-      TestHelpers::create_fake_time_varying_modal_data(
+      TestHelpers::create_fake_time_varying_data(
           make_not_null(&spatial_metric_coefficients),
           make_not_null(&dt_spatial_metric_coefficients),
           make_not_null(&dr_spatial_metric_coefficients),
@@ -116,10 +116,10 @@ void write_scalar_tensor_test_file(const AnalyticSolution& solution,
       // write scalar data
       recorder.append_worldtube_mode_data(
           detail::dataset_name_for_component("/KGPsi"), time, get(kg_psi_modal),
-          l_max);
+          false, true);
       recorder.append_worldtube_mode_data(
           detail::dataset_name_for_component("/dtKGPsi"), time,
-          get(kg_pi_modal), l_max);
+          get(kg_pi_modal), false, true);
     }
   }
 }

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp
@@ -3,32 +3,64 @@
 
 #pragma once
 
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/Version.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 
-namespace Cce {
-namespace TestHelpers {
+namespace Cce::TestHelpers {
 
 // records worldtube data in the SpEC h5 style.
 struct WorldtubeModeRecorder {
  public:
-  WorldtubeModeRecorder(const std::string& filename, const size_t l_max)
-      : output_file_{filename} {
+  WorldtubeModeRecorder(const size_t l_max, const std::string& filename)
+      : l_max_(l_max), output_file_{filename} {
     // write the .ver that indicates that the derivatives are correctly
     // normalized.
     output_file_.insert<h5::Version>(
         "/VersionHist", "Bugfix in CCE radial derivatives (ticket 1096).");
     output_file_.close_current_object();
-    file_legend_.emplace_back("time");
-    for (int l = 0; l <= static_cast<int>(l_max); ++l) {
+    all_modal_file_legend_.emplace_back("time");
+    all_nodal_file_legend_.emplace_back("time");
+    real_file_legend_.emplace_back("time");
+    complex_nodal_legend_.emplace_back("time");
+
+    // Modal legends
+    for (int l = 0; l <= static_cast<int>(l_max_); ++l) {
       for (int m = -l; m <= l; ++m) {
-        file_legend_.push_back("Real Y_" + std::to_string(l) + "," +
-                               std::to_string(m));
-        file_legend_.push_back("Imag Y_" + std::to_string(l) + "," +
-                               std::to_string(m));
+        all_modal_file_legend_.push_back("Real Y_" + std::to_string(l) + "," +
+                                         std::to_string(m));
+        all_modal_file_legend_.push_back("Imag Y_" + std::to_string(l) + "," +
+                                         std::to_string(m));
+
+        if (m >= 0) {
+          real_file_legend_.push_back("Real Y_" + std::to_string(l) + "," +
+                                      std::to_string(m));
+          if (m != 0) {
+            real_file_legend_.push_back("Imag Y_" + std::to_string(l) + "," +
+                                        std::to_string(m));
+          }
+        }
       }
+    }
+
+    const size_t num_points =
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max_);
+
+    // Nodal legends
+    for (size_t i = 0; i < num_points; i++) {
+      all_nodal_file_legend_.push_back("Point" + std::to_string(i));
+
+      complex_nodal_legend_.push_back("Real Point" + std::to_string(i));
+      complex_nodal_legend_.push_back("Imag Point" + std::to_string(i));
     }
   }
 
@@ -37,33 +69,81 @@ struct WorldtubeModeRecorder {
   void append_worldtube_mode_data(const std::string& dataset_path,
                                   const double time,
                                   const ComplexModalVector& modes,
-                                  const size_t l_max) {
-    auto& output_mode_dataset =
-        output_file_.try_insert<h5::Dat>(dataset_path, file_legend_, 0);
-    const size_t output_size = square(l_max + 1);
-    std::vector<double> data_to_write(2 * output_size + 1);
+                                  const bool is_spec_data = true,
+                                  const bool is_real = false) {
+    const size_t modal_size = square(l_max_ + 1);
+    ASSERT(modes.size() == modal_size, "Expected modes of size "
+                                           << modal_size << " but got "
+                                           << modes.size() << " instead.");
+    auto& output_mode_dataset = output_file_.try_insert<h5::Dat>(
+        dataset_path, is_real ? real_file_legend_ : all_modal_file_legend_, 0);
+    const size_t output_size = (is_real ? 1 : 2) * modal_size;
+    std::vector<double> data_to_write(output_size + 1);
     data_to_write[0] = time;
-    for (int l = 0; l <= static_cast<int>(l_max); ++l) {
-      for (int m = -l; m <= l; ++m) {
-        data_to_write[2 * Spectral::Swsh::goldberg_mode_index(
-                              l_max, static_cast<size_t>(l), -m) +
-                      1] =
-            real(modes[Spectral::Swsh::goldberg_mode_index(
-                l_max, static_cast<size_t>(l), m)]);
-        data_to_write[2 * Spectral::Swsh::goldberg_mode_index(
-                              l_max, static_cast<size_t>(l), -m) +
-                      2] =
-            imag(modes[Spectral::Swsh::goldberg_mode_index(
-                l_max, static_cast<size_t>(l), m)]);
+    for (int l = 0; l <= static_cast<int>(l_max_); ++l) {
+      for (int m = (is_real ? 0 : -l); m <= l; ++m) {
+        const int em = is_spec_data ? -m : m;
+        const size_t to_write_index =
+            is_real ? static_cast<size_t>(m == 0 ? square(l) + 1
+                                                 : square(l) + 2 * abs(m))
+                    : (2 * Spectral::Swsh::goldberg_mode_index(
+                               l_max_, static_cast<size_t>(l), em) +
+                       1);
+        const size_t mode_index = Spectral::Swsh::goldberg_mode_index(
+            l_max_, static_cast<size_t>(l), m);
+        data_to_write[to_write_index] = real(modes[mode_index]);
+        if (not is_real or m != 0) {
+          data_to_write[to_write_index + 1] = imag(modes[mode_index]);
+        }
       }
     }
+
+    output_mode_dataset.append(data_to_write);
+    output_file_.close_current_object();
+  }
+
+  template <typename T>
+  void append_worldtube_mode_data(const std::string& dataset_path,
+                                  const double time, const T& nodes,
+                                  const bool /*unused*/ = true) {
+    static_assert(std::is_same_v<T, ComplexDataVector> or
+                  std::is_same_v<T, DataVector>);
+    constexpr bool is_complex = std::is_same_v<T, ComplexDataVector>;
+
+    auto& output_mode_dataset = output_file_.try_insert<h5::Dat>(
+        dataset_path,
+        is_complex ? complex_nodal_legend_ : all_nodal_file_legend_, 0);
+    const size_t output_size =
+        (is_complex ? 2 : 1) *
+        Spectral::Swsh::number_of_swsh_collocation_points(l_max_);
+
+    std::vector<double> data_to_write(output_size + 1);
+    data_to_write[0] = time;
+
+    if ((is_complex ? 2 : 1) * nodes.size() != output_size) {
+      ERROR("Trying to write test worldtube data. Data passed in has size "
+            << (is_complex ? 2 : 1) * nodes.size() << " but expected size "
+            << output_size);
+    }
+    for (size_t i = 0; i < nodes.size(); i++) {
+      if constexpr (is_complex) {
+        data_to_write[2 * i + 1] = real(nodes[i]);
+        data_to_write[2 * i + 2] = imag(nodes[i]);
+      } else {
+        data_to_write[i + 1] = nodes[i];
+      }
+    }
+
     output_mode_dataset.append(data_to_write);
     output_file_.close_current_object();
   }
 
  private:
+  size_t l_max_;
   h5::H5File<h5::AccessType::ReadWrite> output_file_;
-  std::vector<std::string> file_legend_;
+  std::vector<std::string> all_modal_file_legend_;
+  std::vector<std::string> all_nodal_file_legend_;
+  std::vector<std::string> real_file_legend_;
+  std::vector<std::string> complex_nodal_legend_;
 };
-}  // namespace TestHelpers
-}  // namespace Cce
+}  // namespace Cce::TestHelpers


### PR DESCRIPTION
## Proposed changes

This PR allows CCE to be able to read in metric modal, metric nodal, bondi modal, and bondi nodal data from disk. 
Another feature addition is that data can be read in in time-varies-fastest form which is useful for time interpolation, or in modes/nodes-varies-fastest which is more useful for just reading in data at specific times. There is no functionality change to the current CCE code, only new features.


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #6396 .~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
