### PR TITLE
Support tracking ObjectCenters in TimeDependentTripleGaussian

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.cpp
@@ -17,10 +17,11 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Options/ParseError.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
-#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
 #include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace gh::ConstraintDamping {
@@ -29,10 +30,12 @@ TimeDependentTripleGaussian::TimeDependentTripleGaussian(CkMigrateMessage* msg)
 
 TimeDependentTripleGaussian::TimeDependentTripleGaussian(
     const double constant, const double amplitude_1, const double width_1,
-    const std::array<double, 3>& center_1, const double amplitude_2,
-    const double width_2, const std::array<double, 3>& center_2,
+    const std::optional<std::array<double, 3>>& center_1,
+    const double amplitude_2, const double width_2,
+    const std::optional<std::array<double, 3>>& center_2,
     const double amplitude_3, const double width_3,
-    const std::array<double, 3>& center_3)
+    const std::array<double, 3>& center_3, const std::string& movement_method,
+    const Options::Context& context)
     : constant_(constant),
       amplitude_1_(amplitude_1),
       inverse_width_1_(1.0 / width_1),
@@ -42,7 +45,44 @@ TimeDependentTripleGaussian::TimeDependentTripleGaussian(
       center_2_(center_2),
       amplitude_3_(amplitude_3),
       inverse_width_3_(1.0 / width_3),
-      center_3_(center_3) {}
+      center_3_(center_3),
+      movement_method_(movement_method == "ExpansionFactor"
+                           ? MovementMethods::ExpansionFactor
+                           : MovementMethods::ObjectCenters) {
+  if (movement_method != "ExpansionFactor" and
+      movement_method != "ObjectCenters") {
+    PARSE_ERROR(
+        context,
+        "The movement method must be either 'ExpansionFactor' (for BBH "
+        "simulations) or 'ObjectCenters' (for BNS simulations) but got '"
+            << movement_method << "'");
+  }
+  if (movement_method == "ObjectCenters") {
+    if (center_1_.has_value()) {
+      PARSE_ERROR(context,
+                  "You cannot set the Center of Gaussian1 when using the "
+                  "ObjectCenters movement method. The center is determine from "
+                  "the ObjectCenters function of time.");
+    }
+    if (center_2_.has_value()) {
+      PARSE_ERROR(context,
+                  "You cannot set the Center of Gaussian2 when using the "
+                  "ObjectCenters movement method. The center is determine from "
+                  "the ObjectCenters function of time.");
+    }
+  } else {
+    if (not center_1_.has_value()) {
+      PARSE_ERROR(context,
+                  "You must set the Center of Gaussian1 when using the "
+                  "ExpansionFactor movement method.");
+    }
+    if (not center_2_.has_value()) {
+      PARSE_ERROR(context,
+                  "You must set the Center of Gaussian1 when using the "
+                  "ExpansionFactor movement method.");
+    }
+  }
+}
 
 template <typename T>
 void TimeDependentTripleGaussian::apply_call_operator(
@@ -51,17 +91,6 @@ void TimeDependentTripleGaussian::apply_call_operator(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  ASSERT(functions_of_time.at(function_of_time_for_scaling_)
-                 ->func(time)[0]
-                 .size() == 1,
-         "FunctionOfTimeForScaling in TimeDependentTripleGaussian must be a "
-         "scalar FunctionOfTime, not "
-             << functions_of_time.at(function_of_time_for_scaling_)
-                    ->func(time)[0]
-                    .size());
-  const double function_of_time_value =
-      functions_of_time.at(function_of_time_for_scaling_)->func(time)[0][0];
-
   // Start by setting the result to the constant
   get(*value_at_x) = constant_;
 
@@ -70,19 +99,53 @@ void TimeDependentTripleGaussian::apply_call_operator(
       get<0>(x), std::numeric_limits<double>::signaling_NaN());
 
   const auto add_gauss_to_value_at_x =
-      [&value_at_x, &centered_coords, &x, &function_of_time_value](
+      [&centered_coords, &x, &functions_of_time, time, this, &value_at_x](
           const double amplitude, const double inverse_width,
           const std::array<double, 3>& center) {
         for (size_t i = 0; i < 3; ++i) {
           centered_coords.get(i) = x.get(i) - gsl::at(center, i);
         }
-        get(*value_at_x) +=
-            amplitude *
-            exp(-get(dot_product(centered_coords, centered_coords)) *
-                square(inverse_width * function_of_time_value));
+        if (this->movement_method_ == MovementMethods::ExpansionFactor) {
+          ASSERT(functions_of_time.at(function_of_time_for_scaling_)
+                         ->func(time)[0]
+                         .size() == 1,
+                 "FunctionOfTimeForScaling in TimeDependentTripleGaussian must "
+                 "be a scalar FunctionOfTime, not "
+                     << functions_of_time.at(function_of_time_for_scaling_)
+                            ->func(time)[0]
+                            .size());
+          const double expansion_factor_value =
+              functions_of_time.at(function_of_time_for_scaling_)
+                  ->func(time)[0][0];
+          get(*value_at_x) +=
+              amplitude *
+              exp(-get(dot_product(centered_coords, centered_coords)) *
+                  square(inverse_width * expansion_factor_value));
+        } else {
+          get(*value_at_x) +=
+              amplitude *
+              exp(-get(dot_product(centered_coords, centered_coords)) *
+                  square(inverse_width));
+        }
       };
-  add_gauss_to_value_at_x(amplitude_1_, inverse_width_1_, center_1_);
-  add_gauss_to_value_at_x(amplitude_2_, inverse_width_2_, center_2_);
+  if (this->movement_method_ == MovementMethods::ExpansionFactor) {
+    add_gauss_to_value_at_x(amplitude_1_, inverse_width_1_, center_1_.value());
+    add_gauss_to_value_at_x(amplitude_2_, inverse_width_2_, center_2_.value());
+  } else {
+    const DataVector centers =
+        functions_of_time.at(function_of_time_for_centers_)->func(time)[0];
+    ASSERT(centers.size() == 6,
+           "FunctionOfTimeForCenters in TimeDependentTripleGaussian must have "
+           "6 components, not "
+               << functions_of_time.at(function_of_time_for_centers_)
+                      ->func(time)[0]
+                      .size());
+    const std::array center_1{centers[0], centers[1], centers[2]};
+    const std::array center_2{centers[3], centers[4], centers[5]};
+    add_gauss_to_value_at_x(amplitude_1_, inverse_width_1_, center_1);
+    add_gauss_to_value_at_x(amplitude_2_, inverse_width_2_, center_2);
+  }
+  // Gaussian 3 should be the one centered at the origin in a binary simulation.
   add_gauss_to_value_at_x(amplitude_3_, inverse_width_3_, center_3_);
 }  // namespace gh::ConstraintDamping
 
@@ -116,11 +179,27 @@ void TimeDependentTripleGaussian::pup(PUP::er& p) {
   p | amplitude_3_;
   p | inverse_width_3_;
   p | center_3_;
+  p | movement_method_;
 }
 
 auto TimeDependentTripleGaussian::get_clone() const
     -> std::unique_ptr<DampingFunction<3, Frame::Grid>> {
   return std::make_unique<TimeDependentTripleGaussian>(*this);
+}
+
+bool operator==(const TimeDependentTripleGaussian& lhs,
+                const TimeDependentTripleGaussian& rhs) {
+  return lhs.constant_ == rhs.constant_ and
+         lhs.amplitude_1_ == rhs.amplitude_1_ and
+         lhs.inverse_width_1_ == rhs.inverse_width_1_ and
+         lhs.center_1_ == rhs.center_1_ and
+         lhs.amplitude_2_ == rhs.amplitude_2_ and
+         lhs.inverse_width_2_ == rhs.inverse_width_2_ and
+         lhs.center_2_ == rhs.center_2_ and
+         lhs.amplitude_3_ == rhs.amplitude_3_ and
+         lhs.inverse_width_3_ == rhs.inverse_width_3_ and
+         lhs.center_3_ == rhs.center_3_ and
+         lhs.movement_method_ == rhs.movement_method_;
 }
 
 bool operator!=(const TimeDependentTripleGaussian& lhs,

--- a/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TimeDependentTripleGaussian.hpp
@@ -12,6 +12,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/DampingFunction.hpp"
+#include "Options/Auto.hpp"
 #include "Options/String.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -46,12 +47,16 @@ namespace gh::ConstraintDamping {
  * domain::FunctionsOfTime::FunctionOfTime \f$f(t)\f$: \f$w_\alpha(t) = w_\alpha
  * / f(t)\f$.
  *
- * The name of the domain::FunctionsOfTime::FunctionOfTime is hardcoded to be
- * `Expansion` as this class will typically be used with a domain that has an
- * expansion map and potentially an expansion control system, the names of which
- * will be `Expansion`.
+ * You can choose one of two methods for tracking the object
+ * centers. `ExpansionFactor` should be used for BBH simulations where the
+ * expansion control system is used to track the objects. `ObjectCenters`
+ * sholud be used for BNS simulations where the coordinate centers of the two
+ * stars is tracked separately and there is no expansion control system.
  */
 class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
+ private:
+  enum class MovementMethods { ExpansionFactor, ObjectCenters };
+
  public:
   template <size_t GaussianNumber>
   struct Gaussian {
@@ -85,14 +90,30 @@ class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
   template <typename Group>
   struct Center {
     using group = Group;
-    using type = std::array<double, 3>;
+    using type = tmpl::conditional_t<std::is_same_v<Group, Gaussian<3>>,
+                                     std::array<double, 3>,
+                                     Options::Auto<std::array<double, 3>>>;
     static constexpr Options::String help = {"The center of the Gaussian."};
   };
 
-  using options = tmpl::list<
-      Constant, Amplitude<Gaussian<1>>, Width<Gaussian<1>>, Center<Gaussian<1>>,
-      Amplitude<Gaussian<2>>, Width<Gaussian<2>>, Center<Gaussian<2>>,
-      Amplitude<Gaussian<3>>, Width<Gaussian<3>>, Center<Gaussian<3>>>;
+  /// \brief How to track the movement of the compact objects.
+  ///
+  /// - `ExpansionFactor` for BBH simulations.
+  /// - `ObjectCenters` for BNS simulations.
+  struct MovementMethod {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "How to track the movement of the compact objects.\n\n"
+        "- `ExpansionFactor` for BBH simulations.\n"
+        "- `ObjectCenters` for BNS simulations."};
+  };
+
+  using options =
+      tmpl::list<Constant, Amplitude<Gaussian<1>>, Width<Gaussian<1>>,
+                 Center<Gaussian<1>>, Amplitude<Gaussian<2>>,
+                 Width<Gaussian<2>>, Center<Gaussian<2>>,
+                 Amplitude<Gaussian<3>>, Width<Gaussian<3>>,
+                 Center<Gaussian<3>>, MovementMethod>;
 
   static constexpr Options::String help = {
       "Computes a sum of a constant and 3 Gaussians (each with its own "
@@ -107,13 +128,12 @@ class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
 
   explicit TimeDependentTripleGaussian(CkMigrateMessage* msg);
 
-  TimeDependentTripleGaussian(double constant, double amplitude_1,
-                              double width_1,
-                              const std::array<double, 3>& center_1,
-                              double amplitude_2, double width_2,
-                              const std::array<double, 3>& center_2,
-                              double amplitude_3, double width_3,
-                              const std::array<double, 3>& center_3);
+  TimeDependentTripleGaussian(
+      double constant, double amplitude_1, double width_1,
+      const std::optional<std::array<double, 3>>& center_1, double amplitude_2,
+      double width_2, const std::optional<std::array<double, 3>>& center_2,
+      double amplitude_3, double width_3, const std::array<double, 3>& center_3,
+      const std::string& movement_method, const Options::Context& context = {});
 
   TimeDependentTripleGaussian() = default;
   ~TimeDependentTripleGaussian() override = default;
@@ -125,13 +145,13 @@ class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
   TimeDependentTripleGaussian& operator=(
       TimeDependentTripleGaussian&& /*rhs*/) = default;
 
-  void operator()(const gsl::not_null<Scalar<double>*> value_at_x,
+  void operator()(gsl::not_null<Scalar<double>*> value_at_x,
                   const tnsr::I<double, 3, Frame::Grid>& x, double time,
                   const std::unordered_map<
                       std::string,
                       std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
                       functions_of_time) const override;
-  void operator()(const gsl::not_null<Scalar<DataVector>*> value_at_x,
+  void operator()(gsl::not_null<Scalar<DataVector>*> value_at_x,
                   const tnsr::I<DataVector, 3, Frame::Grid>& x, double time,
                   const std::unordered_map<
                       std::string,
@@ -146,35 +166,26 @@ class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
 
  private:
   friend bool operator==(const TimeDependentTripleGaussian& lhs,
-                         const TimeDependentTripleGaussian& rhs) {
-    return lhs.constant_ == rhs.constant_ and
-           lhs.amplitude_1_ == rhs.amplitude_1_ and
-           lhs.inverse_width_1_ == rhs.inverse_width_1_ and
-           lhs.center_1_ == rhs.center_1_ and
-           lhs.amplitude_2_ == rhs.amplitude_2_ and
-           lhs.inverse_width_2_ == rhs.inverse_width_2_ and
-           lhs.center_2_ == rhs.center_2_ and
-           lhs.amplitude_3_ == rhs.amplitude_3_ and
-           lhs.inverse_width_3_ == rhs.inverse_width_3_ and
-           lhs.center_3_ == rhs.center_3_;
-  }
+                         const TimeDependentTripleGaussian& rhs);
 
   double constant_ = std::numeric_limits<double>::signaling_NaN();
   double amplitude_1_ = std::numeric_limits<double>::signaling_NaN();
   double inverse_width_1_ = std::numeric_limits<double>::signaling_NaN();
-  std::array<double, 3> center_1_{};
+  std::optional<std::array<double, 3>> center_1_{};
   double amplitude_2_ = std::numeric_limits<double>::signaling_NaN();
   double inverse_width_2_ = std::numeric_limits<double>::signaling_NaN();
-  std::array<double, 3> center_2_{};
+  std::optional<std::array<double, 3>> center_2_{};
   double amplitude_3_ = std::numeric_limits<double>::signaling_NaN();
   double inverse_width_3_ = std::numeric_limits<double>::signaling_NaN();
   std::array<double, 3> center_3_{};
+  MovementMethods movement_method_{MovementMethods::ExpansionFactor};
   inline static const std::string function_of_time_for_scaling_{"Expansion"};
+  inline static const std::string function_of_time_for_centers_{"GridCenters"};
 
   template <typename T>
   void apply_call_operator(
-      const gsl::not_null<Scalar<T>*> value_at_x,
-      const tnsr::I<T, 3, Frame::Grid>& x, double time,
+      gsl::not_null<Scalar<T>*> value_at_x, const tnsr::I<T, 3, Frame::Grid>& x,
+      double time,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -248,6 +248,7 @@ EvolutionSystem:
           Amplitude: {{ Gamma0OriginAmplitude }}
           Width: {{ Gamma0OriginWidth }}
           Center: [0.0, 0.0, 0.0]
+        MovementMethod: ExpansionFactor
     DampingFunctionGamma1:
       GaussianPlusConstant:
         Constant: -0.999

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -126,12 +126,13 @@ EvolutionSystem:
           Center: [0.0, 0.0, 0.0]
         Gaussian2:
           Amplitude: 0.1
-          Width: 100.0
+          Width: 100.
           Center: [0.0, 0.0, 0.0]
         Gaussian3:
           Amplitude: 0.0
           Width: 100.0
           Center: [0.0, 0.0, 0.0]
+        MovementMethod: ExpansionFactor
     DampingFunctionGamma1:
       Constant:
         Value: -1.0
@@ -150,6 +151,7 @@ EvolutionSystem:
           Amplitude: 0.0
           Width: 100.0
           Center: [0.0, 0.0, 0.0]
+        MovementMethod: ExpansionFactor
 
 Filtering:
   ExpFilter0:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -117,6 +117,7 @@ EvolutionSystem:
           Amplitude: 0.075            # 0.075 / (m_A + m_B)
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
+        MovementMethod: ExpansionFactor
     DampingFunctionGamma1:
       GaussianPlusConstant:
         Constant: -0.999
@@ -138,6 +139,7 @@ EvolutionSystem:
           Amplitude: 0.075            # 0.075 / (m_A + m_B)
           Width: 38.415              # 2.5 * (x_B - x_A)
           Center: [0.0, 0.0, 0.0]
+        MovementMethod: ExpansionFactor
 
 Amr:
   Criteria:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -124,15 +124,16 @@ EvolutionSystem:
       # Parameters from SpEC run of equal mass non-spinning,
       # polytrope K=100 Gamma=2
       TimeDependentTripleGaussian:
+        MovementMethod: ObjectCenters
         Constant: 0.01
         Gaussian1:
           Amplitude: 0.06277857994
           Width: 7.884855
-          Center: [16, 0.0, 0.0]
+          Center: Auto
         Gaussian2:
           Amplitude: 0.06277857994
           Width: 7.884855
-          Center: [-16, 0.0, 0.0]
+          Center: Auto
         Gaussian3:
           Amplitude: 0.06277857994
           Width: 51.60996
@@ -147,15 +148,16 @@ EvolutionSystem:
       # Parameters from SpEC run of equal mass non-spinning,
       # polytrope K=100 Gamma=2
       TimeDependentTripleGaussian:
+        MovementMethod: ObjectCenters
         Constant: 0.01
         Gaussian1:
           Amplitude: 0.94167869922
           Width: 7.884855
-          Center: [16, 0.0, 0.0] # [x_A, 0, 0]
+          Center: Auto
         Gaussian2:
           Amplitude: 0.94167869922
           Width: 7.884855
-          Center: [-16, 0.0, 0.0]  # [x_B, 0, 0]
+          Center: Auto
         Gaussian3:
           Amplitude: 0.19182343873
           Width: 51.60996

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Python/TestFunctions.py
@@ -83,3 +83,47 @@ def time_dependent_triple_gaussian_call_operator(
             center_3,
         )
     )
+
+
+def time_dependent_triple_gaussian_object_centers_call_operator(
+    coords,
+    time,
+    constant,
+    amplitude_1,
+    width_1,
+    unused_center_1,
+    amplitude_2,
+    width_2,
+    unused_center_2,
+    amplitude_3,
+    width_3,
+    center_3,
+):
+    center_1 = np.asarray([16.0 + time * -1.0e-3, 0.0, 0.0])
+    center_2 = np.asarray([-16.0 + time * 2.0e-3, 0.0, 0.0])
+    return (
+        gaussian_plus_constant_call_operator(
+            coords,
+            time,
+            constant,
+            amplitude_1,
+            width_1,
+            center_1,
+        )
+        + gaussian_plus_constant_call_operator(
+            coords,
+            time,
+            0.0,
+            amplitude_2,
+            width_2,
+            center_2,
+        )
+        + gaussian_plus_constant_call_operator(
+            coords,
+            time,
+            0.0,
+            amplitude_3,
+            width_3,
+            center_3,
+        )
+    )

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/Test_TimeDependentTripleGaussian.cpp
@@ -53,9 +53,9 @@ void test_triple_gaussian_random(const DataType& used_for_size) {
   // in the TimeDependentTripleGaussian
   const std::string function_of_time_for_scaling{"Expansion"s};
 
-  gh::ConstraintDamping::TimeDependentTripleGaussian triple_gauss{
-      constant, amplitude_1, width_1,     center_1, amplitude_2,
-      width_2,  center_2,    amplitude_3, width_3,  center_3};
+  const gh::ConstraintDamping::TimeDependentTripleGaussian triple_gauss{
+      constant, amplitude_1, width_1, center_1, amplitude_2,      width_2,
+      center_2, amplitude_3, width_3, center_3, "ExpansionFactor"};
 
   TestHelpers::gh::ConstraintDamping::check(
       std::move(triple_gauss), "time_dependent_triple_gaussian", used_for_size,
@@ -63,17 +63,34 @@ void test_triple_gaussian_random(const DataType& used_for_size) {
       width_1, center_1, amplitude_2, width_2, center_2, amplitude_3, width_3,
       center_3);
 
-  std::unique_ptr<gh::ConstraintDamping::TimeDependentTripleGaussian>
+  const std::unique_ptr<gh::ConstraintDamping::TimeDependentTripleGaussian>
       triple_gauss_unique_ptr =
           std::make_unique<gh::ConstraintDamping::TimeDependentTripleGaussian>(
               constant, amplitude_1, width_1, center_1, amplitude_2, width_2,
-              center_2, amplitude_3, width_3, center_3);
+              center_2, amplitude_3, width_3, center_3, "ExpansionFactor");
 
   TestHelpers::gh::ConstraintDamping::check(
       triple_gauss_unique_ptr->get_clone(), "time_dependent_triple_gaussian",
       used_for_size, {{{-1.0, 1.0}}}, {function_of_time_for_scaling}, constant,
       amplitude_1, width_1, center_1, amplitude_2, width_2, center_2,
       amplitude_3, width_3, center_3);
+
+  const std::unique_ptr<gh::ConstraintDamping::TimeDependentTripleGaussian>
+      triple_gauss_object_centers_unique_ptr =
+          std::make_unique<gh::ConstraintDamping::TimeDependentTripleGaussian>(
+              constant, amplitude_1, width_1, std::nullopt, amplitude_2,
+              width_2, std::nullopt, amplitude_3, width_3, center_3,
+              "ObjectCenters");
+
+  REQUIRE(
+      dynamic_cast<const gh::ConstraintDamping::TimeDependentTripleGaussian&>(
+          *triple_gauss_object_centers_unique_ptr->get_clone()) ==
+      *triple_gauss_object_centers_unique_ptr);
+  TestHelpers::gh::ConstraintDamping::check(
+      triple_gauss_object_centers_unique_ptr->get_clone(),
+      "time_dependent_triple_gaussian_object_centers", used_for_size,
+      {{{-1.0, 1.0}}}, {"GridCenters"}, constant, amplitude_1, width_1,
+      center_1, amplitude_2, width_2, center_2, amplitude_3, width_3, center_3);
 }
 }  // namespace
 
@@ -101,8 +118,9 @@ SPECTRE_TEST_CASE(
   const std::array<double, 3> center_3_3d{{7.7, -8.8, 9.9}};
 
   const gh::ConstraintDamping::TimeDependentTripleGaussian triple_gauss_3d{
-      constant_3d, amplitude_1_3d, width_1_3d,     center_1_3d, amplitude_2_3d,
-      width_2_3d,  center_2_3d,    amplitude_3_3d, width_3_3d,  center_3_3d};
+      constant_3d,    amplitude_1_3d, width_1_3d,       center_1_3d,
+      amplitude_2_3d, width_2_3d,     center_2_3d,      amplitude_3_3d,
+      width_3_3d,     center_3_3d,    "ExpansionFactor"};
   const auto created_triple_gauss = TestHelpers::test_creation<
       gh::ConstraintDamping::TimeDependentTripleGaussian>(
       "Constant: 5.0\n"
@@ -117,7 +135,8 @@ SPECTRE_TEST_CASE(
       "Gaussian3:\n"
       "  Amplitude: 5.0\n"
       "  Width: 1.0\n"
-      "  Center: [7.7, -8.8, 9.9]");
+      "  Center: [7.7, -8.8, 9.9]\n"
+      "MovementMethod: ExpansionFactor\n");
   CHECK(created_triple_gauss == triple_gauss_3d);
   CHECK_FALSE(created_triple_gauss != triple_gauss_3d);
   const auto created_triple_gauss_gh_damping_function =
@@ -136,7 +155,8 @@ SPECTRE_TEST_CASE(
           "  Gaussian3:\n"
           "    Amplitude: 5.0\n"
           "    Width: 1.0\n"
-          "    Center: [7.7, -8.8, 9.9]");
+          "    Center: [7.7, -8.8, 9.9]\n"
+          "  MovementMethod: ExpansionFactor\n");
 
   test_serialization(triple_gauss_3d);
 }

--- a/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GeneralizedHarmonic/ConstraintDamping/TestHelpers.hpp
@@ -75,16 +75,31 @@ void check_impl(
                   std::string,
                   std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
                   functions_of_time{};
-              for (auto function_of_time_name : function_of_time_names) {
-                // The randomly selected time will be between the
-                // random_value_bounds, so set the earliest time of the
-                // function_of_times to the lower bound in random_value_bounds.
-                functions_of_time[function_of_time_name] = std::make_unique<
-                    ::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
-                    std::min(gsl::at(random_value_bounds, 0).first,
-                             gsl::at(random_value_bounds, 0).second),
-                    std::array<DataVector, 4>{{{1.0}, {0.2}, {0.06}, {0.024}}},
-                    std::numeric_limits<double>::max());
+              for (const auto& function_of_time_name : function_of_time_names) {
+                if (function_of_time_name == "GridCenters") {
+                  functions_of_time[function_of_time_name] = std::make_unique<
+                      ::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                      std::min(gsl::at(random_value_bounds, 0).first,
+                               gsl::at(random_value_bounds, 0).second),
+                      std::array<DataVector, 4>{
+                          {{16.0, 0.0, 0.0, -16.0, 0.0, 0.0},
+                           {-0.001, 0.0, 0.0, 0.002, 0.0, 0.0},
+                           {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                           {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}}},
+                      std::numeric_limits<double>::max());
+                } else {
+                  // The randomly selected time will be between the
+                  // random_value_bounds, so set the earliest time of the
+                  // function_of_times to the lower bound in
+                  // random_value_bounds.
+                  functions_of_time[function_of_time_name] = std::make_unique<
+                      ::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+                      std::min(gsl::at(random_value_bounds, 0).first,
+                               gsl::at(random_value_bounds, 0).second),
+                      std::array<DataVector, 4>{
+                          {{1.0}, {0.2}, {0.06}, {0.024}}},
+                      std::numeric_limits<double>::max());
+                }
               }
               // Default-construct the scalar, to test that the damping
               // function's call operator correctly resizes it


### PR DESCRIPTION
## Proposed changes

This is necessary to have the Gaussian centers move radially with the BNS. Rotation control already takes care of the angular movement, but since BNS doesn't use an expansion map, we need to track the object centers explicitly.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The time dependent triple gaussian input file now needs:
```
        MovementMethod: ExpansionFactor
```
to preserve the same behavior.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
