### PR TITLE
Revamp some deadlock analysis for GH

### DIFF
--- a/src/ControlSystem/Actions/PrintCurrentMeasurement.hpp
+++ b/src/ControlSystem/Actions/PrintCurrentMeasurement.hpp
@@ -20,13 +20,14 @@ struct PrintCurrentMeasurement {
             typename ArrayIndex>
   static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/) {
+                    const ArrayIndex& /*array_index*/,
+                    const std::string& file_name) {
     const int current_measurement =
         db::get<control_system::Tags::CurrentNumberOfMeasurements>(box);
 
-    Parallel::printf("%s: Current measurement = %d\n",
-                     pretty_type::name<ParallelComponent>(),
-                     current_measurement);
+    Parallel::fprintf(file_name, "%s: Current measurement = %d\n",
+                      pretty_type::name<ParallelComponent>(),
+                      current_measurement);
   }
 };
 }  // namespace control_system::Actions

--- a/src/Evolution/Deadlock/CMakeLists.txt
+++ b/src/Evolution/Deadlock/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   PrintDgElementArray.hpp
+  PrintFunctionsOfTime.hpp
   )
 
 target_link_libraries(
@@ -17,6 +18,7 @@ target_link_libraries(
   INTERFACE
   DataStructures
   DiscontinuousGalerkin
+  FunctionsOfTime
   Parallel
   Printf
   Time

--- a/src/Evolution/Deadlock/PrintDgElementArray.hpp
+++ b/src/Evolution/Deadlock/PrintDgElementArray.hpp
@@ -52,7 +52,8 @@ struct PrintElementInfo {
             typename ArrayIndex>
   static void apply(db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index) {
+                    const ArrayIndex& array_index,
+                    const std::string& file_name) {
     if constexpr (Parallel::is_dg_element_collection_v<ParallelComponent>) {
       auto& element =
           Parallel::local_synchronous_action<
@@ -60,12 +61,12 @@ struct PrintElementInfo {
                   typename ParallelComponent::element_collection_tag>>(
               Parallel::get_parallel_component<ParallelComponent>(cache))
               ->at(array_index);
-      apply<ParallelComponent>(box, cache, array_index, &element);
+      apply<ParallelComponent>(box, cache, array_index, &element, file_name);
     } else {
       apply<ParallelComponent>(
           box, cache, array_index,
           Parallel::local(Parallel::get_parallel_component<ParallelComponent>(
-              cache)[array_index]));
+              cache)[array_index]), file_name);
     }
   }
 
@@ -74,7 +75,8 @@ struct PrintElementInfo {
             typename ArrayIndex, typename T>
   static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& array_index, T* local_object_ptr) {
+                    const ArrayIndex& array_index, T* local_object_ptr,
+                    const std::string& file_name) {
     auto& local_object = *local_object_ptr;
 
     const bool terminated = local_object.get_terminate();
@@ -139,7 +141,7 @@ struct PrintElementInfo {
       ss << "\n";
     }
 
-    Parallel::printf("%s", ss.str());
+    Parallel::fprintf(file_name, "%s", ss.str());
   }
 };
 }  // namespace deadlock

