### PR TITLE
Allow CCE ObserveFields to write volume data synchronously

### DIFF
--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -203,9 +203,6 @@ struct CharacteristicEvolution {
           typename Metavariables::cce_boundary_component,
           CharacteristicEvolution<Metavariables>>,
       ::Actions::Label<CceEvolutionLabelTag>,
-      tmpl::conditional_t<evolve_ccm, tmpl::list<>,
-                          evolution::Actions::RunEventsAndTriggers<
-                              Metavariables::local_time_stepping>>,
       Actions::ReceiveWorldtubeData<
           Metavariables,
           typename Metavariables::cce_boundary_communication_tags>,
@@ -222,6 +219,9 @@ struct CharacteristicEvolution {
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      tmpl::conditional_t<evolve_ccm, tmpl::list<>,
+                          evolution::Actions::RunEventsAndTriggers<
+                              Metavariables::local_time_stepping>>,
       compute_scri_quantities_and_observe,
       ::Actions::TakeLtsStep<cce_system,
                              typename Metavariables::cce_step_choosers>,

--- a/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
+++ b/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
@@ -30,6 +30,8 @@
 #include "Options/ParseError.hpp"
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/Gsl.hpp"
@@ -130,7 +132,9 @@ std::string name() {
  * spin weighted quantities above (and time as the first column).
  *
  * All data will be written into the `observers::OptionTags::ReductionFileName`
- * file.
+ * file. If CCE is run on a single core, then this will write the volume data
+ * immediately (synchronously) instead of sending it to the ObserverWriter to be
+ * written asynchronously.
  */
 class ObserveFields : public Event {
   template <typename Tag, bool IncludeSecondDeriv = true>
@@ -197,6 +201,9 @@ class ObserveFields : public Event {
                   const ArrayIndex& /*array_index*/,
                   const ParallelComponent* const /*component*/,
                   const ObservationValue& /*observation_value*/) const {
+    const bool write_synchronously =
+        Parallel::number_of_procs<size_t>(cache) == 1;
+
     // Number of points
     const size_t l_max = get<Tags::LMax>(box);
     const size_t l_max_plus_one_squared = square(l_max + 1);
@@ -324,11 +331,18 @@ class ObserveFields : public Event {
         inertial_retarded_time_to_write[i + 1] = data_to_write[2 * i + 1];
       }
 
-      // Send to observer writer
-      Parallel::threaded_action<
-          observers::ThreadedActions::WriteReductionDataRow>(
-          observer_proxy, subfile_name, inertial_retarded_time_legend,
-          std::make_tuple(std::move(inertial_retarded_time_to_write)));
+      if (write_synchronously) {
+        Parallel::local_synchronous_action<
+            observers::ThreadedActions::WriteReductionDataRow>(
+            observer_proxy, cache, subfile_name, inertial_retarded_time_legend,
+            std::make_tuple(std::move(inertial_retarded_time_to_write)));
+      } else {
+        // Send to observer writer
+        Parallel::threaded_action<
+            observers::ThreadedActions::WriteReductionDataRow>(
+            observer_proxy, subfile_name, inertial_retarded_time_legend,
+            std::make_tuple(std::move(inertial_retarded_time_to_write)));
+      }
     }
 
     // One minus y is also special because every angular grid point for a given
@@ -359,11 +373,18 @@ class ObserveFields : public Event {
                                         std::to_string(radial_index));
       }
 
-      // Send to observer writer
-      Parallel::threaded_action<
-          observers::ThreadedActions::WriteReductionDataRow>(
-          observer_proxy, subfile_name, one_minus_y_legend,
-          std::make_tuple(std::move(one_minus_y_to_write)));
+      if (write_synchronously) {
+        Parallel::local_synchronous_action<
+            observers::ThreadedActions::WriteReductionDataRow>(
+            observer_proxy, cache, subfile_name, one_minus_y_legend,
+            std::make_tuple(std::move(one_minus_y_to_write)));
+      } else {
+        // Send to observer writer
+        Parallel::threaded_action<
+            observers::ThreadedActions::WriteReductionDataRow>(
+            observer_proxy, subfile_name, one_minus_y_legend,
+            std::make_tuple(std::move(one_minus_y_to_write)));
+      }
     }
 
     // Everything needs the same time so we just write it once here. We use the
@@ -400,11 +421,18 @@ class ObserveFields : public Event {
         transform_to_modal(tag{}, spin_weighted_transform, goldberg_modes,
                            radial_index);
 
-        // Send to observer writer
-        Parallel::threaded_action<
-            observers::ThreadedActions::WriteReductionDataRow>(
-            observer_proxy, subfile_name, file_legend,
-            std::make_tuple(data_to_write));
+        if (write_synchronously) {
+          Parallel::local_synchronous_action<
+              observers::ThreadedActions::WriteReductionDataRow>(
+              observer_proxy, cache, subfile_name, file_legend,
+              std::make_tuple(data_to_write));
+        } else {
+          // Send to observer writer
+          Parallel::threaded_action<
+              observers::ThreadedActions::WriteReductionDataRow>(
+              observer_proxy, subfile_name, file_legend,
+              std::make_tuple(data_to_write));
+        }
       }
     });
   }

