### PR TITLE
Print worldtube status

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -276,7 +276,8 @@ struct EvolutionMetavars {
       CurvedScalarWave::Worldtube::Tags::SelfForceTurnOnInterval,
       CurvedScalarWave::Worldtube::Tags::Mass,
       CurvedScalarWave::Worldtube::Tags::MaxIterations,
-      CurvedScalarWave::Worldtube::Tags::ObserveCoefficientsTrigger>;
+      CurvedScalarWave::Worldtube::Tags::ObserveCoefficientsTrigger,
+      CurvedScalarWave::Worldtube::Tags::Verbosity>;
 
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ObserveWorldtubeSolution.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/ObserveWorldtubeSolution.hpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
 #include "IO/Observer/Helpers.hpp"
@@ -36,7 +37,8 @@ namespace CurvedScalarWave::Worldtube::Actions {
 /*!
  * \brief When Tags::ObserveCoefficientsTrigger is triggered, write the
  * coefficients of the Taylor expansion of the regular field as well as the
- * current particle's position, velocity and acceleration to file.
+ * current particle's position, velocity and acceleration to file. A brief
+ * summary is printed to stdout.
  */
 struct ObserveWorldtubeSolution {
   using reduction_data = Parallel::ReductionData<
@@ -118,6 +120,14 @@ struct ObserveWorldtubeSolution {
         }
       }();
       const auto current_time = db::get<::Tags::Time>(box);
+      if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Quiet) {
+        Parallel::printf(
+            "Time: %.16f, field value: %.16f, worldtube radius: %.16f, orbital "
+            "radius: %.16f\n",
+            current_time, psi_coefs[9], db::get<Tags::WorldtubeRadius>(box),
+            get(magnitude(inertial_particle_position))[0]);
+      }
+
       const auto observation_id =
           observers::ObservationId(current_time, "/Worldtube");
       auto& reduction_writer = Parallel::get_parallel_component<

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -139,8 +139,7 @@ struct SelfForceOptions {
 template <bool IsWorldtube>
 struct RadiusOptions {
   static constexpr Options::String help = {
-      "Options for the scalar self-force. Select `None` for a purely geodesic "
-      "evolution"};
+      "Options for the radii of the excision spheres"};
   using group = Worldtube;
   using type = RadiusOptions;
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -24,6 +24,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BackgroundSpacetime.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Auto.hpp"
 #include "Options/String.hpp"
@@ -229,6 +230,16 @@ struct ExpansionOrder {
   static size_t upper_bound() { return 1; }
   using group = Worldtube;
 };
+
+/*!
+ * \brief The verbosity of the worldtube executable.
+ */
+struct Verbosity {
+  using type = ::Verbosity;
+  static constexpr Options::String help{
+      "Gives the verbosity of the worldtube executable."};
+  using group = Worldtube;
+};
 }  // namespace OptionTags
 
 /*!
@@ -356,6 +367,18 @@ struct MaxIterations : db::SimpleTag {
   static size_t create_from_options(
       const std::optional<OptionTags::SelfForceOptions>& self_force_options) {
     return self_force_options.has_value() ? self_force_options->iterations : 0;
+  }
+};
+
+/*!
+ * \brief The verbosity of the worldtube executable.
+ */
+struct Verbosity : db::SimpleTag {
+  using type = ::Verbosity;
+  using option_tags = tmpl::list<OptionTags::Verbosity>;
+  static constexpr bool pass_metavariables = false;
+  static ::Verbosity create_from_options(const ::Verbosity& verbosity) {
+    return verbosity;
   }
 };
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -236,68 +236,6 @@ struct ExpansionOrder {
  */
 namespace Tags {
 /*!
- * \brief Dummy tag that throws an error if the input file does not describe a
- * circular orbit.
- */
-template <size_t Dim, typename BackgroundType>
-struct CheckInputFile : db::SimpleTag {
-  using type = bool;
-  using option_tags = tmpl::list<
-      domain::OptionTags::DomainCreator<Dim>, OptionTags::ExcisionSphere,
-      CurvedScalarWave::OptionTags::BackgroundSpacetime<BackgroundType>>;
-
-  // puncture field is specialised on Kerr-Schild bakckground.
-  static_assert(std::is_same_v<BackgroundType, gr::Solutions::KerrSchild>);
-  static constexpr bool pass_metavariables = false;
-  static bool create_from_options(
-      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator,
-      const std::string& excision_sphere_name,
-      const BackgroundType& kerr_schild_background) {
-    if (not kerr_schild_background.zero_spin()) {
-      ERROR(
-          "Black hole spin is not implemented yet but you requested non-zero "
-          "spin.");
-    }
-    if (not equal_within_roundoff(kerr_schild_background.center(),
-                                  make_array(0., 0., 0.))) {
-      ERROR("The central black hole must be centered at [0., 0., 0.].");
-    }
-    if (not equal_within_roundoff(kerr_schild_background.mass(), 1.)) {
-      ERROR("The central black hole must have mass 1.");
-    }
-    const auto domain = domain_creator->create_domain();
-    const auto& excision_spheres = domain.excision_spheres();
-    const auto& excision_sphere = excision_spheres.at(excision_sphere_name);
-    const double orbital_radius = get<0>(excision_sphere.center());
-    const auto& functions_of_time = domain_creator->functions_of_time();
-    if (not functions_of_time.count("Rotation")) {
-      ERROR("Expected functions of time to contain 'Rotation'.");
-    }
-    // dynamic cast to access `angle_func_and_deriv` method
-    const auto* rotation_function_of_time =
-        dynamic_cast<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>*>(
-            &*functions_of_time.at("Rotation"));
-    if (rotation_function_of_time == nullptr) {
-      ERROR("Failed dynamic cast to QuaternionFunctionOfTime.");
-    }
-    const auto angular_velocity =
-        rotation_function_of_time->angle_func_and_deriv(0.).at(1);
-    if (equal_within_roundoff(orbital_radius, 0.)) {
-      ERROR("The orbital radius was set to 0.");
-    }
-    if (not equal_within_roundoff(
-            angular_velocity,
-            DataVector{0.0, 0.0, pow(orbital_radius, -1.5)})) {
-      ERROR(
-          "Only circular orbits are implemented at the moment so the "
-          "angular velocity should be [0., 0., orbital_radius^(-3/2)] = "
-          << "[0., 0., " << pow(orbital_radius, -1.5) << "]");
-    }
-    return true;
-  }
-};
-
-/*!
  * \brief The excision sphere corresponding to the worldtube
  */
 template <size_t Dim>

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -145,6 +145,7 @@ Worldtube:
       EvenlySpaced:
         Interval: 200
         Offset: 0
+  Verbosity: Quiet
 
 InterpolationTargets:
   PsiAlongAxis1:

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ObserveWorldtubeSolution.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_ObserveWorldtubeSolution.cpp
@@ -19,6 +19,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/IO/Observers/MockWriteReductionDataRow.hpp"
+#include "IO/Logging/Verbosity.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -73,7 +74,8 @@ struct MockMetavariables {
   using component_list = tmpl::list<
       MockWorldtubeSingleton<MockMetavariables<Dim>>,
       TestHelpers::observers::MockObserverWriter<MockMetavariables<Dim>>>;
-  using const_global_cache_tags = tmpl::list<Tags::ExpansionOrder>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::ExpansionOrder, Tags::WorldtubeRadius, Tags::Verbosity>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
@@ -121,7 +123,7 @@ void check_observe_worldtube_solution(
       wt_radius, tnsr::I<double, Dim, Frame::Grid>{{0., 0., 0.}}, {});
 
   ActionTesting::MockRuntimeSystem<MockMetavariables<Dim>> runner{
-      {expansion_order}};
+      {expansion_order, wt_radius, ::Verbosity::Silent}};
 
   // this should NOT trigger because the initial time is too low and the substep
   // is not 0

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateAcceleration.cpp
@@ -108,11 +108,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CSW.Worldtube.UpdateAcceleration",
   const auto self_force_acc =
       self_force_acceleration(dt_psi_monopole, psi_dipole, vel, charge,
                               evolved_mass, inverse_metric, dilation);
+
+  const Approx approx = Approx::custom().epsilon(1e-12);
   for (size_t i = 0; i < Dim; ++i) {
     CHECK(get<::Tags::dt<Tags::EvolvedPosition<Dim>>>(dt_vars).get(i)[0] ==
-          vel.get(i));
+          approx(vel.get(i)));
     CHECK(get<::Tags::dt<Tags::EvolvedVelocity<Dim>>>(dt_vars).get(i)[0] ==
-          geodesic_acc.get(i) + roll_on * self_force_acc.get(i));
+          approx(geodesic_acc.get(i) + roll_on * self_force_acc.get(i)));
   }
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -664,69 +664,6 @@ void test_puncture_field() {
   CHECK(not puncture_field_nullopt.has_value());
 }
 