--- a/src/Evolution/Deadlock/PrintFunctionsOfTime.hpp
+++ b/src/Evolution/Deadlock/PrintFunctionsOfTime.hpp
@@ -28,7 +28,8 @@ struct PrintFunctionsOfTime {
             typename ArrayIndex>
   static void apply(db::DataBox<DbTags>& /*box*/,
                     Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& /*array_index*/) {
+                    const ArrayIndex& /*array_index*/,
+                    const std::string& file_name) {
     const auto& functions_of_time =
         Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
     const std::string time_bounds =
@@ -42,13 +43,14 @@ struct PrintFunctionsOfTime {
       const std::string measurement_time_bounds =
           ::domain::FunctionsOfTime::output_time_bounds(measurement_timescales);
 
-      Parallel::printf(
+      Parallel::fprintf(
+          file_name,
           "Node %zu\nFunctionsOfTime:\n%s\n\nMeasurementTimescales:\n%s\n",
           Parallel::my_node<size_t>(cache), time_bounds,
           measurement_time_bounds);
     } else {
-      Parallel::printf("Node %zu\nFunctionsOfTime:%s\n",
-                       Parallel::my_node<size_t>(cache), time_bounds);
+      Parallel::fprintf(file_name, "Node %zu\nFunctionsOfTime:%s\n",
+                        Parallel::my_node<size_t>(cache), time_bounds);
     }
   }
 };

--- a/src/Evolution/Deadlock/PrintFunctionsOfTime.hpp
+++ b/src/Evolution/Deadlock/PrintFunctionsOfTime.hpp
@@ -10,12 +10,18 @@
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Info.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Printf/Printf.hpp"
+
+namespace control_system::Tags {
+struct MeasurementTimescales;
+}  // namespace control_system::Tags
 
 namespace deadlock {
 /*!
- * \brief Simple action that will print the `domain::Tags::FunctionsOfTime` time
- * bounds for each node of a simulation.
+ * \brief Simple action that will print the `domain::Tags::FunctionsOfTime` and
+ * `control_system::Tags::MeasurementTimescales` (if it exists) time bounds for
+ * each node of a simulation.
  */
 struct PrintFunctionsOfTime {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
@@ -25,12 +31,25 @@ struct PrintFunctionsOfTime {
                     const ArrayIndex& /*array_index*/) {
     const auto& functions_of_time =
         Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
-
     const std::string time_bounds =
         ::domain::FunctionsOfTime::output_time_bounds(functions_of_time);
 
-    Parallel::printf("Node %zu\n%s\n", Parallel::my_node<size_t>(cache),
-                     time_bounds);
+    if constexpr (Parallel::is_in_global_cache<
+                      Metavariables,
+                      control_system::Tags::MeasurementTimescales>) {
+      const auto& measurement_timescales =
+          Parallel::get<control_system::Tags::MeasurementTimescales>(cache);
+      const std::string measurement_time_bounds =
+          ::domain::FunctionsOfTime::output_time_bounds(measurement_timescales);
+
+      Parallel::printf(
+          "Node %zu\nFunctionsOfTime:\n%s\n\nMeasurementTimescales:\n%s\n",
+          Parallel::my_node<size_t>(cache), time_bounds,
+          measurement_time_bounds);
+    } else {
+      Parallel::printf("Node %zu\nFunctionsOfTime:%s\n",
+                       Parallel::my_node<size_t>(cache), time_bounds);
+    }
   }
 };
 }  // namespace deadlock

--- a/src/Evolution/Deadlock/PrintFunctionsOfTime.hpp
+++ b/src/Evolution/Deadlock/PrintFunctionsOfTime.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/FunctionsOfTime/OutputTimeBounds.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Printf/Printf.hpp"
+
+namespace deadlock {
+/*!
+ * \brief Simple action that will print the `domain::Tags::FunctionsOfTime` time
+ * bounds for each node of a simulation.
+ */
+struct PrintFunctionsOfTime {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/) {
+    const auto& functions_of_time =
+        Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
+
+    const std::string time_bounds =
+        ::domain::FunctionsOfTime::output_time_bounds(functions_of_time);
+
+    Parallel::printf("Node %zu\n%s\n", Parallel::my_node<size_t>(cache),
+                     time_bounds);
+  }
+};
+}  // namespace deadlock

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -91,10 +91,11 @@ struct DgElementArray {
 
   static void execute_next_phase(
       const Parallel::Phase next_phase,
-      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache,
+      const bool force = false) {
     auto& local_cache = *Parallel::local_branch(global_cache);
     Parallel::get_parallel_component<DgElementArray>(local_cache)
-        .start_phase(next_phase);
+        .start_phase(next_phase, force);
   }
 };
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/ArrayCollection/SimpleActionOnElement.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Utilities/FileSystem.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -30,25 +31,39 @@ template <typename DgElementArray, typename ControlComponents,
 void run_deadlock_analysis_simple_actions(
     Parallel::GlobalCache<Metavariables>& cache,
     const std::vector<std::string>& deadlocked_components) {
+  const std::string deadlock_dir{"deadlock"};
+  if (file_system::check_if_dir_exists(deadlock_dir)) {
+    file_system::rm(deadlock_dir, true);
+  }
+
+  file_system::create_directory(deadlock_dir);
+
   Parallel::simple_action<::deadlock::PrintFunctionsOfTime>(
       Parallel::get_parallel_component<
-          observers::ObserverWriter<Metavariables>>(cache));
+          observers::ObserverWriter<Metavariables>>(cache),
+      deadlock_dir + "functions_of_time.out");
 
   if (alg::count(deadlocked_components, pretty_type::name<DgElementArray>()) ==
       1) {
-    tmpl::for_each<ControlComponents>([&cache](auto component_v) {
+    tmpl::for_each<ControlComponents>([&cache,
+                                       &deadlock_dir](auto component_v) {
       using component = tmpl::type_from<decltype(component_v)>;
       Parallel::simple_action<control_system::Actions::PrintCurrentMeasurement>(
-          Parallel::get_parallel_component<component>(cache));
+          Parallel::get_parallel_component<component>(cache),
+          deadlock_dir + "/control_systems.out");
     });
 
+    const std::string element_array_file =
+        deadlock_dir + "/dg_element_array.out";
     if constexpr (Parallel::is_dg_element_collection_v<DgElementArray>) {
       Parallel::threaded_action<Parallel::Actions::SimpleActionOnElement<
           ::deadlock::PrintElementInfo, true>>(
-          Parallel::get_parallel_component<DgElementArray>(cache));
+          Parallel::get_parallel_component<DgElementArray>(cache),
+          element_array_file);
     } else {
       Parallel::simple_action<::deadlock::PrintElementInfo>(
-          Parallel::get_parallel_component<DgElementArray>(cache));
+          Parallel::get_parallel_component<DgElementArray>(cache),
+          element_array_file);
     }
   }
 }

--- a/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
@@ -51,6 +51,13 @@ void run_deadlock_analysis_simple_actions(
           observers::ObserverWriter<Metavariables>>(cache),
       deadlock_dir + "functions_of_time.out");
 
