### PR TITLE
Support GridCenters BNS tracking in SeparationLessThan

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -504,7 +504,7 @@ struct EvolutionMetavars {
         tmpl::pair<
             Trigger,
             tmpl::append<Triggers::logical_triggers, Triggers::time_triggers,
-                         tmpl::list<Triggers::SeparationLessThan>>>>;
+                         tmpl::list<Triggers::SeparationLessThan<false>>>>>;
   };
 
   // A tmpl::list of tags to be added to the GlobalCache by the

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBS_TO_LINK
   EventsAndDenseTriggers
   EventsAndTriggers
   Evolution
+  EvolutionTriggers
   GeneralRelativitySolutions
   GeneralizedHarmonic
   GhGrMhdAnalyticData

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -104,6 +104,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/Tags/Filter.hpp"
+#include "Evolution/Triggers/SeparationLessThan.hpp"
 #include "Evolution/TypeTraits.hpp"
 #include "Evolution/VariableFixing/Actions.hpp"
 #include "Evolution/VariableFixing/FixToAtmosphere.hpp"
@@ -645,8 +646,13 @@ struct GhValenciaDivCleanTemplateBase<
         tmpl::pair<TimeSequence<std::uint64_t>,
                    TimeSequences::all_time_sequences<std::uint64_t>>,
         tmpl::pair<TimeStepper, TimeSteppers::time_steppers>,
-        tmpl::pair<Trigger, tmpl::append<Triggers::logical_triggers,
-                                         Triggers::time_triggers>>>;
+        tmpl::pair<
+            Trigger,
+            tmpl::append<Triggers::logical_triggers, Triggers::time_triggers,
+                         tmpl::conditional_t<
+                             UseControlSystems,
+                             tmpl::list<Triggers::SeparationLessThan<true>>,
+                             tmpl::list<>>>>>;
   };
 
   using interpolation_target_tags = tmpl::list<InterpolationTargetTags...>;

