### PR TITLE
Update python on ocean to 3.12.9, with dependencies bootstrapped

### DIFF
--- a/support/Environments/ocean_gcc.sh
+++ b/support/Environments/ocean_gcc.sh
@@ -26,7 +26,7 @@ spectre_unload_modules() {
     module unload openmpi/4.1.4
     module unload llvm/13.0.1
     module unload cmake/3.24.1
-    module unload python/3.9.5
+    module unload python/3.12.9
     module unload openblas-0.3.20-gcc-11.3.0-tc4qxfv
     module unload zlib-1.2.12-gcc-11.3.0-ge3ye5j
     module unload blaze-3.8-gcc-11.3.0-y7sgzzc
@@ -56,7 +56,7 @@ spectre_load_modules() {
     module load openmpi/4.1.4
     module load llvm/13.0.1
     module load cmake/3.24.1
-    module load python/3.9.5
+    module load python/3.12.9
     export MODULEPATH=$MODULEPATH:/opt/ohpc/pub/apps\
 /spack2022/share/spack/modules/linux-centos7-broadwell/
     module load openblas-0.3.20-gcc-11.3.0-tc4qxfv


### PR DESCRIPTION
## Proposed changes

This PR updates the python used on the ocean cluster to version 3.12.9. Instead of installing dependencies system wide, building spectre on ocean now uses spectre to bootstrap python dependencies.

This fixes an issue where many tests were failing on ocean because of a crash related to `numpy`. Thanks to @JackKutcka for reporting this issue.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
