### PR TITLE
Implement 3D 4-th order finite difference second partial derivatives

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -59,6 +59,32 @@ struct deriv<Tag, Dim, Frame, Requires<tt::is_a_v<Tensor, typename Tag::type>>>
 
 /*!
  * \ingroup DataBoxTagsGroup
+ * \brief Prefix indicating symmetric second spatial derivatives
+ *
+ * Prefix indicating the symmetric second spatial derivatives of a Tensor.
+ *
+ * \tparam Tag The tag to wrap
+ * \tparam Dim The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
+ * \tparam Frame The frame of the derivative index
+ *
+ * \see Tags::DerivCompute
+ */
+template <typename Tag, typename Dim, typename Frame, typename = std::nullptr_t>
+struct second_deriv;
+
+/// \cond
+template <typename Tag, typename Dim, typename Frame>
+struct second_deriv<Tag, Dim, Frame,
+                    Requires<tt::is_a_v<Tensor, typename Tag::type>>>
+    : db::PrefixTag, db::SimpleTag {
+  using type = TensorMetafunctions::prepend_two_symmetric_spatial_indices<
+      typename Tag::type, Dim::value, UpLo::Lo, Frame>;
+  using tag = Tag;
+};
+/// \endcond
+
+/*!
+ * \ingroup DataBoxTagsGroup
  * \brief Prefix indicating spacetime derivatives
  *
  * Prefix indicating the spacetime derivatives of a Tensor or that a Variables

--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -53,6 +53,13 @@ struct check_index_symmetry_impl<2> {
                  tmpl::insert<IndexSymm, tmpl::pair<tmpl::front<Symm>, Index0>>,
                  IndexPack...>;
 };
+
+// helper function for prepending indices
+template <typename TheTensor>
+using new_sym_index =
+    tmpl::int32_t<1 +
+                  tmpl::fold<typename TheTensor::symmetry, tmpl::int32_t<0>,
+                             tmpl::max<tmpl::_state, tmpl::_element>>::value>;
 }  // namespace detail
 
 /*!
@@ -78,14 +85,31 @@ constexpr bool check_index_symmetry_v =
  */
 template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
           typename Fr = Frame::Grid>
-using prepend_spatial_index = ::Tensor<
+using prepend_spatial_index =
+    ::Tensor<typename TheTensor::type,
+             tmpl::push_front<typename TheTensor::symmetry,
+                              detail::new_sym_index<TheTensor>>,
+             tmpl::push_front<typename TheTensor::index_list,
+                              SpatialIndex<VolumeDim, Ul, Fr>>>;
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Add two symmetric spatial indices to the front of a Tensor (e.g. when
+ * doing second derivatives)
+ *
+ * \tparam TheTensor the tensor type to which the new indices is prepended
+ * \tparam VolumeDim the volume dimension of the tensor indices to prepend
+ * \tparam Fr the ::Frame of the tensor indices to prepend
+ */
+template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
+          typename Fr = Frame::Grid>
+using prepend_two_symmetric_spatial_indices = ::Tensor<
     typename TheTensor::type,
-    tmpl::push_front<
-        typename TheTensor::symmetry,
-        tmpl::int32_t<
-            1 + tmpl::fold<typename TheTensor::symmetry, tmpl::int32_t<0>,
-                           tmpl::max<tmpl::_state, tmpl::_element>>::value>>,
-    tmpl::push_front<typename TheTensor::index_list,
+    tmpl::push_front<tmpl::push_front<typename TheTensor::symmetry,
+                                      detail::new_sym_index<TheTensor>>,
+                     detail::new_sym_index<TheTensor>>,
+    tmpl::push_front<tmpl::push_front<typename TheTensor::index_list,
+                                      SpatialIndex<VolumeDim, Ul, Fr>>,
                      SpatialIndex<VolumeDim, Ul, Fr>>>;
 
 /*!
@@ -98,15 +122,12 @@ using prepend_spatial_index = ::Tensor<
  */
 template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
           typename Fr = Frame::Grid>
-using prepend_spacetime_index = ::Tensor<
-    typename TheTensor::type,
-    tmpl::push_front<
-        typename TheTensor::symmetry,
-        tmpl::int32_t<
-            1 + tmpl::fold<typename TheTensor::symmetry, tmpl::int32_t<0>,
-                           tmpl::max<tmpl::_state, tmpl::_element>>::value>>,
-    tmpl::push_front<typename TheTensor::index_list,
-                     SpacetimeIndex<VolumeDim, Ul, Fr>>>;
+using prepend_spacetime_index =
+    ::Tensor<typename TheTensor::type,
+             tmpl::push_front<typename TheTensor::symmetry,
+                              detail::new_sym_index<TheTensor>>,
+             tmpl::push_front<typename TheTensor::index_list,
+                              SpacetimeIndex<VolumeDim, Ul, Fr>>>;
 
 /// \ingroup TensorGroup
 /// \brief remove the first index of a tensor

--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -45,8 +45,15 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   DataStructures
+  DomainStructure
+  ErrorHandling
+  DgSubcell
+  FiniteDifference
   GeneralRelativity
   Options
+  Spectral
   Utilities
   INTERFACE
   )
