### PR TITLE
Link jemalloc only into executables

### DIFF
--- a/cmake/PrintUsefulCMakeInfo.cmake
+++ b/cmake/PrintUsefulCMakeInfo.cmake
@@ -78,11 +78,3 @@ if(DOXYGEN_FOUND)
 else()
   message(STATUS "Doxygen: Not found, documentation cannot be built.")
 endif()
-
-if(BUILD_PYTHON_BINDINGS AND "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
-  message(STATUS
-    "When using the python bindings you must run python as:\n"
-    "   LD_PRELOAD=${JEMALLOC_LIBRARIES} python ...\n"
-    "Alternatively, use the system allocator by setting \n"
-    "-D MEMORY_ALLOCATOR=SYSTEM")
-endif()

--- a/cmake/SetupJemalloc.cmake
+++ b/cmake/SetupJemalloc.cmake
@@ -50,3 +50,8 @@ else()
 endif()
 
 mark_as_advanced(JEMALLOC_LIB_TYPE)
+
+if("${JEMALLOC_LIB_TYPE}" STREQUAL STATIC)
+  message(WARNING "It's probably a better idea to use jemalloc as a shared "
+    "library. Statically linking jemalloc might work but has not been tested.")
+endif()

--- a/cmake/SpectreAddLibraries.cmake
+++ b/cmake/SpectreAddLibraries.cmake
@@ -18,29 +18,10 @@ function(ADD_SPECTRE_LIBRARY LIBRARY_NAME)
     TYPE
     )
 
-  # We need to link custom allocators before we link anything else so that
-  # any third-party libraries, which generally should all be built as shared
-  # libraries, use the allocator that we use. Unfortunately, how exactly
-  # CMake decides on the linking order is not clear when using
-  # INTERFACE_LINK_LIBRARIES and targets. To this end, we set a global
-  # property SPECTRE_ALLOCATOR_LIBRARY that contains the link flag to link
-  # to the memory allocator. By linking to the allocator library first
-  # explicitly in target_link_libraries CMake correctly places the allocator
-  # library as the first entry in the link libraries. We also link to the
-  # SpectreAllocator target to pull in any additional allocator-related
-  # flags, such as include directories.
-  get_property(
-    SPECTRE_ALLOCATOR_LIBRARY
-    GLOBAL
-    PROPERTY SPECTRE_ALLOCATOR_LIBRARY
-    )
+  # We do _not_ link a custom allocator here, such as jemalloc or tcmalloc, but
+  # only dynamically link it into executables. This allows to use the libraries
+  # in Python bindings, where the custom allocator would cause problems.
   if (NOT ${LIBRARY_TYPE} STREQUAL INTERFACE_LIBRARY)