--- a/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
@@ -14,12 +14,18 @@
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
+#include "Parallel/NodeLock.hpp"
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -64,14 +70,43 @@ struct MockWriteReductionDataRow {
   }
 };
 
+void check_h5_file(const std::string& filename_prefix) {
+  const h5::H5File<h5::AccessType::ReadOnly> h5_file{filename_prefix + ".h5"};
+  const size_t l_plus_one_squared = square(l_max + 1);
+  {
+    const auto& cce_subfile =
+        h5_file.get<h5::Dat>("/Cce/VolumeData/InertialRetardedTime.dat");
+    CHECK(cce_subfile.get_legend().size() == l_plus_one_squared + 1);
+    CHECK(cce_subfile.get_data()(0, 0) == time);
+    h5_file.close_current_object();
+  }
+  {
+    const auto& cce_subfile =
+        h5_file.get<h5::Dat>("/Cce/VolumeData/OneMinusY.dat");
+    CHECK(cce_subfile.get_legend().size() == num_radial_grid_points + 1);
+    CHECK(cce_subfile.get_data()(0, 0) == time);
+    h5_file.close_current_object();
+  }
+  {
+    const auto& cce_subfile =
+        h5_file.get<h5::Dat>("/Cce/VolumeData/J/CompactifiedRadius_0.dat");
+    CHECK(cce_subfile.get_legend().size() == 2 * l_plus_one_squared + 1);
+    CHECK(cce_subfile.get_data()(0, 0) == time);
+    h5_file.close_current_object();
+  }
+}
+
 template <typename Metavariables>
 struct MockObserverWriter {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockNodeGroupChare;
   using array_index = int;
-  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
-      Parallel::Phase::Initialization,
-      tmpl::list<ActionTesting::InitializeDataBox<tmpl::list<>>>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 tmpl::list<observers::Tags::H5FileLock>>>>>;
+  using const_global_cache_tags =
+      tmpl::list<observers::Tags::ReductionFileName>;
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
 
   using replace_these_threaded_actions =
@@ -99,20 +134,28 @@ struct Metavars {
       tmpl::list<MockObserverWriter<Metavars>, MockElement<Metavars>>;
 };
 
-void test() {
+void test(const bool write_synchronously) {
   using metavars = Metavars;
   using obs_writer = MockObserverWriter<metavars>;
   using element = MockElement<metavars>;
 
-  Cce::Events::ObserveFields fields{std::vector<std::string>{
+  const Cce::Events::ObserveFields fields{std::vector<std::string>{
       "InertialRetardedTime", "J", "Psi0", "Dy(H)", "OneMinusY"}};
-  Cce::Events::ObserveFields serialized_fields =
+  const Cce::Events::ObserveFields serialized_fields =
       serialize_and_deserialize(fields);
 
+  const std::string filename_prefix{"PineTree"};
+  if (file_system::check_if_file_exists(filename_prefix + ".h5")) {
+    file_system::rm(filename_prefix + ".h5", true);
+  }
+
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{}};
+  MockRuntimeSystem runner{
+      {filename_prefix},
+      {},
+      std::vector<size_t>{write_synchronously ? 1_st : 2_st}};
   ActionTesting::emplace_nodegroup_component_and_initialize<obs_writer>(
-      make_not_null(&runner), {});
+      make_not_null(&runner), {Parallel::NodeLock{}});
   ActionTesting::emplace_singleton_component_and_initialize<element>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, {});
@@ -160,13 +203,17 @@ void test() {
 
   serialized_fields(obs_box, cache, array_index, component, observation_value);
 
-  // 1 for InertialRetardedTime and OneMinusY and 2 for each other tag
-  const size_t expected_number_of_actions = 8;
-  CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer>(
-            runner, 0) == expected_number_of_actions);
-  for (size_t i = 0; i < expected_number_of_actions; i++) {
-    ActionTesting::invoke_queued_threaded_action<obs_writer>(
-        make_not_null(&runner), 0);
+  if (write_synchronously) {
+    check_h5_file(filename_prefix);
+  } else {
+    // 1 for InertialRetardedTime and OneMinusY and 2 for each other tag
+    const size_t expected_number_of_actions = 8;
+    CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer>(
+              runner, 0) == expected_number_of_actions);
+    for (size_t i = 0; i < expected_number_of_actions; i++) {
+      ActionTesting::invoke_queued_threaded_action<obs_writer>(
+          make_not_null(&runner), 0);
+    }
   }
 }
 
@@ -184,7 +231,8 @@ void test_errors() {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Events.ObserveFields",
                   "[Unit][Evolution]") {
-  test();
+  test(true);
+  test(false);
   test_errors();
 }
 }  // namespace

