### PR TITLE
Add ability to preprocess non-GH evolution data

### DIFF
--- a/.github/workflows/DeployStaticExecutables.yaml
+++ b/.github/workflows/DeployStaticExecutables.yaml
@@ -67,6 +67,14 @@ jobs:
           ./tests/InputFiles/PreprocessCceWorldtube/PreprocessCceWorldtube.yaml
           ./CceExecutables/PreprocessCceWorldtube/PreprocessCceWorldtube.yaml
 
+          cp
+          ./tests/InputFiles/PreprocessCceWorldtube/AdmFirstOrderDriverPreprocessCceWorldtube.yaml
+          ./CceExecutables/PreprocessCceWorldtube/AdmFirstOrderDriverPreprocessCceWorldtube.yaml
+
+          cp
+          ./tests/InputFiles/PreprocessCceWorldtube/AdmSecondOrderDriverPreprocessCceWorldtube.yaml
+          ./CceExecutables/PreprocessCceWorldtube/AdmSecondOrderDriverPreprocessCceWorldtube.yaml
+
           docker cp
           static-execs:/work/spectre/build/bin/CharacteristicExtract
           ./CceExecutables/

--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -277,6 +277,8 @@ configure_file(
 # These paths should be relative to the input file directory passed to
 # `add_input_file_tests`
 set(INPUT_FILE_WHITELIST
-    "PreprocessCceWorldtube/PreprocessCceWorldtube.yaml")
+    "PreprocessCceWorldtube/PreprocessCceWorldtube.yaml"
+    "PreprocessCceWorldtube/AdmFirstOrderDriverPreprocessCceWorldtube.yaml"
+    "PreprocessCceWorldtube/AdmSecondOrderDriverPreprocessCceWorldtube.yaml")
 
-add_input_file_tests("${CMAKE_SOURCE_DIR}/tests/InputFiles/" ${INPUT_FILE_WHITELIST})
+add_input_file_tests("${CMAKE_SOURCE_DIR}/tests/InputFiles/" "${INPUT_FILE_WHITELIST}")

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -477,6 +477,8 @@ RUN if [ "$TARGETARCH" = "$BUILDARCH" ] ; then \
         cd spectre/build \
         && make ${PARALLEL_MAKE_ARG} cli \
         && make ${PARALLEL_MAKE_ARG} CharacteristicExtract \
+        && make ${PARALLEL_MAKE_ARG} PreprocessCceWorldtube \
+        && make ${PARALLEL_MAKE_ARG} WriteCceWorldtubeCoordsToFile \
         && make ${PARALLEL_MAKE_ARG} SolveXcts \
     ; fi
 

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -21,6 +21,8 @@ that have no official support (yet).
 
 ### Running containerized releases
 
+#### CLI Entrypoint
+
 A quick way to run the code without installing anything at all is with our
 containerized releases:
 
@@ -56,6 +58,17 @@ available in the precompiled containers are:
 - Generating initial data
 - Running CCE (see \ref tutorial_cce)
 - Running Python support code with the SpECTRE CLI (see \ref tutorial_cli)
+
+#### Starting a container {#start_deploy_container}
+
+If you'd rather use an image to start a container, you can run
+
+```
+docker run --name spectre -i --entrypoint /bin/bash
+  -t sxscollaboration/spectre:deploy
+```
+
+\note The `--entrypoint /bin/bash` is important so you don't run the CLI.
 
 ### Running static binaries
 

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1323,6 +1323,21 @@ archivePrefix = {arXiv},
   publisher  = "Springer",
 }
 
