### PR TITLE
Support disabling control systems in UpdateFunctionOfTime

### DIFF
--- a/src/ControlSystem/UpdateFunctionOfTime.cpp
+++ b/src/ControlSystem/UpdateFunctionOfTime.cpp
@@ -68,9 +68,13 @@ void UpdateAggregator::insert(const std::string& control_system_name,
                      new_measurement_expiration_time));
 }
 
-bool UpdateAggregator::is_ready() const {
+bool UpdateAggregator::is_ready(
+    const std::unordered_map<std::string, bool>& active_map) const {
   // Short circuit if one name isn't ready
   for (const std::string& control_system_name : active_names_) {
+    if (not active_map.at(control_system_name)) {
+      continue;
+    }
     if (expiration_times_.count(control_system_name) != 1) {
       return false;
     }
@@ -83,8 +87,9 @@ const std::string& UpdateAggregator::combined_name() const {
 }
 
 std::unordered_map<std::string, std::pair<DataVector, double>>
-UpdateAggregator::combined_fot_expiration_times() const {
-  ASSERT(is_ready(),
+UpdateAggregator::combined_fot_expiration_times(
+    const std::unordered_map<std::string, bool>& active_map) const {
+  ASSERT(is_ready(active_map),
          "Trying to get combined expiration times, but have not received "
          "data from all control systems.");
 
@@ -92,12 +97,18 @@ UpdateAggregator::combined_fot_expiration_times() const {
 
   double min_expiration_time = std::numeric_limits<double>::infinity();
   for (const auto& control_system_name : active_names_) {
+    if (not active_map.at(control_system_name)) {
+      continue;
+    }
     min_expiration_time =
         std::min(min_expiration_time,
                  expiration_times_.at(control_system_name).first.second);
   }
 
   for (const auto& control_system_name : active_names_) {
+    if (not active_map.at(control_system_name)) {
+      continue;
+    }
     result[control_system_name] =
         expiration_times_.at(control_system_name).first;
     result[control_system_name].second = min_expiration_time;
@@ -107,8 +118,9 @@ UpdateAggregator::combined_fot_expiration_times() const {
 }
 
 std::pair<double, double>
-UpdateAggregator::combined_measurement_expiration_time() {
-  ASSERT(is_ready(),
+UpdateAggregator::combined_measurement_expiration_time(
+    const std::unordered_map<std::string, bool>& active_map) {
+  ASSERT(is_ready(active_map),
          "Trying to get combined expiration times, but have not received "
          "data from all control systems.");
 
@@ -116,6 +128,9 @@ UpdateAggregator::combined_measurement_expiration_time() {
   double min_expiration_time = std::numeric_limits<double>::infinity();
 
   for (const auto& control_system_name : active_names_) {
+    if (not active_map.at(control_system_name)) {
+      continue;
+    }
     min_measurement_timescale =
         std::min(min_measurement_timescale,
                  expiration_times_[control_system_name].second.first);

--- a/src/ControlSystem/UpdateFunctionOfTime.hpp
+++ b/src/ControlSystem/UpdateFunctionOfTime.hpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "ControlSystem/Tags/IsActiveMap.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
@@ -109,8 +110,12 @@ struct UpdateAggregator {
   /*!
    * \brief Checks if `insert` has been called for all control systems that this
    * class was constructed with.
+   *
+   * The `active_map` is used to inform the aggregator which controls systems
+   * are currently active. This is separate so that individual control
+   * systems can be enabled and disabled during an evolution.
    */
-  bool is_ready() const;
+  bool is_ready(const std::unordered_map<std::string, bool>& active_map) const;
 
   /*!
    * \brief Returns a sorted concatenation of the control system names this
@@ -126,9 +131,14 @@ struct UpdateAggregator {
    *
    * \details This function is expected to only be called when `is_ready` is
    * true. It also must be called before `combined_measurement_expiration_time`.
+   *
+   * The `active_map` is used to inform the aggregator which controls systems
+   * are currently active. This is separate so that individual controls
+   * systems can be enabled and disabled during an evolution.
    */
   std::unordered_map<std::string, std::pair<DataVector, double>>
-  combined_fot_expiration_times() const;
+  combined_fot_expiration_times(
+      const std::unordered_map<std::string, bool>& active_map) const;
 
   /*!
    * \brief Once `is_ready` is true, returns a `std::pair` containing the
@@ -140,8 +150,13 @@ struct UpdateAggregator {
    * systems for this measurement have computed their update values. It also
    * must be called after `combined_fot_expiration_times`. This function clears
    * all stored data when it is called.
+   *
+   * The `active_map` is used to inform the aggregator which controls systems
+   * are currently active. This is separate so that individual controls
+   * systems can be enabled and disabled during an evolution.
    */
-  std::pair<double, double> combined_measurement_expiration_time();
+  std::pair<double, double> combined_measurement_expiration_time(
+      const std::unordered_map<std::string, bool>& active_map);
 
   /// \cond
   void pup(PUP::er& p);
@@ -211,12 +226,14 @@ struct AggregateUpdate {
                       new_measurement_expiration_time,
                       std::move(control_signal), new_fot_expiration_time);
 
-    if (aggregator.is_ready()) {
+    if (aggregator.is_ready(get<Tags::IsActiveMap>(cache))) {
       std::unordered_map<std::string, std::pair<DataVector, double>>
           combined_fot_expiration_times =
-              aggregator.combined_fot_expiration_times();
+              aggregator.combined_fot_expiration_times(
+                  get<Tags::IsActiveMap>(cache));
       const std::pair<double, double> combined_measurement_expiration_time =
-          aggregator.combined_measurement_expiration_time();
+          aggregator.combined_measurement_expiration_time(
+              get<Tags::IsActiveMap>(cache));
 
       Parallel::mutate<Tags::MeasurementTimescales, UpdateSingleFunctionOfTime>(
           cache, combined_name, old_measurement_expiration_time,

--- a/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_Initialization.cpp
@@ -125,16 +125,14 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   system_to_combined_names["LabelA"] = "LabelALabelB";
   system_to_combined_names["LabelB"] = "LabelALabelB";
   system_to_combined_names["LabelC"] = "LabelC";
-  std::unordered_map<std::string, bool> is_active_map{};
-  is_active_map["LabelA"] = true;
-  is_active_map["LabelB"] = false;
-  is_active_map["LabelC"] = true;
+  const std::unordered_map<std::string, bool> is_active_map{
+      {"LabelA", true}, {"LabelB", false}, {"LabelC", true}};
 
   std::unordered_map<std::string, control_system::UpdateAggregator>
       aggregators{};
 
   Parallel::GlobalCache<MockMetavars> cache{
-      {std::move(system_to_combined_names), std::move(is_active_map)},
+      {std::move(system_to_combined_names), is_active_map},
       {std::move(measurement_timescales)}};
 
   const Parallel::GlobalCache<MockMetavars>& cache_reference = cache;
@@ -152,6 +150,6 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Initialization",
   CHECK(aggregators.at("LabelALabelB").combined_name() == "LabelALabelB");
   CHECK(aggregators.at("LabelC").combined_name() == "LabelC");
 
-  CHECK_FALSE(aggregators.at("LabelALabelB").is_ready());
-  CHECK_FALSE(aggregators.at("LabelC").is_ready());
+  CHECK_FALSE(aggregators.at("LabelALabelB").is_ready(is_active_map));
+  CHECK_FALSE(aggregators.at("LabelC").is_ready(is_active_map));
 }

--- a/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_UpdateFunctionOfTime.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "ControlSystem/Tags/IsActiveMap.hpp"
 #include "ControlSystem/Tags/MeasurementTimescales.hpp"
 #include "ControlSystem/Tags/SystemTags.hpp"
 #include "ControlSystem/UpdateFunctionOfTime.hpp"
@@ -52,7 +53,8 @@ struct TestSingleton {
                  // Usually this is constant, but we have it mutable for this
                  // test because we need to change its value to test some
                  // ASSERTs
-                 control_system::Tags::SystemToCombinedNames>;
+                 control_system::Tags::SystemToCombinedNames,
+                 control_system::Tags::IsActiveMap>;
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<
@@ -102,7 +104,8 @@ void test_mutates() {
   ActionTesting::MockRuntimeSystem<TestingMetavariables> runsys{
       {},
       {std::move(f_of_t_map), std::move(measurement_timescales),
-       std::unordered_map<std::string, std::string>{}}};
+       std::unordered_map<std::string, std::string>{},
+       std::unordered_map<std::string, bool>{}}};
   ActionTesting::emplace_singleton_component_and_initialize<
       TestSingleton<TestingMetavariables>>(make_not_null(&runsys),
                                            ActionTesting::NodeId{0},
@@ -177,6 +180,9 @@ void test_update_aggregator() {
   signals["Illinois"] = DataVector{3.0};
   signals["Florida"] = DataVector{2.0};
   signals["California"] = DataVector{1.0};
+  std::unordered_map<std::string, bool> active_map{
+      {"Alaska", false},  {"California", true}, {"Florida", true},
+      {"Illinois", true}, {"Texas", true},      {"Wisconsin", true}};
 
   control_system::UpdateAggregator unserialized_aggregator{combined_name,
                                                            names};
@@ -187,15 +193,15 @@ void test_update_aggregator() {
 
   aggregator.insert("Wisconsin", DataVector{1.0}, 10.0, signals.at("Wisconsin"),
                     5.0);
-  CHECK_FALSE(aggregator.is_ready());
+  CHECK_FALSE(aggregator.is_ready(active_map));
   aggregator.insert("Texas", DataVector{2.0}, 9.0, signals.at("Texas"), 4.0);
-  CHECK_FALSE(aggregator.is_ready());
+  CHECK_FALSE(aggregator.is_ready(active_map));
   aggregator.insert("Illinois", DataVector{3.0}, 8.0, signals.at("Illinois"),
                     3.0);
-  CHECK_FALSE(aggregator.is_ready());
+  CHECK_FALSE(aggregator.is_ready(active_map));
   aggregator.insert("Florida", DataVector{4.0}, 7.0, signals.at("Florida"),
                     2.0);
-  CHECK_FALSE(aggregator.is_ready());
+  CHECK_FALSE(aggregator.is_ready(active_map));
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       aggregator.insert("Florida", DataVector{}, 1.0, DataVector{}, 1.0),
@@ -206,16 +212,20 @@ void test_update_aggregator() {
       Catch::Matchers::ContainsSubstring("Received expiration time data for a "
                                          "non-active control system 'Alaska'"));
 #endif
+  active_map.at("California") = false;
+  CHECK(aggregator.is_ready(active_map));
+  active_map.at("California") = true;
+  CHECK_FALSE(aggregator.is_ready(active_map));
   aggregator.insert("California", DataVector{5.0}, 6.0,
                     signals.at("California"), 1.0);
-  CHECK(aggregator.is_ready());
+  CHECK(aggregator.is_ready(active_map));
 
   const std::unordered_map<std::string, std::pair<DataVector, double>>
-      combined_fot = aggregator.combined_fot_expiration_times();
-  CHECK(aggregator.is_ready());
+      combined_fot = aggregator.combined_fot_expiration_times(active_map);
+  CHECK(aggregator.is_ready(active_map));
   const std::pair<double, double> combined_measurements =
-      aggregator.combined_measurement_expiration_time();
-  CHECK_FALSE(aggregator.is_ready());
+      aggregator.combined_measurement_expiration_time(active_map);
+  CHECK_FALSE(aggregator.is_ready(active_map));
 
   CHECK(combined_fot.size() == names.size());
   for (const auto& name : names) {
@@ -298,6 +308,8 @@ void test_aggregate_update_action() {
   aggregators["FoT1FoT3"] = aggregator13;
   aggregators["FoT2"] = aggregator2;
   auto aggregators_copy = aggregators;
+  const std::unordered_map<std::string, bool> active_map{
+      {"FoT1", true}, {"FoT3", true}, {"FoT2", true}};
 
   std::unordered_map<std::string, std::string> system_to_combined_names{};
   system_to_combined_names["FoT1"] = "FoT1FoT3";
@@ -308,7 +320,7 @@ void test_aggregate_update_action() {
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {},
       {std::move(f_of_t_map), std::move(measurement_map),
-       std::move(system_to_combined_names_copy)}};
+       std::move(system_to_combined_names_copy), active_map}};
   ActionTesting::emplace_singleton_component_and_initialize<component1>(
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, {std::move(aggregators_copy)});
@@ -416,8 +428,8 @@ void test_aggregate_update_action() {
 
   // The aggregators will never "be ready" to use because when they actually are
   // ready, they are reset immediately during the simple action
-  CHECK_FALSE(box_aggregator13.is_ready());
-  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK_FALSE(box_aggregator13.is_ready(active_map));
+  CHECK_FALSE(box_aggregator2.is_ready(active_map));
   CHECK(box_aggregators_component2.empty());
   CHECK(box_aggregators_component3.empty());
 
@@ -428,8 +440,8 @@ void test_aggregate_update_action() {
       old_measurement_expiration13, new_measurement_expiration1, control_signal,
       old_fot_expiration13, new_fot_expiration1);
 
-  CHECK_FALSE(box_aggregator13.is_ready());
-  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK_FALSE(box_aggregator13.is_ready(active_map));
+  CHECK_FALSE(box_aggregator2.is_ready(active_map));
   CHECK(box_aggregators_component2.empty());
   CHECK(box_aggregators_component3.empty());
 
@@ -441,8 +453,8 @@ void test_aggregate_update_action() {
       old_measurement_expiration2, new_measurement_expiration2, control_signal,
       old_fot_expiration2, new_fot_expiration2);
 
-  CHECK_FALSE(box_aggregator13.is_ready());
-  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK_FALSE(box_aggregator13.is_ready(active_map));
+  CHECK_FALSE(box_aggregator2.is_ready(active_map));
   CHECK(box_aggregators_component2.empty());
   CHECK(box_aggregators_component3.empty());
 
@@ -481,8 +493,8 @@ void test_aggregate_update_action() {
       old_measurement_expiration13, new_measurement_expiration3, control_signal,
       old_fot_expiration13, new_fot_expiration3);
 
-  CHECK_FALSE(box_aggregator13.is_ready());
-  CHECK_FALSE(box_aggregator2.is_ready());
+  CHECK_FALSE(box_aggregator13.is_ready(active_map));
+  CHECK_FALSE(box_aggregator2.is_ready(active_map));
   CHECK(box_aggregators_component2.empty());
   CHECK(box_aggregators_component3.empty());
 


### PR DESCRIPTION
## Proposed changes

This is needed because in BNS simulations we disable the rotation control system once the two NSs are close enough to merger.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
