### PR TITLE
Add puncture field as initial data for worldtube simulations

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.cpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.cpp
@@ -9,11 +9,13 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BoundaryCorrections/RegisterDerived.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.hpp"
 #include "Parallel/CharmMain.tpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
-using metavariables = EvolutionMetavars<gr::Solutions::KerrSchild,
-                                        ScalarWave::Solutions::PlaneWave<3>>;
+using metavariables =
+    EvolutionMetavars<gr::Solutions::KerrSchild,
+                      CurvedScalarWave::AnalyticData::ZerothOrderPuncture>;
 
 extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -227,7 +227,6 @@ struct EvolutionMetavars {
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   Parallel::Phase::LoadBalancing>,
                               PhaseControl::CheckpointAndExitAfterWallclock>>,
-
         tmpl::pair<StepChooser<StepChooserUse::Slab>,
                    tmpl::push_back<StepChoosers::standard_slab_choosers<
                                        system, local_time_stepping>,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
@@ -49,4 +49,4 @@ target_link_libraries(
 add_subdirectory(SingletonActions)
 add_subdirectory(ElementActions)
 add_subdirectory(Triggers)
-
+add_subdirectory(InitialData)

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  ZerothOrderPuncture.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  ZerothOrderPuncture.hpp
+  )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.hpp"
+
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeodesicAcceleration.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave::AnalyticData {
+
+ZerothOrderPuncture::ZerothOrderPuncture(
+    const std::array<double, 3> particle_position,
+    const std::array<double, 3> particle_velocity, const double particle_charge,
+    const Options::Context& /*context*/)
+    : particle_position_(particle_position),
+      particle_velocity_(particle_velocity),
+      particle_charge_(particle_charge) {
+  const auto background_vars = kerr_schild_.variables(
+      particle_position_, 0.,
+      tmpl::list<gr::Tags::SpacetimeChristoffelSecondKind<double, 3,
+                                                          Frame::Inertial>>{});
+  const auto& christoffel =
+      get<gr::Tags::SpacetimeChristoffelSecondKind<double, 3, Frame::Inertial>>(
+          background_vars);
+  geodesic_acceleration_ =
+      gr::geodesic_acceleration(particle_velocity_, christoffel);
+}
+
+tuples::TaggedTuple<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                    CurvedScalarWave::Tags::Phi<3>>
+ZerothOrderPuncture::variables(const tnsr::I<DataVector, 3>& x,
+                               tags /*meta*/) const {
+  auto centered_coords = x;
+  for (size_t i = 0; i < 3; ++i) {
+    centered_coords.get(i) -= particle_position_.get(i);
+  }
+  Variables<tmpl::list<CurvedScalarWave::Tags::Psi,
+                       ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+                       ::Tags::deriv<CurvedScalarWave::Tags::Psi,
+                                     tmpl::size_t<3>, Frame::Inertial>>>
+      puncture(get<0>(centered_coords).size());
+  CurvedScalarWave::Worldtube::puncture_field_0(
+      make_not_null(&puncture), centered_coords, particle_position_,
+      particle_velocity_, geodesic_acceleration_, 1.);
+  puncture *= particle_charge_;
+  const auto background_vars =
+      kerr_schild_.variables(x, 0.,
+                             tmpl::list<gr::Tags::Shift<DataVector, 3>,
+                                        gr::Tags::Lapse<DataVector>>{});
+  const auto& shift = get<gr::Tags::Shift<DataVector, 3>>(background_vars);
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(background_vars);
+  const auto shift_dot_dpsi = dot_product(
+      shift, get<::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                               Frame::Inertial>>(puncture));
+
+  return tuples::TaggedTuple<CurvedScalarWave::Tags::Psi,
+                             CurvedScalarWave::Tags::Pi,
+                             CurvedScalarWave::Tags::Phi<3>>{
+      get<CurvedScalarWave::Tags::Psi>(puncture),
+      (get(shift_dot_dpsi) -
+       get(get<::Tags::dt<CurvedScalarWave::Tags::Psi>>(puncture))) /
+          get(lapse),
+      get<::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                        Frame::Inertial>>(puncture)};
+}
+
+void ZerothOrderPuncture::pup(PUP::er& p) {
+  p | particle_position_;
+  p | particle_velocity_;
+  p | geodesic_acceleration_;
+  p | particle_charge_;
+  p | kerr_schild_;
+}
+
+bool operator==(const ZerothOrderPuncture& lhs,
+                const ZerothOrderPuncture& rhs) {
+  return lhs.particle_position_ == rhs.particle_position_ and
+         lhs.particle_velocity_ == rhs.particle_velocity_ and
+         lhs.geodesic_acceleration_ == rhs.geodesic_acceleration_ and
+         lhs.particle_charge_ == rhs.particle_charge_ and
+         lhs.kerr_schild_ == rhs.kerr_schild_;
+}
+bool operator!=(const ZerothOrderPuncture& lhs,
+                const ZerothOrderPuncture& rhs) {
+  return not(lhs == rhs);
+}
+}  // namespace CurvedScalarWave::AnalyticData

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.hpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeodesicAcceleration.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace CurvedScalarWave::AnalyticData {
+
+/*!
+ * \brief Analytic initial data for a scalar point charge in Kerr-Schild
+ * coordinates. This assumes the charge is initially on a geodesic orbit.
+ *
+ * \details The initial data corresponds to the zeroth order puncture field
+ * which is effectively the Lorentz-boosted solution of a scalar charge in flat
+ * space.
+ */
+
+class ZerothOrderPuncture : public MarkAsAnalyticData {
+ public:
+  struct ParticlePosition {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "The initial position of the scalar charge."};
+  };
+
+  struct ParticleVelocity {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "The initial velocity of the scalar charge"};
+  };
+
+  struct ParticleCharge {
+    using type = double;
+    static constexpr Options::String help = {
+        "The value of the particle's charge."};
+    static constexpr double lower_bound() { return 0.; }
+    static constexpr double upper_bound() { return 1.; }
+  };
+
+  using options =
+      tmpl::list<ParticlePosition, ParticleVelocity, ParticleCharge>;
+
+  static constexpr Options::String help = {
+      "Initial data for a scalar charge in Kerr-Schild coordinates. It "
+      "corresponds to the zeroth order puncture field which is the "
+      "Lorentz-boosted solution of a scalar charge in flat space."};
+
+  ZerothOrderPuncture() = default;
+
+  ZerothOrderPuncture(std::array<double, 3> particle_position,
+                      std::array<double, 3> particle_velocity,
+                      double particle_charge,
+                      const Options::Context& context = {});
+
+  static constexpr size_t volume_dim = 3;
+  using tags =
+      tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                 CurvedScalarWave::Tags::Phi<3>>;
+
+  /// Retrieve the evolution variables at spatial coordinates `x`
+  tuples::TaggedTuple<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                      CurvedScalarWave::Tags::Phi<3>>
+  variables(const tnsr::I<DataVector, 3>& x, tags /*meta*/) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/);
+
+ private:
+  // assume a non-spinning black hole of mass 1M centered on the coordinate
+  // origin
+  gr::Solutions::KerrSchild kerr_schild_{1., {{0., 0., 0.}}, {{0., 0., 0.}}};
+  tnsr::I<double, 3> particle_position_{
+      std::numeric_limits<double>::signaling_NaN()};
+  tnsr::I<double, 3> particle_velocity_{
+      std::numeric_limits<double>::signaling_NaN()};
+  tnsr::I<double, 3> geodesic_acceleration_{
+      std::numeric_limits<double>::signaling_NaN()};
+  double particle_charge_{std::numeric_limits<double>::signaling_NaN()};
+
+  friend bool operator==(const ZerothOrderPuncture& lhs,
+                         const ZerothOrderPuncture& rhs);
+
+  friend bool operator!=(const ZerothOrderPuncture& lhs,
+                         const ZerothOrderPuncture& rhs);
+};
+
+}  // namespace CurvedScalarWave::AnalyticData

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -12,14 +12,10 @@ Parallelization:
   ElementDistribution: NumGridPoints
 
 AnalyticData:
