### PR TITLE
Compute ADM angular momentum integral in BBH ID

### DIFF
--- a/src/PointwiseFunctions/Xcts/AdmMomentum.cpp
+++ b/src/PointwiseFunctions/Xcts/AdmMomentum.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "PointwiseFunctions/Xcts/AdmLinearMomentum.hpp"
+#include "PointwiseFunctions/Xcts/AdmMomentum.hpp"
 
 namespace Xcts {
 
@@ -65,6 +65,47 @@ tnsr::I<DataVector, 3> adm_linear_momentum_volume_integrand(
       make_not_null(&result), surface_integrand, conformal_factor,
       deriv_conformal_factor, conformal_metric, inv_conformal_metric,
       conformal_christoffel_second_kind, conformal_christoffel_contracted);
+  return result;
+}
+
+void adm_angular_momentum_z_surface_integrand(
+    gsl::not_null<tnsr::I<DataVector, 3>*> result,
+    const tnsr::II<DataVector, 3>& linear_momentum_surface_integrand,
+    const tnsr::I<DataVector, 3>& coords) {
+  // Note: we can ignore the $1/(8\pi)$ term below because it is already
+  // included in `linear_momentum_surface_integrand`.
+  for (int I = 0; I < 3; I++) {
+    result->get(I) =
+        get<0>(coords) * linear_momentum_surface_integrand.get(1, I) -
+        get<1>(coords) * linear_momentum_surface_integrand.get(0, I);
+  }
+}
+
+tnsr::I<DataVector, 3> adm_angular_momentum_z_surface_integrand(
+    const tnsr::II<DataVector, 3>& linear_momentum_surface_integrand,
+    const tnsr::I<DataVector, 3>& coords) {
+  tnsr::I<DataVector, 3> result;
+  adm_angular_momentum_z_surface_integrand(
+      make_not_null(&result), linear_momentum_surface_integrand, coords);
+  return result;
+}
+
+void adm_angular_momentum_z_volume_integrand(
+    gsl::not_null<Scalar<DataVector>*> result,
+    const tnsr::I<DataVector, 3>& linear_momentum_volume_integrand,
+    const tnsr::I<DataVector, 3>& coords) {
+  // Note: we can ignore the $-1/(8\pi)$ term below because it is already
+  // included in `linear_momentum_volume_integrand`.
+  result->get() = get<0>(coords) * get<1>(linear_momentum_volume_integrand) -
+                  get<1>(coords) * get<0>(linear_momentum_volume_integrand);
+}
+
+Scalar<DataVector> adm_angular_momentum_z_volume_integrand(
+    const tnsr::I<DataVector, 3>& linear_momentum_volume_integrand,
+    const tnsr::I<DataVector, 3>& coords) {
+  Scalar<DataVector> result;
+  adm_angular_momentum_z_volume_integrand(
+      make_not_null(&result), linear_momentum_volume_integrand, coords);
   return result;
 }
 

