### PR TITLE
Allow CellCenteredFlux to work for mixed systems

### DIFF
--- a/src/Evolution/DgSubcell/CellCenteredFlux.hpp
+++ b/src/Evolution/DgSubcell/CellCenteredFlux.hpp
@@ -35,6 +35,7 @@ template <typename System, typename FluxMutator, size_t Dim,
           bool ComputeOnlyOnRollback, typename Fr = Frame::Inertial>
 struct CellCenteredFlux {
   using flux_variables = typename System::flux_variables;
+  using variables = typename System::variables_tag::tags_list;
 
   using return_tags =
       tmpl::list<subcell::Tags::CellCenteredFlux<flux_variables, Dim>>;
@@ -42,7 +43,7 @@ struct CellCenteredFlux {
       typename FluxMutator::argument_tags, subcell::Tags::SubcellOptions<Dim>,
       subcell::Tags::Mesh<Dim>, domain::Tags::Mesh<Dim>,
       domain::Tags::MeshVelocity<Dim, Frame::Inertial>,
-      ::Tags::Variables<flux_variables>, subcell::Tags::DidRollback>;
+      ::Tags::Variables<variables>, subcell::Tags::DidRollback>;
 
   template <typename... FluxTags, typename... Args>
   static void apply(
@@ -51,7 +52,7 @@ struct CellCenteredFlux {
       const subcell::SubcellOptions& subcell_options,
       const Mesh<Dim>& subcell_mesh, const Mesh<Dim>& dg_mesh,
       const std::optional<tnsr::I<DataVector, Dim>>& dg_mesh_velocity,
-      const ::Variables<flux_variables>& cell_centered_flux_vars,
+      const ::Variables<variables>& cell_centered_flux_vars,
       const bool did_rollback, Args&&... args) {
     if (did_rollback or not ComputeOnlyOnRollback) {
       if (subcell_options.finite_difference_derivative_order() !=

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -35,6 +35,7 @@
 #include "Evolution/DgSubcell/Actions/TciAndRollback.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp"
 #include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
+#include "Evolution/DgSubcell/CellCenteredFlux.hpp"
 #include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
 #include "Evolution/DgSubcell/GetActiveTag.hpp"
@@ -763,6 +764,8 @@ struct GhValenciaDivCleanTemplateBase<
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
+      Actions::MutateApply<evolution::dg::subcell::fd::CellCenteredFlux<
+          system, grmhd::ValenciaDivClean::ComputeFluxes, volume_dim, false>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim,
           grmhd::GhValenciaDivClean::subcell::PrimitiveGhostVariables,
@@ -773,6 +776,8 @@ struct GhValenciaDivCleanTemplateBase<
       Actions::MutateApply<
           grmhd::GhValenciaDivClean::subcell::PrimsAfterRollback<
               ordered_list_of_primitive_recovery_schemes>>,
+      Actions::MutateApply<evolution::dg::subcell::fd::CellCenteredFlux<
+          system, grmhd::ValenciaDivClean::ComputeFluxes, volume_dim, true>>,
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           grmhd::GhValenciaDivClean::subcell::TimeDerivative>,
       Actions::RecordTimeStepperData<system>,


### PR DESCRIPTION
Previously CellCenteredFlux assumed that the flux_variables were the same as the evolved variables.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
