### PR TITLE
Add compute tags for constraint gammas in worldtube evolution

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -292,8 +292,6 @@ struct EvolutionMetavars {
       Initialization::Actions::AddSimpleTags<
           CurvedScalarWave::Worldtube::Initialization::
               InitializeCurrentIteration,
-          CurvedScalarWave::Worldtube::Initialization::
-              InitializeConstraintDampingGammas<volume_dim>,
           CurvedScalarWave::Initialization::InitializeEvolvedVariables<
               volume_dim>>,
       Initialization::Actions::AddComputeTags<
@@ -302,6 +300,8 @@ struct EvolutionMetavars {
       Initialization::Actions::AddComputeTags<tmpl::list<
           CurvedScalarWave::Worldtube::Tags::ParticlePositionVelocityCompute<
               volume_dim>,
+          CurvedScalarWave::Worldtube::Tags::ConstraintGamma1Compute,
+          CurvedScalarWave::Worldtube::Tags::ConstraintGamma2Compute,
           CurvedScalarWave::Worldtube::Tags::FaceCoordinatesCompute<
               volume_dim, Frame::Inertial, true>,
           CurvedScalarWave::Worldtube::Tags::FaceCoordinatesCompute<

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -839,5 +839,40 @@ struct dtPsi0 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/*!
+ * \brief Sets Gamma1 to zero throughout the domain. The equations are given in
+ * Initialization::InitializeConstraintDampingGammas.
+ */
+struct ConstraintGamma1Compute : CurvedScalarWave::Tags::ConstraintGamma1,
+                                 db::ComputeTag {
+  static constexpr size_t Dim = 3;
+  using base = CurvedScalarWave::Tags::ConstraintGamma1;
+  using return_type = Scalar<DataVector>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  static void function(gsl::not_null<Scalar<DataVector>*> gamma1,
+                       const tnsr::I<DataVector, Dim, Frame::Inertial>& coords);
+};
+
+/*!
+ * \brief Sets Gamma2 to a Gaussian that falls off to a constant value centered
+ * on the position of the particle. This was found to be necessary for a stable
+ * evolution. The equations are given in
+ * Initialization::InitializeConstraintDampingGammas.
+ */
+struct ConstraintGamma2Compute : CurvedScalarWave::Tags::ConstraintGamma2,
+                                 db::ComputeTag {
+  static constexpr size_t Dim = 3;
+  using base = CurvedScalarWave::Tags::ConstraintGamma2;
+  using return_type = Scalar<DataVector>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 ParticlePositionVelocity<Dim>>;
+  static void function(
+      gsl::not_null<Scalar<DataVector>*> gamma2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
+      const std::array<tnsr::I<double, Dim, Frame::Inertial>, 2>& pos_vel);
+};
+
 }  // namespace Tags
 }  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
## Proposed changes

A stable worldtube evolution requires the profile of gamma2 to track the position of the particle. This PR includes this with a compute tag.
