### PR TITLE
Send more quantities to size control for state 3

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -87,6 +87,28 @@ Size<DerivOrder, Horizon>::Size(
 }
 
 template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+Size<DerivOrder, Horizon>::Size(const Size<DerivOrder, Horizon>& rhs) {
+  *this = rhs;
+}
+
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+Size<DerivOrder, Horizon>& Size<DerivOrder, Horizon>::operator=(
+    const Size<DerivOrder, Horizon>& rhs) {
+  smoother_tuner_ = rhs.smoother_tuner_;
+  horizon_coef_averager_ = rhs.horizon_coef_averager_;
+  info_ = rhs.info_;
+  char_speed_predictor_ = rhs.char_speed_predictor_;
+  comoving_char_speed_predictor_ = rhs.comoving_char_speed_predictor_;
+  delta_radius_predictor_ = rhs.delta_radius_predictor_;
+  state_history_ = rhs.state_history_;
+  legend_ = rhs.legend_;
+  subfile_name_ = rhs.subfile_name_;
+  delta_r_drift_outward_options_ = rhs.delta_r_drift_outward_options_;
+
+  return *this;
+}
+
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
 std::optional<double> Size<DerivOrder, Horizon>::get_suggested_timescale()
     const {
   return info_.suggested_time_scale;

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "ControlSystem/Averager.hpp"
+#include "ControlSystem/ControlErrors/Size/ComovingCharSpeedDerivative.hpp"
 #include "ControlSystem/ControlErrors/Size/Error.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
@@ -18,6 +19,7 @@
 #include "ControlSystem/Tags/QueueTags.hpp"
 #include "ControlSystem/Tags/SystemTags.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -32,6 +34,8 @@
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Printf/Printf.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -240,6 +244,11 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
       "disk."};
 
   Size() = default;
