### PR TITLE
Allow specifying 'None' for control sys in input file

### DIFF
--- a/src/ControlSystem/ExpirationTimes.hpp
+++ b/src/ControlSystem/ExpirationTimes.hpp
@@ -125,7 +125,7 @@ template <size_t Dim, typename... OptionHolders>
 std::unordered_map<std::string, double> initial_expiration_times(
     const double initial_time, const int measurements_per_update,
     const std::unique_ptr<::DomainCreator<Dim>>& domain_creator,
-    const OptionHolders&... option_holders) {
+    const std::optional<OptionHolders>&... option_holders) {
   std::unordered_map<std::string, double> initial_expiration_times{};
 
   using control_systems = tmpl::list<typename OptionHolders::control_system...>;
@@ -149,31 +149,29 @@ std::unordered_map<std::string, double> initial_expiration_times(
       [&initial_time, &measurements_per_update, &domain_creator, &map_of_names,
        &combined_expiration_times,
        &infinite_expiration_times](const auto& option_holder) {
-        const std::string& control_system_name =
-            std::decay_t<decltype(option_holder)>::control_system::name();
+        const std::string& control_system_name = std::decay_t<
+            decltype(option_holder)>::value_type::control_system::name();
         const std::string& combined_name = map_of_names[control_system_name];
 
-        auto tuner = option_holder.tuner;
+        // If not active, leave the expiration time as infinity
+        if (not option_holder.has_value()) {
+          infinite_expiration_times.insert(control_system_name);
+          return;
+        }
+
+        auto tuner = option_holder->tuner;
         Tags::detail::initialize_tuner(make_not_null(&tuner), domain_creator,
                                        initial_time, control_system_name);
 
-        const auto& controller = option_holder.controller;
+        const auto& controller = option_holder->controller;
         const DataVector measurement_timescales =
             calculate_measurement_timescales(controller, tuner,
                                              measurements_per_update);
         const double min_measurement_timescale = min(measurement_timescales);
 
-        double initial_expiration_time = function_of_time_expiration_time(
+        const double initial_expiration_time = function_of_time_expiration_time(
             initial_time, DataVector{1, 0.0},
             DataVector{1, min_measurement_timescale}, measurements_per_update);
-        initial_expiration_time = option_holder.is_active
-                                      ? initial_expiration_time
-                                      : std::numeric_limits<double>::infinity();
-
-        if (initial_expiration_time ==
-            std::numeric_limits<double>::infinity()) {
-          infinite_expiration_times.insert(control_system_name);
-        }
 
         combined_expiration_times[combined_name] = std::min(
             combined_expiration_times[combined_name], initial_expiration_time);
@@ -185,7 +183,7 @@ std::unordered_map<std::string, double> initial_expiration_times(
   // time
   for (const auto& [control_system_name, combined_name] : map_of_names) {
     initial_expiration_times[control_system_name] =
-        infinite_expiration_times.count(control_system_name) == 1
+        infinite_expiration_times.contains(control_system_name)
             ? std::numeric_limits<double>::infinity()
             : combined_expiration_times[combined_name];
   }

--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
@@ -17,6 +17,7 @@
 #include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Options/Auto.hpp"
 #include "Time/OptionTags/InitialTime.hpp"
 #include "Time/OptionTags/InitialTimeStep.hpp"
 #include "Utilities/TMPL.hpp"
@@ -74,14 +75,27 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime,
           tmpl::list<>>,
       domain::OptionTags::DomainCreator<Metavariables::volume_dim>>;
 
+  /// @{
   /// This version of create_from_options is used if the metavariables did
   /// define control systems
   template <typename Metavariables, typename... OptionHolders>
   static type create_from_options(
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
-      const int measurements_per_update,
-     const double initial_time, const OptionHolders&... option_holders) {
+      const int measurements_per_update, const double initial_time,
+      const Options::Auto<OptionHolders,
+                          Options::AutoLabel::None>&... option_holders) {
+    return create_from_options<Metavariables>(
+        domain_creator, measurements_per_update, initial_time,
+        static_cast<const std::optional<OptionHolders>&>(option_holders)...);
+  }
+
+  template <typename Metavariables, typename... OptionHolders>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const int measurements_per_update, const double initial_time,
+      const std::optional<OptionHolders>&... option_holders) {
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
             initial_time, measurements_per_update, domain_creator,
@@ -99,12 +113,13 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime,
 
     return functions_of_time;
   }
+  /// @}
 
   /// This version of create_from_options is used if the metavariables did not
   /// define control systems
   template <typename Metavariables>
   static type create_from_options(
-     const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator) {
     return domain_creator->functions_of_time();
   }

--- a/src/ControlSystem/Tags/IsActiveMap.hpp
+++ b/src/ControlSystem/Tags/IsActiveMap.hpp
@@ -11,6 +11,7 @@
 #include "ControlSystem/Metafunctions.hpp"
 #include "ControlSystem/Tags/OptionTags.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "Options/Auto.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -26,14 +27,14 @@ namespace control_system::Tags {
 namespace detail {
 template <typename... OptionHolders>
 std::unordered_map<std::string, bool> create_is_active_map(
-    const OptionHolders&... option_holders) {
+    const std::optional<OptionHolders>&... option_holders) {
   std::unordered_map<std::string, bool> result{};
 
   [[maybe_unused]] const auto add_to_result =
       [&result](const auto& option_holder) {
-        using control_system =
-            typename std::decay_t<decltype(option_holder)>::control_system;
-        result[control_system::name()] = option_holder.is_active;
+        using control_system = typename std::decay_t<
+            decltype(option_holder)>::value_type::control_system;
+        result[control_system::name()] = option_holder.has_value();
       };
 
   EXPAND_PACK_LEFT_TO_RIGHT(add_to_result(option_holders));
@@ -65,7 +66,16 @@ struct IsActiveMap : db::SimpleTag {
       metafunctions::all_control_components<Metavariables>, system<tmpl::_1>>>;
 
   template <typename Metavariables, typename... OptionHolders>
-  static type create_from_options(const OptionHolders&... option_holders) {
+  static type create_from_options(
+      const Options::Auto<OptionHolders,
+                          Options::AutoLabel::None>&... option_holders) {
+    return create_from_options<Metavariables>(
+        static_cast<const std::optional<OptionHolders>>(option_holders)...);
+  }
+
+  template <typename Metavariables, typename... OptionHolders>
+  static type create_from_options(
+      const std::optional<OptionHolders>&... option_holders) {
     return detail::create_is_active_map(option_holders...);
   }
 };

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -23,6 +23,7 @@
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Options/Auto.hpp"
 #include "Time/OptionTags/InitialTime.hpp"
 #include "Time/OptionTags/InitialTimeStep.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -83,7 +84,21 @@ struct MeasurementTimescales : db::SimpleTag {
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
       const double initial_time, const double initial_time_step,
-      const OptionHolders&... option_holders) {
+      const Options::Auto<OptionHolders,
+                          Options::AutoLabel::None>&... option_holders) {
+    return create_from_options<Metavariables>(
+        measurements_per_update, domain_creator, initial_time,
+        initial_time_step,
+        static_cast<std::optional<OptionHolders>>(option_holders)...);
+  }
+
+  template <typename Metavariables, typename... OptionHolders>
+  static type create_from_options(
+      const int measurements_per_update,
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const double initial_time, const double initial_time_step,
+      const std::optional<OptionHolders>&... option_holders) {
     std::unordered_map<std::string,
                        std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
         timescales{};
@@ -121,25 +136,27 @@ struct MeasurementTimescales : db::SimpleTag {
                 "evolutions.");
           }
 
-          const std::string& control_system_name =
-              std::decay_t<decltype(option_holder)>::control_system::name();
+          const std::string& control_system_name = std::decay_t<
+              decltype(option_holder)>::value_type::control_system::name();
           const std::string& combined_name = map_of_names[control_system_name];
-
-          auto tuner = option_holder.tuner;
-          ::control_system::Tags::detail::initialize_tuner(
-              make_not_null(&tuner), domain_creator, initial_time,
-              control_system_name);
-
-          const auto& controller = option_holder.controller;
-          DataVector measurement_timescales = calculate_measurement_timescales(
-              controller, tuner, measurements_per_update);
-
-          double min_measurement_timescale = min(measurement_timescales);
 
           // If the control system isn't active, set measurement timescale and
           // expiration time to be infinity.
-          if (not option_holder.is_active) {
-            min_measurement_timescale = std::numeric_limits<double>::infinity();
+          double min_measurement_timescale =
+              std::numeric_limits<double>::infinity();
+
+          if (option_holder.has_value()) {
+            auto tuner = option_holder->tuner;
+            ::control_system::Tags::detail::initialize_tuner(
+                make_not_null(&tuner), domain_creator, initial_time,
+                control_system_name);
+
+            const auto& controller = option_holder->controller;
+            DataVector measurement_timescales =
+                calculate_measurement_timescales(controller, tuner,
+                                                 measurements_per_update);
+
+            min_measurement_timescale = min(measurement_timescales);
           }
 
           min_measurement_timescales[combined_name] =

--- a/src/ControlSystem/Tags/OptionTags.hpp
+++ b/src/ControlSystem/Tags/OptionTags.hpp
@@ -12,6 +12,7 @@
 #include "ControlSystem/Protocols/ControlSystem.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "IO/Logging/Verbosity.hpp"
+#include "Options/Auto.hpp"
 #include "Options/String.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -23,6 +24,8 @@ namespace control_system {
 /// This struct collects all the options for a given control system during
 /// option parsing. Then during initialization, the options can be retrieved via
 /// their public member names and assigned to their corresponding DataBox tags.
+///
+/// This class should only be used if a control system is active.
 template <typename ControlSystem>
 struct OptionHolder {
  private:
@@ -34,13 +37,6 @@ struct OptionHolder {
                 ControlSystem, control_system::protocols::ControlSystem>);
   using control_system = ControlSystem;
   static constexpr size_t deriv_order = control_system::deriv_order;
-  struct IsActive {
-    using type = bool;
-    static constexpr Options::String help = {
-        "Whether the control system is actually active. If it isn't active, no "
-        "measurements (horizon finds) will be done and the functions of time "
-        "will never expire."};
-  };
 
   struct Averager {
     using type = ::Averager<deriv_order - 1>;
@@ -71,16 +67,14 @@ struct OptionHolder {
   };
 
   using options =
-      tmpl::list<IsActive, Averager, Controller, TimescaleTuner, ControlError>;
+      tmpl::list<Averager, Controller, TimescaleTuner, ControlError>;
   static constexpr Options::String help = {"Options for a control system."};
 
-  OptionHolder(const bool input_is_active,
-               ::Averager<deriv_order - 1> input_averager,
+  OptionHolder(::Averager<deriv_order - 1> input_averager,
                ::Controller<deriv_order> input_controller,
                ::TimescaleTuner<not is_size> input_tuner,
                typename ControlSystem::control_error input_control_error)
-      : is_active(input_is_active),
-        averager(std::move(input_averager)),
+      : averager(std::move(input_averager)),
         controller(std::move(input_controller)),
         tuner(std::move(input_tuner)),
         control_error(std::move(input_control_error)) {}
@@ -94,7 +88,6 @@ struct OptionHolder {
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) {
-    p | is_active;
     p | averager;
     p | controller;
     p | tuner;
@@ -103,7 +96,6 @@ struct OptionHolder {
 
   // These members are specifically made public for easy access during
   // initialization
-  bool is_active{true};
   ::Averager<deriv_order - 1> averager{};
   ::Controller<deriv_order> controller{};
   ::TimescaleTuner<not is_size> tuner{};
@@ -127,9 +119,12 @@ struct ControlSystemGroup {
 /// Option tag for each individual control system. The name of this option is
 /// the name of the \p ControlSystem struct it is templated on. This way all
 /// control systems will have a unique name.
+///
+/// \details If `None` is specified, this control system is not active.
 template <typename ControlSystem>
 struct ControlSystemInputs {
-  using type = control_system::OptionHolder<ControlSystem>;
+  using type = Options::Auto<control_system::OptionHolder<ControlSystem>,
+                             Options::AutoLabel::None>;
   static constexpr Options::String help{"Options for a control system."};
   static std::string name() { return ControlSystem::name(); }
   using group = ControlSystemGroup;

--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -82,6 +82,8 @@ struct ObserveCenters : ::ah::Tags::ObserveCentersBase, db::SimpleTag {
 ///
 /// To compute the `deriv_order`th derivative of a control error, the max
 /// derivative we need from the averager is the `deriv_order - 1`st derivative.
+///
+/// If the option holder is nullopt, constructs a default Averager.
 template <typename ControlSystem>
 struct Averager : db::SimpleTag {
   using type = ::Averager<ControlSystem::deriv_order - 1>;
@@ -90,8 +92,9 @@ struct Averager : db::SimpleTag {
       tmpl::list<OptionTags::ControlSystemInputs<ControlSystem>>;
   static constexpr bool pass_metavariables = false;
   static type create_from_options(
-      const control_system::OptionHolder<ControlSystem>& option_holder) {
-    return option_holder.averager;
+      const std::optional<control_system::OptionHolder<ControlSystem>>&
+          option_holder) {
+    return option_holder.has_value() ? option_holder->averager : type{};
   }
 };
 
@@ -106,6 +109,8 @@ void initialize_tuner(
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
 /// DataBox tag for the timescale tuner
+///
+/// If the option holder is nullopt, constructs a default TimescaleTuner.
 template <typename ControlSystem>
 struct TimescaleTuner : db::SimpleTag {
  private:
@@ -124,11 +129,16 @@ struct TimescaleTuner : db::SimpleTag {
 
   template <typename Metavariables>
   static type create_from_options(
-      const control_system::OptionHolder<ControlSystem>& option_holder,
+      const std::optional<control_system::OptionHolder<ControlSystem>>&
+          option_holder,
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
       const double initial_time) {
-    auto tuner = option_holder.tuner;
+    if (not option_holder.has_value()) {
+      return type{};
+    }
+
+    auto tuner = option_holder->tuner;
     detail::initialize_tuner(make_not_null(&tuner), domain_creator,
                              initial_time, ControlSystem::name());
     return tuner;
@@ -138,6 +148,8 @@ struct TimescaleTuner : db::SimpleTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
 /// DataBox tag for the controller
+///
+/// If the option holder is nullopt, constructs a default Controller.
 template <typename ControlSystem>
 struct Controller : db::SimpleTag {
   using type = ::Controller<ControlSystem::deriv_order>;
@@ -151,12 +163,17 @@ struct Controller : db::SimpleTag {
 
   template <typename Metavariables>
   static type create_from_options(
-      const control_system::OptionHolder<ControlSystem>& option_holder,
+      const std::optional<control_system::OptionHolder<ControlSystem>>&
+          option_holder,
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
       const double initial_time) {
-    type controller = option_holder.controller;
-    auto tuner = option_holder.tuner;
+    if (not option_holder.has_value()) {
+      return type{};
+    }
+
+    type controller = option_holder->controller;
+    auto tuner = option_holder->tuner;
     detail::initialize_tuner(make_not_null(&tuner), domain_creator,
                              initial_time, ControlSystem::name());
 
@@ -170,6 +187,8 @@ struct Controller : db::SimpleTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
 /// DataBox tag for the control error
+///
+/// If the option holder is nullopt, constructs a default ControlError.
 template <typename ControlSystem>
 struct ControlError : db::SimpleTag {
   using type = typename ControlSystem::control_error;
@@ -179,8 +198,9 @@ struct ControlError : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
 
   static type create_from_options(
-      const control_system::OptionHolder<ControlSystem>& option_holder) {
-    return option_holder.control_error;
+      const std::optional<control_system::OptionHolder<ControlSystem>>&
+          option_holder) {
+    return option_holder.has_value() ? option_holder->control_error : type{};
   }
 };
 

--- a/src/ControlSystem/TimescaleTuner.hpp
+++ b/src/ControlSystem/TimescaleTuner.hpp
@@ -151,13 +151,13 @@ class TimescaleTuner {
 
   DataVector timescale_;
   bool timescales_have_been_set_{false};
-  double initial_timescale_{std::numeric_limits<double>::signaling_NaN()};
-  double max_timescale_;
-  double min_timescale_;
-  double decrease_timescale_threshold_;
-  double increase_timescale_threshold_;
-  double increase_factor_;
-  double decrease_factor_;
+  double initial_timescale_{0.0};
+  double max_timescale_{0.0};
+  double min_timescale_{0.0};
+  double decrease_timescale_threshold_{0.0};
+  double increase_timescale_threshold_{0.0};
+  double increase_factor_{0.0};
+  double decrease_factor_{0.0};
 };
 
 template <bool AllowDecrease>

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -500,8 +500,7 @@ ControlSystems:
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
   Verbosity: Silent
-  Expansion:
-    IsActive: true
+  Expansion: &KinematicControlSystem
     Averager: &KinematicAverager
       AverageTimescaleFraction: &AvgTimescaleFrac 0.25
       Average0thDeriv: false
@@ -517,20 +516,9 @@ ControlSystems:
       IncreaseFactor: &IncreaseFactor 1.01
       DecreaseFactor: &DecreaseFactor 0.98
     ControlError:
-  Rotation:
-    IsActive: true
-    Averager: *KinematicAverager
-    Controller: *KinematicController
-    TimescaleTuner: *KinematicTuner
-    ControlError:
-  Translation:
-    IsActive: false
-    Averager: *KinematicAverager
-    Controller: *KinematicController
-    TimescaleTuner: *KinematicTuner
-    ControlError:
+  Rotation: *KinematicControlSystem
+  Translation: None
   ShapeA:
-    IsActive: true
     Averager: &SizeShapeAverager
       AverageTimescaleFraction: *AvgTimescaleFrac
       Average0thDeriv: true
@@ -545,7 +533,6 @@ ControlSystems:
       DecreaseFactor: *DecreaseFactor
     ControlError:
   ShapeB:
-    IsActive: true
     Averager: *SizeShapeAverager
     Controller: *KinematicController
     TimescaleTuner:
@@ -558,7 +545,6 @@ ControlSystems:
       DecreaseFactor: *DecreaseFactor
     ControlError:
   SizeA:
-    IsActive: true
     Averager: *SizeShapeAverager
     Controller: &SizeController
       UpdateFraction: 0.2
@@ -582,7 +568,6 @@ ControlSystems:
         IncreaseFactor: *IncreaseFactor
         DecreaseFactor: *DecreaseFactor
   SizeB:
-    IsActive: true
     Averager: *SizeShapeAverager
     Controller: *SizeController
     TimescaleTuner:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -326,7 +326,6 @@ ControlSystems:
   MeasurementsPerUpdate: 4
   Verbosity: Silent
   Translation:
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: false
@@ -342,7 +341,6 @@ ControlSystems:
       DecreaseFactor: 0.98
     ControlError:
   Shape:
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       # This is different from inspiral but same as SpEC.
@@ -360,7 +358,6 @@ ControlSystems:
       DecreaseFactor: 0.98
     ControlError:
   Size:
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: true

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -316,7 +316,6 @@ ControlSystems:
   MeasurementsPerUpdate: 4
   Verbosity: Silent
   Expansion:
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: false
@@ -332,7 +331,6 @@ ControlSystems:
       DecreaseFactor: 0.98
     ControlError:
   Rotation:
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: false
@@ -347,24 +345,8 @@ ControlSystems:
       IncreaseFactor: 1.01
       DecreaseFactor: 0.98
     ControlError:
-  Translation:
-    IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      UpdateFraction: 0.3
-    TimescaleTuner:
-      InitialTimescales: [0.2, 0.2, 0.2]
-      MinTimescale: 1.0e-2
-      MaxTimescale: 20.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
-    ControlError:
+  Translation: None
   ShapeA: &ShapeControl
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: false
@@ -381,7 +363,6 @@ ControlSystems:
     ControlError:
   ShapeB: *ShapeControl
   SizeA: &SizeControl
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: true

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -271,61 +271,6 @@ ControlSystems:
   WriteDataToDisk: false
   MeasurementsPerUpdate: 4
   Verbosity: Silent
-  Translation:
-    IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      UpdateFraction: 0.3
-    TimescaleTuner:
-      InitialTimescales: 0.2
-      MinTimescale: 1.0e-2
-      MaxTimescale: 10.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
-    ControlError:
-  Shape:
-    IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      UpdateFraction: 0.03
-    TimescaleTuner:
-      InitialTimescales: 0.2
-      MinTimescale: 1.0e-2
-      MaxTimescale: 10.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
-    ControlError:
-  Size:
-    IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: true
-    Controller:
-      UpdateFraction: 0.06
-    TimescaleTuner:
-      InitialTimescales: 0.2
-      MinTimescale: 1.0e-4
-      MaxTimescale: 20.0
-      IncreaseThreshold: 2.5e-4
-      IncreaseFactor: 1.01
-    ControlError:
-      MaxNumTimesForZeroCrossingPredictor: 4
-      SmoothAvgTimescaleFraction: 0.25
-      DeltaRDriftOutwardOptions: None
-      InitialState: DeltaR
-      SmootherTuner:
-        InitialTimescales: [0.2]
-        MinTimescale: 1.0e-4
-        MaxTimescale: 20.0
-        IncreaseThreshold: 2.5e-4
-        DecreaseThreshold: 1.0e-3
-        IncreaseFactor: 1.01
-        DecreaseFactor: 0.9
+  Translation: None
+  Shape: None
+  Size: None

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -385,24 +385,8 @@ ControlSystems:
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
   Verbosity: Silent
-  Expansion:
-    IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      UpdateFraction: 0.03
-    TimescaleTuner:
-      InitialTimescales: [0.2]
-      MinTimescale: 1.0e-2
-      MaxTimescale: 10.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
-    ControlError:
+  Expansion: None
   Rotation:
-    IsActive: true
     Averager:
       AverageTimescaleFraction: 0.25
       Average0thDeriv: false
@@ -417,22 +401,7 @@ ControlSystems:
       IncreaseFactor: 1.01
       DecreaseFactor: 0.98
     ControlError:
-  Translation:
-    IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      UpdateFraction: 0.3
-    TimescaleTuner:
-      InitialTimescales: [0.2, 0.2, 0.2]
-      MinTimescale: 1.0e-2
-      MaxTimescale: 20.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
-    ControlError:
+  Translation: None
 
 InitialData:
   # SpecInitialData3dEos:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -238,21 +238,6 @@ ControlSystems:
   WriteDataToDisk: false
   MeasurementsPerUpdate: 4
   Verbosity: Silent
-  Shape:
-    IsActive: false
-    Averager:
-      AverageTimescaleFraction: 0.25
-      Average0thDeriv: false
-    Controller:
-      UpdateFraction: 0.03
-    TimescaleTuner:
-      InitialTimescales: 0.2
-      MinTimescale: 1.0e-2
-      MaxTimescale: 10.0
-      IncreaseThreshold: 2.5e-4
-      DecreaseThreshold: 1.0e-3
-      IncreaseFactor: 1.01
-      DecreaseFactor: 0.98
-    ControlError:
+  Shape: None
 
 

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -44,7 +44,6 @@ void test_expansion_control_error() {
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
       "  Expansion:\n"
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -48,7 +48,6 @@ void test_rotation_control_error() {
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
       "  Rotation:\n"
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -57,7 +57,6 @@ void test_translation_control_error() {
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
       "  Translation:\n"
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -66,7 +66,6 @@ void test_expansion_control_system() {
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
       "  Expansion:\n"
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -48,7 +48,6 @@ using CoordMap =
 std::string create_input_string(const std::string& name) {
   const std::string name_str = "  "s + name + ":\n"s;
   const std::string base_string1{
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -71,7 +71,6 @@ void test_rotation_control_system(const bool newtonian) {
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
       "  Rotation:\n"
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -257,7 +257,6 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
       "  ShapeA:\n"
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -73,7 +73,6 @@ void test_translation_control_system() {
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
       "  Translation:\n"
-      "    IsActive: true\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
       "      Average0thDeriv: true\n"

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -217,12 +217,11 @@ void test_functions_of_time_tag() {
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(false, averager, controller, tuner1,
-                                 control_error);
-  OptionHolder<2> option_holder2(true, averager, controller, tuner1,
-                                 control_error);
-  OptionHolder<3> option_holder3(true, averager, controller, tuner2,
-                                 control_error);
+  const std::optional<OptionHolder<1>> option_holder1 = std::nullopt;
+  const std::optional<OptionHolder<2>> option_holder2 =
+      OptionHolder<2>{averager, controller, tuner1, control_error};
+  const std::optional<OptionHolder<3>> option_holder3 =
+      OptionHolder<3>{averager, controller, tuner2, control_error};
 
   // First test construction with only control systems
   fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
@@ -267,11 +266,11 @@ void test_functions_of_time_tag() {
         fot_tag::create_from_options<MetavariablesNoControlSystems>(
             not_controlled_creator);
     CHECK(no_control_sys_fot.size() == 1);
-    CHECK(no_control_sys_fot.count("Uncontrolled") == 1);
+    CHECK(no_control_sys_fot.contains("Uncontrolled"));
     // -3.0 comes from the TestCreator above
     CHECK(no_control_sys_fot.at("Uncontrolled")
               ->func_and_2_derivs(initial_time)[2][0] == -3.0);
-    CHECK(no_control_sys_fot.count("Controlled2") == 0);
+    CHECK_FALSE(no_control_sys_fot.contains("Controlled2"));
   }
 }
 
@@ -288,14 +287,22 @@ void not_controlling(const bool is_active) {
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(is_active, averager, controller, tuner,
-                                 control_error);
-  OptionHolder<2> option_holder2(is_active, averager, controller, tuner,
-                                 control_error);
-  OptionHolder<3> option_holder3(is_active, averager, controller, tuner,
-                                 control_error);
-  OptionHolder<4> option_holder4(is_active, averager, controller, tuner,
-                                 control_error);
+  const std::optional<OptionHolder<1>> option_holder1 =
+      is_active ? std::optional{OptionHolder<1>{averager, controller, tuner,
+                                                control_error}}
+                : std::nullopt;
+  const std::optional<OptionHolder<2>> option_holder2 =
+      is_active ? std::optional{OptionHolder<2>{averager, controller, tuner,
+                                                control_error}}
+                : std::nullopt;
+  const std::optional<OptionHolder<3>> option_holder3 =
+      is_active ? std::optional{OptionHolder<3>{averager, controller, tuner,
+                                                control_error}}
+                : std::nullopt;
+  const std::optional<OptionHolder<4>> option_holder4 =
+      is_active ? std::optional{OptionHolder<4>{averager, controller, tuner,
+                                                control_error}}
+                : std::nullopt;
 
   [[maybe_unused]] fot_tag::type functions_of_time =
       fot_tag::create_from_options<Metavariables>(
@@ -313,12 +320,18 @@ void incompatible(const bool is_active) {
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(is_active, averager, controller, tuner,
-                                 control_error);
-  OptionHolder<2> option_holder2(is_active, averager, controller, tuner,
-                                 control_error);
-  OptionHolder<3> option_holder3(is_active, averager, controller, tuner,
-                                 control_error);
+  const std::optional<OptionHolder<1>> option_holder1 =
+      is_active ? std::optional{OptionHolder<1>{averager, controller, tuner,
+                                                control_error}}
+                : std::nullopt;
+  const std::optional<OptionHolder<2>> option_holder2 =
+      is_active ? std::optional{OptionHolder<2>{averager, controller, tuner,
+                                                control_error}}
+                : std::nullopt;
+  const std::optional<OptionHolder<3>> option_holder3 =
+      is_active ? std::optional{OptionHolder<3>{averager, controller, tuner,
+                                                control_error}}
+                : std::nullopt;
 
   [[maybe_unused]] fot_tag::type functions_of_time =
       fot_tag::create_from_options<Metavariables>(

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -118,20 +118,17 @@ void test_measurement_tag() {
     tuner2.resize_timescales(2);
     const TimescaleTuner<true> tuner4 = tuner2;
     const TimescaleTuner<true>& tuner5 = tuner1;
-    const TimescaleTuner<true>& tuner6 = tuner1;
 
-    OptionHolder<1> option_holder1(true, averager, controller, tuner1,
-                                   control_error);
+    const std::optional<OptionHolder<1>> option_holder1 =
+        OptionHolder<1>{averager, controller, tuner1, control_error};
     // Control system 2 is not active so the measurement timescale and
     // expiration time should both be infinity
-    OptionHolder<2> option_holder2(false, averager, controller, tuner2,
-                                   control_error);
-    OptionHolder<4> option_holder4(true, averager, controller, tuner4,
-                                   control_error);
-    OptionHolder<5> option_holder5(true, averager, controller, tuner5,
-                                   control_error);
-    OptionHolder<6> option_holder6(false, averager, controller, tuner6,
-                                   control_error);
+    const std::optional<OptionHolder<2>> option_holder2 = std::nullopt;
+    const std::optional<OptionHolder<4>> option_holder4 =
+        OptionHolder<4>{averager, controller, tuner4, control_error};
+    const std::optional<OptionHolder<5>> option_holder5 =
+        OptionHolder<5>{averager, controller, tuner5, control_error};
+    const std::optional<OptionHolder<6>> option_holder6 = std::nullopt;
 
     const std::unique_ptr<DomainCreator<3>> creator =
         std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{
@@ -210,12 +207,12 @@ void test_measurement_tag() {
         const Controller<2> controller(0.3);
         const control_system::TestHelpers::ControlError control_error{};
 
-        OptionHolder<1> option_holder1(true, averager, controller, tuner1,
-                                       control_error);
-        OptionHolder<2> option_holder2(true, averager, controller, tuner1,
-                                       control_error);
-        OptionHolder<3> option_holder3(true, averager, controller, tuner2,
-                                       control_error);
+        std::optional<OptionHolder<1>> option_holder1 =
+            OptionHolder<1>{averager, controller, tuner1, control_error};
+        std::optional<OptionHolder<2>> option_holder2 =
+            OptionHolder<2>{averager, controller, tuner1, control_error};
+        std::optional<OptionHolder<3>> option_holder3 =
+            OptionHolder<3>{averager, controller, tuner2, control_error};
 
         const std::unique_ptr<DomainCreator<3>> creator =
             std::make_unique<FakeCreator>(

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -75,12 +75,11 @@ void test_expiration_time_construction() {
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
 
-  OptionHolder<1> option_holder1(true, averager, controller, tuner1,
-                                 control_error);
-  OptionHolder<2> option_holder2(true, averager, controller, tuner2,
-                                 control_error);
-  OptionHolder<3> option_holder3(false, averager, controller, tuner1,
-                                 control_error);
+  const std::optional<OptionHolder<1>> option_holder1 =
+      OptionHolder<1>{averager, controller, tuner1, control_error};
+  const std::optional<OptionHolder<2>> option_holder2 =
+      OptionHolder<2>{averager, controller, tuner2, control_error};
+  const std::optional<OptionHolder<3>> option_holder3 = std::nullopt;
 
   using FakeCreator = control_system::TestHelpers::FakeCreator;
 

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -104,7 +104,6 @@ void test_control_sys_inputs() {
 
   const auto input_holder = TestHelpers::test_option_tag<
       control_system::OptionTags::ControlSystemInputs<system>>(
-      "IsActive: false\n"
       "Averager:\n"
       "  AverageTimescaleFraction: 0.25\n"
       "  Average0thDeriv: true\n"
@@ -119,12 +118,13 @@ void test_control_sys_inputs() {
       "  IncreaseFactor: 1.01\n"
       "  DecreaseFactor: 0.99\n"
       "ControlError:\n");
-  CHECK_FALSE(input_holder.is_active);
-  CHECK(expected_averager == input_holder.averager);
-  CHECK(expected_controller == input_holder.controller);
-  CHECK(expected_tuner == input_holder.tuner);
-  CHECK(expected_name ==
-        std::decay_t<decltype(input_holder)>::control_system::name());
+  REQUIRE(input_holder.has_value());
+  CHECK(expected_averager == input_holder->averager);
+  CHECK(expected_controller == input_holder->controller);
+  CHECK(expected_tuner == input_holder->tuner);
+  CHECK(
+      expected_name ==
+      std::decay_t<decltype(input_holder)>::value_type::control_system::name());
 
   const auto write_data =
       TestHelpers::test_option_tag<control_system::OptionTags::WriteDataToDisk>(
@@ -153,22 +153,21 @@ void test_individual_tags() {
   };
 
   const auto tuner_str = [](const bool is_active) -> std::string {
-    return "IsActive: " + (is_active ? "true"s : "false"s) +
-           "\n"
-           "Averager:\n"
-           "  AverageTimescaleFraction: 0.25\n"
-           "  Average0thDeriv: true\n"
-           "Controller:\n"
-           "  UpdateFraction: 0.3\n"
-           "TimescaleTuner:\n"
-           "  InitialTimescales: 1.\n"
-           "  MinTimescale: 1e-3\n"
-           "  MaxTimescale: 10.\n"
-           "  DecreaseThreshold: 1e-2\n"
-           "  IncreaseThreshold: 1e-4\n"
-           "  IncreaseFactor: 1.01\n"
-           "  DecreaseFactor: 0.99\n"
-           "ControlError:\n";
+    return is_active ? "Averager:\n"
+                       "  AverageTimescaleFraction: 0.25\n"
+                       "  Average0thDeriv: true\n"
+                       "Controller:\n"
+                       "  UpdateFraction: 0.3\n"
+                       "TimescaleTuner:\n"
+                       "  InitialTimescales: 1.\n"
+                       "  MinTimescale: 1e-3\n"
+                       "  MaxTimescale: 10.\n"
+                       "  DecreaseThreshold: 1e-2\n"
+                       "  IncreaseThreshold: 1e-4\n"
+                       "  IncreaseFactor: 1.01\n"
+                       "  DecreaseFactor: 0.99\n"
+                       "ControlError:\n"
+                     : "None";
   };
 
   using tuner_tag = control_system::Tags::TimescaleTuner<system>;
@@ -203,7 +202,7 @@ void test_individual_tags() {
 
   CHECK(created_tuner == create_expected_tuner(2));
   CHECK(quat_created_tuner == create_expected_tuner(3));
-  CHECK(inactive_created_tuner == create_expected_tuner(1));
+  CHECK(inactive_created_tuner == TimescaleTuner<true>{});
 
   using control_error_tag = control_system::Tags::ControlError<system>;
   using control_error_tag2 = control_system::Tags::ControlError<system2>;

--- a/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
+++ b/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
@@ -364,9 +364,13 @@ void test_equality_and_serialization() {
       increase_timescale_threshold, increase_factor,
       decrease_timescale_threshold, decrease_factor);
 
+  TimescaleTuner<AllowDecrease> tst3{};
+
   CHECK(tst1 == tst1);
   CHECK(tst1 != tst2);
   CHECK(serialize_and_deserialize(tst1) == tst1);
+  CHECK(tst1 != tst3);
+  CHECK(serialize_and_deserialize(tst3) == tst3);
 }
 
 void test_errors() {


### PR DESCRIPTION
## Proposed changes

If a control system is inactive, it doesn't make a ton of sense to have to specify parameters that will never be used. This implements a similar system to the time dependent options for the BCO and Sphere where you can specify `None` for a control system to disable it. This also decreases the length in input files like BNS which won't use most control systems.

There was no functionality change in how the control system works. This was purely cosmetic.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To turn a control system off in the input file, use
```yaml
ControlSystems:
  Expansion: None
```
When keeping a control system active, keep all the same previous options, except remove the `IsActive:` option. I.e.
```yaml
ControlSystems:
  Expansion:
    Averager:
      AverageTimescaleFraction: 0.25
      Average0thDeriv: false
    Controller:
      UpdateFraction: 0.03
    TimescaleTuner:
      InitialTimescales: [0.2]
      MinTimescale: 1.0e-2
      MaxTimescale: 10.0
      IncreaseThreshold: 2.5e-4
      DecreaseThreshold: 1.0e-3
      IncreaseFactor: 1.01
      DecreaseFactor: 0.98
    ControlError:
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
