### PR TITLE
Change worldtube radius function

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -2765,6 +2765,19 @@ archivePrefix = {arXiv},
     year = "2024"
 }
 
+@article{Wittek:2024pis,
+    author = "Wittek, Nikolas A. and Barack, Leor and Pfeiffer, Harald P.
+              and Pound, Adam and Deppe, Nils and Kidder, Lawrence E. and
+              Macedo, Alexandra and Nelli, Kyle C. and Throwe, William
+              and Vu, Nils L.",
+    title = "{Relieving scale disparity in binary black hole simulations}",
+    eprint = "2410.22290",
+    archivePrefix = "arXiv",
+    primaryClass = "gr-qc",
+    month = "10",
+    year = "2024"
+}
+
 @article{Yee1999,
   author   = "Yee, H. C. and Sandham, N. D. and Djomehri, M. J.",
   title    = "Low-Dissipative High-Order Shock-Capturing Methods Using

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/RadiusFunctions.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/RadiusFunctions.cpp
@@ -30,17 +30,18 @@ void check_delta(const double delta) {
 }  // namespace detail
 
 double smooth_broken_power_law(const double orbit_radius, const double alpha,
-                               const double amp, const double rb,
+                               const double radius_at_inf, const double rb,
                                const double delta) {
   detail::check_alpha(alpha);
   detail::check_delta(delta);
   const double r_by_rb = orbit_radius / rb;
-  return amp * pow(r_by_rb, alpha) *
-         pow(0.5 * (1. + pow(r_by_rb, 1. / delta)), -alpha * delta);
+  return radius_at_inf * pow(r_by_rb, alpha) *
+         pow(1. + pow(r_by_rb, 1. / delta), -alpha * delta);
 }
 
 double smooth_broken_power_law_derivative(const double orbit_radius,
-                                          const double alpha, const double amp,
+                                          const double alpha,
+                                          const double radius_at_inf,
                                           const double rb, const double delta) {
   detail::check_alpha(alpha);
   detail::check_delta(delta);
@@ -52,10 +53,10 @@ double smooth_broken_power_law_derivative(const double orbit_radius,
   }
   const double r_by_rb = orbit_radius / rb;
   const double temp1 = pow(r_by_rb, 1. / delta - 1.);
-  const double temp2 = 0.5 * temp1 * r_by_rb + 0.5;
+  const double temp2 = temp1 * r_by_rb + 1.;
 
-  return amp * alpha * pow(r_by_rb, alpha - 1) / rb *
-         pow(temp2, -alpha * delta - 1.) * (temp2 - 0.5 * temp1 * r_by_rb);
+  return radius_at_inf * alpha * pow(r_by_rb, alpha - 1) / rb *
+         pow(temp2, -alpha * delta - 1.) * (temp2 - temp1 * r_by_rb);
 }
 
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/RadiusFunctions.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/RadiusFunctions.hpp
@@ -16,28 +16,29 @@ void check_delta(double delta);
  * \brief A smoothly broken power law that falls off to a constant value
  * for larger radii.
  *
- * \details The function is given by
+ * \details The function is given by Eq. (3) of \cite Wittek:2024pis
  *
  * \begin{equation}
- * f(r) = A \left(\frac{r}{r_b}\right)^{\alpha}\left[ \frac{1}{2} \left( 1 +
- * \left(\frac{r}{r_b}\right)^{1 / \Delta}\right)\right]^{-\alpha\Delta}.
+ * f(r) = R_\infty \left(\frac{r}{r_b}\right)^{\alpha} \left( 1 +
+ * \left(\frac{r}{r_b}\right)^{1 / \Delta}\right)^{-\alpha\Delta}.
  * \end{equation}
  *
  * For radii $r \ll r_b$, the function obeys the power law $f(r) \propto
- * r^{\alpha}$. For radii $r \gg r_b$, the function is constant. The parameter
- * $\Delta$ determines the width of the transition region with a larger value of
- * $\Delta$ leading to a more gradual transition.
+ * r^{\alpha}$. For radii $r \gg r_b$, the function asymptotes to $R_\infty$.
+ * The parameter $\Delta$ determines the width of the transition region with a
+ * larger value of $\Delta$ leading to a more gradual transition.
  *
  * This function is used to control the worldtube radius for more eccentric
  * orbits so the radius does not grow too large during the apoapsis passage
  * as this does not lead to performance gains and can cause problems with the
  * domain.
  */
-double smooth_broken_power_law(double orbit_radius, double alpha, double amp,
-                               double rb, double delta);
+double smooth_broken_power_law(double orbit_radius, double alpha,
+                               double radius_at_inf, double rb, double delta);
 /*!
  * \brief Returns the analytical derivative of `smooth_broken_power_law`.
  */
 double smooth_broken_power_law_derivative(double orbit_radius, double alpha,
-                                          double amp, double rb, double delta);
+                                          double radius_at_inf, double rb,
+                                          double delta);
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_RadiusFunctions.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_RadiusFunctions.cpp
@@ -11,25 +11,28 @@
 namespace CurvedScalarWave::Worldtube {
 namespace {
 void test_smooth_broken_power_law_limits() {
-  const double amp = 1.234;
+  const double radius_at_inf = 1.234;
   const double rb = 43.45;
   for (const double exp : {0., 0.01, 0.5, 1., 1.5, 2.456, 3., 4.}) {
     for (const double delta : {0.01, 0.0345, 0.1}) {
       CAPTURE(exp, delta);
       const double r_left_1 = 1.1;
       const double r_left_2 = 1.2;
-      const double v1 = smooth_broken_power_law(r_left_1, exp, amp, rb, delta);
-      const double v2 = smooth_broken_power_law(r_left_2, exp, amp, rb, delta);
+      const double v1 =
+          smooth_broken_power_law(r_left_1, exp, radius_at_inf, rb, delta);
+      const double v2 =
+          smooth_broken_power_law(r_left_2, exp, radius_at_inf, rb, delta);
       const double left_exponent = log(v2 / v1) / log(r_left_2 / r_left_1);
       CHECK(left_exponent == approx(exp));
 
       const double r_right_1 = 100. * rb;
       const double r_right_2 = 100. * rb + 0.1;
       const double v1_const =
-          smooth_broken_power_law(r_right_1, exp, amp, rb, delta);
+          smooth_broken_power_law(r_right_1, exp, radius_at_inf, rb, delta);
       const double v2_const =
-          smooth_broken_power_law(r_right_2, exp, amp, rb, delta);
-      CHECK(v1_const == approx(v2_const));
+          smooth_broken_power_law(r_right_2, exp, radius_at_inf, rb, delta);
+      CHECK(v1_const == approx(radius_at_inf));
+      CHECK(v2_const == approx(radius_at_inf));
     }
   }
 }
@@ -44,7 +47,7 @@ double central_difference_order8(const std::function<double(double)>& func,
 }
 
 void test_smooth_broken_power_law_derivative() {
-  const double amp = 1.234;
+  const double radius_at_inf = 1.234;
   const double rb = 10.;
 
   // the finite difference method carries an error of about 1e-10
@@ -52,8 +55,8 @@ void test_smooth_broken_power_law_derivative() {
 
   for (const double exp : {0., 0.01, 0.5, 1., 1.5, 2.456, 3., 4.}) {
     for (const double delta : {0.01, 0.0345, 0.1}) {
-      auto fd_func = [exp, amp, rb, delta](double r) -> double {
-        return smooth_broken_power_law(r, exp, amp, rb, delta);
+      auto fd_func = [exp, radius_at_inf, rb, delta](double r) -> double {
+        return smooth_broken_power_law(r, exp, radius_at_inf, rb, delta);
       };
       // test for a wide range of radii: critical are the points around rb in
       // the transition region and around rb + 1000 * delta, where the
@@ -64,7 +67,7 @@ void test_smooth_broken_power_law_derivative() {
         const double fd_derivative =
             central_difference_order8(fd_func, test_radius, 1e-3);
         const double analytical_derivative = smooth_broken_power_law_derivative(
-            test_radius, exp, amp, rb, delta);
+            test_radius, exp, radius_at_inf, rb, delta);
         CHECK(fd_derivative == custom_approx(analytical_derivative));
       }
     }


### PR DESCRIPTION
## Proposed changes

This PR makes the radius function consistent with the version given in the letter. The amplitude of the smoothly broken power law then becomes the maximum radius the worldtube asymptotes to.