### PR TITLE
Remove CCE ability to read metric worldtube data

### DIFF
--- a/.github/workflows/DeployStaticExecutables.yaml
+++ b/.github/workflows/DeployStaticExecutables.yaml
@@ -86,8 +86,6 @@ jobs:
 
           sed -i 's/CceR0257/Tests\/BondiSachsCceR0200/g' \
           ./CceExecutables/CharacteristicExtract.yaml
-          sed -i 's/H5IsBondiData: False/H5IsBondiData: True/g' \
-          ./CceExecutables/CharacteristicExtract.yaml
 
           cd ./CceExecutables/
 

--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -359,10 +359,6 @@ a bit on why we chose some of those parameters.
   we also recommend running CCE over several worldtube radii and checking which
   is the best based on the Bianchi identity violations. There isn't necessarily
   a "best radius" to extract waveforms at.
-- If the worldtube data is in the [Bondi-Sachs](#bondi_sachs) form, set
-  `Cce.H5IsBondiData` to `True`. If the worldtube data is the
-  [cartesian_metric](#cartesian_metric_and_derivatives) form, set
-  `Cce.H5IsBondiData` to `False`.
 
 ### Initial data on the null hypersurface
 

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <limits>
 #include <optional>
+#include <stdexcept>
 
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/ComplexModalVector.hpp"
@@ -118,8 +119,7 @@ struct StandaloneExtractionRadius {
   static constexpr Options::String help{
       "Extraction radius of the CCE system for a standalone run. This may be "
       "set to \"Auto\" to infer the radius from the filename (often used for "
-      "SpEC worldtube data). This option is unused if `H5IsBondiData` is "
-      "`true`, and should be \"Auto\" for such runs."};
+      "SpEC worldtube data)."};
   using group = Cce;
 };
 
@@ -165,27 +165,6 @@ struct H5Interpolator {
   using type = std::unique_ptr<intrp::SpanInterpolator>;
   static constexpr Options::String help{
       "The interpolator for imported h5 worldtube data."};
-  using group = Cce;
-};
-
-struct H5IsBondiData {
-  using type = bool;
-  static constexpr Options::String help{
-      "true for boundary data in Bondi form, false for metric data. Metric "
-      "data is more readily available from Cauchy simulations, so historically "
-      "has been the typical format provided by SpEC simulations. Bondi data is "
-      "much more efficient for storage size and performance, but both must be "
-      "supported for compatibility with current CCE data sources."};
-  using group = Cce;
-};
-
-struct FixSpecNormalization {
-  using type = bool;
-  static constexpr Options::String help{
-      "Set to true if corrections for SpEC data impurities should be applied "
-      "automatically based on the `VersionHist.ver` data set in the H5. "
-      "Typically, this should be set to true if the metric data is created "
-      "from SpEC, and false otherwise."};
   using group = Cce;
 };
 
@@ -319,7 +298,6 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
   using option_tags =
       tmpl::list<OptionTags::LMax, OptionTags::BoundaryDataFilename,
                  OptionTags::H5LookaheadTimes, OptionTags::H5Interpolator,
-                 OptionTags::H5IsBondiData, OptionTags::FixSpecNormalization,
                  OptionTags::StandaloneExtractionRadius>;
 
   static constexpr bool pass_metavariables = false;
@@ -327,37 +305,28 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
       const size_t l_max, const std::string& filename,
       const size_t number_of_lookahead_times,
       const std::unique_ptr<intrp::SpanInterpolator>& interpolator,
-      const bool h5_is_bondi_data, const bool fix_spec_normalization,
       const std::optional<double> extraction_radius) {
-    if (h5_is_bondi_data) {
-      if (static_cast<bool>(extraction_radius)) {
+    const std::string text_radius_str = Cce::get_text_radius(filename);
+    try {
+      // If this doesn't throw an exception, then an extraction radius was
+      // supplied in the filename. We don't actually need the value.
+      const double text_radius = std::stod(text_radius_str);
+      (void)text_radius;
+      if (extraction_radius.has_value()) {
         Parallel::printf(
             "Warning: Option ExtractionRadius is set to a specific value and "
-            "H5IsBondiData is set to `true` -- the ExtractionRadius will not "
-            "be used, because all radius information is specified in the input "
-            "file for the Bondi worldtube data format. It is recommended to "
-            "set `ExtractionRadius` to `\"Auto\"` to make the input file "
-            "clearer.\n");
+            "there is an extraction radius in the H5 filename. The value in "
+            "the file name will be ignored.It is recommended to set "
+            "`ExtractionRadius` to `\"Auto\"` if the H5 filename has the "
+            "extraction radius in it to make the input file clearer.\n");
       }
-      return std::make_unique<BondiWorldtubeDataManager>(
-          std::make_unique<BondiWorldtubeH5BufferUpdater<ComplexModalVector>>(
-              filename, extraction_radius),
-          l_max, number_of_lookahead_times, interpolator->get_clone());
-    } else {
-      Parallel::printf(
-          "\nDEPRECATION WARNING: Reading worldtube H5 files that are in the "
-          "Metric data format (i.e. cartesian components of the metric and "
-          "derivs expressed in modal coefficients) is deprecated. Convert your "
-          "data to the Bondi modal format using the 'PreprocessCceWorldtube' "
-          "executable. See https://spectre-code.org/tutorial_cce.html for "
-          "details. Support for reading the Metric data format will be "
-          "dropped in January 2025.\n");
-      return std::make_unique<MetricWorldtubeDataManager>(
-          std::make_unique<MetricWorldtubeH5BufferUpdater<ComplexModalVector>>(
-              filename, extraction_radius),
-          l_max, number_of_lookahead_times, interpolator->get_clone(),
-          fix_spec_normalization);
+    } catch (const std::invalid_argument&) {
     }
+
+    return std::make_unique<BondiWorldtubeDataManager>(
+        std::make_unique<BondiWorldtubeH5BufferUpdater<ComplexModalVector>>(
+            filename, extraction_radius),
+        l_max, number_of_lookahead_times, interpolator->get_clone());
   }
 };
 