-void test_check_input_file() {
-  const auto bbh_correct =
-      TestHelpers::CurvedScalarWave::Worldtube::worldtube_binary_compact_object<
-          false>(7., 0.2, pow(7., -1.5));
-  const gr::Solutions::KerrSchild kerr_schild_correct(
-      1., make_array(0., 0., 0.), make_array(0., 0., 0.));
-  CHECK(Tags::CheckInputFile<3, gr::Solutions::KerrSchild>::create_from_options(
-      bbh_correct, "ExcisionSphereA", kerr_schild_correct));
-  {
-    const auto bbh_incorrect = TestHelpers::CurvedScalarWave::Worldtube::
-        worldtube_binary_compact_object<false>(7., 0.2, 1.);
-    CHECK_THROWS_WITH(
-        (Tags::CheckInputFile<3, gr::Solutions::KerrSchild>::
-             create_from_options(bbh_incorrect, "ExcisionSphereA",
-                                 kerr_schild_correct)),
-        Catch::Matchers::ContainsSubstring(
-            "Only circular orbits are implemented at the moment so the "
-            "angular velocity should be [0., 0., orbital_radius^(-3/2)] = "));
-  }
-  {
-    const std::unique_ptr<DomainCreator<3>> shell =
-        std::make_unique<domain::creators::Sphere>(
-            1.5, 3., domain::creators::Sphere::Excision{}, size_t(1), size_t(6),
-            true);
-    CHECK_THROWS_WITH(
-        (Tags::CheckInputFile<3, gr::Solutions::KerrSchild>::
-             create_from_options(shell, "ExcisionSphere", kerr_schild_correct)),
-        Catch::Matchers::ContainsSubstring(
-            "Expected functions of time to contain 'Rotation'."));
-  }
-  {
-    const gr::Solutions::KerrSchild kerr_schild_off_center(
-        1., make_array(0., 0., 0.), make_array(0.1, 0., 0.));
-    CHECK_THROWS_WITH(
-        (Tags::CheckInputFile<3, gr::Solutions::KerrSchild>::
-             create_from_options(bbh_correct, "ExcisionSphere",
-                                 kerr_schild_off_center)),
-        Catch::Matchers::ContainsSubstring(
-            "The central black hole must be centered at [0., 0., 0.]."));
-  }
-  {
-    const gr::Solutions::KerrSchild kerr_schild_spinning(
-        1., make_array(0.1, 0., 0.), make_array(0., 0., 0.));
-    CHECK_THROWS_WITH((Tags::CheckInputFile<3, gr::Solutions::KerrSchild>::
-                           create_from_options(bbh_correct, "ExcisionSphere",
-                                               kerr_schild_spinning)),
-                      Catch::Matchers::ContainsSubstring(
-                          "Black hole spin is not implemented yet but "
-                          "you requested non-zero spin."));
-  }
-  {
-    const gr::Solutions::KerrSchild kerr_schild_2M(2., make_array(0., 0., 0.),
-                                                   make_array(0., 0., 0.));
-    CHECK_THROWS_WITH(
-        (Tags::CheckInputFile<
-            3, gr::Solutions::KerrSchild>::create_from_options(bbh_correct,
-                                                               "ExcisionSphere",
-                                                               kerr_schild_2M)),
-        Catch::Matchers::ContainsSubstring(
-            "The central black hole must have mass 1."));
-  }
-}
-
 void test_self_force_options() {
   const auto options = TestHelpers::test_creation<OptionTags::SelfForceOptions>(
       "Mass: 0.1\n"
@@ -821,8 +758,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::PunctureField<3>>("PunctureField");
   TestHelpers::db::test_simple_tag<Tags::IteratedPunctureField<3>>(
       "IteratedPunctureField");
-  TestHelpers::db::test_simple_tag<
-      Tags::CheckInputFile<3, gr::Solutions::KerrSchild>>("CheckInputFile");
   TestHelpers::db::test_simple_tag<Tags::ObserveCoefficientsTrigger>(
       "ObserveCoefficientsTrigger");
   TestHelpers::db::test_simple_tag<Tags::GeodesicAcceleration<3>>(
@@ -845,7 +780,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   test_background_quantities_compute();
   test_face_quantities_compute();
   test_puncture_field();
-  test_check_input_file();
   test_constraint_gammas_compute();
 }
 }  // namespace CurvedScalarWave::Worldtube

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -768,6 +768,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
       "BackgroundQuantities");
   TestHelpers::db::test_simple_tag<Tags::AccelerationTerms>(
       "AccelerationTerms");
+  TestHelpers::db::test_simple_tag<Tags::Verbosity>("Verbosity");
   test_excision_sphere_tag();
   test_self_force_options();
   test_radius_options();


### PR DESCRIPTION
## Proposed changes

This PR prints a handy, short update about the worldtube orbit to stdout when an observation is done.

The PR also removes an obsolete tag, corrects a wrong descritption and fixes a random test failure.