### PR TITLE
Store the DG Basis in the Block.

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -24,11 +24,12 @@ Block<VolumeDim>::Block(
         Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
     const size_t id,
     DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
-    std::string name)
+    std::string name, std::array<Spectral::Basis, VolumeDim> dg_basis)
     : stationary_map_(std::move(stationary_map)),
       id_(id),
       neighbors_(std::move(neighbors)),
-      name_(std::move(name)) {
+      name_(std::move(name)),
+      dg_basis_(std::move(dg_basis)) {
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.
   for (const auto& direction : Direction<VolumeDim>::all_directions()) {
@@ -118,7 +119,7 @@ void Block<VolumeDim>::inject_time_dependent_map(
 
 template <size_t VolumeDim>
 void Block<VolumeDim>::pup(PUP::er& p) {
-  size_t version = 1;
+  size_t version = 2;
   p | version;
   // Remember to increment the version number when making changes to this
   // function. Retain support for unpacking data written by previous versions
@@ -135,6 +136,11 @@ void Block<VolumeDim>::pup(PUP::er& p) {
   }
   if (version >= 1) {
     p | name_;
+  }
+  if (version < 2) {
+    dg_basis_ = make_array<VolumeDim>(Spectral::Basis::Legendre);
+  } else {
+    p | dg_basis_;
   }
 }
 
@@ -153,6 +159,7 @@ bool operator==(const Block<VolumeDim>& lhs, const Block<VolumeDim>& rhs) {
       (lhs.id() == rhs.id() and lhs.neighbors() == rhs.neighbors() and
        lhs.external_boundaries() == rhs.external_boundaries() and
        lhs.name() == rhs.name() and
+       lhs.dg_basis() == rhs.dg_basis() and
        lhs.is_time_dependent() == rhs.is_time_dependent() and
        lhs.has_distorted_frame() == rhs.has_distorted_frame());
 

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <iosfwd>
 #include <memory>
@@ -16,6 +17,8 @@
 #include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "Utilities/MakeArray.hpp"
 
 /// \cond
 namespace Frame {
@@ -49,10 +52,15 @@ class Block {
   /// \param neighbors info about the Blocks that share a codimension 1
   /// boundary with this Block.
   /// \param name Human-readable name for the block
+  /// \param dg_basis Spectral::Basis in each dimension used for Elements in
+  /// the Block when using discontinuous Galerkin methods (default value is
+  /// Spectral::Basis::Legendre)
   Block(std::unique_ptr<domain::CoordinateMapBase<
             Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
         size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
-        std::string name = "");
+        std::string name = "",
+        std::array<Spectral::Basis, VolumeDim> dg_basis =
+            make_array<VolumeDim>(Spectral::Basis::Legendre));
 
   Block() = default;
   ~Block() = default;
@@ -159,6 +167,12 @@ class Block {
 
   const std::string& name() const { return name_; }
 
+  /// The basis functions used in each dimension for Elements of this Block
+  /// when using discontinuous Galerkin methods
+  const std::array<Spectral::Basis, VolumeDim>& dg_basis() const {
+    return dg_basis_;
+  }
+
   /// Serialization for Charm++
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
@@ -189,6 +203,7 @@ class Block {
   DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
   std::string name_;
+  std::array<Spectral::Basis, VolumeDim> dg_basis_;
 };
 
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -24,7 +24,9 @@
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 
 namespace domain {
@@ -53,6 +55,7 @@ void test_block_time_independent() {
     // Test id:
     CHECK((block.id()) == 7);
     CHECK(block.name() == "Identity");
+    CHECK(block.dg_basis() == make_array<Dim>(Spectral::Basis::Legendre));
 
     // Test that the block's coordinate_map is Identity:
     const auto& map = block.stationary_map();
@@ -136,6 +139,7 @@ void test_block_time_dependent() {
 
     // Test id:
     CHECK((block.id()) == 7);
+    CHECK(block.dg_basis() == make_array<Dim>(Spectral::Basis::Legendre));
 
     // Test that the block's coordinate_map is Identity:
     const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
@@ -248,6 +252,7 @@ void test_block_time_dependent_distorted() {
 
     // Test id:
     CHECK((block.id()) == 7);
+    CHECK(block.dg_basis() == make_array<Dim>(Spectral::Basis::Legendre));
 
     // Test that the block's coordinate_map is Identity:
     const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
@@ -327,6 +332,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   // Test id:
   CHECK((block.id()) == 3);
   CHECK(block.name() == "Identity");
+  CHECK(block.dg_basis() == make_array<2>(Spectral::Basis::Legendre));
 
   // Test output:
   CHECK(get_output(block) ==
@@ -349,6 +355,14 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   }
   {
     const Block<2> rhs(identity_map.get_clone(), 0, neighbors, "Identity");
+    CHECK(block != rhs);
+  }
+  {
+    const Block<2> rhs(
+        identity_map.get_clone(), 3, neighbors, "Identity",
+        {{Spectral::Basis::Chebyshev, Spectral::Basis::Legendre}});
+    CHECK(rhs.dg_basis() ==
+          std::array{Spectral::Basis::Chebyshev, Spectral::Basis::Legendre});
     CHECK(block != rhs);
   }
 }


### PR DESCRIPTION
The dg_basis will be used to determine the topology of the Block as well as the Spectral::Basis used for a Mesh on an Element of the Block.  It is default initialized to Spectral::Basis::Legendre as that has been the previous choice.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
