### PR TITLE
Enable self force evolution of worldtube

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/CurvedScalarWave/CMakeLists.txt
@@ -83,5 +83,6 @@ target_link_libraries(
   PRIVATE
   ${LIBS_TO_LINK}
   ${INTERPOLATION_LIBS_TO_LINK}
+  ControlSystem
   ScalarWaveWorldtube
   )

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -43,6 +43,8 @@
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/InsideHorizon.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.hpp"
 #include "Evolution/Tags/Filter.hpp"
 #include "IO/Observer/Actions/RegisterEvents.hpp"
 #include "IO/Observer/Helpers.hpp"
@@ -236,8 +238,10 @@ struct EvolutionMetavars {
         tmpl::pair<TimeSequence<std::uint64_t>,
                    TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<TimeStepper, TimeSteppers::time_steppers>,
-        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
-                                         Triggers::time_triggers>>>;
+        tmpl::pair<Trigger,
+                   tmpl::flatten<tmpl::list<
+                       Triggers::logical_triggers, Triggers::time_triggers,
+                       Triggers::OrbitRadius, Triggers::InsideHorizon>>>>;
   };
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::at<typename factory_creation::factory_classes, Event>>;
@@ -271,6 +275,8 @@ struct EvolutionMetavars {
       Tags::AnalyticData<InitialData>,
       CurvedScalarWave::Worldtube::Tags::ExcisionSphere<volume_dim>,
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder,
+      CurvedScalarWave::Worldtube::Tags::WorldtubeRadiusParameters,
+      CurvedScalarWave::Worldtube::Tags::BlackHoleRadiusParameters,
       CurvedScalarWave::Worldtube::Tags::Charge,
       CurvedScalarWave::Worldtube::Tags::SelfForceTurnOnTime,
       CurvedScalarWave::Worldtube::Tags::SelfForceTurnOnInterval,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -81,6 +81,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveLineSegment.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/ObserveSurfaceData.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
@@ -174,29 +175,23 @@ struct EvolutionMetavars {
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                  deriv_compute>;
 
-  template <size_t Number>
-  struct PsiAlongAxis
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    static std::string name() {
-      return "PsiAlongAxis" + std::to_string(Number);
-    }
+  struct Spheres : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+    static std::string name() { return "Spheres"; }
     using temporal_id = ::Tags::Time;
     using vars_to_interpolate_to_target =
         tmpl::list<CurvedScalarWave::Tags::Psi,
                    domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        intrp::TargetPoints::LineSegment<PsiAlongAxis<Number>, volume_dim,
-                                         Frame::Grid>;
+        intrp::TargetPoints::Sphere<Spheres, Frame::Inertial>;
     using post_interpolation_callbacks =
-        tmpl::list<intrp::callbacks::ObserveLineSegment<
-            vars_to_interpolate_to_target, PsiAlongAxis<Number>>>;
+        tmpl::list<intrp::callbacks::ObserveSurfaceData<
+            tmpl::list<CurvedScalarWave::Tags::Psi>, Spheres, Frame::Inertial>>;
     template <typename metavariables>
     using interpolating_component = typename metavariables::dg_element_array;
   };
 
-  using interpolation_target_tags =
-      tmpl::list<PsiAlongAxis<1>, PsiAlongAxis<2>>;
+  using interpolation_target_tags = tmpl::list<Spheres>;
   using interpolator_source_vars =
       tmpl::list<CurvedScalarWave::Tags::Psi,
                  domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
@@ -218,9 +213,7 @@ struct EvolutionMetavars {
             tmpl::flatten<tmpl::list<
                 Events::time_events<system>, Events::Completion,
                 intrp::Events::InterpolateWithoutInterpComponent<
-                    volume_dim, PsiAlongAxis<1>, interpolator_source_vars>,
-                intrp::Events::InterpolateWithoutInterpComponent<
-                    volume_dim, PsiAlongAxis<2>, interpolator_source_vars>,
+                    volume_dim, Spheres, interpolator_source_vars>,
                 dg::Events::field_observations<volume_dim, observe_fields,
                                                non_tensor_compute_tags>>>>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,
@@ -348,8 +341,7 @@ struct EvolutionMetavars {
   using component_list = tmpl::flatten<tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
-      intrp::InterpolationTarget<EvolutionMetavars, PsiAlongAxis<1>>,
-      intrp::InterpolationTarget<EvolutionMetavars, PsiAlongAxis<2>>,
+      intrp::InterpolationTarget<EvolutionMetavars, Spheres>,
       CurvedScalarWave::Worldtube::WorldtubeSingleton<EvolutionMetavars>,
       dg_element_array>>;
 

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -65,6 +65,7 @@
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/FilterAction.hpp"
+#include "ParallelAlgorithms/Actions/FunctionsOfTimeAreReady.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
@@ -207,7 +208,7 @@ struct EvolutionMetavars {
                 CurvedScalarWave::BoundaryConditions::Worldtube<volume_dim>>>>,
         tmpl::pair<DenseTrigger, DenseTriggers::standard_dense_triggers>,
         tmpl::pair<DomainCreator<volume_dim>,
-                   tmpl::list<domain::creators::BinaryCompactObject<false>>>,
+                   tmpl::list<domain::creators::BinaryCompactObject<true>>>,
         tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<
@@ -328,6 +329,7 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<
+                  domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
                   evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
                   PhaseControl::Actions::ExecutePhaseChange>>>>;

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -16,6 +16,7 @@
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/SendAccelerationTerms.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/SendToElements.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateAcceleration.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/UpdateFunctionsOfTime.hpp"
 #include "IO/Observer/Actions/RegisterSingleton.hpp"
 #include "Options/String.hpp"
 #include "Parallel/Algorithms/AlgorithmSingleton.hpp"
@@ -25,6 +26,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Tags/ResourceInfo.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Actions/FunctionsOfTimeAreReady.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
@@ -87,14 +89,16 @@ struct WorldtubeSingleton {
         tmpl::list<Tags::EvolvedPosition<Dim>, Tags::EvolvedVelocity<Dim>>>;
   };
   using step_actions =
-      tmpl::list<Actions::ChangeSlabSize, Actions::ReceiveElementData,
+      tmpl::list<Actions::UpdateFunctionsOfTime, Actions::ChangeSlabSize,
+                 Actions::ReceiveElementData,
                  ::Actions::MutateApply<IterateAccelerationTerms>,
                  Actions::SendAccelerationTerms<Metavariables>,
                  ::Actions::MutateApply<UpdateAcceleration>,
                  ::Actions::RecordTimeStepperData<worldtube_system>,
                  ::Actions::UpdateU<worldtube_system>,
                  ::Actions::CleanHistory<worldtube_system, false>,
-                 Actions::SendToElements<Metavariables>>;
+                 Actions::SendToElements<Metavariables>,
+                 domain::Actions::CheckFunctionsOfTimeAreReady<Dim>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialization_actions>,

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -116,8 +116,7 @@ EventsAndTriggersAtSlabs:
           Interval: 1000
           Offset: 0
     Events:
-      - PsiAlongAxis1
-      - PsiAlongAxis2
+      - Spheres
   - Trigger:
       TimeCompares:
         Comparison: GreaterThan
@@ -157,14 +156,11 @@ Worldtube:
         Offset: 0
 
 InterpolationTargets:
-  PsiAlongAxis1:
-    Begin: [0., 0., 0.]
-    End: [0., 0., 400.]
-    NumberOfPoints: 1000
-  PsiAlongAxis2:
-    Begin: [0., 0., 0.]
-    End: [400., 0., 0.]
-    NumberOfPoints: 1000
+  Spheres:
+    LMax: 10
+    Center: [0.,0.,0.]
+    Radius: [400.]
+    AngularOrdering: Strahlkorper
 
 Filtering:
   ExpFilter0:
@@ -178,3 +174,4 @@ EventsAndDenseTriggers:
 Observers:
   VolumeFileName: "Volume"
   ReductionFileName: "Reductions"
+  SurfaceFileName: "Surfaces"

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -140,6 +140,16 @@ Worldtube:
   ExpansionOrder: 1
   Charge: *Charge
   SelfForceOptions: None
+  WorldtubeRadiusOptions:
+    Amplitude: 2.
+    TransitionRadius: 10.
+    TransitionWidth: 0.05
+    Exponent: 1.5
+  BlackHoleRadiusOptions:
+    Amplitude: 1.9
+    TransitionRadius: 10.
+    TransitionWidth: 0.05
+    Exponent: 1.
   ObserveCoefficientsTrigger:
     Slabs:
       EvenlySpaced:


### PR DESCRIPTION
## Proposed changes

This PR enables the self force evolution of the worldtube executable. It also changes the observation from an axis to an extraction sphere so waveform modes can be computed.