--- a/tests/Unit/Framework/ActionTesting.hpp
+++ b/tests/Unit/Framework/ActionTesting.hpp
@@ -451,10 +451,25 @@ bool InitializeDataBox<tmpl::list<SimpleTags...>,
 /// \endcond
 
 namespace ActionTesting_detail {
+template <typename ChareType>
+struct charm_element_proxy;
+template <>
+struct charm_element_proxy<MockArrayChare> : public CProxyElement_ArrayElement {
+};
+template <>
+struct charm_element_proxy<MockGroupChare> : public CProxyElement_IrrGroup {};
+template <>
+struct charm_element_proxy<MockNodeGroupChare>
+    : public CProxyElement_NodeGroup {};
+template <>
+struct charm_element_proxy<MockSingletonChare>
+    : public CProxyElement_ArrayElement {};
+
 // A mock class for the Charm++ generated CProxyElement_AlgorithmArray. This
 // is each element obtained by indexing a CProxy_AlgorithmArray.
 template <typename Component, typename InboxTagList>
-class MockDistributedObjectProxy : public CProxyElement_ArrayElement {
+class MockDistributedObjectProxy
+    : public charm_element_proxy<typename Component::chare_type> {
  public:
   using Inbox = tuples::tagged_tuple_from_typelist<InboxTagList>;
 
@@ -517,6 +532,17 @@ class MockDistributedObjectProxy : public CProxyElement_ArrayElement {
                 static_cast<int>(mock_node_) and
             mock_distributed_object_->my_local_rank() ==
                 static_cast<int>(mock_local_core_))
+               ? mock_distributed_object_
+               : nullptr;
+  }
+
+  MockDistributedObject<Component>* ckLocalBranch() {
+    return (mock_distributed_object_->my_node() ==
+                static_cast<int>(mock_node_) and
+            (std::is_same_v<MockNodeGroupChare,
+                            typename Component::chare_type> or
+             mock_distributed_object_->my_local_rank() ==
+                 static_cast<int>(mock_local_core_)))
                ? mock_distributed_object_
                : nullptr;
   }

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -563,25 +563,34 @@ struct ComponentA {
       Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
 };
 
+template <typename MyProxy, typename ArrayIndex>
+auto get_local(MyProxy& my_proxy, const ArrayIndex& array_index) {
+  if constexpr (Parallel::is_group_proxy<std::decay_t<MyProxy>>::value or
+                Parallel::is_node_group_proxy<std::decay_t<MyProxy>>::value) {
+    return Parallel::local_branch(my_proxy[array_index]);
+  } else {
+    return Parallel::local(my_proxy[array_index]);
+  }
+}
+
 struct MyProc {
   template <typename MyProxy, typename ArrayIndex, typename RetType>
   static auto f(MyProxy& my_proxy, const ArrayIndex& array_index) -> RetType {
-    return Parallel::my_proc<RetType>(*Parallel::local(my_proxy[array_index]));
+    return Parallel::my_proc<RetType>(*get_local(my_proxy, array_index));
   }
 };
 
 struct MyNode {
   template <typename MyProxy, typename ArrayIndex, typename RetType>
   static auto f(MyProxy& my_proxy, const ArrayIndex& array_index) -> RetType {
-    return Parallel::my_node<RetType>(*Parallel::local(my_proxy[array_index]));
+    return Parallel::my_node<RetType>(*get_local(my_proxy, array_index));
   }
 };
 
 struct LocalRank {
   template <typename MyProxy, typename ArrayIndex, typename RetType>
   static auto f(MyProxy& my_proxy, const ArrayIndex& array_index) -> RetType {
-    return Parallel::my_local_rank<RetType>(
-        *Parallel::local(my_proxy[array_index]));
+    return Parallel::my_local_rank<RetType>(*get_local(my_proxy, array_index));
   }
 };
 
@@ -589,7 +598,7 @@ struct NumProcs {
   template <typename MyProxy, typename ArrayIndex, typename RetType>
   static auto f(MyProxy& my_proxy, const ArrayIndex& array_index) -> RetType {
     return Parallel::number_of_procs<RetType>(
-        *Parallel::local(my_proxy[array_index]));
+        *get_local(my_proxy, array_index));
   }
 };
 
@@ -597,7 +606,7 @@ struct NumNodes {
   template <typename MyProxy, typename ArrayIndex, typename RetType>
   static auto f(MyProxy& my_proxy, const ArrayIndex& array_index) -> RetType {
     return Parallel::number_of_nodes<RetType>(
-        *Parallel::local(my_proxy[array_index]));
+        *get_local(my_proxy, array_index));
   }
 };
 

