### PR TITLE
Add radial partitioning to BCO outer shells

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -95,23 +95,20 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
       radial_distribution_envelope_(radial_distribution_envelope),
       radial_distribution_outer_shell_(radial_distribution_outer_shell),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
+      x_coord_a_(
+          std::visit([](const auto& arg) { return arg.x_coord; }, object_A_)),
+      x_coord_b_(
+          std::visit([](const auto& arg) { return arg.x_coord; }, object_B_)),
+      is_excised_a_(std::visit([](const auto& arg) { return arg.is_excised(); },
+                               object_A_)),
+      is_excised_b_(std::visit([](const auto& arg) { return arg.is_excised(); },
+                               object_B_)),
+      use_single_block_a_(
+          std::holds_alternative<CartesianCubeAtXCoord>(object_A_)),
+      use_single_block_b_(
+          std::holds_alternative<CartesianCubeAtXCoord>(object_B_)),
       time_dependent_options_(std::move(time_dependent_options)),
       opening_angle_(M_PI * opening_angle_in_degrees / 180.0) {
-  // Get useful information about the type of grid used around each compact
-  // object
-  x_coord_a_ =
-      std::visit([](const auto& arg) { return arg.x_coord; }, object_A_);
-  x_coord_b_ =
-      std::visit([](const auto& arg) { return arg.x_coord; }, object_B_);
-  is_excised_a_ =
-      std::visit([](const auto& arg) { return arg.is_excised(); }, object_A_);
-  is_excised_b_ =
-      std::visit([](const auto& arg) { return arg.is_excised(); }, object_B_);
-  use_single_block_a_ =
-      std::holds_alternative<CartesianCubeAtXCoord>(object_A_);
-  use_single_block_b_ =
-      std::holds_alternative<CartesianCubeAtXCoord>(object_B_);
-
   // Determination of parameters for domain construction:
   const double tan_half_opening_angle = tan(0.5 * opening_angle_);
   translation_ = 0.5 * (x_coord_a_ + x_coord_b_);

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -33,6 +33,7 @@
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/ExpandOverBlocks.hpp"
+#include "Domain/Creators/ShellDistribution.hpp"
 #include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
@@ -43,6 +44,7 @@
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Options/ParseError.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
 namespace Frame {
@@ -80,7 +82,9 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
     const typename InitialGridPoints::type& initial_number_of_grid_points,
     const bool use_equiangular_map,
     const CoordinateMaps::Distribution radial_distribution_envelope,
-    const CoordinateMaps::Distribution radial_distribution_outer_shell,
+    const std::vector<double>& radial_partitioning_outer_shell,
+    const typename RadialDistributionOuterShell::type&
+        radial_distribution_outer_shell,
     const double opening_angle_in_degrees,
     std::optional<bco::TimeDependentMapOptions<false>> time_dependent_options,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -93,7 +97,7 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
       outer_radius_(outer_radius),
       use_equiangular_map_(use_equiangular_map),
       radial_distribution_envelope_(radial_distribution_envelope),
-      radial_distribution_outer_shell_(radial_distribution_outer_shell),
+      radial_partitioning_outer_shell_(radial_partitioning_outer_shell),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
       x_coord_a_(
           std::visit([](const auto& arg) { return arg.x_coord; }, object_A_)),
@@ -135,10 +139,16 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
         x_coord_b_ - (x_coord_a_ + x_coord_b_ - length_inner_cube_) * 0.5;
   }
 
+  set_shell_distribution(make_not_null(&number_of_outer_shells_),
+                         make_not_null(&radial_distribution_outer_shell_),
+                         radial_partitioning_outer_shell_,
+                         radial_distribution_outer_shell, envelope_radius_,
+                         outer_radius_, "envelope", "outer", context);
+
   // Calculate number of blocks
   // Object cubes and shells have 6 blocks each, for a total for 24 blocks.
-  // The envelope and outer shell have another 10 blocks each.
-  number_of_blocks_ = 44;
+  // The envelope and each outer shell have another 10 blocks each.
+  number_of_blocks_ = 34 + 10 * number_of_outer_shells_;
   // For each object whose interior is not excised, add 1 block
   if ((not use_single_block_a_) and (not is_excised_a_)) {
     number_of_blocks_++;
@@ -323,7 +333,9 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
   }
   add_outer_region("Envelope");  // 10 blocks
   first_outer_shell_block_ += 10;
-  add_outer_region("OuterShell");  // 10 blocks
+  for (size_t shell = 0; shell < number_of_outer_shells_; shell++) {
+    add_outer_region("OuterShell" + std::to_string(shell));  // 10 blocks
+  }
 
   if ((not use_single_block_a_) and (not is_excised_a_)) {
     add_object_interior("ObjectA");  // 1 block
@@ -544,14 +556,12 @@ Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
   std::move(maps_frustums.begin(), maps_frustums.end(),
             std::back_inserter(maps));
 
-  // --- Outer spherical shell (10 blocks) ---
-  Maps maps_outer_shell =
-      domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                              Frame::Inertial, 3>(
-          sph_wedge_coordinate_maps(envelope_radius_, outer_radius_, 1.0, 1.0,
-                                    use_equiangular_map_, std::nullopt, true,
-                                    {}, {radial_distribution_outer_shell_},
-                                    ShellWedges::All, opening_angle_));
+  // --- Outer spherical shell (10*num_outer_shells blocks) ---
+  Maps maps_outer_shell = domain::make_vector_coordinate_map_base<
+      Frame::BlockLogical, Frame::Inertial, 3>(sph_wedge_coordinate_maps(
+      envelope_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_,
+      std::nullopt, true, radial_partitioning_outer_shell_,
+      radial_distribution_outer_shell_, ShellWedges::All, opening_angle_));
   std::move(maps_outer_shell.begin(), maps_outer_shell.end(),
             std::back_inserter(maps));
 
@@ -841,9 +851,10 @@ BinaryCompactObject<UseWorldtube>::external_boundary_conditions() const {
   }
   // Outer boundary
   const size_t offset_outer_blocks =
-      (use_single_block_a_ and use_single_block_b_)
-          ? 12
-          : ((use_single_block_a_ or use_single_block_b_) ? 23 : 34);
+      ((use_single_block_a_ and use_single_block_b_)
+           ? 12
+           : ((use_single_block_a_ or use_single_block_b_) ? 23 : 34)) +
+      10 * (number_of_outer_shells_ - 1);
   for (size_t i = 0; i < 10; ++i) {
     boundary_conditions[i + offset_outer_blocks][Direction<3>::upper_zeta()] =
         outer_boundary_condition_->get_clone();

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -64,8 +64,7 @@ struct BlockLogical;
 }  // namespace Frame
 /// \endcond
 
-namespace domain {
-namespace creators {
+namespace domain::creators {
 namespace bco {
 /*!
  * \brief Create a set of centers of objects for the binary domains.
@@ -299,13 +298,13 @@ class BinaryCompactObject : public DomainCreator<3> {
     /// working with boundary conditions).
     bool is_excised() const;
 
-    double inner_radius;
-    double outer_radius;
-    double x_coord;
+    double inner_radius{};
+    double outer_radius{};
+    double x_coord{};
     std::optional<
         std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
         inner_boundary_condition;
-    bool use_logarithmic_map;
+    bool use_logarithmic_map{};
   };
 
   // Simpler version of an object: a single cube centered on (xCoord,0,0)
@@ -558,8 +557,8 @@ class BinaryCompactObject : public DomainCreator<3> {
   std::array<double, 2> center_of_mass_offset_{};
   double envelope_radius_ = std::numeric_limits<double>::signaling_NaN();
   double outer_radius_ = std::numeric_limits<double>::signaling_NaN();
-  std::vector<std::array<size_t, 3>> initial_refinement_{};
-  std::vector<std::array<size_t, 3>> initial_number_of_grid_points_{};
+  std::vector<std::array<size_t, 3>> initial_refinement_;
+  std::vector<std::array<size_t, 3>> initial_number_of_grid_points_;
   bool use_equiangular_map_ = true;
   CoordinateMaps::Distribution radial_distribution_envelope_ =
       CoordinateMaps::Distribution::Projective;
@@ -572,11 +571,11 @@ class BinaryCompactObject : public DomainCreator<3> {
   size_t first_outer_shell_block_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_;
-  std::vector<std::string> block_names_{};
+  std::vector<std::string> block_names_;
   std::unordered_map<std::string, std::unordered_set<std::string>>
-      block_groups_{};
+      block_groups_;
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
-      grid_anchors_{};
+      grid_anchors_;
   double offset_x_coord_a_{};
   double offset_x_coord_b_{};
 
@@ -587,8 +586,7 @@ class BinaryCompactObject : public DomainCreator<3> {
   bool is_excised_b_ = false;
   bool use_single_block_a_ = false;
   bool use_single_block_b_ = false;
-  std::optional<bco::TimeDependentMapOptions<false>> time_dependent_options_{};
+  std::optional<bco::TimeDependentMapOptions<false>> time_dependent_options_;
   double opening_angle_ = std::numeric_limits<double>::signaling_NaN();
 };
-}  // namespace creators
-}  // namespace domain
+}  // namespace domain::creators

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -372,6 +372,33 @@ class BinaryCompactObject : public DomainCreator<3> {
     static constexpr Options::String help = {"Radius of the entire domain."};
   };
 
+  struct RadialPartitioningOuterShell {
+    static std::string name() { return "RadialPartitioning"; }
+    using group = OuterShell;
+    using type = std::vector<double>;
+    static constexpr Options::String help = {
+        "Radial coordinates of the boundaries splitting the outer spherical "
+        "shells between the envelope radius and OuterRadius. They must be "
+        "given in ascending order. This should be used if boundaries need to "
+        "be set at specific radii. If the number but not the specific "
+        "locations of the boundaries are important, use InitialRefinement "
+        "instead."};
+  };
+
+  struct RadialDistributionOuterShell {
+    static std::string name() { return "RadialDistribution"; }
+    using group = OuterShell;
+    using type =
+        std::variant<domain::CoordinateMaps::Distribution,
+                     std::vector<domain::CoordinateMaps::Distribution>>;
+    static constexpr Options::String help = {
+        "Select the radial distribution of grid points in each outer spherical "
+        "shell. There must be N+1 radial distributions specified for N radial "
+        "partitions. You can also specify just a single radial distribution "
+        "(not in a vector) which will use the same distribution for all "
+        "partitions."};
+  };
+
   struct OpeningAngle {
     using group = OuterShell;
     static std::string name() { return "OpeningAngle"; }
@@ -428,15 +455,6 @@ class BinaryCompactObject : public DomainCreator<3> {
         "made of ten bulged Frustums."};
   };
 
-  struct RadialDistributionOuterShell {
-    using group = OuterShell;
-    static std::string name() { return "RadialDistribution"; }
-    using type = CoordinateMaps::Distribution;
-    static constexpr Options::String help = {
-        "The distribution of radial grid points in Layer 5, the outer "
-        "spherical shell that covers the wave zone."};
-  };
-
   template <typename BoundaryConditionsBase>
   struct OuterBoundaryCondition {
     using group = OuterShell;
@@ -459,7 +477,8 @@ class BinaryCompactObject : public DomainCreator<3> {
       tmpl::list<ObjectA, ObjectB, CenterOfMassOffset, EnvelopeRadius,
                  OuterRadius, CubeScale, InitialRefinement, InitialGridPoints,
                  UseEquiangularMap, RadialDistributionEnvelope,
-                 RadialDistributionOuterShell, OpeningAngle, TimeDependentMaps>,
+                 RadialPartitioningOuterShell, RadialDistributionOuterShell,
+                 OpeningAngle, TimeDependentMaps>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -502,8 +521,10 @@ class BinaryCompactObject : public DomainCreator<3> {
       bool use_equiangular_map = true,
       CoordinateMaps::Distribution radial_distribution_envelope =
           CoordinateMaps::Distribution::Projective,
-      CoordinateMaps::Distribution radial_distribution_outer_shell =
-          CoordinateMaps::Distribution::Linear,
+      const std::vector<double>& radial_partitioning_outer_shell = {},
+      const typename RadialDistributionOuterShell::type&
+          radial_distribution_outer_shell =
+              CoordinateMaps::Distribution::Linear,
       double opening_angle_in_degrees = 90.0,
       std::optional<bco::TimeDependentMapOptions<false>>
           time_dependent_options = std::nullopt,
@@ -562,11 +583,13 @@ class BinaryCompactObject : public DomainCreator<3> {
   bool use_equiangular_map_ = true;
   CoordinateMaps::Distribution radial_distribution_envelope_ =
       CoordinateMaps::Distribution::Projective;
-  CoordinateMaps::Distribution radial_distribution_outer_shell_ =
-      CoordinateMaps::Distribution::Linear;
+  std::vector<double> radial_partitioning_outer_shell_;
+  std::vector<CoordinateMaps::Distribution> radial_distribution_outer_shell_ = {
+      CoordinateMaps::Distribution::Linear};
   double translation_{};
   double length_inner_cube_{};
   double length_outer_cube_{};
+  size_t number_of_outer_shells_{};
   size_t number_of_blocks_{};
   size_t first_outer_shell_block_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Domain/Creators/CMakeLists.txt
+++ b/src/Domain/Creators/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_sources(
   RotatedBricks.cpp
   RotatedIntervals.cpp
   RotatedRectangles.cpp
+  ShellDistribution.cpp
   Sphere.cpp
   )
 
@@ -46,6 +47,7 @@ spectre_target_headers(
   RotatedBricks.hpp
   RotatedIntervals.hpp
   RotatedRectangles.hpp
+  ShellDistribution.hpp
   Sphere.hpp
   )
 

--- a/src/Domain/Creators/ShellDistribution.cpp
+++ b/src/Domain/Creators/ShellDistribution.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/ShellDistribution.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace domain::creators {
+namespace {
+struct DistributionVisitor {
+  size_t num_shells;
+
+  std::vector<domain::CoordinateMaps::Distribution> operator()(
+      const domain::CoordinateMaps::Distribution distribution) const {
+    // NOLINTNEXTLINE(modernize-return-braced-init-list)
+    return std::vector<domain::CoordinateMaps::Distribution>(num_shells,
+                                                             distribution);
+  }
+
+  std::vector<domain::CoordinateMaps::Distribution> operator()(
+      const std::vector<domain::CoordinateMaps::Distribution>& distributions)
+      const {
+    return distributions;
+  }
+};
+}  // namespace
+
+void set_shell_distribution(
+    const gsl::not_null<size_t*> number_of_shells,
+    const gsl::not_null<std::vector<domain::CoordinateMaps::Distribution>*>
+        radial_distribution,
+    const std::vector<double>& radial_partitioning,
+    const std::variant<domain::CoordinateMaps::Distribution,
+                       std::vector<domain::CoordinateMaps::Distribution>>&
+        input_radial_distribution,
+    const double innermost_shell_radius, const double outermost_shell_radius,
+    const std::string& innermost_radius_name,
+    const std::string& outermost_radius_name, const Options::Context& context) {
+  if (not std::is_sorted(radial_partitioning.begin(),
+                         radial_partitioning.end())) {
+    PARSE_ERROR(context,
+                "Specify radial partitioning in ascending order. Specified "
+                "radial partitioning is: "
+                    << radial_partitioning);
+  }
+
+  if (not radial_partitioning.empty()) {
+    if (radial_partitioning.front() <= innermost_shell_radius) {
+      PARSE_ERROR(context, "First radial partition must be larger than the "
+                               << innermost_radius_name << " radius, but is: "
+                               << innermost_shell_radius);
+    }
+    if (radial_partitioning.back() >= outermost_shell_radius) {
+      PARSE_ERROR(context, "Last radial partition must be smaller than the "
+                               << outermost_radius_name << " radius, but is: "
+                               << outermost_shell_radius);
+    }
+    const auto duplicate = std::adjacent_find(radial_partitioning.begin(),
+                                              radial_partitioning.end());
+    if (duplicate != radial_partitioning.end()) {
+      PARSE_ERROR(context, "Radial partitioning contains duplicate element: "
+                               << *duplicate);
+    }
+  }
+
+  (*number_of_shells) = 1 + radial_partitioning.size();
+  (*radial_distribution) = std::visit(DistributionVisitor{*number_of_shells},
+                                      input_radial_distribution);
+  if (radial_distribution->size() != *number_of_shells) {
+    PARSE_ERROR(context,
+                "Specify a 'RadialDistribution' for every spherical shell. You "
+                "specified "
+                    << radial_distribution->size()
+                    << " items, but the domain has " << *number_of_shells
+                    << " shells.");
+  }
+}
+}  // namespace domain::creators

--- a/src/Domain/Creators/ShellDistribution.hpp
+++ b/src/Domain/Creators/ShellDistribution.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Options/Context.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain::creators {
+/*!
+ * \brief Given info about the radial distribution, set the number of shells and
+ * the distribution for each shell.
+ *
+ * \details This is common code that all domain creators can use.
+ */
+void set_shell_distribution(
+    gsl::not_null<size_t*> number_of_shells,
+    gsl::not_null<std::vector<domain::CoordinateMaps::Distribution>*>
+        radial_distribution,
+    const std::vector<double>& radial_partitioning,
+    const std::variant<domain::CoordinateMaps::Distribution,
+                       std::vector<domain::CoordinateMaps::Distribution>>&
+        input_radial_distribution,
+    double innermost_shell_radius, double outermost_shell_radius,
+    const std::string& innermost_radius_name,
+    const std::string& outermost_radius_name,
+    const Options::Context& context = {});
+}  // namespace domain::creators

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -27,6 +27,7 @@
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/ExpandOverBlocks.hpp"
+#include "Domain/Creators/ShellDistribution.hpp"
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
@@ -35,6 +36,7 @@
 #include "Options/ParseError.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
 namespace Frame {
@@ -50,24 +52,6 @@ Excision::Excision(
         local_boundary_condition)
     : boundary_condition(std::move(local_boundary_condition)) {}
 }  // namespace detail
-
-namespace {
-struct DistributionVisitor {
-  size_t num_shells;
-
-  std::vector<domain::CoordinateMaps::Distribution> operator()(
-      const domain::CoordinateMaps::Distribution distribution) const {
-    return std::vector<domain::CoordinateMaps::Distribution>(num_shells,
-                                                             distribution);
-  }
-
-  std::vector<domain::CoordinateMaps::Distribution> operator()(
-      const std::vector<domain::CoordinateMaps::Distribution>& distributions)
-      const {
-    return distributions;
-  }
-};
-}  // namespace
 
 Sphere::Sphere(
     double inner_radius, double outer_radius,
@@ -106,44 +90,10 @@ Sphere::Sphere(
                 "not with a filled sphere.");
   }
   // Validate radial partitions
-  if (not std::is_sorted(radial_partitioning_.begin(),
-                         radial_partitioning_.end())) {
-    PARSE_ERROR(context,
-                "Specify radial partitioning in ascending order. Specified "
-                "radial partitioning is: " +
-                    get_output(radial_partitioning_));
-  }
-  if (not radial_partitioning_.empty()) {
-    if (radial_partitioning_.front() <= inner_radius_) {
-      PARSE_ERROR(context,
-                  "First radial partition must be larger than inner "
-                  "radius, but is: " +
-                      std::to_string(inner_radius_));
-    }
-    if (radial_partitioning_.back() >= outer_radius_) {
-      PARSE_ERROR(context,
-                  "Last radial partition must be smaller than outer "
-                  "radius, but is: " +
-                      std::to_string(outer_radius_));
-    }
-    const auto duplicate = std::adjacent_find(radial_partitioning_.begin(),
-                                              radial_partitioning_.end());
-    if (duplicate != radial_partitioning_.end()) {
-      PARSE_ERROR(context, "Radial partitioning contains duplicate element: "
-                               << *duplicate);
-    }
-  }
-  num_shells_ = 1 + radial_partitioning_.size();
-  radial_distribution_ =
-      std::visit(DistributionVisitor{num_shells_}, radial_distribution);
-  if (radial_distribution_.size() != num_shells_) {
-    PARSE_ERROR(context,
-                "Specify a 'RadialDistribution' for every spherical shell. You "
-                "specified "
-                    << radial_distribution_.size()
-                    << " items, but the domain has " << num_shells_
-                    << " shells.");
-  }
+  set_shell_distribution(
+      make_not_null(&num_shells_), make_not_null(&radial_distribution_),
+      radial_partitioning_, radial_distribution, inner_radius_, outer_radius_,
+      "inner", "outer", context);
   if (fill_interior_ and radial_distribution_.front() !=
                              domain::CoordinateMaps::Distribution::Linear) {
     PARSE_ERROR(context,

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -433,7 +433,7 @@ class Sphere : public DomainCreator<3> {
   bool use_hard_coded_maps_{false};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_;
-  size_t num_shells_;
+  size_t num_shells_{};
   size_t num_blocks_;
   size_t num_blocks_per_shell_;
   std::vector<std::string> block_names_{};

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -108,6 +108,7 @@ DomainCreator:
       RadialDistribution: Projective
     OuterShell:
       Radius: &outer_radius 1e5
+      RadialPartitioning: []
       RadialDistribution: &outer_shell_distribution Inverse
       OpeningAngle: 120.0
       BoundaryCondition: Robin
@@ -119,7 +120,7 @@ DomainCreator:
       ObjectACube:      [{{ L }}, {{ L }}, {{ L }}]
       ObjectBCube:      [{{ L }}, {{ L }}, {{ L }}]
       Envelope:         [{{ L }}, {{ L }}, {{ L + 1 }}]
-      OuterShell:       [{{ L }}, {{ L }}, {{ L }}]
+      OuterShell0:       [{{ L }}, {{ L }}, {{ L }}]
     # This p-refinement represents a crude manual optimization of the domain. We
     # will need AMR to optimize the domain further.
     InitialGridPoints:
@@ -128,7 +129,7 @@ DomainCreator:
       ObjectACube:    [{{ P + 1}}, {{ P + 1}}, {{ P + 2}}]
       ObjectBCube:    [{{ P + 1}}, {{ P + 1}}, {{ P + 2}}]
       Envelope:       [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]
-      OuterShell:     [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]
+      OuterShell0:     [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]
     TimeDependentMaps:
       InitialTime: 0.
       ExpansionMap: None

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -100,6 +100,7 @@ DomainCreator:
     OuterShell:
       Radius: 600.0
       # Radial distribution is linear to resolve gravitational waves
+      RadialPartitioning: []
       RadialDistribution: Linear
       OpeningAngle: 120.0
       BoundaryCondition:
@@ -117,14 +118,14 @@ DomainCreator:
       ObjectBShell:   [{{ L + 1 }}, {{ L + 1 }}, {{ L + 1 }}]
       ObjectBCube:    [{{ L + 2 }}, {{ L + 2 }}, {{ L + 1 }}]
       Envelope:       [{{ L + 1 }}, {{ L + 1 }}, {{ L + 1 }}]
-      OuterShell:     [{{ L     }}, {{ L     }}, {{ L + 2 }}]
+      OuterShell0:     [{{ L     }}, {{ L     }}, {{ L + 2 }}]
     InitialGridPoints:
       ObjectAShell:   [{{ P + 3 }}, {{ P + 3 }}, {{ P + 1 }}]
       ObjectACube:    [{{ P     }}, {{ P     }}, {{ P - 1 }}]
       ObjectBShell:   [{{ P + 3 }}, {{ P + 3 }}, {{ P + 1 }}]
       ObjectBCube:    [{{ P     }}, {{ P     }}, {{ P - 1 }}]
       Envelope:       [{{ P + 3 }}, {{ P + 3 }}, {{ P + 5 }}]
-      OuterShell:     [{{ P + 3 }}, {{ P + 3 }}, {{ P + 4 }}]
+      OuterShell0:     [{{ P + 3 }}, {{ P + 3 }}, {{ P + 4 }}]
 {% if IdFromEvolution %}
     TimeDependentMaps:
       InitialTime: &InitialTime {{ InitialTime }}

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -62,6 +62,7 @@ DomainCreator:
       Radius: 50.
     OuterShell:
       Radius: 400.
+      RadialPartitioning: []
       RadialDistribution: Linear
       OpeningAngle: 90.0
       BoundaryCondition: ConstraintPreservingSphericalRadiation

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -54,6 +54,7 @@ DomainCreator:
       RadialDistribution: Linear
     OuterShell:
       Radius: 300.0
+      RadialPartitioning: []
       RadialDistribution: Linear
       OpeningAngle: 90.0
     UseEquiangularMap: True
@@ -64,7 +65,7 @@ DomainCreator:
       ObjectACube:    [1, 1, 0]
       ObjectBCube:    [1, 1, 0]
       Envelope: [1, 1, 1]
-      OuterShell:     [1, 1, 1]
+      OuterShell0:     [1, 1, 1]
     InitialGridPoints: 3
     TimeDependentMaps:
       InitialTime: 0.0

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -50,6 +50,7 @@ DomainCreator:
     OuterShell:
       OpeningAngle: 90
       Radius: 250.0
+      RadialPartitioning: []
       RadialDistribution: Linear
       BoundaryCondition:
         ConstraintPreservingFreeOutflow:
@@ -60,7 +61,7 @@ DomainCreator:
       ObjectA: [4, 4, 4]
       ObjectB: [4, 4, 4]
       Envelope: [3, 3, 3]
-      OuterShell: [2 ,2 ,3]
+      OuterShell0: [2 ,2 ,3]
     InitialGridPoints: 5
     TimeDependentMaps:
       InitialTime: 0.0

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -133,6 +133,7 @@ DomainCreator:
       RadialDistribution: Projective
     OuterShell:
       Radius: &outer_radius 1.e9
+      RadialPartitioning: []
       RadialDistribution: &outer_shell_distribution Inverse
       OpeningAngle: 120.0
       BoundaryCondition: Flatness
@@ -144,7 +145,7 @@ DomainCreator:
       ObjectACube:      [0, 0, 0]
       ObjectBCube:      [0, 0, 0]
       Envelope:         [0, 0, 1]
-      OuterShell:       [0, 0, 2]
+      OuterShell0:       [0, 0, 2]
     # This p-refinement represents a crude manual optimization of the domain. We
     # will need AMR to optimize the domain further.
     InitialGridPoints:
@@ -153,7 +154,7 @@ DomainCreator:
       ObjectACube:    [6, 6, 7]
       ObjectBCube:    [6, 6, 7]
       Envelope:       [6, 6, 6]
-      OuterShell:     [6, 6, 6]
+      OuterShell0:     [6, 6, 6]
     TimeDependentMaps: None
 
 Amr:

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -61,6 +61,7 @@ DomainCreator:
       RadialDistribution: Projective
     OuterShell:
       Radius: &outer_radius 600.
+      RadialPartitioning: []
       RadialDistribution: &outer_shell_distribution Inverse
       OpeningAngle: 90.0
       BoundaryCondition: Flatness
@@ -86,16 +87,16 @@ DomainCreator:
       EnvelopeUpperYRight:        [1, 1, 0]
       EnvelopeLowerYRight:        [1, 1, 0]
       EnvelopeUpperX:             [1, 1, 0]
-      OuterShellUpperZLeft:       [0, 1, 0]
-      OuterShellLowerZLeft:       [0, 1, 0]
-      OuterShellUpperYLeft:       [0, 1, 0]
-      OuterShellLowerYLeft:       [0, 1, 0]
-      OuterShellLowerX:           [1, 1, 0]
-      OuterShellUpperZRight:      [0, 1, 0]
-      OuterShellLowerZRight:      [0, 1, 0]
-      OuterShellUpperYRight:      [0, 1, 0]
-      OuterShellLowerYRight:      [0, 1, 0]
-      OuterShellUpperX:           [1, 1, 0]
+      OuterShell0UpperZLeft:       [0, 1, 0]
+      OuterShell0LowerZLeft:       [0, 1, 0]
+      OuterShell0UpperYLeft:       [0, 1, 0]
+      OuterShell0LowerYLeft:       [0, 1, 0]
+      OuterShell0LowerX:           [1, 1, 0]
+      OuterShell0UpperZRight:      [0, 1, 0]
+      OuterShell0LowerZRight:      [0, 1, 0]
+      OuterShell0UpperYRight:      [0, 1, 0]
+      OuterShell0LowerYRight:      [0, 1, 0]
+      OuterShell0UpperX:           [1, 1, 0]
     # This p-refinement represents a crude manual optimization of the domain. We
     # will need AMR to optimize the domain further.
     InitialGridPoints:
@@ -106,7 +107,7 @@ DomainCreator:
       ObjectACube:     [4, 4, 5]
       ObjectBCube:     [4, 4, 5]
       Envelope:        [4, 4, 4]
-      OuterShell:      [4, 4, 3]
+      OuterShell0:      [4, 4, 3]
     TimeDependentMaps: None
 
 Discretization:

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -342,6 +342,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FindTwoCenters",
       {4_st},
       true,
       domain::CoordinateMaps::Distribution::Projective,
+      std::vector<double>{},
       domain::CoordinateMaps::Distribution::Linear,
       90.0,
       time_dep_opts};

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -16,6 +16,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
@@ -139,6 +140,20 @@ void test_connectivity() {
       CAPTURE(outer_radius_objectA);
       CAPTURE(inner_radius_objectB);
       CAPTURE(outer_radius_objectB);
+      std::variant<Distribution, std::vector<Distribution>>
+          variant_radial_distribution_outer_shells =
+              radial_distribution_outer_shell;
+      if (radial_distribution_outer_shell == Distribution::Linear) {
+        variant_radial_distribution_outer_shells = std::vector{
+            radial_distribution_outer_shell, radial_distribution_outer_shell};
+      }
+      const bool multiple_outer_shells =
+          std::holds_alternative<std::vector<Distribution>>(
+              variant_radial_distribution_outer_shells);
+      const std::vector<double> radial_partitioning_outer_shells =
+          multiple_outer_shells
+              ? std::vector<double>{0.5 * (envelope_radius + outer_radius)}
+              : std::vector<double>{};
       std::unordered_map<std::string, std::array<size_t, 3>> refinement{
           {"ObjectAShell", {{1, 1, 1}}},
           {"ObjectACube", {{1, 1, 1}}},
@@ -146,14 +161,18 @@ void test_connectivity() {
           {"ObjectBCube", {{1, 1, 1}}},
           {"Envelope", {{1, 1, 1}}},
           // Add some radial refinement in outer shell
-          {"OuterShell", {{1, 1, 4}}}};
+          {"OuterShell0", {{1, 1, 4}}}};
+      if (multiple_outer_shells) {
+        refinement["OuterShell1"] = std::array{1_st, 1_st, 2_st};
+      }
       if (not excise_interiorA) {
         refinement["ObjectAInterior"] = std::array<size_t, 3>{{1, 1, 1}};
       }
       if (not excise_interiorB) {
         refinement["ObjectBInterior"] = std::array<size_t, 3>{{1, 1, 1}};
       }
-      CAPTURE(radial_distribution_outer_shell);
+      CAPTURE(radial_partitioning_outer_shells);
+      CAPTURE(variant_radial_distribution_outer_shells);
       CAPTURE(radial_distribution_envelope);
       const domain::creators::BinaryCompactObject binary_compact_object{
           Object{inner_radius_objectA, outer_radius_objectA, xcoord_objectA,
@@ -180,7 +199,8 @@ void test_connectivity() {
           grid_points,
           use_equiangular_map,
           radial_distribution_envelope,
-          radial_distribution_outer_shell,
+          radial_partitioning_outer_shells,
+          variant_radial_distribution_outer_shells,
           opening_angle,
           std::nullopt,
           with_boundary_conditions ? create_outer_boundary_condition()
@@ -190,28 +210,28 @@ void test_connectivity() {
           binary_compact_object, with_boundary_conditions);
 
       std::vector<std::string> expected_block_names{
-          "ObjectAShellUpperZ",   "ObjectAShellLowerZ",
-          "ObjectAShellUpperY",   "ObjectAShellLowerY",
-          "ObjectAShellUpperX",   "ObjectAShellLowerX",
-          "ObjectACubeUpperZ",    "ObjectACubeLowerZ",
-          "ObjectACubeUpperY",    "ObjectACubeLowerY",
-          "ObjectACubeUpperX",    "ObjectACubeLowerX",
-          "ObjectBShellUpperZ",   "ObjectBShellLowerZ",
-          "ObjectBShellUpperY",   "ObjectBShellLowerY",
-          "ObjectBShellUpperX",   "ObjectBShellLowerX",
-          "ObjectBCubeUpperZ",    "ObjectBCubeLowerZ",
-          "ObjectBCubeUpperY",    "ObjectBCubeLowerY",
-          "ObjectBCubeUpperX",    "ObjectBCubeLowerX",
-          "EnvelopeUpperZLeft",   "EnvelopeUpperZRight",
-          "EnvelopeLowerZLeft",   "EnvelopeLowerZRight",
-          "EnvelopeUpperYLeft",   "EnvelopeUpperYRight",
-          "EnvelopeLowerYLeft",   "EnvelopeLowerYRight",
-          "EnvelopeUpperX",       "EnvelopeLowerX",
-          "OuterShellUpperZLeft", "OuterShellUpperZRight",
-          "OuterShellLowerZLeft", "OuterShellLowerZRight",
-          "OuterShellUpperYLeft", "OuterShellUpperYRight",
-          "OuterShellLowerYLeft", "OuterShellLowerYRight",
-          "OuterShellUpperX",     "OuterShellLowerX"};
+          "ObjectAShellUpperZ",    "ObjectAShellLowerZ",
+          "ObjectAShellUpperY",    "ObjectAShellLowerY",
+          "ObjectAShellUpperX",    "ObjectAShellLowerX",
+          "ObjectACubeUpperZ",     "ObjectACubeLowerZ",
+          "ObjectACubeUpperY",     "ObjectACubeLowerY",
+          "ObjectACubeUpperX",     "ObjectACubeLowerX",
+          "ObjectBShellUpperZ",    "ObjectBShellLowerZ",
+          "ObjectBShellUpperY",    "ObjectBShellLowerY",
+          "ObjectBShellUpperX",    "ObjectBShellLowerX",
+          "ObjectBCubeUpperZ",     "ObjectBCubeLowerZ",
+          "ObjectBCubeUpperY",     "ObjectBCubeLowerY",
+          "ObjectBCubeUpperX",     "ObjectBCubeLowerX",
+          "EnvelopeUpperZLeft",    "EnvelopeUpperZRight",
+          "EnvelopeLowerZLeft",    "EnvelopeLowerZRight",
+          "EnvelopeUpperYLeft",    "EnvelopeUpperYRight",
+          "EnvelopeLowerYLeft",    "EnvelopeLowerYRight",
+          "EnvelopeUpperX",        "EnvelopeLowerX",
+          "OuterShell0UpperZLeft", "OuterShell0UpperZRight",
+          "OuterShell0LowerZLeft", "OuterShell0LowerZRight",
+          "OuterShell0UpperYLeft", "OuterShell0UpperYRight",
+          "OuterShell0LowerYLeft", "OuterShell0LowerYRight",
+          "OuterShell0UpperX",     "OuterShell0LowerX"};
       std::unordered_map<std::string, std::unordered_set<std::string>>
           expected_block_groups{
               {"ObjectAShell",
@@ -233,12 +253,24 @@ void test_connectivity() {
                 "EnvelopeLowerZRight", "EnvelopeUpperYRight",
                 "EnvelopeLowerYRight", "EnvelopeUpperYLeft",
                 "EnvelopeUpperZLeft", "EnvelopeLowerYLeft", "EnvelopeLowerX"}},
-              {"OuterShell",
-               {"OuterShellUpperZLeft", "OuterShellUpperZRight",
-                "OuterShellLowerZLeft", "OuterShellLowerZRight",
-                "OuterShellUpperYLeft", "OuterShellUpperYRight",
-                "OuterShellLowerYLeft", "OuterShellLowerYRight",
-                "OuterShellUpperX", "OuterShellLowerX"}}};
+              {"OuterShell0",
+               {"OuterShell0UpperZLeft", "OuterShell0UpperZRight",
+                "OuterShell0LowerZLeft", "OuterShell0LowerZRight",
+                "OuterShell0UpperYLeft", "OuterShell0UpperYRight",
+                "OuterShell0LowerYLeft", "OuterShell0LowerYRight",
+                "OuterShell0UpperX", "OuterShell0LowerX"}}};
+      if (multiple_outer_shells) {
+        const std::vector<std::string> shell_1_names = {
+            "OuterShell1UpperZLeft", "OuterShell1UpperZRight",
+            "OuterShell1LowerZLeft", "OuterShell1LowerZRight",
+            "OuterShell1UpperYLeft", "OuterShell1UpperYRight",
+            "OuterShell1LowerYLeft", "OuterShell1LowerYRight",
+            "OuterShell1UpperX",     "OuterShell1LowerX"};
+        expected_block_groups["OuterShell1"] = std::unordered_set<std::string>{
+            shell_1_names.begin(), shell_1_names.end()};
+        expected_block_names.insert(expected_block_names.end(),
+                                    shell_1_names.begin(), shell_1_names.end());
+      }
       if (not excise_interiorA) {
         expected_block_names.emplace_back("ObjectAInterior");
       }
@@ -300,8 +332,9 @@ void test_connectivity() {
                 (excise_interiorA and excise_interiorB) ? cube_scale
                                                         : cube_scales[0],
                 refinement, grid_points, use_equiangular_map,
-                radial_distribution_envelope, radial_distribution_outer_shell,
-                opening_angle, std::nullopt, std::make_unique<PeriodicBc>(),
+                radial_distribution_envelope, radial_partitioning_outer_shells,
+                variant_radial_distribution_outer_shells, opening_angle,
+                std::nullopt, std::make_unique<PeriodicBc>(),
                 Options::Context{false, {}, 1, 1}),
             Catch::Matchers::ContainsSubstring(
                 "Cannot have periodic boundary "
@@ -325,9 +358,10 @@ void test_connectivity() {
                   (excise_interiorA and excise_interiorB) ? cube_scale
                                                           : cube_scales[0],
                   refinement, grid_points, use_equiangular_map,
-                  radial_distribution_envelope, radial_distribution_outer_shell,
-                  opening_angle, std::nullopt,
-                  create_outer_boundary_condition(),
+                  radial_distribution_envelope,
+                  radial_partitioning_outer_shells,
+                  variant_radial_distribution_outer_shells, opening_angle,
+                  std::nullopt, create_outer_boundary_condition(),
                   Options::Context{false, {}, 1, 1}),
               Catch::Matchers::ContainsSubstring(
                   "Cannot have periodic boundary "
@@ -352,9 +386,10 @@ void test_connectivity() {
                   (excise_interiorA and excise_interiorB) ? cube_scale
                                                           : cube_scales[0],
                   refinement, grid_points, use_equiangular_map,
-                  radial_distribution_envelope, radial_distribution_outer_shell,
-                  opening_angle, std::nullopt, nullptr,
-                  Options::Context{false, {}, 1, 1}),
+                  radial_distribution_envelope,
+                  radial_partitioning_outer_shells,
+                  variant_radial_distribution_outer_shells, opening_angle,
+                  std::nullopt, nullptr, Options::Context{false, {}, 1, 1}),
               Catch::Matchers::ContainsSubstring(
                   "Must specify either both inner and outer boundary "
                   "conditions or neither."));
@@ -376,9 +411,10 @@ void test_connectivity() {
                   (excise_interiorA and excise_interiorB) ? cube_scale
                                                           : cube_scales[0],
                   refinement, grid_points, use_equiangular_map,
-                  radial_distribution_envelope, radial_distribution_outer_shell,
-                  opening_angle, std::nullopt,
-                  create_outer_boundary_condition(),
+                  radial_distribution_envelope,
+                  radial_partitioning_outer_shells,
+                  variant_radial_distribution_outer_shells, opening_angle,
+                  std::nullopt, create_outer_boundary_condition(),
                   Options::Context{false, {}, 1, 1}),
               Catch::Matchers::ContainsSubstring(
                   "Must specify either both inner and outer boundary "
@@ -475,7 +511,11 @@ std::string create_option_string(
          "    RadialDistribution: Projective\n"
          "  OuterShell:\n"
          "    Radius: 25.0\n"
-         "    RadialDistribution: Linear\n" +
+         "    RadialPartitioning: [" +
+         (excise_B ? "23.5" : "") +
+         "]\n"
+         "    RadialDistribution: " +
+         (excise_B ? "[Logarithmic, Linear]" : "Linear") + "\n" +
          "    OpeningAngle: " + std::to_string(opening_angle) + "\n" +
          outer_boundary_condition + "  InitialRefinement:\n" +
          (excise_A ? "" : "    ObjectAInterior: [1, 1, 1]\n") +
@@ -489,11 +529,10 @@ std::string create_option_string(
          "    ObjectACube: [1, 1, 1]\n"
          "    ObjectBCube: [1, 1, 1]\n"
          "    Envelope: [1, 1, 1]\n"
-         "    OuterShell: [1, 1, " +
-         std::to_string(1 + additional_refinement_outer) +
-         "]\n"
-         "  InitialGridPoints: 3\n" +
-         "  CubeScale: " + cube_scale +
+         "    OuterShell0: [1, 1, " +
+         std::to_string(1 + additional_refinement_outer) + "]\n" +
+         (excise_B ? "    OuterShell1: [1, 1, 0]\n" : "") +
+         "  InitialGridPoints: 3\n" + "  CubeScale: " + cube_scale +
          "\n"
          "  UseEquiangularMap: " +
          stringize(use_equiangular_map) + "\n" + time_dependence;
@@ -534,7 +573,8 @@ void test_bns_domain_with_cubes() {
       {"ObjectA", {{1, 1, 1}}},
       {"ObjectB", {{1, 1, 1}}},
       {"Envelope", {{1, 1, 1}}},
-      {"OuterShell", {{1, 1, 4}}}};
+      {"OuterShell0", {{1, 1, 4}}},
+      {"OuterShell1", {{1, 1, 2}}}};
 
   for (const auto cube_scale : cube_scales) {
     const domain::creators::BinaryCompactObject binary_compact_object{
@@ -548,6 +588,7 @@ void test_bns_domain_with_cubes() {
         grid_points,
         use_equiangular_map,
         radial_distribution_envelope,
+        std::vector<double>{0.49 * (envelope_radius + outer_radius)},
         radial_distribution_outer_shell,
         opening_angle,
         std::nullopt,
@@ -568,16 +609,26 @@ void test_bns_domain_with_cubes() {
                                                   "EnvelopeLowerYRight",
                                                   "EnvelopeUpperX",
                                                   "EnvelopeLowerX",
-                                                  "OuterShellUpperZLeft",
-                                                  "OuterShellUpperZRight",
-                                                  "OuterShellLowerZLeft",
-                                                  "OuterShellLowerZRight",
-                                                  "OuterShellUpperYLeft",
-                                                  "OuterShellUpperYRight",
-                                                  "OuterShellLowerYLeft",
-                                                  "OuterShellLowerYRight",
-                                                  "OuterShellUpperX",
-                                                  "OuterShellLowerX"};
+                                                  "OuterShell0UpperZLeft",
+                                                  "OuterShell0UpperZRight",
+                                                  "OuterShell0LowerZLeft",
+                                                  "OuterShell0LowerZRight",
+                                                  "OuterShell0UpperYLeft",
+                                                  "OuterShell0UpperYRight",
+                                                  "OuterShell0LowerYLeft",
+                                                  "OuterShell0LowerYRight",
+                                                  "OuterShell0UpperX",
+                                                  "OuterShell0LowerX",
+                                                  "OuterShell1UpperZLeft",
+                                                  "OuterShell1UpperZRight",
+                                                  "OuterShell1LowerZLeft",
+                                                  "OuterShell1LowerZRight",
+                                                  "OuterShell1UpperYLeft",
+                                                  "OuterShell1UpperYRight",
+                                                  "OuterShell1LowerYLeft",
+                                                  "OuterShell1LowerYRight",
+                                                  "OuterShell1UpperX",
+                                                  "OuterShell1LowerX"};
     std::unordered_map<std::string, std::unordered_set<std::string>>
         expected_block_groups{
             {"Envelope",
@@ -585,12 +636,18 @@ void test_bns_domain_with_cubes() {
               "EnvelopeLowerZRight", "EnvelopeUpperYRight",
               "EnvelopeLowerYRight", "EnvelopeUpperYLeft", "EnvelopeUpperZLeft",
               "EnvelopeLowerYLeft", "EnvelopeLowerX"}},
-            {"OuterShell",
-             {"OuterShellUpperZLeft", "OuterShellUpperZRight",
-              "OuterShellLowerZLeft", "OuterShellLowerZRight",
-              "OuterShellUpperYLeft", "OuterShellUpperYRight",
-              "OuterShellLowerYLeft", "OuterShellLowerYRight",
-              "OuterShellUpperX", "OuterShellLowerX"}}};
+            {"OuterShell0",
+             {"OuterShell0UpperZLeft", "OuterShell0UpperZRight",
+              "OuterShell0LowerZLeft", "OuterShell0LowerZRight",
+              "OuterShell0UpperYLeft", "OuterShell0UpperYRight",
+              "OuterShell0LowerYLeft", "OuterShell0LowerYRight",
+              "OuterShell0UpperX", "OuterShell0LowerX"}},
+            {"OuterShell1",
+             {"OuterShell1UpperZLeft", "OuterShell1UpperZRight",
+              "OuterShell1LowerZLeft", "OuterShell1LowerZRight",
+              "OuterShell1UpperYLeft", "OuterShell1UpperYRight",
+              "OuterShell1LowerYLeft", "OuterShell1LowerYRight",
+              "OuterShell1UpperX", "OuterShell1LowerX"}}};
     CHECK(binary_compact_object.block_names() == expected_block_names);
     CHECK(binary_compact_object.block_groups() == expected_block_groups);
   }
@@ -741,11 +798,52 @@ void test_binary_factory() {
 void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
+          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{20.0},
+          Distribution::Linear, 120.0, std::nullopt,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "First radial partition must be larger than the envelope radius"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{40.0},
+          Distribution::Linear, 120.0, std::nullopt,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Last radial partition must be smaller than the outer radius"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{28.0, 28.0},
+          Distribution::Linear, 120.0, std::nullopt,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Radial partitioning contains duplicate element"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{28.0, 29.0},
+          std::vector{Distribution::Linear}, 120.0, std::nullopt,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Specify a 'RadialDistribution' for every spherical shell."));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of ObjectA's center is expected to be positive."));
   CHECK_THROWS_WITH(
@@ -753,8 +851,9 @@ void test_parse_errors() {
           Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of ObjectB's center is expected to be negative."));
   CHECK_THROWS_WITH(
@@ -762,8 +861,9 @@ void test_parse_errors() {
           Object{0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius for the enveloping cube is too "
           "small! The Frustums will be malformed."));
@@ -772,8 +872,9 @@ void test_parse_errors() {
           Object{0.3, 1.0, 8.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -7.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 0.5, 2_st, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The cube length should be greater than or equal to the initial "
           "separation between the two objects."));
@@ -782,8 +883,9 @@ void test_parse_errors() {
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "ObjectB's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
@@ -791,8 +893,9 @@ void test_parse_errors() {
           Object{3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "ObjectA's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
@@ -800,8 +903,9 @@ void test_parse_errors() {
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
           Object{0.5, 1.0, -1.0, std::nullopt, true},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, true, 6_st,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Using a logarithmically spaced radial grid in the "
           "part of Layer 1 enveloping Object B requires excising the interior "
@@ -811,8 +915,9 @@ void test_parse_errors() {
           Object{0.3, 1.0, 1.0, std::nullopt, true},
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Using a logarithmically spaced radial grid in the "
           "part of Layer 1 enveloping Object A requires excising the interior "
@@ -830,8 +935,9 @@ void test_parse_errors() {
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0,
           std::vector<std::array<size_t, 3>>{}, 6_st, true,
-          Distribution::Projective, Distribution::Linear, 120.0, std::nullopt,
-          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("Invalid 'InitialRefinement'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
@@ -839,7 +945,7 @@ void test_parse_errors() {
           Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st,
           std::vector<std::array<size_t, 3>>{}, true, Distribution::Projective,
-          Distribution::Linear, 120.0, std::nullopt,
+          std::vector<double>{}, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("Invalid 'InitialGridPoints'"));
   // Note: the boundary condition-related parse errors are checked in the
@@ -876,6 +982,7 @@ void test_kerr_horizon_conforming() {
       6_st,
       true,
       Distribution::Projective,
+      std::vector<double>{},
       Distribution::Inverse,
       120.,
       domain::creators::bco::TimeDependentMapOptions<false>{

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -456,7 +456,7 @@ void test_parse_errors() {
                        radial_distribution, which_wedges, std::nullopt, nullptr,
                        Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "First radial partition must be larger than inner"));
+          "First radial partition must be larger than the inner"));
   CHECK_THROWS_WITH(
       creators::Sphere(inner_radius, outer_radius, inner_cube, refinement,
                        initial_extents, use_equiangular_map,
@@ -464,7 +464,7 @@ void test_parse_errors() {
                        radial_distribution, which_wedges, std::nullopt, nullptr,
                        Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "Last radial partition must be smaller than outer"));
+          "Last radial partition must be smaller than the outer"));
   CHECK_THROWS_WITH(
       creators::Sphere(inner_radius, outer_radius, inner_cube, refinement,
                        initial_extents, use_equiangular_map,

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -54,6 +54,7 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "    RadialDistribution: Linear\n"
       "  OuterShell:\n"
       "    Radius: 50.0\n"
+      "    RadialPartitioning: []\n"
       "    RadialDistribution: Linear\n"
       "    OpeningAngle: 90.0\n"
       "    BoundaryCondition:\n"

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -290,7 +290,7 @@ void test_interpolate_on_element(
                 {"ObjectBShell", std::array{2_st, 2_st, 2_st}},
                 {"ObjectBCube", std::array{2_st, 2_st, 2_st}},
                 {"Envelope", std::array{0_st, 0_st, 0_st}},
-                {"OuterShell", std::array{0_st, 0_st, 0_st}}},
+                {"OuterShell0", std::array{0_st, 0_st, 0_st}}},
             7_st);
       } else {
         return std::make_unique<domain::creators::Sphere>(

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -130,6 +130,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
         6_st,
         true,
         domain::CoordinateMaps::Distribution::Projective,
+        std::vector<double>{},
         domain::CoordinateMaps::Distribution::Inverse,
         120.};
     const auto domain = domain_creator.create_domain();

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -24,6 +24,7 @@ SourceDomainCreator:
       RadialDistribution: Projective
     OuterShell:
       Radius: 350.
+      RadialPartitioning: []
       RadialDistribution: Inverse
       OpeningAngle: 90.0
     UseEquiangularMap: True
@@ -52,6 +53,7 @@ TargetDomainCreator:
       RadialDistribution: Projective
     OuterShell:
       Radius: 300.
+      RadialPartitioning: []
       RadialDistribution: Linear
       OpeningAngle: 90.0
     UseEquiangularMap: True


### PR DESCRIPTION
## Proposed changes

This was requested for BNS simulations, and will probably be needed for BBH as well at some point. I purposefully didn't add this to the cylindrical domain because that domain needs a lot of work and it wasn't clear how to add radial partitioning easily.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When using the BCO domain creator, whenever you specify the "OuterShell" block name, now you must specify "OuterShell0", along with any more shells that are added to the `RadialPartitioning:`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
