### PR TITLE
Add disabling rotation control system to BNS

### DIFF
--- a/src/ControlSystem/Actions/CMakeLists.txt
+++ b/src/ControlSystem/Actions/CMakeLists.txt
@@ -1,10 +1,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  GridCenters.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  GridCenters.hpp
   Initialization.hpp
   InitializeMeasurements.hpp
   LimitTimeStep.hpp

--- a/src/ControlSystem/Actions/GridCenters.cpp
+++ b/src/ControlSystem/Actions/GridCenters.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/Actions/GridCenters.hpp"
+
+#include <array>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace control_system {
+void DisableRotationWhen::pup(PUP::er& p) {
+  p | disable_at_separation;
+  p | rotation_decay_timescale;
+}
+
+namespace Tags {
+control_system::DisableRotationWhen DisableRotationWhen::create_from_options(
+    const control_system::DisableRotationWhen& disable_rotation_when) {
+  return disable_rotation_when;
+}
+}  // namespace Tags
+
+namespace Actions {
+void SwitchGridRotationToSettle::UpdateRotationToSettle::apply(
+    const gsl::not_null<std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+        f_of_t_list,
+    const std::string& function_of_time_name,
+    const std::array<DataVector, 3>& initial_func_and_derivs,
+    const double match_time, const double decay_time) {
+  if (not f_of_t_list->contains(function_of_time_name)) {
+    ERROR("Cannot find function of time name '"
+          << function_of_time_name
+          << "' in the set of functions of time: " << keys_of(*f_of_t_list));
+  }
+  f_of_t_list->at(function_of_time_name) =
+      std::make_unique<domain::FunctionsOfTime::SettleToConstantQuaternion>(
+          initial_func_and_derivs, match_time, decay_time);
+}
+
+void SwitchGridRotationToSettle::DisableControlSystem::apply(
+    const gsl::not_null<std::unordered_map<std::string, bool>*> is_active_map,
+    const std::string& control_system_name) {
+  if (not is_active_map->contains(control_system_name)) {
+    ERROR("Cannot find control system '" << control_system_name
+                                         << "' in the active control systems, "
+                                         << keys_of(*is_active_map));
+  }
+  is_active_map->at(control_system_name) = false;
+}
+}  // namespace Actions
+}  // namespace control_system