+  Size(const Size& rhs);
+  Size& operator=(const Size& rhs);
+  Size(Size&& /*rhs*/) = default;
+  Size& operator=(Size&& /*rhs*/) = default;
+  virtual ~Size() = default;
 
   /*!
    * \brief Initializes the `intrp::ZeroCrossingPredictor`s and the horizon
@@ -345,6 +354,35 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
         inverse_spatial_metric_on_excision = tuples::get<
             QueueTags::InverseSpatialMetricOnExcisionSurface<Frame::Distorted>>(
             excision_quantities);
+    const tnsr::Ijj<DataVector, 3, Frame::Distorted>& spatial_christoffel =
+        tuples::get<QueueTags::SpatialChristoffelSecondKind<Frame::Distorted>>(
+            excision_quantities);
+    const tnsr::i<DataVector, 3, Frame::Distorted>& deriv_lapse =
+        tuples::get<QueueTags::DerivLapse<Frame::Distorted>>(
+            excision_quantities);
+    const tnsr::iJ<DataVector, 3, Frame::Distorted>& deriv_shift =
+        tuples::get<QueueTags::DerivShift<Frame::Distorted>>(
+            excision_quantities);
+    const ::InverseJacobian<DataVector, 3, Frame::Grid,
+                            Frame::Distorted>& inv_jac_grid_to_distorted =
+        tuples::get<QueueTags::InverseJacobian<Frame::Grid, Frame::Distorted>>(
+            excision_quantities);
+
+    db::mutate<gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Distorted>,
+               ylm::Tags::Strahlkorper<Frame::Distorted>>(
+        [&inverse_spatial_metric_on_excision, &excision_surface](
+            const gsl::not_null<tnsr::II<DataVector, 3, Frame::Distorted>*>
+                inv_spatial_metric,
+            const gsl::not_null<ylm::Strahlkorper<Frame::Distorted>*>
+                strahlkorper) {
+          for (size_t i = 0; i < inv_spatial_metric->size(); i++) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            (*inv_spatial_metric)[i].set_data_ref(const_cast<DataVector*>(
+                &inverse_spatial_metric_on_excision[i]));
+          }
+          *strahlkorper = excision_surface;
+        },
+        make_not_null(&char_speed_box_));
 
     const double Y00 = 0.25 * M_2_SQRTPI;
 
@@ -418,6 +456,33 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
                                         delta_r_drift_outward_options_.value()
                                             .outward_drift_timescale)
             : std::nullopt;
+
+    // Currently we don't do anything with the derivative of the comoving char
+    // speed. Eventually, we will pass it to the computation of the control
+    // error below
+    Scalar<DataVector> deriv_comoving_char_speed{};
+    {
+      const tnsr::i<DataVector, 3, Frame::Distorted>& excision_normal_one_form =
+          db::get<ylm::Tags::NormalOneForm<Frame::Distorted>>(char_speed_box_);
+      const DataVector& one_over_excision_normal_one_form_norm_dv =
+          db::get<ylm::Tags::OneOverOneFormMagnitude>(char_speed_box_);
+      Scalar<DataVector> one_over_excision_normal_one_form_norm{};
+      get(one_over_excision_normal_one_form_norm)
+          // NOLINTNEXTLINE
+          .set_data_ref(const_cast<DataVector*>(
+              &one_over_excision_normal_one_form_norm_dv));
+
+      const tnsr::i<DataVector, 3, Frame::Distorted>& rhat =
+          db::get<ylm::Tags::Rhat<Frame::Distorted>>(char_speed_box_);
+
+      size::comoving_char_speed_derivative(
+          make_not_null(&deriv_comoving_char_speed), lambda_00, dt_lambda_00,
+          horizon_00, dt_horizon_00, grid_frame_excision_sphere_radius, rhat,
+          excision_normal_one_form, one_over_excision_normal_one_form_norm,
+          shifty_quantity, inverse_spatial_metric_on_excision,
+          spatial_christoffel, deriv_lapse, deriv_shift,
+          inv_jac_grid_to_distorted);
+    }
 
     info_.damping_time = min(tuner.current_timescale());
 
@@ -494,6 +559,18 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
   std::vector<std::string> legend_{};
   std::string subfile_name_{};
   std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options_{};
+  db::compute_databox_type<tmpl::list<
+      gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Distorted>,
+      ylm::Tags::Strahlkorper<Frame::Distorted>,
+      ylm::Tags::ThetaPhiCompute<Frame::Distorted>,
+      ylm::Tags::InvJacobianCompute<Frame::Distorted>,
+      ylm::Tags::RadiusCompute<Frame::Distorted>,
+      ylm::Tags::RhatCompute<Frame::Distorted>,
+      ylm::Tags::DxRadiusCompute<Frame::Distorted>,
+      ylm::Tags::NormalOneFormCompute<Frame::Distorted>,
+      ylm::Tags::OneOverOneFormMagnitudeCompute<DataVector, 3,
+                                                Frame::Distorted>>>
+      char_speed_box_{};
 };
 }  // namespace ControlErrors
 }  // namespace control_system

--- a/src/ControlSystem/ControlErrors/Size/ComovingCharSpeedDerivative.cpp
+++ b/src/ControlSystem/ControlErrors/Size/ComovingCharSpeedDerivative.cpp
@@ -21,7 +21,7 @@ void comoving_char_speed_derivative(
     const double dt_horizon_00, const double grid_frame_excision_sphere_radius,
     const tnsr::i<DataVector, 3, Frame::Distorted>& excision_rhat,
     const tnsr::i<DataVector, 3, Frame::Distorted>& excision_normal_one_form,
-    const Scalar<DataVector>& excision_normal_one_form_norm,
+    const Scalar<DataVector>& one_over_excision_normal_one_form_norm,
     const tnsr::I<DataVector, 3, Frame::Distorted>&
         distorted_components_of_grid_shift,
     const tnsr::II<DataVector, 3, Frame::Distorted>&
@@ -91,7 +91,7 @@ void comoving_char_speed_derivative(
   //   Third, scale by norm^3 so that result contains
   //   1/a (n^k n_j InvJac^j_k / r_EB + n_p n_j gamma^{pk} xi^i Gamma^j_{ki}),
   //   which is (almost) the last two terms of d/dlambda00(n_hati).
-  get(*result) /= cube(get(excision_normal_one_form_norm));
+  get(*result) *= cube(get(one_over_excision_normal_one_form_norm));
 
   // Set deriv_normal_one_form to the first two terms of d/dlambda00 (n_hati).
   // Possible memory optimization: excision_normal_vector isn't used anymore,
@@ -111,9 +111,9 @@ void comoving_char_speed_derivative(
     for (size_t j = 0; j < 3; ++j) {
       deriv_normal_one_form.get(i) +=
           excision_normal_one_form.get(j) *
-          inverse_jacobian_grid_to_distorted.get(j, i) * Y00 /
-          (grid_frame_excision_sphere_radius *
-           get(excision_normal_one_form_norm));
+          inverse_jacobian_grid_to_distorted.get(j, i) * Y00 *
+          get(one_over_excision_normal_one_form_norm) /
+          grid_frame_excision_sphere_radius;
     }
   }
 
@@ -131,7 +131,7 @@ void comoving_char_speed_derivative(
                                     deriv_of_distorted_shift(ti::j, ti::I));
 
   // Put in the norm factor.
-  get(*result) /= get(excision_normal_one_form_norm);
+  get(*result) *= get(one_over_excision_normal_one_form_norm);
 
   // Add the dlapse term (without the Y00 factor).
   tenex::update<>(

--- a/src/ControlSystem/ControlErrors/Size/ComovingCharSpeedDerivative.hpp
+++ b/src/ControlSystem/ControlErrors/Size/ComovingCharSpeedDerivative.hpp
@@ -36,7 +36,8 @@ namespace control_system::size {
  *        spacetime tensor: it is raised/lowered with \f$\delta_{ij}\f$
  * \param excision_normal_one_form the unnormalized one-form
  *        \f$\hat{s}_\hat{i}\f$
- * \param excision_normal_one_form_norm the norm of the one-form \f$a\f$
+ * \param one_over_excision_normal_one_form_norm one over the norm of the
+ *        one-form \f$a\f$
  * \param distorted_components_of_grid_shift the quantity
  *        \f$\beta^i \frac{\partial x^\hat{i}}{\partial x_i}\f$
  *        evaluated on the excision boundary.  This is not the shift in
@@ -404,7 +405,7 @@ void comoving_char_speed_derivative(
     double grid_frame_excision_sphere_radius,
     const tnsr::i<DataVector, 3, Frame::Distorted>& excision_rhat,
     const tnsr::i<DataVector, 3, Frame::Distorted>& excision_normal_one_form,
-    const Scalar<DataVector>& excision_normal_one_form_norm,
+    const Scalar<DataVector>& one_over_excision_normal_one_form_norm,
     const tnsr::I<DataVector, 3, Frame::Distorted>&
         distorted_components_of_grid_shift,
     const tnsr::II<DataVector, 3, Frame::Distorted>&

--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -10,8 +10,10 @@
 #include "ControlSystem/Protocols/Measurement.hpp"
 #include "ControlSystem/Protocols/Submeasurement.hpp"
 #include "ControlSystem/RunCallbacks.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Domain/TagsTimeDependent.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp"
@@ -23,6 +25,7 @@
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Tags/TimeAndPrevious.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -73,11 +76,18 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
 
       using temporal_id = ::Tags::TimeAndPrevious<1>;
 
-      using vars_to_interpolate_to_target =
-          tmpl::list<gr::Tags::Lapse<DataVector>,
-                     gr::Tags::Shift<DataVector, 3, Frame::Distorted>,
-                     gr::Tags::ShiftyQuantity<DataVector, 3, Frame::Distorted>,
-                     gr::Tags::SpatialMetric<DataVector, 3, Frame::Distorted>>;
+      using vars_to_interpolate_to_target = tmpl::list<
+          gr::Tags::Lapse<DataVector>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Distorted>,
+          gr::Tags::Shift<DataVector, 3, Frame::Distorted>,
+          ::Tags::deriv<gr::Tags::Shift<DataVector, 3, Frame::Distorted>,
+                        tmpl::size_t<3>, Frame::Distorted>,
+          gr::Tags::ShiftyQuantity<DataVector, 3, Frame::Distorted>,
+          gr::Tags::SpatialMetric<DataVector, 3, Frame::Distorted>,
+          ::domain::Tags::InverseJacobian<3, Frame::Grid, Frame::Distorted>,
+          gr::Tags::SpatialChristoffelSecondKind<DataVector, 3,
+                                                 Frame::Distorted>>;
       using compute_vars_to_interpolate =
           ah::ComputeExcisionBoundaryVolumeQuantities;
       using compute_items_on_source =

--- a/src/ControlSystem/Tags/QueueTags.hpp
+++ b/src/ControlSystem/Tags/QueueTags.hpp
@@ -6,6 +6,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
@@ -88,6 +89,34 @@ struct InverseSpatialMetricOnExcisionSurface {
   using type = tnsr::II<DataVector, 3, Frame>;
 };
 
+/// \ingroup ControlSystemGroup
+/// Holds the spatial christoffel symbol on the `ExcisionSurface`
+template <typename Frame>
+struct SpatialChristoffelSecondKind {
+  using type = tnsr::Ijj<DataVector, 3, Frame>;
+};
+
+/// \ingroup ControlSystemGroup
+/// Holds the spatial derivative of the lapse on the `ExcisionSurface`
+template <typename Frame>
+struct DerivLapse {
+  using type = tnsr::i<DataVector, 3, Frame>;
+};
+
+/// \ingroup ControlSystemGroup
+/// Holds the spatial derivative of the `Frame` shift on the `ExcisionSurface`
+template <typename Frame>
+struct DerivShift {
+  using type = tnsr::iJ<DataVector, 3, Frame>;
+};
+
+/// \ingroup ControlSystemGroup
+/// Holds the inverse jacobian between frames on the `ExcisionSurface`
+template <typename SrcFrame, typename DestFrame>
+struct InverseJacobian {
+  using type = ::InverseJacobian<DataVector, 3, SrcFrame, DestFrame>;
+};
+
 /*!
  * \ingroup ControlSystemGroup
  * \brief A queue tag that holds a TaggedTuple of all quantities needed for the
@@ -100,14 +129,19 @@ struct InverseSpatialMetricOnExcisionSurface {
  * - `control_system::QueueTags::ShiftyQuantity`
  * - `control_system::QueueTags::SpatialMetricOnExcisionSurface`
  * - `control_system::QueueTags::InverseSpatialMetricOnExcisionSurface`
+ * - `control_system::QueueTags::SpatialChristoffelSecondKind`
+ * - `control_system::QueueTags::DerivLapse`
+ * - `control_system::QueueTags::DerivShift`
+ * - `control_system::QueueTags::InverseJacobian<::Frame::Grid, Frame>`
  */
 template <typename Frame>
 struct SizeExcisionQuantities {
-  using type =
-      tuples::TaggedTuple<ExcisionSurface<Frame>, LapseOnExcisionSurface,
-                          ShiftyQuantity<Frame>,
-                          SpatialMetricOnExcisionSurface<Frame>,
-                          InverseSpatialMetricOnExcisionSurface<Frame>>;
+  using type = tuples::TaggedTuple<
+      ExcisionSurface<Frame>, LapseOnExcisionSurface, ShiftyQuantity<Frame>,
+      SpatialMetricOnExcisionSurface<Frame>,
+      InverseSpatialMetricOnExcisionSurface<Frame>,
+      SpatialChristoffelSecondKind<Frame>, DerivLapse<Frame>, DerivShift<Frame>,
+      InverseJacobian<::Frame::Grid, Frame>>;
 };
 
 /*!

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -5,7 +5,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
@@ -73,6 +75,8 @@ struct ComputeExcisionBoundaryVolumeQuantities
           jac_logical_to_target,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
           invjac_logical_to_target,
+      const InverseJacobian<DataVector, 3, Frame::Grid, TargetFrame>&
+          invjac_grid_to_target,
       const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity,
       const tnsr::I<DataVector, 3, TargetFrame>&
           grid_to_target_frame_mesh_velocity);
@@ -87,12 +91,17 @@ struct ComputeExcisionBoundaryVolumeQuantities
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>>;
 
   template <typename TargetFrame>
-  using allowed_dest_tags_target_frame =
-      tmpl::list<gr::Tags::SpatialMetric<DataVector, 3, TargetFrame>,
-                 gr::Tags::SpacetimeMetric<DataVector, 3, TargetFrame>,
-                 gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<DataVector, 3, TargetFrame>,
-                 gr::Tags::ShiftyQuantity<DataVector, 3, TargetFrame>>;
+  using allowed_dest_tags_target_frame = tmpl::list<
+      gr::Tags::SpatialMetric<DataVector, 3, TargetFrame>,
+      gr::Tags::SpacetimeMetric<DataVector, 3, TargetFrame>,
+      gr::Tags::Lapse<DataVector>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>, TargetFrame>,
+      gr::Tags::Shift<DataVector, 3, TargetFrame>,
+      ::Tags::deriv<gr::Tags::Shift<DataVector, 3, TargetFrame>,
+                    tmpl::size_t<3>, TargetFrame>,
+      gr::Tags::ShiftyQuantity<DataVector, 3, TargetFrame>,
+      ::domain::Tags::InverseJacobian<3, Frame::Grid, TargetFrame>,
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, TargetFrame>>;
 
   template <typename TargetFrame>
   using allowed_dest_tags = tmpl::remove_duplicates<

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.tpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.tpp
@@ -23,7 +23,11 @@
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
@@ -69,13 +73,26 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   using spatial_metric_tag = gr::Tags::SpatialMetric<DataVector, 3>;
   using inv_spatial_metric_tag = gr::Tags::InverseSpatialMetric<DataVector, 3>;
   using lapse_tag = gr::Tags::Lapse<DataVector>;
+  using deriv_lapse_tag =
+      ::Tags::deriv<lapse_tag, tmpl::size_t<3>, Frame::Inertial>;
   using shift_tag = gr::Tags::Shift<DataVector, 3>;
+  using deriv_shift_tag =
+      ::Tags::deriv<shift_tag, tmpl::size_t<3>, Frame::Inertial>;
+  using spatial_christoffel_tag =
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, 3>;
+  // Needed for an intermediate computation
+  using spacetime_normal_vector_tag =
+      gr::Tags::SpacetimeNormalVector<DataVector, 3>;
+  using inv_spacetime_metric_tag =
+      gr::Tags::InverseSpacetimeMetric<DataVector, 3>;
 
   // All of the temporary tags, including some that may be repeated
   // in the target_variables (for now).
   using full_temp_tags_list =
       tmpl::list<spacetime_metric_tag, spatial_metric_tag,
-                 inv_spatial_metric_tag, lapse_tag, shift_tag>;
+                 inv_spatial_metric_tag, lapse_tag, deriv_lapse_tag, shift_tag,
+                 deriv_shift_tag, spatial_christoffel_tag,
+                 spacetime_normal_vector_tag, inv_spacetime_metric_tag>;
 
   // temp tags without variables that are already in DestTagList.
   using temp_tags_list =
@@ -84,17 +101,28 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
 
   // These may or may not be temporaries
   auto& lapse = *(get<lapse_tag>(target_vars, make_not_null(&buffer)));
+  auto& deriv_lapse =
+      *(get<deriv_lapse_tag>(target_vars, make_not_null(&buffer)));
   auto& shift = *(get<shift_tag>(target_vars, make_not_null(&buffer)));
+  auto& deriv_shift =
+      *(get<deriv_shift_tag>(target_vars, make_not_null(&buffer)));
   auto& spatial_metric =
       *(get<spatial_metric_tag>(target_vars, make_not_null(&buffer)));
   auto& spacetime_metric =
       *(get<spacetime_metric_tag>(target_vars, make_not_null(&buffer)));
   auto& inv_spatial_metric =
       *(get<inv_spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& spacetime_normal_vector =
+      *(get<spacetime_normal_vector_tag>(target_vars, make_not_null(&buffer)));
+  auto& inv_spacetime_metric =
+      *(get<inv_spacetime_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& spatial_christoffel =
+      *(get<spatial_christoffel_tag>(target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
   const auto& src_spacetime_metric =
       get<gr::Tags::SpacetimeMetric<DataVector, 3>>(src_vars);
+  const auto& phi = get<gh::Tags::Phi<DataVector, 3>>(src_vars);
   spacetime_metric = src_spacetime_metric;
 
   gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
@@ -103,13 +131,24 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
                           make_not_null(&inv_spatial_metric), spatial_metric);
   gr::shift(make_not_null(&shift), spacetime_metric, inv_spatial_metric);
   gr::lapse(make_not_null(&lapse), shift, spacetime_metric);
+  gr::spacetime_normal_vector(make_not_null(&spacetime_normal_vector), lapse,
+                              shift);
+  gh::spatial_deriv_of_lapse(make_not_null(&deriv_lapse), lapse,
+                             spacetime_normal_vector, phi);
+  gr::inverse_spacetime_metric(make_not_null(&inv_spacetime_metric), lapse,
+                               shift, inv_spatial_metric);
+  gh::spatial_deriv_of_shift(make_not_null(&deriv_shift), lapse,
+                             inv_spacetime_metric, spacetime_normal_vector,
+                             phi);
+  gh::christoffel_second_kind(make_not_null(&spatial_christoffel), phi,
+                              inv_spatial_metric);
 }
 
 /// Dual frame case
 template <typename SrcTagList, typename DestTagList, typename TargetFrame>
 void ComputeExcisionBoundaryVolumeQuantities::apply(
     const gsl::not_null<Variables<DestTagList>*> target_vars,
-    const Variables<SrcTagList>& src_vars, const Mesh<3>& /*mesh*/,
+    const Variables<SrcTagList>& src_vars, const Mesh<3>& mesh,
     const Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
         jac_target_to_inertial,
     const InverseJacobian<DataVector, 3, TargetFrame, Frame::Inertial>&