--- a/src/PointwiseFunctions/Xcts/AdmMomentum.hpp
+++ b/src/PointwiseFunctions/Xcts/AdmMomentum.hpp
@@ -18,7 +18,7 @@ namespace Xcts {
  *
  * \begin{equation}
  *   P_\text{ADM}^i = \frac{1}{8\pi}
- *                    \oint_{S_\infty} \psi^10 \Big(
+ *                    \oint_{S_\infty} \psi^{10} \Big(
  *                      K^{ij} - K \gamma^{ij}
  *                    \Big) \, dS_j.
  * \end{equation}
@@ -101,6 +101,79 @@ tnsr::I<DataVector, 3> adm_linear_momentum_volume_integrand(
     const tnsr::II<DataVector, 3>& inv_conformal_metric,
     const tnsr::Ijj<DataVector, 3>& conformal_christoffel_second_kind,
     const tnsr::i<DataVector, 3>& conformal_christoffel_contracted);
+/// @}
+
+/// @{
+/*!
+ * \brief Surface integrand for the z-component of the ADM angular momentum.
+ *
+ * We define the ADM angular momentum surface integral as (see Eq. 23 in
+ * \cite Ossokine2015yla):
+ *
+ * \begin{equation}
+ *   J_\text{ADM}^z = \frac{1}{8\pi}
+ *                    \oint_{S_\infty} \Big(
+ *                      x P^{yj} - y P^{xj}
+ *                    \Big) \, dS_j,
+ * \end{equation}
+ *
+ * where $1/(8\pi) P^{jk}$ is the result from
+ * `adm_linear_momentum_surface_integrand`.
+ *
+ * \note For consistency with `adm_angular_momentum_z_volume_integrand`, this
+ * integrand needs to be contracted with the Euclidean face normal and
+ * integrated with the Euclidean area element.
+ *
+ * \param result output pointer
+ * \param linear_momentum_surface_integrand the quantity $1/(8\pi) P^{ij}$
+ * (result of `adm_linear_momentum_surface_integrand`)
+ * \param coords the inertial coordinates $x^i$
+ */
+void adm_angular_momentum_z_surface_integrand(
+    gsl::not_null<tnsr::I<DataVector, 3>*> result,
+    const tnsr::II<DataVector, 3>& linear_momentum_surface_integrand,
+    const tnsr::I<DataVector, 3>& coords);
+
+/// Return-by-value overload
+tnsr::I<DataVector, 3> adm_angular_momentum_z_surface_integrand(
+    const tnsr::II<DataVector, 3>& linear_momentum_surface_integrand,
+    const tnsr::I<DataVector, 3>& coords);
+/// @}
+
+/// @{
+/*!
+ * \brief Volume integrand for the z-component of the ADM angular momentum.
+ *
+ * We define the ADM angular momentum volume integral as (see Eq. 23 in
+ * \cite Ossokine2015yla):
+ *
+ * \begin{equation}
+ *   J_\text{ADM}^z = - \frac{1}{8\pi}
+ *                      \int_{V_\infty} \Big(
+ *                        x G^y - y G^x
+ *                      \Big) \, dV,
+ * \end{equation}
+ *
+ * where $-1/(8\pi) G^i$ is the result from
+ * `adm_linear_momentum_volume_integrand`.
+ *
+ * \note For consistency with `adm_angular_momentum_z_surface_integrand`, this
+ * integrand needs to be integrated with the Euclidean volume element.
+ *
+ * \param result output pointer
+ * \param linear_momentum_volume_integrand the quantity $-1/(8\pi) G^i$ (result
+ * of `adm_linear_momentum_volume_integrand`)
+ * \param coords the inertial coordinates $x^i$
+ */
+void adm_angular_momentum_z_volume_integrand(
+    gsl::not_null<Scalar<DataVector>*> result,
+    const tnsr::I<DataVector, 3>& linear_momentum_volume_integrand,
+    const tnsr::I<DataVector, 3>& coords);
+
+/// Return-by-value overload
+Scalar<DataVector> adm_angular_momentum_z_volume_integrand(
+    const tnsr::I<DataVector, 3>& linear_momentum_volume_integrand,
+    const tnsr::I<DataVector, 3>& coords);
 /// @}
 
 }  // namespace Xcts

--- a/src/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -8,8 +8,8 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
-  AdmLinearMomentum.cpp
   AdmMass.cpp
+  AdmMomentum.cpp
   CenterOfMass.cpp
   ExtrinsicCurvature.cpp
   LongitudinalOperator.cpp
@@ -20,8 +20,8 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  AdmLinearMomentum.hpp
   AdmMass.hpp
+  AdmMomentum.hpp
   CenterOfMass.hpp
   ExtrinsicCurvature.hpp
   LongitudinalOperator.hpp

--- a/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
@@ -94,6 +94,8 @@ void test_local_adm_integrals(const double& distance,
   Scalar<double> total_adm_mass;
   total_adm_mass.get() = 0.;
   tnsr::I<double, 3> total_adm_linear_momentum;
+  Scalar<double> total_adm_angular_momentum_z;
+  total_adm_angular_momentum_z.get() = 0.;
   tnsr::I<double, 3> total_center_of_mass;
   for (int I = 0; I < 3; I++) {
     total_adm_linear_momentum.get(I) = 0.;
@@ -246,10 +248,12 @@ void test_local_adm_integrals(const double& distance,
     // Compute local integrals.
     Scalar<double> local_adm_mass;
     tnsr::I<double, 3> local_adm_linear_momentum;
+    Scalar<double> local_adm_angular_momentum_z;
     tnsr::I<double, 3> local_center_of_mass;
     Events::local_adm_integrals(
         make_not_null(&local_adm_mass),
         make_not_null(&local_adm_linear_momentum),
+        make_not_null(&local_adm_angular_momentum_z),
         make_not_null(&local_center_of_mass), conformal_factor,
         deriv_conformal_factor, conformal_metric, inv_conformal_metric,
         conformal_christoffel_second_kind, conformal_christoffel_contracted,
@@ -257,6 +261,7 @@ void test_local_adm_integrals(const double& distance,
         trace_extrinsic_curvature, inertial_coords, inv_jacobian, mesh,
         current_element, conformal_face_normals);
     total_adm_mass.get() += get(local_adm_mass);
+    total_adm_angular_momentum_z.get() += get(local_adm_angular_momentum_z);
     for (int I = 0; I < 3; I++) {
       total_adm_linear_momentum.get(I) += local_adm_linear_momentum.get(I);
       total_center_of_mass.get(I) += local_center_of_mass.get(I);
@@ -270,6 +275,7 @@ void test_local_adm_integrals(const double& distance,
   CHECK(get<1>(total_adm_linear_momentum) == custom_approx(0.));
   CHECK(get<2>(total_adm_linear_momentum) ==
         custom_approx(lorentz_factor * mass * boost_speed));
+  CHECK(get(total_adm_angular_momentum_z) == custom_approx(0.));
   CHECK(get<0>(total_center_of_mass) == custom_approx(0.));
   CHECK(get<1>(total_center_of_mass) == custom_approx(0.));
   CHECK(get<2>(total_center_of_mass) == custom_approx(0.));

--- a/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Xcts/CMakeLists.txt
@@ -4,8 +4,8 @@
 set(LIBRARY Test_XctsPointwiseFunctions)
 
 set(LIBRARY_SOURCES
-  Test_AdmLinearMomentum.cpp
   Test_AdmMass.cpp
+  Test_AdmMomentum.cpp
   Test_CenterOfMass.cpp
   Test_ExtrinsicCurvature.cpp
   Test_LongitudinalOperator.cpp

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
@@ -23,8 +23,8 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
-#include "PointwiseFunctions/Xcts/AdmLinearMomentum.hpp"
 #include "PointwiseFunctions/Xcts/AdmMass.hpp"
+#include "PointwiseFunctions/Xcts/AdmMomentum.hpp"
 
 namespace {
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR implements the $J_{ADM}$ integral based on [arXiv:1506.01689](https://arxiv.org/abs/1506.01689). We only compute the z-component because that's the quantity of interest to control hyperbolic encounters. Since the $J_{ADM}$ integrand is closely related to the $P_{ADM}$ integrand, I've put both pointwise functions together, renaming `AdmLinearMomentum` to `AdmMomentum`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
