### PR TITLE
Correctly identify external Block boundaries for Topologies other than I1

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -14,6 +14,7 @@
 #include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/HasBoundary.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -34,8 +35,17 @@ Block<VolumeDim>::Block(
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.
   for (const auto& direction : Direction<VolumeDim>::all_directions()) {
+    const bool has_boundary_in_this_direction = has_boundary(
+        gsl::at(topologies_, direction.dimension()), direction.side());
     if (neighbors_.find(direction) == neighbors_.end()) {
-      external_boundaries_.emplace(direction);
+      if (has_boundary_in_this_direction) {
+        external_boundaries_.emplace(direction);
+      }
+    } else {
+      ASSERT(has_boundary_in_this_direction,
+             "Cannot specify a neighbor in a direction with no boundary.  "
+             "Topologies: "
+                 << topologies_ << "; Direction: " << direction);
     }
   }
 }

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_sources(
   DirectionalId.cpp
   Element.cpp
   ElementId.cpp
+  HasBoundary.cpp
   Hypercube.cpp
   InitialElementIds.cpp
   Neighbors.cpp
@@ -43,6 +44,7 @@ spectre_target_headers(
   DirectionMap.hpp
   Element.hpp
   ElementId.hpp
+  HasBoundary.hpp
   Hypercube.hpp
   IndexToSliceAt.hpp
   InitialElementIds.hpp

--- a/src/Domain/Structure/HasBoundary.cpp
+++ b/src/Domain/Structure/HasBoundary.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/HasBoundary.hpp"
+
+#include "Domain/Structure/Side.hpp"
+#include "Domain/Structure/Topology.hpp"
+
+namespace domain {
+bool has_boundary(const domain::Topology topology, const Side side) {
+  return topology == Topology::I1 or
+         (topology == Topology::B2Radial and side == Side::Upper);
+}
+}  // namespace domain

--- a/src/Domain/Structure/HasBoundary.hpp
+++ b/src/Domain/Structure/HasBoundary.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdint>
+
+/// \cond
+namespace domain {
+enum class Topology : uint8_t;
+}  // namespace domain
+enum class Side : uint8_t;
+/// \endcond
+
+namespace domain {
+/// \brief Whether or not a Topology has a boundary on a given Side
+///
+/// \note the boundary can either be an internal (i.e. an interface between
+/// neighboring Elements or Blocks) or external boundary
+bool has_boundary(domain::Topology topology, Side side);
+}  // namespace domain

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_DirectionalId.cpp
   Test_Element.cpp
   Test_ElementId.cpp
+  Test_HasBoundary.cpp
   Test_Hypercube.cpp
   Test_IndexToSliceAt.cpp
   Test_InitialElementIds.cpp

--- a/tests/Unit/Domain/Structure/Test_HasBoundary.cpp
+++ b/tests/Unit/Domain/Structure/Test_HasBoundary.cpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Domain/Structure/HasBoundary.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Domain/Structure/Topology.hpp"
+
+namespace {
+void test() {
+  for (const auto side : std::array{Side::Lower, Side::Upper}) {
+    CHECK(domain::has_boundary(domain::Topology::I1, side));
+    CHECK_FALSE(domain::has_boundary(domain::Topology::S1, side));
+    CHECK_FALSE(domain::has_boundary(domain::Topology::S2Colatitude, side));
+    CHECK_FALSE(domain::has_boundary(domain::Topology::S2Longitude, side));
+    CHECK_FALSE(domain::has_boundary(domain::Topology::B2Angular, side));
+  }
+  CHECK_FALSE(domain::has_boundary(domain::Topology::B2Radial, Side::Lower));
+  CHECK(domain::has_boundary(domain::Topology::B2Radial, Side::Upper));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.HasBoundary", "[Domain][Unit]") {
+  test();
+}

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -23,8 +23,8 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Framework/TestHelpers.hpp"
-#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
@@ -291,9 +291,73 @@ void test_block_time_dependent_distorted() {
       translation_distorted_to_inertial_map.get_clone());
   test_move_semantics(std::move(original_block), block_copy);
 }
+
+void test_spherical_shell() {
+  const Block<3> spherical_shell(
+      nullptr, 4, DirectionMap<3, BlockNeighbors<3>>{}, "Shell",
+      std::array{domain::Topology::I1, domain::Topology::S2Colatitude,
+                 domain::Topology::S2Longitude});
+  CHECK(spherical_shell.external_boundaries().size() == 2);
+  CHECK(
+      spherical_shell.external_boundaries().contains(Direction<3>::lower_xi()));
+  CHECK(
+      spherical_shell.external_boundaries().contains(Direction<3>::upper_xi()));
+  CHECK(spherical_shell.neighbors().empty());
+}
+
+void test_cylindrical_shell() {
+  const Block<3> cylindrical_shell(
+      nullptr, 4, DirectionMap<3, BlockNeighbors<3>>{}, "CylindricalShell",
+      std::array{domain::Topology::I1, domain::Topology::S1,
+                 domain::Topology::I1});
+  CHECK(cylindrical_shell.external_boundaries().size() == 4);
+  CHECK(cylindrical_shell.external_boundaries().contains(
+      Direction<3>::lower_xi()));
+  CHECK(cylindrical_shell.external_boundaries().contains(
+      Direction<3>::upper_xi()));
+  CHECK(cylindrical_shell.external_boundaries().contains(
+      Direction<3>::lower_zeta()));
+  CHECK(cylindrical_shell.external_boundaries().contains(
+      Direction<3>::upper_zeta()));
+  CHECK(cylindrical_shell.neighbors().empty());
+}
+
+void test_full_cylinder() {
+  const Block<3> full_cylinder(
+      nullptr, 4, DirectionMap<3, BlockNeighbors<3>>{}, "Cylinder",
+      std::array{domain::Topology::B2Radial, domain::Topology::B2Angular,
+                 domain::Topology::I1});
+  CHECK(full_cylinder.external_boundaries().size() == 3);
+  CHECK(full_cylinder.external_boundaries().contains(Direction<3>::upper_xi()));
+  CHECK(
+      full_cylinder.external_boundaries().contains(Direction<3>::lower_zeta()));
+  CHECK(
+      full_cylinder.external_boundaries().contains(Direction<3>::upper_zeta()));
+  CHECK(full_cylinder.neighbors().empty());
+}
+
+void test_errors() {
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([]() {
+        const BlockNeighbors<1> block_neighbors(
+            1, OrientationMap<1>::create_aligned());
+        const DirectionMap<1, BlockNeighbors<1>> neighbors{
+            {Direction<1>::lower_xi(), block_neighbors}};
+        const Block<1> loop(nullptr, 2, neighbors, "Loop",
+                            std::array{domain::Topology::S1});
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot specify a neighbor in a direction with no boundary"));
+#endif
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
+  test_spherical_shell();
+  test_cylindrical_shell();
+  test_full_cylinder();
+  test_errors();
   test_block_time_independent<1>();
   test_block_time_independent<2>();
   test_block_time_independent<3>();
@@ -359,10 +423,16 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
     CHECK(block != rhs);
   }
   {
-    const Block<2> rhs(identity_map.get_clone(), 3, neighbors, "Identity",
-                       {{domain::Topology::S1, domain::Topology::I1}});
+    const DirectionMap<2, BlockNeighbors<2>> annulus_neighbors{
+        {Direction<2>::upper_xi(), block_neighbor1}};
+
+    const Block<2> rhs(identity_map.get_clone(), 3, annulus_neighbors,
+                       "Identity",
+                       {{domain::Topology::I1, domain::Topology::S1}});
     CHECK(rhs.topologies() ==
-          std::array{domain::Topology::S1, domain::Topology::I1});
+          std::array{domain::Topology::I1, domain::Topology::S1});
+    CHECK(rhs.external_boundaries().size() == 1);
+    CHECK(rhs.neighbors().size() == 1);
     CHECK(block != rhs);
   }
 }


### PR DESCRIPTION
## Proposed changes

- Add a function has_boundary that returns whether or not a Topology has a boundary (external or internal) on a Side
- Use the function to correctly set external boundaries of a Block, and to check that input neighbors are in valid directions

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
