### PR TITLE
Begin adding support for domains with non-conforming blocks

### DIFF
--- a/docs/DevGuide/DomainConcepts.md
+++ b/docs/DevGuide/DomainConcepts.md
@@ -57,8 +57,8 @@ See LICENSE.txt for details.
   The information of how the Block Logical Coordinates of neighboring Blocks are
   related.
 
-* \ref BlockNeighbor "Block Neighbor":<br>
-  The identity and Orientation of a neighboring Block of a given Block.
+* \ref BlockNeighbors "Block Neighbors":<br>
+  The identity and Orientation of neighboring Blocks of a given Block.
 
 * Element:<br> A reference cell that is a refined subregion of a Block
   defined by its Segments in each dimension. The properties of the
@@ -95,8 +95,8 @@ See LICENSE.txt for details.
   A boundary that is not an External Boundary.
 
 * Neighbors:<br>
-  The identities and Orientation of the neighboring Elements of a given Element
-  in a particular Direction .
+  The identities and Orientation of the neighboring Blocks or Elements of a
+  given Block or Element in a particular Direction .
 
 * External Boundary Condition:<br>
   A prescription for updating the solution on an External Boundary. Each

--- a/docs/Tutorials/Orientation.md
+++ b/docs/Tutorials/Orientation.md
@@ -7,6 +7,11 @@ See LICENSE.txt for details.
 \tableofcontents
 
 ### Introduction
+
+This tutorial only applies to a Domain (or a region of the Domain) that is
+constructed from Blocks that are logical hypercubes where each Block has at
+most a single neighboring Block in each direction.
+
 Each element in a domain has a set of internal directions which it uses
 for computations in its own local coordinate system. These are referred to
 as the logical directions \f$\xi\f$, \f$\eta\f$, and \f$\zeta\f$, where
@@ -22,8 +27,8 @@ This class is OrientationMap.
 ### %OrientationMaps between %Blocks
 Each Block in a Domain has a set of BlockNeighbors, which each hold an
 OrientationMap. In this scenario, the Block is referred to as the host, and
-the OrientationMap held by each BlockNeighbor is referred to as "the
-orientation the BlockNeighbor has with respect to the host Block." This is
+the OrientationMap held by each BlockNeighbors is referred to as "the
+orientation the BlockNeighbors has with respect to the host Block." This is
 a convention, so we give an example of constructing and assigning the correct
 OrientationMaps:
 
@@ -33,7 +38,7 @@ In the image above, we see a domain decomposition into two Blocks, which have
 their logical axes rotated relative to one another. With the left block as
 the host Block, we see that it has a neighbor in the \f$+\xi\f$ direction.
 The host Block holds a `std::unordered_map` from Directions to BlockNeighbors;
