### PR TITLE
Allow skipping GRMHD RHS computation in atmosphere/wavezone

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdlib>
 #include <optional>
 #include <ostream>
 #include <type_traits>
@@ -14,6 +15,7 @@
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/PassVariables.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
@@ -112,8 +114,7 @@ void volume_terms(
       "are defined, and that at least one of them is a non-empty list of "
       "tags.");
 
-  using flux_variables =
-      tmpl::list<FluxVariablesTags...>;
+  using flux_variables = tmpl::list<FluxVariablesTags...>;
 
   // Compute d_i u_\alpha for nonconservative products
   if constexpr (has_partial_derivs) {
@@ -124,25 +125,26 @@ void volume_terms(
   // For now just zero dt_vars. If this is a performance bottle neck we
   // can re-evaluate in the future.
   dt_vars_ptr->initialize(mesh.number_of_grid_points(), 0.0);
+  evolution::dg::TimeDerivativeDecisions<Dim> time_derivative_decisions{};
 
   // Compute volume du/dt and fluxes
   if constexpr (std::is_base_of_v<evolution::PassVariables,
                                   ComputeVolumeTimeDerivativeTerms>) {
     if constexpr (sizeof...(FluxVariablesTags) != 0) {
-      ComputeVolumeTimeDerivativeTerms::apply(
+      time_derivative_decisions = ComputeVolumeTimeDerivativeTerms::apply(
           dt_vars_ptr, volume_fluxes, temporaries,
           get<::Tags::deriv<PartialDerivTags, tmpl::size_t<Dim>,
                             Frame::Inertial>>(*partial_derivs)...,
           time_derivative_args...);
     } else {
-      ComputeVolumeTimeDerivativeTerms::apply(
+      time_derivative_decisions = ComputeVolumeTimeDerivativeTerms::apply(
           dt_vars_ptr, temporaries,
           get<::Tags::deriv<PartialDerivTags, tmpl::size_t<Dim>,
                             Frame::Inertial>>(*partial_derivs)...,
           time_derivative_args...);
     }
   } else {
-    ComputeVolumeTimeDerivativeTerms::apply(
+    time_derivative_decisions = ComputeVolumeTimeDerivativeTerms::apply(
         make_not_null(&get<::Tags::dt<VariablesTags>>(*dt_vars_ptr))...,
         make_not_null(&get<::Tags::Flux<FluxVariablesTags, tmpl::size_t<Dim>,
                                         Frame::Inertial>>(*volume_fluxes))...,
@@ -154,6 +156,9 @@ void volume_terms(
 
   // Add volume terms for moving meshes
   if (mesh_velocity.has_value()) {
+    if (not time_derivative_decisions.compute_flux_divergence) {
+      goto end_of_flux_mesh_velocity;  // NOLINT(cppcoreguidelines-avoid-goto)
+    }
     tmpl::for_each<flux_variables>([&div_mesh_velocity, &dt_vars_ptr,
                                     &evolved_vars, &mesh_velocity,
                                     &volume_fluxes](auto tag_v) {
@@ -193,6 +198,7 @@ void volume_terms(
             get(*div_mesh_velocity);
       }
     });
+  end_of_flux_mesh_velocity:
 
     // We add the mesh velocity to all equations that don't have flux terms.
     // This doesn't need to be equal to the equations that have partial
@@ -237,6 +243,9 @@ void volume_terms(
   // Add the flux divergence term to du_\alpha/dt, which must be done
   // after the corrections for the moving mesh are made.
   if constexpr (has_fluxes) {
+    if (not time_derivative_decisions.compute_flux_divergence) {
+      goto end_of_flux_div_calculation;  // NOLINT(cppcoreguidelines-avoid-goto)
+    }
     if (dg_formulation == ::dg::Formulation::StrongInertial) {
       divergence(div_fluxes, *volume_fluxes, mesh,
                  logical_to_inertial_inverse_jacobian);
@@ -289,6 +298,8 @@ void volume_terms(
             }
           }
         });
+  end_of_flux_div_calculation:
+    (void)5;  // null statement required after label at end of block until C++23
   } else {
     (void)dg_formulation;
   }

--- a/src/Evolution/Systems/Burgers/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/Burgers/TimeDerivativeTerms.cpp
@@ -8,10 +8,11 @@
 #include "Utilities/Gsl.hpp"
 
 namespace Burgers {
-void TimeDerivativeTerms::apply(
+evolution::dg::TimeDerivativeDecisions<1> TimeDerivativeTerms::apply(
     const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
     const gsl::not_null<tnsr::I<DataVector, 1, Frame::Inertial>*> flux_u,
     const Scalar<DataVector>& u) {
   get<0>(*flux_u) = 0.5 * square(get(u));
+  return {true};
 }
 }  // namespace Burgers

--- a/src/Evolution/Systems/Burgers/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/Burgers/TimeDerivativeTerms.hpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -30,7 +31,7 @@ struct TimeDerivativeTerms {
   using temporary_tags = tmpl::list<>;
   using argument_tags = tmpl::list<Tags::U>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<1> apply(
       // Time derivatives returned by reference. No source terms or
       // nonconservative products, so not used. All the tags in the
       // variables_tag in the system struct.

--- a/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.cpp
@@ -16,7 +16,7 @@
 
 namespace CurvedScalarWave {
 template <size_t Dim>
-void TimeDerivative<Dim>::apply(
+evolution::dg::TimeDerivativeDecisions<Dim> TimeDerivative<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> dt_psi,
     const gsl::not_null<Scalar<DataVector>*> dt_pi,
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
@@ -62,6 +62,7 @@ void TimeDerivative<Dim>::apply(
                   gamma2() * lapse() * (d_psi(ti::i) - phi(ti::i)) -
                   pi() * deriv_lapse(ti::i) +
                   phi(ti::j) * deriv_shift(ti::i, ti::J));
+  return {true};
 }
 }  // namespace CurvedScalarWave
 // Generate explicit instantiations of partial_derivatives function as well as

--- a/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Characteristics.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
@@ -70,7 +71,7 @@ struct TimeDerivative {
                  gr::Tags::TraceExtrinsicCurvature<DataVector>,
                  Tags::ConstraintGamma1, Tags::ConstraintGamma2>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<Dim> apply(
       gsl::not_null<Scalar<DataVector>*> dt_psi,
       gsl::not_null<Scalar<DataVector>*> dt_pi,
       gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,

--- a/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.cpp
@@ -16,7 +16,7 @@
 
 namespace ForceFree {
 
-void TimeDerivativeTerms::apply(
+evolution::dg::TimeDerivativeDecisions<3> TimeDerivativeTerms::apply(
     const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
         non_flux_terms_dt_tilde_e,
     const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
@@ -107,6 +107,7 @@ void TimeDerivativeTerms::apply(
                        tilde_psi, tilde_phi, tilde_q, *tilde_j_drift, kappa_psi,
                        kappa_phi, lapse, d_lapse, d_shift, inv_spatial_metric,
                        extrinsic_curvature);
+  return {true};
 }
 
 }  // namespace ForceFree

--- a/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/ForceFree/TimeDerivativeTerms.hpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
@@ -67,7 +68,7 @@ struct TimeDerivativeTerms {
       ::Tags::deriv<gr::Tags::SpatialMetric<DataVector, 3>, tmpl::size_t<3>,
                     Frame::Inertial>>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<3> apply(
       // Time derivatives returned by reference.
       gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
           non_flux_terms_dt_tilde_e,

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Gauges.hpp"
@@ -140,7 +141,7 @@ struct TimeDerivative {
                                                Frame::Inertial>,
                  domain::Tags::MeshVelocity<Dim, Frame::Inertial>>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<Dim> apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_pi,
       gsl::not_null<tnsr::iaa<DataVector, Dim>*> dt_phi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
 #include "DataStructures/Tensor/EagerMath/Trace.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Dispatch.hpp"
@@ -30,7 +31,8 @@
 
 namespace gh {
 template <class AllSolutionsForChristoffelAnalytic, size_t Dim>
-void TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
+evolution::dg::TimeDerivativeDecisions<Dim>
+TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     const gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
     const gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_pi,
     const gsl::not_null<tnsr::iaa<DataVector, Dim>*> dt_phi,
@@ -406,5 +408,6 @@ void TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
       }
     }
   }
+  return {true};
 }
 }  // namespace gh

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedContainers.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/PassVariables.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
@@ -68,7 +69,7 @@ struct TimeDerivativeTermsImpl<
     tmpl::list<TraceReversedStressResultTags...>,
     tmpl::list<TraceReversedStressArgumentTags...>> {
   template <typename TemporaryTagsList, typename... ExtraTags>
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<3> apply(
       const gsl::not_null<
           Variables<tmpl::list<GhDtTags..., ValenciaDtTags...>>*>
           dt_vars_ptr,
@@ -174,6 +175,7 @@ struct TimeDerivativeTermsImpl<
         get<grmhd::GhValenciaDivClean::Tags::TraceReversedStressEnergy>(
             *temps_ptr),
         get<gr::Tags::Lapse<DataVector>>(*temps_ptr));
+    return evolution::dg::TimeDerivativeDecisions<3>{true};
   }
 };
 }  // namespace detail
@@ -271,7 +273,7 @@ struct TimeDerivativeTerms : evolution::PassVariables {
                    d_spatial_metric>;
 
   template <typename... Args>
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<3> apply(
       const gsl::not_null<Variables<dt_tags>*> dt_vars_ptr,
       const gsl::not_null<Variables<db::wrap_tags_in<
           ::Tags::Flux, typename ValenciaDivClean::System::flux_variables,
@@ -317,7 +319,7 @@ struct TimeDerivativeTerms : evolution::PassVariables {
       }
     }
 
-    detail::TimeDerivativeTermsImpl<
+    return detail::TimeDerivativeTermsImpl<
         gh_dt_tags, valencia_dt_tags, valencia_flux_tags, gh_temp_tags,
         valencia_temp_tags, gh_gradient_tags, gh_arg_tags, valencia_arg_tags,
         typename grmhd::ValenciaDivClean::TimeDerivativeTerms::argument_tags,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 #include <utility>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -22,6 +23,8 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 // Tag obtained from gh::TimeDerivative needs to be complete here to
 // be used in TemporaryReference.
@@ -92,6 +95,39 @@ struct TimeDerivativeTermsImpl<
                      d_phi,
                      get<Tags::detail::TemporaryReference<GhArgTags>>(
                          arguments)...);
+
+    // If we are in the atmosphere, then we can skip the evolution
+    // of the GRMHD system completely. This inevitably depends on parameters
+    // of the FixToAtmosphere code, so we grab those directly.
+    if (const auto& fix_to_atmosphere = get<Tags::detail::TemporaryReference<
+            ::Tags::VariableFixer<::VariableFixing::FixToAtmosphere<3>>>>(
+            arguments);
+        max(get(get<Tags::detail::TemporaryReference<
+                    hydro::Tags::RestMassDensity<DataVector>>>(arguments))) <=
+        std::min({fix_to_atmosphere.density_of_atmosphere(),
+                  (fix_to_atmosphere.velocity_limiting().has_value()
+                       ? fix_to_atmosphere.velocity_limiting()
+                             ->atmosphere_density_cutoff
+                       : std::numeric_limits<double>::infinity()),
+                  (fix_to_atmosphere.kappa_limiting().has_value()
+                       ? fix_to_atmosphere.kappa_limiting()->density_lower_bound
+                       : std::numeric_limits<double>::infinity())}) *
+            (1.0 + 10.0 * std::numeric_limits<double>::epsilon())) {
+      // Point into the right memory, then set it to zero.
+      ASSERT(
+          max(get(get<tmpl::front<tmpl::list<ValenciaDtTags...>>>(
+              *dt_vars_ptr))) == 0.0,
+          "GH+GRMHD assumes the time derivatives are set to zero in general."
+          " If this is no longer the case, please set them to zero in "
+          "atmosphere by changing the code where this ASSERT was triggered.");
+      // Code that we could use to set the sources to zero if needed.
+      // Variables<tmpl::list<ValenciaDtTags...>> dt_div_clean(
+      //     get<tmpl::front<tmpl::list<ValenciaDtTags...>>>(*dt_vars_ptr)[0]
+      //         .data(),
+      //     0.0);
+      fluxes_ptr->initialize(fluxes_ptr->number_of_grid_points(), 0.0);
+      return evolution::dg::TimeDerivativeDecisions<3>{false};
+    }
 
     if (get<Tags::detail::TemporaryReference<gh::gauges::Tags::GaugeCondition>>(
             arguments)
@@ -265,12 +301,15 @@ struct TimeDerivativeTerms : evolution::PassVariables {
           gh_temp_tags, valencia_temp_tags, valencia_extra_temp_tags,
           trace_reversed_stress_result_tags, extra_temp_tags>>,
       gr::Tags::SpatialMetric<DataVector, 3>>;
-  using argument_tags =
-      tmpl::remove<tmpl::remove<tmpl::append<gh_arg_tags,
+  using argument_tags = tmpl::remove<
+      tmpl::remove<tmpl::append<gh_arg_tags,
 
-                                             valencia_arg_tags>,
-                                gr::Tags::SpatialMetric<DataVector, 3>>,
-                   d_spatial_metric>;
+                                valencia_arg_tags,
+
+                                tmpl::list<::Tags::VariableFixer<
+                                    ::VariableFixing::FixToAtmosphere<3>>>>,
+                   gr::Tags::SpatialMetric<DataVector, 3>>,
+      d_spatial_metric>;
 
   template <typename... Args>
   static evolution::dg::TimeDerivativeDecisions<3> apply(

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/VolumeTermsInstantiation.cpp
@@ -8,6 +8,7 @@
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
 
 namespace evolution::dg::Actions::detail {
 template void volume_terms<::grmhd::GhValenciaDivClean::TimeDerivativeTerms>(
@@ -72,5 +73,6 @@ template void volume_terms<::grmhd::GhValenciaDivClean::TimeDerivativeTerms>(
     const Scalar<DataVector>& rest_mass_density,
     const Scalar<DataVector>& electron_fraction,
     const Scalar<DataVector>& specific_internal_energy,
-    const double& constraint_damping_parameter);
+    const double& constraint_damping_parameter,
+    const ::VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere);
 }  // namespace evolution::dg::Actions::detail

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -113,6 +113,44 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
   for (size_t i = 0; i < 3; ++i) {
     magnetic_field->get(i) = tilde_b.get(i) / get(sqrt_det_spatial_metric);
   }
+
+  // Parameters for quick exit from inversion
+  const double cutoffD =
+      primitive_from_conservative_options.cutoff_d_for_inversion();
+  const double floorD =
+      primitive_from_conservative_options.density_when_skipping_inversion();
+
+  // If the max over the grid is below the cutoff, then just don't do any
+  // work because everything will get reset to atmosphere.
+  if (max(get(tilde_d)) < cutoffD) {
+    get(*rest_mass_density) = floorD;
+    get(*electron_fraction) = min(0.5, max(get(tilde_ye) / get(tilde_d), 0.));
+    if constexpr (eos_is_barotropic) {
+      // Note: default construction for T and Y_e must be okay since the EOS is
+      // barotropic.
+      *specific_internal_energy =
+          equation_of_state
+              .specific_internal_energy_from_density_and_temperature(
+                  *rest_mass_density, Scalar<DataVector>{},
+                  Scalar<DataVector>{});
+    } else {
+      const auto num_points = get(*rest_mass_density).size();
+      for (size_t i = 0; i < num_points; ++i) {
+        get(*specific_internal_energy)[i] =
+            equation_of_state.specific_internal_energy_lower_bound(
+                get(*rest_mass_density)[i], get(*electron_fraction)[i]);
+      }
+    }
+    *temperature = equation_of_state.temperature_from_density_and_energy(
+        *rest_mass_density, *specific_internal_energy, *electron_fraction);
+    *pressure = equation_of_state.pressure_from_density_and_temperature(
+        *rest_mass_density, *temperature, *electron_fraction);
+    get(*lorentz_factor) = 1.0;
+    for (size_t i = 0; i < 3; ++i) {
+      spatial_velocity->get(i) = 0.0;
+    }
+  }
+
   const size_t number_of_points = get<0>(tilde_b).size();
   Variables<
       tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
@@ -148,12 +186,6 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
       get(get<::Tags::TempScalar<4>>(temp_buffer));
   rest_mass_density_times_lorentz_factor =
       get(tilde_d) / get(sqrt_det_spatial_metric);
-
-  // Parameters for quick exit from inversion
-  const double cutoffD =
-      primitive_from_conservative_options.cutoff_d_for_inversion();
-  const double floorD =
-      primitive_from_conservative_options.density_when_skipping_inversion();
 
   // This may need bounds
   // limit Ye to table bounds once that is implemented

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.cpp
@@ -20,7 +20,7 @@
 #include "Utilities/Gsl.hpp"
 
 namespace grmhd::ValenciaDivClean {
-void TimeDerivativeTerms::apply(
+evolution::dg::TimeDerivativeDecisions<3> TimeDerivativeTerms::apply(
     const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_tilde_d*/,
     const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_tilde_ye*/,
     const gsl::not_null<Scalar<DataVector>*> non_flux_terms_dt_tilde_tau,
@@ -154,5 +154,6 @@ void TimeDerivativeTerms::apply(
 
       rest_mass_density, electron_fraction, pressure, specific_internal_energy,
       extrinsic_curvature, constraint_damping_parameter);
+  return {true};
 }
 }  // namespace grmhd::ValenciaDivClean

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp
@@ -6,6 +6,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
@@ -102,7 +103,7 @@ struct TimeDerivativeTerms {
                  gr::Tags::ExtrinsicCurvature<DataVector, 3>,
                  grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<3> apply(
       gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_tilde_d*/,
       gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_tilde_ye*/,
       gsl::not_null<Scalar<DataVector>*> non_flux_terms_dt_tilde_tau,

--- a/src/Evolution/Systems/NewtonianEuler/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TimeDerivativeTerms.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/NewtonianEuler/Sources/Source.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -60,7 +61,7 @@ struct TimeDerivativeTerms {
                  domain::Tags::Coordinates<Dim, Frame::Inertial>, ::Tags::Time,
                  NewtonianEuler::Tags::SourceTerm<Dim>>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<Dim> apply(
       // Time derivatives returned by reference. All the tags in the
       // variables_tag in the system struct.
       const gsl::not_null<Scalar<DataVector>*> non_flux_terms_dt_mass_density,
@@ -101,6 +102,7 @@ struct TimeDerivativeTerms {
            non_flux_terms_dt_energy_density, mass_density_cons,
            momentum_density, energy_density, velocity, pressure,
            specific_internal_energy, *eos_2d, coords, time);
+    return {true};
   }
 };
 

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/TimeDerivativeTerms.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Fluxes.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"
@@ -44,7 +45,7 @@ struct TimeDerivativeTerms {
                     Frame::Inertial>,
       gr::Tags::ExtrinsicCurvature<DataVector, 3>>;
 
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<3> apply(
       const gsl::not_null<typename Tags::TildeE<
           Frame::Inertial,
           NeutrinoSpecies>::type*>... non_flux_terms_dt_tilde_e,
@@ -90,6 +91,7 @@ struct TimeDerivativeTerms {
         non_flux_terms_dt_tilde_e, non_flux_terms_dt_tilde_s, tilde_e, tilde_s,
         tilde_p, source_n, source_i, lapse, d_lapse, d_shift, d_spatial_metric,
         inv_spatial_metric, extrinsic_curvature));
+    return {true};
   }
 };
 }  // namespace RadiationTransport::M1Grey

--- a/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.cpp
@@ -14,7 +14,7 @@
 namespace ScalarAdvection {
 
 template <size_t Dim>
-void TimeDerivativeTerms<Dim>::apply(
+evolution::dg::TimeDerivativeDecisions<Dim> TimeDerivativeTerms<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> /*non_flux_terms_dt_vars*/,
     const gsl::not_null<tnsr::I<DataVector, Dim>*> flux,
     const gsl::not_null<tnsr::I<DataVector, Dim>*> temp_velocity_field,
@@ -22,6 +22,7 @@ void TimeDerivativeTerms<Dim>::apply(
     const tnsr::I<DataVector, Dim>& velocity_field) {
   *temp_velocity_field = velocity_field;
   Fluxes<Dim>::apply(flux, u, velocity_field);
+  return {true};
 }
 
 }  // namespace ScalarAdvection

--- a/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/TimeDerivativeTerms.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -22,7 +23,7 @@ struct TimeDerivativeTerms {
   using temporary_tags = tmpl::list<Tags::VelocityField<Dim>>;
   using argument_tags = tmpl::list<Tags::U, Tags::VelocityField<Dim>>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<Dim> apply(
       // Time derivatives returned by reference. No source terms or
       // nonconservative products, so not used. All the tags in the
       // variables_tag in the system struct.

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
@@ -34,7 +34,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace ScalarTensor {
-void TimeDerivative::apply(
+evolution::dg::TimeDerivativeDecisions<3> TimeDerivative::apply(
     // GH dt variables
     const gsl::not_null<tnsr::aa<DataVector, dim>*> dt_spacetime_metric,
     const gsl::not_null<tnsr::aa<DataVector, dim>*> dt_pi,
@@ -173,6 +173,7 @@ void TimeDerivative::apply(
   add_stress_energy_term_to_dt_pi(dt_pi, *stress_energy, lapse_scalar);
 
   add_scalar_source_to_dt_pi_scalar(dt_pi_scalar, scalar_source, lapse_scalar);
+  return {true};
 }
 }  // namespace ScalarTensor
 

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedContainers.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/CurvedScalarWave/System.hpp"
 #include "Evolution/Systems/CurvedScalarWave/TimeDerivative.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
@@ -68,7 +69,7 @@ struct TimeDerivative {
       tmpl::append<gh_arg_tags, scalar_arg_tags,
                    tmpl::list<ScalarTensor::Tags::ScalarSource>>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<3> apply(
       // GH dt variables
       gsl::not_null<tnsr::aa<DataVector, dim>*> dt_spacetime_metric,
       gsl::not_null<tnsr::aa<DataVector, dim>*> dt_pi,

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
@@ -11,7 +11,7 @@
 
 namespace ScalarWave {
 template <size_t Dim>
-void TimeDerivative<Dim>::apply(
+evolution::dg::TimeDerivativeDecisions<Dim> TimeDerivative<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> dt_psi,
     const gsl::not_null<Scalar<DataVector>*> dt_pi,
     const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
@@ -42,6 +42,7 @@ void TimeDerivative<Dim>::apply(
   for (size_t d = 0; d < Dim; ++d) {
     dt_phi->get(d) = -d_pi.get(d) + get(gamma2) * (d_psi.get(d) - phi.get(d));
   }
+  return {true};
 }
 
 template class TimeDerivative<1>;

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Utilities/TMPL.hpp"
@@ -28,7 +29,7 @@ struct TimeDerivative {
   using argument_tags =
       tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::ConstraintGamma2>;
 
-  static void apply(
+  static evolution::dg::TimeDerivativeDecisions<Dim> apply(
       // Time derivatives returned by reference. All the tags in the
       // variables_tag in the system struct.
       gsl::not_null<Scalar<DataVector>*> dt_psi,

--- a/src/Evolution/VariableFixing/FixToAtmosphere.hpp
+++ b/src/Evolution/VariableFixing/FixToAtmosphere.hpp
@@ -349,6 +349,19 @@ class FixToAtmosphere {
       const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
           equation_of_state) const;
 
+  /// @{
+  /// \brief Other algorithmic decisions may depend on the atmosphere treatment
+  /// so provide access to the values.
+  double density_of_atmosphere() const { return density_of_atmosphere_; }
+  double density_cutoff() const { return density_cutoff_; }
+  const std::optional<VelocityLimitingOptions>& velocity_limiting() const {
+    return velocity_limiting_;
+  }
+  const std::optional<KappaLimitingOptions>& kappa_limiting() const {
+    return kappa_limiting_;
+  }
+  /// @}
+
  private:
   template <size_t ThermodynamicDim>
   void set_density_to_atmosphere(

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_TimeDerivativeTerms.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Test_TimeDerivativeTerms.cpp
@@ -19,6 +19,8 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
@@ -133,7 +135,9 @@ SPECTRE_TEST_CASE(
   using d_SpatialMetricTag =
       ::Tags::deriv<SpatialMetricTag, tmpl::size_t<3>, Frame::Inertial>;
   using arg_variables_type = tuples::tagged_tuple_from_typelist<
-      tmpl::remove<tmpl::append<gh_arg_tags, valencia_arg_tags>,
+      tmpl::remove<tmpl::append<gh_arg_tags, valencia_arg_tags,
+                                tmpl::list<::Tags::VariableFixer<
+                                    ::VariableFixing::FixToAtmosphere<3>>>>,
                    gr::Tags::SpatialMetric<DataVector, 3>>>;
 
   const size_t element_size = 10_st;
@@ -203,6 +207,14 @@ SPECTRE_TEST_CASE(
       metric.get(i + 1, 0) *= 0.01;
     }
   }
+  using Vlo =
+      typename VariableFixing::FixToAtmosphere<3>::VelocityLimitingOptions;
+  using Klo = typename VariableFixing::FixToAtmosphere<3>::KappaLimitingOptions;
+  const VariableFixing::FixToAtmosphere<3> variable_fixer_klo{
+      1.e-12, 3.e-12, Vlo{0.0, 1.e-4, 3.e-12, 1.e-11},
+      Klo{3.e-12, 1.e-3, 3.e-11, 0.01, std::nullopt, false}};
+  tuples::get<::Tags::VariableFixer<::VariableFixing::FixToAtmosphere<3>>>(
+      arg_variables) = variable_fixer_klo;
 
   ComputeVolumeTimeDerivativeTermsHelper<
       gh::TimeDerivative<ghmhd::GhValenciaDivClean::InitialData::
@@ -336,6 +348,15 @@ SPECTRE_TEST_CASE(
       tuples::get<gr::Tags::SpacetimeMetric<DataVector, 3_st>>(arg_variables),
       get<gr::Tags::Shift<DataVector, 3_st>>(expected_temp_variables),
       get<gr::Tags::Lapse<DataVector>>(expected_temp_variables));
+  dt_variables_type expected_dt_vars_no_stress_tensor{
+      expected_dt_variables.number_of_grid_points(), 0.0};
+  tmpl::for_each<gh_dt_variables_tags>(
+      [&expected_dt_vars_no_stress_tensor,
+       &expected_dt_variables]<class Tag>(tmpl::type_<Tag> /*meta*/) {
+        get<Tag>(expected_dt_vars_no_stress_tensor) =
+            get<Tag>(expected_dt_variables);
+      });
+
   // apply the correction to dt pi for the expected variables
   grmhd::GhValenciaDivClean::add_stress_energy_term_to_dt_pi(
       make_not_null(&get<::Tags::dt<gh::Tags::Pi<DataVector, 3_st>>>(
@@ -360,4 +381,40 @@ SPECTRE_TEST_CASE(
   CHECK_VARIABLES_APPROX(dt_variables, expected_dt_variables);
   CHECK_VARIABLES_APPROX(flux_variables, expected_flux_variables);
   CHECK_VARIABLES_APPROX(temp_variables, expected_temp_variables);
+
+  {
+    INFO(
+        "Check that having tiny density means we skip computing the MHD "
+        "system.");
+    get(tuples::get<hydro::Tags::RestMassDensity<DataVector>>(arg_variables)) =
+        0.0;
+    tmpl::for_each<valencia_flux_tags>([&flux_variables]<class Tag>(
+                                           tmpl::type_<Tag> /*meta*/) {
+      for (size_t storage_index = 0;
+           storage_index < get<Tag>(flux_variables).size(); ++storage_index) {
+        get<Tag>(flux_variables)[storage_index] = 1.0e300;
+      }
+    });
+
+    dt_variables.initialize(dt_variables.number_of_grid_points(), 0.0);
+
+    ComputeVolumeTimeDerivativeTermsHelper<
+        grmhd::GhValenciaDivClean::TimeDerivativeTerms, 3_st,
+        tmpl::append<gh_variables_tags, valencia_variables_tags>,
+        typename flux_variables_type::tags_list,
+        typename temp_variables_type::tags_list,
+        typename gradient_variables_type::tags_list,
+        tmpl::remove<tmpl::remove<typename arg_variables_type::tags_list,
+                                  SpatialMetricTag>,
+                     d_SpatialMetricTag>>::
+        apply_packed(
+            make_not_null(&dt_variables), make_not_null(&flux_variables),
+            make_not_null(&temp_variables), gradient_variables, arg_variables);
+
+    expected_flux_variables.initialize(
+        expected_flux_variables.number_of_grid_points(), 0.0);
+    CHECK_VARIABLES_APPROX(flux_variables, expected_flux_variables);
+
+    CHECK_VARIABLES_APPROX(dt_variables, expected_dt_vars_no_stress_tensor);
+  }
 }

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -203,6 +203,32 @@ void test_variable_fixer() {
   test_serialization(variable_fixer);
   test_serialization(variable_fixer_klo);
 
+  const auto check_velocity_limiting_options = [](const auto& var_fixer) {
+    CHECK(var_fixer.density_of_atmosphere() == 1.e-12);
+    CHECK(var_fixer.density_cutoff() == 3.e-12);
+    REQUIRE(var_fixer.velocity_limiting().has_value());
+    CHECK(var_fixer.velocity_limiting().value().atmosphere_max_velocity == 0.);
+    CHECK(var_fixer.velocity_limiting().value().near_atmosphere_max_velocity ==
+          1.e-4);
+    CHECK(var_fixer.velocity_limiting().value().atmosphere_density_cutoff ==
+          3.e-12);
+    CHECK(var_fixer.velocity_limiting().value().transition_density_bound ==
+          1.e-11);
+  };
+  check_velocity_limiting_options(variable_fixer);
+  check_velocity_limiting_options(variable_fixer_klo);
+
+  CHECK(not variable_fixer.kappa_limiting().has_value());
+  REQUIRE(variable_fixer_klo.kappa_limiting().has_value());
+  CHECK(variable_fixer_klo.kappa_limiting()->density_lower_bound == 3.e-12);
+  CHECK(variable_fixer_klo.kappa_limiting()->eplison_kappa_minus == 1.e-3);
+  CHECK(variable_fixer_klo.kappa_limiting()->density_upper_bound == 3.e-11);
+  CHECK(variable_fixer_klo.kappa_limiting()->epsilon_kappa_max == 0.01);
+  CHECK(variable_fixer_klo.kappa_limiting()->epsilon_kappa_plus_minus == 1.1);
+  CHECK(variable_fixer_klo.kappa_limiting()->min_temperature == std::nullopt);
+  CHECK(variable_fixer_klo.kappa_limiting()->limit_above_density_upper_bound ==
+        false);
+
   const auto fixer_from_options =
       TestHelpers::test_creation<VariableFixing::FixToAtmosphere<Dim>>(
           "DensityOfAtmosphere: 1.0e-12\n"

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -224,7 +224,6 @@ void test_variable_fixer() {
   CHECK(variable_fixer_klo.kappa_limiting()->eplison_kappa_minus == 1.e-3);
   CHECK(variable_fixer_klo.kappa_limiting()->density_upper_bound == 3.e-11);
   CHECK(variable_fixer_klo.kappa_limiting()->epsilon_kappa_max == 0.01);
-  CHECK(variable_fixer_klo.kappa_limiting()->epsilon_kappa_plus_minus == 1.1);
   CHECK(variable_fixer_klo.kappa_limiting()->min_temperature == std::nullopt);
   CHECK(variable_fixer_klo.kappa_limiting()->limit_above_density_upper_bound ==
         false);

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -30,8 +30,8 @@
 #include "Domain/Domain.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/InterfaceLogicalCoordinates.hpp"
-#include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/OrientationMapHelpers.hpp"
 #include "Domain/Tags.hpp"
@@ -45,7 +45,7 @@
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/PassVariables.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -54,6 +54,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MetricIdentityJacobian.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
@@ -205,7 +206,7 @@ struct TimeDerivativeTerms {
 
   // Conservative system
   /// [dt_con]
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       // Time derivatives returned by reference. All the tags in the
       // variables_tag in the system struct.
       const gsl::not_null<Scalar<DataVector>*> dt_var1,
@@ -242,11 +243,12 @@ struct TimeDerivativeTerms {
         }
       }
     }
+    return {true};
   }
   /// [dt_con]
 
   // with prims
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       const gsl::not_null<Scalar<DataVector>*> dt_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> dt_var2,
 
@@ -262,11 +264,12 @@ struct TimeDerivativeTerms {
     apply(dt_var1, dt_var2, flux_var1, flux_var2, square_var3, var1, var2,
           var3);
     get(*dt_var1) += get(prim_var1);
+    return {true};
   }
 
   // Nonconservative system
   /// [dt_nc]
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       // Time derivatives returned by reference. All the tags in the
       // variables_tag in the system struct.
       const gsl::not_null<Scalar<DataVector>*> dt_var1,
@@ -295,11 +298,12 @@ struct TimeDerivativeTerms {
         dt_var2->get(d) -= get(var1) * var2.get(i) * d_var2.get(i, d);
       }
     }
+    return {true};
   }
   /// [dt_nc]
 
   // Mixed system
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       const gsl::not_null<Scalar<DataVector>*> dt_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> dt_var2,
 
@@ -331,9 +335,10 @@ struct TimeDerivativeTerms {
         }
       }
     }
+    return {true};
   }
   /// [dt_mp]
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       const gsl::not_null<Scalar<DataVector>*> dt_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> dt_var2,
 
@@ -349,6 +354,7 @@ struct TimeDerivativeTerms {
       const Scalar<DataVector>& var3, const Scalar<DataVector>& prim_var1) {
     apply(dt_var1, dt_var2, flux_var2, square_var3, d_var1, var1, var2, var3);
     get(*dt_var1) += get(prim_var1);
+    return {true};
   }
   /// [dt_mp]
 };
@@ -368,7 +374,7 @@ struct TimeDerivativeTermsWithVariables
   using flux_var2 = ::Tags::Flux<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>;
 
   /// [dt_con_variables]
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       // Time derivatives returned by reference. All the tags in the
       // variables_tag in the system struct.
       const gsl::not_null<Variables<tmpl::list<dt_var1, dt_var2>>*> dt_vars,
@@ -389,11 +395,12 @@ struct TimeDerivativeTermsWithVariables
     base::apply(get<dt_var1>(dt_vars), get<dt_var2>(dt_vars),
                 get<flux_var1>(flux_vars), get<flux_var2>(flux_vars),
                 get<Var3Squared>(temporaries), var1, var2, var3);
+    return {true};
   }
   /// [dt_con_variables]
 
   // with prims
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       const gsl::not_null<Variables<tmpl::list<dt_var1, dt_var2>>*> dt_vars,
 
       const gsl::not_null<Variables<tmpl::list<flux_var1, flux_var2>>*>
@@ -407,11 +414,12 @@ struct TimeDerivativeTermsWithVariables
     base::apply(get<dt_var1>(dt_vars), get<dt_var2>(dt_vars),
                 get<flux_var1>(flux_vars), get<flux_var2>(flux_vars),
                 get<Var3Squared>(temporaries), var1, var2, var3, prim_var1);
+    return {true};
   }
 
   // Nonconservative system
   /// [dt_nc_variables]
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       // Time derivatives returned by reference. All the tags in the
       // variables_tag in the system struct.
       const gsl::not_null<Variables<tmpl::list<dt_var1, dt_var2>>*> dt_vars,
@@ -432,11 +440,12 @@ struct TimeDerivativeTermsWithVariables
     base::apply(get<dt_var1>(dt_vars), get<dt_var2>(dt_vars),
                 get<Var3Squared>(temporaries), d_var1, d_var2, var1, var2,
                 var3);
+    return {true};
   }
   /// [dt_nc_variables]
 
   // Mixed system
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       const gsl::not_null<Variables<tmpl::list<dt_var1, dt_var2>>*> dt_vars,
 
       const gsl::not_null<Variables<tmpl::list<flux_var2>>*> flux_vars,
@@ -452,10 +461,11 @@ struct TimeDerivativeTermsWithVariables
     base::apply(get<dt_var1>(dt_vars), get<dt_var2>(dt_vars),
                 get<flux_var2>(flux_vars), get<Var3Squared>(temporaries),
                 d_var1, var1, var2, var3);
+    return {true};
   }
 
   /// [dt_mp_variables]
-  static void apply(
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
       const gsl::not_null<Variables<tmpl::list<dt_var1, dt_var2>>*> dt_vars,
 
       const gsl::not_null<Variables<tmpl::list<flux_var2>>*> flux_vars,
@@ -471,6 +481,7 @@ struct TimeDerivativeTermsWithVariables
     base::apply(get<dt_var1>(dt_vars), get<dt_var2>(dt_vars),
                 get<flux_var2>(flux_vars), get<Var3Squared>(temporaries),
                 d_var1, var1, var2, var3, prim_var1);
+    return {true};
   }
   /// [dt_mp_variables]
 };


### PR DESCRIPTION
## Proposed changes

No need to do all the extra work. This is currently only on DG since FD will mostly happen there where we are not in atmosphere.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