-  PlaneWave:
-    WaveVector: [0., 0., 0.]
-    Center: [1., 0., 0.]
-    Profile:
-      Sinusoid:
-        Amplitude: 0.
-        Wavenumber: 1.
-        Phase: 1.
+  ZerothOrderPuncture:
+    ParticlePosition: [&XCoordWorldtube 10., 0., 0.]
+    ParticleVelocity: [0., 0.01, 0.]
+    ParticleCharge: &Charge 0.5
 
 BackgroundSpacetime:
   KerrSchild:
@@ -55,7 +51,7 @@ DomainCreator:
     ObjectA:
       InnerRadius: 1.6
       OuterRadius: 2.
-      XCoord: 5.
+      XCoord: *XCoordWorldtube
       Interior:
         ExciseWithBoundaryCondition: Worldtube
       UseLogarithmicMap: false
@@ -76,7 +72,7 @@ DomainCreator:
         AsymptoticVelocityOuterBoundary: 0.
         DecayTimescaleOuterBoundary: 1.
       RotationMap:
-        InitialAngularVelocity: [0., 0., 0.08944271909999159]
+        InitialAngularVelocity: [0., 0., 0.001]
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       SkewMap: None
@@ -142,7 +138,7 @@ EventsAndTriggersAtSlabs:
 Worldtube:
   ExcisionSphere: ExcisionSphereA
   ExpansionOrder: 1