--- a/src/ControlSystem/Actions/GridCenters.hpp
+++ b/src/ControlSystem/Actions/GridCenters.hpp
@@ -1,0 +1,232 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include <memory>
+
+#include "ControlSystem/Tags/IsActiveMap.hpp"
+#include "ControlSystem/Tags/OptionTags.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace Tags {
+struct TimeStep;
+struct TimeStepId;
+template <typename StepperInterface>
+struct TimeStepper;
+}  // namespace Tags
+namespace tuples {
+template <class... Tags>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace control_system {
+/*!
+ * \brief Holds options used to control when to start disabling the rotation
+ * control system in a BNS simulation.
+ */
+struct DisableRotationWhen {
+  /// The separation at which we start turning off rotation.
+  struct DisableAtSeparation {
+    using type = double;
+    static type lower_bound() { return 2.0; }
+    static constexpr Options::String help{
+        "The separation at which we start turning off rotation."};
+  };
+
+  /// The timescale in code units over which grid rotation is disabled. A
+  /// reasonable value is 30M-60M.
+  struct RotationDecayTimescale {
+    using type = double;
+    static type lower_bound() { return 30.0; }
+    static type upper_bound() { return 200.0; }
+    static constexpr Options::String help{
+        "The timescale in code units over which grid rotation is disabled. A "
+        "reasonable value is 40M-60M."};
+  };
+
+  using options = tmpl::list<DisableAtSeparation, RotationDecayTimescale>;
+
+  static constexpr Options::String help{
+      "Constrols the separation at which the rotation control system is "
+      "disabled and the rotation function of time starts settling to a "
+      "constant."};
+
+  void pup(PUP::er& p);
+
+  double disable_at_separation{std::numeric_limits<double>::signaling_NaN()};
+  double rotation_decay_timescale{std::numeric_limits<double>::signaling_NaN()};
+};
+
+namespace OptionTags {
+/// Option tag for controlling when and how the rotation map is disabled.
+struct DisableRotationWhen {
+  static constexpr Options::String help =
+      "Options for controlling how the rotation control system stops as the "
+      "two neutron stars merge.";
+  using type = control_system::DisableRotationWhen;
+  using group = control_system::OptionTags::ControlSystemGroup;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/// Tag for controlling when and how the rotation map is disabled.
+struct DisableRotationWhen : db::SimpleTag {
+  using type = control_system::DisableRotationWhen;
+  using option_tags = tmpl::list<OptionTags::DisableRotationWhen>;
+
+  static constexpr bool pass_metavariables = false;
+  static control_system::DisableRotationWhen create_from_options(
+      const control_system::DisableRotationWhen& disable_rotation_when);
+};
+}  // namespace Tags
+
+namespace Actions {
+/*!
+ * \brief Checks if the Rotation function of time has been updated because the
+ * separation between the neutron star grid centers is small enough.
+ *
+ * \note This is an iterable action that is to be run on the elements. It is
+ * only run on the element that satisfies `is_zeroth_element()`.
+ *
+ * \warning This action should only ever be run in the
+ * `Parallel::Phase::DisableRotationControl` phase.
+ *
+ * The desired separation is controlled via the
+ * control_systems::Tags::DisableRotationWhen tag. The main use for this
+ * functionality is to disable the rotation control system in binary neutron
+ * star mergers when the stars are sufficiently close because as the stars
+ * merge, the dual control system starts to lose anything to lock on to and can
+ * even start counter rotating.
+ *
+ * Tags used and modified:
+ * - DataBox:
+ *   - `domain::Tags::Element<3>`
+ *   - `::Tags::TimeStepId`
+ *   - `::Tags::Time`
+ * - MutableGlobalCache:
+ *  - Uses:
+ *   - `domain::Tags::FunctionsOfTime` ("GridCenters" and "Rotation")
+ *  - Modifies:
+ *    - `domain::Tags::FunctionsOfTime` ("Rotation")
+ *    - `control_system::Tags::IsActiveMap` ("Rotation")
+ */
+struct SwitchGridRotationToSettle {
+  /// Invokable that changes the rotation function of time to a
+  /// QuaternionSettleToConstant matching the current function of time values
+  /// and derivatives for the rotation and decaying over a specified timescale.
+  ///
+  /// Note that the final orientation of the domain is arbitrary. If we want
+  /// to rotate to a specific angle (e.g. aligning logical and inertial
+  /// coordinate axes), we need a (new) QuaternionSettleToSpecifiedValue
+  /// function of time.
+  struct UpdateRotationToSettle {
+    static void apply(
+        gsl::not_null<std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+            f_of_t_list,
+        const std::string& function_of_time_name,
+        const std::array<DataVector, 3>& initial_func_and_derivs,
+        double match_time, double decay_time);
+  };
+
+  /// Invokable used to disable the rotation control system via a call to
+  /// Parallel::mutate.
+  struct DisableControlSystem {
+    static void apply(
+        gsl::not_null<std::unordered_map<std::string, bool>*> is_active_map,
+        const std::string& control_system_name);
+  };
+
+  using const_global_cache_tags =
+      tmpl::list<control_system::Tags::DisableRotationWhen>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box, tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<3>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    if (not is_zeroth_element(element_id)) {
+      // Only one element needs to modify the control system and function of
+      // time.
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+    const auto& time_step_id = db::get<::Tags::TimeStepId>(box);
+    if (not time_step_id.is_at_slab_boundary()) {
+      ERROR(
+          "Expected to be at a Slab boundary when changing the Rotation "
+          "function of time to a SettleToConstant. Current TimeStepId is "
+          << time_step_id);
+    }
+
+    const auto& bns_rotation_control =
+        db::get<control_system::Tags::DisableRotationWhen>(box);
+
+    const double time = db::get<::Tags::Time>(box);
+    if (not get<domain::Tags::FunctionsOfTime>(cache).contains("GridCenters")) {
+      ERROR(
+          "There is no function of time named 'GridCenters', which is required "
+          "when disabling the rotation control system since in a binary "
+          "neutron star simulation we need to track the grid centers of the "
+          "stars to decide when to disable rotation control.");
+    }
+    const domain::FunctionsOfTime::FunctionOfTime& grid_centers_fot =
+        *get<domain::Tags::FunctionsOfTime>(cache).at("GridCenters");
+    const DataVector grid_centers = grid_centers_fot.func(time)[0];
+    const double separation = sqrt(square(grid_centers[0] - grid_centers[3]) +
+                                   square(grid_centers[1] - grid_centers[4]) +
+                                   square(grid_centers[2] - grid_centers[5]));
+    if (separation > bns_rotation_control.disable_at_separation) {
+      ERROR(
+          "Disabling the rotation control system should happen when the "
+          "separation is less than or equal to "
+          << bns_rotation_control.disable_at_separation
+          << " but the separation at time " << time << " is calculated to be "
+          << separation);
+    }
+
+    if (not get<domain::Tags::FunctionsOfTime>(cache).contains("Rotation")) {
+      ERROR(
+          "There is no function of time named 'Rotation', which means that it "
+          "cannot be disabled.");
+    }
+    const domain::FunctionsOfTime::FunctionOfTime& rotation_fot =
+        *get<domain::Tags::FunctionsOfTime>(cache).at("Rotation");
+    const std::array<DataVector, 3> current_func_and_derivs =
+        rotation_fot.func_and_2_derivs(time);
+    Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateRotationToSettle>(
+        cache, std::string{"Rotation"}, current_func_and_derivs, time,
+        bns_rotation_control.rotation_decay_timescale);
+    Parallel::mutate<control_system::Tags::IsActiveMap, DisableControlSystem>(
+        cache, std::string{"Rotation"});
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Actions
+}  // namespace control_system

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -471,6 +471,8 @@ struct GhValenciaDivCleanTemplateBase<
           ::Tags::PointwiseL2NormCompute<gh::Tags::FConstraint<DataVector, 3>>,
           ::Tags::PointwiseL2NormCompute<
               gh::Tags::GaugeH<DataVector, volume_dim>>,
+          ::Tags::PointwiseL2NormCompute<
+              gh::Tags::ConstraintEnergy<DataVector, volume_dim>>,
           ::Tags::PointwiseL2NormCompute<gh::Tags::Phi<DataVector, volume_dim>>,
           ::Tags::PointwiseL2NormCompute<
               ::Tags::deriv<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <vector>
 
+#include "ControlSystem/Actions/GridCenters.hpp"
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
 #include "ControlSystem/Actions/LimitTimeStep.hpp"
 #include "ControlSystem/Component.hpp"
@@ -887,6 +888,16 @@ struct GhValenciaDivCleanTemplateBase<
                   evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
                   PhaseControl::Actions::ExecutePhaseChange>>,
+
+          tmpl::conditional_t<
+              UseControlSystems,
+              Parallel::PhaseActions<
+                  Parallel::Phase::DisableRotationControl,
+                  tmpl::list<
+                      control_system::Actions::SwitchGridRotationToSettle,
+                      Parallel::Actions::TerminatePhase>>,
+              tmpl::list<>>,
+
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,
               tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -28,6 +28,21 @@ Evolution:
       Order: 3
 
 PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          # Trigger checkpoint often enough so it triggers within
+          # the last 30 minutes of the run
+          Interval: 20
+          Offset: 0
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
+          WallclockHours: 119.0
+  - Trigger:
+      SeparationLessThan:
+        Value: &RotationOffSeparation 5
+    PhaseChanges:
+      - VisitAndReturn(DisableRotationControl):
 
 # Values taken from the Xcts/HeadOnBns.yaml input file
 EquationOfState: &eos
@@ -390,6 +405,9 @@ EventsRunAtCleanup:
 
 # Control systems are disabled by default
 ControlSystems:
+  DisableRotationWhen:
+    DisableAtSeparation: *RotationOffSeparation
+    RotationDecayTimescale: 60.0
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
   Verbosity: Silent

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -24,7 +24,7 @@ Evolution:
   MinimumTimeStep: 1e-7
   # Control systems only work with AdamsBashforth
   TimeStepper:
-    AdamsBashforth:
+    AdamsMoultonPcMonotonic:
       Order: 3
 
 PhaseChangeAndTriggers:
@@ -56,40 +56,72 @@ EquationOfState: &eos
 DomainCreator:
   BinaryCompactObject:
     ObjectA:
-      CartesianCubeAtXCoord: &XCoordA 20
+      CartesianCubeAtXCoord: &XCoordA 14
     ObjectB:
-      CartesianCubeAtXCoord: &XCoordB -20
+      CartesianCubeAtXCoord: &XCoordB -14
     CenterOfMassOffset: [0., 0.]
     Envelope:
-      Radius: 100.0
-      RadialDistribution: Linear
+      Radius: 50.0
+      # Radial distribution is logarithmic to transition from grid point
+      # spacing around the excisions to the grid point spacing in the
+      # outer shell
+      RadialDistribution: Logarithmic
     OuterShell:
-      OpeningAngle: 90
-      Radius: 250.0
-      RadialPartitioning: []
-      RadialDistribution: Linear
+      Radius: 605.0
+      # Radial distribution is linear to resolve gravitational waves
+      RadialDistribution: [Linear, Linear, Linear]
+      RadialPartitioning: [80.0, 125.0]
+      OpeningAngle: 120.0
       BoundaryCondition:
         ConstraintPreservingFreeOutflow:
           Type: ConstraintPreservingPhysical
-    UseEquiangularMap: False
+    UseEquiangularMap: True
     CubeScale: 1.0
     InitialRefinement:
       ObjectA: [4, 4, 4]
       ObjectB: [4, 4, 4]
-      Envelope: [3, 3, 3]
-      OuterShell0: [2 ,2 ,3]
-    InitialGridPoints: 5
+      OuterShell0: [2, 2, 0]
+      OuterShell1: [1, 1, 0]
+      OuterShell2: [0, 0, 3]
+      EnvelopeUpperZLeft:  [3, 3, 1]
+      EnvelopeUpperZRight: [3, 3, 1]
+      EnvelopeLowerZLeft:  [3, 3, 1]
+      EnvelopeLowerZRight: [3, 3, 1]
+      EnvelopeUpperYLeft:  [3, 3, 1]
+      EnvelopeUpperYRight: [3, 3, 1]
+      EnvelopeLowerYLeft:  [3, 3, 1]
+      EnvelopeLowerYRight: [3, 3, 1]
+      EnvelopeUpperX:      [3, 3, 0]
+      EnvelopeLowerX:      [3, 3, 0]
+
+    InitialGridPoints:
+      ObjectA: [5, 5, 5]
+      ObjectB: [5, 5, 5]
+      Envelope: [8, 8, 10]
+      OuterShell0: [9, 9, 12]
+      OuterShell1: [11, 11, 14]
+      OuterShell2UpperZLeft:  [12, 12, 14]
+      OuterShell2UpperZRight: [12, 12, 14]
+      OuterShell2LowerZLeft:  [12, 12, 14]
+      OuterShell2LowerZRight: [12, 12, 14]
+      OuterShell2UpperYLeft:  [12, 12, 14]
+      OuterShell2UpperYRight: [12, 12, 14]
+      OuterShell2LowerYLeft:  [12, 12, 14]
+      OuterShell2LowerYRight: [12, 12, 14]
+      OuterShell2UpperX: [13, 13, 14]
+      OuterShell2LowerX: [13, 13, 14]
+
     TimeDependentMaps:
       InitialTime: 0.0
+      SkewMap: None
       ExpansionMap:
         InitialValues: [1.0, 0.0, 0.0]
         AsymptoticVelocityOuterBoundary: -1.0e-6
         DecayTimescaleOuterBoundary: 50.0
       RotationMap:
-        InitialAngularVelocity: [0.0, 0.0, 0.00826225]
+        InitialAngularVelocity: [0.0, 0.0, 0.00801722]
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
-      SkewMap: None
       ShapeMapA: None
       ShapeMapB: None
       GridCenters:
@@ -187,7 +219,7 @@ SpatialDiscretization:
     ProductUpwindPenaltyAndHll:
       UpwindPenalty:
       Hll:
-        MagneticFieldMagnitudeForHydro: 1.0e-30
+        MagneticFieldMagnitudeForHydro: 1.0e-16
         LightSpeedDensityCutoff: 1.0e-8
   DiscontinuousGalerkin:
     Formulation: StrongInertial
@@ -201,12 +233,12 @@ SpatialDiscretization:
           Delta0: 1.0e-7
           Epsilon: 1.0e-3
         FdToDgTci:
-          NumberOfStepsBetweenTciCalls: 1
-          MinTciCallsAfterRollback: 1
-          MinimumClearTcis: 1
+          NumberOfStepsBetweenTciCalls: 20
+          MinTciCallsAfterRollback: 10
+          MinimumClearTcis: 2
         AlwaysUseSubcells: false
         UseHalo: false
-        OnlyDgBlocksAndGroups: None
+        OnlyDgBlocksAndGroups: [Envelope, OuterShell0, OuterShell1, OuterShell2]
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
     TciOptions:
@@ -225,12 +257,14 @@ SpatialDiscretization:
         LowOrderReconstructor: MonotonisedCentral
         AtmosphereTreatment: Never
     FilterOptions:
-      SpacetimeDissipation: 0.1
+      SpacetimeDissipation: 0.3
 
 Filtering:
   ExpFilter0:
-    Alpha: 36
-    HalfPower: 64
+    Alpha: 64
+    # Half power was determined to filter only the last term up to N = 19
+    # since we support up to 20 gridpoints.
+    HalfPower: 420
     Enable: true
     BlocksToFilter: All
 
@@ -245,7 +279,7 @@ EventsAndTriggersAtSlabs:
           DelayChange: 0
           StepChoosers:
             - Cfl:
-                SafetyFactor: &CflSafetyFactor 0.5
+                SafetyFactor: &CflSafetyFactor 0.4
   # Update time step size regularly.
   - Trigger:
       Slabs:
@@ -258,23 +292,32 @@ EventsAndTriggersAtSlabs:
           StepChoosers:
             - Cfl:
                 SafetyFactor: *CflSafetyFactor
+
   - Trigger:
       Slabs:
         EvenlySpaced:
-          Interval: 50
+          Interval: 120
           Offset: 0
     Events:
       - BondiSachsInterpolation
+
   - Trigger:
       Slabs:
         EvenlySpaced:
-          Interval: 1
+          Interval: 10
           Offset: 0
     Events:
       - ObserveTimeStep:
             SubfileName: TimeSteps
             PrintTimeToTerminal: True
             ObservePerCore: False
+
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 2000
+          Offset: 0
+    Events:
       - ObserveNorms:
           SubfileName: MaxDensity
           TensorsToObserve:
@@ -287,6 +330,22 @@ EventsAndTriggersAtSlabs:
           - Name: PointwiseL2Norm(GaugeConstraint)
             NormType: L2Norm
             Components: Sum
+          - Name: PointwiseL2Norm(ThreeIndexConstraint)
+            NormType: L2Norm
+            Components: Sum
+          - Name: PointwiseL2Norm(ConstraintEnergy)
+            NormType: L2Norm
+            Components: Sum
+
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 2000
+          Offset: 0
+    Events:
+      - ObserveNorms:
+          SubfileName: MetricDiagnostics
+          TensorsToObserve:
           - Name: DetSpatialMetric
             NormType: Max
             Components: Individual
@@ -311,37 +370,49 @@ EventsAndTriggersAtSlabs:
           - Name: TildeDUnboundUtCriterion
             NormType: VolumeIntegral
             Components: Individual
-          - Name: MassWeightedCoordsMask(None)
-            NormType: VolumeIntegral
-            Components: Individual
-          - Name: MassWeightedCoordsMask(NegativeXOnly)
-            NormType: VolumeIntegral
-            Components: Individual
-          - Name: MassWeightedCoordsMask(PositiveXOnly)
-            NormType: VolumeIntegral
-            Components: Individual
-          - Name: TildeDMask(NegativeXOnly)
-            NormType: VolumeIntegral
-            Components: Individual
-          - Name: TildeDMask(PositiveXOnly)
-            NormType: VolumeIntegral
-            Components: Individual
+
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 2000
+          Offset: 0
+    Events:
       - ObserveFields:
-          SubfileName: VolumeData
+          SubfileName: VolumeSpacetimeData
           VariablesToObserve:
             - SpacetimeMetric
-            - Lapse
-            - Shift
             - DetSpatialMetric
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Float
+          FloatingPointTypes: [Float]
+          BlocksToObserve: All
+      - ObserveFields:
+          SubfileName: VolumeHydroData
+          VariablesToObserve:
             - RestMassDensity
-            - Pressure
-            - SpatialVelocity
-            - LorentzFactor
-            - SpecificInternalEnergy
             - Temperature
-            - MagneticField
             - ElectronFraction
+            - SpatialVelocity
+            - MagneticField
             - DivergenceCleaningField
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Float
+          FloatingPointTypes: [Float]
+          BlocksToObserve: [ObjectA, ObjectB]
+
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 100
+          Offset: 0
+    Events:
+      - ObserveTimeStepVolume:
+          SubfileName: TimeStepSizeInVolume
+          CoordinatesFloatingPointType: Float
+          FloatingPointType: Float
+      - ObserveFields:
+          SubfileName: VolumeDiagnosticData
+          VariablesToObserve:
             - PointwiseL2Norm(GaugeConstraint)
             - PointwiseL2Norm(ThreeIndexConstraint)
             - TciStatus
@@ -349,17 +420,21 @@ EventsAndTriggersAtSlabs:
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All
+
   - Trigger:
       TimeCompares:
         Comparison: GreaterThan
-        Value: 1.5
+        Value: 6000.0 # About 9 orbits plus 1200M post-merger
     Events:
       - Completion
 
 InterpolationTargets:
   BondiSachsInterpolation:
     LMax: 16
-    Radius: [100, 150, 200]
+    # So far the R=200M_sun seems to be best. Could be that we need a bigger
+    # outer boundary or that BBH and BNS just are sufficiently different that
+    # even a closer worldtube may do better.
+    Radius: [100, 150, 200, 250, 300, 400,  500]
     Center: [0, 0, 0]
     AngularOrdering: Cce
 
@@ -419,7 +494,7 @@ ControlSystems:
     Controller:
       UpdateFraction: 0.03
     TimescaleTuner:
-      InitialTimescales: [0.2, 0.2, 0.2]
+      InitialTimescales: [10.0, 10.0, 10.0]
       MinTimescale: 1.0e-2
       MaxTimescale: 10.0
       IncreaseThreshold: 2.5e-4
@@ -439,7 +514,7 @@ ControlSystems:
       MinTimescale: 1.0e-2
       MaxTimescale: 20.0
       IncreaseThreshold: 2.5e-3
-      DecreaseThreshold: 1.0e-2
+      DecreaseThreshold: 2.5e-2
       IncreaseFactor: 1.01
       DecreaseFactor: 0.98
     ControlError:
@@ -449,6 +524,7 @@ InitialData:
   #   DataDirectory: "/path/to/EvID"
   #   EquationOfState: *eos
   #   DensityCutoff: *AtmosphereDensityCutoff
+  #   AtmosphereDensity: *AtmosphereDensity
   #   ElectronFraction: 0.15
   NumericInitialData:
     FileGlob: BnsVolume*.h5

--- a/tests/Unit/ControlSystem/Actions/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/Actions/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
+  Actions/Test_GridCenters.cpp
   Actions/Test_Initialization.cpp
   Actions/Test_InitializeMeasurements.cpp
   Actions/Test_LimitTimeStep.cpp

--- a/tests/Unit/ControlSystem/Actions/Test_GridCenters.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_GridCenters.cpp
@@ -1,0 +1,249 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "ControlSystem/Actions/GridCenters.hpp"
+#include "ControlSystem/Tags/IsActiveMap.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/SettleToConstantQuaternion.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct FunctionsOfTimeTag : domain::Tags::FunctionsOfTime, db::SimpleTag {
+  using type = std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+};
+
+template <typename Metavariables>
+struct Component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<3>;
+  using mutable_global_cache_tags =
+      tmpl::list<FunctionsOfTimeTag, control_system::Tags::IsActiveMap>;
+  using simple_tags = db::AddSimpleTags<::domain::Tags::Element<3>,
+                                        Tags::TimeStepId, ::Tags::Time>;
+  using compute_tags = tmpl::list<>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, compute_tags>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<control_system::Actions::SwitchGridRotationToSettle>>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<Component<Metavariables>>;
+};
+
+struct UpdateFot {
+  static void apply(gsl::not_null<domain::FunctionsOfTimeMap*> current_fots,
+                    const domain::FunctionsOfTimeMap& new_fots) {
+    *current_fots = clone_unique_ptrs(new_fots);
+  }
+};
+
+void test_action() {
+  register_classes_with_charm<
+      domain::FunctionsOfTime::PiecewisePolynomial<3>,
+      domain::FunctionsOfTime::QuaternionFunctionOfTime<3>,
+      domain::FunctionsOfTime::SettleToConstantQuaternion>();
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using component = Component<Metavariables>;
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time["GridCenters"] =
+      std::make_unique<::domain::FunctionsOfTime::PiecewisePolynomial<3>>(
+          0.0,
+          std::array<DataVector, 4>{{{16.0, 0.0, 0.0, -16.0, 0.0, 0.0},
+                                     {-0.001, 0.0, 0.0, 0.002, 0.0, 0.0},
+                                     {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                                     {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}}},
+          std::numeric_limits<double>::max());
+  const double initial_omega_z = 0.01;
+  auto init_func_rotation = make_array<4, DataVector>(DataVector{3, 0.0});
+  init_func_rotation[1][2] = initial_omega_z;
+  auto init_quaternion = make_array<1, DataVector>(DataVector{4, 0.0});
+  init_quaternion[0][0] = 1.0;
+  functions_of_time["Rotation"] =
+      std::make_unique<domain::FunctionsOfTime::QuaternionFunctionOfTime<3>>(
+          0.0, init_quaternion, init_func_rotation, 1.0e5);
+  std::unordered_map<std::string, bool> is_active_map{{"GridCenters", true},
+                                                      {"Rotation", true}};
+
+  MockRuntimeSystem runner{
+      {control_system::DisableRotationWhen{6.0, 60.0}},
+      {clone_unique_ptrs(functions_of_time), is_active_map}};
+
+  const ElementId<3> element_id_zero{0, {}};
+  const ElementId<3> element_id_nonzero{1, {}};
+  const std::vector element_ids{element_id_zero, element_id_nonzero};
+  TimeStepId time_step_id{true, 1, Time{Slab{0.0, 1.0e3}, Rational{2, 256}}};
+  const double time = time_step_id.step_time().value();
+
+  ActionTesting::emplace_array_component_and_initialize<component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, element_id_zero,
+      {::Element<3>{element_id_zero, {}}, time_step_id, time});
+  ActionTesting::emplace_array_component_and_initialize<component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, element_id_nonzero,
+      {::Element<3>{element_id_nonzero, {}}, time_step_id, time});
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  CHECK_FALSE(ActionTesting::next_action_if_ready<component>(
+      make_not_null(&runner), element_id_zero,
+      Catch::Matchers::ContainsSubstring(
+          "Expected to be at a Slab boundary when changing the "
+          "Rotation function of time to a SettleToConstant")));
+
+  // No error if not on element zero
+  CHECK(ActionTesting::next_action_if_ready<component>(make_not_null(&runner),
+                                                       element_id_nonzero));
+
+  time_step_id = TimeStepId{true, 1, Time{Slab{0.0, 1.0e3}, Rational{0, 256}}};
+
+  for (const auto& id : element_ids) {
+    db::mutate<::Tags::TimeStepId, ::Tags::Time>(
+        [&time_step_id](const gsl::not_null<TimeStepId*> box_time_step_id,
+                        const gsl::not_null<double*> box_time) {
+          *box_time_step_id = time_step_id;
+          *box_time = box_time_step_id->step_time().value();
+        },
+        make_not_null(&ActionTesting::get_databox<component>(
+            make_not_null(&runner), id)));
+  }
+
+  CHECK_FALSE(ActionTesting::next_action_if_ready<component>(
+      make_not_null(&runner), element_id_zero,
+      Catch::Matchers::ContainsSubstring(
+          "Disabling the rotation control system should happen when the "
+          "separation is less than or equal to ")));
+
+  // No error if not on element zero
+  CHECK(ActionTesting::next_action_if_ready<component>(make_not_null(&runner),
+                                                       element_id_nonzero));
+
+  time_step_id =
+      TimeStepId{true, 2, Time{Slab{12.0e3, 17.0e3}, Rational{0, 256}}};
+
+  for (const auto& id : element_ids) {
+    db::mutate<::Tags::TimeStepId, ::Tags::Time>(
+        [&time_step_id](const gsl::not_null<TimeStepId*> box_time_step_id,
+                        const gsl::not_null<double*> box_time) {
+          *box_time_step_id = time_step_id;
+          *box_time = box_time_step_id->step_time().value();
+        },
+        make_not_null(&ActionTesting::get_databox<component>(
+            make_not_null(&runner), id)));
+  }
+
+  // Test that a non-zero Element doesn't change the function of time.
+  CHECK(ActionTesting::next_action_if_ready<component>(make_not_null(&runner),
+                                                       element_id_nonzero));
+  for (const auto& id : element_ids) {
+    CHECK(get<control_system::Tags::IsActiveMap>(
+              ActionTesting::cache<component>(runner, id))
+              .at("Rotation"));
+    REQUIRE(get<domain::Tags::FunctionsOfTime>(
+                ActionTesting::cache<component>(runner, id))
+                .at("Rotation") != nullptr);
+    CHECK(dynamic_cast<
+              const domain::FunctionsOfTime::SettleToConstantQuaternion* const>(
+              get<domain::Tags::FunctionsOfTime>(
+                  ActionTesting::cache<component>(runner, id))
+                  .at("Rotation")
+                  .get()) == nullptr);
+  }
+
+  // Remove things we need from FunctionsOfTime map to test ERRORs
+  auto& cache = ActionTesting::cache<component>(runner, element_id_zero);
+  Parallel::mutate<FunctionsOfTimeTag, UpdateFot>(
+      cache, [&functions_of_time]() {
+        auto local_fots = clone_unique_ptrs(functions_of_time);
+        local_fots.erase("GridCenters");
+        return local_fots;
+      }());
+  CHECK_FALSE(ActionTesting::next_action_if_ready<component>(
+      make_not_null(&runner), element_id_zero,
+      Catch::Matchers::ContainsSubstring("There is no function of time named "
+                                         "'GridCenters', which is required ")));
+  Parallel::mutate<FunctionsOfTimeTag, UpdateFot>(
+      cache, [&functions_of_time]() {
+        auto local_fots = clone_unique_ptrs(functions_of_time);
+        local_fots.erase("Rotation");
+        return local_fots;
+      }());
+  CHECK_FALSE(ActionTesting::next_action_if_ready<component>(
+      make_not_null(&runner), element_id_zero,
+      Catch::Matchers::ContainsSubstring("There is no function of time named "
+                                         "'Rotation', which means that ")));
+  Parallel::mutate<FunctionsOfTimeTag, UpdateFot>(
+      cache, [&functions_of_time]() {
+        auto local_fots = clone_unique_ptrs(functions_of_time);
+        return local_fots;
+      }());
+
+  // Check that the zero Element changes the function of time.
+  REQUIRE(ActionTesting::next_action_if_ready<component>(make_not_null(&runner),
+                                                         element_id_zero));
+  for (const auto& id : element_ids) {
+    CHECK_FALSE(get<control_system::Tags::IsActiveMap>(
+                    ActionTesting::cache<component>(runner, id))
+                    .at("Rotation"));
+    REQUIRE(get<domain::Tags::FunctionsOfTime>(
+                ActionTesting::cache<component>(runner, id))
+                .at("Rotation") != nullptr);
+    CHECK(dynamic_cast<
+              const domain::FunctionsOfTime::SettleToConstantQuaternion* const>(
+              get<domain::Tags::FunctionsOfTime>(
+                  ActionTesting::cache<component>(runner, id))
+                  .at("Rotation")
+                  .get()) != nullptr);
+  }
+}
+
+void test_tags() {
+  TestHelpers::db::test_simple_tag<control_system::Tags::DisableRotationWhen>(
+      "DisableRotationWhen");
+
+  const control_system::DisableRotationWhen disable_opts =
+      serialize_and_deserialize(
+          control_system::Tags::DisableRotationWhen::create_from_options(
+              TestHelpers::test_option_tag<
+                  control_system::OptionTags::DisableRotationWhen>(
+                  "DisableAtSeparation: 6\n"
+                  "RotationDecayTimescale: 40\n")));
+  // REQUIRE because the action tests will fail if this doesn't work.
+  REQUIRE(disable_opts.disable_at_separation == 6.0);
+  REQUIRE(disable_opts.rotation_decay_timescale == 40.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.Actions.GridCenters",
+                  "[Unit][ControlSystem]") {
+  test_tags();
+  test_action();
+}

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -443,7 +443,8 @@ class MockDistributedObject {
 
   /// Invoke the next action in the action list for the current phase,
   /// returning whether the action was ready.
-  bool next_action_if_ready();
+  template <typename CatchMatcher = int>
+  bool next_action_if_ready(const CatchMatcher* matcher = nullptr);
 
   /// Defines the methods used for invoking threaded and simple actions. Since
   /// the two cases are so similar we use a macro to reduce the amount of
@@ -701,8 +702,9 @@ class MockDistributedObject {
     }
   }
 
-  template <typename PhaseDepActions, size_t... Is>
-  bool next_action_impl(std::index_sequence<Is...> /*meta*/);
+  template <typename PhaseDepActions, typename CatchMatcher, size_t... Is>
+  bool next_action_impl(const CatchMatcher* matcher,
+                        std::index_sequence<Is...> /*meta*/);
 
   bool terminate_{false};
   bool halt_algorithm_until_next_phase_{false};
@@ -750,20 +752,22 @@ void MockDistributedObject<Component>::next_action() {
 }
 
 template <typename Component>
-bool MockDistributedObject<Component>::next_action_if_ready() {
+template <typename CatchMatcher>
+bool MockDistributedObject<Component>::next_action_if_ready(
+    const CatchMatcher* const matcher) {
   bool found_matching_phase = false;
   bool was_ready = false;
-  const auto invoke_for_phase =
-      [this, &found_matching_phase, &was_ready](auto phase_dep_v) {
-        using PhaseDep = typename decltype(phase_dep_v)::type;
-        constexpr Parallel::Phase phase = PhaseDep::phase;
-        using actions_list = typename PhaseDep::action_list;
-        if (phase_ == phase) {
-          found_matching_phase = true;
-          was_ready = this->template next_action_impl<PhaseDep>(
-              std::make_index_sequence<tmpl::size<actions_list>::value>{});
-        }
-      };
+  const auto invoke_for_phase = [this, &found_matching_phase, &matcher,
+                                 &was_ready](auto phase_dep_v) {
+    using PhaseDep = typename decltype(phase_dep_v)::type;
+    constexpr Parallel::Phase phase = PhaseDep::phase;
+    using actions_list = typename PhaseDep::action_list;
+    if (phase_ == phase) {
+      found_matching_phase = true;
+      was_ready = this->template next_action_impl<PhaseDep>(
+          matcher, std::make_index_sequence<tmpl::size<actions_list>::value>{});
+    }
+  };
   tmpl::for_each<phase_dependent_action_lists>(invoke_for_phase);
   if (not found_matching_phase) {
     ERROR("Could not find any actions in the current phase ("
@@ -774,9 +778,9 @@ bool MockDistributedObject<Component>::next_action_if_ready() {
 }
 
 template <typename Component>
-template <typename PhaseDepActions, size_t... Is>
+template <typename PhaseDepActions, typename CatchMatcher, size_t... Is>
 bool MockDistributedObject<Component>::next_action_impl(
-    std::index_sequence<Is...> /*meta*/) {
+    const CatchMatcher* const matcher, std::index_sequence<Is...> /*meta*/) {
   if (UNLIKELY(performing_action_)) {
     ERROR(
         "Cannot call an Action while already calling an Action on the same "
@@ -792,8 +796,8 @@ bool MockDistributedObject<Component>::next_action_impl(
   // to only evaluate one per call.
   bool already_did_an_action = false;
   bool was_ready = true;
-  const auto helper = [this, &already_did_an_action,
-                       &was_ready](auto iteration) {
+  const auto helper = [this, &already_did_an_action, &was_ready,
+                       &matcher](auto iteration) {
     constexpr size_t iter = decltype(iteration)::value;
     if (already_did_an_action or algorithm_step_ != iter) {
       return;
@@ -804,7 +808,21 @@ bool MockDistributedObject<Component>::next_action_impl(
 
     performing_action_ = true;
     ++algorithm_step_;
-    if (not invoke_iterable_action<this_action, actions_list>(box_)) {
+    if (matcher != nullptr) {
+      if constexpr (not std::is_same_v<CatchMatcher, int>) {
+        CHECK_THROWS_WITH(
+            (invoke_iterable_action<this_action, actions_list>(box_)),
+            *matcher);
+      } else {
+        ERROR(
+            "The matcher type 'int' is a placeholder and the matcher must be a "
+            "nullptr when the placeholder is used, but in this case the "
+            "matcher pointer was not null. This is likely an internal bug, so "
+            "please file an issue.");
+      }
+      was_ready = false;
+      --algorithm_step_;
+    } else if (not invoke_iterable_action<this_action, actions_list>(box_)) {
       was_ready = false;
       --algorithm_step_;
     }

--- a/tests/Unit/Framework/MockRuntimeSystem.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystem.hpp
@@ -731,6 +731,7 @@ class MockRuntimeSystem {
     }
   }
 
+  /// @{
   /// Invoke the next action in the ActionList on the parallel component
   /// `Component` on the component labeled by `array_index`, returning whether
   /// it was ready.
@@ -746,6 +747,22 @@ class MockRuntimeSystem {
                                 << array_index);
     }
   }
+
+  template <typename Component, typename CatchMatcher>
+  bool next_action_if_ready(const typename Component::array_index& array_index,
+                            const CatchMatcher& matcher) {
+    static_assert(std::is_base_of_v<Catch::Matchers::MatcherBase<std::string>,
+                                    CatchMatcher>);
+    try {
+      return mock_distributed_objects<Component>()
+          .at(array_index)
+          .next_action_if_ready(std::addressof(matcher));
+    } catch (const std::exception& e) {
+      ERROR("Caught exception " << e.what() << " on array index "
+                                << array_index);
+    }
+  }
+  /// @}
 
   /// @{
   /// Access the inboxes for a given component.

--- a/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
+++ b/tests/Unit/Framework/MockRuntimeSystemFreeFunctions.hpp
@@ -7,7 +7,9 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <random>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -269,15 +271,29 @@ void next_action(const gsl::not_null<MockRuntimeSystem<Metavariables>*> runner,
   runner->template next_action<Component>(array_index);
 }
 
+/// @{
 /// Invoke the next action in the ActionList on the parallel component
 /// `Component` on the component labeled by `array_index`, returning whether
 /// it was ready.
+///
+/// If a Catch matcher is specified then it is assumed that the first action
+/// call should throw an exception. Essentially, the action invocation is
+/// wrapped in `CHECK_THROWS_WITH(invoke, matcher)`
 template <typename Component, typename Metavariables>
 bool next_action_if_ready(
     const gsl::not_null<MockRuntimeSystem<Metavariables>*> runner,
     const typename Component::array_index& array_index) {
   return runner->template next_action_if_ready<Component>(array_index);
 }
+
+template <typename Component, typename Metavariables, typename CatchMatcher>
+bool next_action_if_ready(
+    const gsl::not_null<MockRuntimeSystem<Metavariables>*> runner,
+    const typename Component::array_index& array_index,
+    const CatchMatcher& matcher) {
+  return runner->template next_action_if_ready<Component>(array_index, matcher);
+}
+/// @}
 
 /// Runs the simple action `Action` on the `array_index`th element of the
 /// parallel component `Component`.


### PR DESCRIPTION
## Proposed changes

Adds an event to disable the rotation control system for BNS. Also updates the input files to what we are doing nowadays in simulations.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
