### PR TITLE
Elliptic solver: allow to observe fixed sources, support optional direct solve

### DIFF
--- a/src/Domain/Python/SegmentId.cpp
+++ b/src/Domain/Python/SegmentId.cpp
@@ -25,6 +25,13 @@ void bind_segment_id(py::module& m) {
            py::arg("index"))
       .def_property("refinement_level", &SegmentId::refinement_level, nullptr)
       .def_property("index", &SegmentId::index, nullptr)
+      .def_property(
+          "endpoints",
+          [](const SegmentId& segment_id) {
+            return std::array<double, 2>{{segment_id.endpoint(Side::Lower),
+                                          segment_id.endpoint(Side::Upper)}};
+          },
+          nullptr)
       .def("__repr__",
            [](const SegmentId& segment_id) { return get_output(segment_id); })
       // NOLINTNEXTLINE(misc-redundant-expression)

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
 #include "Domain/Creators/Tags/InitialExtents.hpp"
@@ -39,6 +40,7 @@
 #include "Parallel/InboxInserters.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -538,25 +540,27 @@ template <typename System, typename FixedSourcesTag, typename... FluxesArgsTags,
           typename... SourcesArgsTags>
 struct ImposeInhomogeneousBoundaryConditionsOnSource<
     System, FixedSourcesTag, tmpl::list<FluxesArgsTags...>,
