### PR TITLE
Add CMake Presets for mbot

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,9 @@
+{
+    "version": 7,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 28,
+        "patch": 0
+    },
+    "include": ["./support/Environments/Mbot/MbotPresets.json"]
+}

--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -113,3 +113,36 @@ if(NOT APPLE AND CHARM_VERSION VERSION_EQUAL 7.0.0 AND BUILD_PYTHON_BINDINGS)
       "Missing file ${CHARM_CHECK_FILE}")
   endif()
 endif()
+
+if (CHARM_USE_MPI)
+  if(NOT DEFINED SPECTRE_MPI_LAUNCHER)
+    get_filename_component(SPECTRE_MPI_LAUNCHER ${MPIEXEC_EXECUTABLE} NAME)
+  endif()
+  if(NOT DEFINED SPECTRE_MPI_LAUNCHER_DIR)
+    get_filename_component(SPECTRE_MPI_LAUNCHER_DIR ${MPIEXEC_EXECUTABLE}
+      DIRECTORY)
+  endif()
+  if(NOT EXISTS ${SPECTRE_MPI_LAUNCHER_DIR})
+    message(FATAL_ERROR
+      "The SPECTRE_MPI_LAUNCHER_DIR is set to ${SPECTRE_MPI_LAUNCHER_DIR} "
+      "but that directory doesn't exist.")
+  endif()
+  if(NOT EXISTS ${SPECTRE_MPI_LAUNCHER_DIR}/${SPECTRE_MPI_LAUNCHER})
+    message(FATAL_ERROR
+      "The SPECTRE_MPI_LAUNCHER is set to ${SPECTRE_MPI_LAUNCHER} but the file "
+      "${SPECTRE_MPI_LAUNCHER_DIR}/${SPECTRE_MPI_LAUNCHER} doesn't exist.")
+  endif()
+
+  file(WRITE
+    ${CMAKE_BINARY_DIR}/bin/mpirun
+    "#!/bin/sh -e\n\n${SPECTRE_MPI_LAUNCHER_DIR}/${SPECTRE_MPI_LAUNCHER} $@\n"
+  )
+  file(CHMOD ${CMAKE_BINARY_DIR}/bin/mpirun
+    PERMISSIONS
+    OWNER_EXECUTE
+    OWNER_READ
+    OWNER_WRITE
+    GROUP_READ
+    WORLD_READ
+  )
+endif()

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -35,8 +35,26 @@ set(PYTHON_EXE_COMMAND "-m spectre")
 set(PYTHON_EXEC_ENV_VARS "")
 if(BUILD_PYTHON_BINDINGS AND "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
   string(APPEND PYTHON_EXEC_ENV_VARS
-    " LD_PRELOAD=\${LD_PRELOAD}\${LD_PRELOAD:+:}${JEMALLOC_LIBRARIES}")
+    " \\\nLD_PRELOAD=\${LD_PRELOAD}\${LD_PRELOAD:+:}${JEMALLOC_LIBRARIES}")
 endif()
+# TODO: it would be good to figure out if there's a more general way to do this,
+#       and for example if we need to do it for _all_ dependencies. It probably
+#       wouldn't hurt to do it for more dependencies, e.g. MPI.
+unset(_PRELOAD_DIRS)
+foreach(_LIB ${HDF5_C_LIBRARIES})
+  get_filename_component(_LIB_DIR ${_LIB} DIRECTORY)
+  list(FIND _PRELOAD_DIRS ${_LIB_DIR} _FOUND)
+  if(${_FOUND} EQUAL -1)
+    list(APPEND
+      _PRELOAD_DIRS
+      ${_LIB_DIR}
+    )
+  endif()
+endforeach()
+string(REPLACE ";" ":" _PRELOAD_DIRS "${_PRELOAD_DIRS}")
+string(APPEND PYTHON_EXEC_ENV_VARS
+  " \\\nLD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${_PRELOAD_DIRS}")
+
 # ParaView needs specific environment variables set, e.g. 'LD_LIBRARY_PATH', but
 # they can interfere with simulations, e.g. when they point to ParaView's
 # bundled MPI which may be different to the MPI we built with. Therefore we

