### PR TITLE
Check SpEC version when importing

### DIFF
--- a/support/Pipelines/EccentricityControl/EccentricityControlParams.py
+++ b/support/Pipelines/EccentricityControl/EccentricityControlParams.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 import yaml
 
+from spectre.support.CheckSpecImport import check_spec_import
 from spectre.support.Yaml import SafeDumper
 from spectre.Visualization.PlotTrajectories import import_A_and_B
 from spectre.Visualization.ReadH5 import to_dataframe
@@ -88,18 +89,14 @@ def eccentricity_control_params(
         Dictionary with the keys listed in 'EccentricityParams'.
     """
     # Import functions from SpEC until we have ported them over
-    try:
-        from OmegaDotEccRemoval import (
-            ComputeOmegaAndDerivsFromFile,
-            FindTmin,
-            performAllFits,
-        )
-    except ImportError:
-        raise ImportError(
-            "Importing from SpEC failed. Make sure you have pointed "
-            "'-D SPEC_ROOT' to a SpEC installation when configuring the build "
-            "with CMake."
-        )
+    check_spec_import(
+        contains_commit="ecfabf1ce78daeacbdd026625a02215c8e84af0e",
+    )
+    from OmegaDotEccRemoval import (
+        ComputeOmegaAndDerivsFromFile,
+        FindTmin,
+        performAllFits,
+    )
 
     # Make sure h5_files is a sequence
     if isinstance(h5_files, str):

--- a/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
+++ b/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
@@ -7,6 +7,8 @@ from typing import Optional, Sequence, Tuple
 import numpy as np
 from scipy.optimize import minimize
 
+from spectre.support.CheckSpecImport import check_spec_import
+
 logger = logging.getLogger(__name__)
 
 
@@ -103,14 +105,8 @@ def initial_orbital_parameters(
     # call old Fortran code (LSODA) through scipy.integrate.odeint, which leads
     # to lots of noise in stdout. When porting these functions, we should
     # modernize them to use scipy.integrate.solve_ivp.
-    try:
-        from ZeroEccParamsFromPN import nOrbitsAndTotalTime, omegaAndAdot
-    except ImportError:
-        raise ImportError(
-            "Importing from SpEC failed. Make sure you have pointed "
-            "'-D SPEC_ROOT' to a SpEC installation when configuring the build "
-            "with CMake."
-        )
+    check_spec_import()
+    from ZeroEccParamsFromPN import nOrbitsAndTotalTime, omegaAndAdot
 
     # Find an omega0 that gives the right number of orbits or time to merger
     if num_orbits is not None or time_to_merger is not None:

--- a/support/Python/CMakeLists.txt
+++ b/support/Python/CMakeLists.txt
@@ -7,6 +7,7 @@ particular supercomputer" OFF)
 spectre_python_add_module(
   support
   PYTHON_FILES
+  CheckSpecImport.py
   CliExceptions.py
   DirectoryStructure.py
   Logging.py

--- a/support/Python/CheckSpecImport.py
+++ b/support/Python/CheckSpecImport.py
@@ -1,0 +1,40 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from pathlib import Path
+from typing import Optional
+
+
+def check_spec_import(contains_commit: Optional[str] = None):
+    """Check that the SpEC Python modules can be imported.
+
+    Arguments:
+      contains_commit: If specified, check that the SpEC repository contains
+        the specified commit. This can be used as a version check to ensure
+        that the installed SpEC version is compatible with the code that is
+        importing it.
+    """
+    try:
+        import Utils as spec_utils
+    except ImportError:
+        raise ImportError(
+            "Importing from SpEC failed. Make sure you have pointed "
+            "'-D SPEC_ROOT' to a SpEC installation when configuring the build "
+            "with CMake."
+        )
+    if contains_commit:
+        import subprocess
+
+        spec_repo_dir = Path(spec_utils.__file__).parent.parent.parent
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", contains_commit, "HEAD"],
+            cwd=spec_repo_dir,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise ImportError(
+                "SpEC version mismatch: requested revision"
+                f" {contains_commit} is not in the SpEC repository at"
+                f" {spec_repo_dir}."
+            )


### PR DESCRIPTION
## Proposed changes

Check the SpEC version when import Python modules to make sure it's compatible (of course the real solution is to port SpEC modules into SpECTRE when we need them or factor the code into a separate repository, but that requires some work and comes with a maintenance burden keeping the two codes in sync).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To use eccentricity control, make sure you're pointing to a recent enough SpEC version (Aug 2024).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