-    tmpl::list<SourcesArgsTags...>> {
+    tmpl::list<SourcesArgsTags...>>
+    : tt::ConformsTo<::amr::protocols::Projector> {
  private:
   static constexpr size_t Dim = System::volume_dim;
   using BoundaryConditionsBase = typename System::boundary_conditions_base;
 
- public:
+ public:  // DataBox mutator, amr::protocols::Projector
   using const_global_cache_tags =
       tmpl::list<elliptic::dg::Tags::PenaltyParameter,
                  elliptic::dg::Tags::Massive, elliptic::dg::Tags::Formulation,
                  domain::Tags::ExternalBoundaryConditions<Dim>>;
 
-  template <typename DbTags, typename... InboxTags, typename Metavariables,
-            typename ActionList, typename ParallelComponent>
-  static Parallel::iterable_action_return_t apply(
-      db::DataBox<DbTags>& box,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ElementId<Dim>& element_id, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) {
+  using return_tags = tmpl::list<::Tags::DataBox>;
+  using argument_tags = tmpl::list<>;
+
+  template <typename DbTagsList, typename... AmrData>
+  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box_ptr,
+                    const AmrData&... /*amr_data*/) {
+    // Just to get the same semantics as in actions
+    auto& box = *box_ptr;
+    const auto& element_id = db::get<domain::Tags::Element<Dim>>(box).id();
     // Used to retrieve items out of the DataBox to forward to functions
     const auto get_items = [](const auto&... args) {
       return std::forward_as_tuple(args...);
@@ -649,7 +653,6 @@ struct ImposeInhomogeneousBoundaryConditionsOnSource<
           *local_fixed_sources = std::move(fixed_sources);
         },
         make_not_null(&box));
-    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
 /// \endcond

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -334,7 +334,7 @@ struct ReceiveMortarDataAndApplyOperator<
     const auto& temporal_id = get<TemporalIdTag>(box);
     const auto& element = get<domain::Tags::Element<Dim>>(box);
 
-    if (not ::dg::has_received_from_all_mortars<mortar_data_inbox_tag>(
+    if (not::dg::has_received_from_all_mortars<mortar_data_inbox_tag>(
             temporal_id, element, inboxes)) {
       return {Parallel::AlgorithmExecution::Retry, std::nullopt};
     }
@@ -500,6 +500,9 @@ template <typename System, bool Linearized, typename TemporalIdTag,
           typename PrimalMortarFieldsTag = PrimalFieldsTag,
           typename PrimalMortarFluxesTag = PrimalFluxesTag>
 struct DgOperator {
+  using system = System;
+  using temporal_id_tag = TemporalIdTag;
+
  private:
   static constexpr size_t Dim = System::volume_dim;
 

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -31,6 +31,7 @@
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/RandomizeVariables.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
@@ -197,6 +198,7 @@ struct Solver {
           typename db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
                                       fields_tag>::tags_list>,
       tmpl::append<
+          typename fixed_sources_tag::tags_list,
           typename nonlinear_solver::linear_solver_fields_tag::tags_list,
           typename nonlinear_solver::linear_solver_source_tag::tags_list>>;
 
@@ -246,9 +248,16 @@ struct Solver {
           elliptic::amr::Actions::Initialize>,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
       ::Actions::RandomizeVariables<fields_tag, RandomizeInitialGuess>,
-      elliptic::Actions::InitializeFixedSources<system, background_tag>,
       init_analytic_solution_action,
       elliptic::dg::Actions::initialize_operator<system, background_tag>,
+      // Actions below may use faces and normals
+      elliptic::Actions::InitializeFixedSources<system, background_tag>,
+      tmpl::conditional_t<is_linear,
+                          tmpl::list<::Actions::MutateApply<
+                              elliptic::dg::Actions::
+                                  ImposeInhomogeneousBoundaryConditionsOnSource<
+                                      system, fixed_sources_tag>>>,
+                          tmpl::list<>>,
       tmpl::conditional_t<
           is_linear, tmpl::list<>,
           ::Initialization::Actions::AddComputeTags<tmpl::list<
@@ -360,10 +369,6 @@ struct Solver {
                   system, true, linear_solver_iteration_id, fields_tag,
                   fluxes_vars_tag, operator_applied_to_fields_tag, vars_tag,
                   fluxes_vars_tag>::apply_actions,
-              // Modify fixed sources with boundary conditions
-              elliptic::dg::Actions::
-                  ImposeInhomogeneousBoundaryConditionsOnSource<
-                      system, fixed_sources_tag>,
               // Krylov solve
               linear_solve_actions<tmpl::list<>>>,
           // Nonlinear solve
@@ -401,6 +406,14 @@ struct Solver {
       typename dg_operator<true>::amr_projectors,
       tmpl::conditional_t<is_linear, typename build_matrix::amr_projectors,
                           typename dg_operator<false>::amr_projectors>,
+      // Actions below may use faces and normals
+      elliptic::Actions::InitializeFixedSources<system, background_tag>,
+      tmpl::conditional_t<
+          is_linear,
+          tmpl::list<elliptic::dg::Actions::
+                         ImposeInhomogeneousBoundaryConditionsOnSource<
+                             system, fixed_sources_tag>>,
+          tmpl::list<>>,
       elliptic::amr::Actions::Initialize>>;
 
   using component_list = tmpl::flatten<

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -219,7 +219,8 @@ struct Solver {
                           operator_applied_to_fields_tag>>;
 
   using build_matrix = LinearSolver::Actions::BuildMatrix<
-      linear_solver_iteration_id, vars_tag, operator_applied_to_vars_tag,
+      typename dg_operator<true>::temporal_id_tag, fields_tag,
+      fixed_sources_tag, vars_tag, operator_applied_to_vars_tag,
       domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
       LinearSolver::multigrid::Tags::IsFinestGrid>;
 
@@ -416,13 +417,15 @@ struct Solver {
           tmpl::list<>>,
       elliptic::amr::Actions::Initialize>>;
 
-  using component_list = tmpl::flatten<
-      tmpl::list<tmpl::conditional_t<is_linear, tmpl::list<>,
-                                     typename nonlinear_solver::component_list>,
-                 typename linear_solver::component_list,
-                 typename multigrid::component_list,
-                 typename schwarz_smoother::component_list,
-                 ::amr::Component<Metavariables>>>;
+  using component_list = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<
+          is_linear,
+          typename build_matrix::template component_list<Metavariables>,
+          typename nonlinear_solver::component_list>,
+      typename linear_solver::component_list,
+      typename multigrid::component_list,
+      typename schwarz_smoother::component_list,
+      ::amr::Component<Metavariables>>>;
 };
 
 }  // namespace elliptic

--- a/src/Elliptic/Python/ReadH5.py
+++ b/src/Elliptic/Python/ReadH5.py
@@ -24,17 +24,35 @@ def read_matrix(volfiles: Union[spectre_h5.H5Vol, Sequence[spectre_h5.H5Vol]]):
     # Each observation is a column of the matrix
     obs_ids = volfiles[0].list_observation_ids()
     size = len(obs_ids)
-    matrix = np.zeros((size, size))
-    # Collect all variables to be able to order them
+    # Determine dtype (complex or float)
     all_tensor_components = volfiles[0].list_tensor_components(obs_ids[0])
-    variables = sorted(
-        [
+    if "Variable_0" in all_tensor_components:
+        dtype = float
+    elif "Re(Variable_0)" in all_tensor_components:
+        dtype = complex
+    else:
+        raise ValueError(
+            "Expected 'Variable_0' or 'Re(Variable_0)' in tensor components."
+        )
+    # Collect all variables to be able to order them
+    num_vars = len(
+        list(
             component
             for component in all_tensor_components
-            if component.startswith("Variable_")
-        ],
-        key=lambda component: int(component.split("_")[1]),
+            if "Variable_" in component
+        )
     )
+    if dtype is complex:
+        num_vars //= 2
+        variables = sum(
+            (
+                [f"Re(Variable_{i})", f"Im(Variable_{i})"]
+                for i in range(num_vars)
+            ),
+            [],
+        )
+    else:
+        variables = [f"Variable_{i}" for i in range(num_vars)]
     # Collect all element IDs to be able to order them
     num_points_per_element = {
         element.id: element.mesh.number_of_grid_points()
@@ -45,12 +63,20 @@ def read_matrix(volfiles: Union[spectre_h5.H5Vol, Sequence[spectre_h5.H5Vol]]):
     slice_start = 0
     for element_id in element_ids:
         slice_start_per_element[element_id] = slice_start
-        slice_start += num_points_per_element[element_id] * len(variables)
+        slice_start += num_points_per_element[element_id] * num_vars
     del num_points_per_element
     # Fill matrix
+    matrix = np.zeros((size, size), dtype=dtype)
     for element, tensor_data in iter_elements(
         volfiles, obs_ids=None, tensor_components=variables
     ):
+        if dtype is complex:
+            tensor_data = np.array(
+                [
+                    tensor_data[2 * i] + 1j * tensor_data[2 * i + 1]
+                    for i in range(num_vars)
+                ]
+            )
         # Column of the matrix is the observation ID
         col = int(element.time)
         # Slice of the row is determined by ordering of elements

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#include <blaze/math/Submatrix.h>
 #include <cstddef>
 #include <map>
 #include <optional>
 #include <utility>
 #include <vector>
 
+#include "DataStructures/CompressedMatrix.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -33,6 +35,7 @@
 #include "Parallel/Section.hpp"
 #include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -63,6 +66,14 @@ struct MatrixSubfileName {
       "component."};
 };
 
+struct EnableDirectSolve {
+  using type = bool;
+  using group = BuildMatrixOptionsGroup;
+  static constexpr Options::String help = {
+      "Directly invert the assembled matrix and solve the linear problem. "
+      "This can be unfeasible if the linear problem is too big."};
+};
+
 }  // namespace OptionTags
 
 namespace Tags {
@@ -85,11 +96,42 @@ struct LocalFirstIndex : db::SimpleTag {
   using type = size_t;
 };
 
+/// Matrix representation of the linear operator. Stored as sparse matrix. The
+/// full matrix has size `total_num_points` by `total_num_points`. Each element
+/// only stores the rows corresponding to its grid points (starting at
+/// `local_first_index`), but all columns.
+template <typename ValueType>
+struct Matrix : db::SimpleTag {
+  using type = blaze::CompressedMatrix<ValueType>;
+};
+
+struct EnableDirectSolve : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::EnableDirectSolve>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& value) { return value; }
+};
+
 }  // namespace Tags
 
 namespace Actions {
 
 namespace detail {
+
+template <typename IterationIdTag, typename FieldsTag, typename FixedSourcesTag,
+          typename OperandTag, typename OperatorAppliedToOperandTag,
+          typename CoordsTag, typename ArraySectionIdTag>
+struct BuildMatrixMetavars {
+  using iteration_id_tag = IterationIdTag;
+  using fields_tag = FieldsTag;
+  using fixed_sources_tag = FixedSourcesTag;
+  using operand_tag = OperandTag;
+  using operator_applied_to_operand_tag = OperatorAppliedToOperandTag;
+  using coords_tag = CoordsTag;
+  using array_section_id_tag = ArraySectionIdTag;
+
+  using value_type = typename OperatorAppliedToOperandTag::type::value_type;
+};
 
 /// \brief The total number of grid points (size of the matrix) and the index of
 /// the first grid point in this element (the offset into the matrix
@@ -205,23 +247,25 @@ struct RegisterWithVolumeObserver {
 }  // namespace detail
 
 /// \cond
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag>
+template <typename BuildMatrixMetavars>
 struct PrepareBuildMatrix;
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag>
-struct StoreMatrixColumn;
+template <typename BuildMatrixMetavars>
+struct AssembleFullMatrix;
 /// \endcond
 
 /// Dispatch global reduction to get the size of the matrix
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag>
+template <typename BuildMatrixMetavars>
 struct CollectTotalNumPoints {
-  using simple_tags = tmpl::list<Tags::TotalNumPoints, Tags::LocalFirstIndex,
-                                 IterationIdTag, OperandTag>;
+ private:
+  using IterationIdTag = typename BuildMatrixMetavars::iteration_id_tag;
+  using OperandTag = typename BuildMatrixMetavars::operand_tag;
+  using ArraySectionIdTag = typename BuildMatrixMetavars::array_section_id_tag;
+  using value_type = typename BuildMatrixMetavars::value_type;
+
+ public:
+  using simple_tags =
+      tmpl::list<Tags::TotalNumPoints, Tags::LocalFirstIndex, IterationIdTag,
+                 OperandTag, Tags::Matrix<value_type>>;
   using compute_tags = tmpl::list<>;
   using const_global_cache_tags =
       tmpl::list<logging::Tags::Verbosity<OptionTags::BuildMatrixOptionsGroup>>;
@@ -239,10 +283,9 @@ struct CollectTotalNumPoints {
       if (not db::get<Parallel::Tags::Section<ParallelComponent,
                                               ArraySectionIdTag>>(box)
                   .has_value()) {
-        constexpr size_t last_action_index = tmpl::index_of<
-            ActionList, StoreMatrixColumn<IterationIdTag, OperandTag,
-                                          OperatorAppliedToOperandTag,
-                                          CoordsTag, ArraySectionIdTag>>::value;
+        constexpr size_t last_action_index =
+            tmpl::index_of<ActionList,
+                           AssembleFullMatrix<BuildMatrixMetavars>>::value;
         return {Parallel::AlgorithmExecution::Continue, last_action_index + 1};
       }
     }
@@ -259,9 +302,7 @@ struct CollectTotalNumPoints {
     // Collect the total number of grid points
     auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
         make_not_null(&box));
-    Parallel::contribute_to_reduction<PrepareBuildMatrix<
-        IterationIdTag, OperandTag, OperatorAppliedToOperandTag, CoordsTag,
-        ArraySectionIdTag>>(
+    Parallel::contribute_to_reduction<PrepareBuildMatrix<BuildMatrixMetavars>>(
         Parallel::ReductionData<Parallel::ReductionDatum<
             std::map<ElementId<Dim>, size_t>, funcl::Merge<>>>{
             std::map<ElementId<Dim>, size_t>{
@@ -276,10 +317,13 @@ struct CollectTotalNumPoints {
 };
 
 /// Receive the reduction and initialize the algorithm
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag>
+template <typename BuildMatrixMetavars>
 struct PrepareBuildMatrix {
+ private:
+  using IterationIdTag = typename BuildMatrixMetavars::iteration_id_tag;
+  using OperandTag = typename BuildMatrixMetavars::operand_tag;
+  using value_type = typename BuildMatrixMetavars::value_type;
+
  public:
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, size_t Dim>
@@ -298,14 +342,19 @@ struct PrepareBuildMatrix {
           "Building explicit matrix representation of size %zu x %zu.\n",
           total_num_points, total_num_points);
     }
-    db::mutate<Tags::TotalNumPoints, Tags::LocalFirstIndex, IterationIdTag>(
+    db::mutate<Tags::TotalNumPoints, Tags::LocalFirstIndex, IterationIdTag,
+               Tags::Matrix<value_type>>(
         [captured_total_num_points = total_num_points,
-         captured_local_first_index = local_first_index](
+         captured_local_first_index = local_first_index,
+         local_num_points = num_points_per_element.at(element_id)](
             const auto stored_total_num_points,
-            const auto stored_local_first_index, const auto iteration_id) {
+            const auto stored_local_first_index, const auto iteration_id,
+            const gsl::not_null<blaze::CompressedMatrix<value_type>*> matrix) {
           *stored_total_num_points = captured_total_num_points;
           *stored_local_first_index = captured_local_first_index;
           *iteration_id = 0;
+          matrix->clear();
+          matrix->resize(local_num_points, captured_total_num_points);
         },
         make_not_null(&box));
     // Proceed with algorithm
@@ -317,10 +366,13 @@ struct PrepareBuildMatrix {
 /// Set the operand to a unit vector with a '1' at the current grid point.
 /// Applying the operator to this operand gives a column of the matrix. We jump
 /// back to this until we have iterated over all grid points.
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag>
+template <typename BuildMatrixMetavars>
 struct SetUnitVector {
+ private:
+  using IterationIdTag = typename BuildMatrixMetavars::iteration_id_tag;
+  using OperandTag = typename BuildMatrixMetavars::operand_tag;
+
+ public:
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -348,10 +400,18 @@ struct SetUnitVector {
 // --- Linear operator will be applied to the unit vector here ---
 
 /// Write result out to disk, reset operand back to zero, and keep iterating
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag>
+template <typename BuildMatrixMetavars>
 struct StoreMatrixColumn {
+ private:
+  using IterationIdTag = typename BuildMatrixMetavars::iteration_id_tag;
+  using OperandTag = typename BuildMatrixMetavars::operand_tag;
+  using OperatorAppliedToOperandTag =
+      typename BuildMatrixMetavars::operator_applied_to_operand_tag;
+  using CoordsTag = typename BuildMatrixMetavars::coords_tag;
+  using ArraySectionIdTag = typename BuildMatrixMetavars::array_section_id_tag;
+  using value_type = typename BuildMatrixMetavars::value_type;
+
+ public:
   using const_global_cache_tags = tmpl::list<Tags::MatrixSubfileName>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -366,7 +426,7 @@ struct StoreMatrixColumn {
     const size_t local_first_index = get<Tags::LocalFirstIndex>(box);
     if (get<logging::Tags::Verbosity<OptionTags::BuildMatrixOptionsGroup>>(
             box) >= Verbosity::Verbose and
-        local_first_index == 0) {
+        local_first_index == 0 and (iteration_id + 1) % 100 == 0) {
       Parallel::printf("Column %zu / %zu done.\n", iteration_id + 1,
                        get<Tags::TotalNumPoints>(box));
     }
@@ -374,6 +434,18 @@ struct StoreMatrixColumn {
     // is a column of the operator matrix.
     const auto& operator_applied_to_operand =
         get<OperatorAppliedToOperandTag>(box);
+    // Store in sparse matrix
+    db::mutate<Tags::Matrix<value_type>>(
+        [&operator_applied_to_operand, &iteration_id](
+            const gsl::not_null<blaze::CompressedMatrix<value_type>*> matrix) {
+          for (size_t i = 0; i < operator_applied_to_operand.size(); ++i) {
+            const auto value = operator_applied_to_operand.data()[i];
+            if (not equal_within_roundoff(value, 0.)) {
+              matrix->insert(i, iteration_id, value);
+            }
+          }
+        },
+        make_not_null(&box));
     // Write it out to disk
     detail::observe_matrix_column<ParallelComponent>(
         iteration_id, operator_applied_to_operand, element_id,
@@ -396,22 +468,172 @@ struct StoreMatrixColumn {
         [](const auto local_iteration_id) { ++(*local_iteration_id); },
         make_not_null(&box));
     if (get<IterationIdTag>(box) < get<Tags::TotalNumPoints>(box)) {
-      constexpr size_t set_unit_vector_index = tmpl::index_of<
-          ActionList,
-          SetUnitVector<IterationIdTag, OperandTag, OperatorAppliedToOperandTag,
-                        CoordsTag, ArraySectionIdTag>>::value;
+      constexpr size_t set_unit_vector_index =
+          tmpl::index_of<ActionList, SetUnitVector<BuildMatrixMetavars>>::value;
       return {Parallel::AlgorithmExecution::Continue, set_unit_vector_index};
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
 
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag>
+template <typename Metavariables, typename BuildMatrixMetavars>
+struct BuildMatrixSingleton {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using const_global_cache_tags = tmpl::list<>;
+  using metavariables = Metavariables;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<BuildMatrixSingleton>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+
+template <typename ElementArrayComponent, typename BuildMatrixMetavars>
+struct InvertMatrix;
+
+template <typename BuildMatrixMetavars>
+struct AssembleFullMatrix {
+ private:
+  using value_type = typename BuildMatrixMetavars::value_type;
+  using ArraySectionIdTag = typename BuildMatrixMetavars::array_section_id_tag;
+  using FixedSourcesTag = typename BuildMatrixMetavars::fixed_sources_tag;
+  using ReductionType = std::pair<blaze::CompressedMatrix<value_type>,
+                                  typename FixedSourcesTag::type>;
+
+ public:
+  using const_global_cache_tags = tmpl::list<Tags::EnableDirectSolve>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    if (not db::get<Tags::EnableDirectSolve>(box)) {
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+    auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
+        make_not_null(&box));
+    Parallel::contribute_to_reduction<
+        InvertMatrix<ParallelComponent, BuildMatrixMetavars>>(
+        Parallel::ReductionData<Parallel::ReductionDatum<
+            std::map<ElementId<Dim>, ReductionType>, funcl::Merge<>>>{
+            std::map<ElementId<Dim>, ReductionType>{std::make_pair(
+                element_id, ReductionType{get<Tags::Matrix<value_type>>(box),
+                                          get<FixedSourcesTag>(box)})}},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[element_id],
+        Parallel::get_parallel_component<
+            BuildMatrixSingleton<Metavariables, BuildMatrixMetavars>>(cache),
+        make_not_null(&section));
+    // Pause the algorithm for now. The reduction will be received by the next
+    // action which is responsible for restarting the algorithm.
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+  }
+};
+
+template <typename BuildMatrixMetavars>
+struct StoreSolution;
+
+template <typename ElementArrayComponent, typename BuildMatrixMetavars>
+struct InvertMatrix {
+ private:
+  using value_type = typename BuildMatrixMetavars::value_type;
+  using FixedSourcesTag = typename BuildMatrixMetavars::fixed_sources_tag;
+  using ReductionType = std::pair<blaze::CompressedMatrix<value_type>,
+                                  typename FixedSourcesTag::type>;
+
+ public:
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex, size_t Dim>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const std::map<ElementId<Dim>, ReductionType>&
+                        matrix_and_sources_slices) {
+    const size_t total_num_points =
+        matrix_and_sources_slices.begin()->second.first.columns();
+    blaze::DynamicMatrix<value_type> matrix(total_num_points, total_num_points);
+    blaze::DynamicVector<value_type> source(total_num_points);
+    // Assemble the full matrix and source
+    size_t i = 0;
+    for (const auto& [element_id, slice] : matrix_and_sources_slices) {
+      const auto& [matrix_slice, source_slice] = slice;
+      ASSERT(matrix_slice.rows() == source_slice.size(),
+             "Matrix and source slice have different sizes.");
+      const size_t slice_length = matrix_slice.rows();
+      blaze::submatrix(matrix, i, 0, slice_length, matrix_slice.columns()) =
+          matrix_slice;
+      std::copy_n(source_slice.data(), slice_length, source.data() + i);
+      i += slice_length;
+    }
+    ASSERT(i == total_num_points, "The matrix is not fully assembled. Expected "
+                                      << total_num_points << " rows, got "
+                                      << i);
+    // Solve the equations Ax = b. Could use a more efficient solver here if
+    // needed. But anything iterative could be done with the parallel linear
+    // solver, the point here is to assemble the full matrix and invert it
+    // directly.
+    if (get<logging::Tags::Verbosity<OptionTags::BuildMatrixOptionsGroup>>(
+            box) >= Verbosity::Quiet) {
+      Parallel::printf("Inverting matrix of size %zu x %zu\n", total_num_points,
+                       total_num_points);
+    }
+    const blaze::DynamicVector<value_type> solution =
+        blaze::solve(matrix, source);
+    // Broadcast the solution to the elements
+    Parallel::simple_action<StoreSolution<BuildMatrixMetavars>>(
+        Parallel::get_parallel_component<ElementArrayComponent>(cache),
+        solution);
+  }
+};
+
+template <typename BuildMatrixMetavars>
+struct StoreSolution {
+ private:
+  using value_type = typename BuildMatrixMetavars::value_type;
+  using FieldsTag = typename BuildMatrixMetavars::fields_tag;
+
+ public:
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, size_t Dim>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ElementId<Dim>& element_id,
+                    const blaze::DynamicVector<value_type>& solution) {
+    const size_t local_first_index = db::get<Tags::LocalFirstIndex>(box);
+    db::mutate<FieldsTag>(
+        [&solution, &local_first_index](const auto fields) {
+          std::copy_n(
+              solution.begin() + static_cast<ptrdiff_t>(local_first_index),
+              fields->size(), fields->data());
+        },
+        make_not_null(&box));
+    // Proceed with algorithm
+    Parallel::get_parallel_component<ParallelComponent>(cache)[element_id]
+        .perform_algorithm(true);
+  }
+};
+
+template <typename BuildMatrixMetavars>
 struct ProjectBuildMatrix : tt::ConformsTo<::amr::protocols::Projector> {
-  using return_tags = tmpl::list<Tags::TotalNumPoints, Tags::LocalFirstIndex,
-                                 IterationIdTag, OperandTag>;
+ private:
+  using IterationIdTag = typename BuildMatrixMetavars::iteration_id_tag;
+  using OperandTag = typename BuildMatrixMetavars::operand_tag;
+  using value_type = typename BuildMatrixMetavars::value_type;
+
+ public:
+  using return_tags =
+      tmpl::list<Tags::TotalNumPoints, Tags::LocalFirstIndex, IterationIdTag,
+                 OperandTag, Tags::Matrix<value_type>>;
   using argument_tags = tmpl::list<>;
 
   template <typename... AmrData>
@@ -422,7 +644,8 @@ struct ProjectBuildMatrix : tt::ConformsTo<::amr::protocols::Projector> {
 };
 
 /*!
- * \brief Build the explicit matrix representation of the linear operator.
+ * \brief Build the explicit matrix representation of the linear operator and
+ * optionally invert it directly to solve the problem.
  *
  * This is useful for debugging and analysis only, not to actually solve the
  * elliptic problem (that should happen iteratively).
@@ -435,6 +658,10 @@ struct ProjectBuildMatrix : tt::ConformsTo<::amr::protocols::Projector> {
  * \tparam IterationIdTag Used to keep track of the iteration over all matrix
  * columns. Should be the same that's used to identify iterations in the
  * `ApplyOperatorActions`.
+ * \tparam FieldsTag The solution will be stored here (if direct solve is
+ * enabled).
+ * \tparam FixedSourcesTag The source `b` in the problem `Ax = b`. Only used
+ * if direct solve is enabled.
  * \tparam OperandTag Will be set to unit vectors, with the '1' moving through
  * all points over the course of the iteration.
  * \tparam OperatorAppliedToOperandTag Where the `ApplyOperatorActions` store
@@ -444,26 +671,32 @@ struct ProjectBuildMatrix : tt::ConformsTo<::amr::protocols::Projector> {
  * \tparam ArraySectionIdTag Can identify a subset of elements that this
  * algorithm should run over, e.g. in a multigrid setting.
  */
-template <typename IterationIdTag, typename OperandTag,
-          typename OperatorAppliedToOperandTag, typename CoordsTag,
-          typename ArraySectionIdTag = void>
+template <typename IterationIdTag, typename FieldsTag, typename FixedSourcesTag,
+          typename OperandTag, typename OperatorAppliedToOperandTag,
+          typename CoordsTag, typename ArraySectionIdTag = void>
 struct BuildMatrix {
-  template <typename ApplyOperatorActions>
-  using actions = tmpl::list<
-      CollectTotalNumPoints<IterationIdTag, OperandTag,
-                            OperatorAppliedToOperandTag, CoordsTag,
-                            ArraySectionIdTag>,
-      // PrepareBuildMatrix is called on reduction broadcast
-      SetUnitVector<IterationIdTag, OperandTag, OperatorAppliedToOperandTag,
-                    CoordsTag, ArraySectionIdTag>,
-      ApplyOperatorActions,
-      StoreMatrixColumn<IterationIdTag, OperandTag, OperatorAppliedToOperandTag,
-                        CoordsTag, ArraySectionIdTag>>;
+ private:
+  using BuildMatrixMetavars =
+      detail::BuildMatrixMetavars<IterationIdTag, FieldsTag, FixedSourcesTag,
+                                  OperandTag, OperatorAppliedToOperandTag,
+                                  CoordsTag, ArraySectionIdTag>;
 
-  using amr_projectors =
-      tmpl::list<ProjectBuildMatrix<IterationIdTag, OperandTag,
-                                    OperatorAppliedToOperandTag, CoordsTag,
-                                    ArraySectionIdTag>>;
+ public:
+  template <typename Metavariables>
+  using component_list =
+      tmpl::list<BuildMatrixSingleton<Metavariables, BuildMatrixMetavars>>;
+
+  template <typename ApplyOperatorActions>
+  using actions =
+      tmpl::list<CollectTotalNumPoints<BuildMatrixMetavars>,
+                 // PrepareBuildMatrix is called on reduction broadcast
+                 SetUnitVector<BuildMatrixMetavars>, ApplyOperatorActions,
+                 StoreMatrixColumn<BuildMatrixMetavars>,
+                 // Algorithm iterates until matrix is complete, then proceeds
+                 // below
+                 AssembleFullMatrix<BuildMatrixMetavars>>;
+
+  using amr_projectors = tmpl::list<ProjectBuildMatrix<BuildMatrixMetavars>>;
 
   /// Add to the register phase to enable observations
   using register_actions = tmpl::list<observers::Actions::RegisterWithObservers<

--- a/support/Python/CliExceptions.py
+++ b/support/Python/CliExceptions.py
@@ -26,6 +26,6 @@ class RequiredChoiceError(click.UsageError):
             for choice in self.choices:
                 table.add_row(choice)
             console.print(table)
-        choices_cols = capture.get()
+        choices_cols = capture.get().strip("\n")
 
-        return f"{self.message} Available choices:\n\n{choices_cols.strip()}"
+        return f"{self.message} Available choices:\n\n{choices_cols}"

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -127,3 +127,4 @@ PhaseChangeAndTriggers: []
 BuildMatrix:
   MatrixSubfileName: Matrix
   Verbosity: Verbose
+  EnableDirectSolve: True

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -161,3 +161,4 @@ PhaseChangeAndTriggers: []
 BuildMatrix:
   MatrixSubfileName: Matrix
   Verbosity: Verbose
+  EnableDirectSolve: True

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -185,3 +185,4 @@ ResourceInfo:
 BuildMatrix:
   MatrixSubfileName: Matrix
   Verbosity: Verbose
+  EnableDirectSolve: True

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -138,6 +138,7 @@ EventsAndTriggersAtIterations:
 BuildMatrix:
   MatrixSubfileName: Matrix
   Verbosity: Verbose
+  EnableDirectSolve: True
 
 Parallelization:
   ElementDistribution: NumGridPoints

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -24,11 +24,8 @@ OutputFileChecks:
     FileGlob: PoissonProductOfSinusoids1DReductions.h5
     SkipColumns: [1] # Skip walltime
     ExpectedData:
-      # AMR iteration 0
-      - [0, 1.21812092038592e+01]
-      - [1, 2.13145442174570e-01]
-      - [2, 5.92367126759950e-03]
-      - [3, 3.20539282132934e-08]
+      # AMR iteration 0 (solved by building matrix and direct solve)
+      - [0, 1.e-16]
       # AMR iteration 1
       - [0, 2.09447729412913e-01]
       - [1, 2.46546953964650e-03]
@@ -43,7 +40,7 @@ OutputFileChecks:
       - [3, 5.55444538380480e-05]
       - [4, 1.11628047012794e-05]
       - [5, 1.65458379564807e-08]
-    AbsoluteTolerance: 1e-8
+    AbsoluteTolerance: 1e-6
 
 ---
 
@@ -175,3 +172,4 @@ EventsAndTriggersAtIterations:
 BuildMatrix:
   MatrixSubfileName: Matrix
   Verbosity: Verbose
+  EnableDirectSolve: True

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -130,3 +130,4 @@ PhaseChangeAndTriggers: []
 BuildMatrix:
   MatrixSubfileName: Matrix
   Verbosity: Verbose
+  EnableDirectSolve: True

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -134,3 +134,4 @@ PhaseChangeAndTriggers: []
 BuildMatrix:
   MatrixSubfileName: Matrix
   Verbosity: Verbose
+  EnableDirectSolve: True

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -46,6 +46,7 @@
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/Goto.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/SetData.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
@@ -151,9 +152,10 @@ struct ElementArray {
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
-          tmpl::list<::elliptic::dg::Actions::
-                         ImposeInhomogeneousBoundaryConditionsOnSource<
-                             System, fixed_sources_tag>,
+          tmpl::list<::Actions::MutateApply<
+                         ::elliptic::dg::Actions::
+                             ImposeInhomogeneousBoundaryConditionsOnSource<
+                                 System, fixed_sources_tag>>,
                      ::Actions::Label<ApplyOperatorStart>,
                      typename dg_operator::apply_actions, IncrementTemporalId,
                      Parallel::Actions::TerminatePhase>>>;

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.cpp
@@ -38,6 +38,9 @@ namespace {
 struct IterationIdLabel {};
 
 struct TestResult {
+  using const_global_cache_tags =
+      tmpl::list<helpers_distributed::ExpectedResult>;
+
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
   static Parallel::iterable_action_return_t apply(
@@ -70,6 +73,30 @@ struct TestResult {
       }
       SPECTRE_PARALLEL_REQUIRE(row == linear_operator.rows());
     }
+    // Also check the matrix stored in the DataBox
+    const auto& matrix_slice = db::get<LinearSolver::Tags::Matrix<double>>(box);
+    for (size_t row = 0; row < num_points; ++row) {
+      for (const auto& element_data : get<2>(matrix_data[0])) {
+        const size_t col_offset = helpers_distributed::get_index(
+                                      ElementId<1>(element_data.element_name)) *
+                                  num_points;
+        for (size_t col = 0; col < num_points; ++col) {
+          const auto& row_data = get<DataVector>(
+              get<2>(matrix_data[col_offset + col])[element_index]
+                  .tensor_components.front()
+                  .data);
+          SPECTRE_PARALLEL_REQUIRE(row_data[row] ==
+                                   matrix_slice(row, col_offset + col));
+        }
+      }
+    }
+    // Check solution
+    const auto& expected_result =
+        gsl::at(get<helpers_distributed::ExpectedResult>(box), element_index);
+    const auto& result = db::get<helpers_distributed::fields_tag>(box);
+    for (size_t i = 0; i < expected_result.size(); i++) {
+      SPECTRE_PARALLEL_REQUIRE(result.data()[i] == approx(expected_result[i]));
+    }
     return {Parallel::AlgorithmExecution::Pause, std::nullopt};
   }
 };
@@ -90,6 +117,8 @@ struct Metavariables {
 
   using build_matrix = LinearSolver::Actions::BuildMatrix<
       Convergence::Tags::IterationId<IterationIdLabel>,
+      helpers_distributed::fields_tag,
+      db::add_tag_prefix<::Tags::FixedSource, helpers_distributed::fields_tag>,
       helpers_distributed::fields_tag,
       db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
                          helpers_distributed::fields_tag>,
@@ -116,10 +145,11 @@ struct Metavariables {
                  Parallel::PhaseActions<Parallel::Phase::Testing,
                                         tmpl::list<TestResult>>>>;
 
-  using component_list =
-      tmpl::list<element_array, observers::Observer<Metavariables>,
-                 observers::ObserverWriter<Metavariables>,
-                 helpers::OutputCleaner<Metavariables, false, true>>;
+  using component_list = tmpl::flatten<tmpl::list<
+      element_array, typename build_matrix::component_list<Metavariables>,
+      observers::Observer<Metavariables>,
+      observers::ObserverWriter<Metavariables>,
+      helpers::OutputCleaner<Metavariables, false, true>>>;
   using observed_reduction_data_tags = tmpl::list<>;
   static constexpr bool ignore_unrecognized_command_line_options = false;
   static constexpr std::array<Parallel::Phase, 6> default_phase_order{

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.yaml
@@ -42,13 +42,18 @@ LinearOperator:
       [-0.405284734569351,  3.24227787655481 ,  0.810569469138702],
       [-2.836993141985458,  3.242277876554809, 20.26423672846756 ]]
 
-Source:  # Unused
+Source:
   - [0., 0.7071067811865475, 1.]
   - [1., 0.7071067811865476, 0.]
+
+ExpectedResult:
+  - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
+  - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
 
 BuildMatrix:
   Verbosity: Debug
   MatrixSubfileName: Matrix
+  EnableDirectSolve: True
 
 Discretization:
   DiscontinuousGalerkin:


### PR DESCRIPTION
## Proposed changes

Allow to observe the fixed source $b$ in $Ax=b$. Also allow to build the matrix $A$ explicitly and invert it directly to solve the problem for $x=A^{-1}b$. This is mostly useful for debugging and analysis, because usually we solve the problem iteratively and in parallel.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
