### PR TITLE
Properly extend shape map into interior region

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -11,6 +11,7 @@
 #include <pup.h>
 #include <pup_stl.h>
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
@@ -21,10 +22,12 @@
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/PupStlCpp17.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"
 
 namespace domain::CoordinateMaps::TimeDependent {
@@ -47,8 +50,7 @@ void Shape::jacobian_helper(
     gsl::not_null<tnsr::Ij<T, 3, Frame::NoFrame>*> result,
     const ylm::Spherepack::InterpolationInfo<T>& interpolation_info,
     const DataVector& extended_coefs, const std::array<T, 3>& centered_coords,
-    const T& radial_distortion, const T& one_over_radius,
-    const T& transition_func_over_radius) const {
+    const T& radial_distortion, const T& transition_func) const {
   const auto angular_gradient =
       extended_ylm_.gradient_from_coefs(extended_coefs);
 
@@ -77,92 +79,43 @@ void Shape::jacobian_helper(
 
   get<2>(cartesian_gradient) = -sin(col_thetas) * get<0>(angular_gradient);
 
-  // re-use allocation
-  auto& target_gradient_x = get<2, 0>(*result);
-  auto& target_gradient_y = get<2, 1>(*result);
-  auto& target_gradient_z = get<2, 2>(*result);
+  // re-use allocations. The specific buffers that are reused are important to
+  // avoid overwriting anything
+  std::array<T, 3> target_gradient{};
+  for (size_t i = 0; i < 3; i++) {
+    if constexpr (std::is_same_v<T, DataVector>) {
+      gsl::at(target_gradient, i)
+          .set_data_ref(make_not_null(&result->get(2, i)));
+    } else {
+      gsl::at(target_gradient, i) = result->get(2, i);
+    }
 
-  // interpolate the cartesian gradient to the thetas and phis of the
-  // `source_coords`
-  extended_ylm_.interpolate(make_not_null(&target_gradient_x),
-                            get<0>(cartesian_gradient).data(),
-                            interpolation_info);
-  extended_ylm_.interpolate(make_not_null(&target_gradient_y),
-                            get<1>(cartesian_gradient).data(),
-                            interpolation_info);
-  extended_ylm_.interpolate(make_not_null(&target_gradient_z),
-                            get<2>(cartesian_gradient).data(),
-                            interpolation_info);
+    // interpolate the cartesian gradient to the thetas and phis of the
+    // `source_coords`
+    extended_ylm_.interpolate(make_not_null(&gsl::at(target_gradient, i)),
+                              cartesian_gradient.get(i).data(),
+                              interpolation_info);
+  }
 
-  auto transition_func_over_square_radius =
-      transition_func_over_radius * one_over_radius;
-  auto transition_func_over_cube_radius =
-      transition_func_over_square_radius * one_over_radius;
-  auto transition_func_gradient_over_radius =
-      transition_func_->gradient(centered_coords) * one_over_radius;
+  // G / r
+  auto transition_func_over_radius =
+      transition_func_->operator()(centered_coords, {1});
+  auto transition_func_gradient_times_distortion =
+      transition_func_->gradient(centered_coords) * radial_distortion;
 
-  auto& target_gradient_x_times_spatial_part = target_gradient_x;
-  auto& target_gradient_y_times_spatial_part = target_gradient_y;
-  auto& target_gradient_z_times_spatial_part = target_gradient_z;
-  target_gradient_x_times_spatial_part *= transition_func_over_square_radius;
-  target_gradient_y_times_spatial_part *= transition_func_over_square_radius;
-  target_gradient_z_times_spatial_part *= transition_func_over_square_radius;
+  auto& target_gradient_times_spatial_part = target_gradient;
+  target_gradient_times_spatial_part *= transition_func_over_radius;
 
-  const auto& [x_transition_gradient_over_radius,
-               y_transition_gradient_over_radius,
-               z_transition_gradient_over_radius] =
-      transition_func_gradient_over_radius;
-  const auto& [x_centered, y_centered, z_centered] = centered_coords;
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 0; j < 3; j++) {
+      result->get(i, j) =
+          -gsl::at(centered_coords, i) *
+          (gsl::at(transition_func_gradient_times_distortion, j) +
+           gsl::at(target_gradient_times_spatial_part, j));
+    }
 
-  get<0, 0>(*result) =
-      -x_centered * ((x_transition_gradient_over_radius -
-                      x_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_x_times_spatial_part);
-  get<0, 1>(*result) =
-      -x_centered * ((y_transition_gradient_over_radius -
-                      y_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_y_times_spatial_part);
-  get<0, 2>(*result) =
-      -x_centered * ((z_transition_gradient_over_radius -
-                      z_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_z_times_spatial_part);
-  get<1, 0>(*result) =
-      -y_centered * ((x_transition_gradient_over_radius -
-                      x_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_x_times_spatial_part);
-  get<1, 1>(*result) =
-      -y_centered * ((y_transition_gradient_over_radius -
-                      y_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_y_times_spatial_part);
-  get<1, 2>(*result) =
-      -y_centered * ((z_transition_gradient_over_radius -
-                      z_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_z_times_spatial_part);
-  get<2, 0>(*result) =
-      -z_centered * ((x_transition_gradient_over_radius -
-                      x_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_x_times_spatial_part);
-  get<2, 1>(*result) =
-      -z_centered * ((y_transition_gradient_over_radius -
-                      y_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_y_times_spatial_part);
-  get<2, 2>(*result) =
-      -z_centered * ((z_transition_gradient_over_radius -
-                      z_centered * transition_func_over_cube_radius) *
-                         radial_distortion +
-                     target_gradient_z_times_spatial_part);
-
-  get<0, 0>(*result) += 1. - radial_distortion * transition_func_over_radius;
-  get<1, 1>(*result) += 1. - radial_distortion * transition_func_over_radius;
-  get<2, 2>(*result) += 1. - radial_distortion * transition_func_over_radius;
+    result->get(i, i) += 1.0 - radial_distortion * transition_func;
+  }
 }
 
 Shape::Shape(
@@ -227,8 +180,8 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
 #ifdef SPECTRE_DEBUG
   using ReturnType = tt::remove_cvref_wrap_t<T>;
   const ReturnType shift_radii =
-      radial_distortion * transition_func_->operator()(centered_coords) *
-      check_and_compute_one_over_radius(centered_coords);
+      radial_distortion *
+      transition_func_->operator()(centered_coords, std::nullopt);
   if constexpr (std::is_same_v<ReturnType, double>) {
     ASSERT(shift_radii < 1., "Coordinates mapped through the center!");
   } else {
@@ -240,9 +193,8 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
 
   return center_ +
          centered_coords *
-             (1. - radial_distortion *
-                       transition_func_->operator()(centered_coords) *
-                       check_and_compute_one_over_radius(centered_coords));
+             (1. - radial_distortion * transition_func_->operator()(
+                                           centered_coords, std::nullopt));
 }
 
 std::optional<std::array<double, 3>> Shape::inverse(
@@ -282,8 +234,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::frame_velocity(
   ylm_.interpolate_from_coefs(make_not_null(&radii_velocities), coef_derivs,
                               interpolation_info);
   return -centered_coords * radii_velocities *
-         transition_func_->operator()(centered_coords) *
-         check_and_compute_one_over_radius(centered_coords);
+         transition_func_->operator()(centered_coords, std::nullopt);
 }
 
 template <typename T>
@@ -313,7 +264,7 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
   ylm::SpherepackIterator extended_iter(l_max_ + 1, m_max_ + 1);
   ylm::SpherepackIterator iter(l_max_, m_max_);
   for (size_t l = 0; l <= l_max_; ++l) {
-    const int m_max = std::min(l, m_max_);
+    const int m_max = static_cast<int>(std::min(l, m_max_));
     for (int m = -m_max; m <= m_max; ++m) {
       iter.set(l, m);
       extended_iter.set(l, m);
@@ -328,16 +279,13 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
                                        extended_coefs, interpolation_info);
 
   using ReturnType = tt::remove_cvref_wrap_t<T>;
-  const ReturnType one_over_radius =
-      check_and_compute_one_over_radius(centered_coords);
-  const ReturnType transition_func_over_radius =
-      transition_func_->operator()(centered_coords) * one_over_radius;
+  const ReturnType transition_func =
+      transition_func_->operator()(centered_coords, std::nullopt);
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> result(
       get_size(centered_coords[0]));
 
   jacobian_helper(make_not_null(&result), interpolation_info, extended_coefs,
-                  centered_coords, radial_distortion, one_over_radius,
-                  transition_func_over_radius);
+                  centered_coords, radial_distortion, transition_func);
   return result;
 }
 
@@ -356,9 +304,8 @@ void Shape::coords_frame_velocity_jacobian(
       jac->get(i, j).destructive_resize(size);
     }
   }
-  Variables<
-      tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
-                 ::Tags::TempScalar<2>, ::Tags::TempI<0, 3, Frame::Inertial>>>
+  Variables<tmpl::list<::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
+                       ::Tags::TempI<0, 3, Frame::Inertial>>>
       temps(size);
 
   std::array<DataVector, 3> centered_coords{};
@@ -404,25 +351,20 @@ void Shape::coords_frame_velocity_jacobian(
   extended_ylm_.interpolate_from_coefs(make_not_null(&radial_distortion),
                                        extended_coefs, interpolation_info);
 
-  auto& one_over_radius = get(get<::Tags::TempScalar<1>>(temps));
-  one_over_radius = check_and_compute_one_over_radius(centered_coords);
-  auto& transition_func_over_radius = get(get<::Tags::TempScalar<2>>(temps));
-  transition_func_over_radius =
-      transition_func_->operator()(centered_coords) * one_over_radius;
+  auto& transition_func = get(get<::Tags::TempScalar<1>>(temps));
+  transition_func = transition_func_->operator()(centered_coords, std::nullopt);
   *source_and_target_coords =
-      center_ +
-      centered_coords * (1. - radial_distortion * transition_func_over_radius);
+      center_ + centered_coords * (1. - radial_distortion * transition_func);
 
   auto& radii_velocities = get<0, 1>(*jac);
   extended_ylm_.interpolate_from_coefs(make_not_null(&radii_velocities),
                                        extended_coefs_derivs,
                                        interpolation_info);
-  *frame_vel =
-      -centered_coords * radii_velocities * transition_func_over_radius;
+  *frame_vel = -centered_coords * radii_velocities * transition_func;
 
   jacobian_helper<DataVector>(jac, interpolation_info, extended_coefs,
                               centered_coords, radial_distortion,
-                              one_over_radius, transition_func_over_radius);
+                              transition_func);
 }
 
 template <typename T>
@@ -473,24 +415,6 @@ void Shape::check_size(const gsl::not_null<DataVector*>& coefs,
     // Need to multiply lambda_00 by sqrt(2/pi)
     (*coefs)[0] = M_SQRT1_2 * M_2_SQRTPI * l0m0_spherical_harmonic_coef;
   }
-}
-
-template <typename T>
-T Shape::check_and_compute_one_over_radius(
-    const std::array<T, 3>& centered_coords) const {
-  const T radius = magnitude(centered_coords);
-#ifdef SPECTRE_DEBUG
-  for (size_t i = 0; i < get_size(radius); ++i) {
-    if (get_element(radius, i) == 0.0) {
-      ERROR(
-          "The shape map does not support a (centered) point with radius zero. "
-          "All centered coordinates: "
-          << centered_coords);
-    }
-  }
-#endif  // SPECTRE_DEBUG
-
-  return 1.0 / radius;
 }
 
 bool operator==(const Shape& lhs, const Shape& rhs) {

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -98,10 +98,15 @@ namespace domain::CoordinateMaps::TimeDependent {
  *
  * \endparblock
  *
- * An additional dimensionless domain-dependent transition function
- * \f$f(r, \theta, \phi)\f$ ensures that the distortion falls off correctly to
- * zero at a certain boundary (must be a block boundary). The function \f$f(r,
- * \theta, \phi)\f$ is restricted such that
+ * An additional domain-dependent transition function
+ *
+ * \begin{equation}
+ *     G(r,\theta,\phi) = \frac{f(r,\theta,\phi)}{r}
+ * \end{equation}
+ *
+ * ensures that the distortion falls off correctly to zero at a certain boundary
+ * (must be a block boundary). The dimensionless function \f$f(r, \theta,
+ * \phi)\f$ is restricted such that
  *
  * \f{equation}{
  * 0 \leq f(r, \theta, \phi) \leq 1
@@ -123,14 +128,14 @@ namespace domain::CoordinateMaps::TimeDependent {
  * coordinates \f$\xi^i\f$ to coordinates \f$x^i\f$:
  *
  * \f{equation}{\label{eq:map_form_1}
- * x^i = \xi^i - (\xi^i - x_c^i) \frac{f(r, \theta, \phi)}{r} \sum_{lm}
+ * x^i = \xi^i - (\xi^i - x_c^i) G(r,\theta,\phi) \sum_{lm}
  * \lambda_{lm}(t)Y_{lm}(\theta, \phi).
  * \f}
  *
  * Or written another way
  *
  * \f{equation}{\label{eq:map_form_2}
- * x^i = x_c^i + (\xi^i - x_c^i) \left(1 - \frac{f(r, \theta, \phi)}{r}
+ * x^i = x_c^i + (\xi^i - x_c^i) \left(1 - G(r,\theta,\phi)
  * \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta, \phi)\right).
  * \f}
  *
@@ -148,13 +153,13 @@ namespace domain::CoordinateMaps::TimeDependent {
  * \f{equation}{
  * \xi^i = x_c^i + (x^i-x_c^i)*(r/\tilde{r}),
  * \f}
- * where \f$\tilde{r}\f$ is the radius of \f$\xi\f$, calculated by the
- * transition map. In order to compute \f$r/\tilde{r}\f$, the following equation
+ * where \f$\tilde{r}\f$ is the radius of $\vec{x}$, calculated by the
+ * transition map. In order to compute $r/\tilde{r}$, the following equation
  * must be solved
  *
  * \f{equation}{
  * \frac{r}{\tilde{r}} =
- * \frac{1}{1-f(r,\theta,\phi)\sum\lambda_{lm}(t)Y_{lm}(\theta,\phi) / r}
+ * \frac{1}{1-G(r,\theta,\phi)\sum\lambda_{lm}(t)Y_{lm}(\theta,\phi)}
  * \f}
  *
  * For more details, see
@@ -165,7 +170,7 @@ namespace domain::CoordinateMaps::TimeDependent {
  *
  * The frame velocity \f$v^i\ = dx^i / dt\f$ is calculated trivially:
  * \f{equation}{
- * v^i = - (\xi^i - x_c^i) \frac{f(r, \theta, \phi)}{r} \sum_{lm}
+ * v^i = - (\xi^i - x_c^i) G(r, \theta, \phi) \sum_{lm}
  * \dot{\lambda}_{lm}(t)Y_{lm}(\theta, \phi).
  * \f}
  *
@@ -173,18 +178,19 @@ namespace domain::CoordinateMaps::TimeDependent {
  *
  * The Jacobian is given by:
  * \f{align}{
- * \frac{\partial x^i}{\partial \xi^j} = \delta_j^i &\left( 1 - \frac{f(r,
- * \theta, \phi)}{r} \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta, \phi)\right)
- * \nonumber \\
+ * \frac{\partial x^i}{\partial \xi^j} = \delta_j^i &\left( 1 - G(r,\theta,\phi)
+ * \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta, \phi)\right) \nonumber \\
  * &- (\xi^i - x_c^i)
- * \left[\left(\frac{1}{r}\frac{\partial}{\partial \xi^j} f(r, \theta, \phi) -
- * \frac{\xi_j}{r^3} f(r, \theta, \phi)\right) \sum_{lm}
- * \lambda_{lm}(t)Y_{lm}(\theta, \phi) + \frac{f(r, \theta, \phi)}{r}
+ * \left[\frac{\partial G(r,\theta,\phi)}{\partial\xi^j} \sum_{lm}
+ * \lambda_{lm}(t)Y_{lm}(\theta, \phi) + G(r, \theta, \phi)
  * \sum_{lm} \lambda_{lm}(t) \frac{\partial}{\partial \xi^j} Y_{lm}(\theta,
  * \phi) \right].
  * \f}
  *
- * where \f$\xi_j = \xi^j\f$.
+ * where \f$\xi_j = \xi^j\f$. It should be noted that there is an additional
+ * factor of $1/r$ hidden in the $\partial/\partial\xi^j Y_{lm}(\theta, \phi)$
+ * term, so the transition function $G(r,\theta,\phi)$ must have a functional
+ * form to avoid division by zero if $r=0$.
  *
  * ### Inverse Jacobian
  *
@@ -297,8 +303,7 @@ class Shape {
       gsl::not_null<tnsr::Ij<T, 3, Frame::NoFrame>*> result,
       const ylm::Spherepack::InterpolationInfo<T>& interpolation_info,
       const DataVector& extended_coefs, const std::array<T, 3>& centered_coords,
-      const T& radial_distortion, const T& one_over_radius,
-      const T& transition_func_over_radius) const;
+      const T& radial_distortion, const T& transition_func) const;
 
   void check_size(const gsl::not_null<DataVector*>& coefs,
                   const FunctionsOfTimeMap& functions_of_time, double time,
@@ -307,10 +312,6 @@ class Shape {
   // Checks that the vector of coefficients has the right size and that the
   // monopole and dipole coefficients are zero.
   void check_coefficients(const DataVector& coefs) const;
-
-  template <typename T>
-  T check_and_compute_one_over_radius(
-      const std::array<T, 3>& centered_coords) const;
 
   friend bool operator==(const Shape& lhs, const Shape& rhs);
 };

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp
@@ -13,24 +13,29 @@
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
 /*!
- * \brief Abstract base class for the transition functions used by the
- * domain::CoordinateMaps::TimeDependent::Shape map.
+ * \brief Abstract base class for the transition function $G(r,\theta,\phi)$
+ * used by the domain::CoordinateMaps::TimeDependent::Shape map.
  *
  * \details This base class defines the required methods of a transition
- * function used by the shape map. Different domains require the shape map to
- * fall off towards the boundary in different ways. This behavior is controlled
- * by the transition function. It is also needed to find the inverse of the
- * shape map. Since the shape map preserves angles, the problem of finding its
- * inverse reduces to the 1-dimensional problem of finding the original radius
- * from the mapped radius. The mapped radius \f$\tilde{r}\f$ is related to the
- * original \f$r\f$ radius by:
- * \f{equation}{\label{eq:shape_map_radius}
- *  \tilde{r} = r (1 - \frac{f(r,\theta,\phi)}{r}
- *    \sum_{lm} \lambda_{lm}(t)Y_{lm}(\theta,\phi)),
- *  \f}
- * where $f(r,\theta,\phi) \in [0, 1]$ is the transition function (see docs of
- * domain::CoordinateMaps::TimeDependent::Shape map). Depending
- * on the format of the transition function, it should be possible to
+ * function that is defined as
+ *
+ * \begin{equation}
+ * G(r,\theta,\phi) = \frac{f(r,\theta,\phi)}{r}
+ * \end{equation}
+ *
+ * where $0 <= f(r,\theta,\phi) <= 1$. Different domains may require the shape
+ * map to fall off towards the boundary in different ways. This behavior is
+ * controlled by the transition function. It is also needed to find the inverse
+ * of the shape map. Since the shape map preserves angles, the problem of
+ * finding its inverse reduces to the 1-dimensional problem of finding the
+ * original radius from the mapped radius. The mapped radius $\tilde{r}$ is
+ * related to the original $r$ radius by:
+ * \begin{equation}
+ * \label{eq:shape_map_radius}
+ * \tilde{r} = r \left(1 - G(r,\theta,\phi)\sum_{lm}
+ *     \lambda_{lm}(t)Y_{lm}(\theta,\phi)\right),
+ * \end{equation}
+ * Depending on the format of the transition function, it should be possible to
  * analytically derive this map's inverse because it preserves angles and shifts
  * only the radius of each point. Otherwise the inverse has to be computed
  * numerically.
@@ -68,13 +73,20 @@ class ShapeMapTransitionFunction : public PUP::able {
 
   /// @{
   /*!
-   * Evaluate the transition function $f(r,\theta,\phi) \in [0, 1]$ at the
-   * Cartesian coordinates `source_coords`.
+   * Evaluate the transition function $G(r,\theta,\phi)$ at the
+   * Cartesian coordinates `source_coords` and possibly divide by the radius
+   * $r$.
+   *
+   * \details If \p one_over_radius_power has a value, then divide $G$ by $r$ to
+   * that power. This is done here because the transition function knows how to
+   * handle points in various regions of the map.
    */
   virtual double operator()(
-      const std::array<double, 3>& source_coords) const = 0;
+      const std::array<double, 3>& source_coords,
+      const std::optional<size_t>& one_over_radius_power) const = 0;
   virtual DataVector operator()(
-      const std::array<DataVector, 3>& source_coords) const = 0;
+      const std::array<DataVector, 3>& source_coords,
+      const std::optional<size_t>& one_over_radius_power) const = 0;
   /// @}
 
   /*!
@@ -88,8 +100,8 @@ class ShapeMapTransitionFunction : public PUP::able {
    * map.
    *
    * To derive the expression for this inverse, solve Eq.
-   * (\f$\ref{eq:shape_map_radius}\f$) for $r$ after substituting
-   * $f(r,\theta,\phi)$.
+   * ($\ref{eq:shape_map_radius}$) for $r$ after substituting
+   * $G(r,\theta,\phi)$.
    *
    * \param target_coords The mapped Cartesian coordinates $\tilde{x}^i$.
    * \param radial_distortion The spherical harmonic expansion
@@ -110,10 +122,10 @@ class ShapeMapTransitionFunction : public PUP::able {
       const std::array<double, 3>& source_coords) const = 0;
   virtual std::array<DataVector, 3> gradient(
       const std::array<DataVector, 3>& source_coords) const = 0;
+  /// @}
 
   virtual std::unique_ptr<ShapeMapTransitionFunction> get_clone() const = 0;
 
-  /// @}
   virtual bool operator==(const ShapeMapTransitionFunction& other) const = 0;
   virtual bool operator!=(const ShapeMapTransitionFunction& other) const = 0;
 

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
@@ -3,30 +3,43 @@
 
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp"
 
+#include <algorithm>
 #include <array>
 #include <optional>
 #include <pup.h>
+#include <type_traits>
+#include <vector>
 
+#include "DataStructures/Blaze/IntegerPow.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
 SphereTransition::SphereTransition(const double r_min, const double r_max,
-                                   const bool reverse)
-    : r_min_(r_min), r_max_(r_max) {
+                                   const bool reverse, const bool interior)
+    : r_min_(r_min), r_max_(r_max), interior_(interior) {
   if (r_min <= 0.) {
     ERROR("The minimum radius must be greater than 0 but is " << r_min);
   }
+  inverse_cube_r_min_ = 1.0 / cube(r_min_);
   if (r_max <= r_min) {
     ERROR(
         "The maximum radius must be greater than the minimum radius but "
         "r_max =  "
         << r_max << ", and r_min = " << r_min);
+  }
+  if (interior and reverse) {
+    ERROR("Cannot be reverse while also in the interior.");
   }
   a_ = -1.0 / (r_max - r_min);
   b_ = -a_ * r_max;
@@ -37,42 +50,112 @@ SphereTransition::SphereTransition(const double r_min, const double r_max,
 }
 
 double SphereTransition::operator()(
-    const std::array<double, 3>& source_coords) const {
-  return call_impl<double>(source_coords);
+    const std::array<double, 3>& source_coords,
+    const std::optional<size_t>& one_over_radius_power) const {
+  return call_impl<double>(source_coords, one_over_radius_power);
 }
+
 DataVector SphereTransition::operator()(
-    const std::array<DataVector, 3>& source_coords) const {
-  return call_impl<DataVector>(source_coords);
+    const std::array<DataVector, 3>& source_coords,
+    const std::optional<size_t>& one_over_radius_power) const {
+  return call_impl<DataVector>(source_coords, one_over_radius_power);
 }
 
 std::optional<double> SphereTransition::original_radius_over_radius(
     const std::array<double, 3>& target_coords,
     double radial_distortion) const {
   const double mag = magnitude(target_coords);
+  // If we are at the center, the radius is the same
+  if (UNLIKELY(equal_within_roundoff(mag, 0.0))) {
+    return interior_ ? std::optional{1.0} : std::nullopt;
+  }
+
+  // a_ being positive is a sentinel for reversed.
+  // If we aren't reversed, check near or within r_min_.
+  if (a_ < 0.0) {
+    if (mag + radial_distortion < (1.0 - eps_) * r_min_) {
+      if (not interior_) {
+        return std::nullopt;
+      }
+
+      const double factor =
+          1.0 / (inverse_cube_r_min_ * square(mag) * radial_distortion);
+
+      // The following variable names are defined in Numerical Recipes (3rd
+      // edition) pg 228. We choose to keep them as they appear in NR for better
+      // comparison with the book.
+
+      // Numerical Recipes (3rd edition) pg 228, eq 5.6.10
+      const double R = 0.5 * factor;
+      const double Q = factor / 3.0;
+      const bool multiple_real_roots = square(R) < cube(Q);
+
+      if (multiple_real_roots) {
+        // Numerical Recipes (3rd edition) pg 228, eqs 5.6.11 - 5.6.12
+        const double theta = acos(R / sqrt(cube(Q)));
+        std::vector<double> roots{
+            -2.0 * sqrt(Q) * cos(theta / 3.0),
+            -2.0 * sqrt(Q) * cos((theta + 2.0 * M_PI) / 3.0),
+            -2.0 * sqrt(Q) * cos((theta - 2.0 * M_PI) / 3.0)};
+
+        // Radii are positive
+        std::erase_if(roots, [](const double root) { return root < 0.0; });
+
+        // Since the root of this is the original radius over target radius, it
+        // will be of order unity and not something super large, so we take the
+        // smallest of the positive roots. If this turns out to not be robust
+        // enough we can change this.
+        return *alg::min_element(roots);
+      } else {
+        // Numerical Recipes (3rd edition) pg 228, eqs 5.6.13 - 5.6.17
+        const double A = -sgn(R) * cbrt(abs(R) + sqrt(square(R) - cube(Q)));
+        const double B = A == 0.0 ? 0.0 : Q / A;
+
+        return A + B;
+      }
+    } else if (equal_within_roundoff(mag + radial_distortion, r_min_)) {
+      // IntMid: Since the point is on the boundary, we can't tell if this is
+      // the interior or not, but either map will work.
+      return std::optional{r_min_ / (r_min_ - radial_distortion)};
+    }
+  }
+
+  // Beyond the range of validity for both reversed and not reversed
+  if ((a_ < 0.0 and mag > (1.0 + eps_) * r_max_) or
+      (a_ > 0.0 and mag < (1.0 - eps_) * r_min_)) {
+    return std::nullopt;
+  }
+
+  // No distortion means our point is the same
+  if (equal_within_roundoff(radial_distortion, 0.0)) {
+    return std::optional{1.0};
+  }
+
+  // At the f=0 boundary.
+  if ((a_ < 0.0 and equal_within_roundoff(mag, r_max_)) or
+      (a_ > 0.0 and equal_within_roundoff(mag, r_min_))) {
+    return std::optional{1.0};
+  }
+
   const double denom = 1. - radial_distortion * a_;
   // prevent zero division
-  if (equal_within_roundoff(mag, 0.) or equal_within_roundoff(denom, 0.)) {
+  if (UNLIKELY(equal_within_roundoff(denom, 0.))) {
     return std::nullopt;
   }
+
   const double original_radius = (mag + radial_distortion * b_) / denom;
 
-  // If we are within r_min and r_max, doesn't matter if we are reverse, we just
-  // return the value we calculated. If we are reverse and the point is outside
-  // r_max or we aren't reversed and the point is inside r_min, then we return a
-  // simplified formula since the transition function is 1 in this region. If
-  // the above conditions aren't true, then we are in the region where the
-  // transition function is 0, so we return 1.0. Otherwise we return nullopt.
-  if ((original_radius + eps_) >= r_min_ and
-      (original_radius - eps_) <= r_max_) {
-    return std::optional<double>{original_radius / mag};
-  } else if ((a_ > 0.0 and mag > r_max_) or (a_ < 0.0 and mag < r_min_)) {
-    // a_ being positive is a sentinel for reverse (see constructor)
-    return {1.0 + radial_distortion / mag};
-  } else if ((a_ < 0.0 and mag > r_max_) or (a_ > 0.0 and mag < r_min_)) {
-    return {1.0};
-  } else {
-    return std::nullopt;
+  // Check at or beyond f=1 boundary for reversed
+  if (a_ > 0.0) {
+    if (equal_within_roundoff(original_radius, r_max_)) {
+      return std::optional{1.0 + radial_distortion / mag};
+    } else if (original_radius > (1.0 + eps_) * r_max_) {
+      return std::nullopt;
+    }
   }
+
+  // We are within r_min and r_max and not at a boundary
+  return std::optional{original_radius / mag};
 }
 
 std::array<double, 3> SphereTransition::gradient(
@@ -85,20 +168,102 @@ std::array<DataVector, 3> SphereTransition::gradient(
 }
 
 template <typename T>
-T SphereTransition::call_impl(const std::array<T, 3>& source_coords) const {
+T SphereTransition::call_impl(
+    const std::array<T, 3>& source_coords,
+    const std::optional<size_t>& one_over_radius_power) const {
   const T mag = magnitude(source_coords);
-  check_magnitudes(mag, false);
-  // See https://github.com/sxs-collaboration/spectre/issues/6376 for why the
-  // T{} is necessary inside the clamp.
-  return blaze::clamp(T{a_ * mag + b_}, 0.0, 1.0);
+
+#ifdef SPECTRE_DEBUG
+  if (UNLIKELY(one_over_radius_power.value_or(0_st) >= 3)) {
+    for (size_t i = 0; i < get_size(source_coords[0]); i++) {
+      if (equal_within_roundoff(get_element(mag, i), 0.0)) {
+        const std::array<double, 3> point{get_element(source_coords[0], i),
+                                          get_element(source_coords[1], i),
+                                          get_element(source_coords[2], i)};
+        ERROR("Trying to divide by a point "
+              << point << " with radius zero in SphereTransition operator.");
+      }
+    }
+  }
+#endif
+
+  if (interior_) {
+    return inverse_cube_r_min_ *
+           (one_over_radius_power.value_or(0_st) < 3
+                ? T{integer_pow(mag,
+                                static_cast<int>(
+                                    2 - one_over_radius_power.value_or(0_st)))}
+                : 1.0 /
+                      integer_pow(mag, static_cast<int>(
+                                           one_over_radius_power.value() - 2)));
+  }
+
+#ifdef SPECTRE_DEBUG
+  for (size_t i = 0; i < get_size(source_coords[0]); i++) {
+    const std::array<double, 3> point{get_element(source_coords[0], i),
+                                      get_element(source_coords[1], i),
+                                      get_element(source_coords[2], i)};
+    if (UNLIKELY(get_element(mag, i) < (1.0 - eps_) * r_min_)) {
+      ERROR("SphereTransition coord " << point << " with radius "
+                                      << get_element(mag, i)
+                                      << " is within r_min of " << r_min_
+                                      << ", but the class was not constructed "
+                                         "for the interior of the sphere.");
+    } else if (UNLIKELY(get_element(mag, i) > (1.0 + eps_) * r_max_)) {
+      ERROR("SphereTransition coord "
+            << point << " with radius " << get_element(mag, i)
+            << "is beyond r_max of " << r_max_ << ".");
+    }
+  }
+#endif
+
+  T result = (a_ * mag + b_);
+  // Avoid roundoff
+  result = blaze::clamp(result, 0.0, 1.0);
+
+  return result /
+         integer_pow(
+             mag, static_cast<int>(1 + one_over_radius_power.value_or(0_st)));
 }
 
 template <typename T>
 std::array<T, 3> SphereTransition::gradient_impl(
     const std::array<T, 3>& source_coords) const {
+  // Short circuit for the interior
+  if (interior_) {
+    return 2.0 * inverse_cube_r_min_ * source_coords;
+  }
+
+#ifdef SPECTRE_DEBUG
   const T mag = magnitude(source_coords);
-  check_magnitudes(mag, true);
-  return a_ * source_coords / mag;
+
+  for (size_t i = 0; i < get_size(source_coords[0]); i++) {
+    const std::array<double, 3> point{get_element(source_coords[0], i),
+                                      get_element(source_coords[1], i),
+                                      get_element(source_coords[2], i)};
+    if (UNLIKELY(equal_within_roundoff(get_element(mag, i), 0.0))) {
+      ERROR("Trying to divide by a point "
+            << point << " with radius zero in SphereTransition gradient.");
+    }
+
+    if (UNLIKELY(get_element(mag, i) < (1.0 - eps_) * r_min_)) {
+      ERROR("SphereTransition gradient coord "
+            << point << " with radius " << get_element(mag, i)
+            << " is within r_min of " << r_min_
+            << ", but the class was not constructed for the interior of the "
+               "sphere.");
+    } else if (UNLIKELY(get_element(mag, i) > (1.0 + eps_) * r_max_)) {
+      ERROR("SphereTransition gradient coord "
+            << point << " with radius " << get_element(mag, i)
+            << "is beyond r_max of " << r_max_ << ".");
+    }
+  }
+#endif
+
+  // We can call the operator() and be sure it won't error because we did the
+  // checks here as well.
+  return source_coords *
+         (a_ / dot(source_coords, source_coords) - (*this)(source_coords, {2}));
 }
 
 bool SphereTransition::operator==(
@@ -107,9 +272,10 @@ bool SphereTransition::operator==(
     return false;
   }
   const auto& derived = dynamic_cast<const SphereTransition&>(other);
-  // no need to check `a_` and `b_` as they are uniquely determined by
-  // `r_min_` and `r_max_`.
-  return this->r_min_ == derived.r_min_ and this->r_max_ == derived.r_max_;
+  // no need to check `a_` or `b_` as they are uniquely determined by `r_min_`
+  // and `r_max_`.
+  return this->r_min_ == derived.r_min_ and this->r_max_ == derived.r_max_ and
+         this->interior_ == derived.interior_;
 }
 
 bool SphereTransition::operator!=(
@@ -117,37 +283,9 @@ bool SphereTransition::operator!=(
   return not(*this == other);
 }
 
-// if we need the point to be between the r_min and r_max, check that,
-// otherwise just check that the radius is positive
-template <typename T>
-void SphereTransition::check_magnitudes(
-    [[maybe_unused]] const T& mag,
-    [[maybe_unused]] const bool check_bounds) const {
-#ifdef SPECTRE_DEBUG
-  for (size_t i = 0; i < get_size(mag); ++i) {
-    const bool point_is_bad = check_bounds
-                                  ? (get_element(mag, i) + eps_ < r_min_ or
-                                     get_element(mag, i) - eps_ > r_max_)
-                                  : get_element(mag, i) <= 0.0;
-    if (point_is_bad) {
-      ERROR(
-          "The sphere transition map was called with bad coordinates. The "
-          "requested point has magnitude "
-          << get_element(mag, i)
-          << (check_bounds
-                  ? (MakeString{} << " which is outside the set minimum and "
-                                     "maxiumum radius. The minimum radius is "
-                                  << r_min_ << ", the maximum radius is "
-                                  << r_max_ << ".")
-                  : (MakeString{} << " <= 0.0")));
-    }
-  }
-#endif  // SPECTRE_DEBUG
-}
-
 void SphereTransition::pup(PUP::er& p) {
   ShapeMapTransitionFunction::pup(p);
-  size_t version = 0;
+  size_t version = 1;
   p | version;
   // Remember to increment the version number when making changes to this
   // function. Retain support for unpacking data written by previous versions
@@ -158,11 +296,21 @@ void SphereTransition::pup(PUP::er& p) {
     p | a_;
     p | b_;
   }
+
+  if (p.isUnpacking()) {
+    inverse_cube_r_min_ = 1.0 / cube(r_min_);
+  }
+
+  if (version >= 1) {
+    p | interior_;
+  } else if (p.isUnpacking()) {
+    interior_ = false;
+  }
 }
 
 SphereTransition::SphereTransition(CkMigrateMessage* const msg)
     : ShapeMapTransitionFunction(msg) {}
 
-PUP::able::PUP_ID SphereTransition::my_PUP_ID = 0;
+PUP::able::PUP_ID SphereTransition::my_PUP_ID = 0;  // NOLINT
 
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.hpp
@@ -14,35 +14,56 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
 /*!
  * \ingroup CoordMapsTimeDependentGroup
- * \brief A transition function that falls off as $f(r) = ar + b$.
+ * \brief A transition function that falls off as $G(r,\theta,\phi) =
+ * \frac{f(r)}{r} = \frac{ar + b}{r}$.
  *
  * \details The coefficients $a$ and $b$ are chosen so that the function $f(r) =
- * ar + b$ falls off linearly from 1 at `r_min` to 0 at `r_max`. The
+ * ar + b$ falls off linearly from 1 at \p r_min to 0 at \p r_max. The
  * coefficients are
  *
  * \f{align}{
+ * \label{eq:transition_func}
  * a &= \frac{-1}{r_{\text{max}} - r_{\text{min}}} \\
  * b &= \frac{r_{\text{max}}}{r_{\text{max}} - r_{\text{min}}} = -a
  * r_{\text{max}}
  * \f}
  *
  * If \p reverse is set to `true`, then the function falls off from 0 at
- * `r_min` to 1 at `r_max`. To do this, the coefficients are modified as
+ * \p r_min to 1 at \p r_max. To do this, the coefficients are modified as
  * $a \rightarrow -a$ and $b \rightarrow 1-b$.
  *
- * The function can be called beyond `r_min` and `r_max`. Within `r_min` the
- * value is 1, and outside `r_max` the value is 0. This is reversed if \p
- * reverse is true. However, the gradient function cannot be called with a point
- * beyond `r_min` and `r_max`.
+ * The function can be called within \p r_min, but only if \p interior is `true`
+ * and \p reverse is `false`. Within \p r_min,
+ *
+ * \begin{equation}
+ * G(r,\theta,\phi) = \frac{r^2}{r_{\text{min}}^3}.
+ * \end{equation}
+ *
+ * which is chosen to match Eq. $\ref{eq:transition_func}$ at $r_{\text{min}}$
+ * and go to 0 at $r=0$.
+ *
+ * This function cannot be called beyond \p r_max.
+ *
+ * If \p interior is `false` and if the `operator()` or `gradient()` is called
+ * with a point within \p r_min, an error will occur and
+ * `original_radius_over_radius` will return `std::nullopt`.
+ *
+ * This is a special, simplified, case of the
+ * `domain::CoordinateMaps::ShapeMapTransitionFunctions::Wedge` class where both
+ * the inner and outer surface are spheres centered on the same center.
  */
 class SphereTransition final : public ShapeMapTransitionFunction {
  public:
   explicit SphereTransition() = default;
-  SphereTransition(double r_min, double r_max, bool reverse = false);
+  SphereTransition(double r_min, double r_max, bool reverse = false,
+                   bool interior = false);
 
-  double operator()(const std::array<double, 3>& source_coords) const override;
+  double operator()(
+      const std::array<double, 3>& source_coords,
+      const std::optional<size_t>& one_over_radius_power) const override;
   DataVector operator()(
-      const std::array<DataVector, 3>& source_coords) const override;
+      const std::array<DataVector, 3>& source_coords,
+      const std::optional<size_t>& one_over_radius_power) const override;
 
   std::optional<double> original_radius_over_radius(
       const std::array<double, 3>& target_coords,
@@ -54,7 +75,7 @@ class SphereTransition final : public ShapeMapTransitionFunction {
       const std::array<DataVector, 3>& source_coords) const override;
 
   WRAPPED_PUPable_decl_template(SphereTransition);
-  explicit SphereTransition(CkMigrateMessage* const msg);
+  explicit SphereTransition(CkMigrateMessage* msg);
   void pup(PUP::er& p) override;
 
   std::unique_ptr<ShapeMapTransitionFunction> get_clone() const override {
@@ -66,19 +87,18 @@ class SphereTransition final : public ShapeMapTransitionFunction {
 
  private:
   template <typename T>
-  T call_impl(const std::array<T, 3>& source_coords) const;
+  T call_impl(const std::array<T, 3>& source_coords,
+              const std::optional<size_t>& one_over_radius_power) const;
 
   template <typename T>
   std::array<T, 3> gradient_impl(const std::array<T, 3>& source_coords) const;
 
-  // checks that the magnitudes are all between `r_min_` and `r_max_`
-  template <typename T>
-  void check_magnitudes(const T& mag, bool check_bounds) const;
-
   double r_min_{};
+  double inverse_cube_r_min_{};
   double r_max_{};
   double a_{};
   double b_{};
+  bool interior_{};
   static constexpr double eps_ = std::numeric_limits<double>::epsilon() * 100;
 };
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
@@ -3,6 +3,7 @@
 
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <limits>
@@ -10,7 +11,9 @@
 #include <pup.h>
 #include <pup_stl.h>
 #include <type_traits>
+#include <vector>
 
+#include "DataStructures/Blaze/IntegerPow.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
@@ -47,14 +50,25 @@ void Wedge::Surface::pup(PUP::er& p) {
 }
 
 size_t Wedge::axis_index(const Axis axis) {
+  if (axis == Axis::Interior or axis == Axis::None) {
+    ERROR("Cannot get the index of the axis " << axis);
+  }
   return static_cast<size_t>(abs(static_cast<int>(axis)) - 1);
 }
 
 double Wedge::axis_sgn(const Axis axis) {
+  if (axis == Axis::Interior or axis == Axis::None) {
+    ERROR("Cannot get the sign of the axis " << axis);
+  }
   return static_cast<double>(sgn(static_cast<int>(axis)));
 }
 
 std::ostream& operator<<(std::ostream& os, const Wedge::Axis axis) {
+  if (axis == Wedge::Axis::Interior or axis == Wedge::Axis::None) {
+    os << (axis == Wedge::Axis::Interior ? "Interior" : "None");
+    return os;
+  }
+
   os << (Wedge::axis_sgn(axis) < 0.0 ? "-" : "+") << Wedge::axis_index(axis);
   return os;
 }
@@ -91,6 +105,12 @@ Wedge::Wedge(const std::array<double, 3>& inner_center,
     ERROR(
         "Axis for Wedge shape map transition function cannot be 'None'. Please "
         "choose another.");
+  }
+  if (axis_ == Axis::Interior and
+      (inner_surface_.sphericity != 1.0 or reverse)) {
+    ERROR(
+        "When the axis is 'Interior', the inner surface must be a sphere "
+        "(sphericity 1.0) and reverse must be 'false'.");
   }
 }
 
@@ -313,26 +333,76 @@ std::array<T, 3> Wedge::compute_lambda_gradient(
   return result;
 }
 
-double Wedge::operator()(const std::array<double, 3>& source_coords) const {
-  return call_impl<double>(source_coords);
+double Wedge::operator()(
+    const std::array<double, 3>& source_coords,
+    const std::optional<size_t>& one_over_radius_power) const {
+  return call_impl<double>(source_coords, one_over_radius_power);
 }
 
 DataVector Wedge::operator()(
-    const std::array<DataVector, 3>& source_coords) const {
-  return call_impl<DataVector>(source_coords);
+    const std::array<DataVector, 3>& source_coords,
+    const std::optional<size_t>& one_over_radius_power) const {
+  return call_impl<DataVector>(source_coords, one_over_radius_power);
 }
 
 template <typename T>
-T Wedge::call_impl(const std::array<T, 3>& source_coords) const {
+T Wedge::call_impl(const std::array<T, 3>& source_coords,
+                   const std::optional<size_t>& one_over_radius_power) const {
   // The source coords are centered
   const T centered_coords_magnitude = magnitude(source_coords);
 
+#ifdef SPECTRE_DEBUG
+  using ::operator<<;
+  if (UNLIKELY(one_over_radius_power.value_or(0_st) >= 3)) {
+    for (size_t i = 0; i < get_size(source_coords[0]); i++) {
+      if (UNLIKELY(equal_within_roundoff(
+              get_element(centered_coords_magnitude, i), 0.0))) {
+        const std::array<double, 3> point{get_element(source_coords[0], i),
+                                          get_element(source_coords[1], i),
+                                          get_element(source_coords[2], i)};
+        ERROR("Trying to divide by a point "
+              << point << " with radius zero in Wedge transition operator.");
+      }
+    }
+  }
+#endif
+
+  // If the axis is the interior, short circuit
+  if (axis_ == Axis::Interior) {
+    return 1.0 / cube(inner_surface_.radius) *
+           (one_over_radius_power.value_or(0_st) < 3
+                ? T{integer_pow(centered_coords_magnitude,
+                                static_cast<int>(
+                                    2 - one_over_radius_power.value_or(0_st)))}
+                : 1.0 / integer_pow(centered_coords_magnitude,
+                                    static_cast<int>(
+                                        one_over_radius_power.value() - 2)));
+  }
+
+  // First check if we are at the inner center to avoid dividing by zero below
+#ifdef SPECTRE_DEBUG
+  for (size_t i = 0; i < get_size(source_coords[0]); i++) {
+    if (UNLIKELY(equal_within_roundoff(
+            get_element(centered_coords_magnitude, i), 0.0))) {
+      const std::array<double, 3> point{get_element(source_coords[0], i),
+                                        get_element(source_coords[1], i),
+                                        get_element(source_coords[2], i)};
+      ERROR(
+          "The Wedge transition was called with a point that has zero "
+          "centered "
+          "radius, but the axis isn't the 'Interior'. Point is "
+          << point << ", axis is " << axis_);
+    }
+  }
+#endif
+
+  // Now we can safely compute lambda without worrying about dividing by zero
   const T lambda =
       compute_lambda(source_coords, centered_coords_magnitude, {axis_});
 
   const T inner_distance =
       inner_surface_.sphericity == 1.0
-          ? make_with_value<T>(lambda, inner_surface_.radius)
+          ? make_with_value<T>(centered_coords_magnitude, inner_surface_.radius)
           : magnitude(compute_inner_surface_vector(
                 source_coords, centered_coords_magnitude, {axis_}));
 
@@ -340,28 +410,45 @@ T Wedge::call_impl(const std::array<T, 3>& source_coords) const {
       compute_outer_surface_vector(source_coords, lambda);
   const T outer_distance = magnitude(outer_surface_vector);
 
-  check_distances(inner_distance, outer_distance, centered_coords_magnitude,
-                  source_coords, false);
-
-  T result = (outer_distance - centered_coords_magnitude) /
-             (outer_distance - inner_distance);
-
-  if (projection_center_ != std::array{0.0, 0.0, 0.0} and
-      (min(result) < -eps_ or max(result) > 1.0 + eps_)) {
-    ERROR(
-        "The Wedge transition cannot be called inside the inner surface or "
-        "outside the outer surface if the centers of the inner and outer "
-        "surface are different. Min function value "
-        << min(result) << ", max function value " << max(result));
+  // Check if the point we were passed is within the transition region
+#ifdef SPECTRE_DEBUG
+  for (size_t i = 0; i < get_size(source_coords[0]); i++) {
+    const std::array<double, 3> point{get_element(source_coords[0], i),
+                                      get_element(source_coords[1], i),
+                                      get_element(source_coords[2], i)};
+    if (get_element(centered_coords_magnitude, i) <
+        (1.0 - eps_) * get_element(inner_distance, i)) {
+      ERROR("Wedge transition called with centered coordinate "
+            << point << " (with radius "
+            << get_element(centered_coords_magnitude, i)
+            << ") which is inside the inner surface ("
+            << get_element(inner_distance, i)
+            << ") while the axis was not 'Interior' (" << axis_ << ")");
+    } else if (get_element(centered_coords_magnitude, i) >
+               (1.0 + eps_) * get_element(outer_distance, i)) {
+      ERROR("Wedge transition called with centered coordinate "
+            << point << " (with radius "
+            << get_element(centered_coords_magnitude, i)
+            << ") which is outside the outer surface ("
+            << get_element(outer_distance, i) << ").");
+    }
   }
+#endif
 
-  result = blaze::clamp(result, 0.0, 1.0);
+  T linear_transition_func = (outer_distance - centered_coords_magnitude) /
+                             (outer_distance - inner_distance);
 
   if (reverse_) {
-    return 1.0 - result;
-  } else {
-    return result;
+    linear_transition_func = 1.0 - linear_transition_func;
   }
+
+  // Accounts for roundoff
+  linear_transition_func = blaze::clamp(linear_transition_func, 0.0, 1.0);
+
+  return linear_transition_func /
+         integer_pow(
+             centered_coords_magnitude,
+             static_cast<int>(1 + one_over_radius_power.value_or(0_st)));
 }
 
 std::optional<double> Wedge::original_radius_over_radius(
@@ -373,10 +460,20 @@ std::optional<double> Wedge::original_radius_over_radius(
   CAPTURE_FOR_ERROR(radial_distortion);
   CAPTURE_FOR_ERROR(centered_coords_magnitude);
 
-  // Couple protections that would make a point completely outside of the domain
-  // of validity for any wedge
+  // There are a number of different special cases that can (and should) be
+  // accounted for before we go to the general inverse formula. To denote all
+  // these special cases we introduce the following notation. For the 3 possible
+  // regions, we use Int (Interior), Ext (Exterior), and Mid
+  // (middle/transition). For the boundaries between these regions we'll combine
+  // them: IntMid (inner surface) and MidExt (outer surface). Then for reverse,
+  // we'll add 'R+' (e.g. R+Ext accounts for a point in the exterior region when
+  // the transition is reversed). The absence of 'R+' means this is the
+  // "regular" transition.
+
+  // Int: Protect against point that wouldn't have any radial distortion
   if (equal_within_roundoff(centered_coords_magnitude, 0.0)) {
-    return std::nullopt;
+    return (axis_ == Axis::Interior and not reverse_) ? std::optional{1.0}
+                                                      : std::nullopt;
   }
 
   const double inner_distance =
@@ -385,36 +482,94 @@ std::optional<double> Wedge::original_radius_over_radius(
           : magnitude(compute_inner_surface_vector(
                 target_coords, centered_coords_magnitude, std::nullopt));
 
+  if (not reverse_) {
+    // Check if we are within the interior region or at the inner surface. The
+    // formula is simplified at the inner surface
+    if (centered_coords_magnitude + radial_distortion <
+        (1.0 - eps_) * inner_distance) {
+      // Int: Unless the axis_ is Interior, this block doesn't contain this
+      // point
+      if (axis_ != Axis::Interior) {
+        return std::nullopt;
+      }
+
+      const double factor =
+          cube(inner_surface_.radius) /
+          (square(centered_coords_magnitude) * radial_distortion);
+
+      // The following variable names are defined in Numerical Recipes (3rd
+      // edition) pg 228. We choose to keep them as they appear in NR for better
+      // comparison with the book.
+
+      // Numerical Recipes (3rd edition) pg 228, eq 5.6.10
+      const double R = 0.5 * factor;
+      const double Q = factor / 3.0;
+      const bool multiple_real_roots = square(R) < cube(Q);
+
+      if (multiple_real_roots) {
+        // Numerical Recipes (3rd edition) pg 228, eqs 5.6.11 - 5.6.12
+        const double theta = acos(R / sqrt(cube(Q)));
+        std::vector<double> roots{
+            -2.0 * sqrt(Q) * cos(theta / 3.0),
+            -2.0 * sqrt(Q) * cos((theta + 2.0 * M_PI) / 3.0),
+            -2.0 * sqrt(Q) * cos((theta - 2.0 * M_PI) / 3.0)};
+
+        // Radii are positive
+        std::erase_if(roots, [](const double root) { return root < 0.0; });
+
+        // Since the root of this is the original radius over target radius, it
+        // will be of order unity and not something super large, so we take the
+        // smallest of the positive roots. If this turns out to not be robust
+        // enough we can change this.
+        return *alg::min_element(roots);
+      } else {
+        // Numerical Recipes (3rd edition) pg 228, eqs 5.6.13 - 5.6.17
+        const double A = -sgn(R) * cbrt(abs(R) + sqrt(square(R) - cube(Q)));
+        const double B = A == 0.0 ? 0.0 : Q / A;
+
+        return A + B;
+      }
+    } else if (equal_within_roundoff(
+                   centered_coords_magnitude + radial_distortion,
+                   inner_distance)) {
+      // IntMid: Since the point is on the boundary, we can't tell if this is
+      // the interior or not, but either map will work.
+      return std::optional{inner_distance /
+                           (inner_distance - radial_distortion)};
+    }
+  }
+
   const double lambda =
       compute_lambda(target_coords, centered_coords_magnitude, std::nullopt);
 
   const double outer_distance =
       magnitude(compute_outer_surface_vector(target_coords, lambda));
 
-  // First we check the extremal case of being outside the outer distance. We
-  // can check the outermost distance because its surface doesn't move. We can't
-  // check the innermost surface because the inner bound is the origin which we
-  // already checked above. This logic is reversed if we are in reverse mode.
-  if ((not reverse_ and (centered_coords_magnitude > outer_distance + eps_)) or
-      (reverse_ and (centered_coords_magnitude < inner_distance - eps_))) {
-    return projection_center_ == std::array{0.0, 0.0, 0.0} ? std::optional{1.0}
-                                                           : std::nullopt;
+  // Ext,R+Int: First we check the extremal cases where we are outside the
+  // transition region. If we are reversed and inside the inner surface, we
+  // return nullopt. If we aren't reversed and beyond the outer surface we
+  // return nullopt because we could still be in the interior region.
+  if ((not reverse_ and
+       centered_coords_magnitude > (1.0 + eps_) * outer_distance) or
+      (reverse_ and
+       centered_coords_magnitude < (1.0 - eps_) * inner_distance)) {
+    return std::nullopt;
   }
 
-  // If distorted radius is 0, this means the map is the identity so the radius
-  // and the original radius are equal. Also we don't want to divide by 0 below.
-  // We do this check after we check if the point is beyond the outer distance
-  // because if a point is outside the distorted frame, this function should
-  // return nullopt.
+  // All remaining cases: If distorted radius is 0, this means the map is the
+  // identity so the radius and the original radius are equal. Also we don't
+  // want to divide by 0 below. We do this check after we check if the point is
+  // beyond the outer distance because if a point is outside the distorted
+  // frame, this function should return nullopt.
   if (equal_within_roundoff(radial_distortion, 0.0)) {
     return std::optional{1.0};
   }
 
-  // If we are at the overall outer distance, then the transition function is 0
-  // so the map is again the identity so the radius and original radius are
-  // equal. We can't check the overall inner distance because that has been
-  // distorted so we don't know where the mapped inner distance is.
-  // This logic is reversed if we are in reverse mode.
+  // MidExt,R+IntMid: If we are at the overall outer distance, then the
+  // transition function is 0 so the map is again the identity so the radius and
+  // original radius are equal. We can't check the overall inner distance
+  // because that has been distorted so we don't know where the mapped inner
+  // distance is. This logic is reversed if we are in reverse mode.
   if ((not reverse_ and
        equal_within_roundoff(centered_coords_magnitude, outer_distance)) or
       (reverse_ and
@@ -437,27 +592,18 @@ std::optional<double> Wedge::original_radius_over_radius(
   const double original_radius =
       original_radius_over_radius * centered_coords_magnitude;
 
-  // If we are within the inner distance and the outer distance, doesn't matter
-  // if we are reverse, we just return the value we calculated. If the centers
-  // are the same, then if we are reverse and the point is outside the outer
-  // distance or we aren't reversed and the point is inside the inner distance,
-  // then we return a simplified formula since the transition function is 1 in
-  // this region. If the above conditions aren't true, then we are in the region
-  // where the transition function is 0, so we return 1.0. Otherwise we return
-  // nullopt.
-  if ((original_radius + eps_) >= inner_distance and
-      (original_radius - eps_) <= outer_distance) {
-    return std::optional{original_radius_over_radius};
-  } else if (projection_center_ == std::array{0.0, 0.0, 0.0}) {
-    if ((not reverse_ and original_radius < inner_distance) or
-        (reverse_ and original_radius > outer_distance)) {
-      return std::optional{1.0 + radial_distortion / centered_coords_magnitude};
-    } else {
-      return std::optional{1.0};
+  // R+MidExt,R+Ext: Extremal transition at outer boundary for reverse has a
+  // simplified formula.
+  if (reverse_) {
+    if (equal_within_roundoff(original_radius, outer_distance)) {
+      return {1.0 + radial_distortion / centered_coords_magnitude};
+    } else if (original_radius > (1.0 + eps_) * outer_distance) {
+      return std::nullopt;
     }
-  } else {
-    return std::nullopt;
   }
+
+  // Mid,R+Mid
+  return {original_radius_over_radius};
 }
 
 std::array<double, 3> Wedge::gradient(
@@ -474,6 +620,26 @@ std::array<T, 3> Wedge::gradient_impl(
     const std::array<T, 3>& source_coords) const {
   // The source coords are centered
   const T centered_coords_magnitude = magnitude(source_coords);
+
+  // Short circuit if we are in the interior
+  if (axis_ == Axis::Interior) {
+    return 2.0 / cube(inner_surface_.radius) * source_coords;
+  }
+
+// First check if we are at the inner center to avoid dividing by zero below
+#ifdef SPECTRE_DEBUG
+  for (size_t i = 0; i < get_size(centered_coords_magnitude); i++) {
+    if (UNLIKELY(equal_within_roundoff(
+            get_element(centered_coords_magnitude, i), 0.0))) {
+      ERROR(
+          "The gradient of the wedge transition was called with a point that "
+          "has zero centered radius, but the axis isn't the 'Interior'. Point "
+          "is "
+          << inner_surface_.center << ", axis is " << axis_);
+    }
+  }
+#endif
+
   const T one_over_centered_coords_magnitude = 1.0 / centered_coords_magnitude;
 
   const T lambda =
@@ -489,13 +655,35 @@ std::array<T, 3> Wedge::gradient_impl(
       compute_outer_surface_vector(source_coords, lambda);
   const T outer_distance = magnitude(outer_surface_vector);
 
-  check_distances(inner_distance, outer_distance, centered_coords_magnitude,
-                  source_coords, true);
+// Check if the point we were passed is within the transition region
+#ifdef SPECTRE_DEBUG
+  for (size_t i = 0; i < get_size(centered_coords_magnitude); i++) {
+    const std::array<double, 3> point{get_element(source_coords[0], i),
+                                      get_element(source_coords[1], i),
+                                      get_element(source_coords[2], i)};
+    if (get_element(centered_coords_magnitude, i) <
+        (1.0 - eps_) * get_element(inner_distance, i)) {
+      ERROR("Wedge transition called with centered coordinate "
+            << point << " (with radius "
+            << get_element(centered_coords_magnitude, i)
+            << ") which is inside the inner surface ("
+            << get_element(inner_distance, i)
+            << ") while the axis was not 'Interior' (" << axis_ << ")");
+    } else if (get_element(centered_coords_magnitude, i) >
+               (1.0 + eps_) * get_element(outer_distance, i)) {
+      ERROR("Wedge transition called with centered coordinate "
+            << point << " (with radius "
+            << get_element(centered_coords_magnitude, i)
+            << ") which is outside the outer surface ("
+            << get_element(outer_distance, i) << ").");
+    }
+  }
+#endif
 
   // This can only be called if the projection center is 0, otherwise this
   // formula won't work. And if the projection center isn't 0, then we require
-  // that the sphericity of the inner surface is 1, so we ASSERT that here as
-  // well
+  // that the sphericity of the inner surface is 1, so we ASSERT that here
+  // as well
   const auto inner_surface_gradient = [&]() -> std::array<T, 3> {
     using ::operator<<;
     ASSERT((projection_center_ == std::array{0.0, 0.0, 0.0}),
@@ -512,11 +700,9 @@ std::array<T, 3> Wedge::gradient_impl(
 
     const T& axis_coord = gsl::at(source_coords, axis_idx);
 
-    const double factor =
-        inner_surface_.radius * (1.0 - inner_surface_.sphericity) / sqrt(3.0);
-
     std::array<T, 3> grad = make_array<3, T>(
-        factor * one_over_centered_coords_magnitude / abs(axis_coord));
+        inner_surface_.radius * (1.0 - inner_surface_.sphericity) / sqrt(3.0) *
+        one_over_centered_coords_magnitude / abs(axis_coord));
 
     // Dividing by axis_coord here takes care of the sgn(axis_coord) that would
     // have been necessary
@@ -544,7 +730,9 @@ std::array<T, 3> Wedge::gradient_impl(
             source_coords * one_over_centered_coords_magnitude -
             (outer_distance - centered_coords_magnitude) * outer_gradient *
                 one_over_distance_difference) *
-           one_over_distance_difference * (reverse_ ? -1.0 : 1.0);
+               one_over_distance_difference *
+               one_over_centered_coords_magnitude * (reverse_ ? -1.0 : 1.0) -
+           source_coords * (*this)(source_coords, {2});
   } else {
     const std::array<T, 3> inner_gradient = inner_surface_gradient();
 
@@ -553,7 +741,9 @@ std::array<T, 3> Wedge::gradient_impl(
             (outer_distance - centered_coords_magnitude) *
                 (outer_gradient - inner_gradient) *
                 one_over_distance_difference) *
-           one_over_distance_difference * (reverse_ ? -1.0 : 1.0);
+               one_over_distance_difference *
+               one_over_centered_coords_magnitude * (reverse_ ? -1.0 : 1.0) -
+           source_coords * (*this)(source_coords, {2});
   }
 }
 
@@ -574,43 +764,6 @@ bool Wedge::operator==(const ShapeMapTransitionFunction& other) const {
 
 bool Wedge::operator!=(const ShapeMapTransitionFunction& other) const {
   return not(*this == other);
-}
-
-template <typename T>
-void Wedge::check_distances(
-    [[maybe_unused]] const T& inner_distance,
-    [[maybe_unused]] const T& outer_distance,
-    [[maybe_unused]] const T& centered_coords_magnitude,
-    [[maybe_unused]] const std::array<T, 3>& source_coords,
-    [[maybe_unused]] const bool check_bounds) const {
-#ifdef SPECTRE_DEBUG
-  const T result = (outer_distance - centered_coords_magnitude) /
-                   (outer_distance - inner_distance);
-  for (size_t i = 0; i < get_size(centered_coords_magnitude); ++i) {
-    const bool point_is_bad =
-        check_bounds ? (get_element(result, i) + eps_ < 0.0 or
-                        get_element(result, i) - eps_ > 1.0)
-                     : get_element(centered_coords_magnitude, i) <= 0.0;
-    if (point_is_bad) {
-      ERROR(
-          "The Wedge transition map was called with bad coordinates.\nThe "
-          "requested (centered) point is "
-          << source_coords << "\nThe requested (centered) point has radius "
-          << get_element(centered_coords_magnitude, i)
-          << "\nThe inner surface has center, "
-             "radius, and sphericity (c="
-          << inner_surface_.center << ",r=" << inner_surface_.radius
-          << ",s=" << inner_surface_.sphericity
-          << ")\nThe outer surface has center, radius, and sphericity (c="
-          << outer_surface_.center << ",r=" << outer_surface_.radius
-          << ",s=" << outer_surface_.sphericity
-          << ")\nThe distance to the inner surface is "
-          << get_element(inner_distance, i)
-          << "\nThe distance to the outer surface is "
-          << get_element(outer_distance, i));
-    }
-  }
-#endif
 }
 
 namespace {

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.hpp
@@ -16,16 +16,23 @@
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 /*!
- * \brief A transition function that falls off linearly from an inner surface of
- * a wedge to an outer surface of a wedge. Meant to be used in
- * `domain::CoordinateMaps::Wedge` blocks.
+ * \brief A transition function $G(r,\theta,\phi)$ with $f(r,\theta,\phi)$ that
+ * falls off linearly from an inner surface of a wedge to an outer surface of a
+ * wedge. Meant to be used in `domain::CoordinateMaps::Wedge` blocks.
  *
  * \details The functional form of this transition is
  *
  * \begin{equation}
- * f(r, \theta, \phi) = \frac{D_{\text{out}}(r, \theta, \phi) -
- * r}{D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)},
- * \label{eq:transition_func}
+ *     G(r,\theta,\phi) = \frac{f(r,\theta,\phi)}{r}
+ *     \label{eq:transition_func}
+ * \end{equation}
+ *
+ * where
+ *
+ * \begin{equation}
+ *     f(r, \theta, \phi) = \frac{D_{\text{out}}(r, \theta, \phi) -
+ *     r}{D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)},
+ * \label{eq:linear_transition_func}
  * \end{equation}
  *
  * where, in general,
@@ -37,22 +44,6 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * \label{eq:distance}
  * \end{equation}
  *
- * \note If \p reverse is true, then the functional form of the transition is
- * actually
- * \begin{equation}
- * f(r, \theta, \phi) = 1 - \frac{D_{\text{out}}(r, \theta, \phi) -
- * r}{D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)} =
- * \frac{r - \frac{D_{\text{in}}(r, \theta, \phi)}
- * {D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)}.
- * \label{eq:transition_func_reverse}
- * \end{equation}
- *
- * The function is also defined beyond $D_{\text{in}}(r, \theta, \phi)$ and
- * $D_{\text{out}}(r, \theta, \phi)$, but slighly differently. Within
- * $D_{\text{in}}(r, \theta, \phi)$, $f(r, \theta, \phi) = 1$ and beyond
- * $D_{\text{out}}(r, \theta, \phi)$, $f(r, \theta, \phi) = 0$. If \p reverse is
- * true, this logic is flipped.
- *
  * Here, $s$ is the sphericity of the surface which goes from 0 (flat) to 1
  * (spherical), $R$ is the radius of the spherical surface, $\text{out}$ is the
  * outer surface, and $\text{in}$ is the inner surface. If the sphericity is 1,
@@ -61,18 +52,48 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * `domain::CoordinateMaps::Wedge` for more of an explanation of these boundary
  * surfaces and their sphericities.
  *
+ * \note If \p reverse is true, then the functional form of the transition is
+ * actually
+ * \begin{equation}
+ * f(r, \theta, \phi) = 1 - \frac{D_{\text{out}}(r, \theta, \phi) -
+ * r}{D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)} =
+ * \frac{r - D_{\text{in}}(r, \theta, \phi)}
+ * {D_{\text{out}}(r, \theta, \phi) - D_{\text{in}}(r, \theta, \phi)}.
+ * \label{eq:linear_transition_func_reverse}
+ * \end{equation}
+ *
+ * \parblock
+ *
  * \note Because the shape map distorts only radii and does not affect angles,
  * $D$ is not a function of $r$ so we have that $D(r,\theta,\phi) =
  * D(\theta, \phi)$.
+ *
+ * \endparblock
+ *
+ * The transition function is also defined within $D_{\text{in}}(r, \theta,
+ * \phi)$ if the axis is `Axis::Interior`. Within $D_{\text{in}}(r, \theta,
+ * \phi)$, the transition function is
+ *
+ * \begin{equation}
+ *     \label{eq:interior_transition_func}
+ *     G(r,\theta,\phi) = \frac{r^2}{D_{\text{in}}(r, \theta, \phi)^3} =
+ *     \frac{r^3}{R_0^3}
+ * \end{equation}
+ *
+ * and none of the vector formulation is necessary. This is chosen to match Eq.
+ * $\ref{eq:transition_func}$ at $D_{\text{in}}(r, \theta, \phi)$ and go to 0 at
+ * $r=0$. The second equality is explained by one of the following bullets.
  *
  * There are several assumptions made for this mapping:
  *
  * - The coordinates $r, \theta, \phi$ are assumed to be from the center of the
  *   inner surface, not the center of the computational domain.
  * - The wedges are concentric. (see the constructor) This is also enforced by
- *   the center of the inner surface being within the outer surface
+ *   the center of the inner surface being within the outer surface.
  * - If the centers of the inner and outer surface are different, then the inner
- *   sphericity must be 1 (i.e. $D_{\text{in}} = R$)
+ *   sphericity must be 1 (i.e. $D_{\text{in}} = R$).
+ * - If the axis is `Axis::Interior`, then the inner sphericity must be 1 and
+ *    \p reverse must be false.
  * - The $\max$ in the denominator of $\ref{eq:distance}$ can be simplified a
  *   bit to $\max(|x|, |y|, |z|)/r$. It was written the other way in
  *   $\ref{eq:distance}$ to emphasize that $D$ has no radial dependence.
@@ -92,9 +113,9 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * intersects the outer surface along the same ray as $\vec x - \vec P$. Any
  * cube has a side length of $2L$.
  *
- * In this way, we can reformulate Eq. $\ref{eq:transition_func}$ as
+ * In this way, we can reformulate Eq. $\ref{eq:linear_transition_func}$ as
  *
- * \begin{equation}\label{eq:transition_func_vec}
+ * \begin{equation}\label{eq:linear_transition_func_vec}
  *     f(\vec x) = \frac{|\vec x_1 - \vec P| - r}{|\vec x_1 - \vec P| - |\vec
  * x_0 - \vec P|}
  * \end{equation}
@@ -224,10 +245,22 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  *
  * \begin{equation}
  * \frac{r}{\tilde{r}} =
- * \frac{1}{1-\frac{f(r,\theta,\phi)}{r}\Sigma(\theta,\phi)}
+ * \frac{1}{1-G(r)\Sigma(\theta,\phi)}
  * \end{equation}
  *
- * After plugging in the transition and solving, we get
+ * If the axis is `Axis::Interior`, this formula becomes (after simplification
+ * and because the inner surface must be spherical)
+ *
+ * \begin{equation}
+ *    0 = \left(\frac{r}{\tilde{r}}\right)^3 - \left(\frac{r}{\tilde{r}}\right)
+ *    \frac{R_0^3}{\tilde{r}^2\Sigma(\theta,\phi)} +
+ *    \frac{R_0^3}{\tilde{r}^2\Sigma(\theta,\phi)}
+ * \end{equation}
+ *
+ * This is a special case of a cubic root, so we use the method outlined in
+ * \cite NumericalRecipes on pg 228.
+ *
+ * For other axes, after plugging in $f(r,\theta,\phi)/r$ and solving, we get
  *
  * \begin{equation}
  * \frac{r}{\tilde{r}} = \frac{1 + \frac{|\vec x_1 - \vec P|\Sigma(\theta,
@@ -243,26 +276,21 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  * \parblock
  *
  * \note If \p reverse is true, then the value multiplying $\Sigma$ in the
- * numerator is now $-|\vec x_0 - \vec P|$ and in the denomintor $\Sigma$ picks
+ * numerator is now $-|\vec x_0 - \vec P|$ and in the denominator $\Sigma$ picks
  * up a minus sign factor.
- *
- * \endparblock
- *
- * \parblock
- *
- * \note If we are inside the inner surface, then this simplifies to
- * \begin{equation}
- * \frac{r}{\tilde{r}} = 1 + \frac{\Sigma(\theta, \phi)}{\tilde{r}}
- * \end{equation}
- * because $f(r, \theta, \phi) = 1$. If we are outside the outer surface, then
- * $r/\tilde{r} = 1$ because $f(r, \theta, \phi) = 0$. If \p reverse is true,
- * this logic is reversed.
  *
  * \endparblock
  *
  * ## Gradient
  *
  * The cartesian gradient of the transition function is
+ *
+ * \begin{equation}
+ *     \frac{\partial G}{\partial x_i} = \frac{1}{r}\frac{\partial f}{\partial
+ *     \xi^i} - \frac{f \xi_i}{r^3}
+ * \end{equation}
+ *
+ * where
  *
  * \begin{equation}
  * \frac{\partial f}{\partial x_i} = \frac{\frac{\partial
@@ -275,14 +303,14 @@ namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
  *
  * \note If \p reverse is true, the gradient picks up an overall factor of -1.0.
  *
- * \parblock
+ * If the axis is `Axis::Interior`, then the gradient is
  *
- * \note The gradient is not supported if points lie beyond the inner or outer
- * surface.
+ * \begin{equation}
+ * \frac{\partial G}{\partial x_i} = \frac{2(x_i-P_i)}{R_0^3}
+ * \end{equation}
  *
- * \endparblock
- *
- * Therefore, we need to compute the gradients of $\vec x_0$ and $\vec x_1$.
+ * For the other axes, we need to compute the gradients of $\vec x_0$ and $\vec
+ * x_1$.
  *
  * ### Gradient of vector to inner surface
  *
@@ -397,15 +425,18 @@ class Wedge final : public ShapeMapTransitionFunction {
   /*!
    * \brief Class to represent the direction of the wedge relative to the outer
    * center.
+   *
+   * \details \p Interior means within inner surface.
    */
   enum class Axis : int {
+    Interior = 4,
     PlusZ = 3,
     MinusZ = -3,
     PlusY = 2,
     MinusY = -2,
     PlusX = 1,
     MinusX = -1,
-    None = 0
+    None = 0,
   };
 
   friend std::ostream& operator<<(std::ostream& os, Axis axis);
@@ -425,7 +456,8 @@ class Wedge final : public ShapeMapTransitionFunction {
    * the outermost wedge.
    *
    * \note If \p inner_center and \p outer_center are different, then
-   * \p inner_sphericity must be 1.0.
+   * \p inner_sphericity must be 1.0. if the \p axis is `Axis::Interior`, then
+   * \p inner_sphericity must be 1.0 and \p reverse must be false.
    *
    * \param inner_center Center of the inner surface
    * \param inner_radius Inner radius of innermost wedge
@@ -434,7 +466,7 @@ class Wedge final : public ShapeMapTransitionFunction {
    * \param outer_radius Outermost radius of outermost wedge
    * \param outer_sphericity Sphericity of outermost surface of outermost wedge
    * \param axis The direction that this wedge is in.
-   * \param reverse If true, the transition function will be 0 at the inner
+   * \param reverse If true, the function $f$ will be 0 at the inner
    * boundary and 1 at the outer boundary (useful for deforming star surfaces).
    * Otherwise, it will be 1 at the inner boundary and 0 at the outer boundary
    * (useful for deforming black hole excision surfaces).
@@ -444,9 +476,12 @@ class Wedge final : public ShapeMapTransitionFunction {
         double outer_radius, double outer_sphericity, Axis axis,
         bool reverse = false);
 
-  double operator()(const std::array<double, 3>& source_coords) const override;
+  double operator()(
+      const std::array<double, 3>& source_coords,
+      const std::optional<size_t>& one_over_radius_power) const override;
   DataVector operator()(
-      const std::array<DataVector, 3>& source_coords) const override;
+      const std::array<DataVector, 3>& source_coords,
+      const std::optional<size_t>& one_over_radius_power) const override;
 
   std::optional<double> original_radius_over_radius(
       const std::array<double, 3>& target_coords,
@@ -470,7 +505,8 @@ class Wedge final : public ShapeMapTransitionFunction {
 
  private:
   template <typename T>
-  T call_impl(const std::array<T, 3>& source_coords) const;
+  T call_impl(const std::array<T, 3>& source_coords,
+              const std::optional<size_t>& one_over_radius_power) const;
 
   template <typename T>
   std::array<T, 3> gradient_impl(const std::array<T, 3>& source_coords) const;
@@ -520,8 +556,8 @@ class Wedge final : public ShapeMapTransitionFunction {
                        const std::array<T, 3>& source_coords,
                        bool check_bounds) const;
 
-  Surface inner_surface_{};
-  Surface outer_surface_{};
+  Surface inner_surface_;
+  Surface outer_surface_;
   std::array<double, 3> projection_center_{};
   Axis axis_{};
   bool reverse_{false};

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -40,6 +40,7 @@
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Options/ParseError.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -713,20 +714,22 @@ Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
         time_dependent_options_
             ->grid_to_inertial_map<domain::ObjectLabel::None>(std::nullopt,
                                                               true);
-    // Inside the excision sphere we add the grid to inertial map from the
-    // envelope. This allows the center of the excisions/horizons to be mapped
-    // properly to the inertial frame.
+    // Inside the excision sphere we add a special grid to inertial map that can
+    // be evaluated at the center. This allows the center of the
+    // excisions/horizons to be mapped properly to the inertial frame.
     if (is_excised_a_ and
         grid_to_inertial_block_maps[number_of_blocks_ - 1] != nullptr) {
       domain.inject_time_dependent_map_for_excision_sphere(
           "ExcisionSphereA",
-          grid_to_inertial_block_maps[final_block_envelope]->get_clone());
+          time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::A>(
+              {0}, true, true));
     }
     if (is_excised_b_ and
         grid_to_inertial_block_maps[number_of_blocks_ - 1] != nullptr) {
       domain.inject_time_dependent_map_for_excision_sphere(
           "ExcisionSphereB",
-          grid_to_inertial_block_maps[final_block_envelope]->get_clone());
+          time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::B>(
+              {0}, true, true));
     }
 
     const size_t first_block_object_B = use_single_block_a_ ? 1 : 12;

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -30,6 +30,7 @@
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
 #include "Options/ParseError.hpp"
@@ -926,9 +927,13 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
     // outer shell. This allows the center of the excisions/horizons to be
     // mapped properly to the inertial frame.
     domain.inject_time_dependent_map_for_excision_sphere(
-        "ExcisionSphereA", grid_to_inertial_block_maps[0]->get_clone());
+        "ExcisionSphereA",
+        time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::A>(
+            true, true, true));
     domain.inject_time_dependent_map_for_excision_sphere(
-        "ExcisionSphereB", grid_to_inertial_block_maps[0]->get_clone());
+        "ExcisionSphereB",
+        time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::B>(
+            true, true, true));
 
     // Because we require that both objects have inner shells, object A
     // corresponds to blocks 46-59 and object B corresponds to blocks 60-73.

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -383,6 +383,13 @@ Domain<3> Sphere::create_domain() const {
             hard_coded_options.grid_to_inertial_map(
                 block_number, is_outer_shell, is_inner_cube);
       }
+
+      // Inject time dependent map into the excision
+      if (not fill_interior_ and which_wedges_ == ShellWedges::All) {
+        domain.inject_time_dependent_map_for_excision_sphere(
+            "ExcisionSphere",
+            hard_coded_options.grid_to_inertial_map(0, false, true));
+      }
     } else {
       const auto& time_dependence = std::get<std::unique_ptr<
           domain::creators::time_dependence::TimeDependence<3>>>(

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
@@ -372,6 +372,20 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
                                       std::move(transition_func),
                                       gsl::at(shape_names, i),
                                       gsl::at(size_names, i)};
+
+      transition_func =
+          std::make_unique<domain::CoordinateMaps::ShapeMapTransitionFunctions::
+                               SphereTransition>(radii[0], radii[1], false,
+                                                 true);
+
+      // Last two are the interior maps
+      gsl::at(shape_maps_, shape_maps_.size() - 2 + i) =
+          Shape{gsl::at(object_centers, i),
+                initial_l_max,
+                initial_l_max,
+                std::move(transition_func),
+                gsl::at(shape_names, i),
+                gsl::at(size_names, i)};
     } else {
       // These must match the order of orientations_for_sphere_wrappings() in
       // DomainHelpers.hpp. The values must match that of Wedge::Axis
@@ -437,6 +451,21 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
                                                     std::move(transition_func),
                                                     gsl::at(shape_names, i),
                                                     gsl::at(size_names, i)};
+      }
+
+      // Add the interior maps if we are excised (aka not filled)
+      if (not filled) {
+        transition_func = std::make_unique<Wedge>(
+            inner_center, inner_radius, inner_sphericity, outer_center,
+            outer_radius, outer_sphericity, Wedge::Axis::Interior);
+
+        gsl::at(gsl::at(shape_maps_, i), gsl::at(shape_maps_, i).size() - 1) =
+            Shape{inner_center,
+                  initial_l_max,
+                  initial_l_max,
+                  std::move(transition_func),
+                  gsl::at(shape_names, i),
+                  gsl::at(size_names, i)};
       }
     }
   }
@@ -565,7 +594,7 @@ typename TimeDependentMapOptions<IsCylindrical>::template MapType<
     Frame::Grid, Frame::Inertial>
 TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
     const IncludeDistortedMapType& include_distorted_map,
-    const bool use_rigid_map) const {
+    const bool use_rigid_map, const bool return_excision_map) const {
   bool block_has_shape_map = Object == domain::ObjectLabel::A
                                  ? shape_options_A_.has_value()
                                  : shape_options_B_.has_value();
@@ -573,6 +602,12 @@ TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
   if constexpr (IsCylindrical) {
     block_has_shape_map = block_has_shape_map and include_distorted_map;
   } else if (block_has_shape_map) {
+    if (return_excision_map and include_distorted_map.value_or(6) >= 6) {
+      ERROR(
+          "If 'return_excision_map' is true, then 'include_distorted_map' must "
+          "be less than 6.");
+    }
+
     const bool transition_ends_at_cube =
         Object == domain::ObjectLabel::A
             ? time_dependent_options::
@@ -583,7 +618,8 @@ TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
                       shape_options_B_.value());
     block_has_shape_map =
         block_has_shape_map and include_distorted_map.has_value() and
-        (transition_ends_at_cube or include_distorted_map.value() < 6);
+        (transition_ends_at_cube or include_distorted_map.value() < 6 or
+         return_excision_map);
   }
 
   const auto& rot_scale_trans = rot_scale_trans_map_.has_value()
@@ -596,7 +632,9 @@ TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
     const size_t index = get_index(Object);
     const std::optional<Shape>* shape{};
     if constexpr (IsCylindrical) {
-      shape = &gsl::at(shape_maps_, index);
+      shape = &gsl::at(shape_maps_, return_excision_map
+                                        ? shape_maps_.size() - 2 + index
+                                        : index);
     } else {
       if (include_distorted_map.value() >= 12) {
         ERROR(
@@ -605,7 +643,9 @@ TimeDependentMapOptions<IsCylindrical>::grid_to_inertial_map(
             << include_distorted_map.value());
       }
       shape =
-          &gsl::at(gsl::at(shape_maps_, index), include_distorted_map.value());
+          &gsl::at(gsl::at(shape_maps_, index),
+                   return_excision_map ? gsl::at(shape_maps_, index).size() - 1
+                                       : include_distorted_map.value());
     }
     ASSERT(shape->has_value(), "Shape map was requested but not built.");
     // The skew map is only applied within the envelope, which is also where we
@@ -677,7 +717,7 @@ template class TimeDependentMapOptions<false>;
                                                          Frame::Inertial>    \
   TimeDependentMapOptions<ISCYL(data)>::grid_to_inertial_map<OBJECT(data)>(  \
       const TimeDependentMapOptions<ISCYL(data)>::IncludeDistortedMapType&,  \
-      const bool) const;
+      const bool, const bool) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (true, false),
                         (domain::ObjectLabel::A, domain::ObjectLabel::B,

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
@@ -329,12 +329,18 @@ struct TimeDependentMapOptions {
    * `Shape` (with size FunctionOfTime) and `RotScaleTrans` map. If
    * not, there will only be a `RotScaleTrans` map.
    *
+   * If \p return_excision_map is true, this will use a special shape map within
+   * the excision. Also if \p return_excision_map is true, then
+   * \p include_distorted_map must be either 'true' (if \p IsCylindrical is
+   * true) or have a value less than 6, but it doesn't matter what value
+   * (because inside the excision isn't a specific block).
+   *
    * \see IncludeDistortedMapType
    */
   template <domain::ObjectLabel Object>
   MapType<Frame::Grid, Frame::Inertial> grid_to_inertial_map(
-      const IncludeDistortedMapType& include_distorted_map,
-      bool use_rigid_map) const;
+      const IncludeDistortedMapType& include_distorted_map, bool use_rigid_map,
+      bool return_excision_map = false) const;
 
   // Names are public because they need to be used when constructing maps in the
   // BCO domain creators themselves
@@ -366,8 +372,8 @@ struct TimeDependentMapOptions {
   std::optional<std::pair<RotScaleTrans, RotScaleTrans>> rot_scale_trans_map_{};
   std::optional<Skew> skew_map_{};
   using ShapeMapType =
-      tmpl::conditional_t<IsCylindrical, std::array<std::optional<Shape>, 2>,
-                          std::array<std::array<std::optional<Shape>, 12>, 2>>;
+      tmpl::conditional_t<IsCylindrical, std::array<std::optional<Shape>, 4>,
+                          std::array<std::array<std::optional<Shape>, 13>, 2>>;
   ShapeMapType shape_maps_{};
 
   // helper function that creates the functions of time used by the worldtube

--- a/src/Domain/Creators/TimeDependentOptions/Sphere.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Sphere.cpp
@@ -168,6 +168,15 @@ void TimeDependentMapOptions::build_maps(
       shape_maps_[0] =
           ShapeMap{center,     l_max,    l_max, std::move(transition_func),
                    shape_name, size_name};
+
+      // Interior map
+      transition_func =
+          std::make_unique<domain::CoordinateMaps::ShapeMapTransitionFunctions::
+                               SphereTransition>(
+              inner_radius, shape_outer_radius, false, true);
+      shape_maps_[1] =
+          ShapeMap{center,     l_max,    l_max, std::move(transition_func),
+                   shape_name, size_name};
     }
   }
 
@@ -250,12 +259,12 @@ TimeDependentMapOptions::grid_to_distorted_map(const size_t block_number,
 }
 
 TimeDependentMapOptions::MapType<Frame::Grid, Frame::Inertial>
-TimeDependentMapOptions::grid_to_inertial_map(const size_t block_number,
-                                              const bool is_outer_shell,
-                                              const bool is_inner_cube) const {
+TimeDependentMapOptions::grid_to_inertial_map(
+    const size_t block_number, const bool is_outer_shell,
+    const bool is_central_region) const {
   const bool block_has_shape_map = shape_map_options_.has_value() and
                                    block_number < (filled_ ? 12 : 6) and
-                                   not is_inner_cube;
+                                   not(is_central_region and filled_);
   if (block_has_shape_map) {
     // If the interior is not filled we use the SphereTransition function and
     // build only one shape map at index 0 (see `build_maps` above). Otherwise,
@@ -263,7 +272,8 @@ TimeDependentMapOptions::grid_to_inertial_map(const size_t block_number,
     // direction, so we have to use the block number here to get the correct
     // shape map.
     return std::make_unique<GridToInertialComposition>(
-        gsl::at(shape_maps_, filled_ ? block_number : 0),
+        gsl::at(shape_maps_,
+                filled_ ? block_number : (is_central_region ? 1 : 0)),
         inner_rot_scale_trans_map_);
   } else if (is_outer_shell and transition_rot_scale_trans_) {
     return std::make_unique<GridToInertialSimple>(

--- a/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
@@ -183,7 +183,7 @@ struct TimeDependentMapOptions {
    * transition to zero.
    */
   MapType<Frame::Grid, Frame::Inertial> grid_to_inertial_map(
-      size_t block_number, bool is_outer_shell, bool is_inner_cube) const;
+      size_t block_number, bool is_outer_shell, bool is_central_region) const;
 
   /*!
    * \brief Whether or not the distorted frame is being used. I.e. whether or

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Framework/TestHelpers.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
@@ -14,6 +15,8 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
 
 namespace domain::CoordinateMaps::ShapeMapTransitionFunctions {
 
@@ -29,40 +32,79 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
           0.0, std::array{DataVector{num_coefs, 1.e-3}}, 10.0);
 
+  const std::vector<std::array<double, 3>> test_points{
+      {2., 0., 0.},
+      {(1.0 - eps) * 2., 0., 0.},
+      {3., 0., 0.},
+      {4., 0., 0.},
+      {(1.0 + eps) * 4., 0., 0.}};
+
   {
     INFO("Sphere transition");
-    const SphereTransition sphere_transition{2., 4.};
+    SphereTransition sphere_transition{2., 4.};
+    sphere_transition = serialize_and_deserialize(sphere_transition);
+    SphereTransition sphere_transition_interior{2., 4., false, true};
+    sphere_transition_interior =
+        serialize_and_deserialize(sphere_transition_interior);
     const domain::CoordinateMaps::TimeDependent::Shape shape_map{
         std::array{0.0, 0.0, 0.0}, l_max, l_max,
         std::make_unique<SphereTransition>(sphere_transition), "Shape"};
+    const domain::CoordinateMaps::TimeDependent::Shape shape_map_interior{
+        std::array{0.0, 0.0, 0.0}, l_max, l_max,
+        std::make_unique<SphereTransition>(sphere_transition_interior),
+        "Shape"};
 
-    const std::vector<std::array<double, 3>> test_points{
-        {2., 0., 0.}, {2. - eps, 0., 0.}, {1., 0., 0.}, {3., 0., 0.},
-        {4., 0., 0.}, {4. + eps, 0., 0.}, {5., 0., 0.}};
-    const std::vector<double> function_values{1.0, 1.0, 1.0, 0.5,
-                                              0.0, 0.0, 0.0};
+    const std::vector<double> function_values{0.5, 0.5, 0.5 / 3.0, 0.0, 0.0};
 
     for (size_t i = 0; i < test_points.size(); i++) {
-      CHECK(sphere_transition(test_points[i]) == approx(function_values[i]));
+      CAPTURE(test_points[i]);
+      CAPTURE(function_values[i]);
+      CHECK(sphere_transition(test_points[i], std::nullopt) ==
+            approx(function_values[i]));
+      const double radius = std::max(magnitude(test_points[i]), 2.0);
+      CHECK(sphere_transition(test_points[i], {1}) ==
+            approx(function_values[i] / radius));
       test_inverse_map(shape_map, test_points[i], time, functions_of_time);
     }
+
+    const std::vector<std::array<double, 3>> interior_points{{1.0, 0.0, 0.0},
+                                                             {0.0, 0.0, 0.0}};
+    const std::vector<double> interior_function_values{0.125, 0.0};
+    for (size_t i = 0; i < interior_points.size(); i++) {
+      CAPTURE(interior_points[i]);
+      CHECK(sphere_transition_interior(interior_points[i], std::nullopt) ==
+            interior_function_values[i]);
+      test_inverse_map(shape_map_interior, interior_points[i], time,
+                       functions_of_time);
+    }
+
+    // Check close, but not at, center and r_min
+    test_inverse_map(shape_map_interior, std::array{2.0 * eps, 0.0, 0.0}, time,
+                     functions_of_time);
+    test_inverse_map(shape_map_interior,
+                     std::array{(1.0 - eps) * 2.0, 0.0, 0.0}, time,
+                     functions_of_time);
   }
   {
     INFO("Reverse sphere transition");
-    const SphereTransition sphere_transition{2., 4., true};
+    SphereTransition sphere_transition{2., 4., true};
+    sphere_transition = serialize_and_deserialize(sphere_transition);
 
     const domain::CoordinateMaps::TimeDependent::Shape shape_map{
         std::array{0.0, 0.0, 0.0}, 4, 4,
         std::make_unique<SphereTransition>(sphere_transition), "Shape"};
 
-    const std::vector<std::array<double, 3>> test_points{
-        {2., 0., 0.}, {2. - eps, 0., 0.}, {1., 0., 0.}, {3., 0., 0.},
-        {4., 0., 0.}, {4. + eps, 0., 0.}, {5., 0., 0.}};
-    const std::vector<double> function_values{0.0, 0.0, 0.0, 0.5,
-                                              1.0, 1.0, 1.0};
+    const std::vector<double> function_values{0.0, 0.0, 0.5 / 3.0, 0.25, 0.25};
 
     for (size_t i = 0; i < test_points.size(); i++) {
-      CHECK(sphere_transition(test_points[i]) == approx(function_values[i]));
+      CAPTURE(test_points[i]);
+      CAPTURE(function_values[i]);
+      CHECK(sphere_transition(test_points[i], std::nullopt) ==
+            approx(function_values[i]));
+      const double radius = std::min(magnitude(test_points[i]), 4.0);
+      CHECK(sphere_transition(test_points[i], {1}) ==
+            approx(function_values[i] /
+                   (equal_within_roundoff(radius, 0.0) ? 1.0 : radius)));
       test_inverse_map(shape_map, test_points[i], time, functions_of_time);
     }
   }

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
@@ -76,9 +76,12 @@ void test_gradient_no_offset() {
         (1.0 - inner_sphericity) * inner_radius * grad_base;
     const std::array<double, 3> outer_grad =
         (1.0 - outer_sphericity) * outer_radius * grad_base;
-    return (outer_grad - point / radius) / distance_difference -
-           (outer_distance - radius) * (outer_grad - inner_grad) /
-               square(distance_difference);
+    return ((outer_grad - point / radius) / distance_difference -
+            (outer_distance - radius) * (outer_grad - inner_grad) /
+                square(distance_difference)) /
+               radius -
+           point * (outer_distance - radius) / distance_difference /
+               cube(radius);
   };
 
   const auto test_z_axis = [&](const double inner_sphericity,
@@ -150,6 +153,18 @@ void test_gradient_no_offset() {
     test_z_axis(0.0, 0.0);
     test_corners(0.0, 0.0);
   }
+  {
+    INFO("Interior region");
+    const auto center_wedge =
+        make_wedge(1.0, 0.0, std::array{0.0, 0.0, 0.0},
+                   std::array{0.0, 0.0, 0.0}, Wedge::Axis::Interior);
+    CHECK(center_wedge.gradient(std::array{0.0, 0.0, 0.0}) ==
+          std::array{0.0, 0.0, 0.0});
+    CHECK(center_wedge.gradient(std::array{0.0, 0.0, inner_radius}) ==
+          std::array{0.0, 0.0, 8.0});
+    CHECK(center_wedge.gradient(std::array{0.0, 0.0, 0.5 * inner_radius}) ==
+          std::array{0.0, 0.0, 4.0});
+  }
 }
 
 void test_only_transition_no_offset() {
@@ -171,20 +186,23 @@ void test_only_transition_no_offset() {
   const double distance_difference = outer_distance - inner_distance;
 
   std::array<double, 3> point{4.0, 0.0, 0.0};
-  const double function_value = (outer_distance - 4.0) / distance_difference;
+  const double linear_function_value =
+      (outer_distance - 4.0) / distance_difference;
 
-  CHECK(wedge(point) == approx(function_value));
-  CHECK(wedge_reverse(point) == approx(1.0 - function_value));
-  CHECK_ITERABLE_APPROX(wedge.gradient(point),
-                        (std::array{-1.0 / distance_difference, 0.0, 0.0}));
-  CHECK_ITERABLE_APPROX(wedge_reverse.gradient(point),
-                        (std::array{1.0 / distance_difference, 0.0, 0.0}));
-#ifdef SPECTRE_DEBUG
-  CHECK_THROWS_WITH(
-      wedge.gradient(20.0 * point),
-      Catch::Matchers::ContainsSubstring(
-          "The Wedge transition map was called with bad coordinates."));
-#endif
+  CHECK(wedge(point, std::nullopt) == approx(0.25 * linear_function_value));
+  CHECK(wedge(point, {1}) == approx(0.0625 * linear_function_value));
+  CHECK(wedge_reverse(point, std::nullopt) ==
+        approx(0.25 * (1.0 - linear_function_value)));
+  CHECK(wedge_reverse(point, {1}) ==
+        approx(0.0625 * (1.0 - linear_function_value)));
+  CHECK_ITERABLE_APPROX(
+      wedge.gradient(point),
+      (0.25 * std::array{-1.0 / distance_difference, 0.0, 0.0} -
+       cube(0.25) * linear_function_value * point));
+  CHECK_ITERABLE_APPROX(
+      wedge_reverse.gradient(point),
+      (0.25 * std::array{1.0 / distance_difference, 0.0, 0.0} -
+       cube(0.25) * (1.0 - linear_function_value) * point));
 
   std::optional<double> orig_rad_over_rad{};
   std::optional<double> orig_rad_over_rad_reverse{};
@@ -203,21 +221,24 @@ void test_only_transition_no_offset() {
   CHECK(orig_rad_over_rad.value() == approx(1.0));
   CHECK(orig_rad_over_rad_reverse.has_value());
   CHECK(orig_rad_over_rad_reverse.value() == approx(1.0));
-  set_orig_rad_over_rad(point * (1.0 - 0.25 * function_value * 0.5), 0.5);
+  set_orig_rad_over_rad(point * (1.0 - 0.25 * linear_function_value * 0.5),
+                        0.5);
   CHECK(orig_rad_over_rad.has_value());
   CHECK(orig_rad_over_rad.value() ==
-        approx(4.0 / magnitude(point * (1.0 - 0.25 * function_value * 0.5))));
-  set_orig_rad_over_rad(point * (1.0 + 0.25 * function_value * 0.5), -0.5);
+        approx(4.0 /
+               magnitude(point * (1.0 - 0.25 * linear_function_value * 0.5))));
+  set_orig_rad_over_rad(point * (1.0 + 0.25 * linear_function_value * 0.5),
+                        -0.5);
   CHECK(orig_rad_over_rad.has_value());
   CHECK(orig_rad_over_rad.value() ==
-        approx(4.0 / magnitude(point * (1.0 + 0.25 * function_value * 0.5))));
+        approx(4.0 /
+               magnitude(point * (1.0 + 0.25 * linear_function_value * 0.5))));
   set_orig_rad_over_rad(point * 15.0, 0.0);
-  CHECK(orig_rad_over_rad.has_value());
-  CHECK(orig_rad_over_rad.value() == 1.0);
+  CHECK_FALSE(orig_rad_over_rad.has_value());
   // Hit some internal checks
   set_orig_rad_over_rad(point * 0.0, 0.0);
-  CHECK_FALSE(orig_rad_over_rad.has_value());
-  CHECK_FALSE(orig_rad_over_rad_reverse.has_value());
+  CHECK_FALSE(orig_rad_over_rad == std::optional{1.0});
+  CHECK_FALSE(orig_rad_over_rad_reverse == std::optional{1.0});
   // Wedge is in x direction. Check other directions
   const auto check_other_directions =
       [&](const std::array<double, 3>& mapped_point) {
@@ -238,8 +259,7 @@ void test_only_transition_no_offset() {
   CHECK(orig_rad_over_rad.value() == approx(5.0));
   // Inside inner boundary
   set_orig_rad_over_rad(std::array{0.0, 0.0, 0.1 * inner_radius}, 0.4);
-  CHECK(orig_rad_over_rad.has_value());
-  CHECK(orig_rad_over_rad.value() == (1.0 + 0.4 / (0.1 * inner_radius)));
+  CHECK_FALSE(orig_rad_over_rad.has_value());
 }
 
 void test_only_transition_offset() {
@@ -267,11 +287,18 @@ void test_only_transition_offset() {
   const double outer_distance = (half_cube_length + 1) * sqrt(26.0) / 5.0;
   const double distance_difference = outer_distance - inner_distance;
 
-  const double function_value =
+  const double linear_function_value =
       (outer_distance - radius_from_inner_center) / distance_difference;
 
-  CHECK(wedge(centered_point) == approx(function_value));
-  CHECK(wedge_reverse(centered_point) == approx(1.0 - function_value));
+  CHECK(wedge(centered_point, std::nullopt) ==
+        approx(linear_function_value / radius_from_inner_center));
+  CHECK(wedge(centered_point, {1}) ==
+        approx(linear_function_value / square(radius_from_inner_center)));
+  CHECK(wedge_reverse(centered_point, std::nullopt) ==
+        approx((1.0 - linear_function_value) / radius_from_inner_center));
+  CHECK(
+      wedge_reverse(centered_point, {1}) ==
+      approx((1.0 - linear_function_value) / square(radius_from_inner_center)));
   const std::array<double, 3> projection_center = inner_center - outer_center;
   // Because of PlusX
   const std::array<double, 3> outer_gradient =
@@ -281,14 +308,20 @@ void test_only_transition_offset() {
           (half_cube_length - projection_center[0]) / square(centered_point[0]),
           0.0, 0.0} *
           radius_from_inner_center;
-  const std::array<double, 3> expected_gradient =
+  const std::array<double, 3> expected_linear_gradient =
       (outer_gradient - centered_point / radius_from_inner_center) /
           distance_difference -
       ((outer_distance - radius_from_inner_center) * outer_gradient /
        square(distance_difference));
-  CHECK_ITERABLE_APPROX(wedge.gradient(centered_point), expected_gradient);
-  CHECK_ITERABLE_APPROX(wedge_reverse.gradient(centered_point),
-                        -1.0 * expected_gradient);
+  CHECK_ITERABLE_APPROX(wedge.gradient(centered_point),
+                        expected_linear_gradient / radius_from_inner_center -
+                            centered_point * linear_function_value /
+                                cube(radius_from_inner_center));
+  CHECK_ITERABLE_APPROX(
+      wedge_reverse.gradient(centered_point),
+      -1.0 * expected_linear_gradient / radius_from_inner_center -
+          centered_point * (1.0 - linear_function_value) /
+              cube(radius_from_inner_center));
 
   std::optional<double> orig_rad_over_rad{};
   std::optional<double> orig_rad_over_rad_reverse{};
@@ -309,27 +342,28 @@ void test_only_transition_offset() {
   CHECK(orig_rad_over_rad_reverse.value() == approx(1.0));
 
   std::array<double, 3> mapped_point =
-      centered_point * (1.0 - function_value / radius_from_inner_center * 0.5);
+      centered_point *
+      (1.0 - linear_function_value / radius_from_inner_center * 0.5);
   set_orig_rad_over_rad(mapped_point, 0.5);
   CHECK(orig_rad_over_rad.has_value());
   CHECK(orig_rad_over_rad.value() ==
         approx(radius_from_inner_center / magnitude(mapped_point)));
 
-  mapped_point = centered_point * (1.0 - (1.0 - function_value) /
+  mapped_point = centered_point * (1.0 - (1.0 - linear_function_value) /
                                              radius_from_inner_center * 0.5);
   set_orig_rad_over_rad(mapped_point, 0.5);
   CHECK(orig_rad_over_rad_reverse.has_value());
   CHECK(orig_rad_over_rad_reverse.value() ==
         approx(radius_from_inner_center / magnitude(mapped_point)));
 
-  mapped_point =
-      centered_point * (1.0 + function_value / radius_from_inner_center * 0.5);
+  mapped_point = centered_point *
+                 (1.0 + linear_function_value / radius_from_inner_center * 0.5);
   set_orig_rad_over_rad(mapped_point, -0.5);
   CHECK(orig_rad_over_rad.has_value());
   CHECK(orig_rad_over_rad.value() ==
         approx(radius_from_inner_center / magnitude(mapped_point)));
 
-  mapped_point = centered_point * (1.0 + (1.0 - function_value) /
+  mapped_point = centered_point * (1.0 + (1.0 - linear_function_value) /
                                              radius_from_inner_center * 0.5);
   set_orig_rad_over_rad(mapped_point, -0.5);
   CHECK(orig_rad_over_rad_reverse.has_value());
@@ -433,8 +467,8 @@ void test_in_shape_map_no_offset(const gsl::not_null<Generator*> generator,
   // This guarantees the radius of the point is within an acceptable distance of
   // the inner/outer surface of the wedge even if we are reversed
   // NOLINTNEXTLINE(misc-const-correctness)
-  std::uniform_real_distribution<double> radial_dist{(0.8 * inner_radius),
-                                                     (outer_radius + 0.2)};
+  std::uniform_real_distribution<double> radial_dist{
+      inner_radius + 1.e-3, outer_radius / sqrt(3.0) - 1.e-3};
 
   for (const auto& [inner_sphericity, outer_sphericity] :
        cartesian_product(std::array{1.0, 0.0}, std::array{1.0, 0.0})) {
@@ -471,14 +505,22 @@ void test_in_shape_map_no_offset(const gsl::not_null<Generator*> generator,
       CAPTURE(centered_point);
       CAPTURE(axis_for_wedge);
 
-      const bool check_jacobians = radius >= (inner_radius + 1.e-3) and
-                                   radius <= (outer_radius / sqrt(3.0) - 1.e-3);
-
       test_points_shape_map(inner_sphericity, outer_sphericity, center, center,
                             static_cast<Wedge::Axis>(axis_for_wedge),
                             check_time, fot_name, functions_of_time,
-                            centered_point + center, reverse, check_jacobians);
+                            centered_point + center, reverse, true);
     }
+  }
+
+  const double eps = std::numeric_limits<double>::epsilon();
+  // Check for points within the interior
+  for (const auto& point :
+       {center, center + std::array{0.0, 2.0 * eps, 0.0},
+        center + std::array{0.0, 0.5 * inner_radius, 0.0},
+        center + std::array{0.0, (1.0 - 2.0 * eps) * inner_radius, 0.0},
+        center + std::array{0.0, inner_radius, 0.0}}) {
+    test_points_shape_map(1.0, 0.0, center, center, Wedge::Axis::Interior,
+                          check_time, fot_name, functions_of_time, point);
   }
 }
 
@@ -635,7 +677,19 @@ void test_in_shape_map_offset(const gsl::not_null<Generator*> generator,
         }  // for other_length_2
       }    // for other_length_1
     }      // for axis
-  }        // for outer sphericity
+
+    const double eps = std::numeric_limits<double>::epsilon();
+    // Check for points within the interior
+    for (const auto& point :
+         {inner_center, inner_center + std::array{0.0, 2.0 * eps, 0.0},
+          inner_center + std::array{0.0, 0.5 * inner_radius, 0.0},
+          inner_center + std::array{0.0, (1.0 - 2.0 * eps) * inner_radius, 0.0},
+          inner_center + std::array{0.0, inner_radius, 0.0}}) {
+      test_points_shape_map(1.0, outer_sphericity, inner_center, outer_center,
+                            Wedge::Axis::Interior, check_time, fot_name,
+                            functions_of_time, point);
+    }
+  }  // for outer sphericity
 }
 
 void test_errors() {
@@ -659,6 +713,21 @@ void test_errors() {
       Catch::Matchers::ContainsSubstring("Axis for Wedge shape map transition "
                                          "function cannot be 'None'. Please "
                                          "choose another."));
+
+  CHECK_THROWS_WITH(
+      (Wedge{std::array{0.0, 0.0, 0.0}, inner_radius, 1.0,
+             std::array{0.0, 0.0, 0.0}, outer_radius, 1.0,
+             Wedge::Axis::Interior, true}),
+      Catch::Matchers::ContainsSubstring(
+          "When the axis is 'Interior', the inner surface must be a sphere "
+          "(sphericity 1.0) and reverse must be 'false'."));
+  CHECK_THROWS_WITH(
+      (Wedge{std::array{0.0, 0.0, 0.0}, inner_radius, 0.5,
+             std::array{0.0, 0.0, 0.0}, outer_radius, 1.0,
+             Wedge::Axis::Interior}),
+      Catch::Matchers::ContainsSubstring(
+          "When the axis is 'Interior', the inner surface must be a sphere "
+          "(sphericity 1.0) and reverse must be 'false'."));
 }
 
 template <typename Generator>

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -338,7 +338,7 @@ std::array<DataVector, 3> calculate_analytical_map(
         lambda_00_coef, l_max, m_max);
   }
   const DataVector spatial_part =
-      transition_func(centered_coords) / magnitude(centered_coords);
+      transition_func(centered_coords, std::nullopt);
   return target_points - centered_coords * angular_part * spatial_part;
 }
 
@@ -420,10 +420,10 @@ tnsr::Ij<DataVector, 3, Frame::NoFrame> calculate_analytical_jacobian(
 
   // this part essentially duplicates the code from the map
   const DataVector radius = magnitude(centered_coords);
-  const DataVector spatial_part = transition_func(centered_coords) / radius;
+  const DataVector spatial_part =
+      transition_func(centered_coords, std::nullopt);
   const std::array<DataVector, 3> spatial_gradient =
-      transition_func.gradient(centered_coords) / radius -
-      centered_coords * spatial_part / square(radius);
+      transition_func.gradient(centered_coords);
   tnsr::Ij<DataVector, 3, Frame::NoFrame> result(num_points);
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -622,8 +622,7 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       *binary_compact_object, with_boundary_conditions, false, times_to_check);
 
-  const auto& blocks = domain.blocks();
-  const auto& final_envelope_block = excise_B ? blocks[33] : blocks[21];
+  const auto& excision_spheres = domain.excision_spheres();
 
   std::unordered_map<std::string, ExcisionSphere<3>>
       expected_excision_spheres{};
@@ -638,10 +637,13 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
                          {4, Direction<3>::lower_zeta()},
                          {5, Direction<3>::lower_zeta()}}});
   if (with_time_dependence) {
+    // Unfortunately, it'd be very hard to create the grid to inertial map
+    // necessary for the excision outside of the TimeDependentOptions class so
+    // we just clone the actual one here.
     expected_excision_spheres.at("ExcisionSphereA")
-        .inject_time_dependent_maps(
-            final_envelope_block.moving_mesh_grid_to_inertial_map()
-                .get_clone());
+        .inject_time_dependent_maps(excision_spheres.at("ExcisionSphereA")
+                                        .moving_mesh_grid_to_inertial_map()
+                                        .get_clone());
   }
   if (excise_B) {
     expected_excision_spheres.emplace(
@@ -655,14 +657,16 @@ void test_bbh_time_dependent_factory(const bool with_boundary_conditions,
                            {16, Direction<3>::lower_zeta()},
                            {17, Direction<3>::lower_zeta()}}});
     if (with_time_dependence) {
+      // Unfortunately, it'd be very hard to create the grid to inertial map
+      // necessary for the excision outside of the TimeDependentOptions class so
+      // we just clone the actual one here.
       expected_excision_spheres.at("ExcisionSphereB")
-          .inject_time_dependent_maps(
-              final_envelope_block.moving_mesh_grid_to_inertial_map()
-                  .get_clone());
+          .inject_time_dependent_maps(excision_spheres.at("ExcisionSphereB")
+                                          .moving_mesh_grid_to_inertial_map()
+                                          .get_clone());
     }
   }
 
-  const auto& excision_spheres = domain.excision_spheres();
   CHECK(excision_spheres == expected_excision_spheres);
 
   const auto check_excision_sphere_map =

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -123,8 +123,7 @@ void test_r_theta_phi(const tnsr::I<double, 3, SourceFrame>& input,
   const double transition_factor =
       std::make_unique<Transition>(Transition{inner_radius, outer_radius})
           ->
-          operator()(std::array{radius, 0.0, 0.0}) /
-      radius;
+          operator()(std::array{radius, 0.0, 0.0}, std::nullopt);
   const double expected_output_centered_spherical =
       input_centered_spherical[0] *
       (1.0 + transition_factor * (kerr_schild_radius - inner_radius));

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
@@ -433,6 +433,12 @@ void test(const bool include_expansion, const bool include_rotation,
     const auto grid_to_inertial_map_B =
         time_dep_options.template grid_to_inertial_map<domain::ObjectLabel::B>(
             include_distorted_map_B, true);
+    const auto grid_to_inertial_map_excision_A =
+        time_dep_options.template grid_to_inertial_map<domain::ObjectLabel::A>(
+            include_distorted_map_A, true, true);
+    const auto grid_to_inertial_map_excision_B =
+        time_dep_options.template grid_to_inertial_map<domain::ObjectLabel::B>(
+            include_distorted_map_B, true, true);
     // Even though the distorted to inertial map is not tied to a specific
     // object, we use `excise_?` to determine if the distorted map is
     // included just for testing.
@@ -476,6 +482,14 @@ void test(const bool include_expansion, const bool include_rotation,
     {
       INFO("grid_to_inertial_map_B");
       check_map(grid_to_inertial_map_B, false, false);
+    }
+    {
+      INFO("grid_to_inertial_map_excision_A");
+      check_map(grid_to_inertial_map_excision_A, false, false);
+    }
+    {
+      INFO("grid_to_inertial_map_excision_B");
+      check_map(grid_to_inertial_map_excision_B, false, false);
     }
     {
       INFO("distorted_to_inertial_map_A");


### PR DESCRIPTION
This is only allowed when the inner surface is spherical and when we are using the "regular" transition (i.e. not reversed).

## Proposed changes

Fixes #6451.

A previous PR (#6359) attempted to extend the shape map into the excision, but did so incorrectly. This PR implements this correctly. In order to do this, the meaning of the transition function had to be changed slightly. Previously, the shape map was

$$
\tilde{r} = r \left(1 - \frac{f(r, \theta, \phi)}{r} \sum_{\ell,m} \lambda_{\ell m}Y_{\ell m}(\theta, \phi)\right)
$$

and the transition function was $f(r, \theta, \phi)$. The functional form of the shape map hasn't changed, but now it reads

$$
\tilde{r} = r \left(1 - G(r, \theta, \phi) \sum_{\ell,m} \lambda_{\ell m}Y_{\ell m}(\theta, \phi)\right)
$$
$$
G(r, \theta, \phi) = \frac{f(r, \theta, \phi)}{r}
$$

where $G(r, \theta, \phi)$ is the transition. The $1/r$ factor was just absorbed into the transition function because the full $G$ is different inside the excision, not just $f$.

Also, the transition function inside the excisions is

$$
G(r, \theta, \phi) = \frac{r^2}{r_{\text{min}}^3}
$$

which is different than it is in SpEC. The transition defined in SpEC causes the jacobian to be undefined at the center of the shape map, which means the full frame velocity of all the maps can't be computed at the center of the shape map. This new transition inside the excision allows for this and has the correct behavior.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
