### PR TITLE
Enable interpolation for shells using spherical harmonics

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1003,6 +1003,19 @@ eprint = {https://doi.org/10.1137/0916035}
   adsurl =       {https://ui.adsabs.harvard.edu/abs/1998ApJ...494..297F},
 }
 
+@article{Fornberg1998,
+  author =       {Fornberg, Bengt},
+  title =        {Classroom Note: Calculation of Weights in Finite
+                  Difference Formulas},
+  journal =      {SIAM Review},
+  volume =       40,
+  number =       3,
+  pages =        {685-691},
+  year =         1998,
+  doi =          {10.1137/S0036144596322507},
+  url =          "https://doi.org/10.1137/S0036144596322507"
+}
+
 @article{Fortunato2019jl,
   title     = "Efficient Operator-Coarsening Multigrid Schemes for Local
                Discontinuous {Galerkin} Methods",

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   BarycentricRationalSpanInterpolator.cpp
   CubicSpanInterpolator.cpp
   CubicSpline.cpp
+  InterpolationWeights.cpp
   IrregularInterpolant.cpp
   LinearLeastSquares.cpp
   LinearRegression.cpp
@@ -31,6 +32,7 @@ spectre_target_headers(
   BarycentricRationalSpanInterpolator.hpp
   CubicSpanInterpolator.hpp
   CubicSpline.hpp
+  InterpolationWeights.hpp
   IrregularInterpolant.hpp
   LagrangePolynomial.hpp
   LinearLeastSquares.hpp

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   BarycentricRational.cpp
   BarycentricRationalSpanInterpolator.cpp
+  CardinalInterpolator.cpp
   CubicSpanInterpolator.cpp
   CubicSpline.cpp
   InterpolationWeights.cpp
@@ -30,6 +31,7 @@ spectre_target_headers(
   HEADERS
   BarycentricRational.hpp
   BarycentricRationalSpanInterpolator.hpp
+  CardinalInterpolator.hpp
   CubicSpanInterpolator.hpp
   CubicSpline.hpp
   InterpolationWeights.hpp

--- a/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.cpp
@@ -1,0 +1,211 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "CardinalInterpolator.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationWeights.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+template <size_t Dim>
+Cardinal<Dim>::Cardinal(
+    const Mesh<Dim>& source_mesh,
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points)
+    : n_target_points_(get<0>(target_points).size()),
+      source_mesh_(source_mesh) {
+  for (size_t d = 0; d < Dim; ++d) {
+    switch (source_mesh_.basis(d)) {
+      case Spectral::Basis::Chebyshev:
+        [[fallthrough]];
+      case Spectral::Basis::Legendre: {
+        const DataVector xi =
+            get<0>(logical_coordinates(source_mesh_.slice_through(d)));
+        gsl::at(interpolation_matrices_, d) =
+            fornberg_interpolation_matrix(target_points.get(d), xi);
+        break;
+      }
+      case Spectral::Basis::SphericalHarmonic: {
+        using_spherical_harmonics_ = true;
+        switch (source_mesh_.quadrature(d)) {
+          case Spectral::Quadrature::Gauss: {
+            const DataVector theta =
+                get<0>(logical_coordinates(source_mesh_.slice_through(d)));
+            const DataVector cos_theta_source = cos(theta);
+            const DataVector cos_theta_target = cos(target_points.get(d));
+            const Matrix theta_matrix = fornberg_interpolation_matrix(
+                cos_theta_target, cos_theta_source);
+            const size_t n_th = source_mesh_.extents(d);
+            gsl::at(interpolation_matrices_, d)
+                .resize(n_target_points_, 2 * n_th);
+            const DataVector csc_theta_source = 1.0 / sin(theta);
+            const DataVector sin_theta_target = sin(target_points.get(d));
+            for (size_t k = 0; k < n_target_points_; ++k) {
+              for (size_t i_th = 0; i_th < n_th; ++i_th) {
+                const double factor =
+                    0.5 * sin_theta_target[k] * csc_theta_source[i_th];
+                gsl::at(interpolation_matrices_, d)(k, i_th) =
+                    theta_matrix(k, i_th) * (0.5 + factor);
+                gsl::at(interpolation_matrices_, d)(k, n_th + i_th) =
+                    theta_matrix(k, i_th) * (0.5 - factor);
+              }
+            }
+            break;
+          }
+          case Spectral::Quadrature::Equiangular: {
+            const DataVector phi =
+                get<0>(logical_coordinates(source_mesh_.slice_through(d)));
+            const DataVector& phi_target = target_points.get(d);
+            DataVector extended_phi_target{2 * n_target_points_};
+            for (size_t k = 0; k < n_target_points_; ++k) {
+              extended_phi_target[2 * k] = phi_target[k];
+              extended_phi_target[2 * k + 1] = phi_target[k] + M_PI;
+            }
+            gsl::at(interpolation_matrices_, d) = fourier_interpolation_matrix(
+                extended_phi_target, source_mesh_.extents(d));
+            break;
+          }
+          default:
+            ERROR(
+                "Quadrature must be Gauss or Equiangular for Basis "
+                "SphericalHarmonic, not "
+                << source_mesh_.quadrature(d));
+        }
+        break;
+      }
+      default:
+        ERROR("Basis " << source_mesh_.basis(d)
+                       << " is not supported by the Cardinal interpolator.");
+    }
+  }
+}
+
+template <>
+DataVector Cardinal<1>::interpolate(const DataVector& f_source) const {
+  const size_t n_source_points = source_mesh_.number_of_grid_points();
+  ASSERT(f_source.size() == n_source_points,
+         "Size of source data ("
+             << f_source.size() << ") does not match size of source mesh ("
+             << n_source_points
+             << ") that this interpolator was constructed with.");
+  DataVector result{n_target_points_};
+  dgemv_('N', n_target_points_, n_source_points, 1.0,
+         interpolation_matrices_[0].data(),
+         interpolation_matrices_[0].spacing(), f_source.data(), 1, 0.0,
+         result.data(), 1);
+  return result;
+}
+
+template <>
+DataVector Cardinal<2>::interpolate(const DataVector& f_source) const {
+  ASSERT(f_source.size() == source_mesh_.number_of_grid_points(),
+         "Size of source data ("
+             << f_source.size() << ") does not match size of source mesh ("
+             << source_mesh_.number_of_grid_points()
+             << ") that this interpolator was constructed with.");
+  DataVector result{n_target_points_};
+  if (using_spherical_harmonics_) {
+    const auto [n_th, n_ph] = source_mesh_.extents().indices();
+    DataVector intermediate_result{2 * n_th};
+    for (size_t k = 0; k < n_target_points_; ++k) {
+      dgemv_('N', n_th, n_ph, 1.0, f_source.data(), n_th,
+             interpolation_matrices_[1].data() + 2 * k, 2 * n_target_points_,
+             0.0, intermediate_result.data(), 1);
+      dgemv_('N', n_th, n_ph, 1.0, f_source.data(), n_th,
+             interpolation_matrices_[1].data() + (2 * k + 1),
+             2 * n_target_points_, 0.0, intermediate_result.data() + n_th, 1);
+      result[k] = ddot_(2 * n_th, interpolation_matrices_[0].data() + k,
+                        n_target_points_, intermediate_result.data(), 1);
+    }
+    return result;
+  }
+  const auto [n_xi, n_eta] = source_mesh_.extents().indices();
+  Matrix intermediate_result{n_target_points_, n_eta};
+  dgemm_('N', 'N', n_target_points_, n_eta, n_xi, 1.0,
+         interpolation_matrices_[0].data(),
+         interpolation_matrices_[0].spacing(), f_source.data(), n_xi, 0.0,
+         intermediate_result.data(), n_target_points_);
+  for (size_t k = 0; k < n_target_points_; ++k) {
+    result[k] =
+        ddot_(n_eta, interpolation_matrices_[1].data() + k, n_target_points_,
+              intermediate_result.data() + k, n_target_points_);
+  }
+  return result;
+}
+
+template <>
+DataVector Cardinal<3>::interpolate(const DataVector& f_source) const {
+  ASSERT(f_source.size() == source_mesh_.number_of_grid_points(),
+         "Size of source data ("
+             << f_source.size() << ") does not match size of source mesh ("
+             << source_mesh_.number_of_grid_points()
+             << ") that this interpolator was constructed with.");
+  const auto [n0, n1, n2] = source_mesh_.extents().indices();
+  Matrix intermediate_matrix{n_target_points_, n1 * n2};
+  dgemm_('N', 'N', n_target_points_, n1 * n2, n0, 1.0,
+         interpolation_matrices_[0].data(),
+         interpolation_matrices_[0].spacing(), f_source.data(), n0, 0.0,
+         intermediate_matrix.data(), n_target_points_);
+  auto transpose = intermediate_matrix.transpose();
+  DataVector result{n_target_points_};
+  if (using_spherical_harmonics_) {
+    DataVector intermediate_vector{2 * n1};
+    for (size_t k = 0; k < n_target_points_; ++k) {
+      dgemv_('N', n1, n2, 1.0, transpose.data() + k * n1 * n2, n1,
+             interpolation_matrices_[2].data() + 2 * k, 2 * n_target_points_,
+             0.0, intermediate_vector.data(), 1);
+      dgemv_('N', n1, n2, 1.0, transpose.data() + k * n1 * n2, n1,
+             interpolation_matrices_[2].data() + (2 * k + 1),
+             2 * n_target_points_, 0.0, intermediate_vector.data() + n1, 1);
+      result[k] = ddot_(2 * n1, interpolation_matrices_[1].data() + k,
+                        n_target_points_, intermediate_vector.data(), 1);
+    }
+    return result;
+  }
+  DataVector intermediate_vector{n2};
+  for (size_t k = 0; k < n_target_points_; ++k) {
+    dgemv_('T', n1, n2, 1.0, transpose.data() + k * n1 * n2, n1,
+           interpolation_matrices_[1].data() + k, n_target_points_, 0.0,
+           intermediate_vector.data(), 1);
+    result[k] = ddot_(n2, interpolation_matrices_[2].data() + k,
+                      n_target_points_, intermediate_vector.data(), 1);
+  }
+  return result;
+}
+
+template <size_t Dim>
+const std::array<Matrix, Dim>& Cardinal<Dim>::interpolation_matrices() const {
+  return interpolation_matrices_;
+}
+
+template <size_t Dim>
+bool operator==(const Cardinal<Dim>& lhs, const Cardinal<Dim>& rhs) {
+  return lhs.interpolation_matrices() == rhs.interpolation_matrices();
+}
+
+template <size_t Dim>
+bool operator!=(const Cardinal<Dim>& lhs, const Cardinal<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template class Cardinal<1>;
+template class Cardinal<2>;
+template class Cardinal<3>;
+template bool operator==(const Cardinal<1>& lhs, const Cardinal<1>& rhs);
+template bool operator==(const Cardinal<2>& lhs, const Cardinal<2>& rhs);
+template bool operator==(const Cardinal<3>& lhs, const Cardinal<3>& rhs);
+template bool operator!=(const Cardinal<1>& lhs, const Cardinal<1>& rhs);
+template bool operator!=(const Cardinal<2>& lhs, const Cardinal<2>& rhs);
+template bool operator!=(const Cardinal<3>& lhs, const Cardinal<3>& rhs);
+
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace intrp {
+/*!
+ * \brief Interpolates by doing partial summation in each dimension using
+ * one-dimensional interpolation
+ *
+ * \details The one-dimensional matrices used to do the interpolation depend
+ * upon the Spectral::Basis used in each dimension:
+ * - For a Chebyshev or Legendre basis, the matrices are given by
+ * intrp::fornberg_interpolation_matrix at the quadrature points of the
+ * source_mesh.  (These are equivalent to those returned by
+ * Spectral::interpolation_matrix.)
+ * - For a Fourier basis, the matrix is given by
+ * intrp::fourier_interpolation_matrix at the quadrature points of the
+ * source_mesh
+ *
+ */
+template <size_t Dim>
+class Cardinal {
+ public:
+  Cardinal(
+      const Mesh<Dim>& source_mesh,
+      const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points);
+
+  Cardinal();
+
+  /// Interpolates the function `f` provided on the `source_mesh` to the
+  /// `target_points` with which the interpolator was constructed.
+  DataVector interpolate(const DataVector& f) const;
+
+  /// The one-dimensional interpolation matrices used to do the interpolation
+  const std::array<Matrix, Dim>& interpolation_matrices() const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+ private:
+  size_t n_target_points_;
+  Mesh<Dim> source_mesh_;
+  std::array<Matrix, Dim> interpolation_matrices_;
+  bool using_spherical_harmonics_{false};
+};
+
+template <size_t Dim>
+bool operator==(const Cardinal<Dim>& lhs, const Cardinal<Dim>& rhs);
+
+template <size_t Dim>
+bool operator!=(const Cardinal<Dim>& lhs, const Cardinal<Dim>& rhs);
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationWeights.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationWeights.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/InterpolationWeights.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+
+namespace intrp {
+Matrix fornberg_interpolation_matrix(const DataVector& x_target,
+                                     const DataVector& x_source) {
+  Matrix result{x_target.size(), x_source.size()};
+  const size_t n_source_pts = x_source.size();
+  for (size_t k = 0; k < x_target.size(); ++k) {
+    double c1 = 1.0;
+    double c4 = x_source[0] - x_target[k];
+    result(k, 0) = 1.0;
+    for (size_t i = 1; i < n_source_pts; ++i) {
+      double c2 = 1.0;
+      const double c5 = c4;
+      c4 = x_source[i] - x_target[k];
+      for (size_t j = 0; j < i; ++j) {
+        const double c3 = x_source[i] - x_source[j];
+        c2 *= c3;
+        if (j + 1 == i) {
+          result(k, i) = -c1 * c5 * result(k, i - 1) / c2;
+        }
+        result(k, j) = c4 * result(k, j) / c3;
+      }
+      c1 = c2;
+    }
+  }
+  return result;
+}
+
+Matrix fourier_interpolation_matrix(const DataVector& x_target,
+                                    const size_t n_source_points) {
+  if (n_source_points == 1) {
+    return Matrix{x_target.size(), 1, 1.0};
+  }
+  DataVector x_source{n_source_points,
+                      2.0 * M_PI / static_cast<double>(n_source_points)};
+  for (size_t i = 0; i < n_source_points; ++i) {
+    x_source[i] *= static_cast<double>(i);
+  }
+  Matrix result{x_target.size(), n_source_points,
+                1.0 / static_cast<double>(n_source_points)};
+  const bool n_source_points_is_even = n_source_points % 2 == 0;
+  for (size_t k = 0; k < x_target.size(); ++k) {
+    for (size_t i = 0; i < n_source_points; ++i) {
+      double c0 = 1.0;
+      double c1 = cos(x_target[k] - x_source[i]);
+      const double cdx2 = 2.0 * c1;
+      double sum = c1;
+      for (size_t j = 2; j <= n_source_points / 2; ++j) {
+        const double tmp = c1;
+        c1 = cdx2 * c1 - c0;
+        c0 = tmp;
+        sum += c1;
+      }
+      result(k, i) *=
+          n_source_points_is_even ? 2.0 * sum + 1.0 - c1 : 2.0 * sum + 1.0;
+    }
+  }
+  return result;
+}
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationWeights.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationWeights.hpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+class Matrix;
+/// \endcond
+
+namespace intrp {
+/*!
+ * \brief Computes the matrix for polynomial interpolation of a non-periodic
+ * function known at the set of points \f$x_{source}\f$ to the set of points
+ * \f$x_{target}\f$
+ *
+ * \details The algorithm is from \cite Fornberg1998.  The returned matrix
+ * \f$M\f$ will have \f$n_{target}\f$ rows and \f$n_{source}\f$ columns so that
+ * \f$f_{target} = M f_{source}\f$
+ *
+ * \note The accuracy of the interpolation will depend upon the number and
+ * distribution of the source points.  It is strongly suggested that you
+ * carefully investigate the accuracy for your use case.
+ */
+Matrix fornberg_interpolation_matrix(const DataVector& x_target,
+                                     const DataVector& x_source);
+
+/*!
+ * \brief Computes the matrix for interpolating a periodic function known at the
+ * set of \f$n\f$ equally spaced points on the periodic domain \f$[0, 2 \pi]\f$
+ * to the set of points \f$x_{target}\f$
+ *
+ * \details The returned matrix \f$M\f$ will have \f$n_{target}\f$ rows and
+ * \f$n_{source}\f$ columns so that \f$f_{target} = M f_{source}\f$
+ * Formally, this computes the sum
+ * \f[ n w_j = 1 + 2 \sum_{k=1}^{\lfloor (n-1)/2 \rfloor} \cos(k(x - X_j))
+ *     \left[ + \cos\left(\frac{n}{2}(x - X_j)\right) \right] \f]
+ * for each target point \f$x\f$, where \f$ X_j = \frac{2 \pi j}{n}\f$, and
+ * the term in brackets is evaluated only if \f$n\f$ is even.
+ *
+ */
+Matrix fourier_interpolation_matrix(const DataVector& x_target,
+                                    size_t n_source_points);
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
@@ -105,9 +106,26 @@ Matrix interpolation_matrix(
       }
     }
     return result;
+  } else if (mesh.basis()[0] == Spectral::Basis::SphericalHarmonic) {
+    ASSERT(mesh.basis()[1] == Spectral::Basis::SphericalHarmonic,
+           "Expected both dimensions to have spherical harmonic basis. Mesh = "
+               << mesh);
+    const intrp::Cardinal cardinal_interpolator(mesh, points);
+    const auto [n_th, n_ph] = mesh.extents().indices();
+    const auto& [m_th, m_ph] = cardinal_interpolator.interpolation_matrices();
+    for (size_t i_ph = 0, s = 0; i_ph < n_ph; ++i_ph) {
+      for (size_t i_th = 0; i_th < n_th; ++i_th) {
+        for (size_t k = 0; k < number_of_target_points; ++k) {
+          result(k, s) = m_th(k, i_th) * m_ph(2 * k, i_ph) +
+                         m_th(k, i_th + n_th) * m_ph(2 * k + 1, i_ph);
+        }
+        ++s;
+      }
+    }
+    return result;
   }
 
-  // Not FD, so use spectral interpolation
+  // Not FD or special basis, so use 1D spectral interpolation matrices
   const std::array<Matrix, 2> matrices{
       {Spectral::interpolation_matrix(mesh.slice_through(0), get<0>(points)),
        Spectral::interpolation_matrix(mesh.slice_through(1), get<1>(points))}};
@@ -175,9 +193,31 @@ Matrix interpolation_matrix(
       }
     }
     return result;
+  } else if (mesh.basis()[1] == Spectral::Basis::SphericalHarmonic) {
+    ASSERT(mesh.basis()[2] == Spectral::Basis::SphericalHarmonic,
+           "Expected last two dimensions to each have spherical harmonic "
+           "basis. Mesh = "
+               << mesh);
+    const intrp::Cardinal cardinal_interpolator(mesh, points);
+    const auto [n_r, n_th, n_ph] = mesh.extents().indices();
+    const auto& [m_r, m_th, m_ph] =
+        cardinal_interpolator.interpolation_matrices();
+    for (size_t i_ph = 0, s = 0; i_ph < n_ph; ++i_ph) {
+      for (size_t i_th = 0; i_th < n_th; ++i_th) {
+        for (size_t i_r = 0; i_r < n_r; ++i_r) {
+          for (size_t k = 0; k < number_of_target_points; ++k) {
+            result(k, s) =
+                m_r(k, i_r) * (m_th(k, i_th) * m_ph(2 * k, i_ph) +
+                               m_th(k, i_th + n_th) * m_ph(2 * k + 1, i_ph));
+          }
+          ++s;
+        }
+      }
+    }
+    return result;
   }
 
-  // Not FD, so use spectral interpolation
+  // Not FD or special basis, so use 1D spectral interpolation matrices
   const std::array<Matrix, 3> matrices{
       {Spectral::interpolation_matrix(mesh.slice_through(0), get<0>(points)),
        Spectral::interpolation_matrix(mesh.slice_through(1), get<1>(points)),

--- a/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.cpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.cpp
@@ -8,72 +8,59 @@
 
 namespace YlmTestFunctions {
 
-ProductOfPolynomials::ProductOfPolynomials(const size_t n_r, const size_t L,
-                                           const size_t M, const size_t pow_nx,
+ProductOfPolynomials::ProductOfPolynomials(const size_t pow_nx,
                                            const size_t pow_ny,
                                            const size_t pow_nz)
-    : pow_nx_{pow_nx}, pow_ny_{pow_ny}, pow_nz_{pow_nz} {
-  ASSERT(std::hypot(pow_nx_, pow_ny_, pow_nz_) <= L,
-         "Cannot represent function on mesh");
-  ASSERT(std::hypot(pow_nx_, pow_ny_) <= M,
-         "Cannot represent function on mesh");
-  const Mesh<3> mesh{
-      {n_r, L + 1, 2 * M + 1},
-      {Spectral::Basis::Legendre, Spectral::Basis::SphericalHarmonic,
-       Spectral::Basis::SphericalHarmonic},
-      {Spectral::Quadrature::Gauss, Spectral::Quadrature::Gauss,
-       Spectral::Quadrature::Equiangular}};
-  const auto xi = logical_coordinates(mesh);
-  n_pts_ = mesh.number_of_grid_points();
-  theta_ = xi.get(1);
-  phi_ = xi.get(2);
+    : pow_nx_{pow_nx}, pow_ny_{pow_ny}, pow_nz_{pow_nz} {}
+
+DataVector ProductOfPolynomials::operator()(const DataVector& theta,
+                                            const DataVector& phi) const {
+  return pow(sin(theta), pow_nx_ + pow_ny_) * pow(cos(theta), pow_nz_) *
+         pow(cos(phi), pow_nx_) * pow(sin(phi), pow_ny_);
 }
 
-DataVector ProductOfPolynomials::f() const {
-  return pow(sin(theta_), pow_nx_ + pow_ny_) * pow(cos(theta_), pow_nz_) *
-         pow(cos(phi_), pow_nx_) * pow(sin(phi_), pow_ny_);
-}
-
-DataVector ProductOfPolynomials::df_dth() const {
+DataVector ProductOfPolynomials::df_dth(const DataVector& theta,
+                                        const DataVector& phi) const {
   if (pow_nx_ + pow_ny_ + pow_nz_ == 0) {
-    return DataVector{n_pts_, 0.0};
+    return DataVector{theta.size(), 0.0};
   }
   if (pow_nx_ + pow_ny_ == 0) {
-    return -static_cast<double>(pow_nz_) * sin(theta_) *
-           pow(cos(theta_), pow_nz_ - 1) * pow(cos(phi_), pow_nx_) *
-           pow(sin(phi_), pow_ny_);
+    return -static_cast<double>(pow_nz_) * sin(theta) *
+           pow(cos(theta), pow_nz_ - 1) * pow(cos(phi), pow_nx_) *
+           pow(sin(phi), pow_ny_);
   }
   if (pow_nz_ == 0) {
     return static_cast<double>(pow_nx_ + pow_ny_) *
-           pow(sin(theta_), pow_nx_ + pow_ny_ - 1) * cos(theta_) *
-           pow(cos(phi_), pow_nx_) * pow(sin(phi_), pow_ny_);
+           pow(sin(theta), pow_nx_ + pow_ny_ - 1) * cos(theta) *
+           pow(cos(phi), pow_nx_) * pow(sin(phi), pow_ny_);
   }
   return (static_cast<double>(pow_nx_ + pow_ny_) *
-              pow(sin(theta_), pow_nx_ + pow_ny_ - 1) *
-              pow(cos(theta_), pow_nz_ + 1) -
+              pow(sin(theta), pow_nx_ + pow_ny_ - 1) *
+              pow(cos(theta), pow_nz_ + 1) -
           static_cast<double>(pow_nz_) *
-              pow(sin(theta_), pow_nx_ + pow_ny_ + 1) *
-              pow(cos(theta_), pow_nz_ - 1)) *
-         pow(cos(phi_), pow_nx_) * pow(sin(phi_), pow_ny_);
+              pow(sin(theta), pow_nx_ + pow_ny_ + 1) *
+              pow(cos(theta), pow_nz_ - 1)) *
+         pow(cos(phi), pow_nx_) * pow(sin(phi), pow_ny_);
 }
 
-DataVector ProductOfPolynomials::df_dph() const {
+DataVector ProductOfPolynomials::df_dph(const DataVector& theta,
+                                        const DataVector& phi) const {
   if (pow_nx_ + pow_ny_ == 0) {
-    return DataVector{n_pts_, 0.0};
+    return DataVector{theta.size(), 0.0};
   }
   if (pow_nx_ == 0) {
-    return static_cast<double>(pow_ny_) * pow(sin(theta_), pow_nx_ + pow_ny_) *
-           pow(cos(theta_), pow_nz_) * cos(phi_) * pow(sin(phi_), pow_ny_ - 1);
+    return static_cast<double>(pow_ny_) * pow(sin(theta), pow_nx_ + pow_ny_) *
+           pow(cos(theta), pow_nz_) * cos(phi) * pow(sin(phi), pow_ny_ - 1);
   }
   if (pow_ny_ == 0) {
-    return -static_cast<double>(pow_nx_) * pow(sin(theta_), pow_nx_ + pow_ny_) *
-           pow(cos(theta_), pow_nz_) * pow(cos(phi_), pow_nx_ - 1) * sin(phi_);
+    return -static_cast<double>(pow_nx_) * pow(sin(theta), pow_nx_ + pow_ny_) *
+           pow(cos(theta), pow_nz_) * pow(cos(phi), pow_nx_ - 1) * sin(phi);
   }
-  return pow(sin(theta_), pow_nx_ + pow_ny_) * pow(cos(theta_), pow_nz_) *
-         (static_cast<double>(pow_ny_) * pow(cos(phi_), pow_nx_ + 1) *
-              pow(sin(phi_), pow_ny_ - 1) -
-          static_cast<double>(pow_nx_) * *pow(cos(phi_), pow_nx_ - 1) *
-              pow(sin(phi_), pow_ny_ + 1));
+  return pow(sin(theta), pow_nx_ + pow_ny_) * pow(cos(theta), pow_nz_) *
+         (static_cast<double>(pow_ny_) * pow(cos(phi), pow_nx_ + 1) *
+              pow(sin(phi), pow_ny_ - 1) -
+          static_cast<double>(pow_nx_) * *pow(cos(phi), pow_nx_ - 1) *
+              pow(sin(phi), pow_ny_ + 1));
 }
 
 double ProductOfPolynomials::definite_integral() const {

--- a/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp
@@ -18,23 +18,41 @@
 
 namespace YlmTestFunctions {
 
+/*!
+ * \brief Product of polynomials regular on the surface of a sphere
+ *
+ * \details Computes \f$ n_x^{k_x} n_y^{k_y} n_z^{k_z} \f$ where \f$n_x = \sin
+ * \theta \cos \phi\f$, \f$n_y = \sin \theta \sin \phi\f$, and \f$n_z = \cos
+ * \theta\f$.  The function and its first derivatives are exactly representable
+ * by spherical harmonics of order \f$(L,M)\f$ if \f$L > k_x + k_y + k_z\f$ and
+ * \f$M > k_x + k_y\f$.
+ *
+ */
 class ProductOfPolynomials {
  public:
-  ProductOfPolynomials(size_t n_r, size_t L, size_t M, size_t pow_nx,
-                       size_t pow_ny, size_t pow_nz);
-  DataVector f() const;
-  DataVector df_dth() const;
+  ProductOfPolynomials(size_t pow_nx, size_t pow_ny, size_t pow_nz);
+  DataVector operator()(const DataVector& theta, const DataVector& phi) const;
+  template <typename Fr>
+  DataVector operator()(const tnsr::I<DataVector, 2, Fr>& theta_and_phi) const {
+    return operator()(get<0>(theta_and_phi), get<1>(theta_and_phi));
+  }
+  DataVector df_dth(const DataVector& theta, const DataVector& phi) const;
+  template <typename Fr>
+  DataVector df_dth(const tnsr::I<DataVector, 2, Fr>& theta_and_phi) const {
+    return df_dth(get<0>(theta_and_phi), get<1>(theta_and_phi));
+  }
   // This is the Pfaffiaan derivative (extra factor 1/sin(th))
-  DataVector df_dph() const;
+  DataVector df_dph(const DataVector& theta, const DataVector& phi) const;
+  template <typename Fr>
+  DataVector df_dph(const tnsr::I<DataVector, 2, Fr>& theta_and_phi) const {
+    return df_dph(get<0>(theta_and_phi), get<1>(theta_and_phi));
+  }
   double definite_integral() const;
 
  private:
-  size_t n_pts_;
   size_t pow_nx_;
   size_t pow_ny_;
   size_t pow_nz_;
-  DataVector theta_;
-  DataVector phi_;
 };
 
 template <size_t l, int m>

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY "Test_NumericalInterpolation")
 set(LIBRARY_SOURCES
   Test_BarycentricRational.cpp
   Test_CubicSpline.cpp
+  Test_InterpolationWeights.cpp
   Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp
   Test_MultiLinearSpanInterpolation.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY "Test_NumericalInterpolation")
 
 set(LIBRARY_SOURCES
   Test_BarycentricRational.cpp
+  Test_CardinalInterpolator.cpp
   Test_CubicSpline.cpp
   Test_InterpolationWeights.cpp
   Test_IrregularInterpolant.cpp
@@ -40,6 +41,7 @@ target_link_libraries(
   ParallelInterpolation
   RelativisticEulerSolutions
   Spectral
+  SphericalHarmonicsHelpers
   SpinWeightedSphericalHarmonics
   Utilities
   )

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CardinalInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CardinalInterpolator.cpp
@@ -1,0 +1,248 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
+#include "NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Math.hpp"
+
+namespace {
+// Polynomial of given degree with leading coefficinet \f$a_0\f$, and with
+// \f$a_{n+1} = a_n / falloff
+class Polynomial {
+ public:
+  Polynomial(const size_t degree, const double a_0, const double falloff)
+      : coefficients_(degree + 1) {
+    double n = falloff * a_0;
+    std::generate(coefficients_.begin(), coefficients_.end(), [&falloff, &n]() {
+      n /= falloff;
+      return n;
+    });
+  }
+  Polynomial() = default;
+  DataVector operator()(const DataVector& x) const {
+    return evaluate_polynomial(coefficients_, x);
+  }
+
+ private:
+  std::vector<double> coefficients_;
+};
+
+template <size_t Dim>
+class ProductOfPolynomials {
+ public:
+  ProductOfPolynomials(const std::array<size_t, Dim>& degree,
+                       const std::array<double, Dim>& a_0,
+                       const std::array<double, Dim>& falloff) {
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(polynomials_, d) =
+          Polynomial{gsl::at(degree, d), gsl::at(a_0, d), gsl::at(falloff, d)};
+    }
+  }
+  DataVector operator()(
+      const tnsr::I<DataVector, Dim, Frame::ElementLogical>& x) const {
+    DataVector result = polynomials_[0](get<0>(x));
+    for (size_t d = 1; d < Dim; ++d) {
+      result *= gsl::at(polynomials_, d)(x.get(d));
+    }
+    return result;
+  }
+
+ private:
+  std::array<Polynomial, Dim> polynomials_;
+};
+
+void test_1d(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  for (size_t n_target_points = 1; n_target_points < 101;
+       n_target_points += 11) {
+    const auto xi_target =
+        make_with_random_values<tnsr::I<DataVector, 1, Frame::ElementLogical>>(
+            generator, make_not_null(&xi_distribution), n_target_points);
+    for (const auto basis :
+         std::array{Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto quadrature :
+           std::array{Spectral::Quadrature::Gauss,
+                      Spectral::Quadrature::GaussLobatto}) {
+        for (size_t n_xi = 2; n_xi < 21; ++n_xi) {
+          const Mesh<1> source_mesh{n_xi, basis, quadrature};
+          const Polynomial f{n_xi - 1, 1.5, 2.0};
+          const auto xi_source = logical_coordinates(source_mesh);
+          const DataVector f_source = f(get<0>(xi_source));
+          const DataVector f_expected = f(get<0>(xi_target));
+          const intrp::Cardinal<1> interpolator(source_mesh, xi_target);
+          const DataVector f_interpolated = interpolator.interpolate(f_source);
+          CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+        }
+      }
+    }
+  }
+}
+
+void test_2d_cartesian(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  const auto bases =
+      std::array{Spectral::Basis::Legendre, Spectral::Basis::Chebyshev};
+  const auto quadratures = std::array{Spectral::Quadrature::Gauss,
+                                      Spectral::Quadrature::GaussLobatto};
+  for (size_t n_target_points = 1; n_target_points < 13;
+       n_target_points += 11) {
+    const auto xi_target =
+        make_with_random_values<tnsr::I<DataVector, 2, Frame::ElementLogical>>(
+            generator, make_not_null(&xi_distribution), n_target_points);
+    for (const auto xi_basis : bases) {
+      for (const auto xi_quadrature : quadratures) {
+        for (const auto eta_basis : bases) {
+          for (const auto eta_quadrature : quadratures) {
+            for (size_t n_xi = 2; n_xi < 21; n_xi += 3) {
+              for (size_t n_eta = 2; n_eta < 21; n_eta += 3) {
+                const Mesh<2> source_mesh{
+                    std::array{n_xi, n_eta}, std::array{xi_basis, eta_basis},
+                    std::array{xi_quadrature, eta_quadrature}};
+                const ProductOfPolynomials<2> f{std::array{n_xi - 1, n_eta - 1},
+                                                std::array{1.5, 2.5},
+                                                std::array{2.0, 4.0}};
+                const auto xi_source = logical_coordinates(source_mesh);
+                const DataVector f_source = f(xi_source);
+                const DataVector f_expected = f(xi_target);
+                const intrp::Cardinal<2> interpolator(source_mesh, xi_target);
+                const DataVector f_interpolated =
+                    interpolator.interpolate(f_source);
+                CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+void test_2d_spherical(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  std::uniform_real_distribution<> phi_distribution(0.0, 2.0 * M_PI);
+  for (size_t n_target_points = 1; n_target_points < 13;
+       n_target_points += 11) {
+    tnsr::I<DataVector, 2, Frame::ElementLogical> xi_target{n_target_points};
+    get<0>(xi_target) = acos(make_with_random_values<DataVector>(
+        generator, make_not_null(&xi_distribution), xi_target));
+    get<1>(xi_target) = make_with_random_values<DataVector>(
+        generator, make_not_null(&phi_distribution), xi_target);
+    for (size_t n_z = 0; n_z < 4; ++n_z) {
+      for (size_t n_y = 0; n_y < 4; ++n_y) {
+        for (size_t n_x = 0; n_x < 4; ++n_x) {
+          const Mesh<2> source_mesh{
+              std::array{n_x + n_y + n_z + 2, 2 * (n_x + n_y) + 3},
+              std::array{Spectral::Basis::SphericalHarmonic,
+                         Spectral::Basis::SphericalHarmonic},
+              std::array{Spectral::Quadrature::Gauss,
+                         Spectral::Quadrature::Equiangular}};
+          const YlmTestFunctions::ProductOfPolynomials f(n_x, n_y, n_z);
+          const auto xi_source = logical_coordinates(source_mesh);
+          const DataVector f_source = f(xi_source);
+          const DataVector f_expected = f(xi_target);
+          const intrp::Cardinal<2> interpolator(source_mesh, xi_target);
+          const DataVector f_interpolated = interpolator.interpolate(f_source);
+          CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+        }
+      }
+    }
+  }
+}
+
+void test_3d_cartesian(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  for (size_t n_target_points = 1; n_target_points < 13;
+       n_target_points += 11) {
+    const auto xi_target =
+        make_with_random_values<tnsr::I<DataVector, 3, Frame::ElementLogical>>(
+            generator, make_not_null(&xi_distribution), n_target_points);
+    for (size_t n_xi = 2; n_xi < 21; n_xi += 3) {
+      for (size_t n_eta = 2; n_eta < 21; n_eta += 3) {
+        for (size_t n_zeta = 2; n_zeta < 21; n_zeta += 3) {
+          const Mesh<3> source_mesh{std::array{n_xi, n_eta, n_zeta},
+                                    Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto};
+          const ProductOfPolynomials<3> f{
+              std::array{n_xi - 1, n_eta - 1, n_zeta - 1},
+              std::array{1.5, 2.5, 3.5}, std::array{2.0, 4.0, 2.5}};
+          const auto xi_source = logical_coordinates(source_mesh);
+          const DataVector f_source = f(xi_source);
+          const DataVector f_expected = f(xi_target);
+          const intrp::Cardinal<3> interpolator(source_mesh, xi_target);
+          const DataVector f_interpolated = interpolator.interpolate(f_source);
+          CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+        }
+      }
+    }
+  }
+}
+
+void test_3d_spherical(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  std::uniform_real_distribution<> phi_distribution(0.0, 2.0 * M_PI);
+  for (size_t n_target_points = 1; n_target_points < 13;
+       n_target_points += 11) {
+    tnsr::I<DataVector, 3, Frame::ElementLogical> xi_target{n_target_points};
+    get<0>(xi_target) = make_with_random_values<DataVector>(
+        generator, make_not_null(&xi_distribution), xi_target);
+    get<1>(xi_target) = acos(make_with_random_values<DataVector>(
+        generator, make_not_null(&xi_distribution), xi_target));
+    get<2>(xi_target) = make_with_random_values<DataVector>(
+        generator, make_not_null(&phi_distribution), xi_target);
+    for (size_t n_r = 2; n_r < 4; ++n_r) {
+      for (size_t n_z = 0; n_z < 4; ++n_z) {
+        for (size_t n_y = 0; n_y < 4; ++n_y) {
+          for (size_t n_x = 0; n_x < 4; ++n_x) {
+            const Mesh<3> source_mesh{
+                std::array{n_r, n_x + n_y + n_z + 2, 2 * (n_x + n_y) + 3},
+                std::array{Spectral::Basis::Legendre,
+                           Spectral::Basis::SphericalHarmonic,
+                           Spectral::Basis::SphericalHarmonic},
+                std::array{Spectral::Quadrature::GaussLobatto,
+                           Spectral::Quadrature::Gauss,
+                           Spectral::Quadrature::Equiangular}};
+            const Polynomial f_r{n_r - 1, 1.5, 2.0};
+            const YlmTestFunctions::ProductOfPolynomials f_a(n_x, n_y, n_z);
+            const auto xi_source = logical_coordinates(source_mesh);
+            const DataVector f_source =
+                f_r(get<0>(xi_source)) *
+                f_a(get<1>(xi_source), get<2>(xi_source));
+            const DataVector f_expected =
+                f_r(get<0>(xi_target)) *
+                f_a(get<1>(xi_target), get<2>(xi_target));
+            const intrp::Cardinal<3> interpolator(source_mesh, xi_target);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          }
+        }
+      }
+    }
+  }
+}
+}  // namespace
+
+// [[Timeout, 20]]
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.Cardinal",
+                  "[Unit][NumericalAlgorithms]") {
+  MAKE_GENERATOR(generator);
+  test_1d(make_not_null(&generator));
+  test_2d_cartesian(make_not_null(&generator));
+  test_2d_spherical(make_not_null(&generator));
+  test_3d_cartesian(make_not_null(&generator));
+  test_3d_spherical(make_not_null(&generator));
+}

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationWeights.cpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationWeights.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void test_fornberg_matrix(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  for (size_t n_target_points = 1; n_target_points < 101;
+       n_target_points += 11) {
+    const auto x_target = make_with_random_values<DataVector>(
+        generator, make_not_null(&xi_distribution), n_target_points);
+    for (size_t n_source_points = 4; n_source_points < 20; ++n_source_points) {
+      // Check that we get the same matrices as Spectral::interpolation_matrix
+      // for collocation points of existing Basis and Quadrature
+      for (const auto basis :
+           std::array{Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+        for (const auto quadrature :
+             std::array{Spectral::Quadrature::Gauss,
+                        Spectral::Quadrature::GaussLobatto}) {
+          const Mesh<1> mesh{n_source_points, basis, quadrature};
+          const auto xi = logical_coordinates(mesh);
+          const Matrix spectral_matrix =
+              Spectral::interpolation_matrix(mesh, x_target);
+          const Matrix fornberg_matrix =
+              intrp::fornberg_interpolation_matrix(x_target, get<0>(xi));
+          CHECK(fornberg_matrix.rows() == n_target_points);
+          CHECK(fornberg_matrix.columns() == n_source_points);
+          CHECK(spectral_matrix == fornberg_matrix);
+        }
+      }
+    }
+  }
+}
+
+DataVector f_periodic(const DataVector& x) { return sin(M_PI * cos(x)); }
+
+void test_fourier_matrix(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> phi_distribution(0.0, 2 * M_PI);
+  const size_t n_source_points = 48;
+  const DataVector x_source = get<0>(logical_coordinates(
+      Mesh<1>{n_source_points, Spectral::Basis::SphericalHarmonic,
+              Spectral::Quadrature::Equiangular}));
+  DataVector f_source = f_periodic(x_source);
+  for (size_t n_target_points = 1; n_target_points < 101;
+       n_target_points += 11) {
+    const auto x_target = make_with_random_values<DataVector>(
+        generator, make_not_null(&phi_distribution), n_target_points);
+    const DataVector f_target = f_periodic(x_target);
+    const Matrix m =
+        intrp::fourier_interpolation_matrix(x_target, n_source_points);
+    DataVector f_interp{n_target_points};
+    dgemv_('N', n_target_points, n_source_points, 1.0, m.data(),
+           n_target_points, f_source.data(), 1, 0.0, f_interp.data(), 1);
+    for (size_t k = 0; k < n_target_points; ++k) {
+      CHECK_THAT(f_interp[k], Catch::Matchers::WithinAbs(f_target[k], 1.e-13));
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.Weights",
+                  "[Unit][NumericalAlgorithms]") {
+  MAKE_GENERATOR(generator);
+  test_fornberg_matrix(make_not_null(&generator));
+  test_fourier_matrix(make_not_null(&generator));
+}

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -30,6 +30,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
@@ -47,6 +48,26 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace {
+// Polynomial of given degree with leading coefficinet \f$a_0\f$, and with
+// \f$a_{n+1} = a_n / falloff
+class Polynomial {
+ public:
+  Polynomial(const size_t degree, const double a_0, const double falloff)
+      : coefficients_(degree + 1) {
+    double n = falloff * a_0;
+    std::generate(coefficients_.begin(), coefficients_.end(), [&falloff, &n]() {
+      n /= falloff;
+      return n;
+    });
+  }
+  Polynomial() = default;
+  DataVector operator()(const DataVector& x) const {
+    return evaluate_polynomial(coefficients_, x);
+  }
+
+ private:
+  std::vector<double> coefficients_;
+};
 
 using Affine = domain::CoordinateMaps::Affine;
 using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
@@ -411,6 +432,81 @@ void test_tov() {
   }
 }
 
+void test_2d_spherical(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  std::uniform_real_distribution<> phi_distribution(0.0, 2.0 * M_PI);
+  for (size_t n_target_points = 1; n_target_points < 13;
+       n_target_points += 11) {
+    tnsr::I<DataVector, 2, Frame::ElementLogical> xi_target{n_target_points};
+    get<0>(xi_target) = acos(make_with_random_values<DataVector>(
+        generator, make_not_null(&xi_distribution), xi_target));
+    get<1>(xi_target) = make_with_random_values<DataVector>(
+        generator, make_not_null(&phi_distribution), xi_target);
+    for (size_t n_z = 0; n_z < 4; ++n_z) {
+      for (size_t n_y = 0; n_y < 4; ++n_y) {
+        for (size_t n_x = 0; n_x < 4; ++n_x) {
+          const Mesh<2> source_mesh{
+              std::array{n_x + n_y + n_z + 2, 2 * (n_x + n_y) + 3},
+              std::array{Spectral::Basis::SphericalHarmonic,
+                         Spectral::Basis::SphericalHarmonic},
+              std::array{Spectral::Quadrature::Gauss,
+                         Spectral::Quadrature::Equiangular}};
+          const YlmTestFunctions::ProductOfPolynomials f(n_x, n_y, n_z);
+          const auto xi_source = logical_coordinates(source_mesh);
+          const DataVector f_source = f(xi_source);
+          const DataVector f_expected = f(xi_target);
+          const intrp::Irregular<2> interpolator(source_mesh, xi_target);
+          const DataVector f_interpolated = interpolator.interpolate(f_source);
+          CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+        }
+      }
+    }
+  }
+}
+
+void test_3d_spherical(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  std::uniform_real_distribution<> phi_distribution(0.0, 2.0 * M_PI);
+  for (size_t n_target_points = 1; n_target_points < 13;
+       n_target_points += 11) {
+    tnsr::I<DataVector, 3, Frame::ElementLogical> xi_target{n_target_points};
+    get<0>(xi_target) = make_with_random_values<DataVector>(
+        generator, make_not_null(&xi_distribution), xi_target);
+    get<1>(xi_target) = acos(make_with_random_values<DataVector>(
+        generator, make_not_null(&xi_distribution), xi_target));
+    get<2>(xi_target) = make_with_random_values<DataVector>(
+        generator, make_not_null(&phi_distribution), xi_target);
+    for (size_t n_r = 2; n_r < 4; ++n_r) {
+      for (size_t n_z = 0; n_z < 4; ++n_z) {
+        for (size_t n_y = 0; n_y < 4; ++n_y) {
+          for (size_t n_x = 0; n_x < 4; ++n_x) {
+            const Mesh<3> source_mesh{
+                std::array{n_r, n_x + n_y + n_z + 2, 2 * (n_x + n_y) + 3},
+                std::array{Spectral::Basis::Legendre,
+                           Spectral::Basis::SphericalHarmonic,
+                           Spectral::Basis::SphericalHarmonic},
+                std::array{Spectral::Quadrature::GaussLobatto,
+                           Spectral::Quadrature::Gauss,
+                           Spectral::Quadrature::Equiangular}};
+            const Polynomial f_r{n_r - 1, 1.5, 2.0};
+            const YlmTestFunctions::ProductOfPolynomials f_a(n_x, n_y, n_z);
+            const auto xi_source = logical_coordinates(source_mesh);
+            const DataVector f_source =
+                f_r(get<0>(xi_source)) *
+                f_a(get<1>(xi_source), get<2>(xi_source));
+            const DataVector f_expected =
+                f_r(get<0>(xi_target)) *
+                f_a(get<1>(xi_target), get<2>(xi_target));
+            const intrp::Irregular<3> interpolator(source_mesh, xi_target);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          }
+        }
+      }
+    }
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
@@ -429,4 +525,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
   test_polynomial_interpolant<3, 1>({{11, 9, 9}});
   test_polynomial_interpolant<3, 1>({{11, 9, 13}});
   test_tov();
+  MAKE_GENERATOR(generator);
+  test_2d_spherical(make_not_null(&generator));
+  test_3d_spherical(make_not_null(&generator));
 }

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -125,11 +125,11 @@ void test_definite_integral_spherical_shell(const size_t n_r, const size_t L) {
       CAPTURE(pow_ny);
       for (size_t pow_nz = 0; pow_nz <= L - pow_nx - pow_ny; ++pow_nz) {
         CAPTURE(pow_nz);
-        const YlmTestFunctions::ProductOfPolynomials y_lm{
-            n_r, L, L, pow_nx, pow_ny, pow_nz};
+        const YlmTestFunctions::ProductOfPolynomials f{pow_nx, pow_ny, pow_nz};
 
-        const DataVector integrand = r * y_lm.f();
-        CHECK(4.0 * y_lm.definite_integral() ==
+        const DataVector integrand =
+            r * f(get<1>(xi_vector), get<2>(xi_vector));
+        CHECK(4.0 * f.definite_integral() ==
               approx(definite_integral(integrand, mesh)));
       }
     }


### PR DESCRIPTION
## Proposed changes

Adds ability to interpolate if the basis is spherical harmonic

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
