### PR TITLE
Add Skew map to BCO

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -59,7 +59,8 @@ create_grid_anchors(const std::array<double, 3>& center_a,
       tnsr::I<double, 3, Frame::Grid>{center_a};
   result["Center" + get_output(ObjectLabel::B)] =
       tnsr::I<double, 3, Frame::Grid>{center_b};
-  result["Center"] = tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}};
+  result["Center"] =
+      tnsr::I<double, 3, Frame::Grid>{0.5 * (center_a + center_b)};
 
   return result;
 }
@@ -388,8 +389,11 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
                               center_of_mass_offset_[1]},
                    std::array{x_coord_b_, center_of_mass_offset_[0],
                               center_of_mass_offset_[1]}},
-        cube_A_center, cube_B_center, radii_A, radii_B, not is_excised_a_,
-        not is_excised_b_, envelope_radius_, outer_radius_);
+        cube_A_center, cube_B_center,
+        std::array{translation_, center_of_mass_offset[0],
+                   center_of_mass_offset[1]},
+        radii_A, radii_B, not is_excised_a_, not is_excised_b_,
+        envelope_radius_, outer_radius_);
   }
 }
 

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -413,10 +413,15 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
 
   if (time_dependent_options_.has_value()) {
     const double inner_common_radius = 3.0 * (center_A_[2] - center_B_[2]);
+    const auto center_A_aligned = rotate_from_z_to_x_axis(center_A_);
+    const auto center_B_aligned = rotate_from_z_to_x_axis(center_B_);
     time_dependent_options_->build_maps(
-        std::array{rotate_from_z_to_x_axis(center_A_),
-                   rotate_from_z_to_x_axis(center_B_)},
-        std::nullopt, std::nullopt, std::array{radius_A_, outer_radius_A_},
+        std::array{center_A_aligned, center_B_aligned}, std::nullopt,
+        std::nullopt,
+        std::array{z_cutting_plane_,
+                   0.5 * (center_A_aligned[1] + center_B_aligned[1]),
+                   0.5 * (center_A_aligned[2] + center_B_aligned[2])},
+        std::array{radius_A_, outer_radius_A_},
         std::array{radius_B_, outer_radius_B_}, false, false,
         inner_common_radius, outer_radius_);
   }

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
@@ -19,6 +19,7 @@
 #include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/SkewMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
@@ -41,6 +42,7 @@ TimeDependentMapOptions<IsCylindrical>::TimeDependentMapOptions(
     double initial_time, ExpansionMapOptionType expansion_map_options,
     RotationMapOptionType rotation_map_options,
     TranslationMapOptionType translation_map_options,
+    SkewMapOptionType skew_map_options,
     ShapeMapOptionType<domain::ObjectLabel::A> shape_options_A,
     ShapeMapOptionType<domain::ObjectLabel::B> shape_options_B,
     const Options::Context& context)
