### PR TITLE
Reduce StaticCache compile time

### DIFF
--- a/src/Evolution/DgSubcell/Matrices.cpp
+++ b/src/Evolution/DgSubcell/Matrices.cpp
@@ -37,118 +37,33 @@ const Matrix& projection_matrix(
              subcell_quadrature == Spectral::Quadrature::CellCentered,
          "subcell_quadrature option in projection_matrix should be "
          "FaceCentered or CellCentered");
-  switch (dg_mesh.quadrature(0)) {
-    case Spectral::Quadrature::GaussLobatto: {
-      switch (subcell_quadrature) {
-        case Spectral::Quadrature::CellCentered: {
-          static const auto cache_gl = make_static_cache<
-              CacheRange<Spectral::minimum_number_of_points<
-                             Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto>,
-                         Spectral::maximum_number_of_points<
-                             Spectral::Basis::Legendre> +
-                             1>,
-              CacheRange<Spectral::minimum_number_of_points<
-                             Spectral::Basis::FiniteDifference,
-                             Spectral::Quadrature::CellCentered>,
-                         Spectral::maximum_number_of_points<
-                             Spectral::Basis::FiniteDifference> +
-                             1>>([](const size_t local_num_dg_points,
-                                    const size_t local_num_fd_points) {
-            return Spectral::interpolation_matrix<
-                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>(
-                local_num_dg_points,
-                Spectral::collocation_points<
-                    Spectral::Basis::FiniteDifference,
-                    Spectral::Quadrature::CellCentered>(local_num_fd_points));
-          });
-          return cache_gl(dg_mesh.extents(0), subcell_extents);
-        }
-        case Spectral::Quadrature::FaceCentered: {
-          static const auto cache_gl = make_static_cache<
-              CacheRange<Spectral::minimum_number_of_points<
-                             Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto>,
-                         Spectral::maximum_number_of_points<
-                             Spectral::Basis::Legendre> +
-                             1>,
-              CacheRange<Spectral::minimum_number_of_points<
-                             Spectral::Basis::FiniteDifference,
-                             Spectral::Quadrature::CellCentered>,
-                         Spectral::maximum_number_of_points<
-                             Spectral::Basis::FiniteDifference> +
-                             1>>([](const size_t local_num_dg_points,
-                                    const size_t local_num_fd_points) {
-            return Spectral::interpolation_matrix<
-                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>(
-                local_num_dg_points,
-                Spectral::collocation_points<
-                    Spectral::Basis::FiniteDifference,
-                    Spectral::Quadrature::FaceCentered>(local_num_fd_points));
-          });
-          return cache_gl(dg_mesh.extents(0), subcell_extents);
-        }
-        default:
-          ERROR("Unsupported quadrature type in FD subcell projection matrix");
-      }
-    }
-    case Spectral::Quadrature::Gauss: {
-      switch (subcell_quadrature) {
-        case Spectral::Quadrature::CellCentered: {
-          static const auto cache_g = make_static_cache<
-              CacheRange<
-                  Spectral::minimum_number_of_points<
-                      Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>,
-                  Spectral::maximum_number_of_points<
-                      Spectral::Basis::Legendre> +
-                      1>,
-              CacheRange<Spectral::minimum_number_of_points<
-                             Spectral::Basis::FiniteDifference,
-                             Spectral::Quadrature::CellCentered>,
-                         Spectral::maximum_number_of_points<
-                             Spectral::Basis::FiniteDifference> +
-                             1>>([](const size_t local_num_dg_points,
-                                    const size_t local_num_fd_points) {
-            return Spectral::interpolation_matrix<Spectral::Basis::Legendre,
-                                                  Spectral::Quadrature::Gauss>(
-                local_num_dg_points,
-                Spectral::collocation_points<
-                    Spectral::Basis::FiniteDifference,
-                    Spectral::Quadrature::CellCentered>(local_num_fd_points));
-          });
-          return cache_g(dg_mesh.extents(0), subcell_extents);
-        }
-        case Spectral::Quadrature::FaceCentered: {
-          static const auto cache_g = make_static_cache<
-              CacheRange<
-                  Spectral::minimum_number_of_points<
-                      Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>,
-                  Spectral::maximum_number_of_points<
-                      Spectral::Basis::Legendre> +
-                      1>,
-              CacheRange<Spectral::minimum_number_of_points<
-                             Spectral::Basis::FiniteDifference,
-                             Spectral::Quadrature::CellCentered>,
-                         Spectral::maximum_number_of_points<
-                             Spectral::Basis::FiniteDifference> +
-                             1>>([](const size_t local_num_dg_points,
-                                    const size_t local_num_fd_points) {
-            return Spectral::interpolation_matrix<Spectral::Basis::Legendre,
-                                                  Spectral::Quadrature::Gauss>(
-                local_num_dg_points,
-                Spectral::collocation_points<
-                    Spectral::Basis::FiniteDifference,
-                    Spectral::Quadrature::FaceCentered>(local_num_fd_points));
-          });
-          return cache_g(dg_mesh.extents(0), subcell_extents);
-        }
-        default:
-          ERROR("Unsupported quadrature type in FD subcell projection matrix");
-      }
-    }
-    default:
-      ERROR("Unsupported quadrature type in FD subcell projection matrix");
-  };
+  static const auto cache = make_static_cache<
+      CacheRange<
+          Spectral::minimum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>,
+          Spectral::maximum_number_of_points<Spectral::Basis::Legendre> + 1>,
+      CacheRange<Spectral::minimum_number_of_points<
+                     Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered>,
+                 Spectral::maximum_number_of_points<
+                     Spectral::Basis::FiniteDifference> +
+                     1>,
+      CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
+                       Spectral::Quadrature::GaussLobatto>,
+      CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::CellCentered,
+                       Spectral::Quadrature::FaceCentered>>(
+      [](const size_t local_num_dg_points, const size_t local_num_fd_points,
+         const Spectral::Quadrature dg_quadrature,
+         const Spectral::Quadrature local_subcell_quadrature) {
+        return Spectral::interpolation_matrix(
+            Mesh<1>{local_num_dg_points, Spectral::Basis::Legendre,
+                    dg_quadrature},
+            Spectral::collocation_points(
+                Mesh<1>{local_num_fd_points, Spectral::Basis::FiniteDifference,
+                        local_subcell_quadrature}));
+      });
+  return cache(dg_mesh.extents(0), subcell_extents, dg_mesh.quadrature(0),
+               subcell_quadrature);
 }
 
 namespace {
@@ -437,9 +352,8 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
   ASSERT(ghost_zone_size <= max_ghost_zone_size and ghost_zone_size >= 2,
          "ghost_zone_size must be in [2, " << max_ghost_zone_size
                                            << " ] but got " << ghost_zone_size);
-  switch (dg_mesh.quadrature(0)) {
-    case Spectral::Quadrature::GaussLobatto: {
-      static const auto cache_gl = make_static_cache<
+  static const auto cache =
+      make_static_cache<
           CacheRange<
               Spectral::minimum_number_of_points<
                   Spectral::Basis::Legendre,
@@ -453,9 +367,12 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
                          Spectral::Basis::FiniteDifference> +
                          1>,
           CacheRange<2_st, max_ghost_zone_size + 1>,
+          CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
+                           Spectral::Quadrature::GaussLobatto>,
           CacheEnumeration<Side, Side::Lower, Side::Upper>>(
           [](const size_t local_num_dg_points, const size_t local_num_fd_points,
-             const size_t local_ghost_zone_size, const Side local_side) {
+             const size_t local_ghost_zone_size,
+             const Spectral::Quadrature dg_quadrature, const Side local_side) {
             const DataVector& fd_points = Spectral::collocation_points<
                 Spectral::Basis::FiniteDifference,
                 Spectral::Quadrature::CellCentered>(local_num_fd_points);
@@ -466,50 +383,13 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
                                                : (local_num_fd_points -
                                                   local_ghost_zone_size + i)];
             }
-            return Spectral::interpolation_matrix<
-                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>(
-                local_num_dg_points, target_points);
+            return Spectral::interpolation_matrix(
+                Mesh<1>{local_num_dg_points, Spectral::Basis::Legendre,
+                        dg_quadrature},
+                target_points);
           });
-      return cache_gl(dg_mesh.extents(0), subcell_extents, ghost_zone_size,
-                      side);
-    }
-    case Spectral::Quadrature::Gauss: {
-      static const auto cache_g = make_static_cache<
-          CacheRange<
-              Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
-                                                 Spectral::Quadrature::Gauss>,
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre> +
-                  1>,
-          CacheRange<Spectral::minimum_number_of_points<
-                         Spectral::Basis::FiniteDifference,
-                         Spectral::Quadrature::CellCentered>,
-                     Spectral::maximum_number_of_points<
-                         Spectral::Basis::FiniteDifference> +
-                         1>,
-          CacheRange<2_st, max_ghost_zone_size + 1>,
-          CacheEnumeration<Side, Side::Lower, Side::Upper>>(
-          [](const size_t local_num_dg_points, const size_t local_num_fd_points,
-             const size_t local_ghost_zone_size, const Side local_side) {
-            const DataVector& fd_points = Spectral::collocation_points<
-                Spectral::Basis::FiniteDifference,
-                Spectral::Quadrature::CellCentered>(local_num_fd_points);
-            DataVector target_points(local_ghost_zone_size);
-            for (size_t i = 0; i < local_ghost_zone_size; ++i) {
-              target_points[i] = fd_points[local_side == Side::Lower
-                                               ? i
-                                               : (local_num_fd_points -
-                                                  local_ghost_zone_size + i)];
-            }
-            return Spectral::interpolation_matrix<Spectral::Basis::Legendre,
-                                                  Spectral::Quadrature::Gauss>(
-                local_num_dg_points, target_points);
-          });
-      return cache_g(dg_mesh.extents(0), subcell_extents, ghost_zone_size,
-                     side);
-    }
-    default:
-      ERROR("Unsupported quadrature type in FD subcell projection matrix");
-  };
+  return cache(dg_mesh.extents(0), subcell_extents, ghost_zone_size,
+               dg_mesh.quadrature(0), side);
 }
 
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -94,6 +94,20 @@ class StaticCache {
       static_assert(
           tt::is_integer_v<std::remove_cv_t<T1>>,
           "The parameter passed for a CacheRange must be an integer type.");
+
+      // Check range here because the nested range checks in the unwrap_cache
+      // function cause significant compile time overhead.
+      if (UNLIKELY(Range::start >
+                       static_cast<decltype(Range::start)>(parameter) or
+                   static_cast<decltype(Range::start)>(parameter) >=
+                       Range::start +
+                           static_cast<decltype(Range::start)>(Range::size))) {
+        ERROR("Index out of range: "
+              << Range::start << " <= " << parameter << " < "
+              << Range::start +
+                     static_cast<decltype(Range::start)>(Range::size));
+      }
+
       return std::make_tuple(
           static_cast<typename Range::value_type>(parameter),
           std::integral_constant<typename Range::value_type, Range::start>{},
@@ -118,14 +132,6 @@ class StaticCache {
           std::integer_sequence<std::remove_cv_t<decltype(IndexOffset)>, Is...>>
           parameter0,
       Args... parameters) const {
-    if (UNLIKELY(IndexOffset > std::get<0>(parameter0) or
-                 std::get<0>(parameter0) >=
-                     IndexOffset +
-                         static_cast<decltype(IndexOffset)>(sizeof...(Is)))) {
-      ERROR("Index out of range: "
-            << IndexOffset << " <= " << std::get<0>(parameter0) << " < "
-            << IndexOffset + static_cast<decltype(IndexOffset)>(sizeof...(Is)));
-    }
     // note that the act of assigning to the specified function pointer type
     // fixes the template arguments that need to be inferred.
     static const std::array<

--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -83,26 +83,23 @@ class StaticCache {
   }
 
  private:
-  template <typename Range, typename T1,
-            Requires<not std::is_enum<T1>::value> = nullptr>
+  template <typename Range, typename T1>
   auto generate_tuple(const T1 parameter) const {
-    static_assert(
-        tt::is_integer_v<std::remove_cv_t<T1>>,
-        "The parameter passed for a CacheRange must be an integer type.");
-    return std::make_tuple(
-        static_cast<typename Range::value_type>(parameter),
-        std::integral_constant<typename Range::value_type, Range::start>{},
-        std::make_integer_sequence<typename Range::value_type, Range::size>{});
-  }
-
-  template <typename Range, typename T1,
-            Requires<std::is_enum<T1>::value> = nullptr>
-  std::tuple<std::remove_cv_t<T1>, Range> generate_tuple(
-      const T1 parameter) const {
-    static_assert(
+    if constexpr (std::is_enum<T1>::value) {
+      static_assert(
         std::is_same<typename Range::value_type, std::remove_cv_t<T1>>::value,
         "Mismatched enum parameter type and cached type.");
-    return {parameter, Range{}};
+      return std::tuple<std::remove_cv_t<T1>, Range>{parameter, Range{}};
+    } else {
+      static_assert(
+          tt::is_integer_v<std::remove_cv_t<T1>>,
+          "The parameter passed for a CacheRange must be an integer type.");
+      return std::make_tuple(
+          static_cast<typename Range::value_type>(parameter),
+          std::integral_constant<typename Range::value_type, Range::start>{},
+          std::make_integer_sequence<typename Range::value_type,
+                                     Range::size>{});
+    }
   }
 
   template <typename... IntegralConstantValues>


### PR DESCRIPTION
## Proposed changes

Some timings on mbot:
```
Timings for DgSubcell/Matrices.cpp
 Original: 46
 Combine static cache generate_tuple functions: 46
 Move integral static cache range check: 40
 Change StaticCache enum indexing and bounds check:  22
 Combine enum and integer caching logic in StaticCache: 20
Improve StaticCache compilation time using multiple peelings: 10
Simplifying DgSubcell matrix caching code: 12
```
The last commit simplifies the code quite a bit, IMO, which is why I did it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