--- a/support/Environments/Mbot/MbotCommon.cmake
+++ b/support/Environments/Mbot/MbotCommon.cmake
@@ -1,0 +1,37 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+list(APPEND
+  CMAKE_PREFIX_PATH
+  /opt/sxs/software/gcc-11.4.0/blaze/3.8
+  /opt/sxs/software/gcc-11.4.0/boost/1.82.0
+  /opt/sxs/software/gcc-11.4.0/catch/3.5.1
+  /opt/sxs/software/gcc-11.4.0/ccache/4.9
+  /opt/sxs/software/gcc-11.4.0/charm/7.0.0
+  /opt/sxs/software/gcc-11.4.0/doxygen/1.10.0
+  /opt/sxs/software/gcc-11.4.0/fftw/3.3.10
+  /opt/sxs/software/gcc-11.4.0/google_benchmark/1.8.3
+  /opt/sxs/software/gcc-11.4.0/gsl/2.7
+  /opt/sxs/software/gcc-11.4.0/hdf5/1.12.3
+  /opt/sxs/software/gcc-11.4.0/intel/mpi/2021.11/mpi/2021.11
+  /opt/sxs/software/gcc-11.4.0/intel/mpi/2021.11/mpi/2021.11/opt/mpi/libfabric
+  /opt/sxs/software/gcc-11.4.0/jemalloc/5.3.0
+  /opt/sxs/software/gcc-11.4.0/libbacktrace/1.0
+  /opt/sxs/software/gcc-11.4.0/libxsmm/1.16.1
+  /opt/sxs/software/gcc-11.4.0/ninja/1.10.1
+  /opt/sxs/software/gcc-11.4.0/openblas/0.3.25
+  /opt/sxs/software/gcc-11.4.0/paraview/5.11.1
+  /opt/sxs/software/gcc-11.4.0/petsc/3.13.6
+  /opt/sxs/software/gcc-11.4.0/spectre-python/3.10.3
+  /opt/sxs/software/gcc-11.4.0/xsimd/12.1.1
+  /opt/sxs/software/gcc-11.4.0/yaml-cpp/0.8.0
+  )
+set(CHARM_ROOT /opt/sxs/software/gcc-11.4.0/charm/7.0.0 CACHE PATH "")
+set(USE_XSIMD ON CACHE  BOOL "")
+set(SPEC_ROOT /opt/sxs/software/gcc-11.4.0/spec-exporter/2024-02-06
+  CACHE PATH "")
+set(ENABLE_PARAVIEW ON CACHE BOOL "")
+set(BUILD_DOCS ON CACHE BOOL "")
+set(BUILD_PYTHON_BINDINGS ON CACHE BOOL "")
+set(MACHINE "Mbot" CACHE STRING "")
+set(SPECTRE_MPI_LAUNCHER "mpirun" CACHE STRING "")

--- a/support/Environments/Mbot/MbotPresets.json
+++ b/support/Environments/Mbot/MbotPresets.json
@@ -1,0 +1,39 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "MbotClang",
+            "displayName": "Mbot Clang config",
+            "generator": "Ninja",
+            "environment": {
+                "I_MPI_ROOT": "/opt/sxs/software/gcc-11.4.0/intel/mpi/2021.11/mpi/2021.11",
+                "CC": "/opt/sxs/software/gcc-11.4.0/llvm/17.0.6/bin/clang",
+                "CXX": "/opt/sxs/software/gcc-11.4.0/llvm/17.0.6/bin/clang++",
+                "FC": "/opt/sxs/software/gcc-11.4.0/llvm/17.0.6/bin/gfortran",
+                "PYTHONPATH": "/opt/sxs/software/gcc-11.4.0/python/3.10.3/lib/python3.10/site-packages/:/opt/sxs/software/gcc-11.4.0/spectre-python/3.10.3/lib/python3.10/site-packages",
+                "VIRTUAL_ENV": "/opt/sxs/software/gcc-11.4.0/spectre-python/3.10.3"
+            },
+            "toolchainFile": "./support/Environments/Mbot/MbotCommon.cmake"
+        },
+        {
+            "name": "MbotGcc",
+            "displayName": "Debug config on Mbot cluster",
+            "description": "Debug build using Ninja and clang",
+            "generator": "Ninja",
+            "environment": {
+                "I_MPI_ROOT": "/opt/sxs/software/gcc-11.4.0/intel/mpi/2021.11/mpi/2021.11",
+                "CC": "/opt/sxs/software/gcc/11.4.0/bin/gcc",
+                "CXX": "/opt/sxs/software/gcc/11.4.0/bin/g++",
+                "FC": "/opt/sxs/software/gcc/11.4.0/bin/gfortran",
+                "PYTHONPATH": "/opt/sxs/software/gcc-11.4.0/python/3.10.3/lib/python3.10/site-packages/:/opt/sxs/software/gcc-11.4.0/spectre-python/3.10.3/lib/python3.10/site-packages",
+                "VIRTUAL_ENV": "/opt/sxs/software/gcc-11.4.0/spectre-python/3.10.3"
+            },
+            "toolchainFile": "./support/Environments/Mbot/MbotCommon.cmake"
+        }
+    ]
+}


### PR DESCRIPTION
## Proposed changes

This might be a nice way to simplify using spectre on clusters.

To run CMake do, eg
```
cmake -S /path/to/source --preset=MbotClang -D CMAKE_BUILD_TYPE=Debug -D BUILD_SHARED_LIBS=ON
```
and to compile do, eg from build dir
```
cmake --build ./ -j4 -t unit-tests
```


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
