### PR TITLE
Add volume data output to Schwarz solver

### DIFF
--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
@@ -67,12 +67,12 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
                  Tags::ParentMesh<Dim>,
                  observers::Tags::ObservationKey<Tags::MultigridLevel>,
                  observers::Tags::ObservationKey<Tags::IsFinestGrid>,
-                 Tags::ObservationId<OptionsGroup>,
+                 LinearSolver::Tags::ObservationId<OptionsGroup>,
                  Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>;
   using compute_tags = tmpl::list<>;
   using const_global_cache_tags =
       tmpl::list<Tags::MaxLevels<OptionsGroup>,
-                 Tags::OutputVolumeData<OptionsGroup>>;
+                 LinearSolver::Tags::OutputVolumeData<OptionsGroup>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
@@ -90,7 +90,7 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
   using argument_tags =
       tmpl::list<domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
                  domain::Tags::InitialRefinementLevels<Dim>,
-                 Tags::OutputVolumeData<OptionsGroup>>;
+                 LinearSolver::Tags::OutputVolumeData<OptionsGroup>>;
   using return_tags = tmpl::append<simple_tags, simple_tags_from_options>;
 
   template <typename... AmrData>
@@ -146,11 +146,12 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
       // Preserve state of observation ID
       if constexpr (tt::is_a_v<tuples::TaggedTuple, AmrData...>) {
         // h-refinement: copy from the parent
-        *observation_id = get<Tags::ObservationId<OptionsGroup>>(amr_data...);
+        *observation_id =
+            get<LinearSolver::Tags::ObservationId<OptionsGroup>>(amr_data...);
       } else if constexpr (tt::is_a_v<std::unordered_map, AmrData...>) {
         // h-coarsening: copy from one of the children (doesn't matter which)
-        *observation_id =
-            get<Tags::ObservationId<OptionsGroup>>(amr_data.begin()->second...);
+        *observation_id = get<LinearSolver::Tags::ObservationId<OptionsGroup>>(
+            amr_data.begin()->second...);
       } else {
         (void)observation_id;
       }
@@ -234,7 +235,7 @@ struct PreparePreSmoothing {
     }
 
     // Record pre-smoothing initial fields and source
