### PR TITLE
Fix CI for Python 3.9

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -586,9 +586,9 @@ jobs:
           rm cmake-install.sh
       - name: Install Python version
         if: matrix.PYTHON_VERSION
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.PYTHON_VERSION }}
+        run: |
+          add-apt-repository ppa:deadsnakes/ppa
+          apt install -y python${{ matrix.PYTHON_VERSION }}
       - name: Install Python dependencies
         if: matrix.PYTHON_VERSION
         run: |


### PR DESCRIPTION
## Proposed changes

Because our containers are Ubuntu 22.04 and the `actions/setup-python@v5` action was pulling python3.9 built for 24.04, there was a GLIBC version mismatch. Here we just pull from deadsnakes instead.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
