### PR TITLE
Improve some parsing error messages

### DIFF
--- a/src/Options/Auto.hpp
+++ b/src/Options/Auto.hpp
@@ -12,9 +12,10 @@
 #include <variant>
 
 #include "Options/Options.hpp"
-#include "Options/ParseOptions.hpp"
+#include "Options/ParseError.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 namespace Options {
 /// The label representing the absence of a value for `Options::Auto`

--- a/src/Options/Factory.hpp
+++ b/src/Options/Factory.hpp
@@ -108,14 +108,14 @@ std::unique_ptr<BaseClass> create(const Option& options) {
   } else if (node.IsMap()) {
     if (node.size() != 1) {
       PARSE_ERROR(derived_opts.context(),
-                  "Expected a single class to create, got "
-                  << node.size() << ":\n" << node);
+                  "Expected a class name (and possibly options), got multiple "
+                  "key-value pairs:\n" << node);
     }
     id = node.begin()->first.as<std::string>();
     derived_opts.set_node(node.begin()->second);
   } else if (node.IsNull()) {
     PARSE_ERROR(derived_opts.context(),
-                "Expected a class to create:\n"
+                "Expected a class name (and possibly options):\n"
                 << help_derived<creatable_classes>());
   } else {
     PARSE_ERROR(derived_opts.context(),

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -1233,6 +1233,8 @@ struct create_from_yaml<std::variant<T...>> {
                                                            Metavariables>(
           options, alternative_parsable_types{});
     } else {
+      const std::string error_separator =
+          "\n--------------------------------------------------\n";
       Result result{};
       std::string errors{};
       bool constructed = false;
@@ -1245,11 +1247,11 @@ struct create_from_yaml<std::variant<T...>> {
           constructed = true;
         } catch (const Options::detail::propagate_context& e) {
           // This alternative failed, but a later one may succeed.
-          errors += "\n\n" + e.message();
+          errors += error_separator + e.message();
         }
       }
 
-      const auto try_parse = [&constructed, &errors, &options,
+      const auto try_parse = [&constructed, &error_separator, &errors, &options,
                               &result](auto alternative_v) {
         using Alternative = tmpl::type_from<decltype(alternative_v)>;
         if (use_hybrid_parsing and
@@ -1265,7 +1267,7 @@ struct create_from_yaml<std::variant<T...>> {
           constructed = true;
         } catch (const Options::detail::propagate_context& e) {
           // This alternative failed, but a later one may succeed.
-          errors += "\n\n" + e.message();
+          errors += error_separator + e.message();
         }
       };
       EXPAND_PACK_LEFT_TO_RIGHT(try_parse(tmpl::type_<T>{}));

--- a/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
@@ -43,6 +43,7 @@
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -409,15 +409,15 @@ void trigger_missing_arg() {
 SPECTRE_TEST_CASE("Unit.Options.Factory.missing", "[Unit][Options]") {
   CHECK_THROWS_WITH(trigger_missing(),
                     Catch::Matchers::ContainsSubstring(
-                        "At line 1 column 1:\nExpected a class to "
-                        "create:\nKnown Ids:\n  Test1"));
+                        "At line 1 column 1:\nExpected a class name (and "
+                        "possibly options):\nKnown Ids:\n  Test1"));
 }
 
 SPECTRE_TEST_CASE("Unit.Options.Factory.multiple", "[Unit][Options]") {
   CHECK_THROWS_WITH(
       trigger_multiple(),
       Catch::Matchers::ContainsSubstring(
-          "At line 2 column 3:\nExpected a single class to create, got 2"));
+          "At line 2 column 3:\nExpected a class name (and possibly options)"));
 }
 
 SPECTRE_TEST_CASE("Unit.Options.Factory.vector", "[Unit][Options]") {

--- a/tools/ValidateInputFile.py
+++ b/tools/ValidateInputFile.py
@@ -116,19 +116,25 @@ def validate_input_file(
             found_hints = True
             continue
         if found_hints:
-            if line.startswith("In group"):
-                path.append(line[9:-1])
-            elif line.startswith("While parsing option"):
-                path.append(line[21:-1])
-            elif line.startswith("While creating a"):
-                path.append(line[17:-1])
-            elif line.startswith("At line"):
-                match = re.match(r"At line ([0-9]+) column ([0-9]+)", line)
-                line_number, _ = map(int, match.groups())
-            elif line.startswith("While operating factory for"):
-                # remove "unique_ptr" entry from path
-                path.pop()
-            elif "# ERROR #" in line:
+            if line_number is None:
+                if line.startswith("In group"):
+                    path.append(line[9:-1])
+                    continue
+                elif line.startswith("While parsing option"):
+                    path.append(line[21:-1])
+                    continue
+                elif line.startswith("While creating a"):
+                    path.append(line[17:-1])
+                    continue
+                elif line.startswith("At line"):
+                    match = re.match(r"At line ([0-9]+) column ([0-9]+)", line)
+                    line_number, _ = map(int, match.groups())
+                    continue
+                elif line.startswith("While operating factory for"):
+                    # remove "unique_ptr" entry from path
+                    path.pop()
+                    continue
+            if "# ERROR #" in line:
                 break
             else:
                 msg.append(line)


### PR DESCRIPTION
Thanks to @SunPeike for input on the messages.

Example before:
```
/home/wthrowe/spectre/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
:80
   78       - Lower:
   79           DirichletAnalytic:
❱  80         Upper:
   81           DirichletAnalytic:
   82 

In 
DomainCreator.Interval.BoundaryConditions.variant.variant.variant.LowerUpperBoun
daryCondition.Lower.DirichletAnalytic:

InvalidInputFileError: Failed to convert value to type BoundaryCondition or 
LowerUpperBoundaryCondition:
  Lower:
    DirichletAnalytic: ~
  Upper:
    DirichletAnalytic: ~

Possible errors:

Expected a single class to create, got 2:
Lower:
  DirichletAnalytic: ~
Upper:
  DirichletAnalytic: ~

You did not specify the option (AnalyticPrescription)

==== Parsing the option string:
~

==== Description of expected options:
DirichletAnalytic boundary conditions setting the value of Psi, Phi, and Pi to 
the analytic solution or analytic data.

Options:
  AnalyticPrescription:
    type=InitialData
    What analytic solution/data to prescribe.
```
After:
```
/home/wthrowe/spectre/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
:78
   76         Velocity: [0.5]
   77     BoundaryConditions:
❱  78       - Lower:
   79           DirichletAnalytic:
   80         Upper:

In DomainCreator.Interval.BoundaryConditions.variant:

InvalidInputFileError: Failed to convert value to type BoundaryCondition or 
LowerUpperBoundaryCondition:
  Lower:
    DirichletAnalytic: ~
  Upper:
    DirichletAnalytic: ~

Possible errors:
--------------------------------------------------
While creating a variant:
While creating a unique_ptr:
While operating factory for BoundaryCondition:
At line 78 column 9:
Expected a class name (and possibly options), got multiple key-value pairs:
Lower:
  DirichletAnalytic: ~
Upper:
  DirichletAnalytic: ~
--------------------------------------------------
While creating a variant:
While creating a LowerUpperBoundaryCondition:
While parsing option Lower:
While creating a unique_ptr:
While operating factory for BoundaryCondition:
While creating a DirichletAnalytic:
At line 80 column 9:
You did not specify the option (AnalyticPrescription)

==== Parsing the option string:
~

==== Description of expected options:
DirichletAnalytic boundary conditions setting the value of Psi, Phi, and Pi to 
the analytic solution or analytic data.

Options:
  AnalyticPrescription:
    type=InitialData
    What analytic solution/data to prescribe.
```

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