@@ -117,7 +156,9 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
     const Jacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
     /*jac_logical_to_target*/,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
-    /*invjac_logical_to_target*/,
+        invjac_logical_to_target,
+    const InverseJacobian<DataVector, 3, Frame::Grid, TargetFrame>&
+        invjac_grid_to_target,
     const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity,
     const tnsr::I<DataVector, 3, TargetFrame>&
         grid_to_target_frame_mesh_velocity) {
@@ -154,22 +195,36 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   using inv_spatial_metric_tag =
       gr::Tags::InverseSpatialMetric<DataVector, 3, TargetFrame>;
   using lapse_tag = gr::Tags::Lapse<DataVector>;
+  using deriv_lapse_tag =
+      ::Tags::deriv<lapse_tag, tmpl::size_t<3>, TargetFrame>;
   using shift_tag = gr::Tags::Shift<DataVector, 3, TargetFrame>;
+  // Note that this is NOT the same as the shift quantity
+  using deriv_shift_tag =
+      ::Tags::deriv<shift_tag, tmpl::size_t<3>, TargetFrame>;
   using inertial_shift_tag = gr::Tags::Shift<DataVector, 3>;
   using shifty_quantity_tag =
       gr::Tags::ShiftyQuantity<DataVector, 3, TargetFrame>;
+  using spatial_christoffel_tag =
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, TargetFrame>;
 
   // Additional temporary tags used for multiple frames
   using inertial_spatial_metric_tag = gr::Tags::SpatialMetric<DataVector, 3>;
   using inertial_inv_spatial_metric_tag =
       gr::Tags::InverseSpatialMetric<DataVector, 3>;
+  using deriv_spatial_metric_tag =
+      ::Tags::deriv<gr::Tags::SpatialMetric<DataVector, 3, TargetFrame>,
+                    tmpl::size_t<3>, TargetFrame>;
+  using target_phi_tag = gh::Tags::Phi<DataVector, 3, TargetFrame>;
 
   // All of the temporary tags, including some that may be repeated
   // in the target_variables (for now).
   using full_temp_tags_list =
       tmpl::list<spatial_metric_tag, inv_spatial_metric_tag, lapse_tag,
-                 shift_tag, inertial_shift_tag, shifty_quantity_tag,
-                 inertial_spatial_metric_tag, inertial_inv_spatial_metric_tag>;
+                 deriv_lapse_tag, shift_tag, deriv_shift_tag,
+                 inertial_shift_tag, shifty_quantity_tag,
+                 spatial_christoffel_tag, inertial_spatial_metric_tag,
+                 inertial_inv_spatial_metric_tag, deriv_spatial_metric_tag,
+                 target_phi_tag>;
 
   // temp tags without variables that are already in DestTagList.
   using temp_tags_list =
@@ -179,11 +234,17 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   // These may or may not be temporaries, depending on if they are asked for
   // in target_vars.
   auto& lapse = *(get<lapse_tag>(target_vars, make_not_null(&buffer)));
+  auto& deriv_lapse =
+      *(get<deriv_lapse_tag>(target_vars, make_not_null(&buffer)));
   auto& shift = *(get<shift_tag>(target_vars, make_not_null(&buffer)));
+  auto& deriv_shift =
+      *(get<deriv_shift_tag>(target_vars, make_not_null(&buffer)));
   auto& inertial_shift =
       *(get<inertial_shift_tag>(target_vars, make_not_null(&buffer)));
   auto& shifty_quantity =
       *(get<shifty_quantity_tag>(target_vars, make_not_null(&buffer)));
+  auto& spatial_christoffel =
+      *(get<spatial_christoffel_tag>(target_vars, make_not_null(&buffer)));
   auto& inertial_spatial_metric =
       *(get<inertial_spatial_metric_tag>(target_vars, make_not_null(&buffer)));
   auto& inertial_inv_spatial_metric = *(get<inertial_inv_spatial_metric_tag>(
@@ -192,8 +253,18 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
       *(get<spatial_metric_tag>(target_vars, make_not_null(&buffer)));
   auto& inv_spatial_metric =
       *(get<inv_spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& deriv_spatial_metric =
+      *(get<deriv_spatial_metric_tag>(target_vars, make_not_null(&buffer)));
+  auto& target_phi =
+      *(get<target_phi_tag>(target_vars, make_not_null(&buffer)));
 
   // Actual computation starts here
+
+  using invjac_grid_to_target_tag =
+      domain::Tags::InverseJacobian<3, Frame::Grid, TargetFrame>;
+  if constexpr (tmpl::list_contains_v<DestTagList, invjac_grid_to_target_tag>) {
+    get<invjac_grid_to_target_tag>(*target_vars) = invjac_grid_to_target;
+  }
 
   gr::spatial_metric(make_not_null(&inertial_spatial_metric), spacetime_metric);
   // put determinant of 3-metric temporarily into lapse to save memory.
@@ -218,23 +289,33 @@ void ComputeExcisionBoundaryVolumeQuantities::apply(
   // We assume the lapse does note transform between the target and
   // inertial frames.
   gr::lapse(make_not_null(&lapse), inertial_shift, spacetime_metric);
+  partial_derivative(make_not_null(&deriv_lapse), lapse, mesh,
+                     invjac_logical_to_target);
 
   // Transform the shift
   const size_t VolumeDim = 3;
-  auto dest = &shift;
-  const auto& src = inertial_shift;
   for (size_t i = 0; i < VolumeDim; ++i) {
-    dest->get(i) = invjac_target_to_inertial.get(i, 0) *
-                   (src.get(0) + inertial_mesh_velocity.get(0));
+    shift.get(i) = invjac_target_to_inertial.get(i, 0) *
+                   (inertial_shift.get(0) + inertial_mesh_velocity.get(0));
     for (size_t j = 1; j < VolumeDim; ++j) {
-      dest->get(i) += invjac_target_to_inertial.get(i, j) *
-                      (src.get(j) + inertial_mesh_velocity.get(j));
+      shift.get(i) += invjac_target_to_inertial.get(i, j) *
+                      (inertial_shift.get(j) + inertial_mesh_velocity.get(j));
     }
   }
+  // Again, this is NOT the same as the shifty quantity
+  partial_derivative(make_not_null(&deriv_shift), shift, mesh,
+                     invjac_logical_to_target);
 
   tenex::evaluate<ti::I>(
       make_not_null(&shifty_quantity),
       shift(ti::I) + grid_to_target_frame_mesh_velocity(ti::I));
+
+  partial_derivative(make_not_null(&deriv_spatial_metric), spatial_metric, mesh,
+                     invjac_logical_to_target);
+  gh::phi(make_not_null(&target_phi), lapse, deriv_lapse, shift, deriv_shift,
+          spatial_metric, deriv_spatial_metric);
+  gh::christoffel_second_kind(make_not_null(&spatial_christoffel), target_phi,
+                              inv_spatial_metric);
 }
 
 }  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp
@@ -73,6 +73,8 @@ struct ComputeHorizonVolumeQuantities
           jac_logical_to_target,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
           invjac_logical_to_target,
+      const InverseJacobian<DataVector, 3, Frame::Grid, TargetFrame>&
+          invjac_grid_to_target,
       const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_mesh_velocity,
       const tnsr::I<DataVector, 3, TargetFrame>&
           grid_to_target_frame_mesh_velocity);

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp
@@ -126,14 +126,14 @@ void ComputeHorizonVolumeQuantities::apply(
     static_assert(
         tmpl::list_contains_v<SrcTagList,
                               ::Tags::deriv<gh::Tags::Phi<DataVector, 3>,
-                                          tmpl::size_t<3>, Frame::Inertial>>,
+                                            tmpl::size_t<3>, Frame::Inertial>>,
         "If Ricci is requested, SrcTags must include deriv of Phi");
     auto& spatial_ricci =
         get<gr::Tags::SpatialRicci<DataVector, 3>>(*target_vars);
     gh::spatial_ricci_tensor(
         make_not_null(&spatial_ricci), phi,
         get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
-                        Frame::Inertial>>(src_vars),
+                          Frame::Inertial>>(src_vars),
         inv_metric);
   }
 }
@@ -151,6 +151,8 @@ void ComputeHorizonVolumeQuantities::apply(
     /*jac_logical_to_target*/,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>&
         invjac_logical_to_target,
+    const InverseJacobian<DataVector, 3, Frame::Grid, TargetFrame>&
+    /*invjac_grid_to_target*/,
     const tnsr::I<DataVector, 3, Frame::Inertial>& /*inertial_mesh_velocity*/,
     const tnsr::I<DataVector, 3, TargetFrame>&
     /*grid_to_target_frame_mesh_velocity*/) {
@@ -300,7 +302,7 @@ void ComputeHorizonVolumeQuantities::apply(
     static_assert(
         tmpl::list_contains_v<SrcTagList,
                               ::Tags::deriv<gh::Tags::Phi<DataVector, 3>,
-                                          tmpl::size_t<3>, Frame::Inertial>>,
+                                            tmpl::size_t<3>, Frame::Inertial>>,
         "If Ricci is requested, SrcTags must include deriv of Phi");
 
     auto& inertial_spatial_ricci =
@@ -308,7 +310,7 @@ void ComputeHorizonVolumeQuantities::apply(
     gh::spatial_ricci_tensor(
         make_not_null(&inertial_spatial_ricci), phi,
         get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
-                        Frame::Inertial>>(src_vars),
+                          Frame::Inertial>>(src_vars),
         inertial_inv_metric);
 
     if constexpr (tmpl::list_contains_v<

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -14,11 +14,14 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/CoordinateMaps/Composition.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/ElementToBlockLogicalMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -742,17 +745,28 @@ CREATE_HAS_TYPE_ALIAS(compute_vars_to_interpolate)
 CREATE_HAS_TYPE_ALIAS_V(compute_vars_to_interpolate)
 
 namespace detail {
+template <typename T>
+struct is_an_invjac_impl : std::false_type {};
+
+template <typename Arg1, size_t Arg2, typename Arg3, typename Arg4>
+struct is_an_invjac_impl<InverseJacobian<Arg1, Arg2, Arg3, Arg4>>
+    : std::true_type {};
+
+template <typename Tag>
+struct is_an_invjac : is_an_invjac_impl<typename Tag::type> {};
+
 template <typename Tag, typename Frame>
 using any_index_in_frame_impl =
     TensorMetafunctions::any_index_in_frame<typename Tag::type, Frame>;
 }  // namespace detail
 
 /// Returns true if any of the tensors in TagList have any of their
-/// indices in the given frame.
+/// indices in the given frame. We don't count InverseJacobians because these
+/// mess up the frames
 template <typename TagList, typename Frame>
-constexpr bool any_index_in_frame_v =
-    tmpl::any<TagList, tmpl::bind<detail::any_index_in_frame_impl, tmpl::_1,
-                                  Frame>>::value;
+constexpr bool any_index_in_frame_v = tmpl::any<
+    tmpl::filter<TagList, tmpl::not_<detail::is_an_invjac<tmpl::_1>>>,
+    tmpl::bind<detail::any_index_in_frame_impl, tmpl::_1, Frame>>::value;
 
 /// Calls compute_vars_to_interpolate to compute
 /// InterpolationTargetTag::vars_to_interpolate_to_target from the source
@@ -798,10 +812,18 @@ void compute_dest_vars_from_source_vars(
           block.moving_mesh_grid_to_inertial_map()
               .coords_frame_velocity_jacobians(
                   map_logical_to_grid(logical_coords), time, functions_of_time);
+      // Create an identity jacobian since the transformation from grid to grid
+      // is the identity
+      InverseJacobian<DataVector, 3, Frame::Grid, Frame::Grid>
+          invjac_grid_to_grid{
+              DataVector{get<0, 0>(jac_logical_to_grid).size(), 0.0}};
+      get<0, 0>(invjac_grid_to_grid) = 1.0;
+      get<1, 1>(invjac_grid_to_grid) = 1.0;
+      get<2, 2>(invjac_grid_to_grid) = 1.0;
       InterpolationTargetTag::compute_vars_to_interpolate::apply(
           dest_vars, source_vars, mesh, jac_grid_to_inertial,
           invjac_grid_to_inertial, jac_logical_to_grid, invjac_logical_to_grid,
-          inertial_mesh_velocity,
+          invjac_grid_to_grid, inertial_mesh_velocity,
           tnsr::I<DataVector, 3, Frame::Grid>{
               DataVector{get<0, 0>(jac_logical_to_grid).size(), 0.0}});
     } else if constexpr (any_index_in_frame_v<SourceTags, Frame::Inertial> and
@@ -832,12 +854,13 @@ void compute_dest_vars_from_source_vars(
                   element_logical_to_distorted_map(logical_coords, time,
                                                    functions_of_time),
                   time, functions_of_time);
-      const auto grid_to_distorted_mesh_velocity =
-          get<3>(block.moving_mesh_grid_to_distorted_map()
-                     .coords_frame_velocity_jacobians(
-                         element_logical_to_grid_map(logical_coords, time,
-                                                     functions_of_time),
-                         time, functions_of_time));
+      const auto [distorted_coords, invjac_grid_to_distorted,
+                  jac_grid_to_distorted, grid_to_distorted_mesh_velocity] =
+          block.moving_mesh_grid_to_distorted_map()
+              .coords_frame_velocity_jacobians(
+                  element_logical_to_grid_map(logical_coords, time,
+                                              functions_of_time),
+                  time, functions_of_time);
       InterpolationTargetTag::compute_vars_to_interpolate::apply(
           dest_vars, source_vars, mesh, jac_distorted_to_inertial,
           invjac_distorted_to_inertial,
@@ -845,7 +868,8 @@ void compute_dest_vars_from_source_vars(
                                                     functions_of_time),
           element_logical_to_distorted_map.inv_jacobian(logical_coords, time,
                                                         functions_of_time),
-          distorted_to_inertial_mesh_velocity, grid_to_distorted_mesh_velocity);
+          invjac_grid_to_distorted, distorted_to_inertial_mesh_velocity,
+          grid_to_distorted_mesh_velocity);
     } else {
       // No frame transformations needed.
       InterpolationTargetTag::compute_vars_to_interpolate::apply(

--- a/src/ParallelAlgorithms/Interpolation/TagsMetafunctions.hpp
+++ b/src/ParallelAlgorithms/Interpolation/TagsMetafunctions.hpp
@@ -31,7 +31,7 @@ template <template <typename> typename Tag, typename DataType,
 struct replace_frame_in_tag<Tag<DataType>, NewFrame> {
   using type = Tag<DataType>;
 };
-// Specialization for Tags::deriv<Tag> with Tag in gh::Tags
+// Specializations for Tags::deriv<Tag> with Tag in gh::Tags
 template <template <typename, size_t, typename> typename Tag, typename DataType,
           size_t Dim, typename Frame, typename NewFrame>
 struct replace_frame_in_tag<
@@ -39,6 +39,18 @@ struct replace_frame_in_tag<
     NewFrame> {
   using type =
       ::Tags::deriv<Tag<DataType, Dim, NewFrame>, tmpl::size_t<Dim>, NewFrame>;
+};
+template <template <typename> typename Tag, typename DataType, size_t Dim,
+          typename Frame, typename NewFrame>
+struct replace_frame_in_tag<
+    ::Tags::deriv<Tag<DataType>, tmpl::size_t<Dim>, Frame>, NewFrame> {
+  using type = ::Tags::deriv<Tag<DataType>, tmpl::size_t<Dim>, NewFrame>;
+};
+// Specialization for inverse jacobian
+template <template <size_t, typename, typename> typename Tag, size_t Dim,
+          typename SrcFrame, typename TargetFrame, typename NewTargetFrame>
+struct replace_frame_in_tag<Tag<Dim, SrcFrame, TargetFrame>, NewTargetFrame> {
+  using type = Tag<Dim, SrcFrame, NewTargetFrame>;
 };
 
 /// \ingroup TensorGroup

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.cpp
@@ -160,7 +160,7 @@ void trace_christoffel(
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial,
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial,
                          Frame::Spherical<Frame::Inertial>,
                          Frame::Spherical<Frame::Grid>))
 

--- a/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.cpp
@@ -88,7 +88,7 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
           deriv_spatial_metric);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial))
+                        (Frame::Grid, Frame::Distorted, Frame::Inertial))
 
 #undef DIM
 #undef DTYPE

--- a/tests/Unit/ControlSystem/ControlErrors/ComovingCharSpeedDerivative.py
+++ b/tests/Unit/ControlSystem/ControlErrors/ComovingCharSpeedDerivative.py
@@ -8,7 +8,7 @@ def deriv_normalized_normal(
     grid_frame_excision_sphere_radius,
     excision_rhat,
     normalized_normal_one_form,
-    excision_normal_one_form_norm,
+    one_over_excision_normal_one_form_norm,
     inverse_spatial_metric_on_excision_boundary,
     spatial_christoffel_second_kind,
     inverse_jacobian_grid_to_distorted,
@@ -51,7 +51,7 @@ def comoving_char_speed_derivative(
     grid_frame_excision_sphere_radius,
     excision_rhat,
     excision_normal_one_form,
-    excision_normal_one_form_norm,
+    one_over_excision_normal_one_form_norm,
     distorted_components_of_grid_shift,
     inverse_spatial_metric_on_excision_boundary,
     spatial_christoffel_second_kind,
@@ -62,7 +62,7 @@ def comoving_char_speed_derivative(
     Y00 = 0.5 / np.sqrt(np.pi)
 
     normalized_normal_one_form = (
-        excision_normal_one_form / excision_normal_one_form_norm
+        excision_normal_one_form * one_over_excision_normal_one_form_norm
     )
 
     temp = (
@@ -81,7 +81,7 @@ def comoving_char_speed_derivative(
         grid_frame_excision_sphere_radius,
         excision_rhat,
         normalized_normal_one_form,
-        excision_normal_one_form_norm,
+        one_over_excision_normal_one_form_norm,
         inverse_spatial_metric_on_excision_boundary,
         spatial_christoffel_second_kind,
         inverse_jacobian_grid_to_distorted,

--- a/tests/Unit/ControlSystem/ControlErrors/Test_ComovingCharSpeedDerivative.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_ComovingCharSpeedDerivative.cpp
@@ -23,7 +23,7 @@ void test_comoving_char_speed_derivative(const DataType& used_for_size) {
           {1.9, 2.1},
           {-0.8, 0.8},
           {-1., 1.},
-          {1., 2.},
+          {0.5, 1.},
           {-1., 1.},
           {1., 2.},
           {-1., 1.},

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -39,6 +39,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Solutions.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -47,7 +48,7 @@
 
 namespace Frame {
 struct Distorted;
-}
+}  // namespace Frame
 
 namespace {
 constexpr double Y00 = 0.25 * M_2_SQRTPI;
@@ -165,6 +166,21 @@ void test_size_error_one_step(
   const auto& inverse_spatial_metric =
       get<gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Distorted>>(
           vars);
+  const auto& spatial_christoffel = get<
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, Frame::Distorted>>(
+      vars);
+  const auto& deriv_lapse =
+      get<gr::AnalyticSolution<3>::DerivLapse<DataVector, Frame::Distorted>>(
+          vars);
+  const auto& deriv_shift =
+      get<gr::AnalyticSolution<3>::DerivShift<DataVector, Frame::Distorted>>(
+          vars);
+  // Just make it identity for this test
+  InverseJacobian<DataVector, 3, Frame::Grid, Frame::Distorted>
+      invjac_grid_to_distorted{get(lapse)};
+  get<0, 0>(invjac_grid_to_distorted) = 1.0;
+  get<1, 1>(invjac_grid_to_distorted) = 1.0;
+  get<2, 2>(invjac_grid_to_distorted) = 1.0;
 
   // Now compute shifty quantity, which is distorted shift plus
   // grid-to-distorted frame-velocity.
@@ -258,7 +274,9 @@ void test_size_error_one_step(
         control_system::QueueTags::SizeHorizonQuantities<Frame::Distorted>;
     tuples::TaggedTuple<ExcisionQuantities, HorizonQuantities> measurements{
         ExcisionQuantities::type{excision_boundary, lapse, shifty_quantity,
-                                 spatial_metric, inverse_spatial_metric},
+                                 spatial_metric, inverse_spatial_metric,
+                                 spatial_christoffel, deriv_lapse, deriv_shift,
+                                 invjac_grid_to_distorted},
         HorizonQuantities::type{horizon, time_deriv_horizon}};
 
     const double control_error_from_class =

--- a/tests/Unit/ControlSystem/Systems/Test_Size.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Size.cpp
@@ -142,13 +142,19 @@ void test_size_process_measurement() {
   const tnsr::I<DataVector, 3, Frame::Distorted> zero_tnsr_I{};
   const tnsr::ii<DataVector, 3, Frame::Distorted> zero_tnsr_ii{};
   const tnsr::II<DataVector, 3, Frame::Distorted> zero_tnsr_II{};
+  const tnsr::Ijj<DataVector, 3, Frame::Distorted>& spatial_christoffel{};
+  const tnsr::i<DataVector, 3, Frame::Distorted>& deriv_lapse{};
+  const tnsr::iJ<DataVector, 3, Frame::Distorted>& deriv_shift{};
+  const ::InverseJacobian<DataVector, 3, Frame::Grid, Frame::Distorted>&
+      inv_jac_grid_to_distorted{};
   const ylm::Strahlkorper<Frame::Distorted> horizon{};
   const ylm::Strahlkorper<Frame::Grid> excision{2, 2.0,
                                                 std::array{0.0, 0.0, 0.0}};
 
   size::process_measurement::apply<Metavars>(
       char_speed::Excision{}, excision, zero_scalar, zero_tnsr_I, zero_tnsr_ii,
-      zero_tnsr_II, cache, id);
+      zero_tnsr_II, spatial_christoffel, deriv_lapse, deriv_shift,
+      inv_jac_grid_to_distorted, cache, id);
 
   // We only check that the proper number of actions have been called.
   CHECK(ActionTesting::number_of_queued_simple_actions<component>(runner, 0) ==

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/CoordinateMaps/Composition.hpp"
 #include "Domain/Creators/Rectilinear.hpp"
@@ -15,6 +16,8 @@
 #include "Domain/ElementToBlockLogicalMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
@@ -32,6 +35,7 @@
 #include "Time/TimeStepId.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
 template <typename IsTimeDependent, typename TargetFrame, typename SrcTags,
@@ -42,6 +46,9 @@ void test_compute_excision_boundary_volume_quantities() {
   CAPTURE(is_time_dependent);
   CAPTURE(target_frame);
   const size_t number_of_grid_points = 8;
+  // Because we are taking numerical derivatives and have low resolution
+  [[maybe_unused]] Approx deriv_approx =  // NOLINT
+      Approx::custom().epsilon(1.0e-8).scale(1.0);
 
   // slab and temporal_id used only in the TimeDependent version.
   Slab slab(0.0, 1.0);
@@ -108,6 +115,9 @@ void test_compute_excision_boundary_volume_quantities() {
       jacobian_logical_to_target{};
   InverseJacobian<DataVector, 3, Frame::ElementLogical, TargetFrame>
       inv_jacobian_logical_to_target{};
+  // NOLINTNEXTLINE(misc-const-correctness)
+  InverseJacobian<DataVector, 3, Frame::Grid, TargetFrame>
+      inv_jacobian_grid_to_target{};
   tnsr::I<DataVector, 3, Frame::Inertial> frame_velocity_target_to_inertial{};
   tnsr::I<DataVector, 3, TargetFrame> frame_velocity_grid_to_target{
       mesh.number_of_grid_points(), 0.0};
@@ -137,6 +147,12 @@ void test_compute_excision_boundary_volume_quantities() {
           block.moving_mesh_grid_to_inertial_map().jacobian(
               map_logical_to_grid(logical_coords), time, functions_of_time);
       inv_jacobian_logical_to_target = inv_jacobian_logical_to_grid;
+      inv_jacobian_grid_to_target =
+          InverseJacobian<DataVector, 3, Frame::Grid, TargetFrame>{
+              mesh.number_of_grid_points(), 0.0};
+      get<0, 0>(inv_jacobian_grid_to_target) = 1.0;
+      get<1, 1>(inv_jacobian_grid_to_target) = 1.0;
+      get<2, 2>(inv_jacobian_grid_to_target) = 1.0;
       target_frame_coords = map_logical_to_grid(logical_coords);
     } else if constexpr (std::is_same_v<TargetFrame, Frame::Distorted>) {
       const domain::CoordinateMaps::Composition map_logical_to_distorted{
@@ -149,6 +165,9 @@ void test_compute_excision_boundary_volume_quantities() {
               time, functions_of_time);
       inv_jacobian_logical_to_target = map_logical_to_distorted.inv_jacobian(
           logical_coords, time, functions_of_time);
+      inv_jacobian_grid_to_target =
+          block.moving_mesh_grid_to_distorted_map().inv_jacobian(
+              map_logical_to_grid(logical_coords), time, functions_of_time);
       target_frame_coords =
           map_logical_to_distorted(logical_coords, time, functions_of_time);
     } else {
@@ -159,6 +178,7 @@ void test_compute_excision_boundary_volume_quantities() {
       jacobian_target_to_inertial =
           Jacobian<DataVector, 3, TargetFrame, Frame::Inertial>(
               mesh.number_of_grid_points(), 0.0);
+      inv_jacobian_grid_to_target = inv_jacobian_grid_to_inertial;
       for (size_t i = 0; i < 3; ++i) {
         jacobian_target_to_inertial.get(i, i) = 1.0;
       }
@@ -169,7 +189,10 @@ void test_compute_excision_boundary_volume_quantities() {
     // time-independent.
     static_assert(std::is_same_v<TargetFrame, Frame::Inertial>,
                   "TargetFrame must be the Inertial frame");
-    // Don't need to define jacobian_target_to_inertial
+    // Don't need to define jacobian_target_to_inertial or
+    // inv_jacobian_grid_to_target
+    (void)jacobian_target_to_inertial;
+    (void)inv_jacobian_grid_to_target;
     ElementMap<3, Frame::Inertial> map_logical_to_inertial{
         element_ids[0], block.stationary_map().get_clone()};
     target_frame_coords = map_logical_to_inertial(logical_coords);
@@ -186,10 +209,20 @@ void test_compute_excision_boundary_volume_quantities() {
       typename gr::Solutions::KerrSchild::tags<DataVector, TargetFrame>{});
   const auto& lapse =
       get<gr::Tags::Lapse<DataVector>>(solution_vars_target_frame);
+  const auto& deriv_lapse = get<
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>, TargetFrame>>(
+      solution_vars_target_frame);
   const auto& shift = get<gr::Tags::Shift<DataVector, 3, TargetFrame>>(
       solution_vars_target_frame);
+  const auto& deriv_shift =
+      get<::Tags::deriv<gr::Tags::Shift<DataVector, 3, TargetFrame>,
+                        tmpl::size_t<3>, TargetFrame>>(
+          solution_vars_target_frame);
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<DataVector, 3, TargetFrame>>(
+          solution_vars_target_frame);
+  const auto& spatial_christoffel =
+      get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, TargetFrame>>(
           solution_vars_target_frame);
 
   // Fill src vars with analytic solution.
@@ -218,6 +251,13 @@ void test_compute_excision_boundary_volume_quantities() {
 
     get<::gr::Tags::SpacetimeMetric<DataVector, 3, TargetFrame>>(src_vars) =
         gr::spacetime_metric(lapse, shift, spatial_metric);
+    const auto& deriv_spatial_metric =
+        get<::Tags::deriv<gr::Tags::SpatialMetric<DataVector, 3, TargetFrame>,
+                          tmpl::size_t<3>, TargetFrame>>(
+            solution_vars_target_frame);
+    get<::gh::Tags::Phi<DataVector, 3>>(src_vars) =
+        gh::phi(lapse, deriv_lapse, shift, deriv_shift, spatial_metric,
+                deriv_spatial_metric);
   } else if constexpr (std::is_same_v<TargetFrame, Frame::Distorted>) {
     // First figure out jacobians
     const auto coords_frame_velocity_jacobians =
@@ -330,8 +370,8 @@ void test_compute_excision_boundary_volume_quantities() {
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(
         make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
         inv_jacobian_target_to_inertial, jacobian_logical_to_target,
-        inv_jacobian_logical_to_target, frame_velocity_target_to_inertial,
-        frame_velocity_grid_to_target);
+        inv_jacobian_logical_to_target, inv_jacobian_grid_to_target,
+        frame_velocity_target_to_inertial, frame_velocity_grid_to_target);
   } else {
     // time-independent.
     ah::ComputeExcisionBoundaryVolumeQuantities::apply(
@@ -363,10 +403,31 @@ void test_compute_excision_boundary_volume_quantities() {
   }
 
   if constexpr (tmpl::list_contains_v<
+                    DestTags, ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                            tmpl::size_t<3>, TargetFrame>>) {
+    const auto& numerical_deriv_lapse =
+        get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                          TargetFrame>>(dest_vars);
+    CHECK_ITERABLE_CUSTOM_APPROX(deriv_lapse, numerical_deriv_lapse,
+                                 deriv_approx);
+  }
+
+  if constexpr (tmpl::list_contains_v<
                     DestTags, gr::Tags::Shift<DataVector, 3, TargetFrame>>) {
     const auto& numerical_shift =
         get<gr::Tags::Shift<DataVector, 3, TargetFrame>>(dest_vars);
     CHECK_ITERABLE_APPROX(shift, numerical_shift);
+  }
+
+  if constexpr (tmpl::list_contains_v<
+                    DestTags,
+                    ::Tags::deriv<gr::Tags::Shift<DataVector, 3, TargetFrame>,
+                                  tmpl::size_t<3>, TargetFrame>>) {
+    const auto& numerical_deriv_shift =
+        get<::Tags::deriv<gr::Tags::Shift<DataVector, 3, TargetFrame>,
+                          tmpl::size_t<3>, TargetFrame>>(dest_vars);
+    CHECK_ITERABLE_CUSTOM_APPROX(deriv_shift, numerical_deriv_shift,
+                                 deriv_approx);
   }
 
   if constexpr (tmpl::list_contains_v<
@@ -377,6 +438,16 @@ void test_compute_excision_boundary_volume_quantities() {
     const auto shifty_quantity = tenex::evaluate<ti::I>(
         shift(ti::I) + frame_velocity_grid_to_target(ti::I));
     CHECK_ITERABLE_APPROX(shifty_quantity, numerical_shifty_quantity);
+  }
+
+  if constexpr (tmpl::list_contains_v<DestTags,
+                                      gr::Tags::SpatialChristoffelSecondKind<
+                                          DataVector, 3, TargetFrame>>) {
+    const auto& numerical_spatial_christoffel =
+        get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, TargetFrame>>(
+            dest_vars);
+    CHECK_ITERABLE_CUSTOM_APPROX(spatial_christoffel,
+                                 numerical_spatial_christoffel, deriv_approx);
   }
 
   // If TargetFrame is not the same as Inertial frame, we allow
@@ -414,9 +485,20 @@ void test_compute_excision_boundary_volume_quantities() {
           get<gr::Tags::Shift<DataVector, 3>>(dest_vars);
       CHECK_ITERABLE_APPROX(expected_inertial_shift, inertial_shift);
     }
+
+    if constexpr (tmpl::list_contains_v<
+                      DestTags, domain::Tags::InverseJacobian<3, Frame::Grid,
+                                                              TargetFrame>>) {
+      const auto& numerical_inv_jacobian_grid_to_target =
+          get<domain::Tags::InverseJacobian<3, Frame::Grid, TargetFrame>>(
+              dest_vars);
+      CHECK_ITERABLE_APPROX(inv_jacobian_grid_to_target,
+                            numerical_inv_jacobian_grid_to_target);
+    }
   }
 }
 
+// [[Timeout, 20]]
 SPECTRE_TEST_CASE(
     "Unit.ApparentHorizonFinder.ComputeExcisionBoundaryVolumeQuantities",
     "[ApparentHorizonFinder][Unit]") {
@@ -434,7 +516,14 @@ SPECTRE_TEST_CASE(
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
                  gr::Tags::SpatialMetric<DataVector, 3>,
                  gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<DataVector, 3>>>();
+                 ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                               Frame::Inertial>,
+                 gr::Tags::Shift<DataVector, 3>,
+                 ::Tags::deriv<gr::Tags::Shift<DataVector, 3, Frame::Inertial>,
+                               tmpl::size_t<3>, Frame::Inertial>,
+                 domain::Tags::InverseJacobian<3, Frame::Grid, Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelSecondKind<DataVector, 3,
+                                                        Frame::Inertial>>>();
 
   // Leave out a few tags.
   test_compute_excision_boundary_volume_quantities<
@@ -443,15 +532,23 @@ SPECTRE_TEST_CASE(
                  gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>,
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
                  gr::Tags::SpatialMetric<DataVector, 3>,
-                 gr::Tags::Lapse<DataVector>>>();
+                 gr::Tags::Lapse<DataVector>,
+                 ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                               Frame::Inertial>,
+                 gr::Tags::SpatialChristoffelSecondKind<DataVector, 3,
+                                                        Frame::Inertial>>>();
 
   test_compute_excision_boundary_volume_quantities<
       std::false_type, Frame::Inertial,
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
                  gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>,
-      tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
-                 gr::Tags::SpatialMetric<DataVector, 3>,
-                 gr::Tags::Shift<DataVector, 3>>>();
+      tmpl::list<
+          gr::Tags::SpacetimeMetric<DataVector, 3>,
+          gr::Tags::SpatialMetric<DataVector, 3>,
+          gr::Tags::Shift<DataVector, 3>,
+          ::Tags::deriv<gr::Tags::Shift<DataVector, 3, Frame::Inertial>,
+                        tmpl::size_t<3>, Frame::Inertial>,
+          domain::Tags::InverseJacobian<3, Frame::Grid, Frame::Inertial>>>();
 
   // time-dependent.
   // All possible tags.
@@ -463,8 +560,16 @@ SPECTRE_TEST_CASE(
                              Frame::Inertial>>,
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
                  gr::Tags::SpatialMetric<DataVector, 3>,
-                 gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
-                 gr::Tags::Shift<DataVector, 3, Frame::Grid>>>();
+                 gr::Tags::Lapse<DataVector>,
+                 ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                               Frame::Grid>,
+                 gr::Tags::Shift<DataVector, 3>,
+                 gr::Tags::Shift<DataVector, 3, Frame::Grid>,
+                 ::Tags::deriv<gr::Tags::Shift<DataVector, 3, Frame::Grid>,
+                               tmpl::size_t<3>, Frame::Grid>,
+                 domain::Tags::InverseJacobian<3, Frame::Grid, Frame::Grid>,
+                 gr::Tags::SpatialChristoffelSecondKind<DataVector, 3,
+                                                        Frame::Grid>>>();
 
   // Distorted frame.
   test_compute_excision_boundary_volume_quantities<
@@ -473,11 +578,19 @@ SPECTRE_TEST_CASE(
                  gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>,
                  Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
                              Frame::Inertial>>,
-      tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3, Frame::Distorted>,
-                 gr::Tags::SpatialMetric<DataVector, 3, Frame::Distorted>,
-                 gr::Tags::Lapse<DataVector>,
-                 gr::Tags::ShiftyQuantity<DataVector, 3, Frame::Distorted>,
-                 gr::Tags::Shift<DataVector, 3, Frame::Distorted>>>();
+      tmpl::list<
+          gr::Tags::SpacetimeMetric<DataVector, 3, Frame::Distorted>,
+          gr::Tags::SpatialMetric<DataVector, 3, Frame::Distorted>,
+          gr::Tags::Lapse<DataVector>,
+          ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Distorted>,
+          gr::Tags::ShiftyQuantity<DataVector, 3, Frame::Distorted>,
+          gr::Tags::Shift<DataVector, 3, Frame::Distorted>,
+          ::Tags::deriv<gr::Tags::Shift<DataVector, 3, Frame::Distorted>,
+                        tmpl::size_t<3>, Frame::Distorted>,
+          domain::Tags::InverseJacobian<3, Frame::Grid, Frame::Distorted>,
+          gr::Tags::SpatialChristoffelSecondKind<DataVector, 3,
+                                                 Frame::Distorted>>>();
 
   // Leave out a few tags.
   test_compute_excision_boundary_volume_quantities<

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeHorizonVolumeQuantities.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeHorizonVolumeQuantities.cpp
@@ -333,8 +333,10 @@ void test_compute_horizon_volume_quantities() {
     ah::ComputeHorizonVolumeQuantities::apply(
         make_not_null(&dest_vars), src_vars, mesh, jacobian_target_to_inertial,
         inv_jacobian_target_to_inertial, jacobian_logical_to_target,
-        inv_jacobian_logical_to_target, inertial_mesh_velocity,
-        tnsr::I<DataVector, 3, TargetFrame>{});
+        inv_jacobian_logical_to_target,
+        InverseJacobian<DataVector, 3, Frame::Grid, TargetFrame>{
+            mesh.number_of_grid_points(), 0.0},
+        inertial_mesh_velocity, tnsr::I<DataVector, 3, TargetFrame>{});
   } else {
     // time-independent.
     ah::ComputeHorizonVolumeQuantities::apply(make_not_null(&dest_vars),

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
@@ -64,6 +64,8 @@ struct MockComputeVarsToInterpolate
           jac_logical_to_target,
       const InverseJacobian<DataVector, 3, ::Frame::ElementLogical,
                             TargetFrame>& invjac_logical_to_target,
+      const InverseJacobian<DataVector, 3, ::Frame::Grid, TargetFrame>&
+          invjac_grid_to_target,
       const tnsr::I<DataVector, 3, ::Frame::Inertial>& inertial_mesh_velocity,
       const tnsr::I<DataVector, 3, TargetFrame>&
           grid_to_target_frame_mesh_velocity) {
@@ -72,6 +74,7 @@ struct MockComputeVarsToInterpolate
     CHECK(get<0, 0>(invjac_target_to_inertial).size() != 0);
     CHECK(get<0, 0>(jac_logical_to_target).size() != 0);
     CHECK(get<0, 0>(invjac_logical_to_target).size() != 0);
+    CHECK(get<0, 0>(invjac_grid_to_target).size() != 0);
     CHECK(get<0>(inertial_mesh_velocity).size() != 0);
     CHECK(get<0>(grid_to_target_frame_mesh_velocity).size() != 0);
   }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Tags.cpp
@@ -4,11 +4,14 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <type_traits>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "ParallelAlgorithms/Interpolation/PointInfoTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/TagsMetafunctions.hpp"
@@ -49,6 +52,14 @@ void test_tags_metafunctions() {
                                gr::Tags::Lapse<DataVector>>,
                 "Failed testing replace_frame_in_tag_t");
   static_assert(
+      std::is_same_v<TensorMetafunctions::replace_frame_in_tag_t<
+                         Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                     tmpl::size_t<3>, Frame::Inertial>,
+                         Frame::Grid>,
+                     Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                                 Frame::Grid>>,
+      "Failed testing replace_frame_in_tag_t");
+  static_assert(
       std::is_same_v<
           TensorMetafunctions::replace_frame_in_tag_t<
               gh::ConstraintDamping::Tags::ConstraintGamma0, Frame::Grid>,
@@ -67,11 +78,15 @@ void test_tags_metafunctions() {
           TensorMetafunctions::replace_frame_in_taglist<
               tmpl::list<Tags::deriv<gh::Tags::Phi<DataVector, 3>,
                                      tmpl::size_t<3>, Frame::Inertial>,
-                         gh::Tags::Pi<DataVector, 3, Frame::Distorted>>,
+                         gh::Tags::Pi<DataVector, 3, Frame::Distorted>,
+                         Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                     tmpl::size_t<3>, Frame::Distorted>>,
               Frame::Grid>,
           tmpl::list<Tags::deriv<gh::Tags::Phi<DataVector, 3, Frame::Grid>,
                                  tmpl::size_t<3>, Frame::Grid>,
-                     gh::Tags::Pi<DataVector, 3, Frame::Grid>>>,
+                     gh::Tags::Pi<DataVector, 3, Frame::Grid>,
+                     Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                                 Frame::Grid>>>,
       "Failed testing replace_frame_in_taglist");
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

These quantities will be needed for state 3 once it is added in order to compute the total derivative of the comoving characteristic speeds with respect to the map parameter $\lambda_{0,0}$.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