@@ -453,26 +422,20 @@ struct StartTimeFromFile : Tags::StartTime, db::SimpleTag {
   using type = double;
   using option_tags =
       tmpl::list<OptionTags::StartTime, OptionTags::BoundaryDataFilename,
-                 OptionTags::H5IsBondiData>;
+                 OptionTags::StandaloneExtractionRadius>;
 
   static constexpr bool pass_metavariables = false;
-  static double create_from_options(const std::optional<double> start_time,
-                                    const std::string& filename,
-                                    const bool is_bondi_data) {
-    if (start_time) {
+  static double create_from_options(
+      const std::optional<double> start_time, const std::string& filename,
+      const std::optional<double>& extraction_radius) {
+    if (start_time.has_value()) {
       return *start_time;
     }
-    if (is_bondi_data) {
-      BondiWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
-          filename};
-      const auto& time_buffer = h5_boundary_updater.get_time_buffer();
-      return time_buffer[0];
-    } else {
-      MetricWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
-          filename};
-      const auto& time_buffer = h5_boundary_updater.get_time_buffer();
-      return time_buffer[0];
-    }
+
+    BondiWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
+        filename, extraction_radius};
+    const auto& time_buffer = h5_boundary_updater.get_time_buffer();
+    return time_buffer[0];
   }
 };
 
