### PR TITLE
Allow choice of reading Pi and Phi from numeric ID

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
@@ -54,7 +54,8 @@ void initial_gh_variables_from_adm(
 NumericInitialData::NumericInitialData(
     std::string file_glob, std::string subfile_name,
     std::variant<double, importers::ObservationSelector> observation_value,
-    std::optional<double> observation_value_epsilon, bool enable_interpolation,
+    std::optional<double> observation_value_epsilon,
+    const bool enable_interpolation,
     std::variant<AdmVars, GhVars> selected_variables)
     : importer_options_(
           std::move(file_glob), std::move(subfile_name), observation_value,

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiAndPhiFromConstraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiAndPhiFromConstraints.cpp
@@ -33,6 +33,11 @@
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace gh::gauges {
+void SetPiAndPhiFromConstraintsCacheMutator::apply(
+    const gsl::not_null<bool*> value, const bool new_value) {
+  *value = new_value;
+}
+
 template <size_t Dim>
 void SetPiAndPhiFromConstraints<Dim>::apply(
     const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*> pi,
@@ -46,7 +51,11 @@ void SetPiAndPhiFromConstraints<Dim>::apply(
         functions_of_time,
     const tnsr::I<DataVector, Dim, Frame::ElementLogical>& logical_coordinates,
     const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
-    const gauges::GaugeCondition& gauge_condition) {
+    const gauges::GaugeCondition& gauge_condition,
+    const bool set_pi_and_phi_from_constraints) {
+  if (not set_pi_and_phi_from_constraints) {
+    return;
+  }
   const auto grid_coords = logical_to_grid_map(logical_coordinates);
   const auto inv_jac_logical_to_grid =
       logical_to_grid_map.inv_jacobian(logical_coordinates);

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/SetPiAndPhiFromConstraints.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/SetPiAndPhiFromConstraints.hpp
@@ -45,27 +45,27 @@ namespace grmhd::GhValenciaDivClean {
 struct SetPiAndPhiFromConstraints {
  public:
   using return_tags =
-      tmpl::list<gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>;
-  using argument_tags = tmpl::list<
-      ::Tags::Time, domain::Tags::Mesh<3>,
+      typename gh::gauges::SetPiAndPhiFromConstraints<3>::return_tags;
+
+  using argument_tags = tmpl::push_back<
+      typename gh::gauges::SetPiAndPhiFromConstraints<3>::argument_tags,
       evolution::dg::subcell::Tags::Mesh<3>,
-      domain::Tags::ElementMap<3, Frame::Grid>,
-      domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
-                                                  Frame::Inertial>,
-      domain::Tags::FunctionsOfTime,
-      domain::Tags::Coordinates<3, Frame::ElementLogical>,
       evolution::dg::subcell::Tags::Coordinates<3, Frame::ElementLogical>,
-      gr::Tags::SpacetimeMetric<DataVector, 3>,
-      gh::gauges::Tags::GaugeCondition,
       evolution::dg::subcell::Tags::ActiveGrid>;
 
-  using const_global_cache_tags = tmpl::list<gh::gauges::Tags::GaugeCondition>;
+  using compute_tags =
+      typename gh::gauges::SetPiAndPhiFromConstraints<3>::compute_tags;
+  using const_global_cache_tags =
+      typename gh::gauges::SetPiAndPhiFromConstraints<
+          3>::const_global_cache_tags;
+  using mutable_global_cache_tags =
+      typename gh::gauges::SetPiAndPhiFromConstraints<
+          3>::mutable_global_cache_tags;
 
   static void apply(
       const gsl::not_null<tnsr::aa<DataVector, 3, Frame::Inertial>*> pi,
       const gsl::not_null<tnsr::iaa<DataVector, 3, Frame::Inertial>*> phi,
       const double initial_time, const Mesh<3>& dg_mesh,
-      const Mesh<3>& subcell_mesh,
       const ElementMap<3, Frame::Grid>& logical_to_grid_map,
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
           grid_to_inertial_map,
@@ -75,21 +75,22 @@ struct SetPiAndPhiFromConstraints {
           functions_of_time,
       const tnsr::I<DataVector, 3, Frame::ElementLogical>&
           dg_logical_coordinates,
-      const tnsr::I<DataVector, 3, Frame::ElementLogical>&
-          subcell_logical_coordinates,
       const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
       const gh::gauges::GaugeCondition& gauge_condition,
+      const bool set_pi_and_phi_from_constraints, const Mesh<3>& subcell_mesh,
+      const tnsr::I<DataVector, 3, Frame::ElementLogical>&
+          subcell_logical_coordinates,
       const evolution::dg::subcell::ActiveGrid active_grid) {
     if (active_grid == evolution::dg::subcell::ActiveGrid::Dg) {
       gh::gauges::SetPiAndPhiFromConstraints<3>::apply(
           pi, phi, initial_time, dg_mesh, logical_to_grid_map,
           grid_to_inertial_map, functions_of_time, dg_logical_coordinates,
-          spacetime_metric, gauge_condition);
+          spacetime_metric, gauge_condition, set_pi_and_phi_from_constraints);
     } else {
       gh::gauges::SetPiAndPhiFromConstraints<3>::apply(
           pi, phi, initial_time, subcell_mesh, logical_to_grid_map,
           grid_to_inertial_map, functions_of_time, subcell_logical_coordinates,
-          spacetime_metric, gauge_condition);
+          spacetime_metric, gauge_condition, set_pi_and_phi_from_constraints);
     }
   }
 };

--- a/src/ParallelAlgorithms/Actions/MutateApply.hpp
+++ b/src/ParallelAlgorithms/Actions/MutateApply.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
 
 /// \cond
 namespace tuples {
@@ -23,6 +24,12 @@ class GlobalCache;
 /// \endcond
 
 namespace Actions {
+namespace detail {
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(simple_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(compute_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(const_global_cache_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(mutable_global_cache_tags)
+}  // namespace detail
 /*!
  * \ingroup ActionsGroup
  * \brief Apply the function `Mutator::apply` to the DataBox
@@ -40,6 +47,15 @@ namespace Actions {
  */
 template <typename Mutator>
 struct MutateApply {
+  using simple_tags =
+      detail::get_simple_tags_or_default_t<Mutator, tmpl::list<>>;
+  using compute_tags =
+      detail::get_compute_tags_or_default_t<Mutator, tmpl::list<>>;
+  using const_global_cache_tags =
+      detail::get_const_global_cache_tags_or_default_t<Mutator, tmpl::list<>>;
+  using mutable_global_cache_tags =
+      detail::get_mutable_global_cache_tags_or_default_t<Mutator, tmpl::list<>>;
+
   template <typename DataBox, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -22,6 +22,7 @@ InitialData:
     Variables:
       SpacetimeMetric: SpacetimeMetric
       Pi: Pi
+      Phi: Phi
 
 DomainCreator:
   Sphere:


### PR DESCRIPTION
Or setting them based on the 1- and 3-index constraints. Only works for numeric ID from GH vars. Numeric ID from ADM vars still computes phi with numerical derivatives.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