--- a/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
+++ b/tests/Unit/Framework/Tests/Test_ActionTesting.cpp
@@ -193,7 +193,6 @@ struct threaded_action_b_mock {
 struct SimpleActionMockMetavariables {
   using component_list = tmpl::list<
       component_for_simple_action_mock<SimpleActionMockMetavariables>>;
-
 };
 
 template <typename Metavariables>
@@ -348,7 +347,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.IsRetrievable", "[Unit]") {
@@ -415,7 +413,6 @@ struct Component {
 
 struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
-
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.GetInboxTags", "[Unit]") {
@@ -511,7 +508,6 @@ struct CallActionOnComponentB {
 struct Metavariables {
   using component_list =
       tmpl::list<ComponentA<Metavariables>, ComponentBMock<Metavariables>>;
-
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.MockComponent", "[Unit]") {
@@ -685,7 +681,6 @@ struct ActionSetValueTo {
 
 struct MetavariablesOneComponent {
   using component_list = tmpl::list<ComponentA<MetavariablesOneComponent>>;
-
 };
 
 void test_parallel_info_functions() {
@@ -942,7 +937,6 @@ struct GroupComponent {
 struct MetavariablesGroupComponent {
   using component_list =
       tmpl::list<GroupComponent<MetavariablesGroupComponent>>;
-
 };
 
 void test_group_emplace() {
@@ -1018,7 +1012,6 @@ struct NodeGroupComponent {
 struct MetavariablesNodeGroupComponent {
   using component_list =
       tmpl::list<NodeGroupComponent<MetavariablesNodeGroupComponent>>;
-
 };
 
 void test_nodegroup_emplace() {
@@ -1074,7 +1067,6 @@ void test_nodegroup_emplace() {
 
 struct MetavariablesWithPup {
   using component_list = tmpl::list<NodeGroupComponent<MetavariablesWithPup>>;
-
 
   void pup(PUP::er& /*p*/) {}
 };
@@ -1152,7 +1144,6 @@ struct Metavariables {
   // [mutable global cache metavars]
   using mutable_global_cache_tags = tmpl::list<CacheTag>;
   // [mutable global cache metavars]
-
 };
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.MutableGlobalCache", "[Unit]") {


### PR DESCRIPTION
## Proposed changes

When running CCE on one core, volume data that is sent to the ObserverWriter for writing could be held in memory for a long time (until the end) because no core is free. This could cause an OOM error. This PR forces CCE to write ObserveFields data synchronously if running on a single core to avoid that.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
