### PR TITLE
BBH pipeline: set time bounds in ecc control

### DIFF
--- a/support/Pipelines/Bbh/EccentricityControl.py
+++ b/support/Pipelines/Bbh/EccentricityControl.py
@@ -24,7 +24,7 @@ def eccentricity_control(
     id_input_file_path: Union[str, Path],
     pipeline_dir: Union[str, Path],
     # Eccentricity control parameters
-    tmin: Optional[float] = 500,
+    tmin: Optional[float] = None,
     tmax: Optional[float] = None,
     plot_output_dir: Optional[Union[str, Path]] = None,
     ecc_params_output_file: Optional[Union[str, Path]] = None,
@@ -41,13 +41,10 @@ def eccentricity_control(
 
     - Reads orbital parameters from the 'id_input_file_path'.
 
-    - Sets the time boundaries for the eccentricity reduction process, starting
-      at 500 and using all available data by default, with the option to adjust
-      'tmin' and 'tmax' dynamically.
-
     - Get the new orbital parameters by calling the function
       'eccentricity_control_params' in
       'spectre.Pipelines.EccentricityControl.EccentricityControl'.
+      See this function for default values and more details on the arguments.
 
     - If the eccentricity is below a threshold, it prints "Success" and
       indicates that the simulation can continue.

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -378,6 +378,14 @@ def start_inspiral(
             refinement_level=refinement_level,
             polynomial_order=polynomial_order,
         )
+
+    # Set final time for eccentricity control to 2-3 orbits. This can be set
+    # more dynamically in the future.
+    if eccentricity_control:
+        inspiral_params["FinalTime"] = (
+            500 + 5 * np.pi / inspiral_params["InitialAngularVelocity"]
+        )
+
     logger.debug(f"Inspiral parameters: {pretty_repr(inspiral_params)}")
 
     # Resolve directories

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -416,12 +416,12 @@ EventsAndTriggersAtSlabs:
         Value: 2.138
     Events:
       - Completion
-  # If running eccentricity control, only run short inspiral
 {% if eccentricity_control %}
+  # If running eccentricity control, only run short inspiral
   - Trigger:
       TimeCompares:
         Comparison: GreaterThan
-        Value: 2000
+        Value: {{ FinalTime }}
     Events:
       - Completion
 {% endif %}

--- a/support/Pipelines/EccentricityControl/EccentricityControlParams.py
+++ b/support/Pipelines/EccentricityControl/EccentricityControlParams.py
@@ -76,9 +76,11 @@ def eccentricity_control_params(
       subfile_name_ahb_quantities: (Optional) Name of the subfile containing the
         quantities measured on apparent horizon B (masses and spins).
       tmin: (Optional) The lower time bound for the eccentricity estimate.
-        Used to remove initial junk and transients in the data.
+        Used to remove initial junk and transients in the data. If unspecified,
+        uses SpEC's 'OmegaDotEccRemoval.FindTmin' to estimate it.
       tmax: (Optional) The upper time bound for the eccentricity estimate.
         A reasonable value would include 2-3 orbits.
+        Default is '500 + 5 * pi / Omega0'.
       plot_output_dir: (Optional) Output directory for plots.
       ecc_params_output_file: (Optional) Output file for the results.
 
@@ -89,6 +91,7 @@ def eccentricity_control_params(
     try:
         from OmegaDotEccRemoval import (
             ComputeOmegaAndDerivsFromFile,
+            FindTmin,
             performAllFits,
         )
     except ImportError:
@@ -121,12 +124,17 @@ def eccentricity_control_params(
     traj_A, traj_B = import_A_and_B(
         h5_files, subfile_name_aha_trajectories, subfile_name_ahb_trajectories
     )
-    if tmin is not None:
-        traj_A = traj_A[traj_A[:, 0] >= tmin]
-        traj_B = traj_B[traj_B[:, 0] >= tmin]
-    if tmax is not None:
-        traj_A = traj_A[traj_A[:, 0] <= tmax]
-        traj_B = traj_B[traj_B[:, 0] <= tmax]
+    t, Omega, dOmegadt, OmegaVec = ComputeOmegaAndDerivsFromFile(traj_A, traj_B)
+
+    # Set time bounds if not provided
+    if tmin is None:
+        tmin = max(FindTmin(t, dOmegadt, 500), t[0])
+    if tmax is None:
+        tmax = min(500 + 5 * np.pi / Omega0, t[-1])
+    logger.info(
+        "Estimating eccentricity from trajectory data in time range"
+        f" {tmin:.3f} to {tmax:.3f}."
+    )
 
     # Load horizon parameters from evolution data at reference time (tmin)
     def get_horizons_data(reductions_file):
@@ -147,11 +155,9 @@ def eccentricity_control_params(
             return pd.concat(horizons_data, axis=1)
 
     horizon_params = pd.concat(map(get_horizons_data, h5_files))
-    if tmin is not None:
-        horizon_params = horizon_params[horizon_params.index >= tmin]
     if horizon_params.empty:
         logger.warning(
-            "No horizon data found in time range. "
+            "No horizon data found. "
             "Using initial data masses and ignoring spins."
         )
         mA = target_params["MassA"]
@@ -181,7 +187,6 @@ def eccentricity_control_params(
 
     # Call into SpEC's OmegaDotEccRemoval.py
     # Despite the name, this SpEC function takes arrays of data
-    t, Omega, dOmegadt, OmegaVec = ComputeOmegaAndDerivsFromFile(traj_A, traj_B)
     eccentricity, delta_Omega0, delta_adot0, delta_D0, ecc_std_dev, _ = (
         performAllFits(
             XA=traj_A,
@@ -197,9 +202,9 @@ def eccentricity_control_params(
             IDparam_omega0=Omega0,
             IDparam_adot0=adot0,
             IDparam_D0=D0,
-            tmin=tmin or 0.0,
-            tmax=tmax or np.inf,
-            tref=tmin or 0.0,
+            tmin=tmin,
+            tmax=tmax,
+            tref=tmin,
             opt_freq_filter=True,
             opt_varpro=True,
             opt_type="bbh",

--- a/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
+++ b/tools/Status/ExecutableStatus/EvolveGhBinaryBlackHole.py
@@ -271,12 +271,19 @@ class EvolveGhBinaryBlackHole(EvolutionStatus):
         @st.fragment
         def render_eccentricity():
             if st.checkbox("Show eccentricity"):
-                col_tmin, col_tmax = st.columns(2)
+                if st.checkbox("Set time bounds"):
+                    col_tmin, col_tmax = st.columns(2)
+                    tmin = col_tmin.number_input("tmin", value=500, min_value=0)
+                    tmax = col_tmax.number_input(
+                        "tmax", value=1500, min_value=0
+                    )
+                else:
+                    tmin, tmax = None, None
                 ecc, _, _ = eccentricity_control_params(
                     reduction_files,
                     metadata["Next"]["With"]["id_input_file_path"],
-                    tmin=col_tmin.number_input("tmin", value=600, min_value=0),
-                    tmax=col_tmax.number_input("tmax", value=2000, min_value=0),
+                    tmin=tmin,
+                    tmax=tmax,
                 )
                 st.metric("Eccentricity", f"{ecc:e}")
 


### PR DESCRIPTION
## Proposed changes

Run an ecc control iteration for 2-3 orbits and determine tmin for the eccentricity fit dynamically.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