-    target_link_libraries(${LIBRARY_NAME}
-      PUBLIC
-      ${SPECTRE_ALLOCATOR_LIBRARY}
-      SpectreAllocator
-    )
-
     set(SPECTRE_KOKKOS_LAUNCHER "")
     if(SPECTRE_KOKKOS)
       # We need to make sure we don't drop the Kokkos link wrapper

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -33,10 +33,15 @@ configure_or_symlink_py_file(
 # Also link the main entry point to bin/
 set(PYTHON_EXE_COMMAND "-m spectre")
 set(PYTHON_EXEC_ENV_VARS "")
-if(BUILD_PYTHON_BINDINGS AND "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
-  string(APPEND PYTHON_EXEC_ENV_VARS
-    " LD_PRELOAD=\${LD_PRELOAD}\${LD_PRELOAD:+:}${JEMALLOC_LIBRARIES}")
-endif()
+# At some point we needed to preload jemalloc for the Python bindings to work,
+# otherwise we got "cannot allocate memory in static TLS block" errors when
+# using jemalloc. This is fixed by avoiding to link jemalloc into libraries in
+# the first place (we only dynamically link it into executables). If we want to
+# link jemalloc into libraries again (e.g. to use jemalloc features explicitly
+# in the code), the best way to do this would be to build jemalloc with a prefix
+# and use it as a custom allocator where needed, instead of generically
+# replacing the system allocator.
+#
 # ParaView needs specific environment variables set, e.g. 'LD_LIBRARY_PATH', but
 # they can interfere with simulations, e.g. when they point to ParaView's
 # bundled MPI which may be different to the MPI we built with. Therefore we
@@ -87,20 +92,11 @@ configure_or_symlink_py_file(
   "${CMAKE_SOURCE_DIR}/setup.cfg"
   "${SPECTRE_PYTHON_PREFIX_PARENT}/setup.cfg")
 
-set(_JEMALLOC_MESSAGE "")
-if(BUILD_PYTHON_BINDINGS AND "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
-  set(_JEMALLOC_MESSAGE
-    "echo 'You must run python as:'\n"
-    "echo 'LD_PRELOAD=${JEMALLOC_LIBRARIES} python ...'\n")
-  string(REPLACE ";" "" _JEMALLOC_MESSAGE "${_JEMALLOC_MESSAGE}")
-endif()
-
 # Write a file to be able to set up the new python path.
 file(WRITE
   "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"
   "#!/bin/sh\n"
   "export PYTHONPATH=${PYTHONPATH}\n"
-  ${_JEMALLOC_MESSAGE}
   )
 configure_file(
   "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"
@@ -141,18 +137,6 @@ add_custom_target(all-pybindings)
 #                 ${CMAKE_SOURCE_DIR}/src) to add to the module. Omit if
 #                 no python files are to be provided.
 function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
-  if(BUILD_PYTHON_BINDINGS AND
-      "${JEMALLOC_LIB_TYPE}" STREQUAL STATIC
-      AND BUILD_SHARED_LIBS)
-    message(FATAL_ERROR
-      "Cannot build python bindings when using a static library JEMALLOC and "
-      "building SpECTRE with shared libraries. Either disable the python "
-      "bindings using -D BUILD_PYTHON_BINDINGS=OFF, switch to a shared/dynamic "
-      "JEMALLOC library, use the system allocator by passing "
-      "-D MEMORY_ALLOCATOR=SYSTEM to CMake, or build SpECTRE using static "
-      "libraries by passing -D BUILD_SHARED_LIBS=OFF to CMake.")
-  endif()
-
   set(SINGLE_VALUE_ARGS MODULE_PATH LIBRARY_NAME)
   set(MULTI_VALUE_ARGS SOURCES PYTHON_FILES)
   cmake_parse_arguments(
@@ -335,13 +319,6 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS
   spectre_test_timeout(TIMEOUT PYTHON ${TIMEOUT})
 
   set(_PY_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
-  if(BUILD_PYTHON_BINDINGS AND
-      "${JEMALLOC_LIB_TYPE}" STREQUAL SHARED)
-    list(APPEND
-      _PY_TEST_ENV_VARS
-      "LD_PRELOAD=${JEMALLOC_LIBRARIES}"
-      )
-  endif()
 
   # The fail regular expression is what Python.unittest returns when no
   # tests are found to be run. We treat this as a test failure.

--- a/docs/Tutorials/Python.md
+++ b/docs/Tutorials/Python.md
@@ -73,15 +73,6 @@ scripts:
   . BUILD_DIR/bin/LoadPython.sh
   ```
 
-  Note that by default SpECTRE uses `jemalloc` which needs to be pre-loaded for
-  the Python bindings to work. Therefore, you need to run
-  `LD_PRELOAD=/path/to/libjemalloc.so python` to execute Python scripts or start
-  Python consoles. The path to your preferred jemalloc installation is printed
-  out at the end of the `cmake` configuration or can be found by running the
-  script `BUILD_DIR/bin/LoadPython.sh`. Alternatively, you can use your system's
-  memory allocator by appending the flag `-D MEMORY_ALLOCATOR=SYSTEM` to the
-  `cmake` command. In this case you will not need to pre-load any libraries.
-
 Using any of the above options you should be able to import the `spectre` Python
 modules in your scripts or notebooks. You can try it like this:
 


### PR DESCRIPTION
## Proposed changes

jemalloc only needs to be linked dynamically into executables, not into libraries. Doing so avoids issues we had with Pybindings, where loading jemalloc caused problems.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