@@ -504,26 +467,19 @@ struct EndTimeFromFile : Tags::EndTime, db::SimpleTag {
   using type = double;
   using option_tags =
       tmpl::list<OptionTags::EndTime, OptionTags::BoundaryDataFilename,
-                 OptionTags::H5IsBondiData>;
+                 OptionTags::StandaloneExtractionRadius>;
 
   static constexpr bool pass_metavariables = false;
-  static double create_from_options(const std::optional<double> end_time,
-                                    const std::string& filename,
-                                    const bool is_bondi_data) {
+  static double create_from_options(
+      const std::optional<double> end_time, const std::string& filename,
+      const std::optional<double>& extraction_radius) {
     if (end_time) {
       return *end_time;
     }
-    if (is_bondi_data) {
-      BondiWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
-          filename};
-      const auto& time_buffer = h5_boundary_updater.get_time_buffer();
-      return time_buffer[time_buffer.size() - 1];
-    } else {
-      MetricWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
-          filename};
-      const auto& time_buffer = h5_boundary_updater.get_time_buffer();
-      return time_buffer[time_buffer.size() - 1];
-    }
+    BondiWorldtubeH5BufferUpdater<ComplexModalVector> h5_boundary_updater{
+        filename, extraction_radius};
+    const auto& time_buffer = h5_boundary_updater.get_time_buffer();
+    return time_buffer[time_buffer.size() - 1];
   }
 };
 

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -117,17 +117,11 @@ Cce:
   #   ExtractionRadius: 257
   BoundaryDataFilename: CceR0257.h5
   ExtractionRadius: Auto
-  # Assume data is metric & derivs. This is wrong for SpECTRE & SpEC
-  # output, but likely correct for other codes.
-  H5IsBondiData: False
   # How we interpolate the worldtube data in time for CCE.
   H5Interpolator:
     BarycentricRationalSpanInterpolator:
       MinOrder: 10
       MaxOrder: 10
-  # Unless you are using data from an old version of the Spectral Einstein Code,
-  # leave FixSpecNormalization as False.
-  FixSpecNormalization: False
 
   # Loads this many time steps in from the HDF5 files at once. Fewer file system
   # accesses improve performance, but requires more RAM.

--- a/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
@@ -118,17 +118,11 @@ Cce:
   BoundaryDataFilename: CceR0257.h5
   KleinGordonBoundaryDataFilename: CceR0257.h5
   ExtractionRadius: Auto
-  # Assume data is metric & derivs. This is wrong for SpECTRE & SpEC
-  # output, but likely correct for other codes.
-  H5IsBondiData: False
   # How we interpolate the worldtube data in time for CCE.
   H5Interpolator:
     BarycentricRationalSpanInterpolator:
       MinOrder: 10
       MaxOrder: 10
-  # Unless you are using data from an old version of the Spectral Einstein Code,
-  # leave FixSpecNormalization as False.
-  FixSpecNormalization: False
 
   # Loads this many time steps in from the HDF5 files at once. Fewer file system
   # accesses improve performance, but requires more RAM.

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -254,7 +254,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false, false, std::optional<double>{}));
+          std::optional<double>{}));
 
   // this should run the initializations
   for (size_t i = 0; i < 5; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonWorldtubeBoundary.cpp
@@ -86,7 +86,7 @@ void test_klein_gordon_h5_initialization(const gsl::not_null<Generator*> gen) {
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false, false, std::optional<double>{}),
+          std::optional<double>{}),
       Tags::KleinGordonH5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -125,7 +125,7 @@ void test_h5_initialization(const gsl::not_null<Generator*> gen) {
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false, false, std::optional<double>{}));
+          std::optional<double>{}));
 
   // this should run the initialization
   for (size_t i = 0; i < 3; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -229,7 +229,7 @@ void test_klein_gordon_h5_boundary_communication(
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false, false, std::optional<double>{}),
+          std::optional<double>{}),
       Tags::KleinGordonH5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -219,7 +219,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3_st,
                                                                        4_st),
-          false, false, std::optional<double>{}));
+          std::optional<double>{}));
 
   // this should run the initializations
   for (size_t i = 0; i < 5; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -197,7 +197,7 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),
