### PR TITLE
Reset target char speed when going to state DeltaR

### DIFF
--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
@@ -124,6 +124,7 @@ std::string AhSpeed::update(const gsl::not_null<Info*> info,
       info->discontinuous_change_has_occurred = true;
       info->state = std::make_unique<States::DeltaR>();
       info->suggested_time_scale = crossing_time_info.t_delta_radius;
+      info->target_char_speed = 0.0;
       ss << " Switching to DeltaR.\n";
       ss << " Suggested timescale = " << info->suggested_time_scale;
       // Here is where possible transition to State DeltaRDriftInward will go.
@@ -159,6 +160,8 @@ std::string AhSpeed::update(const gsl::not_null<Info*> info,
       ss << " Min char speed " << update_args.min_char_speed
          << " >= target char speed " << info->target_char_speed << "\n";
     }
+    // Must happen after we print the value above
+    info->target_char_speed = 0.0;
     // Here is where possible transition to State DeltaRDriftInward
     // will go.
   } else {

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -313,8 +313,8 @@ void test_size_control_update() {
   // Should change to DeltaR state.
   test_params.min_comoving_char_speed = 0.02;
   do_test<control_system::size::States::AhSpeed,
-          control_system::size::States::DeltaR>(
-      test_params, true, std::nullopt, test_params.original_target_char_speed);
+          control_system::size::States::DeltaR>(test_params, true, std::nullopt,
+                                                0.0);
 
   // Should do nothing because min_comoving_char_speed is smaller than
   // min_char_speed.
@@ -327,8 +327,8 @@ void test_size_control_update() {
   // target_char_speed
   test_params.min_char_speed = 0.012;
   do_test<control_system::size::States::AhSpeed,
-          control_system::size::States::DeltaR>(
-      test_params, true, std::nullopt, test_params.original_target_char_speed);
+          control_system::size::States::DeltaR>(test_params, true, std::nullopt,
+                                                0.0);
 
   // Now it should do nothing because comoving crossing time is very small.
   test_params.min_char_speed = 0.01;
@@ -343,8 +343,8 @@ void test_size_control_update() {
   test_params.crossing_time_info =
       control_system::size::CrossingTimeInfo(std::nullopt, 100.0, std::nullopt);
   do_test<control_system::size::States::AhSpeed,
-          control_system::size::States::DeltaR>(
-      test_params, true, std::nullopt, test_params.original_target_char_speed);
+          control_system::size::States::DeltaR>(test_params, true, std::nullopt,
+                                                0.0);
 
   // Now it should do nothing because comoving is decreasing faster than
   // charspeeds.
@@ -360,8 +360,7 @@ void test_size_control_update() {
       std::nullopt, std::nullopt, 19.0 * test_params.damping_time);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(
-      test_params, true, 19.0 * test_params.damping_time,
-      test_params.original_target_char_speed);
+      test_params, true, 19.0 * test_params.damping_time, 0.0);
 
   // But now with comoving_char_speed negative it should stay in AhSpeed
   // state, but with a change in target speed.
@@ -386,8 +385,7 @@ void test_size_control_update() {
       1.e10, std::nullopt, 4.99 * test_params.damping_time);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(
-      test_params, true, 4.99 * test_params.damping_time,
-      test_params.original_target_char_speed);
+      test_params, true, 4.99 * test_params.damping_time, 0.0);
 
   // If it thinks char speed is in danger, and the target char speed is
   // greater than the char speed, it changes the timescale and
@@ -422,8 +420,8 @@ void test_size_control_update() {
   // and DeltaR is also not in danger.  Should go to DeltaR state.
   test_params.min_char_speed = test_params.original_target_char_speed * 1.10001;
   do_test<control_system::size::States::AhSpeed,
-          control_system::size::States::DeltaR>(
-      test_params, true, std::nullopt, test_params.original_target_char_speed);
+          control_system::size::States::DeltaR>(test_params, true, std::nullopt,
+                                                0.0);
 
   // Again char speed is *barely not* in danger, but for a different reason.
   test_params.min_char_speed = test_params.original_target_char_speed * 1.09999;
@@ -431,8 +429,8 @@ void test_size_control_update() {
       0.99001 * test_params.damping_time, std::nullopt,
       0.992 * test_params.damping_time);
   do_test<control_system::size::States::AhSpeed,
-          control_system::size::States::DeltaR>(
-      test_params, true, std::nullopt, test_params.original_target_char_speed);
+          control_system::size::States::DeltaR>(test_params, true, std::nullopt,
+                                                0.0);
 
   // Now do DeltaRDriftOutward tests
   test_params.min_comoving_char_speed = -0.02;


### PR DESCRIPTION
## Proposed changes

Noticed in plots that this wasn't being reset. Won't change any functionality, but makes the diagnostic plots look better.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
