### PR TITLE
Allow Singletons to use `ExecutePhaseChange`

### DIFF
--- a/docs/DevGuide/Parallelization.md
+++ b/docs/DevGuide/Parallelization.md
@@ -866,4 +866,4 @@ also be run. Which functions are run on each node and core is set by calling
 `Parallel::charmxx::register_init_node_and_proc` in `CkRegisterMainModule()`
 with function pointers to the functions to be called. For example:
 
-\snippet Test_AlgorithmPhaseControl.cpp charm_init_funcs_example
+\snippet Test_AlgorithmPhaseControlNodegroup.cpp charm_init_funcs_example

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -147,8 +147,11 @@ add_algorithm_test(
   "AlgorithmGlobalCache"
   INPUT_FILE "Test_AlgorithmGlobalCache.yaml")
 add_algorithm_test(
-  "AlgorithmPhaseControl"
-  INPUT_FILE "Test_AlgorithmPhaseControl.yaml")
+  "AlgorithmPhaseControlSingleton"
+  INPUT_FILE "Test_AlgorithmPhaseControlSingleton.yaml")
+add_algorithm_test(
+  "AlgorithmPhaseControlNodegroup"
+  INPUT_FILE "Test_AlgorithmPhaseControlNodegroup.yaml")
 add_algorithm_test(
   "DynamicInsertionState"
   INPUT_FILE "Test_DynamicInsertionState.yaml")

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControlNodegroup.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControlNodegroup.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Parallel/Test_AlgorithmPhaseControl.hpp"
+
+#include "Parallel/Algorithms/AlgorithmNodegroup.hpp"
+
+// [charm_init_funcs_example]
+extern "C" void CkRegisterMainModule() {
+  Parallel::charmxx::register_main_module<
+      TestMetavariables<Parallel::Algorithms::Nodegroup>>();
+  Parallel::charmxx::register_init_node_and_proc(
+      {&register_factory_classes_with_charm<
+          TestMetavariables<Parallel::Algorithms::Nodegroup>>},
+      {});
+}
+// [charm_init_funcs_example]

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControlNodegroup.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControlNodegroup.yaml
@@ -4,8 +4,6 @@
 ---
 ---
 
-# note that this is a vector of pairs, so has the peculiar '- -' for the
-# elements
 PhaseChangeAndTriggers:
   - Trigger: RegisterTrigger
     PhaseChanges:

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControlSingleton.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControlSingleton.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Parallel/Test_AlgorithmPhaseControl.hpp"
+
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+
+extern "C" void CkRegisterMainModule() {
+  Parallel::charmxx::register_main_module<
+      TestMetavariables<Parallel::Algorithms::Singleton>>();
+  Parallel::charmxx::register_init_node_and_proc(
+      {&register_factory_classes_with_charm<
+          TestMetavariables<Parallel::Algorithms::Singleton>>},
+      {});
+}

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControlSingleton.yaml
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControlSingleton.yaml
@@ -1,0 +1,17 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+---
+---
+
+PhaseChangeAndTriggers:
+  - Trigger: RegisterTrigger
+    PhaseChanges:
+      - VisitAndReturn(Register)
+  - Trigger: SolveTrigger
+    PhaseChanges:
+      - VisitAndReturn(Solve)
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto


### PR DESCRIPTION
## Proposed changes

This PR allows singletons to contribute to reduction data by calling `ExecutePhaseChange`. I needed this to checkpoint the worldtube singleton.

I duplicate the algorithm unit test for this action it to show that it works with singletons now as well.