### PR TITLE
Status CLI: fix speed measurement

### DIFF
--- a/support/Pipelines/EccentricityControl/EccentricityControlParams.py
+++ b/support/Pipelines/EccentricityControl/EccentricityControlParams.py
@@ -154,7 +154,7 @@ def eccentricity_control_params(
         mA = horizon_params["AhA ChristodoulouMass"].iloc[0]
         mB = horizon_params["AhB ChristodoulouMass"].iloc[0]
         if "AhA DimensionfulSpinVector_x" in horizon_params.columns:
-            sA = np.concat(
+            sA = np.array(
                 [horizon_params.index]
                 + [
                     horizon_params[f"AhA DimensionfulSpinVector_{xyz}"]

--- a/tests/tools/Test_Status.py
+++ b/tests/tools/Test_Status.py
@@ -120,7 +120,7 @@ class TestExecutableStatus(unittest.TestCase):
     def test_evolution_status(self):
         executable_status = match_executable_status("EvolveSomething")
         status = executable_status.status(self.input_file, self.work_dir)
-        self.assertEqual(status, {"Time": 2.0, "Speed": 2640.0})
+        self.assertEqual(status, {"Time": 2.0, "Speed": 2400.0})
         self.assertEqual(executable_status.format("Time", 1.5), "1.5")
         self.assertEqual(executable_status.format("Speed", 1.2), "1.2")
 
@@ -128,7 +128,7 @@ class TestExecutableStatus(unittest.TestCase):
         executable_status = match_executable_status("EvolveGhBinaryBlackHole")
         status = executable_status.status(self.input_file, self.work_dir)
         self.assertEqual(status["Time"], 2.0)
-        self.assertEqual(status["Speed"], 2640.0)
+        self.assertEqual(status["Speed"], 2400.0)
         self.assertEqual(status["Orbits"], 0.5)
         self.assertEqual(status["Separation"], 2.0)
         self.assertEqual(status["3-Index Constraint"], 1.0e-4)
@@ -137,7 +137,7 @@ class TestExecutableStatus(unittest.TestCase):
         executable_status = match_executable_status("EvolveGhSingleBlackHole")
         status = executable_status.status(self.input_file, self.work_dir)
         self.assertEqual(status["Time"], 2.0)
-        self.assertEqual(status["Speed"], 2640.0)
+        self.assertEqual(status["Speed"], 2400.0)
         self.assertEqual(status["Constraint Energy"], 1.0e-3)
 
     def test_elliptic_status(self):


### PR DESCRIPTION
Using max walltime per slab for speed measurement
instead of averaging with the min walltime.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