+  {
+    auto cache_proxy = cache.get_this_proxy();
+
+    cache_proxy.print_mutable_cache_callbacks(deadlock_dir +
+                                              "/mutable_cache_callbacks.out");
+  }
+
   Parallel::simple_action<::deadlock::PrintInterpolator>(
       Parallel::get_parallel_component<intrp::Interpolator<Metavariables>>(
           cache),

--- a/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "ControlSystem/Actions/PrintCurrentMeasurement.hpp"
+#include "Domain/FunctionsOfTime/OutputTimeBounds.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Evolution/Deadlock/PrintDgElementArray.hpp"
+#include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
+#include "Parallel/ArrayCollection/SimpleActionOnElement.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace gh::deadlock {
+template <typename DgElementArray, typename ControlComponents,
+          typename Metavariables>
+void run_deadlock_analysis_simple_actions(
+    Parallel::GlobalCache<Metavariables>& cache,
+    const std::vector<std::string>& deadlocked_components) {
+  const auto& functions_of_time =
+      Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
+
+  const std::string time_bounds =
+      ::domain::FunctionsOfTime::output_time_bounds(functions_of_time);
+
+  Parallel::printf("%s\n", time_bounds);
+
+  if (alg::count(deadlocked_components, pretty_type::name<DgElementArray>()) ==
+      1) {
+    tmpl::for_each<ControlComponents>([&cache](auto component_v) {
+      using component = tmpl::type_from<decltype(component_v)>;
+      Parallel::simple_action<control_system::Actions::PrintCurrentMeasurement>(
+          Parallel::get_parallel_component<component>(cache));
+    });
+
+    if constexpr (Parallel::is_dg_element_collection_v<DgElementArray>) {
+      Parallel::threaded_action<Parallel::Actions::SimpleActionOnElement<
+          ::deadlock::PrintElementInfo, true>>(
+          Parallel::get_parallel_component<DgElementArray>(cache));
+    } else {
+      Parallel::simple_action<::deadlock::PrintElementInfo>(
+          Parallel::get_parallel_component<DgElementArray>(cache));
+    }
+  }
+}
+}  // namespace gh::deadlock

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -122,6 +122,7 @@
 #include "ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp"
 #include "ParallelAlgorithms/EventsAndDenseTriggers/DenseTrigger.hpp"
 #include "ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Factory.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
