### PR TITLE
Use predictor-corrector difference as error in AM

### DIFF
--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -91,15 +91,17 @@ void step_error(const gsl::not_null<T*> u_error,
                  [](const auto& r) { return r.time_step_id.step_time(); });
   control_times.push_back(history.back().time_step_id.step_time() +
                           history.substeps().front().time_step_id.step_size());
+  // We can't use the predictor value from the history because it
+  // might have been modified by variable fixing and filtering and
+  // such.
   auto coefficients = adams_coefficients::coefficients(
       control_times.begin(), control_times.end(),
       history.back().time_step_id.step_time(), step_end);
-  control_times.erase(control_times.begin());
-  const auto lower_order_coefficients = adams_coefficients::coefficients(
-      control_times.begin(), control_times.end(),
+  const auto predictor_coefficients = adams_coefficients::coefficients(
+      control_times.begin(), control_times.end() - 1,
       history.back().time_step_id.step_time(), step_end);
-  for (size_t i = 0; i < lower_order_coefficients.size(); ++i) {
-    coefficients[i + 1] -= lower_order_coefficients[i];
+  for (size_t i = 0; i < predictor_coefficients.size(); ++i) {
+    coefficients[i] -= predictor_coefficients[i];
   }
 
   *u_error = coefficients.back() * history.substeps().front().derivative;


### PR DESCRIPTION
More common choice than using a lower-order corrector.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