--- a/src/Evolution/Triggers/SeparationLessThan.cpp
+++ b/src/Evolution/Triggers/SeparationLessThan.cpp
@@ -3,6 +3,7 @@
 
 #include "Evolution/Triggers/SeparationLessThan.hpp"
 
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <pup.h>
@@ -14,15 +15,19 @@
 #include "Domain/Block.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ExcisionSphere.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 
 namespace Triggers {
-SeparationLessThan::SeparationLessThan(const double separation)
+template <bool UseGridCentersFunctionOfTime>
+SeparationLessThan<UseGridCentersFunctionOfTime>::SeparationLessThan(
+    const double separation)
     : separation_(separation) {}
 
-bool SeparationLessThan::operator()(
+template <bool UseGridCentersFunctionOfTime>
+bool SeparationLessThan<UseGridCentersFunctionOfTime>::operator()(
     const double time, const ::Domain<3>& domain,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
@@ -73,10 +78,36 @@ bool SeparationLessThan::operator()(
            square(get<1>(position_difference)) +
            square(get<2>(position_difference)));
 
-  return calculated_separation <= separation_;
+  return calculated_separation < separation_;
 }
 
-void SeparationLessThan::pup(PUP::er& p) { p | separation_; }
+template <bool UseGridCentersFunctionOfTime>
+bool SeparationLessThan<UseGridCentersFunctionOfTime>::operator()(
+    const double time,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time) const {
+  if (dynamic_cast<const domain::FunctionsOfTime::SettleToConstantQuaternion*>(
+          functions_of_time.at("Rotation").get()) != nullptr) {
+    return false;
+  }
+  const DataVector fot = functions_of_time.at("GridCenters")->func(time)[0];
+  const double separation =
+      std::sqrt(square(fot[0] - fot[3]) + square(fot[1] - fot[4]) +
+                square(fot[2] - fot[5]));
+  return separation < separation_;
+}
 
-PUP::able::PUP_ID SeparationLessThan::my_PUP_ID = 0;  // NOLINT
+template <bool UseGridCentersFunctionOfTime>
+void SeparationLessThan<UseGridCentersFunctionOfTime>::pup(PUP::er& p) {
+  p | separation_;
+}
+
+template <bool UseGridCentersFunctionOfTime>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PUP::able::PUP_ID SeparationLessThan<UseGridCentersFunctionOfTime>::my_PUP_ID =
+    0;
+
+template class SeparationLessThan<true>;
+template class SeparationLessThan<false>;
 }  // namespace Triggers

--- a/src/Evolution/Triggers/SeparationLessThan.hpp
+++ b/src/Evolution/Triggers/SeparationLessThan.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <pup.h>
 #include <string>
@@ -42,19 +43,36 @@ struct Time;
 
 namespace Triggers {
 /*!
- * \brief A standard trigger that monitors the separation between
- * `domain::Tags::ObjectCenter<A>` and `domain::Tags::ObjectCenter<B>` in the
- * inertial frame. Once the separation is smaller than (or equal to) the input
- * separation, then the `operator()` returns true.
+ * \brief A standard trigger that monitors the separation between two objects
+ * (either black holes or neutron stars, typically) is below a threshold.
  *
- * \note This trigger requires that
- * `domain::Tags::ObjectCenter<domain::ObjectLabel::A>` and
+ * If `UseGridCentersFunctionOfTime` is `true` then the distance between the
+ * two object is computed using the `GridCenters` function of time. It is
+ * assume that the `GridCenters` function of time holds the grid coordinates,
+ * `{x_A, y_A, z_A, x_B, y_B, z_B}`. The Cartesian distance is computed
+ * between these two locations.
+ *
+ * If `UseGridCentersFunctionOfTime` is `false` then
+ * `domain::Tags::ObjectCenter<A>` and `domain::Tags::ObjectCenter<B>` (in the
+ * inertial frame) are used to compute the separation.
+ *
+ * Once the separation is smaller than (or equal to) the input separation, then
+ * the `operator()` returns true.
+ *
+ * \note If `UseGridCentersFunctionOfTime` is `false` then this trigger requires
+ * that `domain::Tags::ObjectCenter<domain::ObjectLabel::A>` and
  * `domain::Tags::ObjectCenter<domain::ObjectLabel::B>` are in the DataBox. It
  * also requires that there are two ExcisionSphere%s in the Domain named
  * `ExcisionSphereA/B` and that these ExcisionSphere%s have had time dependent
  * maps injected into them. The coordinate maps from these ExcisionSphere%s will
  * be used to calculate the separation in the inertial frame.
+ *
+ * \note If `UseGridCentersFunctionOfTime` is `true` then this trigger
+ * requires that `GridCenters` and `Rotation` are a valid function of time and
+ * will only trigger `true` if the `Rotation` function of time is not a
+ * `domain::FunctionsOfTime::SettleToConstantQuaternion`.
  */
+template <bool UseGridCentersFunctionOfTime>
 class SeparationLessThan : public Trigger {
  public:
   /// \cond
@@ -67,24 +85,27 @@ class SeparationLessThan : public Trigger {
   struct Value {
     using type = double;
     static constexpr Options::String help = {
-        "Separation of the two horizons to compare against."};
+        "Separation of the two horizons or neutron star centers to compare "
+        "against."};
   };
 
   using options = tmpl::list<Value>;
   static constexpr Options::String help{
-      "Trigger when the separation between the two horizons is less than a "
-      "certain distance."};
+      "Trigger when the separation between the two horizons or neutron star "
+      "centers is less than a certain distance."};
 
   explicit SeparationLessThan(double separation);
 
-  using argument_tags =
+  using argument_tags = tmpl::conditional_t<
+      UseGridCentersFunctionOfTime,
+      tmpl::list<Tags::Time, domain::Tags::FunctionsOfTime>,
       tmpl::list<Tags::Time, domain::Tags::Domain<3>,
                  domain::Tags::FunctionsOfTime,
                  domain::Tags::ObjectCenter<domain::ObjectLabel::A>,
-                 domain::Tags::ObjectCenter<domain::ObjectLabel::B>>;
+                 domain::Tags::ObjectCenter<domain::ObjectLabel::B>>>;
 
   bool operator()(
-      const double time, const ::Domain<3>& domain,
+      double time, const ::Domain<3>& domain,
       const std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
@@ -92,10 +113,16 @@ class SeparationLessThan : public Trigger {
       const tnsr::I<double, 3, Frame::Grid>& grid_object_center_a,
       const tnsr::I<double, 3, Frame::Grid>& grid_object_center_b) const;
 
+  bool operator()(double time,
+                  const std::unordered_map<
+                      std::string,
+                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                      functions_of_time) const;
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;
 
  private:
-  double separation_{};
+  double separation_{std::numeric_limits<double>::signaling_NaN()};
 };
 }  // namespace Triggers

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -21,7 +21,8 @@ namespace control_system {
 namespace {
 void test_expansion_control_error() {
   constexpr size_t deriv_order = 2;
-  using metavars = TestHelpers::MockMetavars<0, 0, deriv_order, 0>;
+  using metavars =
+      TestHelpers::control_system::MockMetavars<0, 0, deriv_order, 0>;
   using element_component = typename metavars::element_component;
   using expansion_system = typename metavars::expansion_system;
 
@@ -31,7 +32,7 @@ void test_expansion_control_error() {
   const double initial_separation = 15.0;
 
   // Set up the system helper.
-  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+  TestHelpers::control_system::SystemHelper<metavars> system_helper{};
 
   const std::string input_options =
       "Evolution:\n"
@@ -62,7 +63,8 @@ void test_expansion_control_error() {
   // Initialize everything within the system helper
   system_helper.setup_control_system_test(
       initial_time, initial_separation, input_options,
-      TestHelpers::initialize_expansion_functions_of_time<expansion_system>);
+      TestHelpers::control_system::initialize_expansion_functions_of_time<
+          expansion_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -24,7 +24,8 @@ void test_rotation_control_error() {
   // Since we are only doing rotation, turn off the
   // other control systems by passing 0 for their deriv orders
   constexpr size_t deriv_order = 2;
-  using metavars = TestHelpers::MockMetavars<0, deriv_order, 0, 0>;
+  using metavars =
+      TestHelpers::control_system::MockMetavars<0, deriv_order, 0, 0>;
   using element_component = typename metavars::element_component;
   using rotation_system = typename metavars::rotation_system;
   MAKE_GENERATOR(gen);
@@ -35,7 +36,7 @@ void test_rotation_control_error() {
   const double initial_separation = 15.0;
 
   // Set up the system helper.
-  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+  TestHelpers::control_system::SystemHelper<metavars> system_helper{};
 
   const std::string input_options =
       "Evolution:\n"
@@ -66,7 +67,8 @@ void test_rotation_control_error() {
   // Initialize everything within the system helper
   system_helper.setup_control_system_test(
       initial_time, initial_separation, input_options,
-      TestHelpers::initialize_rotation_functions_of_time<rotation_system>);
+      TestHelpers::control_system::initialize_rotation_functions_of_time<
+          rotation_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -58,7 +58,7 @@ using Strahlkorper = ylm::Strahlkorper<Frame::Distorted>;
 void test_shape_control_error() {
   constexpr size_t deriv_order = 2;
   using metavars =
-      control_system::TestHelpers::MockMetavars<0, 0, 0, deriv_order>;
+      TestHelpers::control_system::MockMetavars<0, 0, 0, deriv_order>;
   using system = typename metavars::shape_system;
   using ControlError = system::control_error;
   using element_component = typename metavars::element_component;

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -34,7 +34,8 @@ void test_translation_control_error() {
   // Since we are only doing translation, turn off the
   // other control systems by passing 0 for their deriv orders
   constexpr size_t deriv_order = 2;
-  using metavars = TestHelpers::MockMetavars<deriv_order, 0, 0, 0>;
+  using metavars =
+      TestHelpers::control_system::MockMetavars<deriv_order, 0, 0, 0>;
   using element_component = typename metavars::element_component;
   using translation_system = typename metavars::translation_system;
 
@@ -44,7 +45,7 @@ void test_translation_control_error() {
   const double initial_separation = 15.0;
 
   // Set up the system helper.
-  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+  TestHelpers::control_system::SystemHelper<metavars> system_helper{};
 
   const std::string input_options =
       "Evolution:\n"
@@ -75,7 +76,7 @@ void test_translation_control_error() {
   // Initialize everything within the system helper
   system_helper.setup_control_system_test(
       initial_time, initial_separation, input_options,
-      TestHelpers::initialize_translation_functions_of_time<
+      TestHelpers::control_system::initialize_translation_functions_of_time<
           translation_system>);
 
   // Get references to everything that was set up inside the system helper. The

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -37,7 +37,8 @@ using CoordMap =
 
 template <size_t DerivOrder>
 void test_expansion_control_system() {
-  using metavars = TestHelpers::MockMetavars<0, 0, DerivOrder, 0>;
+  using metavars =
+      TestHelpers::control_system::MockMetavars<0, 0, DerivOrder, 0>;
   using expansion_component = typename metavars::expansion_component;
   using element_component = typename metavars::element_component;
   using observer_component = typename metavars::observer_component;
@@ -53,7 +54,7 @@ void test_expansion_control_system() {
   const double final_time = 500.0;
 
   // Set up the system helper.
-  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+  TestHelpers::control_system::SystemHelper<metavars> system_helper{};
 
   const std::string input_options =
       "Evolution:\n"
@@ -84,7 +85,8 @@ void test_expansion_control_system() {
   // Initialize everything within the system helper
   system_helper.setup_control_system_test(
       initial_time, initial_separation, input_options,
-      TestHelpers::initialize_expansion_functions_of_time<expansion_system>);
+      TestHelpers::control_system::initialize_expansion_functions_of_time<
+          expansion_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need
@@ -152,8 +154,9 @@ void test_expansion_control_system() {
 
   const auto horizon_function = [&position_function, &runner,
                                  &coord_map](const double time) {
-    return TestHelpers::build_horizons_for_basic_control_systems<
-        element_component>(time, runner, position_function, coord_map);
+    return TestHelpers::control_system::
+        build_horizons_for_basic_control_systems<element_component>(
+            time, runner, position_function, coord_map);
   };
 
   // Run the actual control system test.
@@ -161,9 +164,9 @@ void test_expansion_control_system() {
                                         horizon_function);
 
   // Grab results
-  const auto grid_positions =
-      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
-          element_component>(final_time, runner, position_function, coord_map);
+  const auto grid_positions = TestHelpers::control_system::
+      grid_frame_horizon_centers_for_basic_control_systems<element_component>(
+          final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const tnsr::I<double, 3, Frame::Grid> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Systems/Test_GridCenters.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_GridCenters.cpp
@@ -86,7 +86,7 @@ using with_these_simple_actions_mock_component =
 
 template <typename Metavariables>
 struct MockComponent
-    : public control_system::TestHelpers::MockControlComponent<Metavariables,
+    : public TestHelpers::control_system::MockControlComponent<Metavariables,
                                                                GridCenters> {
   using replace_these_simple_actions =
       replace_these_simple_actions_mock_component;

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -72,9 +72,8 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   INFO("Translation: "s + get_output(TranslationDerivOrder) + ", Rotation: "s +
        get_output(RotationDerivOrder) + ", Expansion: "s +
        get_output(ExpansionDerivOrder));
-  using metavars =
-      TestHelpers::MockMetavars<TranslationDerivOrder, RotationDerivOrder,
-                                ExpansionDerivOrder, 0>;
+  using metavars = TestHelpers::control_system::MockMetavars<
+      TranslationDerivOrder, RotationDerivOrder, ExpansionDerivOrder, 0>;
   using element_component = typename metavars::element_component;
   using translation_component = typename metavars::translation_component;
   using rotation_component = typename metavars::rotation_component;
@@ -93,7 +92,7 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   const double final_time = 500.0;
 
   // Set up the system helper
-  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+  TestHelpers::control_system::SystemHelper<metavars> system_helper{};
 
   const std::string translation_name =
       system_helper.template name<translation_system>();
@@ -126,13 +125,16 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
          const double local_initial_time,
          const std::unordered_map<std::string, double>&
              initial_expiration_times) {
-        TestHelpers::initialize_expansion_functions_of_time<expansion_system>(
-            functions_of_time, local_initial_time, initial_expiration_times);
-        TestHelpers::initialize_rotation_functions_of_time<rotation_system>(
-            functions_of_time, local_initial_time, initial_expiration_times);
-        return TestHelpers::initialize_translation_functions_of_time<
-            translation_system>(functions_of_time, local_initial_time,
-                                initial_expiration_times);
+        TestHelpers::control_system::initialize_expansion_functions_of_time<
+            expansion_system>(functions_of_time, local_initial_time,
+                              initial_expiration_times);
+        TestHelpers::control_system::initialize_rotation_functions_of_time<
+            rotation_system>(functions_of_time, local_initial_time,
+                             initial_expiration_times);
+        return TestHelpers::control_system::
+            initialize_translation_functions_of_time<translation_system>(
+                functions_of_time, local_initial_time,
+                initial_expiration_times);
       };
 
   // Initialize everything within the system helper
@@ -207,8 +209,9 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
 
   const auto horizon_function = [&position_function, &runner,
                                  &coord_map](const double time) {
-    return TestHelpers::build_horizons_for_basic_control_systems<
-        element_component>(time, runner, position_function, coord_map);
+    return TestHelpers::control_system::
+        build_horizons_for_basic_control_systems<element_component>(
+            time, runner, position_function, coord_map);
   };
 
   // Run the actual control system test.
@@ -216,9 +219,9 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
                                         horizon_function);
 
   // Grab results
-  const auto grid_positions =
-      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
-          element_component>(final_time, runner, position_function, coord_map);
+  const auto grid_positions = TestHelpers::control_system::
+      grid_frame_horizon_centers_for_basic_control_systems<element_component>(
+          final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const tnsr::I<double, 3, Frame::Grid> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -43,7 +43,8 @@ template <size_t DerivOrder>
 void test_rotation_control_system(const bool newtonian) {
   // Since we are only doing rotation, turn off the
   // other control systems by passing 0 for their deriv orders
-  using metavars = TestHelpers::MockMetavars<0, DerivOrder, 0, 0>;
+  using metavars =
+      TestHelpers::control_system::MockMetavars<0, DerivOrder, 0, 0>;
   using rotation_component = typename metavars::rotation_component;
   using element_component = typename metavars::element_component;
   using rotation_system = typename metavars::rotation_system;
@@ -58,7 +59,7 @@ void test_rotation_control_system(const bool newtonian) {
   const double final_time = 300.0;
 
   // Set up the system helper.
-  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+  TestHelpers::control_system::SystemHelper<metavars> system_helper{};
 
   const std::string input_options =
       "Evolution:\n"
@@ -89,7 +90,8 @@ void test_rotation_control_system(const bool newtonian) {
   // Initialize everything within the system helper
   system_helper.setup_control_system_test(
       initial_time, initial_separation, input_options,
-      TestHelpers::initialize_rotation_functions_of_time<rotation_system>);
+      TestHelpers::control_system::initialize_rotation_functions_of_time<
+          rotation_system>);
 
   // Get references to everything that was set up inside the system helper. The
   // domain and two functions of time are not const references because they need
@@ -146,8 +148,9 @@ void test_rotation_control_system(const bool newtonian) {
 
   const auto horizon_function = [&position_function, &runner,
                                  &coord_map](const double time) {
-    return TestHelpers::build_horizons_for_basic_control_systems<
-        element_component>(time, runner, position_function, coord_map);
+    return TestHelpers::control_system::
+        build_horizons_for_basic_control_systems<element_component>(
+            time, runner, position_function, coord_map);
   };
 
   // Run the actual control system test.
@@ -155,9 +158,9 @@ void test_rotation_control_system(const bool newtonian) {
                                         horizon_function);
 
   // Grab results
-  const auto grid_positions =
-      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
-          element_component>(final_time, runner, position_function, coord_map);
+  const auto grid_positions = TestHelpers::control_system::
+      grid_frame_horizon_centers_for_basic_control_systems<element_component>(
+          final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const tnsr::I<double, 3, Frame::Grid> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -57,7 +57,7 @@ using FoTMap = std::unordered_map<
     std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
 using Strahlkorper = ylm::Strahlkorper<Frame::Distorted>;
 template <typename Metavars>
-using SystemHelper = control_system::TestHelpers::SystemHelper<Metavars>;
+using SystemHelper = TestHelpers::control_system::SystemHelper<Metavars>;
 
 template <typename Generator, typename Metavars, size_t DerivOrder>
 void test_shape_control(
@@ -178,7 +178,7 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
                 const double looser_eps, const double stricter_eps) {
   // First 3 zeros are for translation, rotation, and expansion
   using metavars =
-      control_system::TestHelpers::MockMetavars<0, 0, 0, DerivOrder>;
+      TestHelpers::control_system::MockMetavars<0, 0, 0, DerivOrder>;
   using system = typename metavars::shape_system;
 
   // Responsible for running all control system checks

--- a/tests/Unit/ControlSystem/Systems/Test_Size.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Size.cpp
@@ -84,7 +84,7 @@ using with_these_simple_actions_mock_component = tmpl::transform<
 
 template <typename Metavariables>
 struct MockComponent
-    : public control_system::TestHelpers::MockControlComponent<Metavariables,
+    : public TestHelpers::control_system::MockControlComponent<Metavariables,
                                                                size> {
   using replace_these_simple_actions =
       replace_these_simple_actions_mock_component;

--- a/tests/Unit/ControlSystem/Systems/Test_Skew.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Skew.cpp
@@ -81,7 +81,7 @@ using with_these_simple_actions_mock_component = tmpl::transform<
 
 template <typename Metavariables>
 struct MockComponent
-    : public control_system::TestHelpers::MockControlComponent<Metavariables,
+    : public TestHelpers::control_system::MockControlComponent<Metavariables,
                                                                skew> {
   using replace_these_simple_actions =
       replace_these_simple_actions_mock_component;

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -45,7 +45,8 @@ template <size_t DerivOrder>
 void test_translation_control_system() {
   // Since we are only doing translation, turn off the
   // other control systems by passing 0 for their deriv orders
-  using metavars = TestHelpers::MockMetavars<DerivOrder, 0, 0, 0>;
+  using metavars =
+      TestHelpers::control_system::MockMetavars<DerivOrder, 0, 0, 0>;
   using translation_component = typename metavars::translation_component;
   using element_component = typename metavars::element_component;
   using translation_system = typename metavars::translation_system;
@@ -60,7 +61,7 @@ void test_translation_control_system() {
   const double final_time = 600.0;
 
   // Set up the system helper.
-  control_system::TestHelpers::SystemHelper<metavars> system_helper{};
+  TestHelpers::control_system::SystemHelper<metavars> system_helper{};
 
   const std::string input_options =
       "Evolution:\n"
@@ -91,7 +92,7 @@ void test_translation_control_system() {
   // Initialize everything within the system helper
   system_helper.setup_control_system_test(
       initial_time, initial_separation, input_options,
-      TestHelpers::initialize_translation_functions_of_time<
+      TestHelpers::control_system::initialize_translation_functions_of_time<
           translation_system>);
 
   // Get references to everything that was set up inside the system helper. The
@@ -155,8 +156,9 @@ void test_translation_control_system() {
 
   const auto horizon_function = [&position_function, &runner,
                                  &coord_map](const double time) {
-    return TestHelpers::build_horizons_for_basic_control_systems<
-        element_component>(time, runner, position_function, coord_map);
+    return TestHelpers::control_system::
+        build_horizons_for_basic_control_systems<element_component>(
+            time, runner, position_function, coord_map);
   };
 
   // Run the actual control system test.
@@ -164,9 +166,9 @@ void test_translation_control_system() {
                                         horizon_function);
 
   // Grab results
-  const auto grid_positions =
-      TestHelpers::grid_frame_horizon_centers_for_basic_control_systems<
-          element_component>(final_time, runner, position_function, coord_map);
+  const auto grid_positions = TestHelpers::control_system::
+      grid_frame_horizon_centers_for_basic_control_systems<element_component>(
+          final_time, runner, position_function, coord_map);
 
   // Our expected positions are just the initial positions
   const tnsr::I<double, 3, Frame::Grid> expected_grid_position_of_a{

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -98,7 +98,7 @@ void test_measurement_tag() {
   static_assert(
       tmpl::size<measurement_tag::option_tags<Metavariables>>::value == 9);
 
-  using FakeCreator = control_system::TestHelpers::FakeCreator;
+  using FakeCreator = TestHelpers::control_system::FakeCreator;
 
   const double time_step = 0.2;
   {

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -81,7 +81,7 @@ void test_expiration_time_construction() {
       OptionHolder<2>{averager, controller, tuner2, control_error};
   const std::optional<OptionHolder<3>> option_holder3 = std::nullopt;
 
-  using FakeCreator = control_system::TestHelpers::FakeCreator;
+  using FakeCreator = TestHelpers::control_system::FakeCreator;
 
   const std::unique_ptr<DomainCreator<3>> creator1 =
       std::make_unique<FakeCreator>(std::unordered_map<std::string, size_t>{});

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -43,7 +43,7 @@ struct MetavarsEmpty {
   static constexpr size_t volume_dim = 3;
 };
 
-using FakeCreator = control_system::TestHelpers::FakeCreator;
+using FakeCreator = TestHelpers::control_system::FakeCreator;
 
 void test_all_tags() {
   INFO("Test all tags");

--- a/tests/Unit/Evolution/Triggers/Test_SeparationLessThan.cpp
+++ b/tests/Unit/Evolution/Triggers/Test_SeparationLessThan.cpp
@@ -20,7 +20,9 @@
 #include "Domain/ExcisionSphere.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/Triggers/SeparationLessThan.hpp"
@@ -29,24 +31,29 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Utilities/CartesianProduct.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
+template <bool UseGridCentersFunctionOfTime>
 struct Metavariables {
   using component_list = tmpl::list<>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<
-        tmpl::pair<Trigger, tmpl::list<Triggers::SeparationLessThan>>>;
+    using factory_classes =
+        tmpl::map<tmpl::pair<Trigger, tmpl::list<Triggers::SeparationLessThan<
+                                          UseGridCentersFunctionOfTime>>>>;
   };
 };
 
 using TranslationMap = domain::CoordinateMaps::TimeDependent::Translation<3>;
 
-void test() {
+void test_horizons() {
+  INFO("Testing with horizons");
+  register_factory_classes_with_charm<Metavariables<false>>();
   const std::string f_of_t_name = "LlamasWithHats";
   std::unique_ptr<domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>
       map = std::make_unique<
@@ -57,6 +64,7 @@ void test() {
                          const double separation, const double time,
                          const double x_center_a, const double x_center_b,
                          const bool expected_is_triggered) {
+    CAPTURE(separation, time, x_center_a, x_center_b, expected_is_triggered);
     const tnsr::I<double, 3, Frame::Grid> center_a{
         std::array{x_center_a, 0.0, 0.0}};
     const tnsr::I<double, 3, Frame::Grid> center_b{
@@ -76,7 +84,7 @@ void test() {
 
     const Domain<3> domain{{}, std::move(excision_spheres)};
 
-    const Triggers::SeparationLessThan trigger{separation};
+    const Triggers::SeparationLessThan<false> trigger{separation};
 
     // The coefs are zero because we want the inertial point to be the same
     // as the grid point for easy checking
@@ -95,16 +103,62 @@ void test() {
 
   for (const auto& [separation, x_center] : cartesian_product(
            make_array(10.0, 5.0, 2.0), make_array(6.0, 5.0, 2.0, 0.75))) {
-    check(separation, 0.0, x_center, -x_center, 2.0 * x_center <= separation);
+    check(separation, 0.0, x_center, -x_center, 2.0 * x_center < separation);
   }
 
-  TestHelpers::test_creation<std::unique_ptr<Trigger>, Metavariables>(
+  TestHelpers::test_creation<std::unique_ptr<Trigger>, Metavariables<false>>(
       "SeparationLessThan:\n"
       "  Value: 2.3");
 }
 
-void test_errors() {
-  const Triggers::SeparationLessThan trigger{1.0};
+void test_grid_centers() {
+  INFO("Testing with grid centers");
+  register_factory_classes_with_charm<Metavariables<true>>();
+
+  const Triggers::SeparationLessThan<false> trigger{6.0};
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time["GridCenters"] =
+      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>{
+          std::make_unique<::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+              0.0,
+              std::array<DataVector, 4>{{{16.0, 0.0, 0.0, -16.0, 0.0, 0.0},
+                                         {-0.001, 0.0, 0.0, 0.001, 0.0, 0.0},
+                                         {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                                         {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}}},
+              std::numeric_limits<double>::max())};
+  const double initial_omega_z = 0.01;
+  auto init_func_rotation = make_array<4, DataVector>(DataVector{3, 0.0});
+  init_func_rotation[1][2] = initial_omega_z;
+  auto init_quaternion = make_array<1, DataVector>(DataVector{4, 0.0});
+  init_quaternion[0][0] = 1.0;
+  functions_of_time["Rotation"] =
+      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+          0.0, init_quaternion, init_func_rotation, 1.0e5);
+
+  CHECK_FALSE(trigger(0.0, functions_of_time));
+  CHECK_FALSE(trigger(9.0e3, functions_of_time));
+  CHECK_FALSE(trigger(12.9999999e3, functions_of_time));
+  CHECK(trigger(13.001e3, functions_of_time));
+  CHECK(trigger(14.0e3, functions_of_time));
+  CHECK(trigger(15.0e3, functions_of_time));
+
+  const double match_time = 14.5e3;
+  const std::array<DataVector, 3> settle_initial_func_and_derivs =
+      functions_of_time.at("Rotation")->func_and_2_derivs(match_time);
+  functions_of_time["Rotation"] =
+      std::make_unique<domain::FunctionsOfTime::SettleToConstantQuaternion>(
+          settle_initial_func_and_derivs, match_time, 60.0);
+  CHECK_FALSE(trigger(15.0e3, functions_of_time));
+
+  TestHelpers::test_creation<std::unique_ptr<Trigger>, Metavariables<true>>(
+      "SeparationLessThan:\n"
+      "  Value: 2.3");
+}
+
+void test_errors_horizons() {
+  const Triggers::SeparationLessThan<false> trigger{1.0};
 
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
 
@@ -124,11 +178,11 @@ void test_errors() {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Triggers.SeparationLessThan",
                   "[Unit][Evolution]") {
-  register_factory_classes_with_charm<Metavariables>();
   domain::FunctionsOfTime::register_derived_with_charm();
   PUPable_reg(SINGLE_ARG(
       domain::CoordinateMap<Frame::Grid, Frame::Inertial, TranslationMap>));
-  test();
-  test_errors();
+  test_horizons();
+  test_grid_centers();
+  test_errors_horizons();
 }
 }  // namespace

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -82,15 +82,15 @@ struct InitialTime;
 }  // namespace OptionTags
 /// \endcond
 
-namespace control_system::TestHelpers {
+namespace TestHelpers::control_system {
 template <typename ControlSystem>
 using init_simple_tags =
-    tmpl::list<control_system::Tags::Averager<ControlSystem>,
-               control_system::Tags::TimescaleTuner<ControlSystem>,
-               control_system::Tags::Controller<ControlSystem>,
-               control_system::Tags::ControlError<ControlSystem>,
-               control_system::Tags::CurrentNumberOfMeasurements,
-               control_system::Tags::UpdateAggregators,
+    tmpl::list<::control_system::Tags::Averager<ControlSystem>,
+               ::control_system::Tags::TimescaleTuner<ControlSystem>,
+               ::control_system::Tags::Controller<ControlSystem>,
+               ::control_system::Tags::ControlError<ControlSystem>,
+               ::control_system::Tags::CurrentNumberOfMeasurements,
+               ::control_system::Tags::UpdateAggregators,
                typename ControlSystem::MeasurementQueue>;
 
 class FakeCreator : public DomainCreator<3> {
@@ -196,13 +196,13 @@ struct MockControlComponent {
   using simple_tags = init_simple_tags<ControlSystem>;
 
   using const_global_cache_tags =
-      tmpl::list<control_system::Tags::MeasurementsPerUpdate,
-                 control_system::Tags::WriteDataToDisk,
-                 control_system::Tags::Verbosity,
-                 control_system::Tags::IsActiveMap,
+      tmpl::list<::control_system::Tags::MeasurementsPerUpdate,
+                 ::control_system::Tags::WriteDataToDisk,
+                 ::control_system::Tags::Verbosity,
+                 ::control_system::Tags::IsActiveMap,
                  domain::Tags::ObjectCenter<domain::ObjectLabel::A>,
                  domain::Tags::ObjectCenter<domain::ObjectLabel::B>,
-                 control_system::Tags::SystemToCombinedNames>;
+                 ::control_system::Tags::SystemToCombinedNames>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
       Parallel::Phase::Initialization,
@@ -223,7 +223,7 @@ struct MockElementComponent {
 
   using mutable_global_cache_tags =
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize,
-                 control_system::Tags::MeasurementTimescales>;
+                 ::control_system::Tags::MeasurementTimescales>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
@@ -285,17 +285,18 @@ struct MockMetavars {
 
   using element_component = MockElementComponent<metavars>;
 
-  using BothHorizons = control_system::measurements::BothHorizons;
+  using BothHorizons = ::control_system::measurements::BothHorizons;
 
   using expansion_system =
-      control_system::Systems::Expansion<exp_deriv_order, BothHorizons>;
+      ::control_system::Systems::Expansion<exp_deriv_order, BothHorizons>;
   using rotation_system =
-      control_system::Systems::Rotation<rot_deriv_order, BothHorizons>;
+      ::control_system::Systems::Rotation<rot_deriv_order, BothHorizons>;
   using translation_system =
-      control_system::Systems::Translation<trans_deriv_order, BothHorizons, 2>;
+      ::control_system::Systems::Translation<trans_deriv_order, BothHorizons,
+                                             2>;
   using shape_system =
-      control_system::Systems::Shape<::domain::ObjectLabel::A,
-                                     shape_deriv_order, BothHorizons>;
+      ::control_system::Systems::Shape<::domain::ObjectLabel::A,
+                                       shape_deriv_order, BothHorizons>;
 
   using control_systems = tmpl::flatten<tmpl::list<
       tmpl::conditional_t<using_expansion, expansion_system, tmpl::list<>>,
@@ -555,20 +556,22 @@ struct SystemHelper {
       using system = tmpl::type_from<decltype(system_v)>;
 
       auto& init_tuple = get<LocalTag<system>>(all_init_tags_);
-      auto& averager = get<control_system::Tags::Averager<system>>(init_tuple);
+      auto& averager =
+          get<::control_system::Tags::Averager<system>>(init_tuple);
       const auto& controller =
-          get<control_system::Tags::Controller<system>>(init_tuple);
+          get<::control_system::Tags::Controller<system>>(init_tuple);
       const auto& tuner =
-          get<control_system::Tags::TimescaleTuner<system>>(init_tuple);
+          get<::control_system::Tags::TimescaleTuner<system>>(init_tuple);
       const DataVector measurement_timescale =
-          control_system::calculate_measurement_timescales(
+          ::control_system::calculate_measurement_timescales(
               controller, tuner, measurements_per_update_);
       const double min_measurement_timescale = min(measurement_timescale);
       averager.assign_time_between_measurements(min_measurement_timescale);
 
-      const double measurement_expr_time = measurement_expiration_time(
-          initial_time_, DataVector{0.0}, DataVector{min_measurement_timescale},
-          measurements_per_update_);
+      const double measurement_expr_time =
+          ::control_system::measurement_expiration_time(
+              initial_time_, DataVector{0.0},
+              DataVector{min_measurement_timescale}, measurements_per_update_);
 
       individual_minimums[name<system>()] =
           std::make_pair(min_measurement_timescale, measurement_expr_time);
@@ -596,10 +599,11 @@ struct SystemHelper {
     for (const auto& [system_name, min_measure_expr_time] :
          individual_minimums) {
       (void)min_measure_expr_time;
-      initial_expiration_times[system_name] = function_of_time_expiration_time(
-          initial_time_, DataVector{0.0},
-          DataVector{overall_min_measurement_timescale},
-          measurements_per_update_);
+      initial_expiration_times[system_name] =
+          ::control_system::function_of_time_expiration_time(
+              initial_time_, DataVector{0.0},
+              DataVector{overall_min_measurement_timescale},
+              measurements_per_update_);
     }
 
     const double excision_radius =
@@ -664,7 +668,7 @@ struct SystemHelper {
       const F horizon_function) {
     auto& cache = ActionTesting::cache<element_component>(runner, 0);
     const auto& measurement_timescales =
-        Parallel::get<control_system::Tags::MeasurementTimescales>(cache);
+        Parallel::get<::control_system::Tags::MeasurementTimescales>(cache);
     const auto& functions_of_time =
         Parallel::get<::domain::Tags::FunctionsOfTime>(cache);
 
@@ -700,16 +704,16 @@ struct SystemHelper {
         // Depending on the measurement, apply the submeasurements
         if constexpr (is_shape) {
           system::process_measurement::apply(
-              measurements::SingleHorizon<
+              ::control_system::measurements::SingleHorizon<
                   ::domain::ObjectLabel::A>::Submeasurement{},
               horizon_a_, cache, measurement_id);
         } else {
           system::process_measurement::apply(
-              measurements::BothHorizons::FindHorizon<
+              ::control_system::measurements::BothHorizons::FindHorizon<
                   ::domain::ObjectLabel::A>{},
               horizon_a_, cache, measurement_id);
           system::process_measurement::apply(
-              measurements::BothHorizons::FindHorizon<
+              ::control_system::measurements::BothHorizons::FindHorizon<
                   ::domain::ObjectLabel::B>{},
               horizon_b_, cache, measurement_id);
         }
@@ -771,21 +775,21 @@ struct SystemHelper {
 
  private:
   template <typename Component>
-  using option_tag = control_system::OptionTags::ControlSystemInputs<
+  using option_tag = ::control_system::OptionTags::ControlSystemInputs<
       typename Component::system>;
   using option_list = tmpl::push_back<
       tmpl::remove_duplicates<tmpl::transform<
           control_components, tmpl::bind<option_tag, tmpl::_1>>>,
-      control_system::OptionTags::WriteDataToDisk, ::OptionTags::InitialTime,
+      ::control_system::OptionTags::WriteDataToDisk, ::OptionTags::InitialTime,
       domain::OptionTags::DomainCreator<3>,
-      control_system::OptionTags::MeasurementsPerUpdate>;
+      ::control_system::OptionTags::MeasurementsPerUpdate>;
   template <typename System>
   using creatable_tags = tmpl::list_difference<
       init_simple_tags<System>,
       tmpl::list<typename System::MeasurementQueue,
-                 control_system::Tags::CurrentNumberOfMeasurements,
-                 control_system::Tags::UpdateAggregators,
-                 control_system::Tags::MeasurementsPerUpdate>>;
+                 ::control_system::Tags::CurrentNumberOfMeasurements,
+                 ::control_system::Tags::UpdateAggregators,
+                 ::control_system::Tags::MeasurementsPerUpdate>>;
 
   void parse_options(const std::string& option_string) {
     Options::Parser<option_list> parser{"Peter Parker the option parser."};
@@ -798,12 +802,14 @@ struct SystemHelper {
 
     const auto created_measurements_per_update =
         Parallel::create_from_options<Metavars>(
-            options, tmpl::list<control_system::Tags::MeasurementsPerUpdate>{});
+            options,
+            tmpl::list<::control_system::Tags::MeasurementsPerUpdate>{});
 
-    measurements_per_update_ = get<control_system::Tags::MeasurementsPerUpdate>(
-        created_measurements_per_update);
+    measurements_per_update_ =
+        get<::control_system::Tags::MeasurementsPerUpdate>(
+            created_measurements_per_update);
 
-    std::unordered_map<std::string, control_system::UpdateAggregator>
+    std::unordered_map<std::string, ::control_system::UpdateAggregator>
         update_aggregators{};
     std::unordered_set<std::string> control_system_names{};
 
@@ -813,7 +819,7 @@ struct SystemHelper {
           control_system_names.insert(system::name());
         });
 
-    update_aggregators[combined_name_] = control_system::UpdateAggregator{
+    update_aggregators[combined_name_] = ::control_system::UpdateAggregator{
         combined_name_, std::move(control_system_names)};
 
     tmpl::for_each<control_systems>([this, &options,
@@ -826,23 +832,24 @@ struct SystemHelper {
 
       get<LocalTag<system>>(all_init_tags_) =
           tuples::tagged_tuple_from_typelist<init_simple_tags<system>>{
-              get<control_system::Tags::Averager<system>>(created_tags),
-              get<control_system::Tags::TimescaleTuner<system>>(created_tags),
-              get<control_system::Tags::Controller<system>>(created_tags),
-              get<control_system::Tags::ControlError<system>>(created_tags), 0,
-              update_aggregators,
+              get<::control_system::Tags::Averager<system>>(created_tags),
+              get<::control_system::Tags::TimescaleTuner<system>>(created_tags),
+              get<::control_system::Tags::Controller<system>>(created_tags),
+              get<::control_system::Tags::ControlError<system>>(created_tags),
+              0, update_aggregators,
               // Just need an empty queue. It will get filled in as the control
               // system is updated
               LinkedMessageQueue<
                   double,
                   tmpl::conditional_t<
                       std::is_same_v<system, typename Metavars::shape_system>,
-                      tmpl::list<QueueTags::Horizon<::Frame::Distorted,
-                                                    ::domain::ObjectLabel::A>>,
-                      tmpl::list<QueueTags::Center<::domain::ObjectLabel::A,
-                                                   Frame::Grid>,
-                                 QueueTags::Center<::domain::ObjectLabel::B,
-                                                   Frame::Grid>>>>{}};
+                      tmpl::list<::control_system::QueueTags::Horizon<
+                          ::Frame::Distorted, ::domain::ObjectLabel::A>>,
+                      tmpl::list<
+                          ::control_system::QueueTags::Center<
+                              ::domain::ObjectLabel::A, Frame::Grid>,
+                          ::control_system::QueueTags::Center<
+                              ::domain::ObjectLabel::B, Frame::Grid>>>>{}};
     });
   }
 
@@ -874,9 +881,10 @@ struct SystemHelper {
   int measurements_per_update_{};
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
   std::unordered_map<std::string, std::string> system_to_combined_names_{
-      control_system::system_to_combined_names<control_systems>()};
+      ::control_system::system_to_combined_names<control_systems>()};
   // Only one because all systems use the same measurement
-  std::string combined_name_{control_system::combined_name<control_systems>()};
+  std::string combined_name_{
+      ::control_system::combined_name<control_systems>()};
 
   // Initialization members. These are the values that will be used when the
   // reset() function is called. We don't need the horizons because those are
@@ -893,4 +901,4 @@ struct SystemHelper {
   // spheres which are the only important part
   std::unordered_map<std::string, ExcisionSphere<3>> stored_excision_spheres_{};
 };
-}  // namespace control_system::TestHelpers
+}  // namespace TestHelpers::control_system


### PR DESCRIPTION
## Proposed changes

I need a trigger to use when the stars get too close and we need to disable rotation control.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