@@ -48,12 +50,14 @@ TimeDependentMapOptions<IsCylindrical>::TimeDependentMapOptions(
       expansion_map_options_(std::move(expansion_map_options)),
       rotation_map_options_(std::move(rotation_map_options)),
       translation_map_options_(std::move(translation_map_options)),
+      skew_map_options_(std::move(skew_map_options)),
       shape_options_A_(std::move(shape_options_A)),
       shape_options_B_(std::move(shape_options_B)) {
   if (not(expansion_map_options_.has_value() or
           rotation_map_options_.has_value() or
           translation_map_options_.has_value() or
-          shape_options_A_.has_value() or shape_options_B_.has_value())) {
+          skew_map_options_.has_value() or shape_options_A_.has_value() or
+          shape_options_B_.has_value())) {
     PARSE_ERROR(context,
                 "Time dependent map options were specified, but all options "
                 "were 'None'. If you don't want time dependent maps, specify "
@@ -86,6 +90,9 @@ TimeDependentMapOptions<IsCylindrical>::create_worldtube_functions_of_time()
     const {
   if (translation_map_options_.has_value()) {
     ERROR("Translation map is not implemented for worldtube evolutions.");
+  }
+  if (skew_map_options_.has_value()) {
+    ERROR("Skew map is not implemented for worldtube evolutions.");
   }
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -192,6 +199,7 @@ TimeDependentMapOptions<IsCylindrical>::create_functions_of_time(
       {expansion_name, std::numeric_limits<double>::infinity()},
       {rotation_name, std::numeric_limits<double>::infinity()},
       {translation_name, std::numeric_limits<double>::infinity()},
+      {skew_name, std::numeric_limits<double>::infinity()},
       {gsl::at(size_names, 0), std::numeric_limits<double>::infinity()},
       {gsl::at(size_names, 1), std::numeric_limits<double>::infinity()},
       {gsl::at(shape_names, 0), std::numeric_limits<double>::infinity()},
@@ -226,6 +234,13 @@ TimeDependentMapOptions<IsCylindrical>::create_functions_of_time(
     result[translation_name] = time_dependent_options::get_translation(
         translation_map_options_.value(), initial_time_,
         expiration_times.at(translation_name));
+  }
+
+  // SkewMap FunctionOfTime
+  if (skew_map_options_.has_value()) {
+    result[skew_name] = time_dependent_options::get_skew(
+        skew_map_options_.value(), initial_time_,
+        expiration_times.at(skew_name));
   }
 
   // Size and Shape FunctionOfTime for objects A and B
@@ -266,6 +281,7 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
     const std::array<std::array<double, 3>, 2>& object_centers,
     const std::optional<std::array<double, 3>>& cube_A_center,
     const std::optional<std::array<double, 3>>& cube_B_center,
+    const std::array<double, 3>& center_of_mass,
     const std::optional<std::array<double, IsCylindrical ? 2 : 3>>&
         object_A_radii,
     const std::optional<std::array<double, IsCylindrical ? 2 : 3>>&
@@ -297,6 +313,9 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
             envelope_radius, domain_outer_radius,
             domain::CoordinateMaps::TimeDependent::RotScaleTrans<
                 3>::BlockRegion::Transition});
+  }
+  if (skew_map_options_.has_value()) {
+    skew_map_ = Skew{skew_name, center_of_mass, envelope_radius};
   }
 
   for (size_t i = 0; i < 2; i++) {
@@ -469,8 +488,21 @@ TimeDependentMapOptions<IsCylindrical>::distorted_to_inertial_map(
                                     : RotScaleTrans{};
 
   if (block_has_shape_map) {
-    if (rot_scale_trans_map_.has_value()) {
+    // The skew map is only applied within the envelope, which is also where we
+    // apply the rigid RotScaleTrans map, so `use_rigid_map` is a sentinel
+    // for where we put the skew map (if we have one).
+    if (not use_rigid_map) {
+      ERROR(
+          "'use_rigid_map' must be true when requesting the distorted to "
+          "inertial map with a shape map.");
+    }
+    if (rot_scale_trans_map_.has_value() and skew_map_.has_value()) {
+      return std::make_unique<detail::di_map<Skew, RotScaleTrans>>(
+          skew_map_.value(), rot_scale_trans);
+    } else if (rot_scale_trans_map_.has_value()) {
       return std::make_unique<detail::di_map<RotScaleTrans>>(rot_scale_trans);
+    } else if (skew_map_.has_value()) {
+      return std::make_unique<detail::di_map<Skew>>(skew_map_.value());
     } else {
       return std::make_unique<detail::di_map<Identity>>(Identity{});
     }
@@ -576,15 +608,38 @@ TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
           &gsl::at(gsl::at(shape_maps_, index), include_distorted_map.value());
     }
     ASSERT(shape->has_value(), "Shape map was requested but not built.");
-    if (rot_scale_trans_map_.has_value()) {
+    // The skew map is only applied within the envelope, which is also where we
+    // apply the rigid RotScaleTrans map, so `use_rigid_map` is a sentinel
+    // for where we put the skew map (if we have one).
+    if (not use_rigid_map) {
+      ERROR(
+          "'use_rigid_map' must be true when requesting the grid to inertial "
+          "map with a shape map.");
+    }
+    if (rot_scale_trans_map_.has_value() and skew_map_.has_value()) {
+      return std::make_unique<detail::gi_map<Shape, Skew, RotScaleTrans>>(
+          shape->value(), skew_map_.value(), rot_scale_trans);
+    } else if (rot_scale_trans_map_.has_value()) {
       return std::make_unique<detail::gi_map<Shape, RotScaleTrans>>(
           shape->value(), rot_scale_trans);
+    } else if (skew_map_.has_value()) {
+      return std::make_unique<detail::gi_map<Shape, Skew>>(shape->value(),
+                                                           skew_map_.value());
     } else {
       return std::make_unique<detail::gi_map<Shape>>(shape->value());
     }
   } else {
-    if (rot_scale_trans_map_.has_value()) {
+    // The skew map is only applied within the envelope, which is also where we
+    // apply the rigid RotScaleTrans map, so use `use_rigid_map` as a sentinel
+    // for where we put the skew map (if we have one).
+    if (rot_scale_trans_map_.has_value() and
+        (use_rigid_map and skew_map_.has_value())) {
+      return std::make_unique<detail::gi_map<Skew, RotScaleTrans>>(
+          skew_map_.value(), rot_scale_trans);
+    } else if (rot_scale_trans_map_.has_value()) {
       return std::make_unique<detail::gi_map<RotScaleTrans>>(rot_scale_trans);
+    } else if (use_rigid_map and skew_map_.has_value()) {
+      return std::make_unique<detail::gi_map<Skew>>(skew_map_.value());
     } else {
       return nullptr;
     }

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
@@ -17,9 +17,11 @@
 #include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Domain/CoordinateMaps/TimeDependent/Skew.hpp"
 #include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/SkewMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
@@ -115,6 +117,7 @@ struct TimeDependentMapOptions {
   using Expansion = domain::CoordinateMaps::TimeDependent::CubicScale<3>;
   using Rotation = domain::CoordinateMaps::TimeDependent::Rotation<3>;
   using RotScaleTrans = domain::CoordinateMaps::TimeDependent::RotScaleTrans<3>;
+  using Skew = domain::CoordinateMaps::TimeDependent::Skew;
   using Shape = domain::CoordinateMaps::TimeDependent::Shape;
   using Identity = domain::CoordinateMaps::Identity<3>;
 
@@ -134,7 +137,11 @@ struct TimeDependentMapOptions {
                                Rotation>,
       detail::produce_all_maps<Frame::Grid, Frame::Inertial, Shape,
                                RotScaleTrans>,
+      detail::produce_all_maps<Frame::Grid, Frame::Inertial, Shape, Skew,
+                               RotScaleTrans>,
       detail::produce_all_maps<Frame::Distorted, Frame::Inertial,
+                               RotScaleTrans>,
+      detail::produce_all_maps<Frame::Distorted, Frame::Inertial, Skew,
                                RotScaleTrans>>;
 
   /// \brief The initial time of the functions of time.
@@ -165,6 +172,11 @@ struct TimeDependentMapOptions {
   using TranslationMapOptionType =
       typename TranslationMapOptions::type::value_type;
 
+  /// \brief Options for the Skew map
+  using SkewMapOptions =
+      domain::creators::time_dependent_options::SkewMapOptions;
+  using SkewMapOptionType = typename SkewMapOptions::type::value_type;
+
   /// \brief Options for the shape map
   template <domain::ObjectLabel Object>
   using ShapeMapOptions =
@@ -175,7 +187,8 @@ struct TimeDependentMapOptions {
 
   using options =
       tmpl::list<InitialTime, ExpansionMapOptions, RotationMapOptions,
-                 TranslationMapOptions, ShapeMapOptions<domain::ObjectLabel::A>,
+                 TranslationMapOptions, SkewMapOptions,
+                 ShapeMapOptions<domain::ObjectLabel::A>,
                  ShapeMapOptions<domain::ObjectLabel::B>>;
   static constexpr Options::String help{
       "The options for all time dependent maps in a binary compact object "
@@ -187,6 +200,7 @@ struct TimeDependentMapOptions {
       double initial_time, ExpansionMapOptionType expansion_map_options,
       RotationMapOptionType rotation_map_options,
       TranslationMapOptionType translation_map_options,
+      SkewMapOptionType skew_map_options,
       ShapeMapOptionType<domain::ObjectLabel::A> shape_options_A,
       ShapeMapOptionType<domain::ObjectLabel::B> shape_options_B,
       const Options::Context& context = {});
@@ -197,6 +211,7 @@ struct TimeDependentMapOptions {
    *
    * Currently, this will add:
    *
+   * - Skew: `PiecewisePolynomial<2>`
    * - Expansion: `PiecewisePolynomial<2>`
    * - ExpansionOuterBoundary: `FixedSpeedCubic`
    * - Rotation: `QuaternionFunctionOfTime<3>`
@@ -206,6 +221,7 @@ struct TimeDependentMapOptions {
    *
    *  When `UseWorldtube` is set to true, they are
    *
+   * - Skew: None
    * - Expansion: `IntegratedFunctionOfTime`
    * - ExpansionOuterBoundary: `FixedSpeedCubic`
    * - Rotation: `IntegratedFunctionOfTime`
@@ -224,6 +240,7 @@ struct TimeDependentMapOptions {
    *
    * Currently, this constructs a:
    *
+   * - Skew: `domain::CoordinateMaps::TimeDependent::Skew`
    * - Rotation, Expansion, Translation: `RotScaleTrans<3>`
    * - ShapeA/B: `Shape` (with size FunctionOfTime)
    *
@@ -249,6 +266,7 @@ struct TimeDependentMapOptions {
       const std::array<std::array<double, 3>, 2>& object_centers,
       const std::optional<std::array<double, 3>>& cube_A_center,
       const std::optional<std::array<double, 3>>& cube_B_center,
+      const std::array<double, 3>& center_of_mass,
       const std::optional<std::array<double, IsCylindrical ? 2 : 3>>&
           object_A_radii,
       const std::optional<std::array<double, IsCylindrical ? 2 : 3>>&
@@ -325,6 +343,7 @@ struct TimeDependentMapOptions {
       "ExpansionOuterBoundary"};
   inline static const std::string rotation_name{"Rotation"};
   inline static const std::string translation_name{"Translation"};
+  inline static const std::string skew_name{"Skew"};
   inline static const std::array<std::string, 2> size_names{{"SizeA", "SizeB"}};
   inline static const std::array<std::string, 2> shape_names{
       {"ShapeA", "ShapeB"}};
@@ -336,6 +355,7 @@ struct TimeDependentMapOptions {
   ExpansionMapOptionType expansion_map_options_;
   RotationMapOptionType rotation_map_options_;
   TranslationMapOptionType translation_map_options_;
+  SkewMapOptionType skew_map_options_;
   ShapeMapOptionType<domain::ObjectLabel::A> shape_options_A_{};
   ShapeMapOptionType<domain::ObjectLabel::B> shape_options_B_{};
   std::array<std::optional<double>, 2> deformed_radii_{};
@@ -344,6 +364,7 @@ struct TimeDependentMapOptions {
   std::optional<Expansion> expansion_map_{};
   std::optional<Rotation> rotation_map_{};
   std::optional<std::pair<RotScaleTrans, RotScaleTrans>> rot_scale_trans_map_{};
+  std::optional<Skew> skew_map_{};
   using ShapeMapType =
       tmpl::conditional_t<IsCylindrical, std::array<std::optional<Shape>, 2>,
                           std::array<std::array<std::optional<Shape>, 12>, 2>>;

--- a/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   FromVolumeFile.cpp
   RotationMap.cpp
   ShapeMap.cpp
+  SkewMap.cpp
   Sphere.cpp
   TranslationMap.cpp
 )
@@ -22,6 +23,7 @@ spectre_target_headers(
   FromVolumeFile.hpp
   RotationMap.hpp
   ShapeMap.hpp
+  SkewMap.hpp
   Sphere.hpp
   TranslationMap.hpp
   )

--- a/src/Domain/Creators/TimeDependentOptions/SkewMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/SkewMap.cpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/SkewMap.hpp"
+
+#include <array>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+
+namespace domain::creators::time_dependent_options {
+SkewMapOptions::SkewMapOptions(const std::array<double, 3>& initial_angles_y_in,
+                               const std::array<double, 3>& initial_angles_z_in)
+    : initial_angles_y(initial_angles_y_in),
+      initial_angles_z(initial_angles_z_in) {}
+
+std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_skew(
+    const std::variant<SkewMapOptions, FromVolumeFile>& skew_map_options,
+    const double initial_time, const double expiration_time) {
+  const std::string name{"Skew"};
+  std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> result{};
+
+  if (std::holds_alternative<FromVolumeFile>(skew_map_options)) {
+    const auto& from_vol_file = std::get<FromVolumeFile>(skew_map_options);
+    const auto volume_fot =
+        from_vol_file.retrieve_function_of_time({name}, initial_time);
+
+    // It must be a PiecewisePolynomial
+    if (UNLIKELY(dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+                     volume_fot.at(name).get()) == nullptr)) {
+      ERROR_NO_TRACE(
+          "Skew function of time read from volume data is not a "
+          "PiecewisePolynomial<2>. Cannot use it to initialize the skew map.");
+    }
+
+    result = volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+  } else if (std::holds_alternative<SkewMapOptions>(skew_map_options)) {
+    const auto& hard_coded_options = std::get<SkewMapOptions>(skew_map_options);
+
+    result = std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+        initial_time,
+        std::array{
+            DataVector{hard_coded_options.initial_angles_y[0],
+                       hard_coded_options.initial_angles_z[0]},
+            DataVector{hard_coded_options.initial_angles_y[1],
+                       hard_coded_options.initial_angles_z[1]},
+            DataVector{hard_coded_options.initial_angles_y[2],
+                       hard_coded_options.initial_angles_z[2]},
+        },
+        expiration_time);
+  } else {
+    ERROR("Unknown SkewMap.");
+  }
+
+  return result;
+}
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/SkewMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/SkewMap.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace domain::creators::time_dependent_options {
+/*!
+ * \brief Class that holds hard coded skew map options from the input
+ * file.
+ *
+ * \details This class can also be used as an option tag with the \p type type
+ * alias, `name()` function, and \p help string.
+ */
+struct SkewMapOptions {
+ private:
+  struct Y {};
+  struct Z {};
+
+ public:
+  using type = Options::Auto<std::variant<SkewMapOptions, FromVolumeFile>,
+                             Options::AutoLabel::None>;
+  static std::string name() { return "SkewMap"; }
+  static constexpr Options::String help = {
+      "Options for a time-dependent skew of the x coordinate (y and z "
+      "coordinates are left unchanged). Specify 'None' to not use this map."};
+
+  template <typename Coord>
+  struct InitialValues {
+    using type = std::array<double, 3>;
+    static std::string name() {
+      return "InitialValues" + pretty_type::name<Coord>();
+    }
+    static constexpr Options::String help =
+        "Initial value, and two time derivatives.";
+  };
+
+  using options = tmpl::list<InitialValues<Y>, InitialValues<Z>>;
+
+  SkewMapOptions() = default;
+  SkewMapOptions(const std::array<double, 3>& initial_angles_y_in,
+                 const std::array<double, 3>& initial_angles_z_in);
+
+  std::array<double, 3> initial_angles_y{};
+  std::array<double, 3> initial_angles_z{};
+};
+
+/*!
+ * \brief Helper function that takes the variant of the skew map options,
+ * and returns the fully constructed skew function of time.
+ *
+ * \details Even if the function of time is read from a file, it will have a
+ * new \p initial_time and \p expiration_time.
+ */
+std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_skew(
+    const std::variant<SkewMapOptions, FromVolumeFile>& skew_map_options,
+    double initial_time, double expiration_time);
+}  // namespace domain::creators::time_dependent_options

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -180,6 +180,23 @@ struct ExportCoordinates {
               jac_diag.component_name(jac_diag.get_tensor_index(i)),
           jac_diag.get(i));
     }
+    for (size_t i = 0; i < Dim; i++) {
+      for (size_t j = 0; j < Dim; j++) {
+        components.emplace_back(
+            "Jacobian_" + jacobian.component_name(jacobian.get_tensor_index(
+                              jacobian.get_storage_index(i, j))),
+            jacobian.get(i, j));
+      }
+    }
+    for (size_t i = 0; i < Dim; i++) {
+      for (size_t j = 0; j < Dim; j++) {
+        components.emplace_back(
+            "InvJacobian_" +
+                inv_jacobian.component_name(inv_jacobian.get_tensor_index(
+                    inv_jacobian.get_storage_index(i, j))),
+            inv_jacobian.get(i, j));
+      }
+    }
 
     // Also output the computation domain metric
     const auto& flat_logical_metric =

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -134,6 +134,7 @@ DomainCreator:
       ExpansionMap: None
       RotationMap: None
       TranslationMap: None
+      SkewMap: None
       ShapeMapA:
         LMax: 20
         InitialValues:

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -154,6 +154,7 @@ DomainCreator:
         InitialAngularVelocity: [0.0, 0.0, {{ InitialAngularVelocity }}]
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      SkewMap: None
       ShapeMapA:
         LMax: &ShapeLMax 10
   {% if SpecDataDirectory is defined %}

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -79,6 +79,7 @@ DomainCreator:
         InitialAngularVelocity: [0., 0., 0.08944271909999159]
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      SkewMap: None
       ShapeMapA:
         LMax: 8
         InitialValues: Spherical

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -76,6 +76,9 @@ DomainCreator:
         InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      SkewMap:
+        InitialValuesY: [-0.4, 0.0, 0.0]
+        InitialValuesZ: [-0.4, 0.0, 0.0]
       ShapeMapA:
         LMax: 8
         InitialValues: Spherical

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -65,6 +65,7 @@ DomainCreator:
         InitialAngularVelocity: [0.0, 0.0, 1.5264577062000000e-02]
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      SkewMap: None
       ShapeMapA:
         LMax: &LMax 10
         InitialValues: Spherical

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -72,6 +72,7 @@ DomainCreator:
         InitialAngularVelocity: [0.0, 0.0, 0.00826225]
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      SkewMap: None
       ShapeMapA: None
       ShapeMapB: None
 

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -328,6 +328,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FindTwoCenters",
           std::array{0.0, 0.0, 0.1}},
       std::nullopt,
       std::nullopt,
+      std::nullopt,
       std::nullopt};
   const domain::creators::BinaryCompactObject<false> binary_compact_object{
       domain::creators::BinaryCompactObject<false>::CartesianCubeAtXCoord{20.0},

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -412,7 +412,10 @@ std::string create_option_string(
             "      InitialAngularVelocity: [0.0, 0.0, -0.2]\n"
             "    TranslationMap:\n"
             "      InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], "
-            "      [0.0, 0.0, 0.0]]\n"s +
+            "      [0.0, 0.0, 0.0]]\n"s
+            "    SkewMap:\n"
+            "      InitialValuesY: [0.0, -0.01, 0.0]\n"
+            "      InitialValuesZ: [0.0, -0.01, 0.0]\n" +
                 (excise_A ? "    ShapeMapA:\n"
                             "      LMax: 8\n"
                             "      InitialValues: Spherical\n"
@@ -873,7 +876,7 @@ void test_kerr_horizon_conforming() {
       Distribution::Inverse,
       120.,
       domain::creators::bco::TimeDependentMapOptions<false>{
-          0., std::nullopt, std::nullopt, std::nullopt,
+          0., std::nullopt, std::nullopt, std::nullopt, std::nullopt,
           HardcodedShape<domain::ObjectLabel::A>{
               32_st, domain::creators::time_dependent_options::
                          KerrSchildFromBoyerLindquist{mass_A, spin_A}},

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -249,6 +249,7 @@ std::string create_option_string(
                             "    RotationMap:\n"
                             "      InitialAngularVelocity: [0.0, 0.0, -0.2]\n"
                             "    TranslationMap: None\n"
+                            "    SkewMap: None\n"
                             "    ShapeMapA:\n"
                             "      LMax: 8\n"
                             "      InitialValues: Spherical\n"
@@ -407,6 +408,7 @@ TimeDepOptions construct_time_dependent_options() {
           std::array{initial_angular_velocity[0], initial_angular_velocity[1],
                      initial_angular_velocity[2]}},
       std::nullopt,
+      std::nullopt,
       domain::creators::time_dependent_options::ShapeMapOptions<
           false, domain::ObjectLabel::A>{
           8_st,
@@ -484,7 +486,7 @@ void test_parse_errors() {
               0.0, std::nullopt,
               domain::creators::time_dependent_options::RotationMapOptions<
                   false>{std::array{0.0, 0.0, 0.0}},
-              std::nullopt, std::nullopt, std::nullopt},
+              std::nullopt, std::nullopt, std::nullopt, std::nullopt},
           create_inner_boundary_condition(), create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   TimeDependentOptions/Test_FromVolumeFile.cpp
   TimeDependentOptions/Test_RotationMap.cpp
   TimeDependentOptions/Test_ShapeMap.cpp
+  TimeDependentOptions/Test_Skew.cpp
   TimeDependentOptions/Test_Sphere.cpp
   TimeDependentOptions/Test_TranslationMap.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
@@ -15,6 +15,7 @@
 #include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/SkewMap.hpp"
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/IntegratedFunctionOfTime.hpp"
@@ -42,6 +43,9 @@ using RotMapOptions =
 template <bool IsCylindrical>
 using TransMapOptions =
     typename TimeDependentMapOptions<IsCylindrical>::TranslationMapOptionType;
+template <bool IsCylindrical>
+using SkewMapOptions =
+    typename TimeDependentMapOptions<IsCylindrical>::SkewMapOptionType;
 template <bool IsCylindrical>
 using ShapeMapAOptions = typename TimeDependentMapOptions<
     IsCylindrical>::template ShapeMapOptionType<domain::ObjectLabel::A>;
@@ -115,18 +119,21 @@ static_assert(check_maps_list_v<combo_maps_4_expected, combo_maps_4>);
 
 template <bool IsCylindrical>
 void test(const bool include_expansion, const bool include_rotation,
-          const bool include_translation, const bool include_shape_a,
-          const bool include_shape_b, const bool transition_ends_at_cube_A,
+          const bool include_translation, const bool include_skew,
+          const bool include_shape_a, const bool include_shape_b,
+          const bool transition_ends_at_cube_A,
           const bool transition_ends_at_cube_B) {
   CAPTURE(IsCylindrical);
   CAPTURE(include_expansion);
   CAPTURE(include_rotation);
   CAPTURE(include_translation);
+  CAPTURE(include_skew);
   CAPTURE(include_shape_a);
   CAPTURE(include_shape_b);
   ExpMapOptions<IsCylindrical> exp_map_options{};
   RotMapOptions<IsCylindrical> rot_map_options{};
   TransMapOptions<IsCylindrical> trans_map_options{};
+  SkewMapOptions<IsCylindrical> skew_map_options{};
   ShapeMapAOptions<IsCylindrical> shape_map_a_options{};
   ShapeMapBOptions<IsCylindrical> shape_map_b_options{};
 
@@ -149,6 +156,13 @@ void test(const bool include_expansion, const bool include_rotation,
       std::array{0.0, 0.0, 0.0}};
   if (include_translation) {
     trans_map_options = TransMapOptions<IsCylindrical>{translation_values};
+  }
+
+  const std::array<std::array<double, 3>, 2> skew_values{
+      std::array{-0.1, 0.0, 0.0}, std::array{-0.1, 0.0, 0.0}};
+  if (include_skew) {
+    skew_map_options =
+        time_dependent_options::SkewMapOptions{skew_values[0], skew_values[1]};
   }
 
   const std::array<double, 3> size_A_values{0.9, 0.08, 0.007};
@@ -183,12 +197,12 @@ void test(const bool include_expansion, const bool include_rotation,
 
   const double initial_time = 1.5;
   if ((not include_expansion) and (not include_rotation) and
-      (not include_translation) and (not include_shape_a) and
-      (not include_shape_b)) {
+      (not include_translation) and (not include_skew) and
+      (not include_shape_a) and (not include_shape_b)) {
     CHECK_THROWS_WITH(
         (TimeDependentMapOptions<IsCylindrical>{
             initial_time, exp_map_options, rot_map_options, trans_map_options,
-            shape_map_a_options, shape_map_b_options}),
+            skew_map_options, shape_map_a_options, shape_map_b_options}),
         Catch::Matchers::ContainsSubstring(
             "Time dependent map options were specified, but all options "
             "were 'None'. If you don't want time dependent maps, specify "
@@ -198,8 +212,9 @@ void test(const bool include_expansion, const bool include_rotation,
   }
 
   TimeDependentMapOptions<IsCylindrical> time_dep_options{
-      initial_time,      exp_map_options,     rot_map_options,
-      trans_map_options, shape_map_a_options, shape_map_b_options};
+      initial_time,       exp_map_options,  rot_map_options,
+      trans_map_options,  skew_map_options, shape_map_a_options,
+      shape_map_b_options};
 
   CHECK(time_dep_options.has_distorted_frame_options(domain::ObjectLabel::A) ==
         include_shape_a);
@@ -212,6 +227,8 @@ void test(const bool include_expansion, const bool include_rotation,
        std::numeric_limits<double>::infinity()},
       {TimeDependentMapOptions<IsCylindrical>::translation_name,
        std::numeric_limits<double>::infinity()},
+      {TimeDependentMapOptions<IsCylindrical>::skew_name,
+       std::numeric_limits<double>::infinity()},
       {gsl::at(TimeDependentMapOptions<IsCylindrical>::size_names, 0), 15.5},
       {gsl::at(TimeDependentMapOptions<IsCylindrical>::size_names, 1),
        std::numeric_limits<double>::infinity()},
@@ -223,6 +240,7 @@ void test(const bool include_expansion, const bool include_rotation,
   using ExpBdryFoT = domain::FunctionsOfTime::FixedSpeedCubic;
   using RotFoT = domain::FunctionsOfTime::QuaternionFunctionOfTime<3>;
   using TransFoT = domain::FunctionsOfTime::PiecewisePolynomial<2>;
+  using SkewFoT = domain::FunctionsOfTime::PiecewisePolynomial<2>;
   using SizeFoT = domain::FunctionsOfTime::PiecewisePolynomial<3>;
   using ShapeFoT = ExpFoT;
   ExpFoT expansion{
@@ -247,6 +265,12 @@ void test(const bool include_expansion, const bool include_rotation,
                  DataVector{translation_values[2]}},
       expiration_times.at(
           TimeDependentMapOptions<IsCylindrical>::translation_name)};
+  SkewFoT skew{
+      initial_time,
+      std::array{DataVector{skew_values[0][0], skew_values[1][0]},
+                 DataVector{skew_values[0][1], skew_values[1][1]},
+                 DataVector{skew_values[0][2], skew_values[1][2]}},
+      expiration_times.at(TimeDependentMapOptions<IsCylindrical>::skew_name)};
   SizeFoT size_A{initial_time,
                  std::array<DataVector, 4>{{{gsl::at(size_A_values, 0)},
                                             {gsl::at(size_A_values, 1)},
@@ -277,7 +301,7 @@ void test(const bool include_expansion, const bool include_rotation,
           gsl::at(TimeDependentMapOptions<IsCylindrical>::shape_names, 1))};
 
   const std::array<std::array<double, 3>, 2> centers{
-      std::array{5.0, 0.01, 0.02}, std::array{-5.0, -0.01, -0.02}};
+      std::array{5.0, -0.01, -0.02}, std::array{-5.0, -0.01, -0.02}};
   const std::optional<std::array<double, 3>> cube_a_center =
       IsCylindrical ? std::optional<std::array<double, 3>>{}
                     : std::array<double, 3>{{4.25, -0.3, 0.2}};
@@ -288,11 +312,12 @@ void test(const bool include_expansion, const bool include_rotation,
   const double domain_outer_radius = 20.0;
 
   const auto anchors = create_grid_anchors(centers[0], centers[1]);
+  const std::array<double, 3> center_of_mass = 0.5 * (centers[0] + centers[1]);
   CHECK(anchors.count("Center") == 1);
   CHECK(anchors.count("CenterA") == 1);
   CHECK(anchors.count("CenterB") == 1);
   CHECK(anchors.at("Center") ==
-        tnsr::I<double, 3, Frame::Grid>(std::array{0.0, 0.0, 0.0}));
+        tnsr::I<double, 3, Frame::Grid>(center_of_mass));
   CHECK(anchors.at("CenterA") == tnsr::I<double, 3, Frame::Grid>(centers[0]));
   CHECK(anchors.at("CenterB") == tnsr::I<double, 3, Frame::Grid>(centers[1]));
 
@@ -314,15 +339,16 @@ void test(const bool include_expansion, const bool include_rotation,
     } else {
       inner_outer_radii_B = std::array{0.5, 0.9, 2.1};
     }
-    const auto build_maps = [&time_dep_options, &centers, &inner_outer_radii_A,
-                             &inner_outer_radii_B, &domain_envelope_radius,
-                             &domain_outer_radius, &cube_a_center,
-                             &cube_b_center, filled_A = not excise_A,
+    const auto build_maps = [&time_dep_options, &centers, &center_of_mass,
+                             &inner_outer_radii_A, &inner_outer_radii_B,
+                             &domain_envelope_radius, &domain_outer_radius,
+                             &cube_a_center, &cube_b_center,
+                             filled_A = not excise_A,
                              filled_B = not excise_B]() {
       time_dep_options.build_maps(centers, cube_a_center, cube_b_center,
-                                  inner_outer_radii_A, inner_outer_radii_B,
-                                  filled_A, filled_B, domain_envelope_radius,
-                                  domain_outer_radius);
+                                  center_of_mass, inner_outer_radii_A,
+                                  inner_outer_radii_B, filled_A, filled_B,
+                                  domain_envelope_radius, domain_outer_radius);
     };
 
     if constexpr (not IsCylindrical) {
@@ -379,14 +405,16 @@ void test(const bool include_expansion, const bool include_rotation,
     }
 
     if ((not include_rotation) and (not include_expansion) and
-        (not include_translation) and (not include_shape_a)) {
+        (not include_translation) and (not include_skew) and
+        (not include_shape_a)) {
       CHECK(time_dep_options
                 .template grid_to_inertial_map<domain::ObjectLabel::A>(
                     include_distorted_map_A, true) == nullptr);
       continue;
     }
     if ((not include_rotation) and (not include_expansion) and
-        (not include_translation) and (not include_shape_b)) {
+        (not include_translation) and (not include_skew) and
+        (not include_shape_b)) {
       CHECK(time_dep_options
                 .template grid_to_inertial_map<domain::ObjectLabel::B>(
                     include_distorted_map_B, true) == nullptr);
@@ -453,13 +481,15 @@ void test(const bool include_expansion, const bool include_rotation,
       INFO("distorted_to_inertial_map_A");
       check_map(distorted_to_inertial_map_A, not include_shape_a,
                 (not include_rotation) and (not include_expansion) and
-                    (not include_translation) and include_shape_a);
+                    (not include_translation) and (not include_skew) and
+                    include_shape_a);
     }
     {
       INFO("distorted_to_inertial_map_B");
       check_map(distorted_to_inertial_map_B, not include_shape_b,
                 (not include_rotation) and (not include_expansion) and
-                    (not include_translation) and include_shape_b);
+                    (not include_translation) and (not include_skew) and
+                    include_shape_b);
     }
     // Test functions of time
     const auto functions_of_time =
@@ -508,6 +538,17 @@ void test(const bool include_expansion, const bool include_rotation,
     } else {
       CHECK(functions_of_time.count(
                 TimeDependentMapOptions<IsCylindrical>::translation_name) == 0);
+    }
+    if (include_skew) {
+      CHECK(functions_of_time.count(
+                TimeDependentMapOptions<IsCylindrical>::skew_name) == 1);
+      CHECK(dynamic_cast<TransFoT&>(
+                *functions_of_time
+                     .at(TimeDependentMapOptions<IsCylindrical>::skew_name)
+                     .get()) == skew);
+    } else {
+      CHECK(functions_of_time.count(
+                TimeDependentMapOptions<IsCylindrical>::skew_name) == 0);
     }
     if (include_shape_a) {
       CHECK(functions_of_time.count(gsl::at(
@@ -566,6 +607,7 @@ void check_names() {
   CHECK(TimeDependentMapOptions<IsCylindrical>::rotation_name == "Rotation"s);
   CHECK(TimeDependentMapOptions<IsCylindrical>::translation_name ==
         "Translation"s);
+  CHECK(TimeDependentMapOptions<IsCylindrical>::skew_name == "Skew"s);
   CHECK(TimeDependentMapOptions<IsCylindrical>::size_names ==
         std::array{"SizeA"s, "SizeB"s});
   CHECK(TimeDependentMapOptions<IsCylindrical>::shape_names ==
@@ -578,7 +620,7 @@ void test_errors() {
   CAPTURE(IsCylindrical);
   CHECK_THROWS_WITH(
       (TimeDependentMapOptions<IsCylindrical>{
-          1.0, std::nullopt, std::nullopt, std::nullopt,
+          1.0, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
           time_dependent_options::ShapeMapOptions<
               not IsCylindrical, domain::ObjectLabel::A>{1, {}},
           time_dependent_options::ShapeMapOptions<
@@ -586,7 +628,7 @@ void test_errors() {
       Catch::Matchers::ContainsSubstring("Initial LMax for object"));
   CHECK_THROWS_WITH(
       (TimeDependentMapOptions<IsCylindrical>{
-          1.0, std::nullopt, std::nullopt, std::nullopt,
+          1.0, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
           time_dependent_options::ShapeMapOptions<
               not IsCylindrical, domain::ObjectLabel::A>{6, {}},
           time_dependent_options::ShapeMapOptions<
@@ -594,7 +636,7 @@ void test_errors() {
       Catch::Matchers::ContainsSubstring("Initial LMax for object"));
   CHECK_THROWS_WITH((TimeDependentMapOptions<IsCylindrical>{
                         1.0, std::nullopt, std::nullopt, std::nullopt,
-                        std::nullopt, std::nullopt}),
+                        std::nullopt, std::nullopt, std::nullopt}),
                     Catch::Matchers::ContainsSubstring(
                         "Time dependent map options were "
                         "specified, but all options were 'None'."));
@@ -613,14 +655,15 @@ void test_errors() {
               std::nullopt,
               std::nullopt,
               std::nullopt,
+              std::nullopt,
               time_dependent_options::ShapeMapOptions<not IsCylindrical,
                                                       domain::ObjectLabel::A>{
                   8, std::nullopt},
               std::nullopt};
           time_dep_opts.build_maps(
               std::array{std::array{5.0, 0.0, 0.0}, std::array{-5.0, 0.0, 0.0}},
-              {{7.5, 0.0, 0.0}}, {{-7.5, 0.0, 0.0}}, radii, radii, false, false,
-              25.0, 100.0);
+              {{7.5, 0.0, 0.0}}, {{-7.5, 0.0, 0.0}}, std::array{0.0, 0.0, 0.0},
+              radii, radii, false, false, 25.0, 100.0);
         }()),
         Catch::Matchers::ContainsSubstring(
             "When using the CylindricalBinaryCompactObject domain creator, "
@@ -650,6 +693,7 @@ void test_worldtube_fots() {
           1.0},
       time_dependent_options::RotationMapOptions<false>{
           std::array{0.0, 0.0, 1.0}},
+      std::nullopt,
       std::nullopt,
       time_dependent_options::ShapeMapOptions<true, domain::ObjectLabel::A>{
           2, {}, std::make_optional(size_a_opts)},
@@ -738,22 +782,22 @@ SPECTRE_TEST_CASE(
     "Unit.Domain.Creators.TimeDependentOptions.BinaryCompactObject",
     "[Domain][Unit]") {
   for (const auto& [include_expansion, include_rotation, include_translation,
-                    include_shape_a, include_shape_b, transition_ends_at_cube_A,
-                    transition_ends_at_cube_B] :
+                    include_skew, include_shape_a, include_shape_b,
+                    transition_ends_at_cube_A, transition_ends_at_cube_B] :
        cartesian_product(make_array(true, false), make_array(true, false),
                          make_array(true, false), make_array(true, false),
                          make_array(true, false), make_array(true, false),
-                         make_array(true, false))) {
+                         make_array(true, false), make_array(true, false))) {
     test<false>(include_expansion, include_rotation, include_translation,
-                include_shape_a, include_shape_b, transition_ends_at_cube_A,
-                transition_ends_at_cube_B);
+                include_skew, include_shape_a, include_shape_b,
+                transition_ends_at_cube_A, transition_ends_at_cube_B);
     // Filter out cases that are not valid for the cylindrical domain
     if (transition_ends_at_cube_A or transition_ends_at_cube_B) {
       continue;
     }
     test<true>(include_expansion, include_rotation, include_translation,
-               include_shape_a, include_shape_b, transition_ends_at_cube_A,
-               transition_ends_at_cube_B);
+               include_skew, include_shape_a, include_shape_b,
+               transition_ends_at_cube_A, transition_ends_at_cube_B);
   }
   check_names<true>();
   check_names<false>();

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_Skew.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_Skew.cpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <variant>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
+#include "Domain/Creators/TimeDependentOptions/SkewMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Domain/Creators/TimeDependent/TestHelpers.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace domain::creators::time_dependent_options {
+namespace {
+void test_skew_map_options() {
+  {
+    INFO("None");
+    const auto skew_map_options =
+        TestHelpers::test_option_tag<SkewMapOptions>("None");
+
+    CHECK(not skew_map_options.has_value());
+  }
+  {
+    INFO("Hardcoded options");
+    const auto skew_map_options = TestHelpers::test_option_tag<
+        domain::creators::time_dependent_options::SkewMapOptions>(
+        "InitialValuesY: [0.1, -0.2, 0.3]\n"
+        "InitialValuesZ: [-0.4, 0.5, -0.6]\n");
+
+    REQUIRE(skew_map_options.has_value());
+    CHECK(std::holds_alternative<SkewMapOptions>(skew_map_options.value()));
+    const auto& hard_coded_options =
+        std::get<SkewMapOptions>(skew_map_options.value());
+    CHECK(hard_coded_options.initial_angles_y == std::array{0.1, -0.2, 0.3});
+    CHECK(hard_coded_options.initial_angles_z == std::array{-0.4, 0.5, -0.6});
+
+    const auto skew_ptr = get_skew(skew_map_options.value(), 0.1, 65.8);
+
+    const auto* skew =
+        dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+            skew_ptr.get());
+
+    CHECK(skew != nullptr);
+
+    CHECK(skew->time_bounds() == std::array{0.1, 65.8});
+    CHECK(skew->func_and_2_derivs(0.1) == std::array{
+                                              DataVector{0.1, -0.4},
+                                              DataVector{-0.2, 0.5},
+                                              DataVector{0.3, -0.6},
+                                          });
+  }
+  {
+    INFO("FromVolumeFile");
+    std::unordered_map<std::string,
+                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+        functions_of_time{};
+    functions_of_time["Skew"] =
+        std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+            0.0,
+            std::array{DataVector{2, 1.0}, DataVector{2, 2.0},
+                       DataVector{2, 3.0}},
+            100.0);
+    const std::string filename{"Wildfires.h5"};
+    const std::string subfile_name{"VolumeData"};
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+
+    TestHelpers::domain::creators::write_volume_data(filename, subfile_name,
+                                                     functions_of_time);
+
+    const auto skew_map_options = TestHelpers::test_option_tag<
+        domain::creators::time_dependent_options::SkewMapOptions>(
+        "H5Filename: " + filename + "\nSubfileName: " + subfile_name);
+
+    REQUIRE(skew_map_options.has_value());
+    CHECK(std::holds_alternative<FromVolumeFile>(skew_map_options.value()));
+
+    const auto skew_ptr = get_skew(skew_map_options.value(), 0.1, 65.8);
+
+    const auto* skew =
+        dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>*>(
+            skew_ptr.get());
+
+    CHECK(skew != nullptr);
+
+    CHECK(skew->time_bounds() == std::array{0.1, 65.8});
+    CHECK_ITERABLE_APPROX(skew->func_and_2_derivs(0.3),
+                          functions_of_time.at("Skew")->func_and_2_derivs(0.3));
+
+    if (file_system::check_if_file_exists(filename)) {
+      file_system::rm(filename, true);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependentOptions.SkewMap",
+                  "[Domain][Unit]") {
+  domain::FunctionsOfTime::register_derived_with_charm();
+  test_skew_map_options();
+}
+}  // namespace domain::creators::time_dependent_options

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -73,6 +73,7 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       angular_velocity_stream.str() +
       "]\n"
       "    TranslationMap: None\n"
+      "    SkewMap: None\n"
       "    ShapeMapA:\n"
       "      LMax: 2\n"
       "      InitialValues: Spherical\n"


### PR DESCRIPTION
## Proposed changes

Adds the Skew map to the BinaryCompactObject domain. Sets it to None in all input files for now until a control system is written for it.

Part of #4603.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When using the BinaryCompactObject domain creator, you must add the following option to the time depndent options:
```yaml
  TimeDependentOptions:
    SkewMap:
      InitialValuesY: [0.0, 0.01, 0.0]
      InitialValuesZ: [0.0, 0.01, 0.0]
```
It has the same capabilities to be `None` or from a volume file as the other time dependent map options.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #6446.~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