-the BlockNeighbor itself holds an OrientationMap that determines the mapping
+the BlockNeighbors itself holds an OrientationMap that determines the mapping
 from each logical direction in the host Block to that in the neighboring Block.
 That is, the OrientationMap takes as input local information (i.e. logical
 directions in the host's coordinate system) and returns neighbor information
@@ -42,20 +47,20 @@ OrientationMap is constructed by passing in the block neighbor directions that
 correspond to the \f$+\xi\f$, \f$+\eta\f$, \f$+\zeta\f$ directions in the host.
 In this case, these directions in the host map to the \f$+\zeta\f$,
 \f$+\xi\f$, \f$+\eta\f$ directions in the neighbor, respectively.
-This BlockNeighbor thus holds the OrientationMap constructed with the list
+This BlockNeighbors thus holds the OrientationMap constructed with the list
 (\f$+\zeta\f$, \f$+\xi\f$, \f$+\eta\f$). With the right block as the host
-block, we see that it has a BlockNeighbor in the \f$-\zeta\f$ direction, and
-the OrientationMap held by this BlockNeighbor is the one constructed with the
+block, we see that it has a BlockNeighbors in the \f$-\zeta\f$ direction, and
+the OrientationMap held by this BlockNeighbors is the one constructed with the
 array (\f$+\eta\f$, \f$+\zeta\f$, \f$+\xi\f$). For convenience, OrientationMap
 has a method `inverse_map` which returns the OrientationMap that takes as input
 neighbor information and returns local information.
 
-OrientationMaps need to be provided for each BlockNeighbor in each direction
+OrientationMaps need to be provided for each BlockNeighbors in each direction
 for each Block. This quickly becomes too large of a number to determine by
 hand as the number of Blocks and the number of dimensions increases. A remedy
 to this problem is the corner numbering scheme.
 
-### Encoding BlockNeighbor information using Corner Orderings and Numberings
+### Encoding BlockNeighbors information using Corner Orderings and Numberings
 The orientation of the \f${dim}\f$ logical directions within each element
 determines an ordering of the \f$2^{dim}\f$ vertices of that element. This is
 called the local corner numbering scheme (Local CNS) with respect to that

--- a/src/Domain/Amr/NeighborsOfChild.hpp
+++ b/src/Domain/Amr/NeighborsOfChild.hpp
@@ -24,7 +24,7 @@ template <size_t VolumeDim>
 class ElementId;
 template <size_t VolumeDim>
 class Mesh;
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename IdType>
 class Neighbors;
 /// \endcond
 
@@ -34,7 +34,7 @@ namespace amr {
 /// `child_id`, whose parent Element is `parent` which has Info `parent_info`
 /// and neighbor Info `parent_neighbor_info`
 template <size_t VolumeDim>
-std::pair<DirectionMap<VolumeDim, Neighbors<VolumeDim>>,
+std::pair<DirectionMap<VolumeDim, Neighbors<VolumeDim, ElementId<VolumeDim>>>,
           DirectionalIdMap<VolumeDim, Mesh<VolumeDim>>>
 neighbors_of_child(
     const Element<VolumeDim>& parent, const Info<VolumeDim>& parent_info,

--- a/src/Domain/Amr/NeighborsOfParent.hpp
+++ b/src/Domain/Amr/NeighborsOfParent.hpp
@@ -24,7 +24,7 @@ template <size_t VolumeDim>
 class ElementId;
 template <size_t VolumeDim>
 class Mesh;
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename IdType>
 class Neighbors;
 /// \endcond
 
@@ -33,7 +33,7 @@ namespace amr {
 /// \brief returns the neighbors and their Mesh%es of the Element with ElementId
 /// `parent_id`, that is created from its `children_elements_and_neighbor_info`
 template <size_t VolumeDim>
-std::pair<DirectionMap<VolumeDim, Neighbors<VolumeDim>>,
+std::pair<DirectionMap<VolumeDim, Neighbors<VolumeDim, ElementId<VolumeDim>>>,
           DirectionalIdMap<VolumeDim, Mesh<VolumeDim>>>
 neighbors_of_parent(
     const ElementId<VolumeDim>& parent_id,

--- a/src/Domain/Amr/NewNeighborIds.hpp
+++ b/src/Domain/Amr/NewNeighborIds.hpp
@@ -18,7 +18,7 @@ template <size_t VolumeDim>
 class ElementId;
 template <size_t VolumeDim>
 class Mesh;
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename IdType>
 class Neighbors;
 /// \endcond
 
@@ -37,7 +37,8 @@ namespace amr {
 template <size_t VolumeDim>
 std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>> new_neighbor_ids(
     const ElementId<VolumeDim>& my_id, const Direction<VolumeDim>& direction,
-    const Neighbors<VolumeDim>& previous_neighbors_in_direction,
+    const Neighbors<VolumeDim, ElementId<VolumeDim>>&
+        previous_neighbors_in_direction,
     const std::unordered_map<ElementId<VolumeDim>, Info<VolumeDim>>&
         previous_neighbors_amr_info);
 }  // namespace amr

--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -11,7 +11,7 @@
 #include <typeinfo>
 #include <utility>
 
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
@@ -24,7 +24,7 @@ Block<VolumeDim>::Block(
     std::unique_ptr<domain::CoordinateMapBase<
         Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
     const size_t id,
-    DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
+    DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>> neighbors,
     std::string name, std::array<domain::Topology, VolumeDim> topologies)
     : stationary_map_(std::move(stationary_map)),
       id_(id),

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -14,7 +14,7 @@
 #include <unordered_set>
 
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/Topology.hpp"
@@ -57,7 +57,7 @@ class Block {
   /// domain::Topology::I1)
   Block(std::unique_ptr<domain::CoordinateMapBase<
             Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
-        size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
+        size_t id, DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>> neighbors,
         std::string name = "",
         std::array<domain::Topology, VolumeDim> topologies =
             make_array<VolumeDim>(domain::Topology::I1));
@@ -156,7 +156,7 @@ class Block {
   size_t id() const { return id_; }
 
   /// Information about the neighboring Blocks.
-  const DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>& neighbors() const {
+  const DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>& neighbors() const {
     return neighbors_;
   }
 
@@ -200,7 +200,7 @@ class Block {
       moving_mesh_distorted_to_inertial_map_{nullptr};
 
   size_t id_{0};
-  DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
+  DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
   std::string name_;
   std::array<domain::Topology, VolumeDim> topologies_;

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -147,12 +147,11 @@ Element<VolumeDim> create_initial_element(
         SegmentId(perpendicular_segment_id.refinement_level(),
                   direction.side() == Side::Upper ? index + 1 : index - 1);
     return std::make_pair(
-        direction,
-        Neighbors<VolumeDim>(
-            {{ElementId<VolumeDim>{element_id.block_id(),
-                                   std::move(segment_ids_of_neighbor),
-                                   element_id.grid_index()}}},
-            OrientationMap<VolumeDim>::create_aligned()));
+        direction, Neighbors<VolumeDim>(
+                       {ElementId<VolumeDim>{element_id.block_id(),
+                                             std::move(segment_ids_of_neighbor),
+                                             element_id.grid_index()}},
+                       OrientationMap<VolumeDim>::create_aligned()));
   };
 
   typename Element<VolumeDim>::Neighbors_t neighbors_of_element;

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -42,8 +42,10 @@ Element<VolumeDim> create_initial_element(
 
         // SegmentIds of the current element using the neighbor's axes.
         auto segment_ids_of_unrefined_neighbor = orientation(segment_ids);
+        ASSERT(block_neighbor.size() == 1,
+               "Multiple block neighbors not supported by this function.");
         const auto& refinement_of_neighbor =
-            initial_refinement_levels[block_neighbor.id()];
+            initial_refinement_levels[*block_neighbor.begin()];
 
         // Check whether each dimension will have multiple neighbors
         // because the neighboring block is more refined.  For dimensions
@@ -73,7 +75,7 @@ Element<VolumeDim> create_initial_element(
                     << gsl::at(refinement_of_neighbor, d) << " and "
                     << gsl::at(segment_ids_of_unrefined_neighbor, d)
                            .refinement_level()
-                    << " in blocks " << block_neighbor.id() << " and "
+                    << " in blocks " << *block_neighbor.begin() << " and "
                     << block.id() << " differ by more than one.");
           }
         }
@@ -126,7 +128,7 @@ Element<VolumeDim> create_initial_element(
             }
           }
           neighbor_ids.insert(
-              {block_neighbor.id(), segment_ids_of_neighbor, grid_index});
+              {*block_neighbor.begin(), segment_ids_of_neighbor, grid_index});
         next_index:;
         }
         return std::make_pair(

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -40,7 +40,6 @@
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Options/ParseError.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/MakeArray.hpp"

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -20,7 +20,6 @@
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -18,7 +18,6 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Options/ParseError.hpp"

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -20,7 +20,6 @@
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Options/ParseError.hpp"
 
 namespace Frame {

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -18,7 +18,6 @@
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -30,7 +30,6 @@
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Options/ParseError.hpp"

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -8,7 +8,7 @@
 
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Utilities/Algorithm.hpp"
@@ -35,7 +35,7 @@ Domain<VolumeDim>::Domain(
         block_groups)
     : excision_spheres_(std::move(excision_spheres)),
       block_groups_(std::move(block_groups)) {
-  std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
+  std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(&neighbors_of_all_blocks, maps);
   ASSERT(block_names.empty() or block_names.size() == maps.size(),
@@ -67,7 +67,7 @@ Domain<VolumeDim>::Domain(
       "Must pass same number of maps as block corner sets, but maps.size() == "
           << maps.size() << " and corners_of_all_blocks.size() == "
           << corners_of_all_blocks.size());
-  std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
+  std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(&neighbors_of_all_blocks,
                                      corners_of_all_blocks);

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -380,7 +380,10 @@ void set_cartesian_periodic_boundaries(
               opposite_block.end()) {
             continue;
           } else {
-            opposite_block_id = opposite_block[opposite_block_direction].id();
+            ASSERT(opposite_block[opposite_block_direction].size() == 1,
+                   "Multiple block neighbors not supported by this function.");
+            opposite_block_id =
+                *(opposite_block[opposite_block_direction].begin());
             opposite_block = (*neighbors_of_all_blocks)[opposite_block_id];
             opposite_block_direction =
                 orientations_of_all_blocks[opposite_block_id](direction)

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -28,7 +28,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -347,7 +347,7 @@ void set_cartesian_periodic_boundaries(
         corners_of_all_blocks,
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
     const gsl::not_null<
-        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
+        std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>*>
         neighbors_of_all_blocks) {
   if (orientations_of_all_blocks.size() != corners_of_all_blocks.size()) {
     ERROR("Each block must have an OrientationMap relative to an edifice.");
@@ -445,13 +445,13 @@ void set_cartesian_periodic_boundaries(
 template <size_t VolumeDim>
 void set_internal_boundaries(
     const gsl::not_null<
-        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
+        std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>*>
         neighbors_of_all_blocks,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks) {
   for (size_t block1_index = 0; block1_index < corners_of_all_blocks.size();
        block1_index++) {
-    DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbor;
+    DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>> neighbor;
     for (size_t block2_index = 0; block2_index < corners_of_all_blocks.size();
          block2_index++) {
       if (block1_index != block2_index and
@@ -463,7 +463,7 @@ void set_internal_boundaries(
             obtain_correspondence_between_blocks<VolumeDim>(
                 block1_index, block2_index, corners_of_all_blocks);
         neighbor.emplace(std::move((orientation_helper.first)[0]),
-                         BlockNeighbor<VolumeDim>(
+                         BlockNeighbors<VolumeDim>(
                              block2_index, OrientationMap<VolumeDim>(
                                                orientation_helper.first,
                                                orientation_helper.second)));
@@ -476,12 +476,12 @@ void set_internal_boundaries(
 template <size_t VolumeDim>
 void set_internal_boundaries(
     const gsl::not_null<
-        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
+        std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>*>
         neighbors_of_all_blocks,
     const std::vector<std::unique_ptr<domain::CoordinateMapBase<
         Frame::BlockLogical, Frame::Inertial, VolumeDim>>>& maps) {
   for (size_t block1_index = 0; block1_index < maps.size(); block1_index++) {
-    DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbor;
+    DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>> neighbor;
     for (size_t block2_index = 0; block2_index < maps.size(); block2_index++) {
       const auto corners_for_blocks1_and_2 =
           corners_from_two_maps(maps[block1_index], maps[block2_index]);
@@ -494,7 +494,7 @@ void set_internal_boundaries(
                 0, 1, corners_for_blocks1_and_2);
 
         neighbor.emplace(std::move((orientation_helper.first)[0]),
-                         BlockNeighbor<VolumeDim>(
+                         BlockNeighbors<VolumeDim>(
                              block2_index, OrientationMap<VolumeDim>(
                                                orientation_helper.first,
                                                orientation_helper.second)));
@@ -510,7 +510,7 @@ void set_identified_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
     const gsl::not_null<
-        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
+        std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>*>
         neighbors_of_all_blocks) {
   for (const auto& pair : identifications) {
     const auto& face1 = pair.first;
@@ -548,9 +548,9 @@ void set_identified_boundaries(
         obtain_correspondence_between_blocks2.first,
         obtain_correspondence_between_blocks2.second);
     (*neighbors_of_all_blocks)[id1].emplace(
-        face1_normal_dir, BlockNeighbor<VolumeDim>(id2, connect1));
+        face1_normal_dir, BlockNeighbors<VolumeDim>(id2, connect1));
     (*neighbors_of_all_blocks)[id2].emplace(
-        face2_normal_dir, BlockNeighbor<VolumeDim>(id1, connect2));
+        face2_normal_dir, BlockNeighbors<VolumeDim>(id1, connect2));
   }
 }
 
@@ -1418,7 +1418,7 @@ Domain<VolumeDim> rectilinear_domain(
     corners_of_all_blocks[i] =
         discrete_rotation(rotations_of_all_blocks[i], corners_of_all_blocks[i]);
   }
-  std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
+  std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(&neighbors_of_all_blocks,
                                      corners_of_all_blocks);
@@ -1528,13 +1528,13 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
 #define INSTANTIATE(_, data)                                                \
   template void set_internal_boundaries(                                    \
       const gsl::not_null<                                                  \
-          std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>*>  \
+          std::vector<DirectionMap<DIM(data), BlockNeighbors<DIM(data)>>>*> \
           neighbors_of_all_blocks,                                          \
       const std::vector<std::array<size_t, two_to_the(DIM(data))>>&         \
           corners_of_all_blocks);                                           \
   template void set_internal_boundaries(                                    \
       const gsl::not_null<                                                  \
-          std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>*>  \
+          std::vector<DirectionMap<DIM(data), BlockNeighbors<DIM(data)>>>*> \
           neighbors_of_all_blocks,                                          \
       const std::vector<std::unique_ptr<domain::CoordinateMapBase<          \
           Frame::BlockLogical, Frame::Inertial, DIM(data)>>>& maps);        \
@@ -1543,12 +1543,12 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
       const std::vector<std::array<size_t, two_to_the(DIM(data))>>&         \
           corners_of_all_blocks,                                            \
       const gsl::not_null<                                                  \
-          std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>*>  \
+          std::vector<DirectionMap<DIM(data), BlockNeighbors<DIM(data)>>>*> \
           neighbors_of_all_blocks);                                         \
   template auto indices_for_rectilinear_domains(                            \
       const Index<DIM(data)>& domain_extents,                               \
       const std::vector<Index<DIM(data)>>& block_indices_to_exclude)        \
-      ->std::vector<Index<DIM(data)>>;                                      \
+      -> std::vector<Index<DIM(data)>>;                                     \
   template std::vector<std::array<size_t, two_to_the(DIM(data))>>           \
   corners_for_rectilinear_domains(                                          \
       const Index<DIM(data)>& domain_extents,                               \

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -24,7 +24,7 @@
 
 /// \cond
 template <size_t VolumeDim>
-class BlockNeighbor;
+class BlockNeighbors;
 namespace domain {
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
@@ -69,7 +69,7 @@ struct PairOfFaces {
 template <size_t VolumeDim>
 void set_internal_boundaries(
     gsl::not_null<
-        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
+        std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>*>
         neighbors_of_all_blocks,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks);
@@ -82,7 +82,7 @@ void set_internal_boundaries(
 template <size_t VolumeDim>
 void set_internal_boundaries(
     gsl::not_null<
-        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
+        std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>*>
         neighbors_of_all_blocks,
     const std::vector<std::unique_ptr<domain::CoordinateMapBase<
         Frame::BlockLogical, Frame::Inertial, VolumeDim>>>& maps);
@@ -97,7 +97,7 @@ void set_identified_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
     gsl::not_null<
-        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
+        std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>*>
         neighbors_of_all_blocks);
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/Python/Block.cpp
+++ b/src/Domain/Python/Block.cpp
@@ -29,7 +29,10 @@ void bind_block_impl(py::module& m) {  // NOLINT
           [](const Block<Dim>& block) {
             std::unordered_map<Direction<Dim>, size_t> neighbors{};
             for (const auto& [direction, neighbor] : block.neighbors()) {
-              neighbors[direction] = neighbor.id();
+              ASSERT(
+                  neighbor.size() == 1,
+                  "Multiple block neighbors not supported by this function.");
+              neighbors[direction] = *neighbor.begin();
             }
             return neighbors;
           })

--- a/src/Domain/Structure/BlockNeighbor.cpp
+++ b/src/Domain/Structure/BlockNeighbor.cpp
@@ -3,60 +3,6 @@
 
 #include "Domain/Structure/BlockNeighbor.hpp"
 
-#include <ostream>
-
-#include "Utilities/GenerateInstantiations.hpp"
-
-template <size_t VolumeDim>
-BlockNeighbor<VolumeDim>::BlockNeighbor(size_t id,
-                                        OrientationMap<VolumeDim> orientation)
-    : id_(id), orientation_(std::move(orientation)) {}
-
-template <size_t VolumeDim>
-void BlockNeighbor<VolumeDim>::pup(PUP::er& p) {
-  size_t version = 0;
-  p | version;
-  // Remember to increment the version number when making changes to this
-  // function. Retain support for unpacking data written by previous versions
-  // whenever possible. See `Domain` docs for details.
-  if (version >= 0) {
-    p | id_;
-    p | orientation_;
-  }
-}
-
-template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os,
-                         const BlockNeighbor<VolumeDim>& block_neighbor) {
-  os << "Id = " << block_neighbor.id()
-     << "; orientation = " << block_neighbor.orientation();
-  return os;
-}
-
-template <size_t VolumeDim>
-bool operator==(const BlockNeighbor<VolumeDim>& lhs,
-                const BlockNeighbor<VolumeDim>& rhs) {
-  return lhs.id() == rhs.id() and lhs.orientation() == rhs.orientation();
-}
-
-template <size_t VolumeDim>
-bool operator!=(const BlockNeighbor<VolumeDim>& lhs,
-                const BlockNeighbor<VolumeDim>& rhs) {
-  return not(lhs == rhs);
-}
-
-#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-
-#define INSTANTIATION(r, data)                                       \
-  template class BlockNeighbor<GET_DIM(data)>;                       \
-  template std::ostream& operator<<(                                 \
-      std::ostream& os, const BlockNeighbor<GET_DIM(data)>& block);  \
-  template bool operator==(const BlockNeighbor<GET_DIM(data)>& lhs,  \
-                           const BlockNeighbor<GET_DIM(data)>& rhs); \
-  template bool operator!=(const BlockNeighbor<GET_DIM(data)>& lhs,  \
-                           const BlockNeighbor<GET_DIM(data)>& rhs);
-
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
-
-#undef GET_DIM
-#undef INSTANTIATION
+template class BlockNeighbor<1>;
+template class BlockNeighbor<2>;
+template class BlockNeighbor<3>;

--- a/src/Domain/Structure/BlockNeighbor.cpp
+++ b/src/Domain/Structure/BlockNeighbor.cpp
@@ -1,8 +1,0 @@
-// Distributed under the MIT License.
-// See LICENSE.txt for details.
-
-#include "Domain/Structure/BlockNeighbor.hpp"
-
-template class BlockNeighbor<1>;
-template class BlockNeighbor<2>;
-template class BlockNeighbor<3>;

--- a/src/Domain/Structure/BlockNeighbor.hpp
+++ b/src/Domain/Structure/BlockNeighbor.hpp
@@ -1,68 +1,18 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// Defines class template BlockNeighbor.
-
 #pragma once
 
 #include <cstddef>
-#include <iosfwd>
 
-#include "Domain/Structure/OrientationMap.hpp"
-
-/// \cond
-namespace PUP {
-class er;
-}  // namespace PUP
-/// \endcond
+#include "Domain/Structure/Neighbors.hpp"
 
 /// \ingroup ComputationalDomainGroup
 /// Information about the neighbor of a host Block in a particular direction.
 ///
 /// \tparam VolumeDim the volume dimension.
 template <size_t VolumeDim>
-class BlockNeighbor {
+class BlockNeighbor : public Neighbors<VolumeDim, size_t> {
  public:
-  BlockNeighbor() = default;
-
-  /// Construct with the Id and orientation of the neighbor relative to the
-  /// host.
-  ///
-  /// \param id the Id of the neighbor.
-  /// \param orientation This OrientationMap takes objects in the logical
-  /// coordinate frame of the host Block and maps them to the logical
-  /// coordinate frame of the neighbor Block.
-  BlockNeighbor(size_t id, OrientationMap<VolumeDim> orientation);
-  ~BlockNeighbor() = default;
-  BlockNeighbor(const BlockNeighbor<VolumeDim>& neighbor) = default;
-  BlockNeighbor(BlockNeighbor<VolumeDim>&&) = default;
-  BlockNeighbor<VolumeDim>& operator=(const BlockNeighbor<VolumeDim>& rhs) =
-      default;
-  BlockNeighbor<VolumeDim>& operator=(BlockNeighbor<VolumeDim>&&) = default;
-
-  size_t id() const { return id_; }
-
-  const OrientationMap<VolumeDim>& orientation() const { return orientation_; }
-
-  // Serialization for Charm++
-  // NOLINTNEXTLINE(google-runtime-references)
-  void pup(PUP::er& p);
-
- private:
-  size_t id_{0};
-  OrientationMap<VolumeDim> orientation_;
+  using Neighbors<VolumeDim, size_t>::Neighbors;
 };
-
-/// Output operator for BlockNeighbor.
-template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os,
-                         const BlockNeighbor<VolumeDim>& block_neighbor);
-
-template <size_t VolumeDim>
-bool operator==(const BlockNeighbor<VolumeDim>& lhs,
-                const BlockNeighbor<VolumeDim>& rhs);
-
-template <size_t VolumeDim>
-bool operator!=(const BlockNeighbor<VolumeDim>& lhs,
-                const BlockNeighbor<VolumeDim>& rhs);

--- a/src/Domain/Structure/BlockNeighbors.cpp
+++ b/src/Domain/Structure/BlockNeighbors.cpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/BlockNeighbors.hpp"
+
+template class BlockNeighbors<1>;
+template class BlockNeighbors<2>;
+template class BlockNeighbors<3>;

--- a/src/Domain/Structure/BlockNeighbors.hpp
+++ b/src/Domain/Structure/BlockNeighbors.hpp
@@ -8,11 +8,11 @@
 #include "Domain/Structure/Neighbors.hpp"
 
 /// \ingroup ComputationalDomainGroup
-/// Information about the neighbor of a host Block in a particular direction.
+/// Information about the neighbors of a host Block in a particular direction.
 ///
 /// \tparam VolumeDim the volume dimension.
 template <size_t VolumeDim>
-class BlockNeighbor : public Neighbors<VolumeDim, size_t> {
+class BlockNeighbors : public Neighbors<VolumeDim, size_t> {
  public:
   using Neighbors<VolumeDim, size_t>::Neighbors;
 };

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -9,7 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   BlockGroups.cpp
-  BlockNeighbor.cpp
+  BlockNeighbors.cpp
   ChildSize.cpp
   CreateInitialMesh.cpp
   Direction.cpp
@@ -34,7 +34,7 @@ spectre_target_headers(
   HEADERS
   BlockGroups.hpp
   BlockId.hpp
-  BlockNeighbor.hpp
+  BlockNeighbors.hpp
   ChildSize.hpp
   CreateInitialMesh.hpp
   Direction.hpp

--- a/src/Domain/Structure/Neighbors.cpp
+++ b/src/Domain/Structure/Neighbors.cpp
@@ -13,9 +13,9 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"
 
-template <size_t VolumeDim>
-Neighbors<VolumeDim>::Neighbors(std::unordered_set<ElementId<VolumeDim>> ids,
-                                OrientationMap<VolumeDim> orientation)
+template <size_t VolumeDim, typename IdType>
+Neighbors<VolumeDim, IdType>::Neighbors(std::unordered_set<IdType> ids,
+                                        OrientationMap<VolumeDim> orientation)
     : ids_(std::move(ids)), orientation_(std::move(orientation)) {
   // Assuming a maximum 2-to-1 refinement between neighboring elements:
   ASSERT(ids_.size() <= maximum_number_of_neighbors_per_direction(VolumeDim),
@@ -25,9 +25,9 @@ Neighbors<VolumeDim>::Neighbors(std::unordered_set<ElementId<VolumeDim>> ids,
          "Cannot use a default-constructed OrientationMap in Neighbors.");
 }
 
-template <size_t VolumeDim>
-void Neighbors<VolumeDim>::add_ids(
-    const std::unordered_set<ElementId<VolumeDim>>& additional_ids) {
+template <size_t VolumeDim, typename IdType>
+void Neighbors<VolumeDim, IdType>::add_ids(
+    const std::unordered_set<IdType>& additional_ids) {
   for (const auto& id : additional_ids) {
     ids_.insert(id);
   }
@@ -37,26 +37,27 @@ void Neighbors<VolumeDim>::add_ids(
                        << " dimensions");
 }
 
-template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os, const Neighbors<VolumeDim>& n) {
+template <size_t VolumeDim, typename IdType>
+std::ostream& operator<<(std::ostream& os,
+                         const Neighbors<VolumeDim, IdType>& n) {
   os << "Ids = " << n.ids() << "; orientation = " << n.orientation();
   return os;
 }
 
-template <size_t VolumeDim>
-bool operator==(const Neighbors<VolumeDim>& lhs,
-                const Neighbors<VolumeDim>& rhs) {
+template <size_t VolumeDim, typename IdType>
+bool operator==(const Neighbors<VolumeDim, IdType>& lhs,
+                const Neighbors<VolumeDim, IdType>& rhs) {
   return (lhs.ids() == rhs.ids() and lhs.orientation() == rhs.orientation());
 }
 
-template <size_t VolumeDim>
-bool operator!=(const Neighbors<VolumeDim>& lhs,
-                const Neighbors<VolumeDim>& rhs) {
+template <size_t VolumeDim, typename IdType>
+bool operator!=(const Neighbors<VolumeDim, IdType>& lhs,
+                const Neighbors<VolumeDim, IdType>& rhs) {
   return not(lhs == rhs);
 }
 
-template <size_t VolumeDim>
-void Neighbors<VolumeDim>::pup(PUP::er& p) {
+template <size_t VolumeDim, typename IdType>
+void Neighbors<VolumeDim, IdType>::pup(PUP::er& p) {
   p | ids_;
   p | orientation_;
 }

--- a/src/Domain/Structure/Neighbors.cpp
+++ b/src/Domain/Structure/Neighbors.cpp
@@ -44,8 +44,9 @@ void Neighbors<VolumeDim, IdType>::add_ids(
 
 template <size_t VolumeDim, typename IdType>
 std::ostream& operator<<(std::ostream& os,
-                         const Neighbors<VolumeDim, IdType>& n) {
-  os << "Ids = " << n.ids() << "; orientation = " << n.orientation();
+                         const Neighbors<VolumeDim, IdType>& neighbors) {
+  os << "Ids = " << neighbors.ids()
+     << "; orientation = " << neighbors.orientation();
   return os;
 }
 
@@ -63,16 +64,38 @@ bool operator!=(const Neighbors<VolumeDim, IdType>& lhs,
 
 template <size_t VolumeDim, typename IdType>
 void Neighbors<VolumeDim, IdType>::pup(PUP::er& p) {
-  p | ids_;
-  p | orientation_;
+  if constexpr (std::is_same_v<IdType, size_t>) {
+    size_t version = 1;
+    p | version;
+    if (version == 0) {
+      // Deserialize old BlockNeighbor class
+      size_t id = 0;
+      p | id;
+      ids_.clear();
+      ids_.emplace(id);
+    } else {
+      p | ids_;
+    }
+    p | orientation_;
+  } else {
+    p | ids_;
+    p | orientation_;
+  }
 }
 
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATION(r, data)                                              \
+  template class Neighbors<GET_DIM(data), size_t>;                          \
+  template std::ostream& operator<<(                                        \
+      std::ostream& os, const Neighbors<GET_DIM(data), size_t>& neighbors); \
+  template bool operator==(const Neighbors<GET_DIM(data), size_t>& lhs,     \
+                           const Neighbors<GET_DIM(data), size_t>& rhs);    \
+  template bool operator!=(const Neighbors<GET_DIM(data), size_t>& lhs,     \
+                           const Neighbors<GET_DIM(data), size_t>& rhs);    \
   template class Neighbors<GET_DIM(data)>;                                  \
-  template std::ostream& operator<<(std::ostream& os,                       \
-                                    const Neighbors<GET_DIM(data)>& block); \
+  template std::ostream& operator<<(                                        \
+      std::ostream& os, const Neighbors<GET_DIM(data)>& neighbors);         \
   template bool operator==(const Neighbors<GET_DIM(data)>& lhs,             \
                            const Neighbors<GET_DIM(data)>& rhs);            \
   template bool operator!=(const Neighbors<GET_DIM(data)>& lhs,             \

--- a/src/Domain/Structure/Neighbors.cpp
+++ b/src/Domain/Structure/Neighbors.cpp
@@ -26,6 +26,11 @@ Neighbors<VolumeDim, IdType>::Neighbors(std::unordered_set<IdType> ids,
 }
 
 template <size_t VolumeDim, typename IdType>
+Neighbors<VolumeDim, IdType>::Neighbors(const IdType id,
+                                        OrientationMap<VolumeDim> orientation)
+    : Neighbors(std::unordered_set{std::move(id)}, std::move(orientation)) {}
+
+template <size_t VolumeDim, typename IdType>
 void Neighbors<VolumeDim, IdType>::add_ids(
     const std::unordered_set<IdType>& additional_ids) {
   for (const auto& id : additional_ids) {

--- a/src/Domain/Structure/Neighbors.hpp
+++ b/src/Domain/Structure/Neighbors.hpp
@@ -38,6 +38,15 @@ class Neighbors {
   Neighbors(std::unordered_set<IdType> ids,
             OrientationMap<VolumeDim> orientation);
 
+  /// Construct with the id and orientation of a single neighbor relative to the
+  /// host.
+  ///
+  /// \param id the id of the neighbors.
+  /// \param orientation This OrientationMap takes objects in the logical
+  /// coordinate frame of the host Element and maps them to the logical
+  /// coordinate frame of the neighbor Element.
+  Neighbors(IdType id, OrientationMap<VolumeDim> orientation);
+
   /// Default constructor for Charm++ serialization.
   Neighbors() = default;
   ~Neighbors() = default;

--- a/src/Domain/Structure/Neighbors.hpp
+++ b/src/Domain/Structure/Neighbors.hpp
@@ -1,13 +1,11 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// Defines class template Neighbors.
-
 #pragma once
 
 #include <cstddef>
 #include <iosfwd>
+#include <type_traits>
 #include <unordered_set>
 
 #include "Domain/Structure/OrientationMap.hpp"
@@ -21,20 +19,25 @@ class ElementId;
 /// \endcond
 
 /// \ingroup ComputationalDomainGroup
-/// Information about the neighbors of a host Element in a particular direction.
+/// Information about the neighbors of a host Element or Block in a particular
+/// direction.
 ///
 /// \tparam VolumeDim the volume dimension.
-/// \tparam IdType the type of the Id of the neighbor
+/// \tparam IdType the type of the Id of the neighbor (either ElementId or
+/// size_t for a Block)
 template <size_t VolumeDim, typename IdType = ElementId<VolumeDim>>
 class Neighbors {
+  static_assert(std::is_same_v<IdType, size_t> or
+                std::is_same_v<IdType, ElementId<VolumeDim>>);
+
  public:
   /// Construct with the ids and orientation of the neighbors relative to the
   /// host.
   ///
   /// \param ids the ids of the neighbors.
   /// \param orientation This OrientationMap takes objects in the logical
-  /// coordinate frame of the host Element and maps them to the logical
-  /// coordinate frame of the neighbor Element.
+  /// coordinate frame of the host and maps them to the logical coordinate frame
+  /// of the neighbor.
   Neighbors(std::unordered_set<IdType> ids,
             OrientationMap<VolumeDim> orientation);
 
@@ -103,7 +106,7 @@ class Neighbors {
 /// Output operator for Neighbors.
 template <size_t VolumeDim, typename IdType>
 std::ostream& operator<<(std::ostream& os,
-                         const Neighbors<VolumeDim, IdType>& n);
+                         const Neighbors<VolumeDim, IdType>& neighbors);
 
 template <size_t VolumeDim, typename IdType>
 bool operator==(const Neighbors<VolumeDim, IdType>& lhs,

--- a/src/Domain/Structure/Neighbors.hpp
+++ b/src/Domain/Structure/Neighbors.hpp
@@ -24,7 +24,8 @@ class ElementId;
 /// Information about the neighbors of a host Element in a particular direction.
 ///
 /// \tparam VolumeDim the volume dimension.
-template <size_t VolumeDim>
+/// \tparam IdType the type of the Id of the neighbor
+template <size_t VolumeDim, typename IdType = ElementId<VolumeDim>>
 class Neighbors {
  public:
   /// Construct with the ids and orientation of the neighbors relative to the
@@ -34,29 +35,29 @@ class Neighbors {
   /// \param orientation This OrientationMap takes objects in the logical
   /// coordinate frame of the host Element and maps them to the logical
   /// coordinate frame of the neighbor Element.
-  Neighbors(std::unordered_set<ElementId<VolumeDim>> ids,
+  Neighbors(std::unordered_set<IdType> ids,
             OrientationMap<VolumeDim> orientation);
 
   /// Default constructor for Charm++ serialization.
   Neighbors() = default;
   ~Neighbors() = default;
-  Neighbors(const Neighbors<VolumeDim>& neighbor) = default;
-  Neighbors(Neighbors<VolumeDim>&&) = default;
+  Neighbors(const Neighbors& neighbor) = default;
+  Neighbors(Neighbors&&) = default;
   Neighbors& operator=(const Neighbors& rhs) = default;
   Neighbors& operator=(Neighbors&&) = default;
 
-  const std::unordered_set<ElementId<VolumeDim>>& ids() const { return ids_; }
+  const std::unordered_set<IdType>& ids() const { return ids_; }
 
   const OrientationMap<VolumeDim>& orientation() const { return orientation_; }
 
   /// Reset the ids of the neighbors.
-  void set_ids_to(const std::unordered_set<ElementId<VolumeDim>> new_ids) {
+  void set_ids_to(const std::unordered_set<IdType> new_ids) {
     ids_ = std::move(new_ids);
   }
 
   /// Add ids of neighbors.
   /// Adding an existing neighbor is allowed.
-  void add_ids(const std::unordered_set<ElementId<VolumeDim>>& additional_ids);
+  void add_ids(const std::unordered_set<IdType>& additional_ids);
 
   /// Serialization for Charm++
   // NOLINTNEXTLINE(google-runtime-references)
@@ -65,47 +66,40 @@ class Neighbors {
   /// The number of neighbors
   size_t size() const { return ids_.size(); }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::iterator begin() {
+  typename std::unordered_set<IdType>::iterator begin() { return ids_.begin(); }
+
+  typename std::unordered_set<IdType>::iterator end() { return ids_.end(); }
+
+  typename std::unordered_set<IdType>::const_iterator begin() const {
     return ids_.begin();
   }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::iterator end() {
+  typename std::unordered_set<IdType>::const_iterator end() const {
     return ids_.end();
   }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator begin()
-      const {
+  typename std::unordered_set<IdType>::const_iterator cbegin() const {
     return ids_.begin();
   }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator end()
-      const {
-    return ids_.end();
-  }
-
-  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator cbegin()
-      const {
-    return ids_.begin();
-  }
-
-  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator cend()
-      const {
+  typename std::unordered_set<IdType>::const_iterator cend() const {
     return ids_.end();
   }
 
  private:
-  std::unordered_set<ElementId<VolumeDim>> ids_;
+  std::unordered_set<IdType> ids_;
   OrientationMap<VolumeDim> orientation_;
 };
 
-/// Output operator for Neighborss.
-template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os, const Neighbors<VolumeDim>& n);
+/// Output operator for Neighbors.
+template <size_t VolumeDim, typename IdType>
+std::ostream& operator<<(std::ostream& os,
+                         const Neighbors<VolumeDim, IdType>& n);
 
-template <size_t VolumeDim>
-bool operator==(const Neighbors<VolumeDim>& lhs,
-                const Neighbors<VolumeDim>& rhs);
+template <size_t VolumeDim, typename IdType>
+bool operator==(const Neighbors<VolumeDim, IdType>& lhs,
+                const Neighbors<VolumeDim, IdType>& rhs);
 
-template <size_t VolumeDim>
-bool operator!=(const Neighbors<VolumeDim>& lhs,
-                const Neighbors<VolumeDim>& rhs);
+template <size_t VolumeDim, typename IdType>
+bool operator!=(const Neighbors<VolumeDim, IdType>& lhs,
+                const Neighbors<VolumeDim, IdType>& rhs);

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -32,7 +32,6 @@
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -28,7 +28,7 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -53,7 +53,7 @@ void test_brick_construction(
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
-    const std::vector<DirectionMap<3, BlockNeighbor<3>>>&
+    const std::vector<DirectionMap<3, BlockNeighbors<3>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<3>>>&
         expected_external_boundaries,
@@ -114,7 +114,7 @@ void test_brick() {
                                 std::array<bool, 3>{{false, false, false}}};
     test_brick_construction(brick, lower_bound, upper_bound, grid_points,
                             refinement_level,
-                            std::vector<DirectionMap<3, BlockNeighbor<3>>>{{}},
+                            std::vector<DirectionMap<3, BlockNeighbors<3>>>{{}},
                             std::vector<std::unordered_set<Direction<3>>>{
                                 {{Direction<3>::lower_xi()},
                                  {Direction<3>::upper_xi()},
@@ -135,7 +135,7 @@ void test_brick() {
           {{create_boundary_condition(), create_boundary_condition()}}}}};
     test_brick_construction(brick_boundary_condition, lower_bound, upper_bound,
                             grid_points, refinement_level,
-                            std::vector<DirectionMap<3, BlockNeighbor<3>>>{{}},
+                            std::vector<DirectionMap<3, BlockNeighbors<3>>>{{}},
                             std::vector<std::unordered_set<Direction<3>>>{
                                 {{Direction<3>::lower_xi()},
                                  {Direction<3>::upper_xi()},
@@ -152,7 +152,7 @@ void test_brick() {
                         grid_points[0],
                         std::array<bool, 3>{{true, false, false}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<3>>>{
@@ -170,7 +170,7 @@ void test_brick() {
               {{create_boundary_condition(), create_boundary_condition()}},
               {{create_boundary_condition(), create_boundary_condition()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<3>>>{
@@ -187,7 +187,7 @@ void test_brick() {
                         grid_points[0],
                         std::array<bool, 3>{{false, true, false}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_eta(), {0, aligned_orientation}},
              {Direction<3>::upper_eta(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<3>>>{
@@ -205,7 +205,7 @@ void test_brick() {
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}},
               {{create_boundary_condition(), create_boundary_condition()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_eta(), {0, aligned_orientation}},
              {Direction<3>::upper_eta(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<3>>>{
@@ -222,7 +222,7 @@ void test_brick() {
                         grid_points[0],
                         std::array<bool, 3>{{false, false, true}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_zeta(), {0, aligned_orientation}},
              {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<3>>>{
@@ -240,7 +240,7 @@ void test_brick() {
               {{create_boundary_condition(), create_boundary_condition()}},
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_zeta(), {0, aligned_orientation}},
              {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<3>>>{
@@ -257,7 +257,7 @@ void test_brick() {
                         grid_points[0],
                         std::array<bool, 3>{{true, true, false}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}},
              {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -274,7 +274,7 @@ void test_brick() {
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}},
               {{create_boundary_condition(), create_boundary_condition()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}},
              {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -291,7 +291,7 @@ void test_brick() {
     test_brick_construction(
         periodic_yz_brick, lower_bound, upper_bound, grid_points,
         refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_eta(), {0, aligned_orientation}},
              {Direction<3>::upper_eta(), {0, aligned_orientation}},
              {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -310,7 +310,7 @@ void test_brick() {
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}},
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_eta(), {0, aligned_orientation}},
              {Direction<3>::upper_eta(), {0, aligned_orientation}},
              {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -327,7 +327,7 @@ void test_brick() {
     test_brick_construction(
         periodic_xz_brick, lower_bound, upper_bound, grid_points,
         refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}},
              {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -344,7 +344,7 @@ void test_brick() {
               {{create_boundary_condition(), create_boundary_condition()}},
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}},
              {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -361,7 +361,7 @@ void test_brick() {
     test_brick_construction(
         periodic_xyz_brick, lower_bound, upper_bound, grid_points,
         refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}},
              {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -379,7 +379,7 @@ void test_brick() {
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}},
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(), {0, aligned_orientation}},
              {Direction<3>::upper_xi(), {0, aligned_orientation}},
              {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -451,7 +451,7 @@ void test_brick_factory() {
     test_brick_construction(
         *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
         {{{2, 3, 2}}},
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(),
               {0, OrientationMap<3>::create_aligned()}},
              {Direction<3>::upper_xi(),
@@ -519,7 +519,7 @@ void test_brick_factory() {
     test_brick_construction(
         *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
         {{{2, 3, 2}}},
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(),
               {0, OrientationMap<3>::create_aligned()}},
              {Direction<3>::upper_xi(),
@@ -543,7 +543,7 @@ void test_brick_factory() {
     test_brick_construction(
         *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
         {{{2, 3, 2}}},
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::lower_xi(),
               {0, OrientationMap<3>::create_aligned()}},
              {Direction<3>::upper_xi(),

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -24,7 +24,7 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -106,14 +106,14 @@ void test_cylinder_construction(
   const OrientationMap<3> quarter_turn_cw(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
        Direction<3>::upper_zeta()}});
-  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{};
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> expected_block_neighbors{};
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   using TargetFrame = Frame::Inertial;
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       coord_maps{};
   if (not is_periodic_in_z) {
-    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbors<3>>>{
         {{Direction<3>::upper_xi(), {1, aligned_orientation}},
          {Direction<3>::upper_eta(), {2, quarter_turn_ccw}},
          {Direction<3>::lower_xi(), {3, half_turn}},
@@ -142,7 +142,7 @@ void test_cylinder_construction(
             {{Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
               Direction<3>::lower_zeta()}}};
   } else {
-    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbors<3>>>{
         {{Direction<3>::upper_xi(), {1, aligned_orientation}},
          {Direction<3>::upper_eta(), {2, quarter_turn_ccw}},
          {Direction<3>::lower_xi(), {3, half_turn}},
@@ -504,14 +504,14 @@ void test_refined_cylinder_boundaries(
   const OrientationMap<3> quarter_turn_cw(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
        Direction<3>::upper_zeta()}});
-  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{};
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> expected_block_neighbors{};
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   using TargetFrame = Frame::Inertial;
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       coord_maps{};
   // This specific domain consists of two stacked discs with 9 blocks each.
-  expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+  expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbors<3>>>{
       // Block 0 - layer 0 center 0
       {{Direction<3>::upper_xi(), {1, aligned_orientation}},
        {Direction<3>::upper_eta(), {2, quarter_turn_ccw}},
@@ -882,13 +882,13 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
   const OrientationMap<3> quarter_turn_cw(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
        Direction<3>::upper_zeta()}});
-  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{};
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> expected_block_neighbors{};
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   using TargetFrame = Frame::Inertial;
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       coord_maps{};
-  expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+  expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbors<3>>>{
       // Block 0 - layer 0 center 0
       {{Direction<3>::upper_xi(), {1, aligned_orientation}},
        {Direction<3>::upper_eta(), {2, quarter_turn_ccw}},

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -34,7 +34,6 @@
 #include "Domain/FunctionsOfTime/FixedSpeedCubic.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -24,7 +24,7 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -57,23 +57,24 @@ void test_disk_construction(
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}});
   const OrientationMap<2> quarter_turn_cw(std::array<Direction<2>, 2>{
       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}});
-  const std::vector<DirectionMap<2, BlockNeighbor<2>>> expected_block_neighbors{
-      {{Direction<2>::lower_eta(), {3, aligned_orientation}},
-       {Direction<2>::upper_eta(), {1, aligned_orientation}},
-       {Direction<2>::lower_xi(), {4, aligned_orientation}}},
-      {{Direction<2>::lower_eta(), {0, aligned_orientation}},
-       {Direction<2>::upper_eta(), {2, aligned_orientation}},
-       {Direction<2>::lower_xi(), {4, quarter_turn_cw}}},
-      {{Direction<2>::lower_eta(), {1, aligned_orientation}},
-       {Direction<2>::upper_eta(), {3, aligned_orientation}},
-       {Direction<2>::lower_xi(), {4, half_turn}}},
-      {{Direction<2>::lower_eta(), {2, aligned_orientation}},
-       {Direction<2>::upper_eta(), {0, aligned_orientation}},
-       {Direction<2>::lower_xi(), {4, quarter_turn_ccw}}},
-      {{Direction<2>::upper_xi(), {0, aligned_orientation}},
-       {Direction<2>::upper_eta(), {1, quarter_turn_ccw}},
-       {Direction<2>::lower_xi(), {2, half_turn}},
-       {Direction<2>::lower_eta(), {3, quarter_turn_cw}}}};
+  const std::vector<DirectionMap<2, BlockNeighbors<2>>>
+      expected_block_neighbors{
+          {{Direction<2>::lower_eta(), {3, aligned_orientation}},
+           {Direction<2>::upper_eta(), {1, aligned_orientation}},
+           {Direction<2>::lower_xi(), {4, aligned_orientation}}},
+          {{Direction<2>::lower_eta(), {0, aligned_orientation}},
+           {Direction<2>::upper_eta(), {2, aligned_orientation}},
+           {Direction<2>::lower_xi(), {4, quarter_turn_cw}}},
+          {{Direction<2>::lower_eta(), {1, aligned_orientation}},
+           {Direction<2>::upper_eta(), {3, aligned_orientation}},
+           {Direction<2>::lower_xi(), {4, half_turn}}},
+          {{Direction<2>::lower_eta(), {2, aligned_orientation}},
+           {Direction<2>::upper_eta(), {0, aligned_orientation}},
+           {Direction<2>::lower_xi(), {4, quarter_turn_ccw}}},
+          {{Direction<2>::upper_xi(), {0, aligned_orientation}},
+           {Direction<2>::upper_eta(), {1, quarter_turn_ccw}},
+           {Direction<2>::lower_xi(), {2, half_turn}},
+           {Direction<2>::lower_eta(), {3, quarter_turn_cw}}}};
   const std::vector<std::unordered_set<Direction<2>>>
       expected_external_boundaries{{{Direction<2>::upper_xi()}},
                                    {{Direction<2>::upper_xi()}},

--- a/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
+++ b/tests/Unit/Domain/Creators/Test_FrustalCloak.cpp
@@ -18,7 +18,6 @@
 #include "Domain/Creators/FrustalCloak.hpp"
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -29,7 +29,7 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -54,7 +54,7 @@ void test_rectangle_construction(
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
-    const std::vector<DirectionMap<2, BlockNeighbor<2>>>&
+    const std::vector<DirectionMap<2, BlockNeighbors<2>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<2>>>&
         expected_external_boundaries,
@@ -107,7 +107,7 @@ void test_rectangle() {
         {lower_bound, upper_bound, refinement_level[0], grid_points[0],
          std::array<bool, 2>{{false, false}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{{}},
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{{}},
         std::vector<std::unordered_set<Direction<2>>>{
             {{Direction<2>::lower_xi()},
              {Direction<2>::upper_xi()},
@@ -132,7 +132,7 @@ void test_rectangle() {
             {{{{test_bc.get_clone(), test_bc.get_clone()}},
               {{test_bc.get_clone(), test_bc.get_clone()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{{}},
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{{}},
         std::vector<std::unordered_set<Direction<2>>>{
             {{Direction<2>::lower_xi()},
              {Direction<2>::upper_xi()},
@@ -148,7 +148,7 @@ void test_rectangle() {
                                     refinement_level[0], grid_points[0],
                                     std::array<bool, 2>{{true, false}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{
             {{Direction<2>::lower_xi(), {0, aligned_orientation}},
              {Direction<2>::upper_xi(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<2>>>{
@@ -162,7 +162,7 @@ void test_rectangle() {
                                     refinement_level[0], grid_points[0],
                                     std::array<bool, 2>{{false, true}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{
             {{Direction<2>::lower_eta(), {0, aligned_orientation}},
              {Direction<2>::upper_eta(), {0, aligned_orientation}}}},
         std::vector<std::unordered_set<Direction<2>>>{
@@ -176,7 +176,7 @@ void test_rectangle() {
                                     refinement_level[0], grid_points[0],
                                     std::array<bool, 2>{{true, true}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{
             {{Direction<2>::lower_xi(), {0, aligned_orientation}},
              {Direction<2>::upper_xi(), {0, aligned_orientation}},
              {Direction<2>::lower_eta(), {0, aligned_orientation}},
@@ -195,7 +195,7 @@ void test_rectangle() {
             {{{{periodic_bc.get_clone(), periodic_bc.get_clone()}},
               {{periodic_bc.get_clone(), periodic_bc.get_clone()}}}}},
         lower_bound, upper_bound, grid_points, refinement_level,
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{
             {{Direction<2>::lower_xi(), {0, aligned_orientation}},
              {Direction<2>::upper_xi(), {0, aligned_orientation}},
              {Direction<2>::lower_eta(), {0, aligned_orientation}},
@@ -229,7 +229,7 @@ void test_rectangle_factory() {
            Direction<2>::lower_eta(), Direction<2>::upper_eta()}};
 
   // for periodic domains:
-  const std::vector<DirectionMap<2, BlockNeighbor<2>>> expected_neighbors{
+  const std::vector<DirectionMap<2, BlockNeighbors<2>>> expected_neighbors{
       {{Direction<2>::lower_xi(), {0, OrientationMap<2>::create_aligned()}},
        {Direction<2>::upper_xi(), {0, OrientationMap<2>::create_aligned()}}}};
 

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -21,7 +21,7 @@
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Creators/RotatedBricks.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -48,7 +48,7 @@ void test_rotated_bricks_construction(
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
-    const std::vector<DirectionMap<3, BlockNeighbor<3>>>&
+    const std::vector<DirectionMap<3, BlockNeighbors<3>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<3>>>&
         expected_external_boundaries,
@@ -179,7 +179,7 @@ void test_rotated_bricks() {
     test_rotated_bricks_construction(
         rotated_bricks, lower_bound, midpoint, upper_bound, grid_points,
         refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::upper_xi(), {1, rotation_F}},
              {Direction<3>::upper_eta(), {2, rotation_R}},
              {Direction<3>::upper_zeta(), {4, rotation_U}}},
@@ -253,7 +253,7 @@ void test_rotated_bricks() {
     test_rotated_bricks_construction(
         rotated_periodic_bricks, lower_bound, midpoint, upper_bound,
         grid_points, refinement_level,
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::upper_xi(), {1, rotation_F}},
              {Direction<3>::upper_eta(), {2, rotation_R}},
              {Direction<3>::upper_zeta(), {4, rotation_U}},
@@ -391,7 +391,7 @@ void test_rotated_bricks_factory() {
          {{0, 2, 1}},
          {{1, 0, 2}},
          {{2, 1, 0}}},
-        std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        std::vector<DirectionMap<3, BlockNeighbors<3>>>{
             {{Direction<3>::upper_xi(), {1, rotation_F}},
              {Direction<3>::upper_eta(), {2, rotation_R}},
              {Direction<3>::upper_zeta(), {4, rotation_U}}},

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -24,7 +24,7 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -46,7 +46,7 @@ void test_rotated_intervals_construction(
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
     const std::vector<std::array<size_t, 1>>& expected_refinement_level,
-    const std::vector<DirectionMap<1, BlockNeighbor<1>>>&
+    const std::vector<DirectionMap<1, BlockNeighbors<1>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<1>>>&
         expected_external_boundaries,
@@ -106,7 +106,7 @@ void test_rotated_intervals() {
         test_rotated_intervals_construction(
             rotated_intervals, lower_bound, midpoint, upper_bound, grid_points,
             refinement_level,
-            std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+            std::vector<DirectionMap<1, BlockNeighbors<1>>>{
                 {{Direction<1>::upper_xi(), {1, flipped}}},
                 {{Direction<1>::upper_xi(), {0, flipped}}}},
             std::vector<std::unordered_set<Direction<1>>>{
@@ -121,7 +121,7 @@ void test_rotated_intervals() {
         test_rotated_intervals_construction(
             periodic_rotated_intervals, lower_bound, midpoint, upper_bound,
             grid_points, refinement_level,
-            std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+            std::vector<DirectionMap<1, BlockNeighbors<1>>>{
                 {{Direction<1>::lower_xi(), {1, flipped}},
                  {Direction<1>::upper_xi(), {1, flipped}}},
                 {{Direction<1>::lower_xi(), {0, flipped}},
@@ -261,7 +261,7 @@ void test_rotated_intervals_factory() {
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
         {{{2}}, {{2}}},
-        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+        std::vector<DirectionMap<1, BlockNeighbors<1>>>{
             {{Direction<1>::lower_xi(), {1, flipped}},
              {Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::lower_xi(), {0, flipped}},
@@ -297,7 +297,7 @@ void test_rotated_intervals_factory() {
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
         {{{2}}, {{2}}},
-        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+        std::vector<DirectionMap<1, BlockNeighbors<1>>>{
             {{Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::upper_xi(), {0, flipped}}}},
         expected_external_boundaries, {}, {}, true);
@@ -332,7 +332,7 @@ void test_rotated_intervals_factory() {
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
         {{{2}}, {{2}}},
-        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+        std::vector<DirectionMap<1, BlockNeighbors<1>>>{
             {{Direction<1>::lower_xi(), {1, flipped}},
              {Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::lower_xi(), {0, flipped}},
@@ -353,7 +353,7 @@ void test_rotated_intervals_factory() {
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
         {{{2}}, {{2}}},
-        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+        std::vector<DirectionMap<1, BlockNeighbors<1>>>{
             {{Direction<1>::lower_xi(), {1, flipped}},
              {Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::lower_xi(), {0, flipped}},
@@ -409,7 +409,7 @@ void test_rotated_intervals_factory() {
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
         {{{2}}, {{2}}},
-        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+        std::vector<DirectionMap<1, BlockNeighbors<1>>>{
             {{Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::upper_xi(), {0, flipped}}}},
         expected_external_boundaries,
@@ -428,7 +428,7 @@ void test_rotated_intervals_factory() {
     test_rotated_intervals_construction(
         *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
         {{{2}}, {{2}}},
-        std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+        std::vector<DirectionMap<1, BlockNeighbors<1>>>{
             {{Direction<1>::upper_xi(), {1, flipped}}},
             {{Direction<1>::upper_xi(), {0, flipped}}}},
         expected_external_boundaries,

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -21,7 +21,7 @@
 #include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Creators/RotatedRectangles.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -41,7 +41,7 @@ void test_rotated_rectangles_construction(
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
-    const std::vector<DirectionMap<2, BlockNeighbor<2>>>&
+    const std::vector<DirectionMap<2, BlockNeighbors<2>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<2>>>&
         expected_external_boundaries,
@@ -115,7 +115,7 @@ void test_rotated_rectangles() {
   test_rotated_rectangles_construction(
       rotated_rectangles, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
-      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbors<2>>>{
           {{Direction<2>::upper_xi(), {1, half_turn}},
            {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
           {{Direction<2>::upper_xi(), {0, half_turn}},
@@ -144,7 +144,7 @@ void test_rotated_rectangles() {
   test_rotated_rectangles_construction(
       rotated_rectangles_boundary_conditions, lower_bound, midpoint,
       upper_bound, grid_points, refinement_level,
-      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbors<2>>>{
           {{Direction<2>::upper_xi(), {1, half_turn}},
            {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
           {{Direction<2>::upper_xi(), {0, half_turn}},
@@ -171,7 +171,7 @@ void test_rotated_rectangles() {
   test_rotated_rectangles_construction(
       rotated_periodic_rectangles, lower_bound, midpoint, upper_bound,
       grid_points, refinement_level,
-      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbors<2>>>{
           {{Direction<2>::upper_xi(), {1, half_turn}},
            {Direction<2>::upper_eta(), {2, quarter_turn_ccw}},
            {Direction<2>::lower_xi(), {1, half_turn}},
@@ -204,7 +204,7 @@ void test_rotated_rectangles() {
   test_rotated_rectangles_construction(
       periodic_rotated_rectangles_boundary_conditions, lower_bound, midpoint,
       upper_bound, grid_points, refinement_level,
-      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbors<2>>>{
           {{Direction<2>::upper_xi(), {1, half_turn}},
            {Direction<2>::upper_eta(), {2, quarter_turn_ccw}},
            {Direction<2>::lower_xi(), {1, half_turn}},
@@ -267,7 +267,7 @@ void test_rotated_rectangles_factory() {
         *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
         {{{3, 1}}, {{2, 1}}, {{4, 3}}, {{4, 2}}},
         {{{2, 1}}, {{2, 1}}, {{1, 2}}, {{1, 2}}},
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{
             {{Direction<2>::upper_xi(), {1, half_turn}},
              {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
             {{Direction<2>::upper_xi(), {0, half_turn}},
@@ -305,7 +305,7 @@ void test_rotated_rectangles_factory() {
         *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
         {{{3, 1}}, {{2, 1}}, {{4, 3}}, {{4, 2}}},
         {{{2, 1}}, {{2, 1}}, {{1, 2}}, {{1, 2}}},
-        std::vector<DirectionMap<2, BlockNeighbor<2>>>{
+        std::vector<DirectionMap<2, BlockNeighbors<2>>>{
             {{Direction<2>::upper_xi(), {1, half_turn}},
              {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
             {{Direction<2>::upper_xi(), {0, half_turn}},

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -42,7 +42,6 @@
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -302,7 +302,7 @@ void test_sphere_construction(
   // verify if adjacent to inner cube
   const auto abuts_inner_cube =
       [&num_blocks](const auto& direction_and_neighbor) {
-        return direction_and_neighbor.second.id() == num_blocks - 1;
+        return *direction_and_neighbor.second.begin() == num_blocks - 1;
       };
 
   for (size_t block_id = 0; block_id < num_blocks; ++block_id) {
@@ -382,7 +382,7 @@ void test_sphere_construction(
         for (const auto& [direction, neighbor_id] : block.neighbors()) {
           CAPTURE(direction);
           if (direction.axis() != Direction<3>::Axis::Zeta) {
-            CHECK(blocks[neighbor_id.id()].external_boundaries() ==
+            CHECK(blocks[*neighbor_id.begin()].external_boundaries() ==
                   external_boundaries);
           }
         }

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LIBRARY "Test_DomainStructure")
 set(LIBRARY_SOURCES
   Test_BlockGroups.cpp
   Test_BlockId.cpp
-  Test_BlockNeighbor.cpp
+  Test_BlockNeighbors.cpp
   Test_ChildSize.cpp
   Test_CreateInitialMesh.cpp
   Test_Direction.cpp

--- a/tests/Unit/Domain/Structure/Test_BlockNeighbor.cpp
+++ b/tests/Unit/Domain/Structure/Test_BlockNeighbor.cpp
@@ -25,7 +25,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockNeighbor", "[Domain][Unit]") {
       {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
        Direction<3>::upper_xi()}});
   BlockNeighbor<3> custom_neighbor(0, custom_orientation);
-  CHECK(custom_neighbor.id() == 0);
+  CHECK(*(custom_neighbor.begin()) == 0);
   CHECK(custom_neighbor.orientation()(Direction<3>::upper_xi()) ==
         Direction<3>::upper_eta());
   CHECK(custom_neighbor.orientation()(Direction<3>::upper_eta()) ==
@@ -34,7 +34,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockNeighbor", "[Domain][Unit]") {
         Direction<3>::upper_xi());
 
   // Test output operator:
-  CHECK(get_output(custom_neighbor) == "Id = 0; orientation = (+1, +2, +0)");
+  CHECK(get_output(custom_neighbor) == "Ids = (0); orientation = (+1, +2, +0)");
 
   // Test comparison operator:
   CHECK(test_block_neighbor != custom_neighbor);

--- a/tests/Unit/Domain/Structure/Test_BlockNeighbors.cpp
+++ b/tests/Unit/Domain/Structure/Test_BlockNeighbors.cpp
@@ -8,23 +8,23 @@
 #include <type_traits>
 #include <utility>
 
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/SegmentId.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/GetOutput.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockNeighbor", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockNeighbors", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
-  BlockNeighbor<3> test_block_neighbor;
+  BlockNeighbors<3> test_block_neighbor;
 
   // Test constructor:
   OrientationMap<3> custom_orientation(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
        Direction<3>::upper_xi()}});
-  BlockNeighbor<3> custom_neighbor(0, custom_orientation);
+  BlockNeighbors<3> custom_neighbor(0, custom_orientation);
   CHECK(*(custom_neighbor.begin()) == 0);
   CHECK(custom_neighbor.orientation()(Direction<3>::upper_xi()) ==
         Direction<3>::upper_eta());
@@ -47,5 +47,5 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockNeighbor", "[Domain][Unit]") {
   const auto custom_copy = custom_neighbor;
   test_copy_semantics(custom_neighbor);
   // clang-tidy: std::move does nothing
-  test_move_semantics(std::move(custom_neighbor), custom_copy); // NOLINT
+  test_move_semantics(std::move(custom_neighbor), custom_copy);  // NOLINT
 }

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -339,8 +339,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
         "Block 3 (Identity):\n"
         "Topology: (I1,I1)\n"
         "Neighbors: "
-        "([+0,Id = 1; orientation = (+0, +1)],"
-        "[-1,Id = 2; orientation = (-0, +1)])\n"
+        "([+0,Ids = (1); orientation = (+0, +1)],"
+        "[-1,Ids = (2); orientation = (-0, +1)])\n"
         "External boundaries: (+1,-0)\n"
         "Is time dependent: false");
 

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -19,7 +19,7 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -306,16 +306,16 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   test_block_time_dependent_distorted<2>();
   test_block_time_dependent_distorted<3>();
 
-  // Create DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>
+  // Create DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>
 
-  // Each BlockNeighbor is an id and an OrientationMap:
-  const BlockNeighbor<2> block_neighbor1(
+  // Each BlockNeighbors is an id and an OrientationMap:
+  const BlockNeighbors<2> block_neighbor1(
       1, OrientationMap<2>(std::array<Direction<2>, 2>{
              {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}));
-  const BlockNeighbor<2> block_neighbor2(
+  const BlockNeighbors<2> block_neighbor2(
       2, OrientationMap<2>(std::array<Direction<2>, 2>{
              {Direction<2>::lower_xi(), Direction<2>::upper_eta()}}));
-  const DirectionMap<2, BlockNeighbor<2>> neighbors{
+  const DirectionMap<2, BlockNeighbors<2>> neighbors{
       {Direction<2>::upper_xi(), block_neighbor1},
       {Direction<2>::lower_eta(), block_neighbor2}};
   using coordinate_map = CoordinateMap<Frame::BlockLogical, Frame::Inertial,

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -20,7 +20,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CreateInitialElement.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/Element.hpp"
@@ -402,8 +402,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           domain::CoordinateMaps::Identity<2>{}),
       0,
-      {{Direction<2>::upper_xi(), BlockNeighbor<2>{1, aligned}},
-       {Direction<2>::upper_eta(), BlockNeighbor<2>{2, unaligned}}});
+      {{Direction<2>::upper_xi(), BlockNeighbors<2>{1, aligned}},
+       {Direction<2>::upper_eta(), BlockNeighbors<2>{2, unaligned}}});
   std::vector<std::array<size_t, 2>> refinement{{{2, 3}}, {{2, 3}}, {{3, 2}}};
 
   // interior element

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -46,7 +46,7 @@
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
@@ -147,11 +147,11 @@ void test_1d_domains() {
     const OrientationMap<1> unaligned_orientation{{{Direction<1>::lower_xi()}},
                                                   {{Direction<1>::upper_xi()}}};
 
-    const std::vector<DirectionMap<1, BlockNeighbor<1>>> expected_neighbors{
+    const std::vector<DirectionMap<1, BlockNeighbors<1>>> expected_neighbors{
         {{Direction<1>::upper_xi(),
-          BlockNeighbor<1>{1, unaligned_orientation}}},
+          BlockNeighbors<1>{1, unaligned_orientation}}},
         {{Direction<1>::upper_xi(),
-          BlockNeighbor<1>{0, unaligned_orientation}}}};
+          BlockNeighbors<1>{0, unaligned_orientation}}}};
 
     const std::vector<std::unordered_set<Direction<1>>> expected_boundaries{
         {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}};
@@ -345,9 +345,9 @@ void test_1d_domains() {
     const auto expected_neighbors = []() {
       OrientationMap<1> orientation{{{Direction<1>::lower_xi()}},
                                     {{Direction<1>::lower_xi()}}};
-      return std::vector<DirectionMap<1, BlockNeighbor<1>>>{
-          {{Direction<1>::lower_xi(), BlockNeighbor<1>{0, orientation}},
-           {Direction<1>::upper_xi(), BlockNeighbor<1>{0, orientation}}}};
+      return std::vector<DirectionMap<1, BlockNeighbors<1>>>{
+          {{Direction<1>::lower_xi(), BlockNeighbors<1>{0, orientation}},
+           {Direction<1>::upper_xi(), BlockNeighbors<1>{0, orientation}}}};
     }();
 
     test_domain_construction(domain, expected_neighbors,
@@ -366,7 +366,7 @@ void test_1d_rectilinear_domains() {
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, {}, {{false}}, {}, true);
     const OrientationMap<1> aligned = OrientationMap<1>::create_aligned();
-    std::vector<DirectionMap<1, BlockNeighbor<1>>> expected_block_neighbors{
+    std::vector<DirectionMap<1, BlockNeighbors<1>>> expected_block_neighbors{
         {{Direction<1>::upper_xi(), {1, aligned}}},
         {{Direction<1>::lower_xi(), {0, aligned}},
          {Direction<1>::upper_xi(), {2, aligned}}},
@@ -391,7 +391,7 @@ void test_1d_rectilinear_domains() {
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, std::vector<OrientationMap<1>>{aligned, antialigned, aligned},
         {{false}}, {}, true);
-    std::vector<DirectionMap<1, BlockNeighbor<1>>> expected_block_neighbors{
+    std::vector<DirectionMap<1, BlockNeighbors<1>>> expected_block_neighbors{
         {{Direction<1>::upper_xi(), {1, antialigned}}},
         {{Direction<1>::lower_xi(), {2, antialigned}},
          {Direction<1>::upper_xi(), {0, antialigned}}},
@@ -429,7 +429,7 @@ void test_2d_rectilinear_domains() {
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks);
-  std::vector<DirectionMap<2, BlockNeighbor<2>>> expected_block_neighbors{
+  std::vector<DirectionMap<2, BlockNeighbors<2>>> expected_block_neighbors{
       {{Direction<2>::upper_xi(), {1, half_turn}},
        {Direction<2>::upper_eta(), {2, quarter_turn_cw}}},
       {{Direction<2>::upper_xi(), {0, half_turn}},
@@ -468,7 +468,7 @@ void test_3d_rectilinear_domains() {
                             std::array<std::vector<double>, 3>{
                                 {{0.0, 1.0, 2.0}, {0.0, 1.0}, {0.0, 1.0}}},
                             {}, orientations_of_all_blocks);
-  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> expected_block_neighbors{
       {{Direction<3>::upper_xi(), {1, quarter_turn_cw_xi}}},
       {{Direction<3>::lower_xi(), {0, quarter_turn_cw_xi.inverse_map()}}}};
   for (size_t i = 0; i < domain.blocks().size(); i++) {

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -25,7 +25,7 @@
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
@@ -43,7 +43,7 @@ namespace {
 void test_periodic_same_block() {
   const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
       {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
-  std::vector<DirectionMap<3, BlockNeighbor<3>>> neighbors_of_all_blocks;
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> neighbors_of_all_blocks;
   set_internal_boundaries<3>(&neighbors_of_all_blocks, corners_of_all_blocks);
 
   const OrientationMap<3> aligned = OrientationMap<3>::create_aligned();
@@ -58,11 +58,11 @@ void test_periodic_same_block() {
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
 
-  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
-      {{Direction<3>::upper_xi(), {0, aligned}},
-       {Direction<3>::lower_xi(), {0, aligned}},
-       {Direction<3>::lower_zeta(), {1, aligned}}},
-      {{Direction<3>::upper_zeta(), {0, aligned}}}};
+  const std::vector<DirectionMap<3, BlockNeighbors<3>>>
+      expected_block_neighbors{{{Direction<3>::upper_xi(), {0, aligned}},
+                                {Direction<3>::lower_xi(), {0, aligned}},
+                                {Direction<3>::lower_zeta(), {1, aligned}}},
+                               {{Direction<3>::upper_zeta(), {0, aligned}}}};
 
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }
@@ -70,7 +70,7 @@ void test_periodic_same_block() {
 void test_periodic_different_blocks() {
   const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
       {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
-  std::vector<DirectionMap<3, BlockNeighbor<3>>> neighbors_of_all_blocks;
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> neighbors_of_all_blocks;
   set_internal_boundaries<3>(&neighbors_of_all_blocks, corners_of_all_blocks);
 
   const OrientationMap<3> aligned = OrientationMap<3>::create_aligned();
@@ -84,11 +84,11 @@ void test_periodic_different_blocks() {
                                &neighbors_of_all_blocks);
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
-  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
-      {{Direction<3>::upper_xi(), {1, aligned}},
-       {Direction<3>::lower_zeta(), {1, aligned}}},
-      {{Direction<3>::lower_xi(), {0, aligned}},
-       {Direction<3>::upper_zeta(), {0, aligned}}}};
+  const std::vector<DirectionMap<3, BlockNeighbors<3>>>
+      expected_block_neighbors{{{Direction<3>::upper_xi(), {1, aligned}},
+                                {Direction<3>::lower_zeta(), {1, aligned}}},
+                               {{Direction<3>::lower_xi(), {0, aligned}},
+                                {Direction<3>::upper_zeta(), {0, aligned}}}};
 
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }
@@ -1563,23 +1563,24 @@ void test_set_cartesian_periodic_boundaries_3() {
       {}, orientations_of_all_blocks, std::array<bool, 2>{{true, true}}, {},
       false);
 
-  const std::vector<DirectionMap<2, BlockNeighbor<2>>> expected_block_neighbors{
-      {{Direction<2>::upper_xi(), {1, flipped}},
-       {Direction<2>::upper_eta(), {2, quarter_turn_cw}},
-       {Direction<2>::lower_xi(), {1, flipped}},
-       {Direction<2>::lower_eta(), {2, quarter_turn_cw}}},
-      {{Direction<2>::upper_xi(), {0, flipped}},
-       {Direction<2>::lower_eta(), {3, quarter_turn_cw}},
-       {Direction<2>::lower_xi(), {0, flipped}},
-       {Direction<2>::upper_eta(), {3, quarter_turn_cw}}},
-      {{Direction<2>::upper_xi(), {0, quarter_turn_ccw}},
-       {Direction<2>::upper_eta(), {3, flipped}},
-       {Direction<2>::lower_xi(), {0, quarter_turn_ccw}},
-       {Direction<2>::lower_eta(), {3, flipped}}},
-      {{Direction<2>::lower_xi(), {1, quarter_turn_ccw}},
-       {Direction<2>::upper_eta(), {2, flipped}},
-       {Direction<2>::upper_xi(), {1, quarter_turn_ccw}},
-       {Direction<2>::lower_eta(), {2, flipped}}}};
+  const std::vector<DirectionMap<2, BlockNeighbors<2>>>
+      expected_block_neighbors{
+          {{Direction<2>::upper_xi(), {1, flipped}},
+           {Direction<2>::upper_eta(), {2, quarter_turn_cw}},
+           {Direction<2>::lower_xi(), {1, flipped}},
+           {Direction<2>::lower_eta(), {2, quarter_turn_cw}}},
+          {{Direction<2>::upper_xi(), {0, flipped}},
+           {Direction<2>::lower_eta(), {3, quarter_turn_cw}},
+           {Direction<2>::lower_xi(), {0, flipped}},
+           {Direction<2>::upper_eta(), {3, quarter_turn_cw}}},
+          {{Direction<2>::upper_xi(), {0, quarter_turn_ccw}},
+           {Direction<2>::upper_eta(), {3, flipped}},
+           {Direction<2>::lower_xi(), {0, quarter_turn_ccw}},
+           {Direction<2>::lower_eta(), {3, flipped}}},
+          {{Direction<2>::lower_xi(), {1, quarter_turn_ccw}},
+           {Direction<2>::upper_eta(), {2, flipped}},
+           {Direction<2>::upper_xi(), {1, quarter_turn_ccw}},
+           {Direction<2>::lower_eta(), {2, flipped}}}};
   const std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
       expected_coordinate_maps = maps_for_rectilinear_domains<Frame::Inertial>(

--- a/tests/Unit/Elliptic/BoundaryConditions/Tags/Test_BoundaryFields.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Tags/Test_BoundaryFields.cpp
@@ -37,11 +37,11 @@ SPECTRE_TEST_CASE("Unit.Elliptic.BoundaryConditions.BoundaryFields",
     const Element<Dim> element{
         ElementId<Dim>{0},
         {{Direction<Dim>::upper_xi(),
-          {{{ElementId<Dim>{1}}}, OrientationMap<Dim>::create_aligned()}},
+          {{ElementId<Dim>{1}}, OrientationMap<Dim>::create_aligned()}},
          {Direction<Dim>::lower_eta(),
-          {{{ElementId<Dim>{1}}}, OrientationMap<Dim>::create_aligned()}},
+          {{ElementId<Dim>{1}}, OrientationMap<Dim>::create_aligned()}},
          {Direction<Dim>::upper_eta(),
-          {{{ElementId<Dim>{1}}}, OrientationMap<Dim>::create_aligned()}}}};
+          {{ElementId<Dim>{1}}, OrientationMap<Dim>::create_aligned()}}}};
     tnsr::i<DataVector, Dim> face_normal{size_t{3}, 0.};
     get<0>(face_normal) = -1.;
     DirectionMap<Dim, tnsr::i<DataVector, Dim>> face_normals{

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
@@ -105,10 +105,10 @@ void test_initialize_domain(const Spectral::Quadrature quadrature) {
     CHECK(get_tag(domain::Tags::Element<1>{}) ==
           Element<1>{element_id,
                      {{Direction<1>::lower_xi(),
-                       {{{ElementId<1>{0, {{SegmentId{2, 0}}}}}},
+                       {{ElementId<1>{0, {{SegmentId{2, 0}}}}},
                         OrientationMap<1>::create_aligned()}},
                       {Direction<1>::upper_xi(),
-                       {{{ElementId<1>{0, {{SegmentId{2, 2}}}}}},
+                       {{ElementId<1>{0, {{SegmentId{2, 2}}}}},
                         OrientationMap<1>::create_aligned()}}}});
     const auto& element_map = get_tag(domain::Tags::ElementMap<1>{});
     const auto& functions_of_time = get_tag(domain::Tags::FunctionsOfTime{});
@@ -177,15 +177,14 @@ void test_initialize_domain(const Spectral::Quadrature quadrature) {
 
     CHECK(get_tag(domain::Tags::Mesh<2>{}) ==
           Mesh<2>{{{4, 3}}, Spectral::Basis::Legendre, quadrature});
-    CHECK(
-        get_tag(domain::Tags::Element<2>{}) ==
-        Element<2>{element_id,
-                   {{Direction<2>::lower_xi(),
-                     {{{ElementId<2>{0, {{SegmentId{2, 0}, SegmentId{0, 0}}}}}},
-                      OrientationMap<2>::create_aligned()}},
-                    {Direction<2>::upper_xi(),
-                     {{{ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{0, 0}}}}}},
-                      OrientationMap<2>::create_aligned()}}}});
+    CHECK(get_tag(domain::Tags::Element<2>{}) ==
+          Element<2>{element_id,
+                     {{Direction<2>::lower_xi(),
+                       {{ElementId<2>{0, {{SegmentId{2, 0}, SegmentId{0, 0}}}}},
+                        OrientationMap<2>::create_aligned()}},
+                      {Direction<2>::upper_xi(),
+                       {{ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{0, 0}}}}},
+                        OrientationMap<2>::create_aligned()}}}});
     const auto& element_map = get_tag(domain::Tags::ElementMap<2>{});
     const tnsr::I<DataVector, 2, Frame::ElementLogical>
         logical_coords_for_element_map{
@@ -249,22 +248,21 @@ void test_initialize_domain(const Spectral::Quadrature quadrature) {
 
     CHECK(get_tag(domain::Tags::Mesh<3>{}) ==
           Mesh<3>{{{4, 3, 2}}, Spectral::Basis::Legendre, quadrature});
-    CHECK(
-        get_tag(domain::Tags::Element<3>{}) ==
-        Element<3>{
-            element_id,
-            {{Direction<3>::lower_xi(),
-              {{{ElementId<3>{
-                   0, {{SegmentId{2, 0}, SegmentId{0, 0}, SegmentId{1, 1}}}}}},
-               OrientationMap<3>::create_aligned()}},
-             {Direction<3>::upper_xi(),
-              {{{ElementId<3>{
-                   0, {{SegmentId{2, 2}, SegmentId{0, 0}, SegmentId{1, 1}}}}}},
-               OrientationMap<3>::create_aligned()}},
-             {Direction<3>::lower_zeta(),
-              {{{ElementId<3>{
-                   0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 0}}}}}},
-               OrientationMap<3>::create_aligned()}}}});
+    CHECK(get_tag(domain::Tags::Element<3>{}) ==
+          Element<3>{
+              element_id,
+              {{Direction<3>::lower_xi(),
+                {{ElementId<3>{
+                     0, {{SegmentId{2, 0}, SegmentId{0, 0}, SegmentId{1, 1}}}}},
+                 OrientationMap<3>::create_aligned()}},
+               {Direction<3>::upper_xi(),
+                {{ElementId<3>{
+                     0, {{SegmentId{2, 2}, SegmentId{0, 0}, SegmentId{1, 1}}}}},
+                 OrientationMap<3>::create_aligned()}},
+               {Direction<3>::lower_zeta(),
+                {{ElementId<3>{
+                     0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 0}}}}},
+                 OrientationMap<3>::create_aligned()}}}});
     const auto& element_map = get_tag(domain::Tags::ElementMap<3>{});
     const tnsr::I<DataVector, 3, Frame::ElementLogical>
         logical_coords_for_element_map{{{{-1., -0.5, 0., 0.1, 1.},

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -19,7 +19,6 @@
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/Element.hpp"

--- a/tests/Unit/Evolution/DgSubcell/Test_SetInterpolators.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SetInterpolators.cpp
@@ -15,7 +15,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
 #include "Domain/ElementMap.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
@@ -108,18 +108,18 @@ void test() {
   }
   const Element<Dim> element{element_id, element_neighbors};
 
-  DirectionMap<Dim, BlockNeighbor<Dim>> block0_neighbors{};
+  DirectionMap<Dim, BlockNeighbors<Dim>> block0_neighbors{};
   block0_neighbors[Direction<Dim>::lower_xi()] =
-      BlockNeighbor<Dim>{1, orientation};
+      BlockNeighbors<Dim>{1, orientation};
   Block<Dim> block0{make_grid_map<Dim, Frame::Inertial>(0), 0,
                     block0_neighbors};
   block0.inject_time_dependent_map(
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<Dim>{}));
 
-  DirectionMap<Dim, BlockNeighbor<Dim>> block1_neighbors{};
+  DirectionMap<Dim, BlockNeighbors<Dim>> block1_neighbors{};
   block1_neighbors[Direction<Dim>::lower_xi()] =
-      BlockNeighbor<Dim>{0, orientation.inverse_map()};
+      BlockNeighbors<Dim>{0, orientation.inverse_map()};
   Block<Dim> block1{make_grid_map<Dim, Frame::Inertial>(1), 1,
                     block1_neighbors};
   block1.inject_time_dependent_map(

--- a/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.hpp
@@ -16,7 +16,7 @@ struct Info;
 }  // namespace amr
 template <size_t Dim>
 class ElementId;
-template <size_t Dim>
+template <size_t Dim, typename IdType>
 class Neighbors;
 /// \endcond
 
@@ -33,5 +33,5 @@ template <size_t Dim>
 valid_info_t<Dim> valid_neighbor_info(
     const ElementId<Dim>& element_id,
     const std::array<::amr::Flag, Dim>& element_flags,
-    const Neighbors<Dim>& neighbors);
+    const Neighbors<Dim, ElementId<Dim>>& neighbors);
 }  // namespace TestHelpers::amr

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -26,7 +26,7 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/InterfaceLogicalCoordinates.hpp"
-#include "Domain/Structure/BlockNeighbor.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
@@ -455,7 +455,7 @@ void dispatch_check_if_maps_are_equal(
 template <size_t VolumeDim, typename TargetFrameGridOrInertial>
 void test_domain_construction(
     const Domain<VolumeDim>& domain,
-    const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
+    const std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
@@ -644,7 +644,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #define INSTANTIATE(_, data)                                                 \
   template void test_domain_construction<DIM(data), GET_FRAME(data)>(        \
       const Domain<DIM(data)>& domain,                                       \
-      const std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>&  \
+      const std::vector<DirectionMap<DIM(data), BlockNeighbors<DIM(data)>>>& \
           expected_block_neighbors,                                          \
       const std::vector<std::unordered_set<Direction<DIM(data)>>>&           \
           expected_external_boundaries,                                      \

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -188,10 +188,10 @@ void test_refinement_levels_of_neighbors(
 template <size_t VolumeDim>
 bool blocks_are_neighbors(const Block<VolumeDim>& host_block,
                           const Block<VolumeDim>& neighbor_block) {
-  return alg::any_of(host_block.neighbors(),
-                     [&neighbor_block](const auto& neighbor) {
-                       return neighbor.second.id() == neighbor_block.id();
-                     });
+  return alg::any_of(
+      host_block.neighbors(), [&neighbor_block](const auto& neighbor) {
+        return neighbor.second.ids().contains(neighbor_block.id());
+      });
 }
 
 // Finds the OrientationMap of a neighboring Block relative to a host Block.
@@ -200,7 +200,7 @@ OrientationMap<VolumeDim> find_neighbor_orientation(
     const Block<VolumeDim>& host_block,
     const Block<VolumeDim>& neighbor_block) {
   for (const auto& neighbor : host_block.neighbors()) {
-    if (neighbor.second.id() == neighbor_block.id()) {
+    if (neighbor.second.ids().contains(neighbor_block.id())) {
       return neighbor.second.orientation();
     }
   }
@@ -213,7 +213,7 @@ Direction<VolumeDim> find_direction_to_neighbor(
     const Block<VolumeDim>& host_block,
     const Block<VolumeDim>& neighbor_block) {
   for (const auto& neighbor : host_block.neighbors()) {
-    if (neighbor.second.id() == neighbor_block.id()) {
+    if (neighbor.second.ids().contains(neighbor_block.id())) {
       return neighbor.first;
     }
   }

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.hpp
@@ -20,7 +20,7 @@
 template <size_t VolumeDim>
 class Block;
 template <size_t VolumeDim>
-class BlockNeighbor;
+class BlockNeighbors;
 namespace domain {
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
@@ -47,7 +47,7 @@ class BoundaryCondition;
 template <size_t VolumeDim, typename TargetFrameGridOrInertial>
 void test_domain_construction(
     const Domain<VolumeDim>& domain,
-    const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
+    const std::vector<DirectionMap<VolumeDim, BlockNeighbors<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,

--- a/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.hpp
@@ -14,7 +14,7 @@ template <size_t Dim>
 class Direction;
 template <size_t Dim>
 class ElementId;
-template <size_t Dim>
+template <size_t Dim, typename IdType>
 class Neighbors;
 class SegmentId;
 namespace gsl {
@@ -76,7 +76,7 @@ std::vector<SegmentId> valid_neighbor_segments(const SegmentId& segment_id,
 /// The `generator` is used to assign a random orientation if the neighbor is
 /// in a different block, i.e. `face_type == FaceType::Block`.
 template <size_t Dim>
-std::vector<Neighbors<Dim>> valid_neighbors(
+std::vector<Neighbors<Dim, ElementId<Dim>>> valid_neighbors(
     gsl::not_null<std::mt19937*> generator, const ElementId<Dim>& element_id,
     const Direction<Dim>& direction,
     const FaceType face_type = FaceType::Internal);
@@ -88,7 +88,7 @@ std::vector<Neighbors<Dim>> valid_neighbors(
 /// parallel to the face between the Element  and the neighbor.  The set is
 /// complete if there are neighboring Element%s they completely cover the face.
 template <size_t Dim>
-void check_neighbors(const Neighbors<Dim>& neighbors,
+void check_neighbors(const Neighbors<Dim, ElementId<Dim>>& neighbors,
                      const ElementId<Dim>& element_id,
                      const Direction<Dim>& direction);
 }  // namespace TestHelpers::domain

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1120,15 +1120,15 @@ void test_impl(const Spectral::Quadrature quadrature,
         Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
         boundary_conditions{2};
     std::vector<Block<Dim>> blocks{2};
-    DirectionMap<Dim, BlockNeighbor<Dim>> neighbors_block0{};
-    DirectionMap<Dim, BlockNeighbor<Dim>> neighbors_block1{};
+    DirectionMap<Dim, BlockNeighbors<Dim>> neighbors_block0{};
+    DirectionMap<Dim, BlockNeighbors<Dim>> neighbors_block1{};
     if constexpr (Dim > 1) {
-      neighbors_block0[Direction<Dim>::lower_eta()] = BlockNeighbor<Dim>{
+      neighbors_block0[Direction<Dim>::lower_eta()] = BlockNeighbors<Dim>{
           1, element.neighbors().at(Direction<Dim>::lower_eta()).orientation()};
       neighbors_block1[element.neighbors()
                            .at(Direction<Dim>::lower_eta())
                            .orientation()(Direction<Dim>::lower_eta())] =
-          BlockNeighbor<Dim>{0, element.neighbors()
+          BlockNeighbors<Dim>{0, element.neighbors()
                                     .at(Direction<Dim>::lower_eta())
                                     .orientation()
                                     .inverse_map()};

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -1,7 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Domain/Creators/Rectilinear.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
@@ -14,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -22,6 +22,7 @@
 #include "DataStructures/FloatingPointType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Rectilinear.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
@@ -111,9 +111,9 @@ void test_weights(const Mesh<Dim>& mesh, const size_t max_overlap) {
     for (const auto& side : std::array<Side, 2>{{Side::Lower, Side::Upper}}) {
       auto& direction_neighbors =
           neighbors
-              .emplace(
-                  Direction<Dim>{d, side},
-                  Neighbors<Dim>{{}, OrientationMap<Dim>::create_aligned()})
+              .emplace(Direction<Dim>{d, side},
+                       Neighbors<Dim>{std::unordered_set<ElementId<Dim>>{},
+                                      OrientationMap<Dim>::create_aligned()})
               .first->second;
       for (size_t i = 0; i < two_to_the(Dim - 1); ++i) {
         direction_neighbors.add_ids({ElementId<Dim>{i + 1}});


### PR DESCRIPTION
## Proposed changes

By non-conforming Blocks I mean that the block logical coordinates of the two Blocks on an interface between them are not related by a discrete rotation (represented by an OrientationMap which could be the identity map, i.e. no rotation).  There are two main consequences that break existing code:
- A Block may have multiple neighboring Blocks in a given Direction
- Boundary data communicated to a non-conforming neighbor can not be copied or projected onto the mortar, but instead must be interpolated.   

Specific changes in this PR:
- Add template parameter IdType to Neighbors in order to use it for neighbors of either a Block or Element
- replace BlockNeighbor with Neighbors in order to support multiple block neighbors in a given direction
- introduce InterfaceDataPolicy which will be used to determine the communication pattern for applying boundary corrections
- store the InterfaceDataPolicy in Neighbors along with the (now optional) OrientationMap 



### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- replace `BlockNeighbor<Dim>` with `Neighbors<Dim, size_t>`
- when constructing block neighbors, it now needs a `std::unordered_set<size_t>` instead of a `size_t` for the Id
- if the neighboring Blocks/Elements are conforming and aligned, you need only construct the Neighbors with the set of Ids
- if the neighboring Blocks/Elements are conforming, but not aligned, you need to construct the Neighbors with the set of Ids, `domain::InterfaceDataPolicy::OrientCopyProject`, and the OrientationMap
- if you call `Neighbors::orientation()` it now returns a `std::optional` so you instead to call `Neighbors::orientation().value_or(OrientationMap<VolumeDim>::create_aligned())` to get the previous behavior.  (In the future, the code calling this will need to be modified in order to support domains with non-conforming Blocks.)
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
