### PR TITLE
Error if overlay removes restart phase change, add ASSERT to power_monitors, increase SW2D test timeout.

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
@@ -21,6 +21,12 @@ namespace PowerMonitors {
 template <size_t Dim>
 void power_monitors(const gsl::not_null<std::array<DataVector, Dim>*> result,
                     const DataVector& u, const Mesh<Dim>& mesh) {
+  ASSERT(u.size() == mesh.number_of_grid_points(),
+         "The number of grid points per element ("
+             << mesh.number_of_grid_points()
+             << ") must match the size of the "
+                "vector ("
+             << u.size() << ").");
   // Get modal coefficients
   const ModalVector modal_coefficients = to_modal_coefficients(u, mesh);
 

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -775,6 +775,13 @@ void Main<Metavariables>::execute_next_phase() {
         current_phase_ = next_phase.value();
       }
     } else {
+      if (current_phase_ ==
+          Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint) {
+        ERROR(
+            "Failed to find the next phase after overlaying options during a "
+            "restart. This is caused by removing the phase change that caused "
+            "the restart.");
+      }
       const auto& default_order = Metavariables::default_phase_order;
       auto it = alg::find(default_order, current_phase_);
       using ::operator<<;

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -4,6 +4,7 @@
 Executable: EvolveScalarWave2D
 Testing:
   Check: parse;execute
+  Timeout: 20
 ExpectedExitCode: 2 0
 ExpectedOutput:
   - Checkpoints/Checkpoint_0000


### PR DESCRIPTION
## Proposed changes

I hit the error that the `UpdateOptionsAtRestartFromCheckpoint` phase wasn't in the default phase order. This is because I overlayed the options for phase changes and (accidentally) removed the phase change that caused the restart. That means it was no longer possible to figure out what phase to move to next.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