-    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+    if (db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
           [](const auto volume_data, const auto& initial_fields,
              const auto& source) {
@@ -292,7 +293,7 @@ struct SkipPostSmoothingAtBottom {
         not db::get<Tags::ParentId<Dim>>(box).has_value();
 
     // Record pre-smoothing result fields and residual
-    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+    if (db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
           [](const auto volume_data, const auto& result_fields,
              const auto& residuals) {
@@ -361,7 +362,7 @@ struct SendCorrectionToFinerGrid {
     const auto& child_ids = db::get<Tags::ChildIds<Dim>>(box);
 
     // Record post-smoothing result fields and residual
-    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+    if (db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
           [](const auto volume_data, const auto& result_fields,
              const auto& residuals) {
@@ -474,7 +475,7 @@ struct ReceiveCorrectionFromCoarserGrid {
         make_not_null(&box));
 
     // Record post-smoothing initial fields and source
-    if (db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+    if (db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
       db::mutate<Tags::VolumeDataForOutput<OptionsGroup, FieldsTag>>(
           [](const auto volume_data, const auto& initial_fields,
              const auto& source) {

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ObserveVolumeData.hpp
@@ -69,12 +69,12 @@ struct ObserveVolumeData {
       Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<Dim>& element_id, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    if (not db::get<Tags::OutputVolumeData<OptionsGroup>>(box)) {
+    if (not db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
       return {Parallel::AlgorithmExecution::Continue, std::nullopt};
     }
     const auto& volume_data = db::get<volume_data_tag>(box);
     const auto& observation_id =
-        db::get<Tags::ObservationId<OptionsGroup>>(box);
+        db::get<LinearSolver::Tags::ObservationId<OptionsGroup>>(box);
     const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
     const auto& inertial_coords =
         db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
@@ -124,7 +124,7 @@ struct ObserveVolumeData {
         ElementVolumeData{element_id, std::move(components), mesh});
 
     // Increment observation ID
-    db::mutate<Tags::ObservationId<OptionsGroup>>(
+    db::mutate<LinearSolver::Tags::ObservationId<OptionsGroup>>(
         [](const auto local_observation_id) { ++(*local_observation_id); },
         make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
@@ -17,6 +17,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Auto.hpp"
 #include "Options/String.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/PupStlCpp17.hpp"
 #include "Utilities/TMPL.hpp"
@@ -122,7 +123,8 @@ template <typename OptionsGroup>
 struct OutputVolumeData : db::SimpleTag {
   using type = bool;
   static constexpr bool pass_metavariables = false;
-  using option_tags = tmpl::list<OptionTags::OutputVolumeData<OptionsGroup>>;
+  using option_tags =
+      tmpl::list<LinearSolver::OptionTags::OutputVolumeData<OptionsGroup>>;
   static type create_from_options(const type value) { return value; };
   static std::string name() {
     return "OutputVolumeData(" + pretty_type::name<OptionsGroup>() + ")";
@@ -189,16 +191,6 @@ struct ParentMesh : db::SimpleTag {
   using type = std::optional<Mesh<Dim>>;
 };
 
-// The following tags are related to volume data output
-
-/// Continuously incrementing ID for volume observations
-template <typename OptionsGroup>
-struct ObservationId : db::SimpleTag {
-  using type = size_t;
-  static std::string name() {
-    return "ObservationId(" + pretty_type::name<OptionsGroup>() + ")";
-  }
-};
 /// @{
 /// Prefix tag for recording volume data in
 /// `LinearSolver::multigrid::Tags::VolumeDataForOutput`

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_headers(
   ComputeTags.hpp
   ElementActions.hpp
   ElementCenteredSubdomainData.hpp
+  ObserveVolumeData.hpp
   OverlapHelpers.hpp
   Schwarz.hpp
   SubdomainOperator.hpp

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -206,17 +206,21 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
       subdomain_solver<FieldsTag, SubdomainOperator, SubdomainPreconditioners>;
   using subdomain_solver_tag =
       Tags::SubdomainSolver<SubdomainSolver, OptionsGroup>;
+  using volume_data_tag =
+      Tags::VolumeDataForOutput<SubdomainData, OptionsGroup>;
 
  public:  // Iterable action
   using simple_tags_from_options = tmpl::list<subdomain_solver_tag>;
 
-  using const_global_cache_tags = tmpl::list<Tags::MaxOverlap<OptionsGroup>>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::MaxOverlap<OptionsGroup>,
+                 LinearSolver::Tags::OutputVolumeData<OptionsGroup>>;
 
-  using simple_tags =
-      tmpl::list<Tags::IntrudingExtents<Dim, OptionsGroup>,
-                 Tags::Weight<OptionsGroup>,
-                 domain::Tags::Faces<Dim, Tags::Weight<OptionsGroup>>,
-                 SubdomainDataBufferTag<SubdomainData, OptionsGroup>>;
+  using simple_tags = tmpl::list<
+      Tags::IntrudingExtents<Dim, OptionsGroup>, Tags::Weight<OptionsGroup>,
+      domain::Tags::Faces<Dim, Tags::Weight<OptionsGroup>>,
+      SubdomainDataBufferTag<SubdomainData, OptionsGroup>,
+      LinearSolver::Tags::ObservationId<OptionsGroup>, volume_data_tag>;
   using compute_tags = tmpl::list<>;
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
@@ -244,7 +248,9 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
       const gsl::not_null<DirectionMap<Dim, Scalar<DataVector>>*>
           intruding_overlap_weights,
       const gsl::not_null<SubdomainData*> subdomain_data,
-      [[maybe_unused]] const gsl::not_null<std::unique_ptr<SubdomainSolver>*>
+      const gsl::not_null<size_t*> observation_id,
+      const gsl::not_null<SubdomainData*> /*volume_data_for_output*/,
+      const gsl::not_null<std::unique_ptr<SubdomainSolver>*>
           subdomain_solver,
       const Element<Dim>& element, const Mesh<Dim>& mesh,
       const tnsr::I<DataVector, Dim, Frame::ElementLogical>& logical_coords,
@@ -299,14 +305,23 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
     // Subdomain solver
     // The subdomain solver initially gets created from options on each element.
     // Then we have to copy it around during AMR.
-    if constexpr (sizeof...(AmrData) == 1) {
+    if constexpr (sizeof...(AmrData) == 0) {
+      *observation_id = 0;
+      (void)subdomain_solver;
+    } else {
       if constexpr (tt::is_a_v<tuples::TaggedTuple, AmrData...>) {
         // h-refinement: copy from the parent
+        *observation_id =
+            get<LinearSolver::Tags::ObservationId<OptionsGroup>>(amr_data...);
         *subdomain_solver = get<subdomain_solver_tag>(amr_data...)->get_clone();
       } else if constexpr (tt::is_a_v<std::unordered_map, AmrData...>) {
         // h-coarsening, copy from one of the children (doesn't matter which)
+        *observation_id = get<LinearSolver::Tags::ObservationId<OptionsGroup>>(
+            amr_data.begin()->second...);
         *subdomain_solver =
             get<subdomain_solver_tag>(amr_data.begin()->second...)->get_clone();
+      } else {
+        (void)observation_id;
       }
       (*subdomain_solver)->reset();
     }
@@ -456,6 +471,15 @@ struct SolveSubdomain {
           db::get<Tags::ObservePerCoreReductions<OptionsGroup>>(box));
     }
 
+    // Record subdomain solution for volume data output
+    if (db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      db::mutate<Tags::VolumeDataForOutput<SubdomainData, OptionsGroup>>(
+          [&subdomain_solution](const auto volume_data) {
+            volume_data->element_data = subdomain_solution.element_data;
+          },
+          make_not_null(&box));
+    }
+
     // Apply weighting
     if (LIKELY(max_overlap > 0)) {
       subdomain_solution.element_data *=
@@ -540,11 +564,22 @@ struct ReceiveOverlapSolution {
                        pretty_type::name<OptionsGroup>(), iteration_id);
     }
 
-    // Add solutions on overlaps to this element's solution in a weighted sum
+    // Extract overlap solutions from inbox
     auto received_overlap_solutions =
         std::move(tuples::get<overlap_solution_inbox_tag>(inboxes)
                       .extract(iteration_id)
                       .mapped());
+
+    // Record overlap solutions for volume data output
+    if (db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      db::mutate<Tags::VolumeDataForOutput<SubdomainData, OptionsGroup>>(
+          [&received_overlap_solutions](const auto volume_data) {
+            volume_data->overlap_data = received_overlap_solutions;
+          },
+          make_not_null(&box));
+    }
+
+    // Add overlap solutions to this element's solution in a weighted sum
     db::mutate<fields_tag>(
         [&received_overlap_solutions](
             const auto fields, const Index<Dim>& full_extents,

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ObserveVolumeData.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ObserveVolumeData.hpp
@@ -1,0 +1,181 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/Observer/GetSectionObservationKey.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/ElementCenteredSubdomainData.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace LinearSolver::Schwarz::detail {
+
+template <typename OptionsGroup, typename ArraySectionIdTag>
+struct RegisterWithVolumeObserver {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename ArrayIndex>
+  static std::pair<observers::TypeOfObservation, observers::ObservationKey>
+  register_info(const db::DataBox<DbTagsList>& box,
+                const ArrayIndex& /*array_index*/) {
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    const std::string subfile_path = "/" + pretty_type::name<OptionsGroup>() +
+                                     section_observation_key.value_or("");
+    return {observers::TypeOfObservation::Volume,
+            observers::ObservationKey(subfile_path)};
+  }
+};
+
+// Contribute the volume data recorded in the other actions to the observer at
+// the end of a step.
+template <typename FieldsTag, typename OptionsGroup, typename SubdomainOperator,
+          typename ArraySectionIdTag>
+struct ObserveVolumeData {
+ private:
+  using fields_tag = FieldsTag;
+  using residual_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
+  static constexpr size_t Dim = SubdomainOperator::volume_dim;
+  using SubdomainData =
+      ElementCenteredSubdomainData<Dim, typename residual_tag::tags_list>;
+  using volume_data_tag =
+      Tags::VolumeDataForOutput<SubdomainData, OptionsGroup>;
+  using VolumeDataVars = typename volume_data_tag::type::ElementData;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    if (not db::get<LinearSolver::Tags::OutputVolumeData<OptionsGroup>>(box)) {
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+    const auto& volume_data = db::get<volume_data_tag>(box);
+    const auto& observation_id =
+        db::get<LinearSolver::Tags::ObservationId<OptionsGroup>>(box);
+    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
+    const auto& inertial_coords =
+        db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    // Collect tensor components to observe
+    std::vector<TensorComponent> components{};
+    const auto record_tensor_components = [&components](
+                                              const auto tensor_tag_v,
+                                              const auto& tensor,
+                                              const std::string& suffix = "") {
+      using tensor_tag = std::decay_t<decltype(tensor_tag_v)>;
+      using TensorType = std::decay_t<decltype(tensor)>;
+      using VectorType = typename TensorType::type;
+      using ValueType = typename VectorType::value_type;
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        const std::string component_name =
+            db::tag_name<tensor_tag>() + suffix + tensor.component_suffix(i);
+        if constexpr (std::is_same_v<ValueType, std::complex<double>>) {
+          components.emplace_back("Re(" + component_name + ")",
+                                  real(tensor[i]));
+          components.emplace_back("Im(" + component_name + ")",
+                                  imag(tensor[i]));
+        } else {
+          components.emplace_back(component_name, tensor[i]);
+        }
+      }
+    };
+    record_tensor_components(domain::Tags::Coordinates<Dim, Frame::Inertial>{},
+                             inertial_coords);
+    const auto& all_intruding_extents =
+        db::get<Tags::IntrudingExtents<Dim, OptionsGroup>>(box);
+    const VolumeDataVars zero_vars{mesh.number_of_grid_points(), 0.};
+    tmpl::for_each<typename VolumeDataVars::tags_list>(
+        [&volume_data, &record_tensor_components, &mesh, &all_intruding_extents,
+         &zero_vars, &element_id](auto tag_v) {
+          using tag = tmpl::type_from<decltype(tag_v)>;
+          record_tensor_components(tag{}, get<tag>(volume_data.element_data),
+                                   "_Center");
+          for (const auto direction : Direction<Dim>::all_directions()) {
+            const auto direction_predicate =
+                [&direction](const auto& overlap_data) {
+                  return overlap_data.first.direction() == direction;
+                };
+            const auto num_overlaps =
+                alg::count_if(volume_data.overlap_data, direction_predicate);
+            if (num_overlaps == 0) {
+              // No overlap data for this direction (e.g. external boundary),
+              // record zero
+              record_tensor_components(tag{}, get<tag>(zero_vars),
+                                       "_Overlap" + get_output(direction));
+            } else if (num_overlaps == 1) {
+              // Overlap data from a single neighbor, record it
+              const auto& overlap_data =
+                  alg::find_if(volume_data.overlap_data, direction_predicate)
+                      ->second;
+              const auto& intruding_extents =
+                  gsl::at(all_intruding_extents, direction.dimension());
+              record_tensor_components(
+                  tag{},
+                  get<tag>(extended_overlap_data(overlap_data, mesh.extents(),
+                                                 intruding_extents, direction)),
+                  "_Overlap" + get_output(direction));
+            } else {
+              ERROR("Multiple neighbors ("
+                    << num_overlaps << ") overlap with element " << element_id
+                    << " in direction " << direction
+                    << ", but we can record only one for volume data output.");
+            }
+          }
+        });
+
+    // Contribute tensor components to observer
+    auto& local_observer = *Parallel::local_branch(
+        Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+            cache));
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    const std::string subfile_path = "/" + pretty_type::name<OptionsGroup>() +
+                                     section_observation_key.value_or("");
+    Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+        local_observer, observers::ObservationId(observation_id, subfile_path),
+        subfile_path,
+        Parallel::make_array_component_id<ParallelComponent>(element_id),
+        ElementVolumeData{element_id, std::move(components), mesh});
+
+    // Increment observation ID
+    db::mutate<LinearSolver::Tags::ObservationId<OptionsGroup>>(
+        [](const auto local_observation_id) { ++(*local_observation_id); },
+        make_not_null(&box));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+}  // namespace LinearSolver::Schwarz::detail

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Schwarz.hpp
@@ -6,6 +6,7 @@
 #include "IO/Observer/Helpers.hpp"
 #include "ParallelAlgorithms/LinearSolver/AsynchronousSolvers/ElementActions.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp"
+#include "ParallelAlgorithms/LinearSolver/Schwarz/ObserveVolumeData.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -174,11 +175,13 @@ struct Schwarz {
 
   using amr_projectors = initialize_element;
 
-  using register_element =
-      tmpl::list<async_solvers::RegisterElement<FieldsTag, OptionsGroup,
-                                                SourceTag, ArraySectionIdTag>,
-                 detail::RegisterElement<FieldsTag, OptionsGroup, SourceTag,
-                                         ArraySectionIdTag>>;
+  using register_element = tmpl::list<
+      async_solvers::RegisterElement<FieldsTag, OptionsGroup, SourceTag,
+                                     ArraySectionIdTag>,
+      detail::RegisterElement<FieldsTag, OptionsGroup, SourceTag,
+                              ArraySectionIdTag>,
+      observers::Actions::RegisterWithObservers<
+          detail::RegisterWithVolumeObserver<OptionsGroup, ArraySectionIdTag>>>;
 
   template <typename ApplyOperatorActions, typename Label = OptionsGroup>
   using solve = tmpl::list<
@@ -189,6 +192,8 @@ struct Schwarz {
                              SubdomainPreconditioners, ArraySectionIdTag>,
       detail::ReceiveOverlapSolution<FieldsTag, OptionsGroup,
                                      SubdomainOperator>,
+      detail::ObserveVolumeData<FieldsTag, OptionsGroup, SubdomainOperator,
+                                ArraySectionIdTag>,
       ApplyOperatorActions,
       async_solvers::CompleteStep<FieldsTag, OptionsGroup, SourceTag, Label,
                                   ArraySectionIdTag>>;

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
@@ -180,6 +180,14 @@ struct SummedIntrudingOverlapWeights : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/// Buffer for recording volume data
+template <typename SubdomainDataType, typename OptionsGroup>
+struct VolumeDataForOutput : db::SimpleTag {
+  using type = SubdomainDataType;
+  static std::string name() {
+    return "VolumeDataForOutput(" + pretty_type::name<OptionsGroup>() + ")";
+  }
+};
 }  // namespace Tags
 }  // namespace LinearSolver::Schwarz
 

--- a/src/ParallelAlgorithms/LinearSolver/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Tags.hpp
@@ -16,7 +16,9 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DynamicMatrix.hpp"
+#include "Options/String.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/GetFundamentalType.hpp"
 
 /*!
@@ -24,6 +26,19 @@
  * \brief Functionality for solving linear systems of equations
  */
 namespace LinearSolver {
+
+namespace OptionTags {
+
+template <typename OptionsGroup>
+struct OutputVolumeData {
+  using type = bool;
+  static constexpr Options::String help =
+      "Record volume data for debugging purposes.";
+  using group = OptionsGroup;
+  static bool suggested_value() { return false; }
+};
+
+}  // namespace OptionTags
 
 /*!
  * \ingroup LinearSolverGroup
@@ -172,6 +187,27 @@ template <typename Tag>
 struct Preconditioned : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
+};
+
+/// Whether or not volume data should be recorded for debugging purposes
+template <typename OptionsGroup>
+struct OutputVolumeData : db::SimpleTag {
+  using type = bool;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::OutputVolumeData<OptionsGroup>>;
+  static type create_from_options(const type value) { return value; };
+  static std::string name() {
+    return "OutputVolumeData(" + pretty_type::name<OptionsGroup>() + ")";
+  }
+};
+
+/// Continuously incrementing ID for volume observations
+template <typename OptionsGroup>
+struct ObservationId : db::SimpleTag {
+  using type = size_t;
+  static std::string name() {
+    return "ObservationId(" + pretty_type::name<OptionsGroup>() + ")";
+  }
 };
 
 }  // namespace Tags

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -235,6 +235,7 @@ LinearSolver:
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates:
   InnerRadius: *outer_shell_inner_radius

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -91,6 +91,7 @@ LinearSolver:
       ExplicitInverse:
         WriteMatrixToFile: None
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 EventsAndTriggersAtIterations:
   - Trigger: HasConverged

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -116,6 +116,7 @@ LinearSolver:
                 WriteMatrixToFile: None
             BoundaryConditions: Auto
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 EventsAndTriggersAtIterations:
   - Trigger: HasConverged

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -131,6 +131,7 @@ LinearSolver:
                 WriteMatrixToFile: None
             BoundaryConditions: Auto
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 EventsAndTriggersAtIterations:
   - Trigger: HasConverged

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -109,6 +109,7 @@ LinearSolver:
       ExplicitInverse:
         WriteMatrixToFile: None
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates:
   InnerRadius: *outer_shell_inner_radius

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -152,6 +152,7 @@ LinearSolver:
       ExplicitInverse:
         WriteMatrixToFile: "SubdomainMatrix"
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates: None
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -93,6 +93,7 @@ LinearSolver:
       ExplicitInverse:
         WriteMatrixToFile: None
     ObservePerCoreReductions: False
+    OutputVolumeData: True
 
 RadiallyCompressedCoordinates: None
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -97,6 +97,7 @@ LinearSolver:
       ExplicitInverse:
         WriteMatrixToFile: None
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates: None
 

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -156,6 +156,7 @@ LinearSolver:
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates: None
 

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -230,6 +230,7 @@ LinearSolver:
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates:
   InnerRadius: *outer_shell_inner_radius

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -168,6 +168,7 @@ LinearSolver:
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates:
   InnerRadius: *outer_shell_inner_radius

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -199,6 +199,7 @@ LinearSolver:
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates: None
 

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -117,6 +117,7 @@ LinearSolver:
             BoundaryConditions: Auto
     SkipResets: True
     ObservePerCoreReductions: False
+    OutputVolumeData: False
 
 RadiallyCompressedCoordinates: None
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -27,6 +27,7 @@
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
 #include "Domain/Creators/Tags/InitialRefinementLevels.hpp"
+#include "Domain/ElementMap.hpp"
 #include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
@@ -270,7 +271,8 @@ struct InitializeElement {
   using simple_tags =
       tmpl::list<domain::Tags::Mesh<1>, domain::Tags::Element<1>,
                  domain::Tags::Coordinates<1, Frame::ElementLogical>,
-                 fields_tag, sources_tag>;
+                 domain::Tags::Coordinates<1, Frame::Inertial>, fields_tag,
+                 sources_tag>;
   using compute_tags = tmpl::list<>;
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
@@ -291,13 +293,17 @@ struct InitializeElement {
         initial_extents, element,
         Parallel::get<elliptic::dg::Tags::Quadrature>(cache));
     auto logical_coords = logical_coordinates(mesh);
+    const ElementMap<1, Frame::Inertial> element_map{
+        element_id, domain.blocks()[element_id.block_id()]};
+    auto inertial_coords = element_map(logical_coords);
     // Element data
     const size_t element_index = get_index(element_id);
     const auto& source = gsl::at(get<Source>(box), element_index);
     const size_t num_points = source.size();
     ::Initialization::mutate_assign<simple_tags>(
         make_not_null(&box), std::move(mesh), std::move(element),
-        std::move(logical_coords), typename fields_tag::type{num_points, 0.},
+        std::move(logical_coords), std::move(inertial_coords),
+        typename fields_tag::type{num_points, 0.},
         typename sources_tag::type{source});
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_Tags.cpp
@@ -28,15 +28,11 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Multigrid.Tags",
       "ParentRefinementLevels");
   TestHelpers::db::test_simple_tag<Tags::MaxLevels<TestSolver>>(
       "MaxLevels(TestSolver)");
-  TestHelpers::db::test_simple_tag<Tags::OutputVolumeData<TestSolver>>(
-      "OutputVolumeData(TestSolver)");
   TestHelpers::db::test_simple_tag<Tags::MultigridLevel>("MultigridLevel");
   TestHelpers::db::test_simple_tag<Tags::IsFinestGrid>("IsFinestGrid");
   TestHelpers::db::test_simple_tag<Tags::ParentId<1>>("ParentId");
   TestHelpers::db::test_simple_tag<Tags::ChildIds<1>>("ChildIds");
   TestHelpers::db::test_simple_tag<Tags::ParentMesh<1>>("ParentMesh");
-  TestHelpers::db::test_simple_tag<Tags::ObservationId<TestSolver>>(
-      "ObservationId(TestSolver)");
   TestHelpers::db::test_prefix_tag<Tags::PreSmoothingInitial<Tag>>(
       "PreSmoothingInitial(Tag)");
   TestHelpers::db::test_prefix_tag<Tags::PreSmoothingSource<Tag>>(

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.yaml
@@ -73,6 +73,7 @@ SchwarzSmoother:
         ExplicitInverse:
           WriteMatrixToFile: None
   ObservePerCoreReductions: False
+  OutputVolumeData: True
 
 ConvergenceReason: NumIterations
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Test_Tags.cpp
@@ -19,6 +19,7 @@ struct Tag : db::SimpleTag {
 struct TestOptionsGroup {
   static std::string name() { return "TestLinearSolver"; }
 };
+struct TestSolver {};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
@@ -42,6 +43,12 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.LinearSolver.Tags",
       LinearSolver::Tags::KrylovSubspaceBasis<Tag>>("KrylovSubspaceBasis(Tag)");
   TestHelpers::db::test_prefix_tag<LinearSolver::Tags::Preconditioned<Tag>>(
       "Preconditioned(Tag)");
+  TestHelpers::db::test_simple_tag<
+      LinearSolver::Tags::OutputVolumeData<TestSolver>>(
+      "OutputVolumeData(TestSolver)");
+  TestHelpers::db::test_simple_tag<
+      LinearSolver::Tags::ObservationId<TestSolver>>(
+      "ObservationId(TestSolver)");
 
   {
     INFO("ResidualCompute");


### PR DESCRIPTION
## Proposed changes

Allows to record and visualize volume data from the Schwarz solver.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In elliptic input files, add the option `LinearSolver.SchwarzSmoother.OutputVolumeData: False`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