+
+add_subdirectory(FiniteDifference)

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  SecondPartialDerivatives.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  SecondPartialDerivatives.hpp
+  SecondPartialDerivatives.tpp
+  )

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.cpp
@@ -1,0 +1,1155 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Transpose.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace Ccz4::fd {
+namespace {
+template <size_t Order, bool UnitStride>
+struct ComputeImpl;
+
+// only the 4-th order is implemented for now
+template <bool UnitStride>
+struct ComputeImpl<4, UnitStride> {
+  static constexpr size_t fd_order = 4;
+
+  // The stencil is used where ghost data from two neighbors is needed.
+  // It uses 13 points including the point of derivative (the 0th
+  // point "o"). We use 1-4 to label the four points distant \delta from the 0th
+  // point, 5-6 to label the two diagonal points distant sqrt(2)*\delta from the
+  // 0th point, 7-10 to label the four points distant 2*\delta from the 0th
+  // point, and 11-12 to label the two diagonal points distant 2*sqrt(2)*\delta
+  // from the 0th point. Since the weights associated with the points of the
+  // same distance to the 0th point are the same, the ordering with each
+  // subgroup above is arbitrary.
+  // Schematically, this stencil (with descending diagonal) appears
+  // 12  x  8  x  x
+  //  x  6  2  x  x
+  //  9  3 o0  1  7
+  //  x  x  4  5  x
+  //  x  x 10  x 11
+  SPECTRE_ALWAYS_INLINE static double mixed_second_deriv_special_pointwise(
+      const std::array<double, 13>& q, const int stride,
+      const std::array<double, 3>& weights) {
+    ASSERT(stride == 1, "Only UnitStride is supported" << stride);
+    return weights[0] * q[0] +
+           weights[1] * (q[1] + q[2] + q[3] + q[4] - q[5] - q[6]) +
+           weights[2] * (q[11] + q[12] - q[7] - q[8] - q[9] - q[10]);
+  }
+
+  static constexpr std::array<double, 3>
+  mixed_second_derivative_special_weights(const double one_over_delta_squared) {
+    return {{-1.25 * one_over_delta_squared,
+             0.66666666666666667 * one_over_delta_squared,
+             0.04166666666666667 * one_over_delta_squared}};
+  }
+
+  // This stencil is used in the bulk.
+  // 0 - (x+\delta, y+\delta), 1 - (x-\delta, y-\delta), 2 - (x+\delta,
+  // y-\delta), 3 - (x-\delta, y+\delta), 4 - (x+2\delta, y+2\delta), 5 -
+  // (x-2\delta, y-2\delta), 6 - (x+2\delta, y-2\delta), 7 - (x-2\delta,
+  // y+2\delta)
+  // 7 x x x 4
+  // x 3 x 0 x
+  // x x o x x
+  // x 1 x 2 x
+  // 5 x x x 6
+  SPECTRE_ALWAYS_INLINE static double mixed_second_deriv_pointwise(
+      const std::array<double, 8>& q, const int stride,
+      const std::array<double, 2>& weights) {
+    ASSERT(stride == 1, "Only UnitStride is supported" << stride);
+    return weights[0] * (q[0] + q[1] - q[2] - q[3]) +
+           weights[1] * (-q[4] - q[5] + q[6] + q[7]);
+  }
+
+  static constexpr std::array<double, 2> mixed_second_derivative_weights(
+      const double one_over_delta_squared) {
+    return {{0.33333333333333333 * one_over_delta_squared,
+             0.02083333333333333 * one_over_delta_squared}};
+  }
+
+  // This stencil is used both in the bulk and the ghost zone.
+  // We label the point of derivative as the 0th point. We use
+  // 1-2 to label the points distant \delta to the 0th point and 3-4 to label
+  // the points distant 2*\delta to the 0th point. Note that this is different
+  // from the pointer arithmetic convention in PartialDerivatives.cpp
+  // 4 2 0 1 3
+  SPECTRE_ALWAYS_INLINE static double pure_second_deriv_pointwise(
+      const std::array<double, 5>& q, const int stride,
+      const std::array<double, 3>& weights) {
+    ASSERT(stride == 1, "Only UnitStride is supported" << stride);
+    return weights[0] * q[0] + weights[1] * (q[1] + q[2]) +
+           weights[2] * (q[3] + q[4]);
+  }
+
+  static constexpr std::array<double, 3> pure_second_derivative_weights(
+      const double one_over_delta_squared) {
+    return {{-2.5 * one_over_delta_squared,
+             1.33333333333333333 * one_over_delta_squared,
+             -0.08333333333333333 * one_over_delta_squared}};
+  }
+};
+
+// Compute the xx, xy derivatives
+// x direction points to right_ghost_data; y direction points to
+// upper_ghost_data. Individual tensor components and different tensors are
+// treated the same, so they all count in number_of_variables
+template <typename DerivativeComputer, size_t Dim>
+void second_logical_partial_derivatives_fastest_dim(
+    const gsl::not_null<gsl::span<double>*> pure_second_derivative,
+    const gsl::not_null<gsl::span<double>*> mixed_second_derivative,
+    const gsl::span<const double>& volume_vars,
+    const gsl::span<const double>& lower_ghost_data,
+    const gsl::span<const double>& upper_ghost_data,
+    const gsl::span<const double>& left_ghost_data,
+    const gsl::span<const double>& right_ghost_data,
+    const Index<Dim>& volume_extents, const size_t number_of_variables,
+    const double delta_squared) {
+  constexpr size_t fd_order = DerivativeComputer::fd_order;
+  ASSERT(Dim == 3, "The dimension is hardcoded to be 3 at this moment.");
+  ASSERT(fd_order == 4,
+         "Only the 4th order finite difference has been implemented");
+  constexpr size_t ghost_zone_for_stencil =
+      fd_order / 2;  // decide points of derivatives that need ghost data
+
+  const std::array<double, 2> mixed_second_derivative_weights =
+      DerivativeComputer::mixed_second_derivative_weights(1.0 / delta_squared);
+  const std::array<double, 3> mixed_second_derivative_special_weights =
+      DerivativeComputer::mixed_second_derivative_special_weights(
+          1.0 / delta_squared);
+  const std::array<double, 3> pure_second_derivative_weights =
+      DerivativeComputer::pure_second_derivative_weights(1.0 / delta_squared);
+
+  size_t number_of_stripes =
+      volume_extents.slice_away(0).product() * number_of_variables;
+  ASSERT(left_ghost_data.size() % number_of_stripes == 0,
+         "The left ghost data must be a multiple of the number of stripes ("
+             << number_of_stripes
+             << "), which is defined as the number of variables ("
+             << number_of_variables
+             << ") times the number of grid points on a 2d slice ("
+             << volume_extents.slice_away(0).product() << ")");
+  ASSERT(volume_extents[0] >= 5 and volume_extents[1] >= 5 and
+             volume_extents[2] >= 5,
+         "At least 5 points must exist in each direction");
+  ASSERT(right_ghost_data.size() == left_ghost_data.size(),
+         "The left ghost data size ("
+             << left_ghost_data.size()
+             << ") must match the right ghost data size, "
+             << right_ghost_data.size());
+  const size_t ghost_pts_in_left_neighbor_data =
+      left_ghost_data.size() / number_of_stripes;
+  const Index<Dim> left_neighbor_extents(ghost_pts_in_left_neighbor_data,
+                                         volume_extents[1], volume_extents[2]);
+
+  // These following code can be simplified if we assume isotropic extents
+  number_of_stripes =
+      volume_extents.slice_away(1).product() * number_of_variables;
+  ASSERT(lower_ghost_data.size() % number_of_stripes == 0,
+         "The lower ghost data must be a multiple of the number of stripes ("
+             << number_of_stripes
+             << "), which is defined as the number of variables ("
+             << number_of_variables
+             << ") times the number of grid points on a 2d slice ("
+             << volume_extents.slice_away(1).product() << ")");
+  ASSERT(lower_ghost_data.size() == upper_ghost_data.size(),
+         "The lower ghost data size ("
+             << lower_ghost_data.size()
+             << ") must match the upper ghost data size, "
+             << upper_ghost_data.size());
+  const size_t ghost_pts_in_lower_neighbor_data =
+      lower_ghost_data.size() / number_of_stripes;
+  const Index<Dim> lower_neighbor_extents(
+      volume_extents[0], ghost_pts_in_lower_neighbor_data, volume_extents[2]);
+
+  constexpr size_t special_mixed_stencil_width = 13;
+  constexpr size_t mixed_stencil_width = 8;
+  constexpr size_t pure_stencil_width = 5;
+  std::array<double, special_mixed_stencil_width> q_mixed_special{};
+  std::array<double, mixed_stencil_width> q_mixed{};
+  std::array<double, pure_stencil_width> q_pure{};
+
+  // deal with each variable or tensor component
+  for (size_t vars_slice = 0; vars_slice < number_of_variables; ++vars_slice) {
+    const size_t vars_slice_offset = vars_slice * volume_extents.product();
+    const size_t left_neighbor_vars_slice_offset =
+        vars_slice * left_ghost_data.size() / number_of_variables;
+    const size_t lower_neighbor_vars_slice_offset =
+        vars_slice * lower_ghost_data.size() / number_of_variables;
+
+    // deal with each 2d xy slice
+    for (size_t k = 0; k < volume_extents[2]; ++k) {
+      // compute second derivatives in the bulk
+      for (size_t i = ghost_zone_for_stencil;
+           i < volume_extents[0] - ghost_zone_for_stencil; ++i) {
+        for (size_t j = ghost_zone_for_stencil;
+             j < volume_extents[1] - ghost_zone_for_stencil; ++j) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          q_pure[1] = volume_vars[vars_collapsed_index - 1];
+          q_pure[2] = volume_vars[vars_collapsed_index + 1];
+          q_pure[3] = volume_vars[vars_collapsed_index - 2];
+          q_pure[4] = volume_vars[vars_collapsed_index + 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed[0] =
+              volume_vars[vars_collapsed_index + volume_extents[0] + 1];
+          q_mixed[1] =
+              volume_vars[vars_collapsed_index - volume_extents[0] - 1];
+          q_mixed[2] =
+              volume_vars[vars_collapsed_index - volume_extents[0] + 1];
+          q_mixed[3] =
+              volume_vars[vars_collapsed_index + volume_extents[0] - 1];
+          q_mixed[4] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0] + 2];
+          q_mixed[5] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0] - 2];
+          q_mixed[6] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0] + 2];
+          q_mixed[7] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0] - 2];
+
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::mixed_second_deriv_pointwise(
+                  q_mixed, 1, mixed_second_derivative_weights);
+        }
+      }
+
+      // compute second derivatives in the ghost zone
+      // compute second derivatives in the left and right strips
+      const size_t right_ghost_zone_start =
+          volume_extents[0] - ghost_zone_for_stencil;
+
+      for (size_t j = ghost_zone_for_stencil;
+           j < volume_extents[1] - ghost_zone_for_stencil; ++j) {
+        // compute second derivatives in the left strip
+        for (size_t i = 0; i < ghost_zone_for_stencil; ++i) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          const size_t neighbor_vars_collapsed_index =
+              collapsed_index(
+                  Index<Dim>(ghost_pts_in_left_neighbor_data - 1, j, k),
+                  left_neighbor_extents) +
+              left_neighbor_vars_slice_offset;
+          q_pure[1] = (i == 0 ? left_ghost_data[neighbor_vars_collapsed_index]
+                              : volume_vars[vars_collapsed_index - 1]);
+          q_pure[2] = volume_vars[vars_collapsed_index + 1];
+          q_pure[3] = left_ghost_data[neighbor_vars_collapsed_index - 1 + i];
+          q_pure[4] = volume_vars[vars_collapsed_index + 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed[0] =
+              volume_vars[vars_collapsed_index + volume_extents[0] + 1];
+          q_mixed[1] =
+              (i == 0
+                   ? left_ghost_data[neighbor_vars_collapsed_index -
+                                     left_neighbor_extents[0]]
+                   : volume_vars[vars_collapsed_index - volume_extents[0] - 1]);
+          q_mixed[2] =
+              volume_vars[vars_collapsed_index - volume_extents[0] + 1];
+          q_mixed[3] =
+              (i == 0
+                   ? left_ghost_data[neighbor_vars_collapsed_index +
+                                     left_neighbor_extents[0]]
+                   : volume_vars[vars_collapsed_index + volume_extents[0] - 1]);
+          q_mixed[4] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0] + 2];
+          q_mixed[5] = left_ghost_data[neighbor_vars_collapsed_index -
+                                       2 * left_neighbor_extents[0] - 1 + i];
+          q_mixed[6] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0] + 2];
+          q_mixed[7] = left_ghost_data[neighbor_vars_collapsed_index +
+                                       2 * left_neighbor_extents[0] - 1 + i];
+
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::mixed_second_deriv_pointwise(
+                  q_mixed, 1, mixed_second_derivative_weights);
+        }
+
+        // compute second derivatives in the right strip
+        for (size_t i = right_ghost_zone_start; i < volume_extents[0]; ++i) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          const size_t neighbor_vars_collapsed_index =
+              collapsed_index(Index<Dim>(0, j, k), left_neighbor_extents) +
+              left_neighbor_vars_slice_offset;
+          q_pure[1] = (i == right_ghost_zone_start
+                           ? volume_vars[vars_collapsed_index + 1]
+                           : right_ghost_data[neighbor_vars_collapsed_index]);
+          q_pure[2] = volume_vars[vars_collapsed_index - 1];
+          q_pure[3] = right_ghost_data[neighbor_vars_collapsed_index + i -
+                                       right_ghost_zone_start];
+          q_pure[4] = volume_vars[vars_collapsed_index - 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed[0] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0] + 1]
+                   : right_ghost_data[neighbor_vars_collapsed_index +
+                                      left_neighbor_extents[0]]);
+          q_mixed[1] =
+              volume_vars[vars_collapsed_index - volume_extents[0] - 1];
+          q_mixed[2] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index - volume_extents[0] + 1]
+                   : right_ghost_data[neighbor_vars_collapsed_index -
+                                      left_neighbor_extents[0]]);
+          q_mixed[3] =
+              volume_vars[vars_collapsed_index + volume_extents[0] - 1];
+          q_mixed[4] = right_ghost_data[neighbor_vars_collapsed_index +
+                                        2 * left_neighbor_extents[0] + i -
+                                        right_ghost_zone_start];
+          q_mixed[5] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0] - 2];
+          q_mixed[6] = right_ghost_data[neighbor_vars_collapsed_index -
+                                        2 * left_neighbor_extents[0] + i -
+                                        right_ghost_zone_start];
+          q_mixed[7] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0] - 2];
+
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::mixed_second_deriv_pointwise(
+                  q_mixed, 1, mixed_second_derivative_weights);
+        }
+      }
+
+      const size_t upper_ghost_zone_start =
+          volume_extents[1] - ghost_zone_for_stencil;
+
+      // compute second derivatives in the upper and lower strips
+      for (size_t i = ghost_zone_for_stencil;
+           i < volume_extents[0] - ghost_zone_for_stencil; ++i) {
+        // compute second derivatives in the lower strip
+        for (size_t j = 0; j < ghost_zone_for_stencil; ++j) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+          const size_t neighbor_vars_collapsed_index =
+              collapsed_index(
+                  Index<Dim>(i, ghost_pts_in_lower_neighbor_data - 1, k),
+                  lower_neighbor_extents) +
+              lower_neighbor_vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          q_pure[1] = volume_vars[vars_collapsed_index - 1];
+          q_pure[2] = volume_vars[vars_collapsed_index + 1];
+          q_pure[3] = volume_vars[vars_collapsed_index - 2];
+          q_pure[4] = volume_vars[vars_collapsed_index + 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed[0] =
+              volume_vars[vars_collapsed_index + volume_extents[0] + 1];
+          q_mixed[1] =
+              (j == 0
+                   ? lower_ghost_data[neighbor_vars_collapsed_index - 1]
+                   : volume_vars[vars_collapsed_index - volume_extents[0] - 1]);
+          q_mixed[2] =
+              (j == 0
+                   ? lower_ghost_data[neighbor_vars_collapsed_index + 1]
+                   : volume_vars[vars_collapsed_index - volume_extents[0] + 1]);
+          q_mixed[3] =
+              volume_vars[vars_collapsed_index + volume_extents[0] - 1];
+          q_mixed[4] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0] + 2];
+          q_mixed[5] =
+              lower_ghost_data[neighbor_vars_collapsed_index -
+                               (1 - j) * lower_neighbor_extents[0] - 2];
+          q_mixed[6] =
+              lower_ghost_data[neighbor_vars_collapsed_index -
+                               (1 - j) * lower_neighbor_extents[0] + 2];
+          q_mixed[7] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0] - 2];
+
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::mixed_second_deriv_pointwise(
+                  q_mixed, 1, mixed_second_derivative_weights);
+        }
+
+        // compute second derivatives in the upper strip
+        for (size_t j = upper_ghost_zone_start; j < volume_extents[1]; ++j) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+          const size_t neighbor_vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, 0, k), lower_neighbor_extents) +
+              lower_neighbor_vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          q_pure[1] = volume_vars[vars_collapsed_index - 1];
+          q_pure[2] = volume_vars[vars_collapsed_index + 1];
+          q_pure[3] = volume_vars[vars_collapsed_index - 2];
+          q_pure[4] = volume_vars[vars_collapsed_index + 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed[0] =
+              (j == upper_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0] + 1]
+                   : upper_ghost_data[neighbor_vars_collapsed_index + 1]);
+          q_mixed[1] =
+              volume_vars[vars_collapsed_index - volume_extents[0] - 1];
+          q_mixed[2] =
+              volume_vars[vars_collapsed_index - volume_extents[0] + 1];
+          q_mixed[3] =
+              (j == upper_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0] - 1]
+                   : upper_ghost_data[neighbor_vars_collapsed_index - 1]);
+          q_mixed[4] = upper_ghost_data[neighbor_vars_collapsed_index + 2 +
+                                        (j - upper_ghost_zone_start) *
+                                            lower_neighbor_extents[0]];
+          q_mixed[5] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0] - 2];
+          q_mixed[6] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0] + 2];
+          q_mixed[7] = upper_ghost_data[neighbor_vars_collapsed_index - 2 +
+                                        (j - upper_ghost_zone_start) *
+                                            lower_neighbor_extents[0]];
+
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::mixed_second_deriv_pointwise(
+                  q_mixed, 1, mixed_second_derivative_weights);
+        }
+      }
+
+      // compute second derivatives in the lower left corner
+      for (size_t i = 0; i < ghost_zone_for_stencil; ++i) {
+        for (size_t j = 0; j < ghost_zone_for_stencil; ++j) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+          const size_t left_neighbor_vars_collapsed_index =
+              collapsed_index(
+                  Index<Dim>(ghost_pts_in_left_neighbor_data - 1, j, k),
+                  left_neighbor_extents) +
+              left_neighbor_vars_slice_offset;
+          const size_t lower_neighbor_vars_collapsed_index =
+              collapsed_index(
+                  Index<Dim>(i, ghost_pts_in_lower_neighbor_data - 1, k),
+                  lower_neighbor_extents) +
+              lower_neighbor_vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          q_pure[1] =
+              (i == 0 ? left_ghost_data[left_neighbor_vars_collapsed_index]
+                      : volume_vars[vars_collapsed_index - 1]);
+          q_pure[2] = volume_vars[vars_collapsed_index + 1];
+          q_pure[3] =
+              left_ghost_data[left_neighbor_vars_collapsed_index - 1 + i];
+          q_pure[4] = volume_vars[vars_collapsed_index + 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed_special[0] = volume_vars[vars_collapsed_index];
+          q_mixed_special[1] =
+              (i == 0 ? left_ghost_data[left_neighbor_vars_collapsed_index]
+                      : volume_vars[vars_collapsed_index - 1]);
+          q_mixed_special[2] = volume_vars[vars_collapsed_index + 1];
+          q_mixed_special[3] =
+              (j == 0 ? lower_ghost_data[lower_neighbor_vars_collapsed_index]
+                      : volume_vars[vars_collapsed_index - volume_extents[0]]);
+          q_mixed_special[4] =
+              volume_vars[vars_collapsed_index + volume_extents[0]];
+          q_mixed_special[5] =
+              (i == 0
+                   ? left_ghost_data[left_neighbor_vars_collapsed_index +
+                                     left_neighbor_extents[0]]
+                   : volume_vars[vars_collapsed_index + volume_extents[0] - 1]);
+          q_mixed_special[6] =
+              (j == 0
+                   ? lower_ghost_data[lower_neighbor_vars_collapsed_index + 1]
+                   : volume_vars[vars_collapsed_index - volume_extents[0] + 1]);
+          q_mixed_special[7] =
+              left_ghost_data[left_neighbor_vars_collapsed_index - 1 + i];
+          q_mixed_special[8] = volume_vars[vars_collapsed_index + 2];
+          q_mixed_special[9] =
+              lower_ghost_data[lower_neighbor_vars_collapsed_index -
+                               (1 - j) * lower_neighbor_extents[0]];
+          q_mixed_special[10] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0]];
+          q_mixed_special[11] =
+              left_ghost_data[left_neighbor_vars_collapsed_index +
+                              2 * left_neighbor_extents[0] - 1 + i];
+          q_mixed_special[12] =
+              lower_ghost_data[lower_neighbor_vars_collapsed_index -
+                               (1 - j) * lower_neighbor_extents[0] + 2];
+
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::mixed_second_deriv_special_pointwise(
+                  q_mixed_special, 1, mixed_second_derivative_special_weights);
+        }
+      }
+
+      // compute second derivative in the upper left corner
+      for (size_t i = 0; i < ghost_zone_for_stencil; ++i) {
+        for (size_t j = upper_ghost_zone_start; j < volume_extents[1]; ++j) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+          const size_t left_neighbor_vars_collapsed_index =
+              collapsed_index(
+                  Index<Dim>(ghost_pts_in_left_neighbor_data - 1, j, k),
+                  left_neighbor_extents) +
+              left_neighbor_vars_slice_offset;
+          const size_t upper_neighbor_vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, 0, k), lower_neighbor_extents) +
+              lower_neighbor_vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          q_pure[1] =
+              (i == 0 ? left_ghost_data[left_neighbor_vars_collapsed_index]
+                      : volume_vars[vars_collapsed_index - 1]);
+          q_pure[2] = volume_vars[vars_collapsed_index + 1];
+          q_pure[3] =
+              left_ghost_data[left_neighbor_vars_collapsed_index - 1 + i];
+          q_pure[4] = volume_vars[vars_collapsed_index + 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed_special[0] = volume_vars[vars_collapsed_index];
+          q_mixed_special[1] =
+              (i == 0 ? left_ghost_data[left_neighbor_vars_collapsed_index]
+                      : volume_vars[vars_collapsed_index - 1]);
+          q_mixed_special[2] = volume_vars[vars_collapsed_index + 1];
+          q_mixed_special[3] =
+              volume_vars[vars_collapsed_index - volume_extents[0]];
+          q_mixed_special[4] =
+              (j == upper_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0]]
+                   : upper_ghost_data[upper_neighbor_vars_collapsed_index]);
+          q_mixed_special[5] =
+              (i == 0
+                   ? left_ghost_data[left_neighbor_vars_collapsed_index -
+                                     left_neighbor_extents[0]]
+                   : volume_vars[vars_collapsed_index - volume_extents[0] - 1]);
+          q_mixed_special[6] =
+              (j == upper_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0] + 1]
+                   : upper_ghost_data[upper_neighbor_vars_collapsed_index + 1]);
+          q_mixed_special[7] =
+              left_ghost_data[left_neighbor_vars_collapsed_index - 1 + i];
+          q_mixed_special[8] = volume_vars[vars_collapsed_index + 2];
+          q_mixed_special[9] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0]];
+          q_mixed_special[10] =
+              upper_ghost_data[upper_neighbor_vars_collapsed_index +
+                               (j - upper_ghost_zone_start) *
+                                   lower_neighbor_extents[0]];
+          q_mixed_special[11] =
+              left_ghost_data[left_neighbor_vars_collapsed_index -
+                              2 * left_neighbor_extents[0] - 1 + i];
+          q_mixed_special[12] =
+              upper_ghost_data[upper_neighbor_vars_collapsed_index + 2 +
+                               (j - upper_ghost_zone_start) *
+                                   lower_neighbor_extents[0]];
+
+          // -1.0 as the weights are opposite for asending diagonal of the
+          // stencil
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              -1.0 *
+              DerivativeComputer::mixed_second_deriv_special_pointwise(
+                  q_mixed_special, 1, mixed_second_derivative_special_weights);
+        }
+      }
+
+      // compute second derivatives in the lower right corner
+      for (size_t i = right_ghost_zone_start; i < volume_extents[0]; ++i) {
+        for (size_t j = 0; j < ghost_zone_for_stencil; ++j) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+          const size_t right_neighbor_vars_collapsed_index =
+              collapsed_index(Index<Dim>(0, j, k), left_neighbor_extents) +
+              left_neighbor_vars_slice_offset;
+          const size_t lower_neighbor_vars_collapsed_index =
+              collapsed_index(
+                  Index<Dim>(i, ghost_pts_in_lower_neighbor_data - 1, k),
+                  lower_neighbor_extents) +
+              lower_neighbor_vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          q_pure[1] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + 1]
+                   : right_ghost_data[right_neighbor_vars_collapsed_index]);
+          q_pure[2] = volume_vars[vars_collapsed_index - 1];
+          q_pure[3] = right_ghost_data[right_neighbor_vars_collapsed_index + i -
+                                       right_ghost_zone_start];
+          q_pure[4] = volume_vars[vars_collapsed_index - 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed_special[0] = volume_vars[vars_collapsed_index];
+          q_mixed_special[1] = volume_vars[vars_collapsed_index - 1];
+          q_mixed_special[2] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + 1]
+                   : right_ghost_data[right_neighbor_vars_collapsed_index]);
+          q_mixed_special[3] =
+              (j == 0 ? lower_ghost_data[lower_neighbor_vars_collapsed_index]
+                      : volume_vars[vars_collapsed_index - volume_extents[0]]);
+          q_mixed_special[4] =
+              volume_vars[vars_collapsed_index + volume_extents[0]];
+          q_mixed_special[5] =
+              (j == 0
+                   ? lower_ghost_data[lower_neighbor_vars_collapsed_index - 1]
+                   : volume_vars[vars_collapsed_index - volume_extents[0] - 1]);
+          q_mixed_special[6] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0] + 1]
+                   : right_ghost_data[right_neighbor_vars_collapsed_index +
+                                      left_neighbor_extents[0]]);
+          q_mixed_special[7] = volume_vars[vars_collapsed_index - 2];
+          q_mixed_special[8] =
+              right_ghost_data[right_neighbor_vars_collapsed_index + i -
+                               right_ghost_zone_start];
+          q_mixed_special[9] =
+              lower_ghost_data[lower_neighbor_vars_collapsed_index -
+                               (1 - j) * lower_neighbor_extents[0]];
+          q_mixed_special[10] =
+              volume_vars[vars_collapsed_index + 2 * volume_extents[0]];
+          q_mixed_special[11] =
+              lower_ghost_data[lower_neighbor_vars_collapsed_index -
+                               (1 - j) * lower_neighbor_extents[0] - 2];
+          q_mixed_special[12] =
+              right_ghost_data[right_neighbor_vars_collapsed_index +
+                               2 * left_neighbor_extents[0] + i -
+                               right_ghost_zone_start];
+
+          // -1.0 as the weights are opposite for asending diagonal of the
+          // stencil
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              -1.0 *
+              DerivativeComputer::mixed_second_deriv_special_pointwise(
+                  q_mixed_special, 1, mixed_second_derivative_special_weights);
+        }
+      }
+
+      // compute second derivatives in the upper right corner
+      for (size_t i = right_ghost_zone_start; i < volume_extents[0]; ++i) {
+        for (size_t j = upper_ghost_zone_start; j < volume_extents[1]; ++j) {
+          const size_t vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, j, k), volume_extents) +
+              vars_slice_offset;
+          const size_t right_neighbor_vars_collapsed_index =
+              collapsed_index(Index<Dim>(0, j, k), left_neighbor_extents) +
+              left_neighbor_vars_slice_offset;
+          const size_t upper_neighbor_vars_collapsed_index =
+              collapsed_index(Index<Dim>(i, 0, k), lower_neighbor_extents) +
+              lower_neighbor_vars_slice_offset;
+
+          q_pure[0] = volume_vars[vars_collapsed_index];
+          q_pure[1] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + 1]
+                   : right_ghost_data[right_neighbor_vars_collapsed_index]);
+          q_pure[2] = volume_vars[vars_collapsed_index - 1];
+          q_pure[3] = right_ghost_data[right_neighbor_vars_collapsed_index + i -
+                                       right_ghost_zone_start];
+          q_pure[4] = volume_vars[vars_collapsed_index - 2];
+
+          (*pure_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::pure_second_deriv_pointwise(
+                  q_pure, 1, pure_second_derivative_weights);
+
+          q_mixed_special[0] = volume_vars[vars_collapsed_index];
+          q_mixed_special[1] = volume_vars[vars_collapsed_index - 1];
+          q_mixed_special[2] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + 1]
+                   : right_ghost_data[right_neighbor_vars_collapsed_index]);
+          q_mixed_special[3] =
+              volume_vars[vars_collapsed_index - volume_extents[0]];
+          q_mixed_special[4] =
+              (j == upper_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0]]
+                   : upper_ghost_data[upper_neighbor_vars_collapsed_index]);
+          q_mixed_special[5] =
+              (j == upper_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index + volume_extents[0] - 1]
+                   : upper_ghost_data[upper_neighbor_vars_collapsed_index - 1]);
+          q_mixed_special[6] =
+              (i == right_ghost_zone_start
+                   ? volume_vars[vars_collapsed_index - volume_extents[0] + 1]
+                   : right_ghost_data[right_neighbor_vars_collapsed_index -
+                                      left_neighbor_extents[0]]);
+          q_mixed_special[7] = volume_vars[vars_collapsed_index - 2];
+          q_mixed_special[8] =
+              right_ghost_data[right_neighbor_vars_collapsed_index + i -
+                               right_ghost_zone_start];
+          q_mixed_special[9] =
+              volume_vars[vars_collapsed_index - 2 * volume_extents[0]];
+          q_mixed_special[10] =
+              upper_ghost_data[upper_neighbor_vars_collapsed_index +
+                               (j - upper_ghost_zone_start) *
+                                   lower_neighbor_extents[0]];
+          q_mixed_special[11] =
+              upper_ghost_data[upper_neighbor_vars_collapsed_index - 2 +
+                               (j - upper_ghost_zone_start) *
+                                   lower_neighbor_extents[0]];
+          q_mixed_special[12] =
+              right_ghost_data[right_neighbor_vars_collapsed_index -
+                               2 * left_neighbor_extents[0] + i -
+                               right_ghost_zone_start];
+
+          (*mixed_second_derivative)[vars_collapsed_index] =
+              DerivativeComputer::mixed_second_deriv_special_pointwise(
+                  q_mixed_special, 1, mixed_second_derivative_special_weights);
+        }
+      }
+    }
+  }
+}
+
+template <typename DerivativeComputer, size_t Dim>
+void second_logical_partial_derivatives_impl(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        pure_second_logical_derivatives,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        mixed_second_logical_derivatives,
+    gsl::span<double>* const in_buffer,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, const size_t number_of_variables) {
+  const size_t number_of_points = volume_mesh.number_of_grid_points();
+#ifdef SPECTRE_DEBUG
+  ASSERT(Dim == 3, "The dimension is hardcoded to be 3 at this moment.");
+  ASSERT(volume_mesh == Mesh<Dim>(volume_mesh.extents(0), volume_mesh.basis(0),
+                                  volume_mesh.quadrature(0)),
+         "The mesh must be isotropic, but got " << volume_mesh);
+  ASSERT(
+      volume_mesh.basis(0) == Spectral::Basis::FiniteDifference,
+      "Mesh basis must be FiniteDifference but got " << volume_mesh.basis(0));
+  ASSERT(volume_mesh.quadrature(0) == Spectral::Quadrature::CellCentered,
+         "Mesh quadrature must be CellCentered but got "
+             << volume_mesh.quadrature(0));
+  // Note that number_of_variables here refers to number of independent
+  // components; e.g. a rank-1 tensor has 3 independent components
+  ASSERT(volume_vars.size() == number_of_points * number_of_variables,
+         "The size of the volume vars must be the number of points ("
+             << number_of_points << ") times the number of variables ("
+             << number_of_variables << ") but is " << volume_vars.size());
+  for (size_t i = 0; i < Dim; ++i) {
+    ASSERT(gsl::at(*pure_second_logical_derivatives, i).size() ==
+               volume_vars.size(),
+           "The pure second logical derivatives must have size "
+               << volume_vars.size() << " but has size "
+               << gsl::at(*pure_second_logical_derivatives, i).size()
+               << " in dimension " << i);
+    ASSERT(gsl::at(*mixed_second_logical_derivatives, i).size() ==
+               volume_vars.size(),
+           "The mixed second logical derivatives must have size "
+               << volume_vars.size() << " but has size "
+               << gsl::at(*mixed_second_logical_derivatives, i).size()
+               << " in dimension " << i);
+  }
+#endif  // SPECTRE_DEBUG
+
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::lower_xi()),
+         "Couldn't find ghost data in lower-xi");
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::upper_xi()),
+         "Couldn't find ghost data in upper-xi");
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::lower_eta()),
+         "Couldn't find ghost data in lower-eta");
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::upper_eta()),
+         "Couldn't find ghost data in upper-eta");
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::lower_zeta()),
+         "Couldn't find ghost data in lower-zeta");
+  ASSERT(ghost_cell_vars.contains(Direction<Dim>::upper_zeta()),
+         "Couldn't find ghost data in upper-zeta");
+
+  const Index<Dim>& volume_extents = volume_mesh.extents();
+
+  const auto& logical_xi_coords =
+      Spectral::collocation_points<Spectral::Basis::FiniteDifference,
+                                   Spectral::Quadrature::CellCentered>(
+          volume_mesh.extents(0));
+
+  // compute the xx, xy derivatives
+  second_logical_partial_derivatives_fastest_dim<DerivativeComputer>(
+      make_not_null(&(*pure_second_logical_derivatives)[0]),
+      make_not_null(&(*mixed_second_logical_derivatives)[0]), volume_vars,
+      ghost_cell_vars.at(Direction<Dim>::lower_eta()),  // lower ghost data
+      ghost_cell_vars.at(Direction<Dim>::upper_eta()),  // upper ghost data
+      ghost_cell_vars.at(Direction<Dim>::lower_xi()),   // left ghost data
+      ghost_cell_vars.at(Direction<Dim>::upper_xi()),   // right ghost data
+      volume_extents, number_of_variables,
+      square(logical_xi_coords[1] - logical_xi_coords[0]));
+
+  // We transpose from (x,y,z,vars) ordering to (y,z,x,vars) ordering
+  // Might not be the most efficient (unclear), but easiest.
+  // We use a single large buffer for both the yz and xz derivatives
+  // to reduce the number of memory allocations and improve data locality.
+
+  // compute the yy, yz derivatives
+  auto& left_ghost = ghost_cell_vars.at(Direction<Dim>::lower_eta());
+  auto& right_ghost = ghost_cell_vars.at(Direction<Dim>::upper_eta());
+  auto& lower_ghost = ghost_cell_vars.at(Direction<Dim>::lower_zeta());
+  auto& upper_ghost = ghost_cell_vars.at(Direction<Dim>::upper_zeta());
+  const size_t derivative_size = (*pure_second_logical_derivatives)[1].size() +
+                                 (*mixed_second_logical_derivatives)[1].size();
+  DataVector buffer{};
+  if (in_buffer != nullptr) {
+    ASSERT(
+        (in_buffer->size() >= volume_vars.size() + lower_ghost.size() +
+                                  upper_ghost.size() + left_ghost.size() +
+                                  right_ghost.size() + derivative_size),
+        "The buffer must have size greater than or equal to "
+            << (volume_vars.size() + lower_ghost.size() + upper_ghost.size() +
+                left_ghost.size() + right_ghost.size() + derivative_size)
+            << " but has size " << in_buffer->size());
+    buffer.set_data_ref(in_buffer->data(), in_buffer->size());
+  } else {
+    buffer = DataVector{volume_vars.size() + lower_ghost.size() +
+                        upper_ghost.size() + left_ghost.size() +
+                        right_ghost.size() + derivative_size};
+  }
+
+  size_t number_of_pts_in_left_ghost = left_ghost.size() / number_of_variables;
+  size_t number_of_pts_in_right_ghost =
+      right_ghost.size() / number_of_variables;
+  size_t number_of_pts_in_lower_ghost =
+      lower_ghost.size() / number_of_variables;
+  size_t number_of_pts_in_upper_ghost =
+      upper_ghost.size() / number_of_variables;
+
+  for (size_t vars_slice = 0; vars_slice < number_of_variables; ++vars_slice) {
+    raw_transpose(
+        make_not_null(&buffer[vars_slice * number_of_points]),
+        volume_vars.subspan(vars_slice * number_of_points, number_of_points)
+            .data(),
+        volume_extents[0], number_of_points / volume_extents[0]);
+    raw_transpose(
+        make_not_null(&buffer[volume_vars.size() +
+                              vars_slice * number_of_pts_in_lower_ghost]),
+        lower_ghost
+            .subspan(vars_slice * number_of_pts_in_lower_ghost,
+                     number_of_pts_in_lower_ghost)
+            .data(),
+        volume_extents[0], number_of_pts_in_lower_ghost / volume_extents[0]);
+    raw_transpose(
+        make_not_null(&buffer[volume_vars.size() + lower_ghost.size() +
+                              vars_slice * number_of_pts_in_upper_ghost]),
+        upper_ghost
+            .subspan(vars_slice * number_of_pts_in_upper_ghost,
+                     number_of_pts_in_upper_ghost)
+            .data(),
+        volume_extents[0], number_of_pts_in_upper_ghost / volume_extents[0]);
+
+    raw_transpose(
+        make_not_null(&buffer[volume_vars.size() + lower_ghost.size() +
+                              upper_ghost.size() +
+                              vars_slice * number_of_pts_in_left_ghost]),
+        left_ghost
+            .subspan(vars_slice * number_of_pts_in_left_ghost,
+                     number_of_pts_in_left_ghost)
+            .data(),
+        volume_extents[0], number_of_pts_in_left_ghost / volume_extents[0]);
+
+    raw_transpose(
+        make_not_null(&buffer[volume_vars.size() + lower_ghost.size() +
+                              upper_ghost.size() + left_ghost.size() +
+                              vars_slice * number_of_pts_in_right_ghost]),
+        right_ghost
+            .subspan(vars_slice * number_of_pts_in_right_ghost,
+                     number_of_pts_in_right_ghost)
+            .data(),
+        volume_extents[0], number_of_pts_in_right_ghost / volume_extents[0]);
+  }
+
+  // Note: assumes isotropic extents
+  const size_t pure_second_derivative_offset_in_buffer =
+      volume_vars.size() + lower_ghost.size() + upper_ghost.size() +
+      left_ghost.size() + right_ghost.size();
+  const size_t mixed_second_derivative_offset_in_buffer =
+      pure_second_derivative_offset_in_buffer +
+      (*pure_second_logical_derivatives)[1].size();
+  gsl::span<double> pure_second_derivative_view =
+      gsl::make_span(&buffer[pure_second_derivative_offset_in_buffer],
+                     (*pure_second_logical_derivatives)[1].size());
+  gsl::span<double> mixed_second_derivative_view =
+      gsl::make_span(&buffer[mixed_second_derivative_offset_in_buffer],
+                     (*mixed_second_logical_derivatives)[1].size());
+
+  const auto& logical_eta_coords =
+      Spectral::collocation_points<Spectral::Basis::FiniteDifference,
+                                   Spectral::Quadrature::CellCentered>(
+          volume_mesh.extents(1));
+
+  second_logical_partial_derivatives_fastest_dim<DerivativeComputer>(
+      make_not_null(&pure_second_derivative_view),
+      make_not_null(&mixed_second_derivative_view),
+      // NOLINTNEXTLINE(readability-container-data-pointer)
+      gsl::make_span(&buffer[0], volume_vars.size()),
+      gsl::make_span(&buffer[volume_vars.size()], lower_ghost.size()),
+      gsl::make_span(&buffer[volume_vars.size() + lower_ghost.size()],
+                     upper_ghost.size()),
+      gsl::make_span(
+          &buffer[volume_vars.size() + lower_ghost.size() + upper_ghost.size()],
+          left_ghost.size()),
+      gsl::make_span(&buffer[volume_vars.size() + lower_ghost.size() +
+                             upper_ghost.size() + left_ghost.size()],
+                     right_ghost.size()),
+      volume_extents, number_of_variables,
+      square(logical_eta_coords[1] - logical_eta_coords[0]));
+
+  // Transpose result back
+  for (size_t vars_slice = 0; vars_slice < number_of_variables; ++vars_slice) {
+    raw_transpose(make_not_null((*pure_second_logical_derivatives)[1].data() +
+                                vars_slice * number_of_points),
+                  pure_second_derivative_view
+                      .subspan(vars_slice * number_of_points, number_of_points)
+                      .data(),
+                  number_of_points / volume_extents[0], volume_extents[0]);
+
+    raw_transpose(make_not_null((*mixed_second_logical_derivatives)[1].data() +
+                                vars_slice * number_of_points),
+                  mixed_second_derivative_view
+                      .subspan(vars_slice * number_of_points, number_of_points)
+                      .data(),
+                  number_of_points / volume_extents[0], volume_extents[0]);
+  }
+
+  // compute the zz, zx derivatives
+  number_of_pts_in_left_ghost =
+      ghost_cell_vars.at(Direction<Dim>::lower_zeta()).size() /
+      number_of_variables;
+  number_of_pts_in_right_ghost =
+      ghost_cell_vars.at(Direction<Dim>::upper_zeta()).size() /
+      number_of_variables;
+  number_of_pts_in_lower_ghost =
+      ghost_cell_vars.at(Direction<Dim>::lower_xi()).size() /
+      number_of_variables;
+  number_of_pts_in_upper_ghost =
+      ghost_cell_vars.at(Direction<Dim>::upper_xi()).size() /
+      number_of_variables;
+
+  const size_t chunk_size = volume_extents[0] * volume_extents[1];
+  const size_t lower_chunk_size =
+      number_of_pts_in_lower_ghost / volume_extents[2];
+  const size_t upper_chunk_size =
+      number_of_pts_in_upper_ghost / volume_extents[2];
+  const size_t number_of_volume_chunks = number_of_points / chunk_size;
+  const size_t number_of_left_neighbor_chunks =
+      number_of_pts_in_left_ghost / chunk_size;
+  const size_t number_of_right_neighbor_chunks =
+      number_of_pts_in_right_ghost / chunk_size;
+  const size_t number_of_lower_neighbor_chunks =
+      number_of_pts_in_lower_ghost / lower_chunk_size;
+  const size_t number_of_upper_neighbor_chunks =
+      number_of_pts_in_upper_ghost / upper_chunk_size;
+
+  for (size_t vars_slice = 0; vars_slice < number_of_variables; ++vars_slice) {
+    raw_transpose(
+        make_not_null(buffer.data() + vars_slice * number_of_points),
+        volume_vars.subspan(vars_slice * number_of_points, number_of_points)
+            .data(),
+        chunk_size, number_of_volume_chunks);
+    raw_transpose(
+        make_not_null(&buffer[volume_vars.size() +
+                              vars_slice * number_of_pts_in_lower_ghost]),
+        ghost_cell_vars.at(Direction<Dim>::lower_xi())
+            .subspan(vars_slice * number_of_pts_in_lower_ghost,
+                     number_of_pts_in_lower_ghost)
+            .data(),
+        lower_chunk_size, number_of_lower_neighbor_chunks);
+    raw_transpose(
+        make_not_null(
+            &buffer[volume_vars.size() +
+                    ghost_cell_vars.at(Direction<Dim>::lower_xi()).size() +
+                    vars_slice * number_of_pts_in_upper_ghost]),
+        ghost_cell_vars.at(Direction<Dim>::upper_xi())
+            .subspan(vars_slice * number_of_pts_in_upper_ghost,
+                     number_of_pts_in_upper_ghost)
+            .data(),
+        upper_chunk_size, number_of_upper_neighbor_chunks);
+    raw_transpose(
+        make_not_null(
+            &buffer[volume_vars.size() +
+                    ghost_cell_vars.at(Direction<Dim>::lower_xi()).size() +
+                    ghost_cell_vars.at(Direction<Dim>::upper_xi()).size() +
+                    vars_slice * number_of_pts_in_left_ghost]),
+        ghost_cell_vars.at(Direction<Dim>::lower_zeta())
+            .subspan(vars_slice * number_of_pts_in_left_ghost,
+                     number_of_pts_in_left_ghost)
+            .data(),
+        chunk_size, number_of_left_neighbor_chunks);
+    raw_transpose(
+        make_not_null(
+            &buffer[volume_vars.size() +
+                    ghost_cell_vars.at(Direction<Dim>::lower_xi()).size() +
+                    ghost_cell_vars.at(Direction<Dim>::upper_xi()).size() +
+                    ghost_cell_vars.at(Direction<Dim>::lower_zeta()).size() +
+                    vars_slice * number_of_pts_in_right_ghost]),
+        ghost_cell_vars.at(Direction<Dim>::upper_zeta())
+            .subspan(vars_slice * number_of_pts_in_right_ghost,
+                     number_of_pts_in_right_ghost)
+            .data(),
+        chunk_size, number_of_right_neighbor_chunks);
+  }
+
+  const auto& logical_zeta_coords =
+      Spectral::collocation_points<Spectral::Basis::FiniteDifference,
+                                   Spectral::Quadrature::CellCentered>(
+          volume_mesh.extents(2));
+
+  second_logical_partial_derivatives_fastest_dim<DerivativeComputer>(
+      make_not_null(&pure_second_derivative_view),
+      make_not_null(&mixed_second_derivative_view),
+      // NOLINTNEXTLINE(readability-container-data-pointer)
+      gsl::make_span(&buffer[0], volume_vars.size()),
+      gsl::make_span(&buffer[volume_vars.size()],
+                     ghost_cell_vars.at(Direction<Dim>::lower_xi()).size()),
+      gsl::make_span(
+          &buffer[volume_vars.size() +
+                  ghost_cell_vars.at(Direction<Dim>::lower_xi()).size()],
+          ghost_cell_vars.at(Direction<Dim>::upper_xi()).size()),
+      gsl::make_span(
+          &buffer[volume_vars.size() +
+                  ghost_cell_vars.at(Direction<Dim>::lower_xi()).size() +
+                  ghost_cell_vars.at(Direction<Dim>::upper_xi()).size()],
+          ghost_cell_vars.at(Direction<Dim>::lower_zeta()).size()),
+      gsl::make_span(
+          &buffer[volume_vars.size() +
+                  ghost_cell_vars.at(Direction<Dim>::lower_xi()).size() +
+                  ghost_cell_vars.at(Direction<Dim>::upper_xi()).size() +
+                  ghost_cell_vars.at(Direction<Dim>::lower_zeta()).size()],
+          ghost_cell_vars.at(Direction<Dim>::upper_zeta()).size()),
+      volume_extents, number_of_variables,
+      square(logical_zeta_coords[1] - logical_zeta_coords[0]));
+
+  // Transpose result back
+  for (size_t vars_slice = 0; vars_slice < number_of_variables; ++vars_slice) {
+    // NOLINTNEXTLINE(readability-suspicious-call-argument)
+    raw_transpose(make_not_null((*pure_second_logical_derivatives)[2].data() +
+                                vars_slice * number_of_points),
+                  pure_second_derivative_view
+                      .subspan(vars_slice * number_of_points, number_of_points)
+                      .data(),
+                  number_of_volume_chunks, chunk_size);
+    // NOLINTNEXTLINE(readability-suspicious-call-argument)
+    raw_transpose(make_not_null((*mixed_second_logical_derivatives)[2].data() +
+                                vars_slice * number_of_points),
+                  mixed_second_derivative_view
+                      .subspan(vars_slice * number_of_points, number_of_points)
+                      .data(),
+                  number_of_volume_chunks, chunk_size);
+  }
+}
+}  // namespace
+
+namespace detail {
+template <size_t Dim>
+void second_logical_partial_derivatives_impl(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        pure_second_logical_derivatives,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        mixed_second_logical_derivatives,
+    gsl::span<double>* const buffer, const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
+    const size_t fd_order) {
+  switch (fd_order) {
+    case 4:
+      ::Ccz4::fd::second_logical_partial_derivatives_impl<ComputeImpl<4, true>>(
+          pure_second_logical_derivatives, mixed_second_logical_derivatives,
+          buffer, volume_vars, ghost_cell_vars, volume_mesh,
+          number_of_variables);
+      break;
+    default:
+      ERROR("Cannot do finite difference derivative of order " << fd_order);
+  };
+}
+}  // namespace detail
+
+template <size_t Dim>
+void second_logical_partial_derivatives(
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        pure_second_logical_derivatives,
+    const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        mixed_second_logical_derivatives,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
+    const size_t fd_order) {
+  detail::second_logical_partial_derivatives_impl(
+      pure_second_logical_derivatives, mixed_second_logical_derivatives,
+      nullptr, volume_vars, ghost_cell_vars, volume_mesh, number_of_variables,
+      fd_order);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void detail::second_logical_partial_derivatives_impl(               \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          pure_second_derivative,                                              \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          mixed_second_derivative,                                             \
+      gsl::span<double>* const buffer,                                         \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Mesh<DIM(data)>& volume_fd_mesh, size_t number_of_variables,       \
+      size_t fd_order);                                                        \
+  template void second_logical_partial_derivatives(                            \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          pure_second_derivative,                                              \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          mixed_second_derivative,                                             \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Mesh<DIM(data)>& volume_fd_mesh, size_t number_of_variables,       \
+      size_t fd_order);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (3))
+
+#undef GET_DIM
+#undef INSTANTIATION
+
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim, typename T>
+class DirectionMap;
+template <size_t Dim>
+class Mesh;
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+/*!
+* \brief The finite difference second derivatives for implementing the CCZ4
+* system.
+*/
+namespace Ccz4::fd {
+/*!
+ * \brief Compute the pure and mixed second logical partial derivatives using
+ * finite difference derivatives. Only 3 dimensions 4th-order fd is supported.
+ *
+ * We use a symmetric stencil in the bulk and slightly asymetric stencil
+ * for the mixed partial derivatives where ghost data from two
+ * neighbors is needed (to avoid communication across diagonal elements).
+ * The `mixed_second_logical_derivatives` return an 3D array corresponding to
+ * xy, yz, xz mixed partial derivatives.
+ *
+ * The stencil for the pure second derivatives is
+ \f[ \frac{\partial^2 f}{\partial x^2} =
+    - \frac{1}{12\delta^2}[f(x+2\delta,y)+f(x-2\delta,y)]
+    + \frac{4}{3\delta^2}[f(x+\delta,y)+f(x-\delta,y)]-\frac{5}{2\delta^2}f(x,y)
+ + O(\delta^4). \f]
+ *
+ * The stencil for the mixed second derivatives in the bulk is
+ \f[ \begin{aligned} \frac{\partial^2 f}{\partial x \partial y} =&
+      \frac{1}{3\delta^2}[f(x+\delta,y+\delta) + f(x-\delta,y-\delta) -
+ f(x+\delta,y-\delta) - f(x-\delta,y+\delta)] \\
+    &+ \frac{1}{48\delta^2}[f(x+2\delta,y-2\delta) + f(x-2\delta,y+2\delta)
+        - f(x+2\delta,y+2\delta) - f(x-2\delta,y-2\delta)] + O(\delta^4).
+ \end{aligned}\f]
+ *
+ * The stencil for the mixed second derivatives in the ghost zone is (with
+ * descending diagonal)
+ \f[ \begin{aligned} \frac{\partial^2 f}{\partial x \partial y} =&
+      \frac{1}{24\delta^2}[f(x+2\delta,y-2\delta) + f(x-2\delta,y+2\delta)
+        - f(x+2\delta,y) - f(x-2\delta,y) - f(x,y+2\delta) - f(x,y-2\delta)] \\
+    &+ \frac{2}{3\delta^2}[f(x+\delta,y) + f(x-\delta,y) + f(x,y+\delta) +
+        f(x,y-\delta) - f(x+\delta,y-\delta) - f(x-\delta,y+\delta)]
+    - \frac{5}{4\delta^2}f(x,y) + O(\delta^4),
+ \end{aligned}\f]
+ *
+ * and the ascending diagonal stencil has the opposite weights.
+ *
+ * \note Currently the stride is always one because we transpose the data before
+ * reconstruction.
+ */
+template <size_t Dim>
+void second_logical_partial_derivatives(
+    gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        pure_second_logical_derivatives,
+    gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        mixed_second_logical_derivatives,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, size_t number_of_variables, size_t fd_order);
+
+/*!
+ * \brief Compute the second partial derivatives on the `DerivativeFrame` using
+ * the `inverse_jacobian` and `inverse_hessian`.
+ * Only 3 dimensions 4th-order fd is supported.
+ *
+ * First and second logical partial derivatives are first computed using the
+ * `fd::logical_partial_derivatives()` and
+ * `Ccz4::fd::second_logical_partial_derivatives()` function.
+ *
+ * \note The `inverse_hessian` has not been implemented, so currently inertial
+ * coordinates cannot mix logical coordinates.
+ */
+template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
+void second_partial_derivatives(
+    gsl::not_null<
+        Variables<db::wrap_tags_in<Tags::second_deriv, DerivativeTags,
+                                   tmpl::size_t<Dim>, DerivativeFrame>>*>
+        second_partial_derivatives,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, size_t number_of_variables,
+    size_t fd_order,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian);
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp
@@ -1,0 +1,250 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+namespace detail {
+template <size_t Dim>
+void second_logical_partial_derivatives_impl(
+    gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        pure_second_logical_derivatives,
+    gsl::not_null<std::array<gsl::span<double>, Dim>*>
+        mixed_second_logical_derivatives,
+    gsl::span<double>* buffer, const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, size_t number_of_variables, size_t fd_order);
+}  // namespace detail
+
+namespace partial_derivatives_detail {
+template <size_t Dim, typename VariableTags, typename DerivativeTags>
+struct LogicalImpl;
+
+// Note that the index of ddu is (i, j, k, d1, d2, s)
+// where d's are the derivative indices and s is the tensor component and
+// i varying the fastest, which is different from any of the logical
+// derivatives index (d, i, j, k, s). We assume ddu is symmetric in the
+// two derivative indices.
+template <typename ResultTags, size_t Dim, typename DerivativeFrame,
+          typename ValueType = typename Variables<ResultTags>::value_type,
+          typename VectorType = typename Variables<ResultTags>::vector_type>
+void second_partial_derivatives_impl(
+    const gsl::not_null<Variables<ResultTags>*> ddu,
+    // we will need the first logical derivatives when implementing
+    // inverse_hessian
+    /*const std::array<const ValueType*, Dim>&
+        first_logical_partial_derivatives_of_u,*/
+    const std::array<const ValueType*, Dim>&
+        pure_second_logical_partial_derivatives_of_u,
+    const std::array<const ValueType*, Dim>&
+        mixed_second_logical_partial_derivatives_of_u,
+    const size_t number_of_independent_components,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian) {
+  ValueType* ptr_ddu = ddu->data();
+  const size_t num_grid_points = ddu->number_of_grid_points();
+  VectorType lhs{};
+  VectorType second_logical_du{};
+
+  std::array<std::array<size_t, Dim>, Dim> jacobian_indices{};
+  for (size_t deriv_index = 0; deriv_index < Dim; ++deriv_index) {
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(gsl::at(jacobian_indices, d), deriv_index) =
+          InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>::get_storage_index(d, deriv_index);
+    }
+  }
+
+  for (size_t component_index = 0;
+       component_index < number_of_independent_components; ++component_index) {
+    for (size_t first_deriv_index = 0; first_deriv_index < Dim;
+         ++first_deriv_index) {
+      for (size_t second_deriv_index = first_deriv_index;
+           second_deriv_index < Dim; ++second_deriv_index) {
+        lhs.set_data_ref(ptr_ddu, num_grid_points);
+        ptr_ddu += num_grid_points;
+
+        // clang-tidy: const cast is fine since we won't modify the data and we
+        // need it to easily hook into the expression templates.
+        second_logical_du.set_data_ref(
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            const_cast<ValueType*>(
+                gsl::at(pure_second_logical_partial_derivatives_of_u, 0)) +
+                component_index * num_grid_points,
+            num_grid_points);
+
+        lhs = (*(inverse_jacobian.begin() +
+                 gsl::at(gsl::at(jacobian_indices, 0), first_deriv_index))) *
+              (*(inverse_jacobian.begin() +
+                 gsl::at(gsl::at(jacobian_indices, 0), second_deriv_index))) *
+              second_logical_du;
+
+        for (size_t first_logical_deriv_index = 0;
+             first_logical_deriv_index < Dim; ++first_logical_deriv_index) {
+          for (size_t second_logical_deriv_index = 0;
+               second_logical_deriv_index < Dim; ++second_logical_deriv_index) {
+            if (first_logical_deriv_index + second_logical_deriv_index != 0) {
+              if (first_logical_deriv_index == second_logical_deriv_index) {
+                // clang-tidy: const cast is fine since we won't modify the data
+                // and we need it to easily hook into the expression templates.
+                second_logical_du.set_data_ref(
+                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                    const_cast<ValueType*>(
+                        gsl::at(pure_second_logical_partial_derivatives_of_u,
+                                first_logical_deriv_index))
+                        + component_index * num_grid_points,
+                    num_grid_points);
+              } else {
+                // we need to map (first_logical_deriv_index,
+                // second_logical_deriv_index) to an index
+                // single_mixed_partial_index into the
+                // mixed_second_logical_partial_derivatives_of_u. For
+                // single_mixed_partial_index, 0 is xy deriv, 1 is yz deriv,
+                // and 2 is xz deriv. So we need a symmetric map (0,1)->0,
+                // (0,2)->2, (1,2)->1.
+                const size_t single_mixed_partial_index =
+                    [first_logical_deriv_index,
+                     second_logical_deriv_index]() -> size_t {
+                  if (first_logical_deriv_index * second_logical_deriv_index !=
+                      0) {
+                    return 1;
+                  } else if (first_logical_deriv_index +
+                                 second_logical_deriv_index ==
+                             1) {
+                    return 0;
+                  } else {
+                    return 2;
+                  }
+                }();
+                // clang-tidy: const cast is fine since we won't modify the data
+                // and we need it to easily hook into the expression templates.
+                second_logical_du.set_data_ref(
+                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                    const_cast<ValueType*>(
+                        gsl::at(mixed_second_logical_partial_derivatives_of_u,
+                                single_mixed_partial_index))
+                        + component_index * num_grid_points,
+                    num_grid_points);
+              }
+
+              lhs +=
+                  (*(inverse_jacobian.begin() +
+                     gsl::at(
+                         gsl::at(jacobian_indices, first_logical_deriv_index),
+                         first_deriv_index))) *
+                  (*(inverse_jacobian.begin() +
+                     gsl::at(
+                         gsl::at(jacobian_indices, second_logical_deriv_index),
+                         second_deriv_index))) *
+                  second_logical_du;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+}  // namespace partial_derivatives_detail
+
+template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
+void second_partial_derivatives(
+    const gsl::not_null<
+        Variables<db::wrap_tags_in<Tags::second_deriv, DerivativeTags,
+                                   tmpl::size_t<Dim>, DerivativeFrame>>*>
+        second_partial_derivatives,
+    const gsl::span<const double>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
+    const size_t fd_order,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian) {
+  // Note: Tags::second_deriv ensures the first two indices (partial derivative
+  // indices) of tensors in second_partial_derivatives are symmetric.
+  ASSERT(fd_order == 4, "Only fd_order == 4 is supported at the moment.");
+  ASSERT(Dim == 3, "Only 3 dimensions is supported at the moment.");
+  ASSERT(second_partial_derivatives->size() ==
+             (Dim - 1) * Dim * volume_vars.size(),
+         "The second partial derivatives Variables must have size "
+             << (Dim - 1) * Dim * volume_vars.size()
+             << " ((Dim-1) * Dim * volume_vars.size()) but has size "
+             << second_partial_derivatives->size() << " and "
+             << second_partial_derivatives->number_of_grid_points()
+             << " grid points.");
+
+  // compute the pure and second logical derivatives
+  const size_t second_logical_derivs_internal_buffer_size =
+      (volume_vars.size() +
+       4 * alg::max_element(ghost_cell_vars,
+                            [](const auto& a, const auto& b) {
+                              return a.second.size() < b.second.size();
+                            })
+               ->second.size() +
+       2 * volume_vars.size());
+  DataVector buffer(3 * Dim * volume_vars.size() +
+                    second_logical_derivs_internal_buffer_size);
+
+  // The first_logical_partial_derivs is only needed for inverse_hessian
+  std::array<gsl::span<double>, Dim> first_logical_partial_derivs{};
+  std::array<gsl::span<double>, Dim> pure_second_logical_partial_derivs{};
+  std::array<gsl::span<double>, Dim> mixed_second_logical_partial_derivs{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(first_logical_partial_derivs, i) =
+        gsl::make_span(&buffer[i * volume_vars.size()], volume_vars.size());
+  }
+  for (size_t i = Dim; i < 2 * Dim; ++i) {
+    gsl::at(pure_second_logical_partial_derivs, i - Dim) =
+        gsl::make_span(&buffer[i * volume_vars.size()], volume_vars.size());
+  }
+  for (size_t i = 2 * Dim; i < 3 * Dim; ++i) {
+    gsl::at(mixed_second_logical_partial_derivs, i - 2 * Dim) =
+        gsl::make_span(&buffer[i * volume_vars.size()], volume_vars.size());
+  }
+  gsl::span<double> span_buffer =
+      gsl::make_span(&buffer[3 * Dim * volume_vars.size()],
+                     second_logical_derivs_internal_buffer_size);
+
+  detail::second_logical_partial_derivatives_impl(
+      make_not_null(&pure_second_logical_partial_derivs),
+      make_not_null(&mixed_second_logical_partial_derivs), &span_buffer,
+      volume_vars, ghost_cell_vars, volume_mesh, number_of_variables, fd_order);
+
+  std::array<const double*, Dim> first_logical_partial_derivs_ptrs{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(first_logical_partial_derivs_ptrs, i) =
+        gsl::at(first_logical_partial_derivs, i).data();
+  }
+
+  std::array<const double*, Dim> pure_second_logical_partial_derivs_ptrs{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(pure_second_logical_partial_derivs_ptrs, i) =
+        gsl::at(pure_second_logical_partial_derivs, i).data();
+  }
+
+  std::array<const double*, Dim> mixed_second_logical_partial_derivs_ptrs{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(mixed_second_logical_partial_derivs_ptrs, i) =
+        gsl::at(mixed_second_logical_partial_derivs, i).data();
+  }
+
+  partial_derivatives_detail::second_partial_derivatives_impl(
+      second_partial_derivatives, pure_second_logical_partial_derivs_ptrs,
+      mixed_second_logical_partial_derivs_ptrs,
+      Variables<DerivativeTags>::number_of_independent_components,
+      inverse_jacobian);
+}
+}  // namespace Ccz4::fd

--- a/tests/Unit/DataStructures/Tensor/Test_Metafunctions.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Metafunctions.cpp
@@ -122,6 +122,12 @@ static_assert(std::is_same_v<tnsr::iJ<double, 3, Frame::Grid>,
                                  tnsr::I<double, 3, Frame::Grid>, 3, UpLo::Lo,
                                  Frame::Grid>>,
               "Failed testing prepend_spatial_index");
+static_assert(
+    std::is_same_v<
+        tnsr::iiJJ<double, 3, Frame::Grid>,
+        TensorMetafunctions::prepend_two_symmetric_spatial_indices<
+            tnsr::II<double, 3, Frame::Grid>, 3, UpLo::Lo, Frame::Grid>>,
+    "Failed testing prepend_two_symmetric_spatial_indices");
 
 // Test remove_first_index
 static_assert(

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
+  FiniteDifference/Test_SecondPartialDerivatives.cpp
   Test_ATilde.cpp
   Test_Christoffel.cpp
   Test_DerivChristoffel.cpp
@@ -26,6 +27,7 @@ target_link_libraries(
   DataBoxTestHelpers
   DataStructures
   Domain
+  ErrorHandling
   GeneralRelativity
   GeneralRelativityHelpers
   GeneralRelativitySolutions

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SecondPartialDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SecondPartialDerivatives.cpp
@@ -1,0 +1,440 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_set>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace {
+template <size_t Dim>
+void test(const size_t points_per_dimension, const size_t fd_order) {
+  // The following code assumes fd_order == 4 and Dim == 3
+  ASSERT((Dim == 3) and (fd_order == 4),
+         "Only 3 spatial dims and 4th-order fd is supported right now!");
+  CAPTURE(points_per_dimension);
+  CAPTURE(fd_order);
+  CAPTURE(Dim);
+
+  const size_t max_degree = fd_order - 1;
+  const size_t number_of_vars = 2;
+
+  const Mesh<Dim> mesh{points_per_dimension, Spectral::Basis::FiniteDifference,
+                       Spectral::Quadrature::CellCentered};
+  auto logical_coords = logical_coordinates(mesh);
+  // Make the logical coordinates different in each direction
+  for (size_t i = 0; i < Dim; ++i) {
+    logical_coords.get(i) += 4.0 * static_cast<double>(i + 1);
+  }
+
+  // Set up a polynomial of max_degree on cell centers in FD cluster of points
+  const auto set_polynomial = [max_degree](
+                                  const gsl::not_null<DataVector*> var1_ptr,
+                                  const gsl::not_null<DataVector*> var2_ptr,
+                                  const auto& local_logical_coords) {
+    *var1_ptr = 0.0;
+    *var2_ptr = 100.0;  // some constant offset to distinguish the var values
+    for (size_t degree_x = 0; degree_x <= max_degree; ++degree_x) {
+      for (size_t degree_y = 0; degree_y <= max_degree; ++degree_y) {
+        for (size_t degree_z = 0; degree_z <= max_degree; ++degree_z) {
+          if (degree_x + degree_y + degree_z <= max_degree) {
+            *var1_ptr += pow(local_logical_coords.get(0), degree_x) *
+                         pow(local_logical_coords.get(1), degree_y) *
+                         pow(local_logical_coords.get(2), degree_z);
+            *var2_ptr += pow(local_logical_coords.get(0), degree_x) *
+                         pow(local_logical_coords.get(1), degree_y) *
+                         pow(local_logical_coords.get(2), degree_z);
+          }
+        }
+      }
+    }
+  };
+
+  // Compute the expected pure second derivatives of the polynomial
+  const auto set_polynomial_pure_second_derivative =
+      [](const gsl::not_null<std::array<DataVector, Dim>*>
+             pure_second_d_var1_ptr,
+         const gsl::not_null<std::array<DataVector, Dim>*>
+             pure_second_d_var2_ptr,
+         const auto& local_logical_coords) {
+        for (size_t deriv_dim = 0; deriv_dim < Dim; ++deriv_dim) {
+          gsl::at(*pure_second_d_var1_ptr, deriv_dim) =
+              2 + 2 * local_logical_coords.get(0) +
+              2 * local_logical_coords.get(1) + 2 * local_logical_coords.get(2);
+          gsl::at(*pure_second_d_var1_ptr, deriv_dim) +=
+              4 * local_logical_coords.get(deriv_dim);
+
+          gsl::at(*pure_second_d_var2_ptr, deriv_dim) =
+              2 + 2 * local_logical_coords.get(0) +
+              2 * local_logical_coords.get(1) + 2 * local_logical_coords.get(2);
+          gsl::at(*pure_second_d_var2_ptr, deriv_dim) +=
+              4 * local_logical_coords.get(deriv_dim);
+        }
+      };
+
+  // Compute the expected mixed second derivatives of the polynomial
+  // deriv_dim = 0 -- xy derivative; 1 -- yz derivative; 2 -- xz derivative
+  const auto set_polynomial_mixed_second_derivative =
+      [](const gsl::not_null<std::array<DataVector, Dim>*>
+             mixed_second_d_var1_ptr,
+         const gsl::not_null<std::array<DataVector, Dim>*>
+             mixed_second_d_var2_ptr,
+         const auto& local_logical_coords) {
+        for (size_t deriv_dim = 0; deriv_dim < Dim; ++deriv_dim) {
+          gsl::at(*mixed_second_d_var1_ptr, deriv_dim) =
+              1 + local_logical_coords.get(0) + local_logical_coords.get(1) +
+              local_logical_coords.get(2);
+          gsl::at(*mixed_second_d_var1_ptr, deriv_dim) +=
+              local_logical_coords.get(deriv_dim % Dim) +
+              local_logical_coords.get((deriv_dim + 1) % Dim);
+          gsl::at(*mixed_second_d_var2_ptr, deriv_dim) =
+              1 + local_logical_coords.get(0) + local_logical_coords.get(1) +
+              local_logical_coords.get(2);
+          gsl::at(*mixed_second_d_var2_ptr, deriv_dim) +=
+              local_logical_coords.get(deriv_dim % Dim) +
+              local_logical_coords.get((deriv_dim + 1) % Dim);
+        }
+      };
+
+  DataVector volume_vars{mesh.number_of_grid_points() * number_of_vars, 0.0};
+  DataVector var1(volume_vars.data(), mesh.number_of_grid_points());
+  DataVector var2(volume_vars.data() + mesh.number_of_grid_points(),
+                  mesh.number_of_grid_points());
+  set_polynomial(&var1, &var2, logical_coords);
+
+  DataVector expected_pure_second_deriv{Dim * volume_vars.size()};
+  std::array<DataVector, Dim> expected_pure_second_d_var1{};
+  std::array<DataVector, Dim> expected_pure_second_d_var2{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(expected_pure_second_d_var1, i)
+        .set_data_ref(&expected_pure_second_deriv[i * volume_vars.size()],
+                      mesh.number_of_grid_points());
+    gsl::at(expected_pure_second_d_var2, i)
+        .set_data_ref(&expected_pure_second_deriv[i * volume_vars.size() +
+                                                  mesh.number_of_grid_points()],
+                      mesh.number_of_grid_points());
+  }
+  set_polynomial_pure_second_derivative(&expected_pure_second_d_var1,
+                                        &expected_pure_second_d_var2,
+                                        logical_coords);
+
+  DataVector expected_mixed_second_deriv{Dim * volume_vars.size()};
+  std::array<DataVector, Dim> expected_mixed_second_d_var1{};
+  std::array<DataVector, Dim> expected_mixed_second_d_var2{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(expected_mixed_second_d_var1, i)
+        .set_data_ref(&expected_mixed_second_deriv[i * volume_vars.size()],
+                      mesh.number_of_grid_points());
+    gsl::at(expected_mixed_second_d_var2, i)
+        .set_data_ref(
+            &expected_mixed_second_deriv[i * volume_vars.size() +
+                                         mesh.number_of_grid_points()],
+            mesh.number_of_grid_points());
+  }
+  set_polynomial_mixed_second_derivative(&expected_mixed_second_d_var1,
+                                         &expected_mixed_second_d_var2,
+                                         logical_coords);
+
+  // Compute the polynomial at the cell center for the neighbor data that we
+  // "received".
+  //
+  // We do this by computing the solution in our entire neighbor, then using
+  // slice_data to get the subset of points that are needed.
+  DirectionMap<Dim, DataVector> neighbor_data{};
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    auto neighbor_logical_coords = logical_coords;
+    neighbor_logical_coords.get(direction.dimension()) +=
+        direction.sign() * 2.0;
+    DataVector neighbor_vars{mesh.number_of_grid_points() * number_of_vars,
+                             0.0};
+    DataVector neighbor_var1(neighbor_vars.data(),
+                             mesh.number_of_grid_points());
+    DataVector neighbor_var2(
+        neighbor_vars.data() + mesh.number_of_grid_points(),
+        mesh.number_of_grid_points());
+    set_polynomial(&neighbor_var1, &neighbor_var2, neighbor_logical_coords);
+
+    // We need two ghost points for 4th order
+    const size_t num_of_ghost_pts = 2;
+    const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+        gsl::make_span(neighbor_vars.data(), neighbor_vars.size()),
+        mesh.extents(), num_of_ghost_pts,
+        std::unordered_set{direction.opposite()}, 0, {});
+    REQUIRE(sliced_data.size() == 1);
+    REQUIRE(sliced_data.contains(direction.opposite()));
+    neighbor_data[direction] = sliced_data.at(direction.opposite());
+    REQUIRE(neighbor_data.at(direction).size() ==
+            number_of_vars * num_of_ghost_pts *
+                mesh.slice_away(0).number_of_grid_points());
+  }
+
+  // Note: reconstructed_num_pts assumes isotropic extents
+  DataVector pure_second_logical_derivative_buffer{volume_vars.size() * Dim};
+  std::array<gsl::span<double>, Dim> pure_second_logical_derivative_view{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(pure_second_logical_derivative_view, i) = gsl::make_span(
+        &pure_second_logical_derivative_buffer[i * volume_vars.size()],
+        volume_vars.size());
+  }
+
+  DataVector mixed_second_logical_derivative_buffer{volume_vars.size() * Dim};
+  std::array<gsl::span<double>, Dim> mixed_second_logical_derivative_view{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(mixed_second_logical_derivative_view, i) = gsl::make_span(
+        &mixed_second_logical_derivative_buffer[i * volume_vars.size()],
+        volume_vars.size());
+  }
+
+  DirectionMap<Dim, gsl::span<const double>> ghost_cell_vars{};
+  for (const auto& [direction, data] : neighbor_data) {
+    ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
+  }
+
+  ::Ccz4::fd::second_logical_partial_derivatives(
+      make_not_null(&pure_second_logical_derivative_view),
+      make_not_null(&mixed_second_logical_derivative_view),
+      gsl::make_span(volume_vars.data(), volume_vars.size()), ghost_cell_vars,
+      mesh, number_of_vars, fd_order);
+
+  // Scale to volume_vars since that sets the subtraction error threshold.
+  Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(
+      *std::max_element(volume_vars.begin(), volume_vars.end()));
+
+  for (size_t i = 0; i < Dim; ++i) {
+    CAPTURE(i);
+    {
+      CAPTURE(logical_coords.get(0));
+      CAPTURE(var1);
+      const DataVector fd_pure_second_d_var1(
+          &gsl::at(pure_second_logical_derivative_view, i)[0],
+          mesh.number_of_grid_points());
+      CHECK_ITERABLE_CUSTOM_APPROX(fd_pure_second_d_var1,
+                                   gsl::at(expected_pure_second_d_var1, i),
+                                   custom_approx);
+    }
+    {
+      CAPTURE(var2);
+      const DataVector fd_pure_second_d_var2(
+          &gsl::at(pure_second_logical_derivative_view,
+                   i)[mesh.number_of_grid_points()],
+          mesh.number_of_grid_points());
+      CHECK_ITERABLE_CUSTOM_APPROX(fd_pure_second_d_var2,
+                                   gsl::at(expected_pure_second_d_var2, i),
+                                   custom_approx);
+    }
+    {
+      CAPTURE(var1);
+      const DataVector fd_mixed_second_d_var1(
+          &gsl::at(mixed_second_logical_derivative_view, i)[0],
+          mesh.number_of_grid_points());
+      CHECK_ITERABLE_CUSTOM_APPROX(fd_mixed_second_d_var1,
+                                   gsl::at(expected_mixed_second_d_var1, i),
+                                   custom_approx);
+    }
+    {
+      CAPTURE(var2);
+      const DataVector fd_mixed_second_d_var2(
+          &gsl::at(mixed_second_logical_derivative_view,
+                   i)[mesh.number_of_grid_points()],
+          mesh.number_of_grid_points());
+      CHECK_ITERABLE_CUSTOM_APPROX(fd_mixed_second_d_var2,
+                                   gsl::at(expected_mixed_second_d_var2, i),
+                                   custom_approx);
+    }
+  }
+
+  // Test second partial derivatives with Jacobian.
+  // We use inertial coords x = \xi^2, y = \eta, and z = \xi + \zeta
+  // We also change the first var to a tensor for generality
+  InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>
+      inverse_jacobian(mesh.number_of_grid_points(), 0.0);
+  inverse_jacobian.get(0, 0) = 0.5 / logical_coords.get(0);
+  inverse_jacobian.get(1, 1) = 1.0;
+  inverse_jacobian.get(2, 0) = -0.5 / logical_coords.get(0);
+  inverse_jacobian.get(2, 2) = 1.0;
+
+  using derivative_tags =
+      tmpl::list<Tags::Tempi<0, Dim, Frame::Inertial, DataVector>,
+                 Tags::TempScalar<1, DataVector>>;
+
+  Variables<db::wrap_tags_in<Tags::second_deriv, derivative_tags,
+                             tmpl::size_t<Dim>, Frame::Inertial>>
+      second_partial_derivatives{mesh.number_of_grid_points()};
+
+  const size_t number_of_independent_components =
+      Variables<derivative_tags>::number_of_independent_components;
+
+  DataVector volume_vars_for_tensor(
+      mesh.number_of_grid_points() * number_of_independent_components, 0.0);
+  DataVector tensor_var_1(volume_vars_for_tensor.data(),
+                          mesh.number_of_grid_points());
+  DataVector tensor_var_2(
+      volume_vars_for_tensor.data() + mesh.number_of_grid_points(),
+      mesh.number_of_grid_points());
+  DataVector tensor_var_3(
+      volume_vars_for_tensor.data() + 2 * mesh.number_of_grid_points(),
+      mesh.number_of_grid_points());
+  DataVector scalar_var(
+      volume_vars_for_tensor.data() + Dim * mesh.number_of_grid_points(),
+      mesh.number_of_grid_points());
+
+  set_polynomial(&tensor_var_1, &tensor_var_2, logical_coords);
+  set_polynomial(&tensor_var_3, &scalar_var, logical_coords);
+
+  // Update ghost data as we include tensor variable
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    auto neighbor_logical_coords = logical_coords;
+    neighbor_logical_coords.get(direction.dimension()) +=
+        direction.sign() * 2.0;
+    DataVector neighbor_vars{
+        mesh.number_of_grid_points() * number_of_independent_components, 0.0};
+    DataVector neighbor_tensor_var1(neighbor_vars.data(),
+                                    mesh.number_of_grid_points());
+    DataVector neighbor_tensor_var2(
+        neighbor_vars.data() + mesh.number_of_grid_points(),
+        mesh.number_of_grid_points());
+    DataVector neighbor_tensor_var3(
+        neighbor_vars.data() + 2 * mesh.number_of_grid_points(),
+        mesh.number_of_grid_points());
+    DataVector neighbor_scalar_var(
+        neighbor_vars.data() + Dim * mesh.number_of_grid_points(),  // NOLINT
+        mesh.number_of_grid_points());
+    set_polynomial(&neighbor_tensor_var1, &neighbor_tensor_var2,
+                   neighbor_logical_coords);
+    set_polynomial(&neighbor_tensor_var3, &neighbor_scalar_var,
+                   neighbor_logical_coords);
+
+    // We need two ghost points for 4th order
+    const size_t num_of_ghost_pts = 2;
+    const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+        gsl::make_span(neighbor_vars.data(), neighbor_vars.size()),
+        mesh.extents(), num_of_ghost_pts,
+        std::unordered_set{direction.opposite()}, 0, {});
+    REQUIRE(sliced_data.size() == 1);
+    REQUIRE(sliced_data.contains(direction.opposite()));
+    neighbor_data[direction] = sliced_data.at(direction.opposite());
+    REQUIRE(neighbor_data.at(direction).size() ==
+            number_of_independent_components * num_of_ghost_pts *
+                mesh.slice_away(0).number_of_grid_points());
+  }
+
+  for (const auto& [direction, data] : neighbor_data) {
+    ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
+  }
+
+  ::Ccz4::fd::second_partial_derivatives<derivative_tags>(
+      make_not_null(&second_partial_derivatives),
+      gsl::make_span(volume_vars_for_tensor.data(),
+                     volume_vars_for_tensor.size()),
+      ghost_cell_vars, mesh, number_of_independent_components, 4,
+      inverse_jacobian);
+
+  Variables<db::wrap_tags_in<Tags::second_deriv, derivative_tags,
+                             tmpl::size_t<Dim>, Frame::Inertial>>
+      expected_second_partial_derivatives{mesh.number_of_grid_points()};
+
+  // transform the expected derivs to inertial coords
+  gsl::at(expected_pure_second_d_var1, 0) =
+      (1 + 2 * logical_coords.get(0) + logical_coords.get(1) +
+       2 * logical_coords.get(2)) /
+      (2 * square(logical_coords.get(0)));
+  gsl::at(expected_pure_second_d_var1, 1) =
+      2 * (1 + logical_coords.get(0) + 3 * logical_coords.get(1) +
+           logical_coords.get(2));
+  gsl::at(expected_pure_second_d_var1, 2) =
+      2 * (1 + logical_coords.get(0) + logical_coords.get(1) +
+           3 * logical_coords.get(2));
+  gsl::at(expected_pure_second_d_var2, 0) =
+      (1 + 2 * logical_coords.get(0) + logical_coords.get(1) +
+       2 * logical_coords.get(2)) /
+      (2 * square(logical_coords.get(0)));
+  gsl::at(expected_pure_second_d_var2, 1) =
+      2 * (1 + logical_coords.get(0) + 3 * logical_coords.get(1) +
+           logical_coords.get(2));
+  gsl::at(expected_pure_second_d_var2, 2) =
+      2 * (1 + logical_coords.get(0) + logical_coords.get(1) +
+           3 * logical_coords.get(2));
+
+  gsl::at(expected_mixed_second_d_var1, 0) =
+      (logical_coords.get(0) - logical_coords.get(2)) /
+      (2 * logical_coords.get(0));
+  gsl::at(expected_mixed_second_d_var1, 1) = 1 + logical_coords.get(0) +
+                                             2 * logical_coords.get(1) +
+                                             2 * logical_coords.get(2);
+  gsl::at(expected_mixed_second_d_var1, 2) =
+      -(1 + logical_coords.get(1) + 4 * logical_coords.get(2)) /
+      (2 * logical_coords.get(0));
+  gsl::at(expected_mixed_second_d_var2, 0) =
+      (logical_coords.get(0) - logical_coords.get(2)) /
+      (2 * logical_coords.get(0));
+  gsl::at(expected_mixed_second_d_var2, 1) = 1 + logical_coords.get(0) +
+                                             2 * logical_coords.get(1) +
+                                             2 * logical_coords.get(2);
+  gsl::at(expected_mixed_second_d_var2, 2) =
+      -(1 + logical_coords.get(1) + 4 * logical_coords.get(2)) /
+      (2 * logical_coords.get(0));
+
+  // putting the expected pure and mixed second derivs into the variable
+  // expected_second_partial_derivatives
+  using second_d_var1_tag =
+      Tags::second_deriv<Tags::Tempi<0, Dim, Frame::Inertial, DataVector>,
+                         tmpl::size_t<Dim>, Frame::Inertial>;
+  using second_d_var2_tag =
+      Tags::second_deriv<Tags::TempScalar<1, DataVector>, tmpl::size_t<Dim>,
+                         Frame::Inertial>;
+  for (size_t deriv_index = 0; deriv_index < Dim; deriv_index++) {
+    for (size_t i = 0; i < Dim; ++i) {
+      (get<second_d_var1_tag>(expected_second_partial_derivatives))
+          .get(deriv_index, deriv_index, i) =
+          gsl::at(expected_pure_second_d_var1, deriv_index);
+      (get<second_d_var1_tag>(expected_second_partial_derivatives))
+          .get(deriv_index, (deriv_index + 1) % Dim, i) =
+          gsl::at(expected_mixed_second_d_var1, deriv_index);
+    }
+    (get<second_d_var2_tag>(expected_second_partial_derivatives))
+        .get(deriv_index, deriv_index) =
+        gsl::at(expected_pure_second_d_var2, deriv_index);
+
+    (get<second_d_var2_tag>(expected_second_partial_derivatives))
+        .get(deriv_index, (deriv_index + 1) % Dim) =
+        gsl::at(expected_mixed_second_d_var2, deriv_index);
+  }
+  {
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        get<second_d_var1_tag>(second_partial_derivatives),
+        get<second_d_var1_tag>(expected_second_partial_derivatives),
+        custom_approx);
+  }
+  {
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        get<second_d_var2_tag>(second_partial_derivatives),
+        get<second_d_var2_tag>(expected_second_partial_derivatives),
+        custom_approx);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.SecondPartialDerivatives",
+                  "[Unit][NumericalAlgorithms]") {
+  const size_t Dim = 3;
+  const size_t points_per_dimension = 5;
+  const size_t fd_deriv_order = 4;
+  test<Dim>(points_per_dimension, fd_deriv_order);
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Implement 3D 4-th order finite difference second partial derivatives without communications across diagonal neighbors (to be used for the second order Ccz4 system under development).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

A new Tags::second_deriv is added to type the second derivatives of tensors. The tag assumes and ensures that the first two indices are symmetric (since partial derivatives should commute for nice functions). Convergence tests on both the logical and inertial derivatives indicate this stencil is indeed 4th order accurate.

Inverse Hessian has NOT been implemented, so currently the inertial second derivatives assume that the inertial coordinates do not mix the logical coordinates.