@@ -613,7 +614,11 @@ struct EvolutionMetavars {
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
                   evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::PostFailureCleanup,
+              tmpl::list<Actions::RunEventsOnFailure<::Tags::Time>,
+                         Parallel::Actions::TerminatePhase>>>>>;
 
   struct BondiSachs : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     static std::string name() { return "BondiSachsInterpolation"; }

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -647,8 +647,8 @@ struct EvolutionMetavars {
   static void run_deadlock_analysis_simple_actions(
       Parallel::GlobalCache<EvolutionMetavars>& cache,
       const std::vector<std::string>& deadlocked_components) {
-    gh::deadlock::run_deadlock_analysis_simple_actions<gh_dg_element_array,
-                                                       control_components>(
+    gh::deadlock::run_deadlock_analysis_simple_actions<
+        gh_dg_element_array, control_components, interpolation_target_tags>(
         cache, deadlocked_components);
   }
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -303,8 +303,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
   static void run_deadlock_analysis_simple_actions(
       Parallel::GlobalCache<EvolutionMetavars>& cache,
       const std::vector<std::string>& deadlocked_components) {
-    gh::deadlock::run_deadlock_analysis_simple_actions<gh_dg_element_array,
-                                                       control_components>(
+    gh::deadlock::run_deadlock_analysis_simple_actions<
+        gh_dg_element_array, control_components, interpolation_target_tags>(
         cache, deadlocked_components);
   }
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -44,6 +44,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
@@ -259,7 +260,11 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
                   evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::PostFailureCleanup,
+              tmpl::list<Actions::RunEventsOnFailure<::Tags::Time>,
+                         Parallel::Actions::TerminatePhase>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = gh_dg_element_array;

--- a/src/Parallel/Algorithms/AlgorithmArray.ci
+++ b/src/Parallel/Algorithms/AlgorithmArray.ci
@@ -69,7 +69,7 @@ module AlgorithmArray {
 
     entry void perform_algorithm(bool);
 
-    entry void start_phase(Parallel::Phase);
+    entry void start_phase(Parallel::Phase, bool force = false);
 
     template <typename ReceiveTag, typename MessageType>
     entry void receive_data(MessageType*);

--- a/src/Parallel/ArrayCollection/DgElementArrayMemberBase.hpp
+++ b/src/Parallel/ArrayCollection/DgElementArrayMemberBase.hpp
@@ -50,7 +50,13 @@ class DgElementArrayMemberBase : PUP::able {
   /// Start execution of the phase-dependent action list in `next_phase`. If
   /// `next_phase` has already been visited, execution will resume at the point
   /// where the previous execution of the same phase left off.
-  virtual void start_phase(Parallel::Phase next_phase) = 0;
+  ///
+  /// If \p force is true, then regardless of how this component terminated
+  /// (error or deadlock), it will resume.
+  ///
+  /// \warning Don't set \p force to true unless you are absolutely sure you
+  /// want to. This can have very unintended consequences if used incorrectly.
+  virtual void start_phase(Parallel::Phase next_phase, bool force = false) = 0;
 
   /// Get the current phase
   Parallel::Phase phase() const;

--- a/src/Parallel/ArrayCollection/ReceiveDataForElement.hpp
+++ b/src/Parallel/ArrayCollection/ReceiveDataForElement.hpp
@@ -89,7 +89,12 @@ struct ReceiveDataForElement {
                           << Parallel::my_node<size_t>(cache););
       auto& element = element_collection->at(element_to_execute_on);
       const std::lock_guard element_lock(element.element_lock());
-      element.start_phase(current_phase);
+      // We always force the phase to start because if a previous phase
+      // terminated properly, then this does nothing. But if a phase didn't
+      // terminate properly, then it likely went into deadlock analysis or
+      // post-failure cleanup, in which case we want to run code after a
+      // failure, so we must force the phase to start.
+      element.start_phase(current_phase, true);
     } else {
       auto& element = element_collection->at(element_to_execute_on);
       std::unique_lock element_lock(element.element_lock(), std::defer_lock);

--- a/src/Parallel/GlobalCache.ci
+++ b/src/Parallel/GlobalCache.ci
@@ -4,6 +4,7 @@
 module GlobalCache {
 
   include "optional";
+  include "string";
   include "Parallel/GlobalCacheDeclare.hpp";
   include "Parallel/ParallelComponentHelpers.hpp";
   include "Parallel/ResourceInfo.hpp";
@@ -33,6 +34,7 @@ module GlobalCache {
     entry void overlay_cache_data(
         tuples::tagged_tuple_from_typelist<
             Parallel::get_overlayable_option_list<Metavariables>>&);
+    entry void print_mutable_cache_callbacks(const std::string& file_name);
   }
   }  // namespace Parallel
 }

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -332,8 +332,8 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
     Overloader{
         [&command_line_options](std::true_type /*meta*/, auto mv,
                                 int /*gcc_bug*/)
-            -> std::void_t<decltype(
-                tmpl::type_from<decltype(mv)>::input_file)> {
+            -> std::void_t<
+                decltype(tmpl::type_from<decltype(mv)>::input_file)> {
           // Metavariables has options and default input file name
           command_line_options.add_options()(
               "input-file",
@@ -348,8 +348,8 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
               "input-file", bpo::value<std::string>(), "Input file name");
         },
         [](std::false_type /*meta*/, auto mv, int /*gcc_bug*/)
-            -> std::void_t<decltype(
-                tmpl::type_from<decltype(mv)>::input_file)> {
+            -> std::void_t<
+                decltype(tmpl::type_from<decltype(mv)>::input_file)> {
           // Metavariables has no options and default input file name
 
           // always false, but must depend on mv
@@ -367,10 +367,10 @@ Main<Metavariables>::Main(CkArgMsg* msg) {
 
     const bool ignore_unrecognized_command_line_options = Overloader{
         [](auto mv, int /*gcc_bug*/)
-            -> decltype(tmpl::type_from<decltype(
-                            mv)>::ignore_unrecognized_command_line_options) {
-          return tmpl::type_from<decltype(
-              mv)>::ignore_unrecognized_command_line_options;
+            -> decltype(tmpl::type_from<decltype(mv)>::
+                            ignore_unrecognized_command_line_options) {
+          return tmpl::type_from<
+              decltype(mv)>::ignore_unrecognized_command_line_options;
         },
         [](auto /*mv*/, auto... /*meta*/) { return false; }}(
         tmpl::type_<Metavariables>{}, 0);

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -37,6 +37,7 @@
 #include "Parallel/ResourceInfo.hpp"
 #include "Parallel/Tags/ResourceInfo.hpp"
 #include "Parallel/TypeTraits.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Formaline.hpp"
@@ -974,15 +975,52 @@ void Main<Metavariables>::check_if_component_terminated_correctly() {
   current_termination_check_index_++;
 }
 
+namespace detail {
+CREATE_IS_CALLABLE(execute_next_phase)
+CREATE_IS_CALLABLE_V(execute_next_phase)
+}  // namespace detail
+
 template <typename Metavariables>
 void Main<Metavariables>::post_deadlock_analysis_termination() {
-  Informer::print_exit_info();
-  if (not components_that_did_not_terminate_.empty()) {
-    sys::abort("");
-  } else {
+  // If no components deadlocked, then we just exit.
+  if (components_that_did_not_terminate_.empty()) {
+    Informer::print_exit_info();
     const Parallel::ExitCode exit_code =
         get<Tags::ExitCode>(phase_change_decision_data_);
     sys::exit(static_cast<int>(exit_code));
+  } else {
+    // Even though we didn't raise an exception, a deadlock is still a
+    // failure and some components may want to run things during cleanup so
+    // we switch phases here and start the PostFailureCleanup phase on each
+    // component.
+    current_phase_ = Parallel::Phase::PostFailureCleanup;
+    Parallel::printf("Entering phase: %s at time %s\n", current_phase_,
+                     sys::pretty_wall_time());
+    tmpl::for_each<component_list>([this](auto component_tag_v) {
+      using component_tag = tmpl::type_from<decltype(component_tag_v)>;
+      // If a component deadlocked, then the terminate_ flag in the
+      // DistributedObject isn't correct and we can't start a new phase.
+      // Therefore, we have to manually set it so that it thinks it terminated
+      // cleanly.
+      if (alg::found(components_that_did_not_terminate_,
+                     pretty_type::name<component_tag>())) {
+        Parallel::printf("Setting terminate to true on %s\n",
+                         pretty_type::name<component_tag>());
+      }
+      if constexpr (detail::is_execute_next_phase_callable_v<
+                        component_tag, Parallel::Phase,
+                        CProxy_GlobalCache<Metavariables>, bool>) {
+        component_tag::execute_next_phase(current_phase_, global_cache_proxy_,
+                                          true);
+      } else {
+        component_tag::execute_next_phase(current_phase_, global_cache_proxy_);
+      }
+    });
+    // As a callback, we set execute_next_phase() because it will just
+    // immediately exit after the PostFailureCleanup phase is complete which is
+    // what we want
+    CkStartQD(CkCallback(CkIndex_Main<Metavariables>::execute_next_phase(),
+                         this->thisProxy));
   }
 }
 

--- a/src/ParallelAlgorithms/Interpolation/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Interpolation/Actions/CMakeLists.txt
@@ -18,6 +18,8 @@ spectre_target_headers(
   InterpolatorReceivePoints.hpp
   InterpolatorReceiveVolumeData.hpp
   InterpolatorRegisterElement.hpp
+  PrintInterpolationTargetForDeadlock.hpp
+  PrintInterpolatorForDeadlock.hpp
   SendPointsToInterpolator.hpp
   TryToInterpolate.hpp
   VerifyTemporalIdsAndSendPoints.hpp

--- a/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp
@@ -24,6 +24,7 @@ class GlobalCache;
 }  // namespace Parallel
 namespace intrp {
 namespace Tags {
+template <size_t Dim>
 struct NumberOfElements;
 template <typename Metavariables>
 struct InterpolatedVarsHolders;

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
@@ -31,6 +31,7 @@ template <typename IdType, typename DataType>
 class IdPair;
 namespace intrp {
 namespace Tags {
+template <size_t Dim>
 struct NumberOfElements;
 template <typename Metavariables>
 struct InterpolatedVarsHolders;

--- a/src/ParallelAlgorithms/Interpolation/Actions/PrintInterpolationTargetForDeadlock.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/PrintInterpolationTargetForDeadlock.hpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iomanip>
+#include <ios>
+#include <limits>
+#include <sstream>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace deadlock {
+/*!
+ * \brief Simple action to print deadlock info on an interpolation target.
+ *
+ * \details This will print the following information for all temporal ids
+ * stored in `intrp::Tags::CurrentTemporalId` (sequential targets) or
+ * `intrp::Tags::TemporalIds` (non-sequential targets).
+ *
+ * - `intrp::Tags::IndicesOfFilledInterpPoints`
+ * - `intrp::Tags::IndicesOfInvalidInterpPoints1
+ * - Size of `intrp::Tags::InterpolatedVars`
+ *
+ * And also any `intrp::Tags::PendingTemporalIds` for sequential targets will be
+ * printed.
+ */
+struct PrintInterpolationTarget {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const std::string& file_name) {
+    std::stringstream ss{};
+    ss << std::setprecision(std::numeric_limits<double>::digits10 + 4)
+       << std::scientific;
+
+    using TargetTag = typename ParallelComponent::interpolation_target_tag;
+    using TemporalId = typename TargetTag::temporal_id::type;
+
+    const auto stream_points = [&](const TemporalId& temporal_id) {
+      const auto& filled_indices =
+          db::get<intrp::Tags::IndicesOfFilledInterpPoints<TemporalId>>(box);
+      const auto& invalid_indices =
+          db::get<intrp::Tags::IndicesOfInvalidInterpPoints<TemporalId>>(box);
+      const auto& interpolated_vars =
+          db::get<intrp::Tags::InterpolatedVars<TargetTag, TemporalId>>(box);
+
+      const size_t expected_size =
+          interpolated_vars.at(temporal_id).number_of_grid_points();
+      const size_t filled_size = filled_indices.count(temporal_id) > 0
+                                     ? filled_indices.at(temporal_id).size()
+                                     : 0_st;
+      const size_t invalid_size = invalid_indices.count(temporal_id) > 0
+                                      ? invalid_indices.at(temporal_id).size()
+                                      : 0_st;
+
+      ss << "Total points expected = " << expected_size
+         << ", valid points received = " << filled_size
+         << ", invalid points received " << invalid_size << ". ";
+    };
+
+    if constexpr (TargetTag::compute_target_points::is_sequential::value) {
+      ss << pretty_type::name<TargetTag>() << ", ";
+
+      const auto& current_temporal_id =
+          db::get<intrp::Tags::CurrentTemporalId<TemporalId>>(box);
+      const auto& pending_temporal_ids =
+          db::get<intrp::Tags::PendingTemporalIds<TemporalId>>(box);
+
+      if (current_temporal_id.has_value()) {
+        ss << "current temporal id " << current_temporal_id.value() << ", ";
+
+        stream_points(current_temporal_id.value());
+      } else {
+        ss << "no current temporal id. ";
+      }
+
+      ss << "Pending ids " << pending_temporal_ids;
+
+      Parallel::fprintf(file_name, "%s\n", ss.str());
+    } else {
+      const auto& temporal_ids =
+          db::get<intrp::Tags::TemporalIds<TemporalId>>(box);
+
+      if (temporal_ids.empty()) {
+        ss << pretty_type::name<TargetTag>() << ", No temporal ids.";
+        Parallel::printf("%s\n", ss.str());
+        return;
+      }
+
+      ss << "========== BEGIN TARGET " << pretty_type::name<TargetTag>()
+         << " ==========\n";
+
+      for (const auto& temporal_id : temporal_ids) {
+        ss << "Temporal id " << temporal_id << ", ";
+
+        stream_points(temporal_id);
+
+        ss << "\n";
+      }
+
+      ss << "========== END TARGET " << pretty_type::name<TargetTag>()
+         << " ============\n";
+
+      Parallel::fprintf(file_name, "%s\n", ss.str());
+    }
+  }
+};
+}  // namespace deadlock

--- a/src/ParallelAlgorithms/Interpolation/Actions/PrintInterpolatorForDeadlock.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/PrintInterpolatorForDeadlock.hpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iomanip>
+#include <ios>
+#include <limits>
+#include <sstream>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace deadlock {
+/*!
+ * \brief Simple action to print information from the Interpolator.
+ *
+ * \details Makes a directory called `interpolator` inside the \p deadlock_dir
+ * if it doesn't exist. Then writes to a new file for each target the following
+ * information only for sequential targets for all temporal ids stored:
+ *
+ * - Interpolator core
+ * - Temporal id
+ * - Iteration number
+ * - Expected number of elements to receive
+ * - Current number of elements received
+ * - Missing elements
+ */
+struct PrintInterpolator {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index,
+                    const std::string& deadlock_dir) {
+    using target_tags = typename Metavariables::interpolation_target_tags;
+
+    const std::string intrp_deadlock_dir = deadlock_dir + "/interpolator";
+    if (not file_system::check_if_dir_exists(intrp_deadlock_dir)) {
+      file_system::create_directory(intrp_deadlock_dir);
+    }
+
+    tmpl::for_each<target_tags>([&](const auto tag_v) {
+      using target_tag = tmpl::type_from<decltype(tag_v)>;
+
+      // Only need to print the sequential targets (aka horizons)
+      if constexpr (target_tag::compute_target_points::is_sequential::value) {
+        const std::string file_name =
+            intrp_deadlock_dir + "/" + pretty_type::name<target_tag>() + ".out";
+
+        const auto& holders =
+            db::get<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(box);
+        const auto& vars_infos =
+            get<intrp::Vars::HolderTag<target_tag, Metavariables>>(holders)
+                .infos;
+        const auto& num_elements =
+            db::get<intrp::Tags::NumberOfElements<Metavariables::volume_dim>>(
+                box);
+
+        if (vars_infos.empty()) {
+          Parallel::fprintf(file_name, "No data on interpolator core %zu\n",
+                            array_index);
+          return;
+        }
+
+        std::stringstream ss{};
+        ss << std::setprecision(std::numeric_limits<double>::digits10 + 4)
+           << std::scientific;
+
+        ss << "========== BEGIN INTERPOLATOR CORE " << array_index
+           << " ==========\n";
+
+        for (const auto& [temporal_id, info] : vars_infos) {
+          ss << "Temporal id " << temporal_id << ": "
+             << "Iteration " << info.iteration << ", expecting data from "
+             << num_elements.size() << " elements, but only received "
+             << info.interpolation_is_done_for_these_elements.size()
+             << ". Missing these elements: ";
+
+          std::unordered_set<ElementId<Metavariables::volume_dim>> difference{};
+          for (const auto& element : num_elements) {
+            if (not info.interpolation_is_done_for_these_elements.contains(
+                    element)) {
+              difference.insert(element);
+            }
+          }
+
+          ss << difference << "\n";
+        }
+
+        ss << "========== END INTERPOLATOR CORE " << array_index
+           << " ============\n";
+
+        Parallel::fprintf(file_name, "%s\n", ss.str());
+      }
+    });
+
+    (void)box;
+    (void)cache;
+    (void)array_index;
+  }
+};
+}  // namespace deadlock

--- a/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -177,9 +179,11 @@ void try_to_interpolate(
 
   // Send interpolated data only if interpolation has been done on all
   // of the local elements.
-  const auto& num_elements = db::get<Tags::NumberOfElements>(*box);
+  const auto& num_elements =
+      db::get<Tags::NumberOfElements<Metavariables::volume_dim>>(*box);
   if (vars_infos.at(temporal_id)
-          .interpolation_is_done_for_these_elements.size() == num_elements) {
+          .interpolation_is_done_for_these_elements.size() ==
+      num_elements.size()) {
     // Send data to InterpolationTarget, but only if the list of points is
     // non-empty.
     if (not vars_infos.at(temporal_id).global_offsets.empty()) {

--- a/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
@@ -85,6 +85,7 @@ struct Interpolator {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<Actions::InitializeInterpolator<
+                         Metavariables::volume_dim,
                          tmpl::transform<
                              all_temporal_ids,
                              tmpl::bind<Tags::VolumeVarsInfo,

--- a/src/ParallelAlgorithms/Interpolation/Tags.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Tags.hpp
@@ -194,9 +194,10 @@ struct InterpolatedVarsHolders : db::SimpleTag {
       typename Metavariables::interpolation_target_tags, Metavariables>>;
 };
 
-/// Number of local `Element`s.
+/// Unordered set of element ids on each interpolator core.
+template <size_t Dim>
 struct NumberOfElements : db::SimpleTag {
-  using type = size_t;
+  using type = std::unordered_set<ElementId<Dim>>;
 };
 
 }  // namespace Tags

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -397,6 +397,14 @@ EventsAndDenseTriggers:
     Events:
       - BondiSachsInterpolation
 
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
+    - ObserveTimeStepVolume:
+        SubfileName: FailureTimeStep
+        FloatingPointType: Double
+        CoordinatesFloatingPointType: Float
+
 Interpolator:
   DumpVolumeDataOnFailure: false
 

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -281,6 +281,14 @@ EventsAndDenseTriggers:
     Events:
       - BondiSachsInterpolation
 
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
+    - ObserveTimeStepVolume:
+        SubfileName: FailureTimeStep
+        FloatingPointType: Double
+        CoordinatesFloatingPointType: Float
+
 Interpolator:
   DumpVolumeDataOnFailure: false
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -76,6 +76,14 @@ DomainCreator:
 
 EventsAndDenseTriggers:
 
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
+    - ObserveTimeStepVolume:
+        SubfileName: FailureTimeStep
+        FloatingPointType: Double
+        CoordinatesFloatingPointType: Float
+
 # Set gauge and constraint damping parameters.
 # The values here are chosen empirically based on values that proved
 # successful in SpEC evolutions of binary black holes.

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -216,6 +216,14 @@ EventsAndTriggersAtSteps:
 
 EventsAndDenseTriggers:
 
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
+    - ObserveTimeStepVolume:
+        SubfileName: FailureTimeStep
+        FloatingPointType: Double
+        CoordinatesFloatingPointType: Float
+
 Observers:
   VolumeFileName: "GhKerrSchildVolume"
   ReductionFileName: "GhKerrSchildReductions"

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -46,6 +46,7 @@ struct ReceivePoints;
 namespace Tags {
 template <typename TemporalId>
 struct InterpolatedVarsHolders;
+template <size_t Dim>
 struct NumberOfElements;
 }  // namespace Tags
 }  // namespace intrp
@@ -79,11 +80,10 @@ struct mock_interpolation_target {
 
 template <typename InterpolationTargetTag>
 struct MockReceivePoints {
-  template <
-      typename ParallelComponent, typename DbTags, typename Metavariables,
-      typename ArrayIndex, size_t VolumeDim,
-      Requires<tmpl::list_contains_v<DbTags, ::intrp::Tags::NumberOfElements>> =
-          nullptr>
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, size_t VolumeDim,
+            Requires<tmpl::list_contains_v<
+                DbTags, ::intrp::Tags::NumberOfElements<VolumeDim>>> = nullptr>
   static void apply(
       db::DataBox<DbTags>& box, Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
@@ -120,6 +120,7 @@ struct mock_interpolator {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolator<
+              metavariables::volume_dim,
               intrp::Tags::VolumeVarsInfo<
                   Metavariables,
                   typename Metavariables::InterpolationTargetA::temporal_id>,

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -251,6 +251,7 @@ struct mock_interpolator {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolator<
+          metavariables::volume_dim,
           intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>,
           intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
 
@@ -426,7 +427,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
     mock_core_for_each_element.insert({element_id, core});
     ActionTesting::simple_action<interp_component,
                                  intrp::Actions::RegisterElement>(
-        make_not_null(&runner), core);
+        make_not_null(&runner), core, element_id);
     if (++core >= num_cores) {
       core = 0;
     }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -106,6 +106,7 @@ struct mock_interpolator {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<intrp::Actions::InitializeInterpolator<
+              metavariables::volume_dim,
               tmpl::transform<all_ids,
                               tmpl::bind<intrp::Tags::VolumeVarsInfo,
                                          tmpl::pin<Metavariables>, tmpl::_1>>,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -45,6 +45,7 @@ struct mock_interpolator {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using simple_tags = typename intrp::Actions::InitializeInterpolator<
+      metavariables::volume_dim,
       tmpl::list<intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
                  intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>>,
       intrp::Tags::InterpolatedVarsHolders<Metavariables>>::simple_tags;
@@ -138,7 +139,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
   ActionTesting::MockRuntimeSystem<metavars> runner{{}};
   ActionTesting::emplace_component_and_initialize<interp_component>(
       &runner, 0,
-      {0_st,
+      {std::unordered_set<ElementId<metavars::volume_dim>>{},
        typename intrp::Tags::VolumeVarsInfo<metavars, ::Tags::TimeStepId>::type{
            std::move(volume_vars_info_bc)},
        typename intrp::Tags::VolumeVarsInfo<metavars, ::Tags::Time>::type{

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -32,6 +32,7 @@ struct mock_interpolator {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<intrp::Actions::InitializeInterpolator<
+          Metavariables::volume_dim,
           tmpl::list<
               intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::Time>,
               intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>>,
@@ -64,9 +65,10 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Initialize",
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
-  CHECK(ActionTesting::get_databox_tag<component,
-                                       ::intrp::Tags::NumberOfElements>(
-            runner, 0) == 0);
+  CHECK(ActionTesting::get_databox_tag<
+            component, ::intrp::Tags::NumberOfElements<metavars::volume_dim>>(
+            runner, 0)
+            .empty());
   CHECK(ActionTesting::get_databox_tag<
             component, ::intrp::Tags::VolumeVarsInfo<metavars, ::Tags::Time>>(
             runner, 0)

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -129,10 +129,12 @@ struct mock_interpolator {
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<::intrp::Actions::InitializeInterpolator<
+          metavariables::volume_dim,
           intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
           intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolator<
+          metavariables::volume_dim,
           intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
           intrp::Tags::InterpolatedVarsHolders<Metavariables>>::
           return_tag_list>;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -196,6 +196,7 @@ struct mock_interpolator {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<::intrp::Actions::InitializeInterpolator<
+              metavariables::volume_dim,
               intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
               intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
@@ -287,7 +288,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
   for (size_t array_index = 0; array_index < 2; array_index++) {
     for (size_t num_elements = 0; num_elements < 4; num_elements++) {
       runner.simple_action<interp_component, ::intrp::Actions::RegisterElement>(
-          array_index);
+          array_index, element_ids[array_index + num_elements * 2]);
     }
   }
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -150,6 +150,7 @@ struct MockInterpolator {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<::intrp::Actions::InitializeInterpolator<
+              metavariables::volume_dim,
               tmpl::list<
                   intrp::Tags::VolumeVarsInfo<Metavariables,
                                               ::Tags::TimeStepId>,
@@ -333,7 +334,7 @@ void run_test(gsl::not_null<Generator*> generator,
     mock_core_for_each_element.insert({element_id, core_for_next_element});
     ActionTesting::simple_action<interp_component,
                                  intrp::Actions::RegisterElement>(
-        make_not_null(&runner), core_for_next_element);
+        make_not_null(&runner), core_for_next_element, element_id);
     if (++core_for_next_element >= num_cores) {
       core_for_next_element = 0;
     }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -409,6 +409,7 @@ struct MockInterpolator {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<::intrp::Actions::InitializeInterpolator<
+              metavariables::volume_dim,
               tmpl::list<
                   intrp::Tags::VolumeVarsInfo<Metavariables,
                                               ::Tags::TimeStepId>,
@@ -687,7 +688,7 @@ void run_test() {
     mock_core_for_each_element.insert({element_id, core_for_next_element});
     ActionTesting::simple_action<interp_component,
                                  intrp::Actions::RegisterElement>(
-        make_not_null(&runner), core_for_next_element);
+        make_not_null(&runner), core_for_next_element, element_id);
     if (++core_for_next_element >= num_cores) {
       core_for_next_element = 0;
     }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -223,6 +223,7 @@ struct mock_interpolator {
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
           tmpl::list<::intrp::Actions::InitializeInterpolator<
+              metavariables::volume_dim,
               intrp::Tags::VolumeVarsInfo<Metavariables, ::Tags::TimeStepId>,
               intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>,
       Parallel::PhaseActions<Parallel::Phase::Register, tmpl::list<>>,
@@ -379,7 +380,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
     mock_core_for_each_element.insert({element_id, core_for_next_element});
     ActionTesting::simple_action<interp_component,
                                  intrp::Actions::RegisterElement>(
-        make_not_null(&runner), core_for_next_element);
+        make_not_null(&runner), core_for_next_element, element_id);
     if (++core_for_next_element >= num_cores) {
       core_for_next_element = 0;
     }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
@@ -100,7 +100,7 @@ SPECTRE_TEST_CASE("Unit.Interpolation.Tags", "[Unit][NumericalAlgorithms]") {
   TestHelpers::db::test_simple_tag<
       intrp::Tags::InterpolatedVarsHolders<Metavars>>(
       "InterpolatedVarsHolders");
-  TestHelpers::db::test_simple_tag<intrp::Tags::NumberOfElements>(
+  TestHelpers::db::test_simple_tag<intrp::Tags::NumberOfElements<3>>(
       "NumberOfElements");
   TestHelpers::db::test_simple_tag<intrp::Tags::InterpPointInfo<Metavars>>(
       "InterpPointInfo");


### PR DESCRIPTION
## Proposed changes

While debugging nodegroup deadlocks, these changes were helpful giving more, better organized, information.

This last commit was useful because sometimes after a deadlock, I'd want to run an event to get some extra information and we have a phase for doing that (`PostFailureCleanup`), but it wasn't run after a deadlock. If the method I have for implementing this needs a lot of discussion, I'm ok leaving it out for now. The other commits are more important I think.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
For BBH and SingleBH executables, must add a block to the input file
```yaml
EventsRunAtCleanup:
  ObservationValue: -1000.0
  Events:
    - Event1
    - Event2
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
