### PR TITLE
Replace Basis with Topology in Block

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -14,6 +14,7 @@
 #include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -24,12 +25,12 @@ Block<VolumeDim>::Block(
         Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
     const size_t id,
     DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
-    std::string name, std::array<Spectral::Basis, VolumeDim> dg_basis)
+    std::string name, std::array<domain::Topology, VolumeDim> topologies)
     : stationary_map_(std::move(stationary_map)),
       id_(id),
       neighbors_(std::move(neighbors)),
       name_(std::move(name)),
-      dg_basis_(std::move(dg_basis)) {
+      topologies_(std::move(topologies)) {
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.
   for (const auto& direction : Direction<VolumeDim>::all_directions()) {
@@ -119,7 +120,7 @@ void Block<VolumeDim>::inject_time_dependent_map(
 
 template <size_t VolumeDim>
 void Block<VolumeDim>::pup(PUP::er& p) {
-  size_t version = 2;
+  size_t version = 3;
   p | version;
   // Remember to increment the version number when making changes to this
   // function. Retain support for unpacking data written by previous versions
@@ -137,16 +138,21 @@ void Block<VolumeDim>::pup(PUP::er& p) {
   if (version >= 1) {
     p | name_;
   }
-  if (version < 2) {
-    dg_basis_ = make_array<VolumeDim>(Spectral::Basis::Legendre);
+  if (version == 2) {
+    auto basis = make_array<VolumeDim>(Spectral::Basis::Uninitialized);
+    p | basis;
+  }
+  if (version < 3) {
+    topologies_ = make_array<VolumeDim>(domain::Topology::I1);
   } else {
-    p | dg_basis_;
+    p | topologies_;
   }
 }
 
 template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os, const Block<VolumeDim>& block) {
   os << "Block " << block.id() << " (" << block.name() << "):\n";
+  os << "Topology: " << block.topologies() << '\n';
   os << "Neighbors: " << block.neighbors() << '\n';
   os << "External boundaries: " << block.external_boundaries() << '\n';
   os << "Is time dependent: " << std::boolalpha << block.is_time_dependent();
@@ -158,8 +164,7 @@ bool operator==(const Block<VolumeDim>& lhs, const Block<VolumeDim>& rhs) {
   bool blocks_are_equal =
       (lhs.id() == rhs.id() and lhs.neighbors() == rhs.neighbors() and
        lhs.external_boundaries() == rhs.external_boundaries() and
-       lhs.name() == rhs.name() and
-       lhs.dg_basis() == rhs.dg_basis() and
+       lhs.name() == rhs.name() and lhs.topologies() == rhs.topologies() and
        lhs.is_time_dependent() == rhs.is_time_dependent() and
        lhs.has_distorted_frame() == rhs.has_distorted_frame());
 

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -17,7 +17,7 @@
 #include "Domain/Structure/BlockNeighbor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
-#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Utilities/MakeArray.hpp"
 
 /// \cond
@@ -52,15 +52,15 @@ class Block {
   /// \param neighbors info about the Blocks that share a codimension 1
   /// boundary with this Block.
   /// \param name Human-readable name for the block
-  /// \param dg_basis Spectral::Basis in each dimension used for Elements in
+  /// \param topologies domain::Topology in each dimension used for Elements in
   /// the Block when using discontinuous Galerkin methods (default value is
-  /// Spectral::Basis::Legendre)
+  /// domain::Topology::I1)
   Block(std::unique_ptr<domain::CoordinateMapBase<
             Frame::BlockLogical, Frame::Inertial, VolumeDim>>&& stationary_map,
         size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors,
         std::string name = "",
-        std::array<Spectral::Basis, VolumeDim> dg_basis =
-            make_array<VolumeDim>(Spectral::Basis::Legendre));
+        std::array<domain::Topology, VolumeDim> topologies =
+            make_array<VolumeDim>(domain::Topology::I1));
 
   Block() = default;
   ~Block() = default;
@@ -169,8 +169,8 @@ class Block {
 
   /// The basis functions used in each dimension for Elements of this Block
   /// when using discontinuous Galerkin methods
-  const std::array<Spectral::Basis, VolumeDim>& dg_basis() const {
-    return dg_basis_;
+  const std::array<domain::Topology, VolumeDim>& topologies() const {
+    return topologies_;
   }
 
   /// Serialization for Charm++
@@ -203,7 +203,7 @@ class Block {
   DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
   std::string name_;
-  std::array<Spectral::Basis, VolumeDim> dg_basis_;
+  std::array<domain::Topology, VolumeDim> topologies_;
 };
 
 template <size_t VolumeDim>

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_sources(
   OrientationMapHelpers.cpp
   SegmentId.cpp
   Side.cpp
+  Topology.cpp
   ZCurve.cpp
   )
 
@@ -52,6 +53,7 @@ spectre_target_headers(
   OrientationMapHelpers.hpp
   SegmentId.hpp
   Side.hpp
+  Topology.hpp
   TrimMap.hpp
   ZCurve.hpp
   )

--- a/src/Domain/Structure/Topology.cpp
+++ b/src/Domain/Structure/Topology.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/Topology.hpp"
+
+#include <ostream>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace domain {
+std::ostream& operator<<(std::ostream& os, const Topology topology) {
+  switch (topology) {
+    case Topology::Uninitialized:
+      return os << "Uninitialized";
+    case Topology::I1:
+      return os << "I1";
+    case Topology::S1:
+      return os << "S1";
+    case Topology::S2Colatitude:
+      return os << "S2Colatitude";
+    case Topology::S2Longitude:
+      return os << "S2Longitude";
+    case Topology::B2Radial:
+      return os << "B2Radial";
+    case Topology::B2Angular:
+      return os << "B2Angular";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("An unknown value of Topology was passed to the stream operator.");
+      // LCOV_EXCL_STOP
+  }
+}
+}  // namespace domain

--- a/src/Domain/Structure/Topology.hpp
+++ b/src/Domain/Structure/Topology.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdint>
+#include <iosfwd>
+
+namespace domain {
+
+/// \brief  The topology of a Block or Element in a particular dimension
+///
+/// \details The Topology is used to determine the geometry of the Block or
+/// Element, which can be used to determine:
+/// - Whether there is an interface (with a neighbor or external boundary) in a
+/// given direction
+/// - The block (element) logical coordinate bounds
+/// - The appropriate Basis and Quadrature for a Mesh on an Element
+/// - Whether or not h-refinement is allowed in the given dimension
+/// - Whether or not the hybrid DG-Subcell scheme can be used
+///
+/// \note Choose I1 to represent an open interval \f$[-1, 1]\f$
+///
+/// \note Choose S1 to represent a periodic interval \f$[0, 2 \pi)\f$
+///
+/// \note In consecutive dimensions, choose S2Colatitude and S2Longitude to
+/// represent the surface of a sphere
+///
+/// \note In consecutive dimensions, choose B2Radial and B2Angular to represent
+/// a disk (including the center) or cross-section of a cylinder
+///
+/// \note Currently h-refinement can only be done in dimensions with
+/// Topology::I1
+///
+/// \note Currently the hybrid DG-Subcell scheme can be used only in Elements
+/// for which all dimensions have Topology::I1
+enum class Topology : uint8_t {
+  Uninitialized = 0,
+  I1 = 1,
+  S1 = 2,
+  S2Colatitude = 3,
+  S2Longitude = 4,
+  B2Radial = 5,
+  B2Angular = 6
+};
+
+/// Output operator for a Topology.
+std::ostream& operator<<(std::ostream& os, Topology topology);
+}  // namespace domain

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Test_OrientationMapHelpers.cpp
   Test_SegmentId.cpp
   Test_Side.cpp
+  Test_Topology.cpp
   Test_TrimMap.cpp
   Test_ZCurve.cpp
   )

--- a/tests/Unit/Domain/Structure/Test_Topology.cpp
+++ b/tests/Unit/Domain/Structure/Test_Topology.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Domain/Structure/Topology.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Topology", "[Domain][Unit]") {
+  CHECK(get_output(domain::Topology::Uninitialized) == "Uninitialized");
+  CHECK(get_output(domain::Topology::I1) == "I1");
+  CHECK(get_output(domain::Topology::S1) == "S1");
+  CHECK(get_output(domain::Topology::S2Colatitude) == "S2Colatitude");
+  CHECK(get_output(domain::Topology::S2Longitude) == "S2Longitude");
+  CHECK(get_output(domain::Topology::B2Radial) == "B2Radial");
+  CHECK(get_output(domain::Topology::B2Angular) == "B2Angular");
+}

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -55,7 +55,7 @@ void test_block_time_independent() {
     // Test id:
     CHECK((block.id()) == 7);
     CHECK(block.name() == "Identity");
-    CHECK(block.dg_basis() == make_array<Dim>(Spectral::Basis::Legendre));
+    CHECK(block.topologies() == make_array<Dim>(domain::Topology::I1));
 
     // Test that the block's coordinate_map is Identity:
     const auto& map = block.stationary_map();
@@ -139,7 +139,7 @@ void test_block_time_dependent() {
 
     // Test id:
     CHECK((block.id()) == 7);
-    CHECK(block.dg_basis() == make_array<Dim>(Spectral::Basis::Legendre));
+    CHECK(block.topologies() == make_array<Dim>(domain::Topology::I1));
 
     // Test that the block's coordinate_map is Identity:
     const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
@@ -252,7 +252,7 @@ void test_block_time_dependent_distorted() {
 
     // Test id:
     CHECK((block.id()) == 7);
-    CHECK(block.dg_basis() == make_array<Dim>(Spectral::Basis::Legendre));
+    CHECK(block.topologies() == make_array<Dim>(domain::Topology::I1));
 
     // Test that the block's coordinate_map is Identity:
     const auto& grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map();
@@ -332,11 +332,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   // Test id:
   CHECK((block.id()) == 3);
   CHECK(block.name() == "Identity");
-  CHECK(block.dg_basis() == make_array<2>(Spectral::Basis::Legendre));
+  CHECK(block.topologies() == make_array<2>(domain::Topology::I1));
 
   // Test output:
   CHECK(get_output(block) ==
         "Block 3 (Identity):\n"
+        "Topology: (I1,I1)\n"
         "Neighbors: "
         "([+0,Id = 1; orientation = (+0, +1)],"
         "[-1,Id = 2; orientation = (-0, +1)])\n"
@@ -358,11 +359,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
     CHECK(block != rhs);
   }
   {
-    const Block<2> rhs(
-        identity_map.get_clone(), 3, neighbors, "Identity",
-        {{Spectral::Basis::Chebyshev, Spectral::Basis::Legendre}});
-    CHECK(rhs.dg_basis() ==
-          std::array{Spectral::Basis::Chebyshev, Spectral::Basis::Legendre});
+    const Block<2> rhs(identity_map.get_clone(), 3, neighbors, "Identity",
+                       {{domain::Topology::S1, domain::Topology::I1}});
+    CHECK(rhs.topologies() ==
+          std::array{domain::Topology::S1, domain::Topology::I1});
     CHECK(block != rhs);
   }
 }


### PR DESCRIPTION
## Proposed changes

- Add a new enum Topology to represent the geometry of a Block
- Use Topology instead of a Basis in a Block

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
