### PR TITLE
BBH pipeline: small ecc control fixes

### DIFF
--- a/support/Pipelines/Bbh/EccentricityControl.py
+++ b/support/Pipelines/Bbh/EccentricityControl.py
@@ -130,9 +130,9 @@ def eccentricity_control(
         orbital_angular_velocity=new_orbital_params["Omega0"],
         radial_expansion_velocity=new_orbital_params["adot0"],
         # Scheduling options
-        control=id_params["control"],
         refinement_level=id_params["control_refinement_level"],
         polynomial_order=id_params["control_polynomial_order"],
+        control=True,
         evolve=True,
         eccentricity_control=True,
         pipeline_dir=pipeline_dir,

--- a/support/Pipelines/Bbh/EccentricityControl.py
+++ b/support/Pipelines/Bbh/EccentricityControl.py
@@ -28,6 +28,7 @@ def eccentricity_control(
     tmax: Optional[float] = None,
     plot_output_dir: Optional[Union[str, Path]] = None,
     # Scheduler options
+    evolve: bool = True,
     **scheduler_kwargs,
 ):
     """Eccentricity reduction post inspiral.
@@ -59,6 +60,9 @@ def eccentricity_control(
       h5_files: files that contain the trajectory data
       id_input_file_path: path to the input file of the initial data run
       pipeline_dir : directory where the pipeline outputs are stored.
+      evolve: Evolve the initial data after generation to continue eccentricity
+        control. You can disable this to generate only the new initial data if
+        you want to manually start the next inspiral.
 
     See the 'eccentricity_control_params' function for details on the other
     arguments, as well as the 'schedule' function for the scheduling options.
@@ -133,7 +137,7 @@ def eccentricity_control(
         refinement_level=id_params["control_refinement_level"],
         polynomial_order=id_params["control_polynomial_order"],
         control=True,
-        evolve=True,
+        evolve=evolve,
         eccentricity_control=True,
         pipeline_dir=pipeline_dir,
         **scheduler_kwargs,
@@ -150,6 +154,15 @@ def eccentricity_control(
         path_type=Path,
     ),
     help="Directory where steps in the pipeline are created.",
+)
+@click.option(
+    "--evolve/--no-evolve",
+    default=True,
+    help=(
+        "Evolve the initial data after generation to continue eccentricity "
+        "control. You can disable this to generate only the new initial data "
+        "if you want to manually start the next inspiral."
+    ),
 )
 @scheduler_options
 def eccentricity_control_command(**kwargs):


### PR DESCRIPTION
## Proposed changes

Make sure that ecc control iterations also do ID control (control total masses to be 1). This didn't work as intended before because the ID input file from the last control iteration was loaded, which had `control=False` set.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
