### PR TITLE
Fix running on CaltechHPC: disable ParaView env vars

### DIFF
--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -37,9 +37,17 @@ if(BUILD_PYTHON_BINDINGS AND "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
   string(APPEND PYTHON_EXEC_ENV_VARS
     " LD_PRELOAD=\${LD_PRELOAD}\${LD_PRELOAD:+:}${JEMALLOC_LIBRARIES}")
 endif()
-if(PARAVIEW_PYTHON_ENV_VARS)
-  string(APPEND PYTHON_EXEC_ENV_VARS " ${PARAVIEW_PYTHON_ENV_VARS}")
-endif()
+# ParaView needs specific environment variables set, e.g. 'LD_LIBRARY_PATH', but
+# they can interfere with simulations, e.g. when they point to ParaView's
+# bundled MPI which may be different to the MPI we built with. Therefore we
+# disable this for now. This means we can't use the pre-built ParaView binaries
+# that bundle their own MPI and Python, unless we find a way to set the needed
+# environment variables only when running ParaView. Everything should work
+# when using a ParaView built with the same MPI and Python as the rest of
+# SpECTRE.
+# if(PARAVIEW_PYTHON_ENV_VARS)
+#   string(APPEND PYTHON_EXEC_ENV_VARS " ${PARAVIEW_PYTHON_ENV_VARS}")
+# endif()
 configure_file(
   "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
   "${CMAKE_BINARY_DIR}/tmp/spectre")


### PR DESCRIPTION
These point to ParaView's bundled MPI, which interferes with the MPI that we compiled executables with.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