-  Charge: 0.5
+  Charge: *Charge
   SelfForceOptions: None
   ObserveCoefficientsTrigger:
     Slabs:

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_KerrSchildDerivatives.cpp
   Test_PunctureField.cpp
   Test_RadiusFunctions.cpp
+  Test_PunctureInitialData.cpp
   Test_SelfForce.cpp
   Test_Tags.cpp
   Test_Triggers.cpp

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureInitialData.cpp
@@ -1,0 +1,102 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeodesicAcceleration.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+namespace CurvedScalarWave {
+namespace {
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.PunctureInitialData",
+                  "[Unit][Evolution]") {
+  const std::array<double, 3> pos_array{{12., 13., 0.}};
+  const std::array<double, 3> vel_array{{0.1, 0.2, 0.}};
+  const double charge = 0.23;
+
+  const AnalyticData::ZerothOrderPuncture zeroth_order_puncture(
+      pos_array, vel_array, charge);
+  const auto copy = zeroth_order_puncture;
+  CHECK(zeroth_order_puncture == copy);
+  test_serialization(zeroth_order_puncture);
+
+  const tnsr::I<double, 3> pos(pos_array);
+  const tnsr::I<double, 3> vel(vel_array);
+
+  const std::uniform_real_distribution sample_dist(-100., 100.);
+  const size_t num_points = 1000;
+  MAKE_GENERATOR(gen);
+
+  const auto sample_coords =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::Inertial>>(
+          make_not_null(&gen), sample_dist, DataVector(num_points));
+
+  const auto vars = zeroth_order_puncture.variables(sample_coords, {});
+  auto sample_coords_centered = sample_coords;
+  for (size_t i = 0; i < 3; ++i) {
+    sample_coords_centered.get(i) -= pos.get(i);
+  }
+
+  // central black hole of mass 1
+  const gr::Solutions::KerrSchild ks{
+      1., {0., 0., 0.}, {0., 0., 0.}, {0., 0., 0.}};
+  const auto background_vars_christoffel = ks.variables(
+      pos, 0.,
+      tmpl::list<gr::Tags::SpacetimeChristoffelSecondKind<double, 3,
+                                                          Frame::Inertial>>{});
+  const auto& christoffel =
+      get<gr::Tags::SpacetimeChristoffelSecondKind<double, 3, Frame::Inertial>>(
+          background_vars_christoffel);
+
+  const auto background_vars =
+      ks.variables(sample_coords, 0.,
+                   tmpl::list<gr::Tags::Shift<DataVector, 3>,
+                              gr::Tags::Lapse<DataVector>>{});
+  const auto& shift = get<gr::Tags::Shift<DataVector, 3>>(background_vars);
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(background_vars);
+  const auto geodesic_acceleration =
+      gr::geodesic_acceleration(vel, christoffel);
+  Variables<tmpl::list<CurvedScalarWave::Tags::Psi,
+                       ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+                       ::Tags::deriv<CurvedScalarWave::Tags::Psi,
+                                     tmpl::size_t<3>, Frame::Inertial>>>
+      expected_puncture_field(num_points);
+
+  Worldtube::puncture_field_0(make_not_null(&expected_puncture_field),
+                              sample_coords_centered, pos, vel,
+                              geodesic_acceleration, 1.);
+  expected_puncture_field *= charge;
+
+  const auto shift_dot_phi = dot_product(shift, get<Tags::Phi<3>>(vars));
+
+  const auto dt_psi =
+      get(shift_dot_phi) - get(lapse) * get(get<Tags::Pi>(vars));
+
+  CHECK_ITERABLE_APPROX(get<Tags::Psi>(vars),
+                        get<Tags::Psi>(expected_puncture_field));
+  CHECK_ITERABLE_APPROX(
+      dt_psi, get(get<::Tags::dt<Tags::Psi>>(expected_puncture_field)));
+  const auto& di_psi =
+      get<::Tags::deriv<Tags::Psi, tmpl::size_t<3>, Frame::Inertial>>(
+          expected_puncture_field);
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK_ITERABLE_APPROX(di_psi.get(i), get<Tags::Phi<3>>(vars).get(i));
+  }
+}
+}  // namespace
+}  // namespace CurvedScalarWave


### PR DESCRIPTION
## Proposed changes

Adds the zeroth order puncture field to be used as initial data for the worldtube simulations.