-          false, false, std::optional<double>{}),
+          std::optional<double>{}),
       Tags::KleinGordonH5WorldtubeBoundaryDataManager::create_from_options(
           l_max, filename, buffer_size,
           std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u),

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -185,11 +185,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   }
   Cce::TestHelpers::write_test_file(
       gr::Solutions::KerrSchild{1.0, {{0.2, 0.2, 0.2}}, {{0.0, 0.0, 0.0}}},
-      filename, 4.0, 100.0, 0.0, 0.1, 8);
+      filename, 4.0, 100.0, 0.1, 0.1, 8);
 
   CHECK(Cce::Tags::H5WorldtubeBoundaryDataManager::create_from_options(
             8, filename, 3, std::make_unique<intrp::CubicSpanInterpolator>(),
-            false, true, std::nullopt)
+            std::nullopt)
             ->get_l_max() == 8);
 
   CHECK(Cce::Tags::FilePrefix::create_from_options("Shrek 2") == "Shrek 2");

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -600,9 +600,9 @@ void test_metric_worldtube_buffer_updater_impl(
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }
-  TestHelpers::write_test_file<T>(solution, filename, target_time,
-                                  extraction_radius, frequency, amplitude,
-                                  file_l_max);
+  TestHelpers::write_test_file<T, false>(solution, filename, target_time,
+                                         extraction_radius, frequency,
+                                         amplitude, file_l_max);
 
   // request an appropriate buffer
   auto buffer_updater =

--- a/tests/Unit/Executables/Test_PreprocessCceWorldtube.cpp
+++ b/tests/Unit/Executables/Test_PreprocessCceWorldtube.cpp
@@ -44,77 +44,6 @@ double compute_time(const double target_time, const size_t time_index) {
   return 0.1 * static_cast<double>(time_index) + target_time - 1.5;
 }
 
-template <bool Modal, typename Solution>
-void write_bondi_test_file(const std::string& worldtube_filename,
-                           const size_t l_max, const double target_time,
-                           const double extraction_radius,
-                           const Solution& solution, const double amplitude,
-                           const double frequency) {
-  const size_t number_of_angular_points =
-      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
-  Variables<Cce::Tags::characteristic_worldtube_boundary_tags<
-      Cce::Tags::BoundaryValue>>
-      boundary_data_variables{number_of_angular_points};
-
-  const size_t libsharp_size =
-      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max);
-  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{libsharp_size};
-  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{libsharp_size};
-  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> shift_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{libsharp_size};
-  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> lapse_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> dt_lapse_coefficients{libsharp_size};
-  Scalar<ComplexModalVector> dr_lapse_coefficients{libsharp_size};
-
-  using RecorderType =
-      tmpl::conditional_t<Modal, Cce::WorldtubeModeRecorder,
-                          Cce::TestHelpers::WorldtubeModeRecorder>;
-  RecorderType recorder{l_max, worldtube_filename};
-  for (size_t t = 0; t < number_of_times; ++t) {
-    const double time = compute_time(target_time, t);
-    Cce::TestHelpers::create_fake_time_varying_data(
-        make_not_null(&spatial_metric_coefficients),
-        make_not_null(&dt_spatial_metric_coefficients),
-        make_not_null(&dr_spatial_metric_coefficients),
-        make_not_null(&shift_coefficients),
-        make_not_null(&dt_shift_coefficients),
-        make_not_null(&dr_shift_coefficients),
-        make_not_null(&lapse_coefficients),
-        make_not_null(&dt_lapse_coefficients),
-        make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
-        amplitude, frequency, time, l_max, false);
-
-    Cce::create_bondi_boundary_data(
-        make_not_null(&boundary_data_variables), spatial_metric_coefficients,
-        dt_spatial_metric_coefficients, dr_spatial_metric_coefficients,
-        shift_coefficients, dt_shift_coefficients, dr_shift_coefficients,
-        lapse_coefficients, dt_lapse_coefficients, dr_lapse_coefficients,
-        extraction_radius, l_max);
-
-    // loop over the tags that we want to dump.
-    tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<>>(
-        [&](auto tag_v) {
-          using tag = typename decltype(tag_v)::type;
-
-          const ComplexDataVector& nodal_data =
-              get(get<tag>(boundary_data_variables)).data();
-
-          if constexpr (Modal) {
-            recorder.template append_modal_data<tag::type::type::spin>(
-                Cce::dataset_label_for_tag<typename tag::tag>(), time,
-                nodal_data, l_max);
-          } else {
-            // This will write nodal data
-            recorder.append_worldtube_mode_data(
-                Cce::dataset_label_for_tag<typename tag::tag>(), time,
-                nodal_data, l_max);
-          }
-        });
-  }
-}
-
 using modal_tags = Cce::Tags::worldtube_boundary_tags_for_writing<
     Spectral::Swsh::Tags::SwshTransform>;
 using ExpectedDataType = std::vector<Variables<modal_tags>>;
