### PR TITLE
Use git-clang-format corresponding to clang-format

### DIFF
--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -38,6 +38,18 @@ if (CLANG_FORMAT_BIN)
     string(REGEX REPLACE "clang-format version " ""
       CLANG_FORMAT_VERSION ${CLANG_FORMAT_VERSION})
   endif()
+
+  # Look for a git-clang-format program in the same place as
+  # clang-format.  Versions of git-clang-format are not always
+  # compatible with other clang-format executables.
+  get_filename_component(CLANG_FORMAT_DIR ${CLANG_FORMAT_BIN} DIRECTORY)
+  get_filename_component(CLANG_FORMAT_NAME ${CLANG_FORMAT_BIN} NAME)
+  find_program(
+    GIT_CLANG_FORMAT_BIN
+    NAMES git-${CLANG_FORMAT_NAME}
+    HINTS ${CLANG_FORMAT_DIR}
+    NO_DEFAULT_PATH
+  )
 endif()
 
 

--- a/tools/Hooks/pre-commit.sh
+++ b/tools/Hooks/pre-commit.sh
@@ -33,10 +33,10 @@ printf '%s\0' "${commit_files[@]}" | run_checks "${standard_checks[@]}"
 
 ###############################################################################
 # Use git-clang-format to check for any suspicious formatting of code.
-@CLANG_FORMAT_BIN@ --version > /dev/null
+@GIT_CLANG_FORMAT_BIN@ --help > /dev/null
 if [ $? -eq 0 ]; then
-    clang_format_diff=$(@GIT_EXECUTABLE@ --no-pager \
-        clang-format --binary @CLANG_FORMAT_BIN@ --diff --quiet)
+    clang_format_diff=$(
+        @GIT_CLANG_FORMAT_BIN@ --binary @CLANG_FORMAT_BIN@ --diff --quiet)
     # Clang-format didn't always return the right exit code before version 15,
     # so we check the diff output instead (see issue:
     # https://github.com/llvm/llvm-project/issues/54758)


### PR DESCRIPTION
Might not be compatible with git-clang-format version.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
