### PR TITLE
Mc adaptive packet count

### DIFF
--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -36,6 +36,8 @@
 #include "Evolution/Particles/MonteCarlo/CellCrossingTime.hpp"
 #include "Evolution/Particles/MonteCarlo/GhostZoneCommunication.hpp"
 #include "Evolution/Particles/MonteCarlo/GhostZoneCommunicationTags.hpp"
+#include "Evolution/Particles/MonteCarlo/GlobalReductions.hpp"
+#include "Evolution/Particles/MonteCarlo/ManagerComponent.hpp"
 #include "Evolution/Particles/MonteCarlo/MonteCarloOptions.hpp"
 #include "Evolution/Particles/MonteCarlo/NeutrinoMomentsFromMonteCarlo.hpp"
 #include "Evolution/Particles/MonteCarlo/System.hpp"
@@ -169,13 +171,15 @@ struct EvolutionMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       Events::Completion,
-                       ::Events::ObserveNorms<observe_fields,
-                                              non_tensor_compute_tags>,
-                       dg::Events::ObserveFields<volume_dim, observe_fields,
-                                                 non_tensor_compute_tags>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                Events::Completion,
+                Events::MonteCarlo::GlobalReductions<
+                    NeutrinoSpecies, observe_fields, non_tensor_compute_tags>,
+                ::Events::ObserveNorms<observe_fields, non_tensor_compute_tags>,
+                dg::Events::ObserveFields<volume_dim, observe_fields,
+                                          non_tensor_compute_tags>>>>,
         tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         tmpl::pair<
             grmhd::AnalyticData::InitialMagneticFields::InitialMagneticField,