@@ -395,26 +324,26 @@ int main() {
       "Test_OutputBondiNodal_R0123.h5"};
 
   // Write metric data
-  Cce::TestHelpers::write_test_file<ComplexModalVector>(
+  Cce::TestHelpers::write_test_file<ComplexModalVector, false>(
       solution, metric_modal_input_worldtube_filename, target_time,
       worldtube_radius, frequency, amplitude, l_max, false);
-  Cce::TestHelpers::write_test_file<DataVector>(
+  Cce::TestHelpers::write_test_file<DataVector, false>(
       solution, metric_nodal_1_input_worldtube_filename, target_time,
       worldtube_radius, frequency, amplitude, l_max, false);
-  Cce::TestHelpers::write_test_file<DataVector>(
+  Cce::TestHelpers::write_test_file<DataVector, false>(
       solution, metric_nodal_2_input_worldtube_filename, second_target_time,
       worldtube_radius, frequency, amplitude, l_max, false);
 
   // Write bondi data
-  write_bondi_test_file<true>(bondi_modal_1_input_worldtube_filename, l_max,
-                              target_time, worldtube_radius, solution,
-                              amplitude, frequency);
-  write_bondi_test_file<true>(bondi_modal_2_input_worldtube_filename, l_max,
-                              second_target_time, worldtube_radius, solution,
-                              amplitude, frequency);
-  write_bondi_test_file<false>(bondi_nodal_input_worldtube_filename, l_max,
-                               target_time, worldtube_radius, solution,
-                               amplitude, frequency);
+  Cce::TestHelpers::write_test_file<ComplexModalVector, true>(
+      solution, bondi_modal_1_input_worldtube_filename, target_time,
+      worldtube_radius, frequency, amplitude, l_max, false);
+  Cce::TestHelpers::write_test_file<ComplexModalVector, true>(
+      solution, bondi_modal_2_input_worldtube_filename, second_target_time,
+      worldtube_radius, frequency, amplitude, l_max, false);
+  Cce::TestHelpers::write_test_file<DataVector, true>(
+      solution, bondi_nodal_input_worldtube_filename, target_time,
+      worldtube_radius, frequency, amplitude, l_max, false);
 
   // Write input file
   write_input_file("MetricModal", {metric_modal_input_worldtube_filename},
@@ -450,6 +379,8 @@ int main() {
                                        input_data_format + ".yaml > " +
                                        input_data_format + ".out 2>&1";
 
+        CAPTURE_FOR_ERROR(input_data_format);
+        CAPTURE_FOR_ERROR(to_execute);
         const int exit_code = std::system(to_execute.c_str());  // NOLINT
 
         SPECTRE_PARALLEL_REQUIRE(exit_code == 0);

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp"
+#include "Evolution/Systems/Cce/WorldtubeModeRecorder.hpp"
 #include "Helpers/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
@@ -288,7 +289,8 @@ void create_fake_time_varying_data(
   }
 }
 
-template <typename T = ComplexModalVector, typename AnalyticSolution>
+template <typename T = ComplexModalVector, bool WriteBondi = true,
+          typename AnalyticSolution>
 void write_test_file(const AnalyticSolution& solution,
                      const std::string& filename, const double target_time,
                      const double extraction_radius, const double frequency,
@@ -298,6 +300,9 @@ void write_test_file(const AnalyticSolution& solution,
   const size_t size =
       is_modal ? square(l_max + 1)
                : Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  (void)number_of_angular_points;
   tnsr::ii<T, 3> spatial_metric_coefficients{size};
   tnsr::ii<T, 3> dt_spatial_metric_coefficients{size};
   tnsr::ii<T, 3> dr_spatial_metric_coefficients{size};
@@ -307,6 +312,12 @@ void write_test_file(const AnalyticSolution& solution,
   Scalar<T> lapse_coefficients{size};
   Scalar<T> dt_lapse_coefficients{size};
   Scalar<T> dr_lapse_coefficients{size};
+  Variables<Cce::Tags::characteristic_worldtube_boundary_tags<
+      Cce::Tags::BoundaryValue>>
+      boundary_data_variables{};
+  if constexpr (WriteBondi) {
+    boundary_data_variables.initialize(number_of_angular_points);
+  }
 
   // write times to file for several steps before and after the target time
   if (file_system::check_if_file_exists(filename)) {
@@ -314,7 +325,11 @@ void write_test_file(const AnalyticSolution& solution,
   }
   // scoped to close the file
   {
-    TestHelpers::WorldtubeModeRecorder recorder{l_max, filename};
+    using RecorderType =
+        tmpl::conditional_t<WriteBondi and is_modal, Cce::WorldtubeModeRecorder,
+                            Cce::TestHelpers::WorldtubeModeRecorder>;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    RecorderType recorder{l_max, filename};
     for (size_t t = 0; t < 30; ++t) {
       const double time = 0.1 * static_cast<double>(t) + target_time - 1.5;
       TestHelpers::create_fake_time_varying_data(
@@ -327,38 +342,70 @@ void write_test_file(const AnalyticSolution& solution,
           make_not_null(&lapse_coefficients),
           make_not_null(&dt_lapse_coefficients),
           make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
-          amplitude, frequency, time, l_max);
-      for (size_t i = 0; i < 3; ++i) {
-        for (size_t j = i; j < 3; ++j) {
+          amplitude, frequency, time, l_max, not WriteBondi);
+
+      if constexpr (WriteBondi) {
+        (void)spec_format;
+        Cce::create_bondi_boundary_data(
+            make_not_null(&boundary_data_variables),
+            spatial_metric_coefficients, dt_spatial_metric_coefficients,
+            dr_spatial_metric_coefficients, shift_coefficients,
+            dt_shift_coefficients, dr_shift_coefficients, lapse_coefficients,
+            dt_lapse_coefficients, dr_lapse_coefficients, extraction_radius,
+            l_max);
+
+        // loop over the tags that we want to dump.
+        tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<>>(
+            [&](auto tag_v) {
+              (void)tag_v;
+              using tag = typename decltype(tag_v)::type;
+
+              const ComplexDataVector& nodal_data =
+                  get(get<tag>(boundary_data_variables)).data();
+
+              if constexpr (is_modal) {
+                recorder.template append_modal_data<tag::type::type::spin>(
+                    Cce::dataset_label_for_tag<typename tag::tag>(), time,
+                    nodal_data, l_max);
+              } else {
+                recorder.append_worldtube_mode_data(
+                    Cce::dataset_label_for_tag<typename tag::tag>(), time,
+                    nodal_data, l_max);
+              }
+            });
+      } else {
+        for (size_t i = 0; i < 3; ++i) {
+          for (size_t j = i; j < 3; ++j) {
+            recorder.append_worldtube_mode_data(
+                detail::dataset_name_for_component("/g", i, j), time,
+                spatial_metric_coefficients.get(i, j), spec_format);
+            recorder.append_worldtube_mode_data(
+                detail::dataset_name_for_component("/Drg", i, j), time,
+                dr_spatial_metric_coefficients.get(i, j), spec_format);
+            recorder.append_worldtube_mode_data(
+                detail::dataset_name_for_component("/Dtg", i, j), time,
+                dt_spatial_metric_coefficients.get(i, j), spec_format);
+          }
           recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/g", i, j), time,
-              spatial_metric_coefficients.get(i, j), spec_format);
+              detail::dataset_name_for_component("/Shift", i), time,
+              shift_coefficients.get(i), spec_format);
           recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/Drg", i, j), time,
-              dr_spatial_metric_coefficients.get(i, j), spec_format);
+              detail::dataset_name_for_component("/DrShift", i), time,
+              dr_shift_coefficients.get(i), spec_format);
           recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/Dtg", i, j), time,
-              dt_spatial_metric_coefficients.get(i, j), spec_format);
+              detail::dataset_name_for_component("/DtShift", i), time,
+              dt_shift_coefficients.get(i), spec_format);
         }
         recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/Shift", i), time,
-            shift_coefficients.get(i), spec_format);
+            detail::dataset_name_for_component("/Lapse"), time,
+            get(lapse_coefficients), spec_format);
         recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/DrShift", i), time,
-            dr_shift_coefficients.get(i), spec_format);
+            detail::dataset_name_for_component("/DrLapse"), time,
+            get(dr_lapse_coefficients), spec_format);
         recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/DtShift", i), time,
-            dt_shift_coefficients.get(i), spec_format);
+            detail::dataset_name_for_component("/DtLapse"), time,
+            get(dt_lapse_coefficients), spec_format);
       }
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/Lapse"), time,
-          get(lapse_coefficients), spec_format);
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/DrLapse"), time,
-          get(dr_lapse_coefficients), spec_format);
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/DtLapse"), time,
-          get(dt_lapse_coefficients), spec_format);
     }
   }
 }

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/KleinGordonBoundaryTestHelpers.hpp
@@ -36,82 +36,26 @@ void write_scalar_tensor_test_file(const AnalyticSolution& solution,
                                    const double extraction_radius,
                                    const double frequency,
                                    const double amplitude, const size_t l_max) {
-  const size_t goldberg_size = square(l_max + 1);
-  tnsr::ii<ComplexModalVector, 3> spatial_metric_coefficients{goldberg_size};
-  tnsr::ii<ComplexModalVector, 3> dt_spatial_metric_coefficients{goldberg_size};
-  tnsr::ii<ComplexModalVector, 3> dr_spatial_metric_coefficients{goldberg_size};
-  tnsr::I<ComplexModalVector, 3> shift_coefficients{goldberg_size};
-  tnsr::I<ComplexModalVector, 3> dt_shift_coefficients{goldberg_size};
-  tnsr::I<ComplexModalVector, 3> dr_shift_coefficients{goldberg_size};
-  Scalar<ComplexModalVector> lapse_coefficients{goldberg_size};
-  Scalar<ComplexModalVector> dt_lapse_coefficients{goldberg_size};
-  Scalar<ComplexModalVector> dr_lapse_coefficients{goldberg_size};
+  write_test_file(solution, filename, target_time, extraction_radius, frequency,
+                  amplitude, l_max);
 
+  const size_t goldberg_size = square(l_max + 1);
   Scalar<ComplexModalVector> kg_psi_modal{goldberg_size};
   Scalar<ComplexModalVector> kg_pi_modal{goldberg_size};
   Scalar<DataVector> kg_psi_nodal;
   Scalar<DataVector> kg_pi_nodal;
 
-  if (file_system::check_if_file_exists(filename)) {
-    file_system::rm(filename, true);
-  }
   // scoped to close the file
   {
     TestHelpers::WorldtubeModeRecorder recorder{l_max, filename};
     // write times to file for several steps before and after the target time
     for (size_t t = 0; t < 30; ++t) {
       const double time = 0.1 * static_cast<double>(t) + target_time - 1.5;
-      // create tensor data
-      TestHelpers::create_fake_time_varying_data(
-          make_not_null(&spatial_metric_coefficients),
-          make_not_null(&dt_spatial_metric_coefficients),
-          make_not_null(&dr_spatial_metric_coefficients),
-          make_not_null(&shift_coefficients),
-          make_not_null(&dt_shift_coefficients),
-          make_not_null(&dr_shift_coefficients),
-          make_not_null(&lapse_coefficients),
-          make_not_null(&dt_lapse_coefficients),
-          make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
-          amplitude, frequency, time, l_max);
-
       // create scalar data
       TestHelpers::create_fake_time_varying_klein_gordon_data(
           make_not_null(&kg_psi_modal), make_not_null(&kg_pi_modal),
           make_not_null(&kg_psi_nodal), make_not_null(&kg_pi_nodal),
           extraction_radius, amplitude, frequency, time, l_max);
-
-      // write tensor data
-      for (size_t i = 0; i < 3; ++i) {
-        for (size_t j = i; j < 3; ++j) {
-          recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/g", i, j), time,
-              spatial_metric_coefficients.get(i, j), l_max);
-          recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/Drg", i, j), time,
-              dr_spatial_metric_coefficients.get(i, j), l_max);
-          recorder.append_worldtube_mode_data(
-              detail::dataset_name_for_component("/Dtg", i, j), time,
-              dt_spatial_metric_coefficients.get(i, j), l_max);
-        }
-        recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/Shift", i), time,
-            shift_coefficients.get(i), l_max);
-        recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/DrShift", i), time,
-            dr_shift_coefficients.get(i), l_max);
-        recorder.append_worldtube_mode_data(
-            detail::dataset_name_for_component("/DtShift", i), time,
-            dt_shift_coefficients.get(i), l_max);
-      }
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/Lapse"), time,
-          get(lapse_coefficients), l_max);
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/DrLapse"), time,
-          get(dr_lapse_coefficients), l_max);
-      recorder.append_worldtube_mode_data(
-          detail::dataset_name_for_component("/DtLapse"), time,
-          get(dt_lapse_coefficients), l_max);
 
       // write scalar data
       recorder.append_worldtube_mode_data(

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/WriteToWorldtubeH5.hpp
@@ -22,10 +22,10 @@ namespace Cce::TestHelpers {
 struct WorldtubeModeRecorder {
  public:
   WorldtubeModeRecorder(const size_t l_max, const std::string& filename)
-      : l_max_(l_max), output_file_{filename} {
+      : l_max_(l_max), output_file_{filename, true} {
     // write the .ver that indicates that the derivatives are correctly
     // normalized.
-    output_file_.insert<h5::Version>(
+    output_file_.try_insert<h5::Version>(
         "/VersionHist", "Bugfix in CCE radial derivatives (ticket 1096).");
     output_file_.close_current_object();
     all_modal_file_legend_.emplace_back("time");

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
@@ -375,6 +375,7 @@ void test_infinite_volume_integral(const double distance, const double mass,
 
 }  // namespace
 
+// [[Timeout, 10]]
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Xcts.AdmLinearMomentum",
                   "[Unit][PointwiseFunctions]") {
   {


### PR DESCRIPTION
## Proposed changes

The CCE executable now only accepts worldtube data in the Bondi-modal format. Other formats should be converted into the Bondi-modal format with the `PreprocessCceWorldtube` executable.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The CCE and KleinGordon CCE executables can no longer read worldtube data written in the "metric" form (i.e. spatial metric, lapse, shift, and their time and radial derivatives). They can only now read worldtube data written in the bondi form, made up of modal coefficients. The preferred method for converting worldtube data is to use the `PreprocessCceWorldtube` executable.

The input file options `H5IsBondiData` and `FixSpecNormalization` are removed from the CCE and KleinGordon CCE input files.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