+@article{Hilditch:2012fp,
+    author = "Hilditch, David and Bernuzzi, Sebastiano and Thierfelder, Marcus
+              and Cao, Zhoujian and Tichy, Wolfgang and Bruegmann, Bernd",
+    title = "{Compact binary evolutions with the Z4c formulation}",
+    eprint = "1212.2901",
+    archivePrefix = "arXiv",
+    primaryClass = "gr-qc",
+    doi = "10.1103/PhysRevD.88.084057",
+    url = "https://doi.org/10.1103/PhysRevD.88.084057",
+    journal = "Phys. Rev. D",
+    volume = "88",
+    pages = "084057",
+    year = "2013"
+}
+
 @article{Holst2004wt,
   author         = "Holst, Michael and Lindblom, Lee and Owen, Robert and
                     Pfeiffer, Harald P. and Scheel, Mark A. and Kidder,

--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -24,7 +24,7 @@ release). Inside this tarball is
 - an example set of Bondi-Sachs worldtube data in the `Tests/` directory (see
    [Input worldtube data formats](#input_worldtube_data_format) section)
 - example output from CCE in the `Tests/` directory
-- a `PreprocessCceWorldtube` executable and YAML file for converting between
+- a `PreprocessCceWorldtube` executable and YAML files for converting between
    [worldtube data formats](#input_worldtube_data_format) in the
    `PreprocessCceWorldtube/` directory
 - a `WriteCceWorldtubeCoordsToFile` executable that writes
@@ -191,13 +191,13 @@ complex modes in m-varies-fastest format. That is,
 Each dataset in the H5 file must also have an attribute
 named `Legend` which is an ASCII-encoded null-terminated variable-length string.
 
-##### Spherical harmonic nodes {#spherical_nodes}
+#### Spherical harmonic nodes {#spherical_nodes}
 
 When we refer to a "nodal" data format, we mean that the worldtube data are
-stored as complex values at specially chosen collocation points (a.k.a. grid
-points or nodes). This allows SpECTRE to perform integrals, derivatives, and
-interpolation exactly on the input data. These grid points are Gauss-Legendre in
-$cos(\theta)$ and equally spaced in $\phi$.
+stored as values at specially chosen collocation points (a.k.a. grid points or
+nodes). This allows SpECTRE to perform integrals, derivatives, and interpolation
+exactly on the input data. These grid points are Gauss-Legendre in $cos(\theta)$
+and equally spaced in $\phi$.
 
 Below is a routine for computing the spherical
 harmonic $\theta$ and $\phi$ values. These can be used to compute the Cartesian
@@ -233,6 +233,51 @@ named `Legend` which is an ASCII-encoded null-terminated variable-length string.
 \note Nodal data is likely the easiest to write out since no conversion to
 spherical harmonic coefficients is necessary.
 
+#### ADM Cartesian metric and derivatives {#adm_cartesian_metric_and_derivatives}
+
+For worldtube data stored in an H5 file in the "ADM metric nodal" format, there
+must be the following datasets with these exact names (including the `.dat`
+suffix):
+
+- `gxx.dat`, `gxy.dat`, `gxz.dat`, `gyy.dat`, `gyz.dat`, `gzz.dat`
+- `Dxgxx.dat`, `Dxgxy.dat`, `Dxgxz.dat`, `Dxgyy.dat`, `Dxgyz.dat`, `Dxgzz.dat`
+- `Dygxx.dat`, `Dygxy.dat`, `Dygxz.dat`, `Dygyy.dat`, `Dygyz.dat`, `Dygzz.dat`
+- `Dzgxx.dat`, `Dzgxy.dat`, `Dzgxz.dat`, `Dzgyy.dat`, `Dzgyz.dat`, `Dzgzz.dat`
+- `Shiftx.dat`, `Shifty.dat`, `Shiftz.dat`
+- `DxShiftx.dat`, `DxShifty.dat`, `DxShiftz.dat`
+- `DyShiftx.dat`, `DyShifty.dat`, `DyShiftz.dat`
+- `DzShiftx.dat`, `DzShifty.dat`, `DzShiftz.dat`
+- `Lapse.dat`, `DxLapse.dat`, `DyLapse.dat`, `DzLapse.dat`
+- `Kxx.dat`, `Kxy.dat`, `Kxz.dat`, `Kyy.dat`, `Kyz.dat`, `Kzz.dat`
+- Either: `AuxiliaryShiftx.dat`, `AuxiliaryShifty.dat`, `AuxiliaryShiftz.dat`
+- Or: `ConformalChristoffelx.dat`, `ConformalChristoffely.dat`,
+  `ConformalChristoffelz.dat`
+
+Here `g` represents the spacetime metric, but we only require the spatial
+components (e.g. `gxx.dat`, `gxy.dat`, etc...) so in practice, those are the
+tensor components of the spatial metric. The temporal components of the
+spacetime metric are stored separately in the lapse and shift. Each of the
+spatial metric, lapse, and shift must also have their cartesian derivatives. `K`
+is the extrinsic curvature, `AuxiliaryShift` is the auxiliary shift vector used
+in the first-order form of the Gamma-driver condition, and
+`ConformalChristoffel` is the trace of the conformal second_order symbols. We
+will compute the time derivative of the spatial metric using Eq. (2.134) of
+\cite BaumgarteShapiro, the time derivative of the lapse using the `1+log`
+slicing condition from Eq. (4.87) of \cite BaumgarteShapiro, and the time
+derivative of the shift using either the first order reduction form of the
+Gamma-driver condition from Eq. (4.89) of \cite BaumgarteShapiro or using the
+integrated Gamma-driver condition from Eq. (12) of \cite Hilditch:2012fp.
+
+\warning If your worldtube data is in the ADM metric nodal format but you have
+not used `1+log` slicing and the Gamma-driver conditions specified above, your
+time derivatives will be **wrong**. If you'd like us to support other commonly
+used gauge conditions (or variants of `1+log` or Gamma-driver), please open an
+issue on our
+[GitHub](https://github.com/sxs-collaboration/spectre).
+
+The layout of each of these datasets must be
+[spherical harmonic nodes](#spherical_nodes).
+
 #### Cartesian metric and derivatives {#cartesian_metric_and_derivatives}
 
 For worldtube data stored in an H5 file in either the "metric nodal" or "metric
@@ -261,7 +306,8 @@ each of these datasets must be in either
 
 In the "bondi nodal" format, you must have the same Bondi variables as the
 [required format](#required_h5_worldtube_data_format), but each variable layout
-must be the [spherical harmonic nodal layout](#spherical_nodes).
+must be the [spherical harmonic nodal layout](#spherical_nodes) with complex
+values interleaved as `Re`, `Im`, `Re`, `Im`, ...
 
 If you already have data in the
 [required "bondi modal" format](#required_h5_worldtube_data_format), then
@@ -307,6 +353,12 @@ Here are some notes about the different options in the YAML input file:
   *ascending* m.
 - `BufferDepth` is an advanced option that lets you load more data into RAM at
   once so there are fewer filesystem accesses.
+- If using the ADM metric nodal input data format with a first-order form gamma
+  driver, specify the `InputDataFormat:` like so:
+\snippet AdmFirstOrderDriverPreprocessCceWorldtube.yaml first_order_input_data_format_example
+- If using the ADM metric nodal input data format with an integrated gamma
+  driver, specify the `InputDataFormat:` like so:
+\snippet AdmSecondOrderDriverPreprocessCceWorldtube.yaml second_order_input_data_format_example
 
 ### What Worldtube data "should" look like {#worldtube_data_looks}
 
@@ -320,7 +372,8 @@ The 2,2 modes are oscillatory and capture the orbits of the two objects. The
 real part of the 2,0 mode contains the gravitational memory of the system. Then
 for this system, all the other modes are subdominant.
 
-If you are using the [cartesian metric](#cartesian_metric_and_derivatives)
+If you are using the [cartesian metric](#cartesian_metric_and_derivatives) or
+[adm cartesian metric](#adm_cartesian_metric_and_derivatives)
 worldtube format, here is a plot of the imaginary part of the 2,2 mode of the
 lapse and its radial and time derivative during inspiral.
 

--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -10,7 +10,7 @@ See LICENSE.txt for details.
 
 There are a couple different ways to acquire the CCE module/executable.
 
-### From a release
+### From a release {#cce_from_release}
 
 Starting from late May 2024, in every
 [Release of SpECTRE](https://github.com/sxs-collaboration/spectre/releases) we
@@ -26,7 +26,7 @@ release). Inside this tarball is
 - example output from CCE in the `Tests/` directory
 - a `PreprocessCceWorldtube` executable and YAML file for converting between
    [worldtube data formats](#input_worldtube_data_format) in the
-   `PreprocessCceWorldtube/` diretory
+   `PreprocessCceWorldtube/` directory
 - a `WriteCceWorldtubeCoordsToFile` executable that writes
    [grid points on a sphere](#spherical_nodes) to a text file in the
    `PreprocessCceWorldtube/` directory
@@ -57,6 +57,16 @@ on the following machines (in addition to the ones above):
 
 - Frontera
 - Delta
+
+### From Docker
+
+You can download a docker image `sxscollaboration/spectre:deploy` which has a
+few pre-built executables within, including the ones listed above in the
+[release](#cce_from_release) section. See the containerized releases section of
+our \ref installation instructions for how start the container.
+
+The input files can be found within the container at
+`/work/spectre/tests/InputFiles/`.
 
 ### From source
 

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
@@ -17,7 +17,12 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
 #include "Evolution/Systems/Cce/ExtractionRadius.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "IO/H5/Dat.hpp"
@@ -27,6 +32,7 @@
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TimeDerivativeOfSpatialMetric.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -307,15 +313,32 @@ double update_buffers_for_time(
 template <typename T>
 MetricWorldtubeH5BufferUpdater<T>::MetricWorldtubeH5BufferUpdater(
     const std::string& cce_data_filename,
-    const std::optional<double> extraction_radius, const bool descending_m)
+    const std::optional<double> extraction_radius, const bool descending_m,
+    const std::optional<AdmOptions>& adm_options)
     : cce_data_file_{cce_data_filename},
       filename_{cce_data_filename},
-      descending_m_(descending_m) {
+      descending_m_(descending_m),
+      adm_options_(adm_options) {
+  if (is_modal and adm_options_.has_value()) {
+    ERROR(
+        "Cannot read in modal data with ADM quantities (like extrinsic "
+        "curvature).");
+  }
+
   get<Tags::detail::InputDataSet<Tags::detail::SpatialMetric<T>>>(
       dataset_names_) = "/g";
   get<Tags::detail::InputDataSet<
       Tags::detail::Dr<Tags::detail::SpatialMetric<T>>>>(dataset_names_) =
       "/Drg";
+  get<Tags::detail::InputDataSet<
+      Tags::detail::Dx<Tags::detail::SpatialMetric<T>>>>(dataset_names_) =
+      "/Dxg";
+  get<Tags::detail::InputDataSet<
+      Tags::detail::Dy<Tags::detail::SpatialMetric<T>>>>(dataset_names_) =
+      "/Dyg";
+  get<Tags::detail::InputDataSet<
+      Tags::detail::Dz<Tags::detail::SpatialMetric<T>>>>(dataset_names_) =
+      "/Dzg";
   get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::SpatialMetric<T>>>>(
       dataset_names_) = "/Dtg";
 
@@ -323,6 +346,12 @@ MetricWorldtubeH5BufferUpdater<T>::MetricWorldtubeH5BufferUpdater(
       "/Shift";
   get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Shift<T>>>>(
       dataset_names_) = "/DrShift";
+  get<Tags::detail::InputDataSet<Tags::detail::Dx<Tags::detail::Shift<T>>>>(
+      dataset_names_) = "/DxShift";
+  get<Tags::detail::InputDataSet<Tags::detail::Dy<Tags::detail::Shift<T>>>>(
+      dataset_names_) = "/DyShift";
+  get<Tags::detail::InputDataSet<Tags::detail::Dz<Tags::detail::Shift<T>>>>(
+      dataset_names_) = "/DzShift";
   get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Shift<T>>>>(
       dataset_names_) = "/DtShift";
 
@@ -330,8 +359,21 @@ MetricWorldtubeH5BufferUpdater<T>::MetricWorldtubeH5BufferUpdater(
       "/Lapse";
   get<Tags::detail::InputDataSet<Tags::detail::Dr<Tags::detail::Lapse<T>>>>(
       dataset_names_) = "/DrLapse";
+  get<Tags::detail::InputDataSet<Tags::detail::Dx<Tags::detail::Lapse<T>>>>(
+      dataset_names_) = "/DxLapse";
+  get<Tags::detail::InputDataSet<Tags::detail::Dy<Tags::detail::Lapse<T>>>>(
+      dataset_names_) = "/DyLapse";
+  get<Tags::detail::InputDataSet<Tags::detail::Dz<Tags::detail::Lapse<T>>>>(
+      dataset_names_) = "/DzLapse";
   get<Tags::detail::InputDataSet<::Tags::dt<Tags::detail::Lapse<T>>>>(
       dataset_names_) = "/DtLapse";
+
+  get<Tags::detail::InputDataSet<Tags::detail::ExtrinsicCurvature<T>>>(
+      dataset_names_) = "/K";
+  get<Tags::detail::InputDataSet<Tags::detail::AuxiliaryShift<T>>>(
+      dataset_names_) = "/AuxiliaryShift";
+  get<Tags::detail::InputDataSet<Tags::detail::ConformalChristoffel<T>>>(
+      dataset_names_) = "/ConformalChristoffel";
 
   // 'VersionHist' is a feature written by SpEC to indicate the details of the
   // file format. This line determines whether or not the radial derivatives
@@ -382,6 +424,24 @@ double MetricWorldtubeH5BufferUpdater<T>::update_buffers_for_time(
   *time_span_start = new_span_pair.first;
   *time_span_end = new_span_pair.second;
   // load the desired time spans into the buffers
+  if (not adm_options_.has_value()) {
+    update_radial_formulation(buffers, computation_l_max, *time_span_start,
+                              *time_span_end, time_varies_fastest);
+  } else if constexpr (not is_modal) {
+    update_adm_formulation(buffers, computation_l_max, *time_span_start,
+                           *time_span_end, time_varies_fastest);
+  }
+
+  // the next time an update will be required
+  return time_buffer_[std::min(*time_span_end - interpolator_length + 1,
+                               time_buffer_.size() - 1)];
+}
+
+template <typename T>
+void MetricWorldtubeH5BufferUpdater<T>::update_radial_formulation(
+    const gsl::not_null<Variables<cce_metric_input_tags<T>>*> buffers,
+    const size_t computation_l_max, const size_t time_span_start,
+    const size_t time_span_end, const bool time_varies_fastest) const {
   // spatial metric
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = i; j < 3; ++j) {
@@ -394,7 +454,7 @@ double MetricWorldtubeH5BufferUpdater<T>::update_buffers_for_time(
                 cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
                     get<Tags::detail::InputDataSet<tag>>(dataset_names_), i,
                     j)),
-                computation_l_max, *time_span_start, *time_span_end,
+                computation_l_max, time_span_start, time_span_end,
                 time_varies_fastest);
             cce_data_file_.close_current_object();
           });
@@ -407,7 +467,7 @@ double MetricWorldtubeH5BufferUpdater<T>::update_buffers_for_time(
               make_not_null(&get<tag>(*buffers).get(i)),
               cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
                   get<Tags::detail::InputDataSet<tag>>(dataset_names_), i)),
-              computation_l_max, *time_span_start, *time_span_end,
+              computation_l_max, time_span_start, time_span_end,
               time_varies_fastest);
           cce_data_file_.close_current_object();
         });
@@ -420,13 +480,282 @@ double MetricWorldtubeH5BufferUpdater<T>::update_buffers_for_time(
             make_not_null(&get(get<tag>(*buffers))),
             cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
                 get<Tags::detail::InputDataSet<tag>>(dataset_names_))),
-            computation_l_max, *time_span_start, *time_span_end,
+            computation_l_max, time_span_start, time_span_end,
             time_varies_fastest);
         cce_data_file_.close_current_object();
       });
-  // the next time an update will be required
-  return time_buffer_[std::min(*time_span_end - interpolator_length + 1,
-                               time_buffer_.size() - 1)];
+}
+
+template <typename T>
+template <typename U>
+typename std::enable_if_t<std::is_same_v<U, DataVector>>
+MetricWorldtubeH5BufferUpdater<T>::update_adm_formulation(
+    const gsl::not_null<Variables<cce_metric_input_tags<DataVector>>*> buffers,
+    const size_t computation_l_max, const size_t time_span_start,
+    const size_t time_span_end, const bool time_varies_fastest) const {
+  // This makes the code much less complicated because of contiguous memory for
+  // a given time
+  if (UNLIKELY(time_varies_fastest)) {
+    ERROR(
+        "Time must not vary fastest when using ADM quantities for the metric "
+        "worldtube buffer updater.");
+  }
+  const size_t number_of_times = time_span_end - time_span_start;
+  const size_t size_of_individual_time =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max_);
+  const size_t size_of_full_buffer =
+      get<0, 0>(get<Tags::detail::SpatialMetric<DataVector>>(*buffers)).size();
+
+  TempBuffer<tmpl::list<
+      ::Tags::Tempi<0, 3>,
+      ::Tags::Tempi<1, 2, ::Frame::Spherical<::Frame::Inertial>>,
+      ::Tags::Tempi<2, 3>, ::Tags::TempiJ<0, 3>, ::Tags::Tempijj<0, 3>,
+      ::Tags::Tempii<0, 3>, ::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
+      ::Tags::TempII<0, 3>, ::Tags::TempI<0, 3>, ::Tags::TempI<1, 3>>>
+      temp_buffer{size_of_full_buffer};
+  auto& cartesian_cauchy_coordinates_buffer =
+      get<::Tags::Tempi<0, 3>>(temp_buffer);
+  auto& unused_angular_cauchy_coordinates_buffer =
+      get<::Tags::Tempi<1, 2, ::Frame::Spherical<::Frame::Inertial>>>(
+          temp_buffer);
+
+  // Have to compute angular coordinates for each time independently
+  for (size_t i = 0; i < number_of_times; i++) {
+    tnsr::i<DataVector, 3> cartesian_cauchy_coordinates{};
+    tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>
+        unused_angular_cauchy_coordinates{};
+    // NOLINTBEGIN
+    for (size_t j = 0; j < 3; j++) {
+      cartesian_cauchy_coordinates[j].set_data_ref(
+          cartesian_cauchy_coordinates_buffer[j].data() +
+              i * size_of_individual_time,
+          size_of_individual_time);
+      if (j < 2) {
+        unused_angular_cauchy_coordinates[j].set_data_ref(
+            unused_angular_cauchy_coordinates_buffer[j].data() +
+                i * size_of_individual_time,
+            size_of_individual_time);
+      }
+      // NOLINTEND
+    }
+
+    // Calling this function is easier than calling the individual parts
+    // that only compute the cartesian coords
+    Spectral::Swsh::create_angular_and_cartesian_coordinates(
+        make_not_null(&cartesian_cauchy_coordinates),
+        make_not_null(&unused_angular_cauchy_coordinates), l_max_);
+  }
+
+  // Need lots of temporaries to convert quantities
+  auto& cartesian_deriv_lapse = get<::Tags::Tempi<2, 3>>(temp_buffer);
+  auto& cartesian_deriv_shift = get<::Tags::TempiJ<0, 3>>(temp_buffer);
+  auto& cartesian_deriv_spatial_metric =
+      get<::Tags::Tempijj<0, 3>>(temp_buffer);
+  auto& extrinsic_curvature = get<::Tags::Tempii<0, 3>>(temp_buffer);
+  auto& trace_extrinsic_curvature = get<::Tags::TempScalar<0>>(temp_buffer);
+  auto& determinant_spatial_metric = get<::Tags::TempScalar<1>>(temp_buffer);
+  auto& inverse_spatial_metric = get<::Tags::TempII<0, 3>>(temp_buffer);
+  auto& auxiliary_shift = get<::Tags::TempI<0, 3>>(temp_buffer);
+  auto& conformal_christoffel = get<::Tags::TempI<1, 3>>(temp_buffer);
+
+  const auto set_radial_deriv =
+      [&cartesian_cauchy_coordinates_buffer](
+          const gsl::not_null<DataVector*> radial_deriv,
+          const DataVector& x_deriv, const DataVector& y_deriv,
+          const DataVector& z_deriv) {
+        // These are unit coords of the collocation points. So
+        // sin(theta)*cos(phi) = x/r = x, when the coords are unit (etc...)
+        (*radial_deriv) =
+            get<0>(cartesian_cauchy_coordinates_buffer) * x_deriv +
+            get<1>(cartesian_cauchy_coordinates_buffer) * y_deriv +
+            get<2>(cartesian_cauchy_coordinates_buffer) * z_deriv;
+      };
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      // extrinsic curvature
+      this->update_buffer(
+          make_not_null(&extrinsic_curvature.get(i, j)),
+          cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+              get<Tags::detail::InputDataSet<
+                  Tags::detail::ExtrinsicCurvature<T>>>(dataset_names_),
+              i, j)),
+          computation_l_max, time_span_start, time_span_end,
+          time_varies_fastest);
+      cce_data_file_.close_current_object();
+
+      // spatial metric
+      this->update_buffer(
+          make_not_null(
+              &get<Tags::detail::SpatialMetric<DataVector>>(*buffers).get(i,
+                                                                          j)),
+          cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+              get<Tags::detail::InputDataSet<Tags::detail::SpatialMetric<T>>>(
+                  dataset_names_),
+              i, j)),
+          computation_l_max, time_span_start, time_span_end,
+          time_varies_fastest);
+      cce_data_file_.close_current_object();
+
+      // dx spatial metric
+      tmpl::for_each<Tags::detail::cartesian_derivs_t<
+          Tags::detail::SpatialMetric<DataVector>>>([&, this](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        constexpr size_t index = tag::index;
+        this->update_buffer(
+            make_not_null(&cartesian_deriv_spatial_metric.get(index, i, j)),
+            cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+                get<Tags::detail::InputDataSet<tag>>(dataset_names_), i, j)),
+            computation_l_max, time_span_start, time_span_end,
+            time_varies_fastest);
+        cce_data_file_.close_current_object();
+      });
+
+      // dr spatial metric
+      set_radial_deriv(
+          make_not_null(
+              &get<Tags::detail::Dr<Tags::detail::SpatialMetric<DataVector>>>(
+                   *buffers)
+                   .get(i, j)),
+          cartesian_deriv_spatial_metric.get(0, i, j),
+          cartesian_deriv_spatial_metric.get(1, i, j),
+          cartesian_deriv_spatial_metric.get(2, i, j));
+    }
+
+    // auxiliary shift (first order) or conformal christoffel (other)
+    if (adm_options_->shift.is_first_order) {
+      this->update_buffer(
+          make_not_null(&auxiliary_shift.get(i)),
+          cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+              get<Tags::detail::InputDataSet<Tags::detail::AuxiliaryShift<T>>>(
+                  dataset_names_),
+              i)),
+          computation_l_max, time_span_start, time_span_end,
+          time_varies_fastest);
+      cce_data_file_.close_current_object();
+    } else {
+      this->update_buffer(
+          make_not_null(&conformal_christoffel.get(i)),
+          cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+              get<Tags::detail::InputDataSet<
+                  Tags::detail::ConformalChristoffel<T>>>(dataset_names_),
+              i)),
+          computation_l_max, time_span_start, time_span_end,
+          time_varies_fastest);
+      cce_data_file_.close_current_object();
+    }
+
+    // shift
+    this->update_buffer(
+        make_not_null(&get<Tags::detail::Shift<DataVector>>(*buffers).get(i)),
+        cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+            get<Tags::detail::InputDataSet<Tags::detail::Shift<T>>>(
+                dataset_names_),
+            i)),
+        computation_l_max, time_span_start, time_span_end, time_varies_fastest);
+    cce_data_file_.close_current_object();
+
+    // dx shift
+    tmpl::for_each<
+        Tags::detail::cartesian_derivs_t<Tags::detail::Shift<DataVector>>>(
+        [&, this](auto tag_v) {
+          using tag = typename decltype(tag_v)::type;
+          constexpr size_t index = tag::index;
+          this->update_buffer(
+              make_not_null(&cartesian_deriv_shift.get(index, i)),
+              cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+                  get<Tags::detail::InputDataSet<tag>>(dataset_names_), i)),
+              computation_l_max, time_span_start, time_span_end,
+              time_varies_fastest);
+          cce_data_file_.close_current_object();
+        });
+
+    // dr shift
+    set_radial_deriv(
+        make_not_null(
+            &get<Tags::detail::Dr<Tags::detail::Shift<DataVector>>>(*buffers)
+                 .get(i)),
+        cartesian_deriv_shift.get(0, i), cartesian_deriv_shift.get(1, i),
+        cartesian_deriv_shift.get(2, i));
+  }
+
+  // lapse
+  this->update_buffer(
+      make_not_null(&get(get<Tags::detail::Lapse<DataVector>>(*buffers))),
+      cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+          get<Tags::detail::InputDataSet<Tags::detail::Lapse<T>>>(
+              dataset_names_))),
+      computation_l_max, time_span_start, time_span_end, time_varies_fastest);
+  cce_data_file_.close_current_object();
+
+  // dx lapse
+  tmpl::for_each<
+      Tags::detail::cartesian_derivs_t<Tags::detail::Lapse<DataVector>>>(
+      [&, this](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        constexpr size_t index = tag::index;
+        this->update_buffer(
+            make_not_null(&get<index>(cartesian_deriv_lapse)),
+            cce_data_file_.get<h5::Dat>(detail::dataset_name_for_component(
+                get<Tags::detail::InputDataSet<tag>>(dataset_names_))),
+            computation_l_max, time_span_start, time_span_end,
+            time_varies_fastest);
+        cce_data_file_.close_current_object();
+      });
+
+  // dr lapse
+  set_radial_deriv(
+      make_not_null(&get(
+          get<Tags::detail::Dr<Tags::detail::Lapse<DataVector>>>(*buffers))),
+      get<0>(cartesian_deriv_lapse), get<1>(cartesian_deriv_lapse),
+      get<2>(cartesian_deriv_lapse));
+
+  const auto& spatial_metric =
+      get<Tags::detail::SpatialMetric<DataVector>>(*buffers);
+  const auto& lapse = get<Tags::detail::Lapse<DataVector>>(*buffers);
+  const auto& shift = get<Tags::detail::Shift<DataVector>>(*buffers);
+  auto& time_deriv_spatial_metric =
+      get<::Tags::dt<Tags::detail::SpatialMetric<DataVector>>>(*buffers);
+  auto& time_deriv_lapse =
+      get<::Tags::dt<Tags::detail::Lapse<DataVector>>>(*buffers);
+  auto& time_deriv_shift =
+      get<::Tags::dt<Tags::detail::Shift<DataVector>>>(*buffers);
+
+  // time deriv of spatial metric
+  gr::time_derivative_of_spatial_metric(
+      make_not_null(&time_deriv_spatial_metric), lapse, shift,
+      cartesian_deriv_shift, spatial_metric, cartesian_deriv_spatial_metric,
+      extrinsic_curvature);
+
+  determinant_and_inverse(make_not_null(&determinant_spatial_metric),
+                          make_not_null(&inverse_spatial_metric),
+                          spatial_metric);
+
+  // trace of extrinsic curvature
+  trace(make_not_null(&trace_extrinsic_curvature), extrinsic_curvature,
+        inverse_spatial_metric);
+
+  // time deriv of lapse and shift
+  get(time_deriv_lapse) = -2.0 * get(lapse) * get(trace_extrinsic_curvature);
+  for (size_t i = 0; i < 3; i++) {
+    if (adm_options_->shift.is_first_order) {
+      time_deriv_shift.get(i) =
+          adm_options_->shift.extra_factor * auxiliary_shift.get(i);
+    } else {
+      time_deriv_shift.get(i) = conformal_christoffel.get(i) -
+                                adm_options_->shift.extra_factor * shift.get(i);
+    }
+
+    if (adm_options_->lapse.is_advective) {
+      get(time_deriv_lapse) += shift.get(i) * cartesian_deriv_lapse.get(i);
+    }
+    if (adm_options_->shift.is_advective) {
+      for (size_t j = 0; j < 3; j++) {
+        time_deriv_shift.get(i) +=
+            shift.get(j) * cartesian_deriv_shift.get(j, i);
+      }
+    }
+  }
 }
 
 template <typename T>