@@ -270,8 +274,8 @@ struct EvolutionMetavars {
 
   using component_list =
       tmpl::list<observers::Observer<EvolutionMetavars>,
-                 observers::ObserverWriter<EvolutionMetavars>,
-                 dg_element_array>;
+                 observers::ObserverWriter<EvolutionMetavars>, dg_element_array,
+                 Particles::MonteCarlo::ManagerComponent<EvolutionMetavars>>;
 
   using const_global_cache_tags = tmpl::list<
       Particles::MonteCarlo::Tags::MonteCarloOptions<NeutrinoSpecies>,

--- a/src/Evolution/Particles/MonteCarlo/Actions/InitializeMonteCarlo.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Actions/InitializeMonteCarlo.hpp
@@ -61,7 +61,7 @@ namespace Initialization::Actions {
 /// - Adds:
 ///   * Particles::MonteCarlo::Tags::PacketsOnElement
 ///   * Particles::MonteCarlo::Tags::RandomNumberGenerator
-///   * Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
+///   * Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<
 ///                                  NeutrinoSpecies>
 ///   * Background hydro variables
 ///   * Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>
@@ -82,7 +82,7 @@ struct InitializeMCTags {
   using simple_tags =
       tmpl::list<Particles::MonteCarlo::Tags::PacketsOnElement,
                  Particles::MonteCarlo::Tags::RandomNumberGenerator,
-                 Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
+                 Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<
                      NeutrinoSpecies>,
                  hydro_variables_tag,
                  Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
@@ -110,7 +110,6 @@ struct InitializeMCTags {
     }
     const Mesh<dim>& mesh =
         db::get<evolution::dg::subcell::Tags::Mesh<dim>>(box);
-    const size_t num_grid_points = mesh.number_of_grid_points();
     // Number of ghost zones for MC is assumed to be 1 for now.
     const size_t num_ghost_zones = 1;
     size_t mesh_size_with_ghost_zones = 1;
@@ -129,9 +128,12 @@ struct InitializeMCTags {
     using HydroVars = typename hydro_variables_tag::type;
     call_with_dynamic_type<void, derived_classes>(
         &db::get<evolution::initial_data::Tags::InitialData>(box),
-        [&box, &num_grid_points](const auto* const data_or_solution) {
+        [&box](const auto* const data_or_solution) {
           static constexpr size_t dim = System::volume_dim;
           const double initial_time = db::get<::Tags::Time>(box);
+          const size_t num_grid_points =
+              db::get<evolution::dg::subcell::Tags::Mesh<dim>>(box)
+                  .number_of_grid_points();
           const auto& inertial_coords = db::get<
               evolution::dg::subcell::Tags::Coordinates<dim, Frame::Inertial>>(
               box);
@@ -172,17 +174,10 @@ struct InitializeMCTags {
         make_not_null(&box), std::move(rng));
 
     // Initial energy of packets, read from MC options
-    typename Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
-        NeutrinoSpecies>::type packet_energy_at_emission =
-        make_with_value<std::array<DataVector, NeutrinoSpecies>>(
-            DataVector{num_grid_points}, 0.0);
-    for (size_t s = 0; s < NeutrinoSpecies; s++) {
-      packet_energy_at_emission[s] = initial_packet_energy[s];
-    }
     Initialization::mutate_assign<
-        tmpl::list<Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
+        tmpl::list<Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<
             NeutrinoSpecies>>>(make_not_null(&box),
-                               std::move(packet_energy_at_emission));
+                               std::move(initial_packet_energy));
 
     // Initialize mortar data and coupling data.
     // Currently assumes a single neighbor on each face (i.e. no h-refinement)

--- a/src/Evolution/Particles/MonteCarlo/Actions/TimeStepActions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Actions/TimeStepActions.hpp
@@ -44,12 +44,12 @@ struct TimeStepMutator {
                  Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
                  Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
                  Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, Dim>,
-                 Particles::MonteCarlo::Tags::RandomNumberGenerator,
-                 Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
-                     NeutrinoSpecies>>;
+                 Particles::MonteCarlo::Tags::RandomNumberGenerator>;
   // To do : check carefully DG vs Subcell quantities... everything should
   // be on the Subcell grid!
   using argument_tags = tmpl::list<
+      Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<
+          NeutrinoSpecies>,
       ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
       hydro::Tags::GrmhdEquationOfState,
       Particles::MonteCarlo::Tags::InteractionRatesTable<EnergyBins,
@@ -86,8 +86,7 @@ struct TimeStepMutator {
       const gsl::not_null<Scalar<DataVector>*> coupling_tilde_rho_ye,
       const gsl::not_null<tnsr::i<DataVector, Dim>*> coupling_tilde_s,
       const gsl::not_null<std::mt19937*> random_number_generator,
-      const gsl::not_null<std::array<DataVector, NeutrinoSpecies>*>
-          single_packet_energy,
+      const std::array<double, NeutrinoSpecies>& minimum_packet_energy,
       const TimeStepId& current_step_id, const TimeStepId& next_step_id,
 
       const EquationsOfState::EquationOfState<true, 3>& equation_of_state,
@@ -147,7 +146,7 @@ struct TimeStepMutator {
     TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies> templated_functions;
     templated_functions.take_time_step_on_element(
         packets, coupling_tilde_tau, coupling_tilde_rho_ye, coupling_tilde_s,
-        random_number_generator, single_packet_energy, start_time, end_time,
+        random_number_generator, minimum_packet_energy, start_time, end_time,
         equation_of_state, interaction_table, electron_fraction,
         rest_mass_density, temperature, lorentz_factor,
         lower_spatial_four_velocity, lapse, shift, d_lapse, d_shift,

--- a/src/Evolution/Particles/MonteCarlo/CMakeLists.txt
+++ b/src/Evolution/Particles/MonteCarlo/CMakeLists.txt
@@ -34,8 +34,10 @@ spectre_target_headers(
   GhostZoneCommunication.hpp
   GhostZoneCommunicationStep.hpp
   GhostZoneCommunicationTags.hpp
+  GlobalReductions.hpp
   ImplicitMonteCarloCorrections.tpp
   InverseJacobianInertialToFluidCompute.hpp
+  ManagerComponent.hpp
   MonteCarloOptions.hpp
   MortarData.hpp
   NeutrinoInteractionTable.hpp

--- a/src/Evolution/Particles/MonteCarlo/EmitPackets.tpp
+++ b/src/Evolution/Particles/MonteCarlo/EmitPackets.tpp
@@ -30,7 +30,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::emit_packets(
     const size_t num_ghost_zones,
     const std::array<std::array<DataVector, EnergyBins>, NeutrinoSpecies>&
         emissivity_in_cell,
-    const std::array<DataVector, NeutrinoSpecies>& single_packet_energy,
+    const std::array<double, NeutrinoSpecies>& minimum_packet_energy,
     const std::array<double, EnergyBins>& energy_at_bin_center,
     const Scalar<DataVector>& lorentz_factor,
     const tnsr::i<DataVector, 3, Frame::Inertial>& lower_spatial_four_velocity,
@@ -64,7 +64,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::emit_packets(
               gsl::at(gsl::at(emissivity_in_cell, s), g)[extended_idx] *
               get(cell_proper_four_volume)[local_idx];
             const double packets_to_create_double =
-              emission_this_cell / gsl::at(single_packet_energy, s)[local_idx];
+              emission_this_cell / gsl::at(minimum_packet_energy, s);
             size_t packets_to_create_int = floor(packets_to_create_double);
             if (rng_uniform_zero_to_one(*random_number_generator) <
               packets_to_create_double -
@@ -137,7 +137,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::emit_packets(
               current_packet.time =
                   time_start_step + time_normalized * time_step;
               current_packet.number_of_neutrinos =
-                  gsl::at(gsl::at(single_packet_energy, s), idx) /
+                  gsl::at(minimum_packet_energy, s) /
                   gsl::at(energy_at_bin_center, g);
               current_packet.index_of_closest_grid_point = idx;
               // 4_momentum_fluid_frame contains p^mu in an orthornormal

--- a/src/Evolution/Particles/MonteCarlo/GlobalReductions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/GlobalReductions.hpp
@@ -1,0 +1,367 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Particles/MonteCarlo/ManagerComponent.hpp"
+#include "Evolution/Particles/MonteCarlo/Packet.hpp"
+#include "Evolution/Particles/MonteCarlo/Tags.hpp"
+#include "IO/Observer/GetSectionObservationKey.hpp"
+#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Options/String.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/TypeTraits.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/OptionalHelpers.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Events::MonteCarlo {
+
+template <size_t NeutrinoSpecies, typename ObservableTensorTagsList,
+          typename NonTensorComputeTagsList = tmpl::list<>,
+          typename ArraySectionIdTag = void, typename OptionName = void>
+class GlobalReductions;
+
+namespace Actions {
+
+/// Action taken by each element after reduction. It is called from
+/// PostReductionManagerAction, which sends global information back
+/// to individual elements.
+///
+/// DataBox changes:
+/// - Modifies:
+///   * Particles::MonteCarlo::Tags::
+///       MinimumPacketEnergyAtEmission<NeutrinoSpecies>
+///   * Particles::MonteCarlo::Tags::PacketsOnElement
+///   * Particles::MonteCarlo::Tags::RandomNumberGenerator
+template <size_t NeutrinoSpecies>
+struct PostReductionComponentAction {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const std::array<double, NeutrinoSpecies>&
+                        updated_minimum_packet_energy) {
+    // Update desired packet energy in low-density regions if we have too many
+    // packets, or too few.
+    db::mutate<Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<
+                   NeutrinoSpecies>,
+               Particles::MonteCarlo::Tags::PacketsOnElement,
+               Particles::MonteCarlo::Tags::RandomNumberGenerator>(
+        [&updated_minimum_packet_energy](
+            const gsl::not_null<std::array<double, NeutrinoSpecies>*>
+                minimum_packet_energy,
+            const gsl::not_null<std::vector<Particles::MonteCarlo::Packet>*>
+                packets,
+            const gsl::not_null<std::mt19937*> random_number_generator) {
+          std::array<bool, NeutrinoSpecies> packet_energy_is_increased;
+          std::array<double, NeutrinoSpecies> survival_probability;
+          bool need_packet_update = false;
+          for (size_t d = 0; d < NeutrinoSpecies; d++) {
+            gsl::at(packet_energy_is_increased, d) = false;
+            gsl::at(survival_probability, d) = 1.0;
+            if (gsl::at(updated_minimum_packet_energy, d) >
+                gsl::at((*minimum_packet_energy), d)) {
+              gsl::at(packet_energy_is_increased, d) = true;
+              need_packet_update = true;
+              gsl::at(survival_probability, d) =
+                  gsl::at((*minimum_packet_energy), d) /
+                  gsl::at(updated_minimum_packet_energy, d);
+            }
+            gsl::at((*minimum_packet_energy), d) =
+                gsl::at(updated_minimum_packet_energy, d);
+          }
+          if (need_packet_update) {
+            // If we increase the minimum energy of packets, we also resample
+            // existing packets
+            std::uniform_real_distribution<double> rng_uniform_zero_to_one(0.0,
+                                                                           1.0);
+            size_t n_packets = packets->size();
+            for (size_t p = 0; p < n_packets; p++) {
+              const size_t& species = (*packets)[p].species;
+              if (gsl::at(packet_energy_is_increased, species)) {
+                // Two possibilities here: either we delete the packet, or we
+                // reweight it to compensate for the removed packets
+                if (rng_uniform_zero_to_one(*random_number_generator) <
+                    gsl::at(survival_probability, species)) {
+                  (*packets)[p].number_of_neutrinos *=
+                      1.0 / gsl::at(survival_probability, species);
+                } else {
+                  std::swap((*packets)[p], (*packets)[n_packets - 1]);
+                  packets->pop_back();
+                  p--;
+                  n_packets--;
+                }
+              }
+            }
+          }
+        },
+        make_not_null(&box));
+  }
+};
+
+/// Action that gather MC information from global reduction and modify
+/// global simulation settings as needed.
+/// So far, this monitors the number of packets and adapt the desired
+/// energy of emitted packets.
+///
+/// DataBox changes:
+/// - Modifies:
+///   * Particles::MonteCarlo::Tags::
+///       MinimumPacketEnergyAtEmission<NeutrinoSpecies>
+template <size_t NeutrinoSpecies>
+struct PostReductionManagerAction {
+  using const_global_cache_tags = tmpl::list<
+      Particles::MonteCarlo::Tags::MonteCarloOptions<NeutrinoSpecies>>;
+
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const double& /*observation_id*/,
+                    const std::array<size_t, NeutrinoSpecies>& n_packets) {
+    const auto mc_options = db::get<
+        Particles::MonteCarlo::Tags::MonteCarloOptions<NeutrinoSpecies>>(box);
+    const auto& initial_packet_energy = mc_options.get_initial_packet_energy();
+    const size_t& desired_packets_per_species =
+        mc_options.get_desired_packets_per_species();
+    std::array<double, NeutrinoSpecies> updated_minimum_packet_energy;
+    for (size_t d = 0; d < NeutrinoSpecies; d++) {
+      gsl::at(updated_minimum_packet_energy, d) = 0.0;
+    }
+
+    // Update desired packet energy in low-density regions if we have too many
+    // packets, or too few.
+    db::mutate<Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<
+        NeutrinoSpecies>>(
+        [&desired_packets_per_species, &n_packets, &initial_packet_energy,
+         &updated_minimum_packet_energy](
+            const gsl::not_null<std::array<double, NeutrinoSpecies>*>
+                minimum_packet_energy) {
+          for (size_t d = 0; d < NeutrinoSpecies; d++) {
+            if (desired_packets_per_species < gsl::at(n_packets, d)) {
+              gsl::at((*minimum_packet_energy), d) *= 1.0 / 0.9;
+            } else if (0.81 * desired_packets_per_species >
+                       gsl::at(n_packets, d)) {
+              gsl::at((*minimum_packet_energy), d) =
+                  std::max(gsl::at((*minimum_packet_energy), d) * 0.9,
+                           gsl::at(initial_packet_energy, d));
+            }
+            gsl::at(updated_minimum_packet_energy, d) =
+                gsl::at((*minimum_packet_energy), d);
+          }
+        },
+        make_not_null(&box));
+    Parallel::printf(
+        "Using packet energies %f %f %f\n", updated_minimum_packet_energy[0],
+        updated_minimum_packet_energy[1], updated_minimum_packet_energy[2]);
+    auto& reduction_target_proxy = Parallel::get_parallel_component<
+        typename Metavariables::dg_element_array>(cache);
+    Parallel::simple_action<PostReductionComponentAction<NeutrinoSpecies>>(
+        reduction_target_proxy, updated_minimum_packet_energy);
+  }
+};
+
+}  // namespace Actions
+
+template <size_t NeutrinoSpecies, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag,
+          typename OptionName>
+class GlobalReductions<NeutrinoSpecies, tmpl::list<ObservableTensorTags...>,
+                       tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag,
+                       OptionName> : public Event {
+ private:
+  using ReductionData = Parallel::ReductionData<
+      // Observation value
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<std::array<size_t, NeutrinoSpecies>,
+                               funcl::Plus<>>>;
+
+ public:
+  static std::string name() { return "GlobalReductionsMonteCarlo"; }
+
+  /// The name of the subfile inside the HDF5 file
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "The name of the subfile inside the HDF5 file without an extension and "
+        "without a preceding '/'."};
+  };
+
+  explicit GlobalReductions(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(GlobalReductions);  // NOLINT
+
+  using options = tmpl::list<SubfileName>;
+
+  static constexpr Options::String help = "Global reductions for MonteCarlo.\n";
+
+  GlobalReductions() = default;
+  explicit GlobalReductions(const std::string& subfile_name);
+
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
+
+  using compute_tags_for_observation_box =
+      tmpl::list<ObservableTensorTags..., NonTensorComputeTags...>;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<::Tags::ObservationBox>;
+
+  template <typename ComputeTagsList, typename DataBoxType,
+            typename Metavariables, size_t VolumeDim,
+            typename ParallelComponent>
+  void operator()(const ObservationBox<ComputeTagsList, DataBoxType>& box,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<VolumeDim>& array_index,
+                  const ParallelComponent* /*meta*/,
+                  const ObservationValue& observation_value) const;
+
+  using observation_registration_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList>
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration(
+      const db::DataBox<DbTagsList>& box) const {
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    if (not section_observation_key.has_value()) {
+      return std::nullopt;
+    }
+    return {{observers::TypeOfObservation::Reduction,
+             observers::ObservationKey(
+                 subfile_path_ + section_observation_key.value() + ".dat")}};
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return false; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  std::string subfile_path_;
+};
+/// @}
+
+/// \cond
+template <size_t NeutrinoSpecies, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag,
+          typename OptionName>
+GlobalReductions<NeutrinoSpecies, tmpl::list<ObservableTensorTags...>,
+                 tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag,
+                 OptionName>::GlobalReductions(CkMigrateMessage* msg)
+    : Event(msg) {}
+
+template <size_t NeutrinoSpecies, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag,
+          typename OptionName>
+GlobalReductions<NeutrinoSpecies, tmpl::list<ObservableTensorTags...>,
+                 tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag,
+                 OptionName>::GlobalReductions(const std::string& subfile_name)
+    : subfile_path_("/" + subfile_name) {}
+
+template <size_t NeutrinoSpecies, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag,
+          typename OptionName>
+template <typename ComputeTagsList, typename DataBoxType,
+          typename Metavariables, size_t VolumeDim, typename ParallelComponent>
+void GlobalReductions<NeutrinoSpecies, tmpl::list<ObservableTensorTags...>,
+                      tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag,
+                      OptionName>::
+operator()(const ObservationBox<ComputeTagsList, DataBoxType>& box,
+           Parallel::GlobalCache<Metavariables>& cache,
+           const ElementId<VolumeDim>& array_index,
+           const ParallelComponent* const /*meta*/,
+           const ObservationValue& observation_value) const {
+  // Skip observation on elements that are not part of a section
+  const std::optional<std::string> section_observation_key =
+      observers::get_section_observation_key<ArraySectionIdTag>(box);
+  if (not section_observation_key.has_value()) {
+    return;
+  }
+
+  const auto& packet_list =
+      (get<Particles::MonteCarlo::Tags::PacketsOnElement>(box));
+  std::array<size_t, NeutrinoSpecies> packets_per_species;
+  for (size_t s = 0; s < NeutrinoSpecies; s++) {
+    packets_per_species[s] = 0;
+  }
+  for (auto& packet : packet_list) {
+    packets_per_species[packet.species]++;
+  }
+
+  // Concatenate the legend info together.
+  const std::vector<std::string> legend{
+    observation_value.name, "PacketsPerSpecies_0",
+    "PacketsPerSpecies_1", "PacketsPerSpecies_2"};
+
+  const std::string subfile_path_with_suffix =
+      subfile_path_ + section_observation_key.value();
+  ReductionData reduction_data{observation_value.value, packets_per_species};
+  auto my_proxy =
+      Parallel::get_parallel_component<ParallelComponent>(cache)[array_index];
+  auto& reduction_target_proxy = Parallel::get_parallel_component<
+      Particles::MonteCarlo::ManagerComponent<Metavariables>>(cache);
+  Parallel::contribute_to_reduction<
+      Actions::PostReductionManagerAction<NeutrinoSpecies>>(
+      std::move(reduction_data), my_proxy, reduction_target_proxy);
+}
+
+template <size_t NeutrinoSpecies, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag,
+          typename OptionName>
+void GlobalReductions<NeutrinoSpecies, tmpl::list<ObservableTensorTags...>,
+                      tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag,
+                      OptionName>::pup(PUP::er& p) {
+  Event::pup(p);
+  p | subfile_path_;
+}
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+template <size_t NeutrinoSpecies, typename... ObservableTensorTags,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag,
+          typename OptionName>
+PUP::able::PUP_ID
+    GlobalReductions<NeutrinoSpecies, tmpl::list<ObservableTensorTags...>,
+                     tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag,
+                     OptionName>::my_PUP_ID = 0;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+/// \endcond
+
+}  // namespace Events::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/ManagerComponent.hpp
+++ b/src/Evolution/Particles/MonteCarlo/ManagerComponent.hpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Particles/MonteCarlo/Tags.hpp"
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Particles::MonteCarlo {
+
+namespace Actions {
+
+template <typename Metavariables>
+struct Initialize {
+  using simple_tags_from_options = tmpl::list<>;
+  using simple_tags =
+      tmpl::list<Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<3>>;
+  using mutable_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  using compute_tags = tmpl::list<>;
+  using return_tags =
+      tmpl::list<Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<3>>;
+  using argument_tags =
+      tmpl::list<Parallel::Tags::GlobalCache,
+                 Particles::MonteCarlo::Tags::MonteCarloOptions<3>>;
+
+  static void apply(
+      const gsl::not_null<std::array<double, 3>*> minimum_packet_energy,
+      const Parallel::GlobalCache<Metavariables>* const& /*cache*/,
+      const Particles::MonteCarlo::MonteCarloOptions<3>& mc_options) {
+    Parallel::printf("Initializing Monte Carlo Manager\n");
+    (*minimum_packet_energy) = mc_options.get_initial_packet_energy();
+  }
+};
+}  // namespace Actions
+
+/*!
+ * \brief The singleton parallel component responsible for managing
+ * the Monte-Carlo evoltuion.
+ *
+ */
+template <class Metavariables>
+struct ManagerComponent {
+  using chare_type = Parallel::Algorithms::Singleton;
+
+  static std::string name() { return "MonteCarloManager"; }
+
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<Initialization::Actions::InitializeItems<
+                     Particles::MonteCarlo::Actions::Initialize<Metavariables>>,
+                 Parallel::Actions::TerminatePhase>>>;
+
+  using simple_tags_from_options = tmpl::list<>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<ManagerComponent<Metavariables>>(
+        local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+}  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/MonteCarloOptions.cpp
+++ b/src/Evolution/Particles/MonteCarlo/MonteCarloOptions.cpp
@@ -16,6 +16,7 @@ template <size_t NeutrinoSpecies>
 void MonteCarloOptions<NeutrinoSpecies>::pup(PUP::er& p) {
   PUP::able::pup(p);
   p | initial_packet_energy_;
+  p | desired_packets_per_species_;
 }
 
 }  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/MonteCarloOptions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/MonteCarloOptions.hpp
@@ -16,12 +16,15 @@ template <size_t NeutrinoSpecies>
 class MonteCarloOptions : public PUP::able {
  public:
   explicit MonteCarloOptions(
-      const std::array<double, NeutrinoSpecies> initial_packet_energy)
-      : initial_packet_energy_(initial_packet_energy) {}
+      const std::array<double, NeutrinoSpecies> initial_packet_energy,
+      const size_t desired_packets_per_species)
+      : initial_packet_energy_(initial_packet_energy),
+        desired_packets_per_species_(desired_packets_per_species) {}
 
   static constexpr Options::String help = {
       "Global options for Monte-Carlo evolution.\n"
-      "InitialPacketEnergy: [double, double, double]    \n"};
+      "InitialPacketEnergy: [double, double, double]    \n"
+      "DesiredPacketsPerSpecies: size_t                 \n"};
 
   struct InitialPacketEnergy {
     using type = std::array<double, NeutrinoSpecies>;
@@ -29,7 +32,13 @@ class MonteCarloOptions : public PUP::able {
         "Initial energy used to create packets"};
   };
 
-  using options = tmpl::list<InitialPacketEnergy>;
+  struct DesiredPacketsPerSpecies {
+    using type = size_t;
+    static constexpr Options::String help{
+        "Target number of MC packets per species"};
+  };
+
+  using options = tmpl::list<InitialPacketEnergy, DesiredPacketsPerSpecies>;
 
   explicit MonteCarloOptions(CkMigrateMessage* msg) : PUP::able(msg) {}
 
@@ -41,8 +50,13 @@ class MonteCarloOptions : public PUP::able {
     return initial_packet_energy_;
   }
 
+  const size_t& get_desired_packets_per_species() const {
+    return desired_packets_per_species_;
+  }
+
  private:
   std::array<double, NeutrinoSpecies> initial_packet_energy_;
+  size_t desired_packets_per_species_;
 };
 
 }  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/Tags.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Tags.hpp
@@ -58,12 +58,12 @@ struct RandomNumberGenerator : db::SimpleTag {
   using type = std::mt19937;
 };
 
-/// Simple tag containing the desired energy of
-/// packets in low-density regions. The energy
-/// can be different for each neutrino species.
+/// Simple tag containing the minimum energy of
+/// packets at the current time. This can depend
+/// on neutrino species and time, but not location.
 template <size_t NeutrinoSpecies>
-struct DesiredPacketEnergyAtEmission : db::SimpleTag {
-  using type = std::array<DataVector, NeutrinoSpecies>;
+struct MinimumPacketEnergyAtEmission : db::SimpleTag {
+  using type = std::array<double, NeutrinoSpecies>;
 };
 
 /// Simple tag for the table of neutrino-matter interaction
@@ -95,11 +95,12 @@ struct MonteCarloOptions : db::SimpleTag {
   using option_tags = typename Particles::MonteCarlo::MonteCarloOptions<
       NeutrinoSpecies>::options;
   static type create_from_options(
-      const std::array<double, NeutrinoSpecies> initial_packet_energy) {
+      const std::array<double, NeutrinoSpecies> initial_packet_energy,
+      const size_t desired_packets_per_species) {
     std::unique_ptr<Particles::MonteCarlo::MonteCarloOptions<NeutrinoSpecies>>
         mc_options_ptr = std::make_unique<
             Particles::MonteCarlo::MonteCarloOptions<NeutrinoSpecies>>(
-            initial_packet_energy);
+            initial_packet_energy, desired_packets_per_species);
     return mc_options_ptr;
     ;
   }

--- a/src/Evolution/Particles/MonteCarlo/TakeTimeStep.tpp
+++ b/src/Evolution/Particles/MonteCarlo/TakeTimeStep.tpp
@@ -79,9 +79,8 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
         const gsl::not_null<Scalar<DataVector>* > coupling_tilde_rho_ye,
         const gsl::not_null<tnsr::i<DataVector,3>* > coupling_tilde_s,
         const gsl::not_null<std::mt19937*> random_number_generator,
-        const gsl::not_null<std::array<DataVector, NeutrinoSpecies>*>
-            single_packet_energy,
 
+        const std::array<double, NeutrinoSpecies>& minimum_packet_energy,
         const double start_time, const double target_end_time,
         const EquationsOfState::EquationOfState<true, 3>& equation_of_state,
         const NeutrinoInteractionTable<EnergyBins, NeutrinoSpecies>&
@@ -205,7 +204,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
   this->emit_packets(
       packets, random_number_generator, coupling_tilde_tau, coupling_tilde_s,
       coupling_tilde_rho_ye, start_time, time_step, mesh, num_ghost_zones,
-      emissivity_in_cell, *single_packet_energy, energy_at_bin_center,
+      emissivity_in_cell,minimum_packet_energy, energy_at_bin_center,
       lorentz_factor, lower_spatial_four_velocity, inertial_to_fluid_jacobian,
       inertial_to_fluid_inverse_jacobian, cell_proper_four_volume);
 

--- a/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
@@ -68,9 +68,7 @@ struct TemplatedLocalFunctions {
       gsl::not_null<Scalar<DataVector>*> coupling_tilde_ye,
       gsl::not_null<tnsr::i<DataVector, 3>*> coupling_tilde_s,
       gsl::not_null<std::mt19937*> random_number_generator,
-      gsl::not_null<std::array<DataVector, NeutrinoSpecies>*>
-          single_packet_energy,
-
+      const std::array<double, NeutrinoSpecies>& minimum_packet_energy,
       double start_time, double target_end_time,
       const EquationsOfState::EquationOfState<true, 3>& equation_of_state,
       const NeutrinoInteractionTable<EnergyBins, NeutrinoSpecies>&
@@ -116,9 +114,9 @@ struct TemplatedLocalFunctions {
    * We emit a total energy emissivity_in_cell * cell_proper_four_volume
    * for each grid
    * cell, neutrino species, and neutrino energy bin. We aim for packets of
-   * energy single_packet_energy in the fluid frame. The number of packets
+   * energy minimum_packet_energy in the fluid frame. The number of packets
    * is, in each bin b and for each species s,
-   * `N = emission_in_cell[s][b] / single_packet_energy[s]`
+   * `N = emission_in_cell[s][b] / minimum_packet_energy[s]`
    * and randomly rounded up or down to get integer number of packets (i.e.
    * if we want N=2.6 packets, there is a 60 percent chance of creating a 3rd
    * packet). The position of the packets is drawn from a homogeneous
@@ -136,8 +134,10 @@ struct TemplatedLocalFunctions {
    * \f$\phi\f$ from a uniform distribution in \f$[0,2*\pi]\f$. We
    * transform to the inertial frame \f$p_t\f$ and \f$p^x,p^y,p^z\f$ using the
    * jacobian/inverse jacobian passed as option. The number of neutrinos in
+
+
    * each packet is defined as
-   * `n = single_packet_energy[s] / energy_at_bin_center[b]`
+   * `n = minimum_packet_energy[s] / energy_at_bin_center[b]`
    * Note that the packet energy is in code units and energy of a bin in MeV.
    *
    * All tensors are assumed to correspond to live points only, except for
@@ -153,7 +153,7 @@ struct TemplatedLocalFunctions {
       const Mesh<3>& mesh, size_t num_ghost_zones,
       const std::array<std::array<DataVector, EnergyBins>, NeutrinoSpecies>&
           emissivity_in_cell,
-      const std::array<DataVector, NeutrinoSpecies>& single_packet_energy,
+      const std::array<double, NeutrinoSpecies>& minimum_packet_energy,
       const std::array<double, EnergyBins>& energy_at_bin_center,
       const Scalar<DataVector>& lorentz_factor,
       const tnsr::i<DataVector, 3, Frame::Inertial>&
@@ -161,7 +161,7 @@ struct TemplatedLocalFunctions {
       const Jacobian<DataVector, 4, Frame::Inertial, Frame::Fluid>&
           inertial_to_fluid_jacobian,
       const InverseJacobian<DataVector, 4, Frame::Inertial, Frame::Fluid>&
-        inertial_to_fluid_inverse_jacobian,
+          inertial_to_fluid_inverse_jacobian,
       const Scalar<DataVector>& cell_proper_four_volume);
 
   /*!

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_EmitPackets.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_EmitPackets.cpp
@@ -35,7 +35,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarloEmission",
   std::array<std::array<DataVector, 2>, 2> emissivity_in_cells = {
       std::array<DataVector, 2>{{zero_dv, zero_dv}},
       std::array<DataVector, 2>{{zero_dv, zero_dv}}};
-  std::array<DataVector, 2> single_packet_energy = {zero_dv, zero_dv};
+  std::array<double, 2> single_packet_energy = {0.0, 0.0};
   const std::array<double, 2> energy_at_bin_center = {2.0, 5.0};
   InverseJacobian<DataVector, 4, Frame::Inertial, Frame::Fluid>
       inverse_jacobian = make_with_value<
@@ -49,8 +49,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Particles.MonteCarloEmission",
 
   // Set data
   for (size_t s = 0; s < 2; s++) {
+    gsl::at(single_packet_energy, s) = 2.0;
     for (size_t i = 0; i < zero_dv.size(); i++) {
-      gsl::at(single_packet_energy, s)[i] = 2.0;
       for (size_t g = 0; g < 2; g++) {
         if (i == 25) {
           gsl::at(gsl::at(emissivity_in_cells, s), g)[i] =

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_InitializeAction.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_InitializeAction.cpp
@@ -187,10 +187,11 @@ void test_initialize_monte_carlo() {
   // Set up Monte Carlo options
   std::array<double, neutrino_species> initial_packet_energy = {1.e-12, 1.e-12,
                                                                 1.e-12};
+  const size_t desired_packets_per_species = 1e6;
   std::unique_ptr<Particles::MonteCarlo::MonteCarloOptions<neutrino_species>>
       monte_carlo_options_ptr = std::make_unique<
           Particles::MonteCarlo::MonteCarloOptions<neutrino_species>>(
-          initial_packet_energy);
+          initial_packet_energy, desired_packets_per_species);
 
   // Set up mock initial data
   std::unique_ptr<RadiationTransport::MonteCarlo::Solutions::HomogeneousSphere>
@@ -222,15 +223,13 @@ void test_initialize_monte_carlo() {
   // Min value is always zero per the mersenner twister engine documentation;
   // called as a simple use of the generator.
   CHECK(generator.min() == 0);
-  const std::array<DataVector, neutrino_species>& desired_energy_at_emission =
+  const std::array<double, neutrino_species>& minimum_energy_at_emission =
       ActionTesting::get_databox_tag<
-          comp, Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
+          comp, Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<
                     neutrino_species>>(runner, self_id);
   for (size_t s = 0; s < neutrino_species; s++) {
-    for (size_t i = 0; i < n_pts; i++) {
-      CHECK(gsl::at(desired_energy_at_emission, s)[i] ==
-            gsl::at(initial_packet_energy, s));
-    }
+    CHECK(gsl::at(minimum_energy_at_emission, s) ==
+          gsl::at(initial_packet_energy, s));
   }
   // Check size of the fluid variables
   const Scalar<DataVector>& lorentz_factor =

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
@@ -137,8 +137,7 @@ void test_flat_space_time_step() {
   const double start_time = 0.0;
   const double final_time = 1.6;
   const double time_step = 0.4;
-  std::array<DataVector, NeutrinoSpecies> single_packet_energy = {zero_dv,
-                                                                  zero_dv};
+  std::array<double, NeutrinoSpecies> single_packet_energy = {0.0, 0.0};
   for (size_t s = 0; s < NeutrinoSpecies; s++) {
     gsl::at(single_packet_energy,s) = 1.0;
   }
@@ -236,7 +235,7 @@ void test_flat_space_time_step() {
   while (current_time < final_time) {
     MonteCarloStruct.take_time_step_on_element(
         &packets, &coupling_tilde_tau, &coupling_tilde_rho_ye,
-        &coupling_tilde_s, &generator, &single_packet_energy, current_time,
+        &coupling_tilde_s, &generator, single_packet_energy, current_time,
         current_time + time_step, equation_of_state, interaction_table,
         electron_fraction, baryon_density, temperature, lorentz_factor,
         lower_spatial_four_velocity, lapse, shift, d_lapse, d_shift,

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_TimeStepAction.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_TimeStepAction.cpp
@@ -83,7 +83,7 @@ struct component {
       Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
       Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, Dim>,
       domain::Tags::NeighborMesh<Dim>,
-      Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<3>,
+      Particles::MonteCarlo::Tags::MinimumPacketEnergyAtEmission<3>,
       hydro::Tags::LowerSpatialFourVelocity<DataVector, Dim, Frame::Inertial>,
       gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<DataVector, Dim, Frame::Inertial>,
@@ -207,10 +207,7 @@ void test_advance_packets() {
   tnsr::i<DataVector, 3, Frame::Inertial> lower_spatial_four_velocity =
       make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(lapse, 0.0);
   Scalar<DataVector> cell_light_crossing_time(zero_dv);
-  std::array<DataVector, 3> single_packet_energy = {zero_dv, zero_dv, zero_dv};
-  gsl::at(single_packet_energy, 0) = 1.0;
-  gsl::at(single_packet_energy, 1) = 1.0;
-  gsl::at(single_packet_energy, 2) = 1.0;
+  std::array<double, 3> single_packet_energy = {1.0, 1.0, 1.0};
   get(cell_light_crossing_time) = 1.0;
 
   // Coupling data


### PR DESCRIPTION
## Proposed changes

Let the MC code choose adaptively the energy of packets, based on a desired total packet count. This currently allows for adaptivity in time, but does not use higher-energy packets in dense regions (this will be coded later).

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
