### PR TITLE
Add `OrbitRadius` trigger

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(
   LinearOperators
   Options
   Parallel
+  Time
   Utilities
   )
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   InsideHorizon.cpp
+  OrbitRadius.cpp
   )
 
 spectre_target_headers(
@@ -13,4 +14,5 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   InsideHorizon.hpp
+  OrbitRadius.hpp
 )

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.hpp"
+
+#include <array>
+#include <vector>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+namespace Triggers {
+
+OrbitRadius::OrbitRadius(const std::vector<double>& radii) : radii_(radii) {}
+
+bool OrbitRadius::operator()(
+    const std::array<tnsr::I<double, 3, Frame::Inertial>, 2>&
+        position_and_velocity,
+    const TimeDelta& time_step) const {
+  const auto& position = position_and_velocity[0];
+  const auto& velocity = position_and_velocity[1];
+  const double current_radius = get(magnitude(position));
+  const double radial_velocity = (get<0>(position) * get<0>(velocity) +
+                                  get<1>(position) * get<1>(velocity) +
+                                  get<2>(position) * get<2>(velocity)) /
+                                 current_radius;
+  // factor 1.2 is for safety because the approximation is just linear
+  // approximation and triggering it multiple times is not a problem
+  const double next_radius =
+      current_radius + 1.2 * radial_velocity * time_step.value();
+  // NOLINTNEXTLINE(readability-use-anyofallof)
+  for (const double radius : radii_) {
+    if ((current_radius - radius) * (next_radius - radius) < 0.) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// NOLINTNEXTLINE(google-runtime-references)
+void OrbitRadius::pup(PUP::er& p) { p | radii_; }
+
+PUP::able::PUP_ID OrbitRadius::my_PUP_ID = 0;  // NOLINT
+}  // namespace Triggers

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <pup.h>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
+#include "Time/Tags/TimeStep.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+namespace Triggers {
+/*!
+ * \brief This trigger returns true when the scalar charge is about to cross one
+ * of the specified areal radii.
+ *
+ * \details As the domain is adjusted to track the position of the scalar
+ * charge, the time step needs to be dynamically adjusted accordingly. This
+ * trigger can be used to set the time step according to the radial position of
+ * the scalar charge which gives a good approximation of when the time step
+ * should be adjusted.
+ * The trigger only approximates whether the particle might cross during the
+ * next time step and may therefore fire twice.
+ */
+class OrbitRadius : public Trigger {
+ public:
+  /// \cond
+  OrbitRadius() = default;
+  explicit OrbitRadius(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(OrbitRadius);  // NOLINT
+  /// \endcond
+
+  struct Radii {
+    using type = std::vector<double>;
+    static constexpr Options::String help =
+        "The orbital radii which should trigger when crossed by the "
+        "scalar charge.";
+  };
+
+  static constexpr Options::String help =
+      "Trigger that fires when the scalar charge crosses specified radii.";
+  using options = tmpl::list<Radii>;
+
+  explicit OrbitRadius(const std::vector<double>& radii);
+
+  using argument_tags =
+      tmpl::list<CurvedScalarWave::Worldtube::Tags::ParticlePositionVelocity<3>,
+                 Tags::TimeStep>;
+
+  bool operator()(
+      const std::array<tnsr::I<double, 3>, 2>& position_and_velocity,
+      const TimeDelta& time_step) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  std::vector<double> radii_{};
+};
+}  // namespace Triggers

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Triggers.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Triggers.cpp
@@ -7,6 +7,7 @@
 
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/RadiusFunctions.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/InsideHorizon.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.hpp"
 #include "Framework/TestHelpers.hpp"
 
 namespace CurvedScalarWave::Worldtube {
@@ -43,9 +44,33 @@ void test_inside_horizon() {
   CHECK(inside_horizon_trigger(pos_vel_inside, wt_radius_params_small) == true);
 }
 
+void test_orbit_radius() {
+  const std::vector<double> radii{3., 17., 23.};
+  const Triggers::OrbitRadius orbit_radius_trigger(radii);
+
+  const tnsr::I<double, 3> position_0{{2.99, 0., 0.}};
+  const tnsr::I<double, 3> velocity_0{{0.01, 0., 0.}};
+
+  const std::array<tnsr::I<double, 3>, 2> pos_vel_0{position_0,
+                                                  velocity_0};
+  const Slab large_slab(0., 1.);
+  const Slab small_slab(0., 0.1);
+
+  CHECK(orbit_radius_trigger(pos_vel_0, large_slab.duration()));
+  CHECK_FALSE(orbit_radius_trigger(pos_vel_0, small_slab.duration()));
+
+  const tnsr::I<double, 3> position_1{{0., 0., 17.01}};
+  const tnsr::I<double, 3> velocity_1{{0., 0., -0.01}};
+  const std::array<tnsr::I<double, 3>, 2> pos_vel_1{position_1,
+    velocity_1};
+  CHECK(orbit_radius_trigger(pos_vel_1, large_slab.duration()));
+  CHECK_FALSE(orbit_radius_trigger(pos_vel_1, small_slab.duration()));
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Triggers",
                   "[Unit][Evolution]") {
   test_inside_horizon();
+  test_orbit_radius();
 }
 }  // namespace
 }  // namespace CurvedScalarWave::Worldtube


### PR DESCRIPTION
## Proposed changes

This trigger fires if the worldtube / scalar charge is about to cross any specified radii. It is used to manually adjust the time step during an inspiral.