@@ -451,6 +780,7 @@ void MetricWorldtubeH5BufferUpdater<T>::pup(PUP::er& p) {
   p | l_max_;
   p | extraction_radius_;
   p | dataset_names_;
+  p | adm_options_;
   if (p.isUnpacking()) {
     cce_data_file_ = h5::H5File<h5::AccessType::ReadOnly>{filename_};
   }

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp
@@ -24,6 +24,7 @@
 #include "IO/H5/File.hpp"
 #include "IO/H5/Version.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp"
+#include "Options/Options.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -41,6 +42,18 @@ template <typename T>
 using Shift = gr::Tags::Shift<T, 3>;
 template <typename T>
 using Lapse = gr::Tags::Lapse<T>;
+// This is B^i in the 3+1 equations
+template <typename T>
+struct AuxiliaryShift : db::SimpleTag {
+  using type = tnsr::I<T, 3, ::Frame::Inertial>;
+};
+// This is \Gamma^i in the Z4c equations
+template <typename T>
+struct ConformalChristoffel : db::SimpleTag {
+  using type = tnsr::I<T, 3, ::Frame::Inertial>;
+};
+template <typename T>
+using ExtrinsicCurvature = gr::Tags::ExtrinsicCurvature<T, 3>;
 
 // The three metric quantities we read in from disk (no derivatives)
 template <typename T>
@@ -52,6 +65,25 @@ struct Dr : db::SimpleTag, db::PrefixTag {
   using type = typename Tag::type;
   using tag = Tag;
 };
+// For cartesian derivs. Each dataset is stored separately in the file, so it
+// doesn't make sense to use ::Tags::deriv here
+template <typename Tag>
+struct Dx : db::SimpleTag, db::PrefixTag {
+  static constexpr size_t index = 0;
+  using type = typename Tag::type;
+};
+template <typename Tag>
+struct Dy : db::SimpleTag, db::PrefixTag {
+  static constexpr size_t index = 1;
+  using type = typename Tag::type;
+};
+template <typename Tag>
+struct Dz : db::SimpleTag, db::PrefixTag {
+  static constexpr size_t index = 2;
+  using type = typename Tag::type;
+};
+template <typename Tag>
+using cartesian_derivs_t = tmpl::list<Dx<Tag>, Dy<Tag>, Dz<Tag>>;
 
 // tag for the string for accessing the quantity associated with `Tag` in
 // worldtube h5 file
@@ -68,6 +100,16 @@ struct apply_derivs {
 };
 template <typename Tag>
 using apply_derivs_t = typename apply_derivs<Tag>::type;
+
+// Puts `Tag`, `::Tags::dt<Tag>`, `Dx<Tag>`, `Dy<Tag>`, `Dz<Tag>` into a
+// `tmpl::list`
+template <typename Tag>
+struct apply_derivs_adm {
+  using type =
+      tmpl::flatten<tmpl::list<Tag, ::Tags::dt<Tag>, cartesian_derivs_t<Tag>>>;
+};
+template <typename Tag>
+using apply_derivs_adm_t = typename apply_derivs_adm<Tag>::type;
 }  // namespace Tags::detail
 
 namespace detail {
@@ -127,6 +169,13 @@ template <typename T>
 using cce_metric_input_tags =
     tmpl::flatten<tmpl::transform<Tags::detail::metric_tags<T>,
                                   Tags::detail::apply_derivs<tmpl::_1>>>;
+
+template <typename T>
+using cce_metric_adm_input_tags = tmpl::flatten<tmpl::push_back<
+    tmpl::transform<Tags::detail::metric_tags<T>,
+                    Tags::detail::apply_derivs_adm<tmpl::_1>>,
+    Tags::detail::ExtrinsicCurvature<T>, Tags::detail::AuxiliaryShift<T>,
+    Tags::detail::ConformalChristoffel<T>>>;
 
 using klein_gordon_input_tags =
     tmpl::list<Spectral::Swsh::Tags::SwshTransform<Tags::KleinGordonPsi>,
@@ -224,6 +273,99 @@ class MetricWorldtubeH5BufferUpdater
  public:
   static constexpr bool is_modal = std::is_same_v<T, ComplexModalVector>;
 
+  /*!
+   * \brief Options needed when reading in the extrinsic curvature and auxiliary
+   * shift (BSSN) or the trace of the conformal christoffel (Z4c) from a non-GH
+   * evolution code.
+   *
+   * \details Can also be used as an option tag
+   */
+  struct AdmOptions {
+    static std::string name() { return "AdmMetricNodal"; }
+
+    struct Advective {
+      using type = bool;
+      static constexpr Options::String help =
+          "Add advective term to time derivative.";
+    };
+
+    struct Lapse {
+      using type = Lapse;
+      Lapse() = default;
+      using options = tmpl::list<Advective>;
+      static constexpr Options::String help =
+          "Options for 1+log slicing of the lapse.";
+      explicit Lapse(const bool advective) : is_advective(advective) {}
+
+      void pup(PUP::er& p) { p | is_advective; }
+
+      bool is_advective;
+    };
+
+    struct Shift {
+      using type = Shift;
+      struct SecondOrderDriverEta {
+        using type = double;
+        static constexpr Options::String help =
+            "Factor 'eta' in front of shift vector in Eq. 12 of Hilditch 2013 "
+            "(typically 2/M). To use this, the trace conformal christoffel "
+            "must be dumped. Here mu_S is assumed to be 1/lapse^2.";
+      };
+      struct FirstOrderDriverFactor {
+        using type = double;
+        static constexpr Options::String help =
+            "Factor in front of auxiliary shift vector B^i in left Eq. 4.89 of "
+            "B&S (typically 0.75). To use this, the auxiliary shift vector B^i "
+            "must be dumped. Here mu_S is assumed to be 1/lapse^2.";
+      };
+      Shift() = default;
+      using options =
+          tmpl::list<Advective,
+                     Options::Alternatives<tmpl::list<SecondOrderDriverEta>,
+                                           tmpl::list<FirstOrderDriverFactor>>>;
+
+      static constexpr Options::String help =
+          "Options for Gamma driver shift condition.";
+      Shift(tmpl::list<Advective, SecondOrderDriverEta> /*meta*/,
+            const bool advective, const double factor)
+          : is_advective(advective),
+            is_first_order(false),
+            extra_factor(factor) {}
+      Shift(tmpl::list<Advective, FirstOrderDriverFactor> /*meta*/,
+            const bool advective, const double factor)
+          : is_advective(advective),
+            is_first_order(true),
+            extra_factor(factor) {}
+
+      void pup(PUP::er& p) {
+        p | is_advective;
+        p | is_first_order;
+        p | extra_factor;
+      }
+
+      bool is_advective;
+      bool is_first_order;
+      double extra_factor;
+    };
+
+    using options = tmpl::list<Lapse, Shift>;
+    static constexpr Options::String help =
+        "Gauge options when reading in extrinsic curvature additional variable "
+        "from non-GH evolutions.";
+
+    AdmOptions() = default;
+    AdmOptions(const Lapse& lapse_in, const Shift& shift_in)
+        : lapse(lapse_in), shift(shift_in) {}
+
+    void pup(PUP::er& p) {
+      p | lapse;
+      p | shift;
+    }
+
+    Lapse lapse;
+    Shift shift;
+  };
+
   // charm needs the empty constructor
   MetricWorldtubeH5BufferUpdater() = default;
 
@@ -236,7 +378,8 @@ class MetricWorldtubeH5BufferUpdater
   explicit MetricWorldtubeH5BufferUpdater(
       const std::string& cce_data_filename,
       std::optional<double> extraction_radius = std::nullopt,
-      bool descending_m = true);
+      bool descending_m = true,
+      const std::optional<AdmOptions>& adm_options = std::nullopt);
 
   // NOLINTNEXTLINE
   WRAPPED_PUPable_decl_base_template(
@@ -288,6 +431,16 @@ class MetricWorldtubeH5BufferUpdater
   void pup(PUP::er& p) override;
 
  private:
+  void update_radial_formulation(
+      gsl::not_null<Variables<cce_metric_input_tags<T>>*> buffers,
+      size_t computation_l_max, size_t time_span_start, size_t time_span_end,
+      bool time_varies_fastest) const;
+  template <typename U = T>
+  typename std::enable_if_t<std::is_same_v<U, DataVector>>
+  update_adm_formulation(
+      gsl::not_null<Variables<cce_metric_input_tags<DataVector>>*> buffers,
+      size_t computation_l_max, size_t time_span_start, size_t time_span_end,
+      bool time_varies_fastest) const;
   void update_buffer(gsl::not_null<T*> buffer_to_update,
                      const h5::Dat& read_data, size_t computation_l_max,
                      size_t time_span_start, size_t time_span_end,
@@ -300,9 +453,12 @@ class MetricWorldtubeH5BufferUpdater
   h5::H5File<h5::AccessType::ReadOnly> cce_data_file_;
   std::string filename_;
   bool descending_m_ = true;
+  std::optional<AdmOptions> adm_options_;
 
-  tuples::tagged_tuple_from_typelist<
-      db::wrap_tags_in<Tags::detail::InputDataSet, cce_metric_input_tags<T>>>
+  tuples::tagged_tuple_from_typelist<db::wrap_tags_in<
+      Tags::detail::InputDataSet,
+      tmpl::remove_duplicates<tmpl::append<cce_metric_input_tags<T>,
+                                           cce_metric_adm_input_tags<T>>>>>
       dataset_names_;
 
   // stores all the times in the input file

--- a/src/Executables/PreprocessCceWorldtube/PreprocessCceWorldtube.cpp
+++ b/src/Executables/PreprocessCceWorldtube/PreprocessCceWorldtube.cpp
@@ -56,6 +56,8 @@ using modal_bondi_input_tags = Cce::Tags::worldtube_boundary_tags_for_writing<
 using nodal_bondi_input_tags =
     Cce::Tags::worldtube_boundary_tags_for_writing<Cce::Tags::BoundaryValue>;
 
+using AdmOptions = Cce::MetricWorldtubeH5BufferUpdater<DataVector>::AdmOptions;
+
 // from a data-varies-fastest set of buffers provided by
 // `MetricWorldtubeH5BufferUpdater` extract the set of coefficients for a
 // particular time given by `buffer_time_offset` into the `time_span` size of
@@ -326,12 +328,13 @@ void bondi_nodal_to_bondi_modal(
   }
 }
 
-void metric_nodal_to_bondi_modal(
-    const std::string& input_file, const std::string& output_file,
-    const size_t input_buffer_depth,
-    const std::optional<double>& extraction_radius) {
+void metric_nodal_to_bondi_modal(const std::string& input_file,
+                                 const std::string& output_file,
+                                 const size_t input_buffer_depth,
+                                 const std::optional<double>& extraction_radius,
+                                 const std::optional<AdmOptions>& adm_options) {
   Cce::MetricWorldtubeH5BufferUpdater<DataVector> buffer_updater{
-      input_file, extraction_radius, false};
+      input_file, extraction_radius, false, adm_options};
   const size_t l_max = buffer_updater.get_l_max();
 
   const size_t number_of_angular_points =
@@ -377,7 +380,50 @@ void metric_nodal_to_bondi_modal(
   }
 }
 
-enum class InputDataFormat { MetricNodal, MetricModal, BondiNodal, BondiModal };
+// If we use the AdmOptions class directly in an option tag, the input file
+// would look like:
+//
+// InputDataFormat:
+//   AdvectiveLapse: True
+//   AdvectiveShift: True
+//   AuxiliaryShiftFactor: False
+//
+// However, this doesn't have the name `AdmMetricNodal`. This is consistent with
+// how our options work, but is confusing (especially for users who are
+// unfamiliar with spectre) since the actual input data format isn't shown. This
+// class now changes the input file to look like:
+//
+// InputDataFormat:
+//   AdmMetricNodal:
+//     AdvectiveLapse: True
+//     AdvectiveShift: True
+//     AuxiliaryShiftFactor: False
+//
+// which is much clearer.
+struct AdmMetricNodalOptions {
+  struct AdmMetricNodal {
+    using type = ::AdmOptions;
+    static constexpr Options::String help = ::AdmOptions::help;
+  };
+
+  using options = tmpl::list<AdmMetricNodal>;
+  static constexpr Options::String help = ::AdmOptions::help;
+
+  AdmMetricNodalOptions() = default;
+  // NOLINTNEXTLINE
+  AdmMetricNodalOptions(::AdmOptions adm_metric_nodal_in)
+      : adm_metric_nodal(adm_metric_nodal_in) {}
+
+  ::AdmOptions adm_metric_nodal;
+};
+
+enum class InputDataFormat {
+  AdmMetricNodal,
+  MetricNodal,
+  MetricModal,
+  BondiNodal,
+  BondiModal
+};
 
 std::ostream& operator<<(std::ostream& os,
                          const InputDataFormat input_data_format) {
@@ -407,10 +453,11 @@ struct InputH5Files {
 };
 
 struct InputDataFormat {
-  using type = ::InputDataFormat;
+  using type = std::variant<::InputDataFormat, AdmMetricNodalOptions>;
   static constexpr Options::String help =
-      "The type of data stored in the 'InputH5Files'. Can be  'MetricNodal', "
-      "'MetricModal', 'BondiNodal', or 'BondiModal'.";
+      "The type of data stored in the 'InputH5Files'. Can be 'AdmMetricNodal' "
+      "with additional options, 'MetricNodal', 'MetricModal', 'BondiNodal', or "
+      "'BondiModal'.";
 };
 
 struct OutputH5File {
@@ -496,11 +543,23 @@ struct InputH5Files : db::SimpleTag {
 };
 
 struct InputDataFormat : db::SimpleTag {
-  using type = ::InputDataFormat;
+ private:
+  using option_type = std::variant<::InputDataFormat, AdmMetricNodalOptions>;
+
+ public:
+  using type = std::variant<::InputDataFormat, AdmOptions>;
   using option_tags = tmpl::list<OptionTags::InputDataFormat>;
   static constexpr bool pass_metavariables = false;
-  static type create_from_options(type input_data_format) {
-    return input_data_format;
+  static type create_from_options(option_type input_data_format) {
+    type result{};
+    if (std::holds_alternative<::InputDataFormat>(input_data_format)) {
+      result = std::get<::InputDataFormat>(input_data_format);
+    } else {
+      result =
+          std::get<AdmMetricNodalOptions>(input_data_format).adm_metric_nodal;
+    }
+
+    return result;
   }
 };
 
@@ -582,8 +641,8 @@ struct Options::create_from_yaml<InputDataFormat> {
       return InputDataFormat::BondiModal;
     }
     PARSE_ERROR(options.context(),
-                "InputDataFormat must be 'MetricNodal', 'MetricModal', "
-                "'BondiNodal', or 'BondiModal'");
+                "InputDataFormat must be 'AdmMetricNodal', 'MetricNodal', "
+                "'MetricModal', 'BondiNodal', or 'BondiModal'");
   }
 };
 
@@ -638,8 +697,12 @@ int main(int argc, char** argv) {
     const TagsTuple inputs =
         Parallel::create_from_options<void>(options, tags{});
 
-    const InputDataFormat input_data_format =
+    const auto& input_data_format =
         tuples::get<ReduceCceTags::InputDataFormat>(inputs);
+    const InputDataFormat input_data_format_enum =
+        std::holds_alternative<InputDataFormat>(input_data_format)
+            ? std::get<InputDataFormat>(input_data_format)
+            : InputDataFormat::AdmMetricNodal;
     const std::vector<std::string>& input_files =
         tuples::get<ReduceCceTags::InputH5Files>(inputs);
     const std::string& output_h5_file =
@@ -651,7 +714,7 @@ int main(int argc, char** argv) {
       // If the input format is BondiModal, then we don't actually have to do
       // any transformations, only combining H5 files. So the temporary file
       // name is just the output file
-      if (input_data_format == InputDataFormat::BondiModal) {
+      if (input_data_format_enum == InputDataFormat::BondiModal) {
         temporary_combined_h5_file = output_h5_file;
       } else {
         // Otherwise we have to do a transformation so a temporary H5 file is
@@ -668,7 +731,7 @@ int main(int argc, char** argv) {
       // Now combine the h5 files into a single file
       h5::combine_h5_dat(input_files, temporary_combined_h5_file.value(),
                          Verbosity::Quiet);
-    } else if (input_data_format == InputDataFormat::BondiModal) {
+    } else if (input_data_format_enum == InputDataFormat::BondiModal) {
       // Error here if the input data format is BondiModal since there's nothing
       // to do
       ERROR_NO_TRACE(
@@ -678,7 +741,7 @@ int main(int argc, char** argv) {
     }
 
     if (tuples::get<ReduceCceTags::FixSpecNormalization>(inputs)) {
-      if (input_data_format != InputDataFormat::MetricModal) {
+      if (input_data_format_enum != InputDataFormat::MetricModal) {
         ERROR_NO_TRACE(
             "The option FixSpecNormalization can only be 'true' when the input "
             "data format is MetricModal. Otherwise, it must be 'false'");
@@ -702,12 +765,13 @@ int main(int argc, char** argv) {
       }
     };
 
-    switch (input_data_format) {
-      case InputDataFormat::BondiModal:
+    switch (input_data_format_enum) {
+      case InputDataFormat::BondiModal: {
         // Nothing to do here because this is the desired output format and the
         // H5 files were combined above
         return 0;
-      case InputDataFormat::BondiNodal:
+      }
+      case InputDataFormat::BondiNodal: {
         bondi_nodal_to_bondi_modal(
             input_worldtube_filename(), output_h5_file,
             tuples::get<ReduceCceTags::BufferDepth>(inputs),
@@ -715,7 +779,8 @@ int main(int argc, char** argv) {
 
         clean_temporary_file();
         return 0;
-      case InputDataFormat::MetricModal:
+      }
+      case InputDataFormat::MetricModal: {
         perform_cce_worldtube_reduction(
             input_worldtube_filename(), output_h5_file,
             tuples::get<ReduceCceTags::BufferDepth>(inputs),
@@ -726,16 +791,25 @@ int main(int argc, char** argv) {
 
         clean_temporary_file();
         return 0;
-      case InputDataFormat::MetricNodal:
+      }
+      case InputDataFormat::AdmMetricNodal: {
+        [[fallthrough]];
+      }
+      case InputDataFormat::MetricNodal: {
+        const std::optional<AdmOptions> adm_options =
+            std::holds_alternative<AdmOptions>(input_data_format)
+                ? std::optional{std::get<AdmOptions>(input_data_format)}
+                : std::nullopt;
         metric_nodal_to_bondi_modal(
             input_worldtube_filename(), output_h5_file,
             tuples::get<ReduceCceTags::BufferDepth>(inputs),
-            tuples::get<ReduceCceTags::ExtractionRadius>(inputs));
+            tuples::get<ReduceCceTags::ExtractionRadius>(inputs), adm_options);
 
         clean_temporary_file();
         return 0;
+      }
       default:
-        ERROR("Unknown input data format " << input_data_format);
+        ERROR("Unknown input data format " << input_data_format_enum);
     }
   } catch (const std::exception& exception) {
     Parallel::printf("%s\n", exception.what());

--- a/tests/InputFiles/PreprocessCceWorldtube/AdmFirstOrderDriverPreprocessCceWorldtube.yaml
+++ b/tests/InputFiles/PreprocessCceWorldtube/AdmFirstOrderDriverPreprocessCceWorldtube.yaml
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+InputH5File: InputFilename.h5
+OutputH5File: ReducedWorldtubeR0292.h5
+# [first_order_input_data_format_example]
+InputDataFormat:
+  AdmMetricNodal:
+    Lapse:
+      Advective: True
+    Shift:
+      Advective: True
+      FirstOrderDriverFactor: 0.75 # Eq. 4.89 B&S
+# [first_order_input_data_format_example]
+ExtractionRadius: 292
+FixSpecNormalization: False
+DescendingM: False
+BufferDepth: Auto
+LMaxFactor: 3

--- a/tests/InputFiles/PreprocessCceWorldtube/AdmSecondOrderDriverPreprocessCceWorldtube.yaml
+++ b/tests/InputFiles/PreprocessCceWorldtube/AdmSecondOrderDriverPreprocessCceWorldtube.yaml
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+InputH5File: InputFilename.h5
+OutputH5File: ReducedWorldtubeR0292.h5
+# [second_order_input_data_format_example]
+InputDataFormat:
+  AdmMetricNodal:
+    Lapse:
+      Advective: True
+    Shift:
+      Advective: True
+      SecondOrderDriverEta: 2.0 # Eq. 12 Hilditch 2013
+# [second_order_input_data_format_example]
+ExtractionRadius: 292
+FixSpecNormalization: False
+DescendingM: False
+BufferDepth: Auto
+LMaxFactor: 3

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -547,11 +547,13 @@ void test_data_manager_with_bondi_buffer_updater(
 template <typename T, typename Generator>
 void test_metric_worldtube_buffer_updater_impl(
     const gsl::not_null<Generator*> gen,
-    const bool extraction_radius_in_filename, const bool time_varies_fastest) {
+    const bool extraction_radius_in_filename, const bool time_varies_fastest,
+    const std::optional<bool>& extra_adm = std::nullopt) {
   constexpr bool is_modal = std::is_same_v<T, ComplexModalVector>;
   CAPTURE(is_modal);
   CAPTURE(extraction_radius_in_filename);
   CAPTURE(time_varies_fastest);
+  CAPTURE(extra_adm);
   UniformCustomDistribution<double> value_dist{0.1, 0.5};
   // first prepare the input for the modal version
   const double mass = value_dist(*gen);
@@ -569,7 +571,9 @@ void test_metric_worldtube_buffer_updater_impl(
   // acceptable parameters for the fake sinusoid variation in the input
   // parameters
   const double frequency = 0.1 * value_dist(*gen);
-  const double amplitude = 0.1 * value_dist(*gen);
+  // If using adm options, need amplitude to be zero since this will change the
+  // coordinates that the variables are at, and we assume a constant radius
+  const double amplitude = extra_adm.has_value() ? 0.0 : 0.1 * value_dist(*gen);
   const double target_time = 50.0 * value_dist(*gen);
   CAPTURE(frequency);
   CAPTURE(amplitude);
@@ -600,16 +604,36 @@ void test_metric_worldtube_buffer_updater_impl(
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }
-  TestHelpers::write_test_file<T, false>(solution, filename, target_time,
-                                         extraction_radius, frequency,
-                                         amplitude, file_l_max);
+  TestHelpers::write_test_file<T, false>(
+      solution, filename, target_time, extraction_radius, frequency, amplitude,
+      file_l_max, true, extra_adm.has_value());
 
+  using AdmOptions = typename MetricWorldtubeH5BufferUpdater<T>::AdmOptions;
+  std::optional<AdmOptions> adm_options{};
+
+  if (extra_adm.has_value()) {
+    using Lapse = typename AdmOptions::Lapse;
+    using Shift = typename AdmOptions::Shift;
+    const Lapse lapse{true};
+    if (extra_adm.value()) {
+      using option_list = tmpl::list<typename AdmOptions::Advective,
+                                     typename Shift::FirstOrderDriverFactor>;
+      const Shift shift{option_list{}, true, 0.75};
+      adm_options = AdmOptions{lapse, shift};
+    } else {
+      using option_list = tmpl::list<typename AdmOptions::Advective,
+                                     typename Shift::SecondOrderDriverEta>;
+      const Shift shift{option_list{}, true, 2.0};
+      adm_options = AdmOptions{lapse, shift};
+    }
+  }
   // request an appropriate buffer
   auto buffer_updater =
       extraction_radius_in_filename
-          ? MetricWorldtubeH5BufferUpdater<T>{filename, std::nullopt, true}
-          : MetricWorldtubeH5BufferUpdater<T>{filename, extraction_radius,
-                                              true};
+          ? MetricWorldtubeH5BufferUpdater<T>{filename, std::nullopt, true,
+                                              adm_options}
+          : MetricWorldtubeH5BufferUpdater<T>{filename, extraction_radius, true,
+                                              adm_options};
   auto serialized_and_deserialized_updater =
       serialize_and_deserialize(buffer_updater);
   size_t time_span_start = 0;
@@ -626,6 +650,17 @@ void test_metric_worldtube_buffer_updater_impl(
             "MetricWorldtubeH5BufferUpdater was constructed with"));
     time_span_start = 0;
     time_span_end = 0;
+    if (extra_adm.has_value()) {
+      CHECK_THROWS_WITH(
+          buffer_updater.update_buffers_for_time(
+              make_not_null(&coefficients_buffers_from_file),
+              make_not_null(&time_span_start), make_not_null(&time_span_end),
+              target_time, computation_l_max, interpolator_length, buffer_size,
+              true),
+          Catch::Matchers::ContainsSubstring("Time must not vary fastest"));
+      time_span_start = 0;
+      time_span_end = 0;
+    }
   }
   buffer_updater.update_buffers_for_time(
       make_not_null(&coefficients_buffers_from_file),
@@ -671,8 +706,17 @@ void test_metric_worldtube_buffer_updater_impl(
   // check that the data in the buffer matches the expected analytic data.
   tmpl::for_each<cce_metric_input_tags<T>>(
       [&expected_coefficients_buffers, &coefficients_buffers_from_file,
-       &coefficients_buffers_from_serialized](auto tag_v) {
+       &coefficients_buffers_from_serialized, &extra_adm](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
+        // Since we don't have an expected value for the time derivatives of the
+        // lapse or shift because of the 1+log slicing and gamma-driver
+        // conditions, we just don't check them here. All other values should be
+        // the same though
+        if (extra_adm.has_value() and
+            (std::is_same_v<tag, ::Tags::dt<Tags::detail::Shift<T>>> or
+             std::is_same_v<tag, ::Tags::dt<Tags::detail::Lapse<T>>>)) {
+          return;
+        }
         INFO(db::tag_name<tag>());
         const auto& test_lhs = get<tag>(expected_coefficients_buffers);
         const auto& test_rhs = get<tag>(coefficients_buffers_from_file);
@@ -908,6 +952,17 @@ void test_metric_worldtube_buffer_updater(const gsl::not_null<Generator*> gen) {
     test_metric_worldtube_buffer_updater_impl<DataVector>(
         gen, extraction_radius_in_filename, time_varies_fastest);
   }
+
+  {
+    INFO("First order form");
+    test_metric_worldtube_buffer_updater_impl<DataVector>(gen, true, false,
+                                                          {true});
+  }
+  {
+    INFO("Conformal Christoffel form");
+    test_metric_worldtube_buffer_updater_impl<DataVector>(gen, true, false,
+                                                          {false});
+  }
 }
 
 template <typename Generator>
@@ -924,9 +979,9 @@ void test_bondi_worldtube_buffer_updater(const gsl::not_null<Generator*> gen) {
 }  // namespace
 
 // An increased timeout because this test seems to have high variance in
-// duration. It usually finishes within ~6 seconds. The high variance may be due
-// to the comparatively high magnitude of disk operations in this test.
-// [[TimeOut, 40]]
+// duration. The high variance may be due to the comparatively high magnitude of
+// disk operations in this test.
+// [[TimeOut, 60]]
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
                   "[Unit][Cce]") {
   register_derived_classes_with_charm<

--- a/tests/Unit/Executables/Test_PreprocessCceWorldtube.cpp
+++ b/tests/Unit/Executables/Test_PreprocessCceWorldtube.cpp
@@ -268,7 +268,28 @@ void write_input_file(const std::string& input_data_format,
   }
 
   input_file += "\nOutputH5File: " + output_filename + "\n";
-  input_file += "InputDataFormat: " + input_data_format + "\n";
+  input_file += "InputDataFormat:";
+  if (input_data_format == "FirstOrderMetricNodal") {
+    input_file +=
+        "\n"
+        "  AdmMetricNodal:\n"
+        "    Lapse:\n"
+        "      Advective: True\n"
+        "    Shift:\n"
+        "      Advective: True\n"
+        "      FirstOrderDriverFactor: 0.75\n";
+  } else if (input_data_format == "ChristoffelMetricNodal") {
+    input_file +=
+        "\n"
+        "  AdmMetricNodal:\n"
+        "    Lapse:\n"
+        "      Advective: True\n"
+        "    Shift:\n"
+        "      Advective: True\n"
+        "      SecondOrderDriverEta: 2.0\n";
+  } else {
+    input_file += " " + input_data_format + "\n";
+  }
   input_file +=
       "ExtractionRadius: " +
       (worldtube_radius.has_value() ? std::to_string(worldtube_radius.value())
@@ -307,6 +328,10 @@ int main() {
       "Test_InputMetricModal_R0123.h5"};
   const std::string metric_modal_spec_input_worldtube_filename{
       "Test_InputMetricModalSpec_R0123.h5"};
+  const std::string first_order_metric_nodal_input_worldtube_filename{
+      "Test_InputFirstOrderMetricNodal.h5"};
+  const std::string christoffel_metric_nodal_input_worldtube_filename{
+      "Test_InputChristoffelMetricNodal.h5"};
   const std::string metric_nodal_1_input_worldtube_filename{
       "Test_InputMetricNodal_1.h5"};
   const std::string metric_nodal_2_input_worldtube_filename{
@@ -323,6 +348,10 @@ int main() {
       "Test_OutputMetricModal_R0123.h5"};
   const std::string metric_modal_spec_output_worldtube_filename{
       "Test_OutputMetricModalSpec_R0123.h5"};
+  const std::string first_order_metric_nodal_output_worldtube_filename{
+      "Test_OutputFirstOrderMetricNodal.h5"};
+  const std::string christoffel_metric_nodal_output_worldtube_filename{
+      "Test_OutputChristoffelMetricNodal.h5"};
   const std::string metric_nodal_output_worldtube_filename{
       "Test_OutputMetricNodal.h5"};
   const std::string bondi_modal_output_worldtube_filename{
@@ -337,6 +366,12 @@ int main() {
   Cce::TestHelpers::write_test_file<ComplexModalVector, false>(
       solution, metric_modal_spec_input_worldtube_filename, target_time,
       worldtube_radius, frequency, amplitude, l_max, true);
+  Cce::TestHelpers::write_test_file<DataVector, false>(
+      solution, first_order_metric_nodal_input_worldtube_filename, target_time,
+      worldtube_radius, frequency, amplitude, l_max, false, true);
+  Cce::TestHelpers::write_test_file<DataVector, false>(
+      solution, christoffel_metric_nodal_input_worldtube_filename, target_time,
+      worldtube_radius, frequency, amplitude, l_max, false, true);
   Cce::TestHelpers::write_test_file<DataVector, false>(
       solution, metric_nodal_1_input_worldtube_filename, target_time,
       worldtube_radius, frequency, amplitude, l_max, false);
@@ -363,6 +398,14 @@ int main() {
                    {metric_modal_spec_input_worldtube_filename},
                    metric_modal_spec_output_worldtube_filename, std::nullopt,
                    true);
+  write_input_file("FirstOrderMetricNodal", "FirstOrderMetricNodal.yaml",
+                   {first_order_metric_nodal_input_worldtube_filename},
+                   first_order_metric_nodal_output_worldtube_filename,
+                   {worldtube_radius}, false);
+  write_input_file("ChristoffelMetricNodal", "ChristoffelMetricNodal.yaml",
+                   {christoffel_metric_nodal_input_worldtube_filename},
+                   christoffel_metric_nodal_output_worldtube_filename,
+                   {worldtube_radius}, false);
   write_input_file("MetricNodal", "MetricNodal.yaml",
                    {metric_nodal_1_input_worldtube_filename,
                     metric_nodal_2_input_worldtube_filename},
@@ -407,6 +450,8 @@ int main() {
   // Call PreprocessCceWorldtube in a shell
   call_preprocess_cce_worldtube("MetricModal");
   call_preprocess_cce_worldtube("MetricModalSpec");
+  call_preprocess_cce_worldtube("FirstOrderMetricNodal");
+  call_preprocess_cce_worldtube("ChristoffelMetricNodal");
   call_preprocess_cce_worldtube("MetricNodal");
   call_preprocess_cce_worldtube("BondiModal");
   call_preprocess_cce_worldtube("BondiNodal");
@@ -419,7 +464,10 @@ int main() {
                            solution, amplitude, frequency);
 
   // Check that the expected bondi modal data is what was written in the output
-  // files for the different InputDataFormats
+  // files for the different InputDataFormats. We don't check
+  // FirstOrderMetricNodal or ChristoffelMetricNodal because our expected data
+  // uses a different gauge than is assumed (1+log and gamma driver), and so
+  // some time derivatives will be incorrect.
   check_expected_data(metric_modal_output_worldtube_filename, l_max,
                       expected_data, second_expected_data, target_time,
                       second_target_time, false);

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/BoundaryTestHelpers.hpp
@@ -21,8 +21,10 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce::TestHelpers {
@@ -120,6 +122,7 @@ void create_fake_time_varying_gh_nodal_data(
          dt_spatial_metric, *phi);
 }
 
+// Overload for all quantities, including Adm and Z4c quantities
 template <typename AnalyticSolution, typename T = ComplexModalVector>
 void create_fake_time_varying_data(
     const gsl::not_null<tnsr::ii<T, 3>*> spatial_metric_coefficients,
@@ -131,6 +134,12 @@ void create_fake_time_varying_data(
     const gsl::not_null<Scalar<T>*> lapse_coefficients,
     const gsl::not_null<Scalar<T>*> dt_lapse_coefficients,
     const gsl::not_null<Scalar<T>*> dr_lapse_coefficients,
+    const gsl::not_null<tnsr::ii<T, 3>*> extrinsic_curvature_coefficients,
+    const gsl::not_null<tnsr::I<T, 3>*> auxiliary_shift_coefficients,
+    const gsl::not_null<tnsr::I<T, 3>*> conformal_christoffel_coefficients,
+    const gsl::not_null<tnsr::ijj<T, 3>*> deriv_spatial_metric_coefficients,
+    const gsl::not_null<tnsr::iJ<T, 3>*> deriv_shift_coefficients,
+    const gsl::not_null<tnsr::i<T, 3>*> deriv_lapse_coefficients,
     const AnalyticSolution& solution, const double extraction_radius,
     const double amplitude, const double frequency, const double time,
     const size_t l_max, const bool convert_to_goldberg = true,
@@ -180,6 +189,21 @@ void create_fake_time_varying_data(
           kerr_schild_variables);
   const auto& d_spatial_metric =
       get<gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector>>(
+          kerr_schild_variables);
+
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<DataVector, 3>>(kerr_schild_variables);
+  const auto auxiliary_shift = [&shift]() {
+    auto result = shift;
+    get<0>(result) = 0.5;
+    get<1>(result) = 0.5;
+    get<2>(result) = 0.5;
+    return result;
+  }();
+  // The value in the KerrSchild vars isn't conformal, but this is just a test
+  // so we don't care
+  const auto& conformal_christoffel =
+      get<gr::Tags::TraceSpatialChristoffelSecondKind<DataVector, 3>>(
           kerr_schild_variables);
 
   DataVector normalization_factor{number_of_angular_points, 1.0};
@@ -270,6 +294,12 @@ void create_fake_time_varying_data(
           TestHelpers::tensor_to_libsharp_coefficients(dr_spatial_metric,
                                                        l_max);
     }
+    (void)extrinsic_curvature_coefficients;
+    (void)auxiliary_shift_coefficients;
+    (void)conformal_christoffel_coefficients;
+    (void)deriv_spatial_metric_coefficients;
+    (void)deriv_shift_coefficients;
+    (void)deriv_lapse_coefficients;
   } else {
     get(*lapse_coefficients) = get(lapse);
     get(*dt_lapse_coefficients) = get(dt_lapse);
@@ -279,14 +309,64 @@ void create_fake_time_varying_data(
       shift_coefficients->get(i) = shift.get(i);
       dt_shift_coefficients->get(i) = dt_shift.get(i);
       dr_shift_coefficients->get(i) = dr_shift.get(i);
+      auxiliary_shift_coefficients->get(i) = auxiliary_shift.get(i);
+      conformal_christoffel_coefficients->get(i) = conformal_christoffel.get(i);
+      deriv_lapse_coefficients->get(i) = d_lapse.get(i);
 
-      for (size_t j = i; j < 3; j++) {
+      for (size_t j = 0; j < 3; j++) {
+        deriv_shift_coefficients->get(i, j) = d_shift.get(i, j);
+        if (j < i) {
+          continue;
+        }
         spatial_metric_coefficients->get(i, j) = spatial_metric.get(i, j);
         dt_spatial_metric_coefficients->get(i, j) = dt_spatial_metric.get(i, j);
         dr_spatial_metric_coefficients->get(i, j) = dr_spatial_metric.get(i, j);
+        extrinsic_curvature_coefficients->get(i, j) =
+            extrinsic_curvature.get(i, j);
+
+        for (size_t k = 0; k < 3; k++) {
+          deriv_spatial_metric_coefficients->get(k, i, j) =
+              d_spatial_metric.get(k, i, j);
+        }
       }
     }
   }
+}
+
+// Overload for only the strictly necessary quantities (time and radial derivs)
+template <typename AnalyticSolution, typename T = ComplexModalVector>
+void create_fake_time_varying_data(
+    const gsl::not_null<tnsr::ii<T, 3>*> spatial_metric_coefficients,
+    const gsl::not_null<tnsr::ii<T, 3>*> dt_spatial_metric_coefficients,
+    const gsl::not_null<tnsr::ii<T, 3>*> dr_spatial_metric_coefficients,
+    const gsl::not_null<tnsr::I<T, 3>*> shift_coefficients,
+    const gsl::not_null<tnsr::I<T, 3>*> dt_shift_coefficients,
+    const gsl::not_null<tnsr::I<T, 3>*> dr_shift_coefficients,
+    const gsl::not_null<Scalar<T>*> lapse_coefficients,
+    const gsl::not_null<Scalar<T>*> dt_lapse_coefficients,
+    const gsl::not_null<Scalar<T>*> dr_lapse_coefficients,
+    const AnalyticSolution& solution, const double extraction_radius,
+    const double amplitude, const double frequency, const double time,
+    const size_t l_max, const bool convert_to_goldberg = true,
+    const bool apply_normalization_bug = false) {
+  tnsr::ii<T, 3> extrinsic_curvature_coefficients{};
+  tnsr::I<T, 3> auxiliary_shift_coefficients{};
+  tnsr::I<T, 3> conformal_christoffel_coefficients{};
+  tnsr::ijj<T, 3> deriv_spatial_metric_coefficients{};
+  tnsr::iJ<T, 3> deriv_shift_coefficients{};
+  tnsr::i<T, 3> deriv_lapse_coefficients{};
+  create_fake_time_varying_data(
+      spatial_metric_coefficients, dt_spatial_metric_coefficients,
+      dr_spatial_metric_coefficients, shift_coefficients, dt_shift_coefficients,
+      dr_shift_coefficients, lapse_coefficients, dt_lapse_coefficients,
+      dr_lapse_coefficients, make_not_null(&extrinsic_curvature_coefficients),
+      make_not_null(&auxiliary_shift_coefficients),
+      make_not_null(&conformal_christoffel_coefficients),
+      make_not_null(&deriv_spatial_metric_coefficients),
+      make_not_null(&deriv_shift_coefficients),
+      make_not_null(&deriv_lapse_coefficients), solution, extraction_radius,
+      amplitude, frequency, time, l_max, convert_to_goldberg,
+      apply_normalization_bug);
 }
 
 template <typename T = ComplexModalVector, bool WriteBondi = true,
@@ -295,7 +375,8 @@ void write_test_file(const AnalyticSolution& solution,
                      const std::string& filename, const double target_time,
                      const double extraction_radius, const double frequency,
                      const double amplitude, const size_t l_max,
-                     const bool descending_m = true) {
+                     const bool descending_m = true,
+                     const bool write_extra_adm_vars = false) {
   const bool is_modal = std::is_same_v<T, ComplexModalVector>;
   const size_t size =
       is_modal ? square(l_max + 1)
@@ -312,6 +393,12 @@ void write_test_file(const AnalyticSolution& solution,
   Scalar<T> lapse_coefficients{size};
   Scalar<T> dt_lapse_coefficients{size};
   Scalar<T> dr_lapse_coefficients{size};
+  tnsr::ii<T, 3> extrinsic_curvature_coefficients{size};
+  tnsr::I<T, 3> auxiliary_shift_coefficients{size};
+  tnsr::I<T, 3> conformal_christoffel_coefficients{size};
+  tnsr::ijj<T, 3> deriv_spatial_metric_coefficients{size};
+  tnsr::iJ<T, 3> deriv_shift_coefficients{size};
+  tnsr::i<T, 3> deriv_lapse_coefficients{size};
   Variables<Cce::Tags::characteristic_worldtube_boundary_tags<
       Cce::Tags::BoundaryValue>>
       boundary_data_variables{};
@@ -341,7 +428,13 @@ void write_test_file(const AnalyticSolution& solution,
           make_not_null(&dr_shift_coefficients),
           make_not_null(&lapse_coefficients),
           make_not_null(&dt_lapse_coefficients),
-          make_not_null(&dr_lapse_coefficients), solution, extraction_radius,
+          make_not_null(&dr_lapse_coefficients),
+          make_not_null(&extrinsic_curvature_coefficients),
+          make_not_null(&auxiliary_shift_coefficients),
+          make_not_null(&conformal_christoffel_coefficients),
+          make_not_null(&deriv_spatial_metric_coefficients),
+          make_not_null(&deriv_shift_coefficients),
+          make_not_null(&deriv_lapse_coefficients), solution, extraction_radius,
           amplitude, frequency, time, l_max, not WriteBondi);
 
       if constexpr (WriteBondi) {
@@ -374,8 +467,20 @@ void write_test_file(const AnalyticSolution& solution,
               }
             });
       } else {
+        const auto deriv_str = [](const std::string& var, const size_t index) {
+          return "/D"s + (index == 0 ? "x"s : (index == 1 ? "y"s : "z"s)) + var;
+        };
         for (size_t i = 0; i < 3; ++i) {
-          for (size_t j = i; j < 3; ++j) {
+          for (size_t j = 0; j < 3; ++j) {
+            if (write_extra_adm_vars) {
+              recorder.append_worldtube_mode_data(
+                  detail::dataset_name_for_component(deriv_str("Shift", i), j),
+                  time, deriv_shift_coefficients.get(i, j), descending_m);
+            }
+
+            if (j < i) {
+              continue;
+            }
             recorder.append_worldtube_mode_data(
                 detail::dataset_name_for_component("/g", i, j), time,
                 spatial_metric_coefficients.get(i, j), descending_m);
@@ -385,6 +490,18 @@ void write_test_file(const AnalyticSolution& solution,
             recorder.append_worldtube_mode_data(
                 detail::dataset_name_for_component("/Dtg", i, j), time,
                 dt_spatial_metric_coefficients.get(i, j), descending_m);
+
+            if (write_extra_adm_vars) {
+              recorder.append_worldtube_mode_data(
+                  detail::dataset_name_for_component("/K", i, j), time,
+                  extrinsic_curvature_coefficients.get(i, j), descending_m);
+
+              for (size_t k = 0; k < 3; k++) {
+                recorder.append_worldtube_mode_data(
+                    detail::dataset_name_for_component(deriv_str("g", k), i, j),
+                    time, deriv_spatial_metric_coefficients.get(k, i, j));
+              }
+            }
           }
           recorder.append_worldtube_mode_data(
               detail::dataset_name_for_component("/Shift", i), time,
@@ -395,6 +512,18 @@ void write_test_file(const AnalyticSolution& solution,
           recorder.append_worldtube_mode_data(
               detail::dataset_name_for_component("/DtShift", i), time,
               dt_shift_coefficients.get(i), descending_m);
+
+          if (write_extra_adm_vars) {
+            recorder.append_worldtube_mode_data(
+                detail::dataset_name_for_component("/AuxiliaryShift", i), time,
+                auxiliary_shift_coefficients.get(i), descending_m);
+            recorder.append_worldtube_mode_data(
+                detail::dataset_name_for_component("/ConformalChristoffel", i),
+                time, conformal_christoffel_coefficients.get(i), descending_m);
+            recorder.append_worldtube_mode_data(
+                detail::dataset_name_for_component(deriv_str("Lapse", i)), time,
+                deriv_lapse_coefficients.get(i), descending_m);
+          }
         }
         recorder.append_worldtube_mode_data(
             detail::dataset_name_for_component("/Lapse"), time,

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -606,6 +606,8 @@ enable_if() {
     is_c++ "$1" && \
         whitelist "$1" \
                   'src/DataStructures/Tensor/Structure.hpp$' \
+                  'src/Evolution/Systems/Cce/WorldtubeBufferUpdater.hpp$'\
+                  'src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp$'\
                   'src/IO/H5/File.hpp$' \
                   'src/Utilities/Requires.hpp$' \
                   'src/Utilities/TMPL.hpp$' \

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -265,6 +265,7 @@ long_lines() {
     whitelist "$1" \
               '.cmake$' \
               '.css$' \
+              '.github/workflows/*' \
               '.h5$' \
               '.html$' \
               '.ipynb$' \


### PR DESCRIPTION
## Proposed changes

This allows codes that evolve BSSN or a variant of Z4 to dump the extrinsic curvature and auxiliary shift vector rather than the time derivative of the metric, lapse, and shift. We then compute these time derivatives instead, assuming 1+log slicing and the gamma-driver condition for the shift. If different lapse and shift conditions will be useful to the community, they can be added later but this should cover a large number of codes already.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
