### PR TITLE
Communication of coupling terms in MC

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/Actions/InitializeMonteCarlo.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Actions/InitializeMonteCarlo.hpp
@@ -62,7 +62,11 @@ namespace Initialization::Actions {
 ///   * Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
 ///                                  NeutrinoSpecies>
 ///   * Background hydro variables
+///   * Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>
+///   * Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>
+///   * Particles::MonteCarlo::Tags::CouplingTildeS<DataVector,dim>
 ///   * Particles::MonteCarlo::Tags::MortarDataTag<dim>
+///   * Particles::MonteCarlo::Tags::GhostZoneCouplingData<dim>
 ///   * Particles::MonteCarlo::Tags::McGhostZoneDataTag<dim>
 ///
 /// - Removes: nothing
@@ -79,7 +83,11 @@ struct InitializeMCTags {
                  Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
                      NeutrinoSpecies>,
                  hydro_variables_tag,
+                 Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, dim>,
                  Particles::MonteCarlo::Tags::MortarDataTag<dim>,
+                 Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<dim>,
                  Particles::MonteCarlo::Tags::McGhostZoneDataTag<dim>,
                  evolution::dg::subcell::Tags::ActiveGrid>;
 
@@ -101,6 +109,18 @@ struct InitializeMCTags {
     const Mesh<dim>& mesh =
         db::get<evolution::dg::subcell::Tags::Mesh<dim>>(box);
     const size_t num_grid_points = mesh.number_of_grid_points();
+    // Number of ghost zones for MC is assumed to be 1 for now.
+    const size_t num_ghost_zones = 1;
+    size_t mesh_size_with_ghost_zones = 1;
+    for (size_t d = 0; d < dim; d++) {
+      mesh_size_with_ghost_zones *= (mesh.extents()[d] + 2 * num_ghost_zones);
+    }
+    const DataVector zero_dv_with_ghost_zones(mesh_size_with_ghost_zones, 0.0);
+    const Scalar<DataVector> zero_scalar_with_ghost_zones =
+        make_with_value<Scalar<DataVector>>(zero_dv_with_ghost_zones, 0.0);
+    const tnsr::i<DataVector, dim, Frame::Inertial> zero_tnsr_with_ghost_zones =
+        make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(
+            zero_dv_with_ghost_zones, 0.0);
     using derived_classes =
         tmpl::at<typename Metavariables::factory_creation::factory_classes,
                  evolution::initial_data::InitialData>;
@@ -121,6 +141,16 @@ struct InitializeMCTags {
           Initialization::mutate_assign<tmpl::list<hydro_variables_tag>>(
               make_not_null(&box), std::move(hydro_variables));
         });
+
+    Initialization::mutate_assign<
+        tmpl::list<Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>>>(
+        make_not_null(&box), zero_scalar_with_ghost_zones);
+    Initialization::mutate_assign<tmpl::list<
+        Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>>>(
+        make_not_null(&box), zero_scalar_with_ghost_zones);
+    Initialization::mutate_assign<tmpl::list<
+        Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, dim>>>(
+        make_not_null(&box), zero_tnsr_with_ghost_zones);
 
     // Read global options for Monte-Carlo evolution
     const auto mc_options = db::get<
@@ -152,28 +182,52 @@ struct InitializeMCTags {
             NeutrinoSpecies>>>(make_not_null(&box),
                                std::move(packet_energy_at_emission));
 
-    // Initialize mortar data. Currently assumes a single neighbor on each
-    // face (i.e. no h-refinement)
+    // Initialize mortar data and coupling data.
+    // Currently assumes a single neighbor on each face (i.e. no h-refinement)
     using MortarData =
         typename Particles::MonteCarlo::Tags::MortarDataTag<dim>::type;
     MortarData mortar_data;
+    using CouplingData =
+        typename Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<
+            dim>::type;
+    CouplingData coupling_data;
     const Element<dim>& element = db::get<::domain::Tags::Element<dim>>(box);
     for (const auto& [direction, neighbors] : element.neighbors()) {
       const size_t sliced_mesh_size =
           mesh.slice_away(direction.dimension()).number_of_grid_points();
-      DataVector zero_dv_ghost_zones(sliced_mesh_size, 0.0);
+      const DataVector zero_dv_slice(sliced_mesh_size, 0.0);
+      const Index<dim - 1> sliced_mesh_extents =
+          mesh.slice_away(direction.dimension()).extents();
+      size_t sliced_mesh_size_with_ghost_zone = 1;
+      for (size_t d = 0; d < dim - 1; d++) {
+        sliced_mesh_size_with_ghost_zone *= sliced_mesh_extents[d];
+      }
+      const DataVector zero_dv_ghost_zones(sliced_mesh_size_with_ghost_zone,
+                                           0.0);
+      const tnsr::i<DataVector, dim, Frame::Inertial> zero_tnsr_ghost_zones =
+          make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(
+              zero_dv_ghost_zones, 0.0);
+
       for (const auto& neighbor : neighbors) {
         const DirectionalId<dim> mortar_id{direction, neighbor};
-        mortar_data.rest_mass_density.emplace(mortar_id, zero_dv_ghost_zones);
-        mortar_data.electron_fraction.emplace(mortar_id, zero_dv_ghost_zones);
-        mortar_data.temperature.emplace(mortar_id, zero_dv_ghost_zones);
-        mortar_data.cell_light_crossing_time.emplace(mortar_id,
-                                                     zero_dv_ghost_zones);
+        mortar_data.rest_mass_density.emplace(mortar_id, zero_dv_slice);
+        mortar_data.electron_fraction.emplace(mortar_id, zero_dv_slice);
+        mortar_data.temperature.emplace(mortar_id, zero_dv_slice);
+        mortar_data.cell_light_crossing_time.emplace(mortar_id, zero_dv_slice);
+        coupling_data.coupling_tilde_tau.emplace(mortar_id,
+                                                 zero_dv_ghost_zones);
+        coupling_data.coupling_tilde_rho_ye.emplace(mortar_id,
+                                                    zero_dv_ghost_zones);
+        coupling_data.coupling_tilde_s.emplace(mortar_id,
+                                               zero_tnsr_ghost_zones);
       }
     }
     Initialization::mutate_assign<
         tmpl::list<Particles::MonteCarlo::Tags::MortarDataTag<dim>>>(
         make_not_null(&box), std::move(mortar_data));
+    Initialization::mutate_assign<
+        tmpl::list<Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<dim>>>(
+        make_not_null(&box), std::move(coupling_data));
 
     using GhostZoneData =
         typename Particles::MonteCarlo::Tags::McGhostZoneDataTag<dim>::type;

--- a/src/Evolution/Particles/MonteCarlo/Actions/TimeStepActions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Actions/TimeStepActions.hpp
@@ -41,6 +41,9 @@ struct TimeStepMutator {
 
   using return_tags =
       tmpl::list<Particles::MonteCarlo::Tags::PacketsOnElement,
+                 Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, Dim>,
                  Particles::MonteCarlo::Tags::RandomNumberGenerator,
                  Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<
                      NeutrinoSpecies>>;
@@ -79,6 +82,9 @@ struct TimeStepMutator {
 
   static void apply(
       const gsl::not_null<std::vector<Packet>*> packets,
+      const gsl::not_null<Scalar<DataVector>*> coupling_tilde_tau,
+      const gsl::not_null<Scalar<DataVector>*> coupling_tilde_rho_ye,
+      const gsl::not_null<tnsr::i<DataVector, Dim>*> coupling_tilde_s,
       const gsl::not_null<std::mt19937*> random_number_generator,
       const gsl::not_null<std::array<DataVector, NeutrinoSpecies>*>
           single_packet_energy,
@@ -140,8 +146,9 @@ struct TimeStepMutator {
 
     TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies> templated_functions;
     templated_functions.take_time_step_on_element(
-        packets, random_number_generator, single_packet_energy, start_time,
-        end_time, equation_of_state, interaction_table, electron_fraction,
+        packets, coupling_tilde_tau, coupling_tilde_rho_ye, coupling_tilde_s,
+        random_number_generator, single_packet_energy, start_time, end_time,
+        equation_of_state, interaction_table, electron_fraction,
         rest_mass_density, temperature, lorentz_factor,
         lower_spatial_four_velocity, lapse, shift, d_lapse, d_shift,
         d_inv_spatial_metric, spatial_metric, inv_spatial_metric,

--- a/src/Evolution/Particles/MonteCarlo/GhostZoneCommunication.hpp
+++ b/src/Evolution/Particles/MonteCarlo/GhostZoneCommunication.hpp
@@ -82,6 +82,43 @@ struct GhostDataMutatorPreStep {
   }
 };
 
+/// Mutator to get required volume data for communication
+/// after a MC step; i.e. data sent from ghost points
+/// in neighbors to live points evolving the fluid. The
+/// data contains information about the back reaction of
+/// neutrinos on the fluid
+template <size_t Dim>
+struct GhostDataMutatorPostStep {
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, Dim>>;
+  static const size_t number_of_components = 2 + Dim;
+
+  static DataVector apply(const Scalar<DataVector>& coupling_tilde_tau,
+                          const Scalar<DataVector>& coupling_tilde_rho_ye,
+                          const tnsr::i<DataVector, Dim>& coupling_tilde_s) {
+    const size_t dv_size = get(coupling_tilde_tau).size();
+    DataVector buffer{dv_size * number_of_components};
+    std::copy(
+        get(coupling_tilde_tau).data(),
+        std::next(get(coupling_tilde_tau).data(), static_cast<int>(dv_size)),
+        buffer.data());
+    std::copy(
+        get(coupling_tilde_rho_ye).data(),
+        std::next(get(coupling_tilde_rho_ye).data(), static_cast<int>(dv_size)),
+        std::next(buffer.data(), static_cast<int>(dv_size)));
+    for (size_t d = 0; d < Dim; d++) {
+      std::copy(
+          coupling_tilde_s.get(d).data(),
+          std::next(coupling_tilde_s.get(d).data(), static_cast<int>(dv_size)),
+          std::next(buffer.data(), static_cast<int>(dv_size * (2 + d))));
+    }
+    return buffer;
+  }
+};
+
 /// Mutator that returns packets currently in ghost zones in a
 /// DirectionMap<Dim,std::vector<Particles::MonteCarlo::Packet>>
 /// and remove them from the list of packets of the current
@@ -165,9 +202,9 @@ struct GhostDataMcPackets {
 /// If CommStep == PreStep, this sends the fluid and
 /// metric variables needed for evolution of MC packets.
 /// If CommStep == PostStep, this sends packets that
-/// have moved from one element to another.
-/// The current code does not yet deal with data required
-/// to calculate the backreaction on the fluid.
+/// have moved from one element to another as well
+/// as coupling information from the ghost zone to the
+/// live points.
 template <size_t Dim, bool LocalTimeStepping,
           Particles::MonteCarlo::CommunicationStep CommStep>
 struct SendDataForMcCommunication {
@@ -204,12 +241,22 @@ struct SendDataForMcCommunication {
     const Mesh<Dim>& subcell_mesh =
         db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(box);
     const TimeStepId& time_step_id = db::get<::Tags::TimeStepId>(box);
+    Index<Dim> extents_with_ghost_zone = subcell_mesh.extents();
+    for (size_t d = 0; d < Dim; d++) {
+      extents_with_ghost_zone[d] += 2 * ghost_zone_size;
+    }
 
     // Fill volume data that should be fed to neighbor ghost zones
+    // PreStep, we send fluid data from the live points to the ghost points.
+    // PostStep, we send coupling data from the ghost points to the live
+    // points (note the different DataVector sizes; the PostStep data has
+    // different dimensions because it is taken from DataVectors including
+    // ghost points.
     DataVector volume_data_to_slice =
         CommStep == Particles::MonteCarlo::CommunicationStep::PreStep
             ? db::mutate_apply(GhostDataMutatorPreStep{}, make_not_null(&box))
-            : DataVector{};
+            : db::mutate_apply(GhostDataMutatorPostStep<Dim>{},
+                               make_not_null(&box));
     const DirectionMap<Dim, DataVector> all_sliced_data =
         CommStep == Particles::MonteCarlo::CommunicationStep::PreStep
             ? evolution::dg::subcell::slice_data(
@@ -217,8 +264,11 @@ struct SendDataForMcCommunication {
                   element.internal_boundaries(), 0,
                   db::get<evolution::dg::subcell::Tags::
                               InterpolatorsFromFdToNeighborFd<Dim>>(box))
-            : DirectionMap<Dim, DataVector>{};
-
+            : evolution::dg::subcell::slice_data(
+                  volume_data_to_slice, extents_with_ghost_zone,
+                  ghost_zone_size, element.internal_boundaries(), 0,
+                  db::get<evolution::dg::subcell::Tags::
+                              InterpolatorsFromFdToNeighborFd<Dim>>(box));
     const DirectionMap<Dim, std::vector<Particles::MonteCarlo::Packet>>
         all_packets_ghost_zone =
             CommStep == Particles::MonteCarlo::CommunicationStep::PostStep
@@ -226,10 +276,6 @@ struct SendDataForMcCommunication {
                                    make_not_null(&box))
                 : DirectionMap<Dim,
                                std::vector<Particles::MonteCarlo::Packet>>{};
-
-    // TO DO:
-    // Need to deal with coupling data, which is brought back from
-    // neighbor's ghost zones to the processor with the live cell!
 
     for (const auto& [direction, neighbors_in_direction] :
          element.neighbors()) {
@@ -240,13 +286,11 @@ struct SendDataForMcCommunication {
             packets_to_send = std::nullopt;
         DataVector subcell_data_to_send{};
 
-        if (CommStep == Particles::MonteCarlo::CommunicationStep::PreStep) {
-          const auto& sliced_data_in_direction = all_sliced_data.at(direction);
-          subcell_data_to_send = DataVector{sliced_data_in_direction.size()};
-          std::copy(sliced_data_in_direction.begin(),
-                    sliced_data_in_direction.end(),
-                    subcell_data_to_send.begin());
-        }
+        // PreStep and PostStep both send slice data to neighboring domains
+        const auto& sliced_data_in_direction = all_sliced_data.at(direction);
+        subcell_data_to_send = DataVector{sliced_data_in_direction.size()};
+        std::copy(sliced_data_in_direction.begin(),
+                  sliced_data_in_direction.end(), subcell_data_to_send.begin());
         if (CommStep == Particles::MonteCarlo::CommunicationStep::PostStep) {
           packets_to_send = all_packets_ghost_zone.at(direction);
           if (packets_to_send.value().empty()) {
@@ -367,21 +411,68 @@ struct ReceiveDataForMcCommunication {
     } else {
       const Mesh<Dim>& subcell_mesh =
           db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(box);
-      // TO DO: Deal with data coupling neutrinos back to fluid evolution
-      db::mutate<Particles::MonteCarlo::Tags::PacketsOnElement>(
+      db::mutate<Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<Dim>,
+                 Particles::MonteCarlo::Tags::PacketsOnElement>(
           [&element, &received_data, &subcell_mesh](
+              const gsl::not_null<GhostZoneCouplingData<Dim>*> coupling_data,
               const gsl::not_null<std::vector<Particles::MonteCarlo::Packet>*>
                   packet_list) {
+            // Two parts here: first deal with coupling data brought back
+            // from ghost zones to live points; then handle packet
+            // communication.
             const Index<Dim>& extents = subcell_mesh.extents();
             for (const auto& [direction, neighbors_in_direction] :
                  element.neighbors()) {
               for (const auto& neighbor : neighbors_in_direction) {
                 DirectionalId<Dim> directional_element_id{direction, neighbor};
+                // Move boundary data to the coupling_data structure for later
+                // use
+                const DataVector& received_data_direction =
+                    received_data[directional_element_id]
+                        .ghost_zone_hydro_variables;
+                if (coupling_data->coupling_tilde_tau[directional_element_id] !=
+                    std::nullopt) {
+                  const size_t coupling_data_size =
+                      coupling_data->coupling_tilde_tau[directional_element_id]
+                          .value()
+                          .size();
+                  ASSERT(received_data_direction.size() ==
+                             coupling_data_size * (2 + Dim),
+                         "Inconsistent sizes between inbox and coupling data");
+                  std::copy(
+                      received_data_direction.data(),
+                      std::next(received_data_direction.data(),
+                                static_cast<int>(coupling_data_size)),
+                      coupling_data->coupling_tilde_tau[directional_element_id]
+                          .value()
+                          .data());
+                  std::copy(std::next(received_data_direction.data(),
+                                      static_cast<int>(coupling_data_size)),
+                            std::next(received_data_direction.data(),
+                                      static_cast<int>(coupling_data_size * 2)),
+                            coupling_data
+                                ->coupling_tilde_rho_ye[directional_element_id]
+                                .value()
+                                .data());
+                  for (size_t d = 0; d < Dim; d++) {
+                    std::copy(
+                        std::next(
+                            received_data_direction.data(),
+                            static_cast<int>(coupling_data_size * (2 + d))),
+                        std::next(
+                            received_data_direction.data(),
+                            static_cast<int>(coupling_data_size * (3 + d))),
+                        coupling_data->coupling_tilde_s[directional_element_id]
+                            .value()
+                            .get(d)
+                            .data());
+                  }
+                }
+                // Get packet data
                 std::optional<std::vector<Particles::MonteCarlo::Packet>>&
                     received_data_packets =
                         received_data[directional_element_id]
                             .packets_entering_this_element;
-                // Temporary: currently no data for coupling to the fluid
                 if (received_data_packets == std::nullopt) {
                   continue;
                 } else {

--- a/src/Evolution/Particles/MonteCarlo/MortarData.hpp
+++ b/src/Evolution/Particles/MonteCarlo/MortarData.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 
 /// \cond
@@ -33,6 +34,23 @@ struct MortarData {
   }
 };
 
+/// Structure used to gather fluid coupling data for Monte-Carlo evolution.
+/// We need the energy, momentum, and composition coupling
+template <size_t Dim>
+struct GhostZoneCouplingData {
+  DirectionalIdMap<Dim, std::optional<DataVector>> coupling_tilde_tau{};
+  DirectionalIdMap<Dim, std::optional<DataVector>> coupling_tilde_rho_ye{};
+  DirectionalIdMap<Dim,
+                   std::optional<tnsr::i<DataVector, Dim, Frame::Inertial>>>
+      coupling_tilde_s{};
+
+  void pup(PUP::er& p) {
+    p | coupling_tilde_tau;
+    p | coupling_tilde_rho_ye;
+    p | coupling_tilde_s;
+  }
+};
+
 namespace Tags {
 
 /// Simple tag containing the fluid and metric data in the ghost zones
@@ -40,6 +58,13 @@ namespace Tags {
 template <size_t Dim>
 struct MortarDataTag : db::SimpleTag {
   using type = MortarData<Dim>;
+};
+
+/// Simple tag containing the coupling data in the ghost zones
+/// for Monte-Carlo packets evolution.
+template <size_t Dim>
+struct GhostZoneCouplingDataTag : db::SimpleTag {
+  using type = GhostZoneCouplingData<Dim>;
 };
 
 }  // namespace Tags

--- a/src/Evolution/Particles/MonteCarlo/Tags.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Tags.hpp
@@ -31,6 +31,27 @@ struct CellLightCrossingTime : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// Simple tag storing the coupling term between
+/// MC and tilde_Tau (i.e. the energy variable)
+template <typename DataType>
+struct CouplingTildeTau : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/// Simple tag storing the coupling term between
+/// MC and tilde_RhoYe (i.e. the composition variable)
+template <typename DataType>
+struct CouplingTildeRhoYe : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/// Simple tag storing the coupling term between
+/// MC and tilde_S (i.e. the momentum variable)
+template <typename DataType, size_t Dim>
+struct CouplingTildeS : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame::Inertial>;
+};
+
 /// Simple tag storing the random number generator
 /// used by Monte-Carlo
 struct RandomNumberGenerator : db::SimpleTag {

--- a/src/Evolution/Particles/MonteCarlo/TakeTimeStep.tpp
+++ b/src/Evolution/Particles/MonteCarlo/TakeTimeStep.tpp
@@ -75,6 +75,9 @@ template <size_t EnergyBins, size_t NeutrinoSpecies>
 void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
     take_time_step_on_element(
         const gsl::not_null<std::vector<Packet>*> packets,
+        const gsl::not_null<Scalar<DataVector>* > coupling_tilde_tau,
+        const gsl::not_null<Scalar<DataVector>* > coupling_tilde_rho_ye,
+        const gsl::not_null<tnsr::i<DataVector,3>* > coupling_tilde_s,
         const gsl::not_null<std::mt19937*> random_number_generator,
         const gsl::not_null<std::array<DataVector, NeutrinoSpecies>*>
             single_packet_energy,
@@ -198,20 +201,10 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
   const std::array<double, EnergyBins>& energy_at_bin_center =
       interaction_table.get_neutrino_energies();
 
-  // Bookkeeping tensors for coupling to fluid
-  // These also include ghost zones.
-  Scalar<DataVector> coupling_tilde_tau =
-      make_with_value<Scalar<DataVector>>(zero_dv_ghost_zones, 0.0);
-  Scalar<DataVector> coupling_rho_ye =
-      make_with_value<Scalar<DataVector>>(zero_dv_ghost_zones, 0.0);
-  tnsr::i<DataVector, 3, Frame::Inertial> coupling_tilde_s =
-      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(
-          zero_dv_ghost_zones, 0.0);
-
   // Emit new MC packets
   this->emit_packets(
-      packets, random_number_generator, &coupling_tilde_tau, &coupling_tilde_s,
-      &coupling_rho_ye, start_time, time_step, mesh, num_ghost_zones,
+      packets, random_number_generator, coupling_tilde_tau, coupling_tilde_s,
+      coupling_tilde_rho_ye, start_time, time_step, mesh, num_ghost_zones,
       emissivity_in_cell, *single_packet_energy, energy_at_bin_center,
       lorentz_factor, lower_spatial_four_velocity, inertial_to_fluid_jacobian,
       inertial_to_fluid_inverse_jacobian, cell_proper_four_volume);
@@ -219,7 +212,7 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
   // Propagate packets
   evolve_packets(
       packets, random_number_generator,
-      &coupling_tilde_tau, &coupling_tilde_s, &coupling_rho_ye,
+      coupling_tilde_tau, coupling_tilde_s, coupling_tilde_rho_ye,
       target_end_time, mesh, mesh_coordinates, num_ghost_zones,
       absorption_opacity, scattering_opacity, energy_at_bin_center,
       lorentz_factor, lower_spatial_four_velocity, lapse, shift, d_lapse,
@@ -227,12 +220,6 @@ void TemplatedLocalFunctions<EnergyBins, NeutrinoSpecies>::
       cell_light_crossing_time,
       mesh_velocity, inverse_jacobian_logical_to_inertial,
       inertial_to_fluid_jacobian, inertial_to_fluid_inverse_jacobian);
-
-  // Couple to hydro needs to be done after communicating coupling terms
-  // between ghost zones... so likely outside of this function. Or at
-  // least we need to correct for GZ information somehow later.
-
-  // Determine new energy of packets and resample as needed.
 }
 
 }  // namespace Particles::MonteCarlo

--- a/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
+++ b/src/Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp
@@ -64,6 +64,9 @@ struct TemplatedLocalFunctions {
    */
   void take_time_step_on_element(
       gsl::not_null<std::vector<Packet>*> packets,
+      gsl::not_null<Scalar<DataVector>*> coupling_tilde_tau,
+      gsl::not_null<Scalar<DataVector>*> coupling_tilde_ye,
+      gsl::not_null<tnsr::i<DataVector, 3>*> coupling_tilde_s,
       gsl::not_null<std::mt19937*> random_number_generator,
       gsl::not_null<std::array<DataVector, NeutrinoSpecies>*>
           single_packet_energy,

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_CommunicationTags.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_CommunicationTags.cpp
@@ -76,6 +76,10 @@ struct component {
       hydro::Tags::ElectronFraction<DataVector>,
       hydro::Tags::Temperature<DataVector>,
       Particles::MonteCarlo::Tags::CellLightCrossingTime<DataVector>,
+      Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<Dim>,
+      Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
+      Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
+      Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, Dim>,
       domain::Tags::NeighborMesh<Dim>,
       evolution::dg::subcell::Tags::InterpolatorsFromFdToNeighborFd<Dim>>;
 
@@ -211,14 +215,28 @@ void test_send_receive_actions() {
       ActionTesting::emplace_array_component_and_initialize<comp>(
           &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
           neighbor_id,
-          {time_step_id, next_time_step_id, Mesh<Dim>{}, Mesh<Dim>{},
-           tnsr::I<DataVector, Dim, Frame::ElementLogical>{}, active_grid,
-           Element<Dim>{}, NeighborDataMap{}, packets_on_element,
+          {time_step_id,
+           next_time_step_id,
+           Mesh<Dim>{},
+           Mesh<Dim>{},
+           tnsr::I<DataVector, Dim, Frame::ElementLogical>{},
+           active_grid,
+           Element<Dim>{},
+           NeighborDataMap{},
+           packets_on_element,
            Variables<evolved_vars_tags>{},
            typename Particles::MonteCarlo::Tags::MortarDataTag<Dim>::type{},
-           Scalar<DataVector>{}, Scalar<DataVector>{}, Scalar<DataVector>{},
            Scalar<DataVector>{},
-           typename domain::Tags::NeighborMesh<Dim>::type{}, Interps{}});
+           Scalar<DataVector>{},
+           Scalar<DataVector>{},
+           Scalar<DataVector>{},
+           typename Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<
+               Dim>::type{},
+           Scalar<DataVector>{},
+           Scalar<DataVector>{},
+           tnsr::i<DataVector, Dim, Frame::Inertial>{},
+           typename domain::Tags::NeighborMesh<Dim>::type{},
+           Interps{}});
     }
   }
 
@@ -250,6 +268,48 @@ void test_send_receive_actions() {
         DataVector(ghost_mesh.number_of_grid_points(), 0.1);
     mortar_data.cell_light_crossing_time[south_neighbor_id] =
         DataVector(ghost_mesh.number_of_grid_points(), 0.1);
+  }
+
+  // Coupling data
+  const size_t ghost_zone_size = 1;
+  const auto& subcell_extents = subcell_mesh.extents();
+  auto extents_with_ghost = subcell_extents;
+  size_t mesh_size_with_ghost = 1;
+  for (size_t d = 0; d < Dim; d++) {
+    extents_with_ghost[d] = subcell_extents[d] + 2 * ghost_zone_size;
+    mesh_size_with_ghost *= extents_with_ghost[d];
+  }
+  const DataVector zero_dv_with_ghost(mesh_size_with_ghost, 0.0);
+  Scalar<DataVector> coupling_tilde_tau =
+      make_with_value<Scalar<DataVector>>(zero_dv_with_ghost, 0.0);
+  Scalar<DataVector> coupling_tilde_rho_ye =
+      make_with_value<Scalar<DataVector>>(zero_dv_with_ghost, 0.0);
+  tnsr::i<DataVector, Dim> coupling_tilde_s =
+      make_with_value<tnsr::i<DataVector, Dim>>(zero_dv_with_ghost, 0.0);
+  Particles::MonteCarlo::GhostZoneCouplingData<Dim> coupling_data{};
+  {
+    const size_t number_of_points_in_ghost_zone =
+        mesh_size_with_ghost / extents_with_ghost[0];
+    coupling_data.coupling_tilde_tau[east_neighbor_id] =
+        DataVector(number_of_points_in_ghost_zone, 0.1);
+    coupling_data.coupling_tilde_rho_ye[east_neighbor_id] =
+        DataVector(number_of_points_in_ghost_zone, 0.1);
+    coupling_data.coupling_tilde_s[east_neighbor_id] =
+        make_with_value<tnsr::i<DataVector, Dim>>(
+            coupling_data.coupling_tilde_tau[east_neighbor_id].value(), 0.1);
+  }
+  if constexpr (Dim > 1) {
+    const size_t number_of_points_in_ghost_zone =
+        mesh_size_with_ghost / extents_with_ghost[1];
+    const DirectionalId<Dim> south_neighbor_id{Direction<Dim>::lower_eta(),
+                                               south_id};
+    coupling_data.coupling_tilde_tau[south_neighbor_id] =
+        DataVector(number_of_points_in_ghost_zone, 0.1);
+    coupling_data.coupling_tilde_rho_ye[south_neighbor_id] =
+        DataVector(number_of_points_in_ghost_zone, 0.1);
+    coupling_data.coupling_tilde_s[south_neighbor_id] =
+        make_with_value<tnsr::i<DataVector, Dim>>(
+            coupling_data.coupling_tilde_tau[east_neighbor_id].value(), 0.1);
   }
 
   const size_t species = 1;
@@ -293,10 +353,25 @@ void test_send_receive_actions() {
   Interps fd_to_neighbor_fd_interpolants{};
   ActionTesting::emplace_array_component_and_initialize<comp>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, self_id,
-      {time_step_id, next_time_step_id, dg_mesh, subcell_mesh, mesh_coordinates,
-       active_grid, element, neighbor_data, packets_on_element, evolved_vars,
-       mortar_data, rest_mass_density, electron_fraction, temperature,
+      {time_step_id,
+       next_time_step_id,
+       dg_mesh,
+       subcell_mesh,
+       mesh_coordinates,
+       active_grid,
+       element,
+       neighbor_data,
+       packets_on_element,
+       evolved_vars,
+       mortar_data,
+       rest_mass_density,
+       electron_fraction,
+       temperature,
        cell_light_crossing_time,
+       coupling_data,
+       coupling_tilde_tau,
+       coupling_tilde_rho_ye,
+       coupling_tilde_s,
        typename domain::Tags::NeighborMesh<Dim>::type{},
        fd_to_neighbor_fd_interpolants});
 
@@ -311,7 +386,6 @@ void test_send_receive_actions() {
   CHECK(get_databox_tag<comp, ghost_data_tag>(runner, self_id).empty());
 
   // Check data sent to neighbors
-  const size_t ghost_zone_size = 1;
   const auto& directions_to_slice = element.internal_boundaries();
   const DirectionMap<Dim, DataVector> all_sliced_data =
       [&rest_mass_density, &electron_fraction, &temperature,
@@ -514,13 +588,65 @@ void test_send_receive_actions() {
   ActionTesting::next_action<comp>(make_not_null(&runner), self_id);
   CHECK(get_databox_tag<comp, ghost_data_tag>(runner, self_id).empty());
 
+  // Check data sent to neighbors (PostStep)
+  const DirectionMap<Dim, DataVector> all_sliced_data_post =
+      [&coupling_tilde_tau, &coupling_tilde_rho_ye, &coupling_tilde_s,
+       &extents_with_ghost, &mesh_size_with_ghost, ghost_zone_size,
+       &directions_to_slice, &fd_to_neighbor_fd_interpolants]() {
+        (void)ghost_zone_size;
+        const size_t number_of_components = 2 + Dim;
+        DataVector buffer{mesh_size_with_ghost * number_of_components};
+        std::copy(get(coupling_tilde_tau).data(),
+                  std::next(get(coupling_tilde_tau).data(),
+                            static_cast<int>(mesh_size_with_ghost)),
+                  buffer.data());
+        std::copy(
+            get(coupling_tilde_rho_ye).data(),
+            std::next(get(coupling_tilde_rho_ye).data(),
+                      static_cast<int>(mesh_size_with_ghost)),
+            std::next(buffer.data(), static_cast<int>(mesh_size_with_ghost)));
+        for (size_t d = 0; d < Dim; d++) {
+          std::copy(
+              coupling_tilde_s.get(d).data(),
+              std::next(coupling_tilde_s.get(d).data(),
+                        static_cast<int>(mesh_size_with_ghost)),
+              std::next(buffer.data(),
+                        static_cast<int>(mesh_size_with_ghost * (2 + d))));
+        }
+
+        return evolution::dg::subcell::slice_data(
+            buffer, extents_with_ghost, ghost_zone_size, directions_to_slice, 0,
+            fd_to_neighbor_fd_interpolants);
+      }();
+
   {
+    const auto& expected_east_data =
+        all_sliced_data_post.at(east_neighbor_id.direction());
+    const auto& east_data = ActionTesting::get_inbox_tag<
+        comp, Particles::MonteCarlo::McGhostZoneDataInboxTag<
+                  Dim, Particles::MonteCarlo::CommunicationStep::PostStep>>(
+        runner, east_id);
+    CHECK(east_data.at(time_step_id)
+              .at(DirectionalId<Dim>{Direction<Dim>::lower_xi(), self_id})
+              .ghost_zone_hydro_variables == expected_east_data);
     // Verify that the packets out of the element have been removed.
     const auto& packets_from_box =
         get_databox_tag<comp, Particles::MonteCarlo::Tags::PacketsOnElement>(
             runner, self_id);
     CHECK(packets_from_box.size() == 1);
     CHECK(packets_from_box[0] == packet_keep);
+  }
+  if constexpr (Dim > 1) {
+    const auto direction = Direction<Dim>::lower_eta();
+    const auto& expected_south_data = all_sliced_data_post.at(direction);
+    const auto& south_data = ActionTesting::get_inbox_tag<
+        comp, Particles::MonteCarlo::McGhostZoneDataInboxTag<
+                  Dim, Particles::MonteCarlo::CommunicationStep::PostStep>>(
+        runner, south_id);
+    CHECK(
+        south_data.at(time_step_id)
+            .at(DirectionalId<Dim>{orientation(direction.opposite()), self_id})
+            .ghost_zone_hydro_variables == expected_south_data);
   }
 
   // Correct coordinates of packets sent east/south to get in the
@@ -592,11 +718,17 @@ void test_send_receive_actions() {
   }
 
   // Set up fake data coming from east neighbor
+  DataVector east_ghost_cells_post{};
   {
+    const size_t number_of_points_in_ghost_zone =
+        mesh_size_with_ghost / extents_with_ghost[0];
+    const size_t number_of_vars = 2 + Dim;
+    east_ghost_cells_post = DataVector{number_of_points_in_ghost_zone *
+                                       ghost_zone_size * number_of_vars};
+    alg::iota(east_ghost_cells_post, 2.0);
     const std::optional<std::vector<Particles::MonteCarlo::Packet>>
         packets_from_east =
             std::vector<Particles::MonteCarlo::Packet>{packet_east};
-    const DataVector east_ghost_cells_post{};
     const size_t items_in_inbox =
         Particles::MonteCarlo::McGhostZoneDataInboxTag<
             Dim, Particles::MonteCarlo::CommunicationStep::PostStep>::
@@ -609,14 +741,21 @@ void test_send_receive_actions() {
     CHECK(items_in_inbox == 1);
   }
   // Set up fake data coming from south neighbor
+  // NOLINTNEXTLINE(misc-const-correctness)
+  [[maybe_unused]] DataVector south_ghost_cells_post{};
   if constexpr (Dim > 1) {
     REQUIRE_FALSE(ActionTesting::next_action_if_ready<comp>(
         make_not_null(&runner), self_id));
 
+    const size_t number_of_points_in_ghost_zone =
+        mesh_size_with_ghost / extents_with_ghost[1];
+    const size_t number_of_vars = 2 + Dim;
+    south_ghost_cells_post = DataVector{number_of_points_in_ghost_zone *
+                                        ghost_zone_size * number_of_vars};
+    alg::iota(south_ghost_cells_post, 2.0);
     const std::optional<std::vector<Particles::MonteCarlo::Packet>>
         packets_from_south =
             std::vector<Particles::MonteCarlo::Packet>{packet_south};
-    const DataVector south_ghost_cells_post{};
     const size_t items_in_inbox =
         Particles::MonteCarlo::McGhostZoneDataInboxTag<
             Dim, Particles::MonteCarlo::CommunicationStep::PostStep>::
@@ -631,6 +770,71 @@ void test_send_receive_actions() {
   // Run the ReceiveDataForReconstruction action on self_id (PostStep)
   ActionTesting::next_action<comp>(make_not_null(&runner), self_id);
 
+  // Check the received data was stored correctly
+  using coupling_data_tag =
+      Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<Dim>;
+  const auto& coupling_data_from_box =
+      get_databox_tag<comp, coupling_data_tag>(runner, self_id);
+  {
+    REQUIRE(coupling_data_from_box.coupling_tilde_tau.find(east_neighbor_id) !=
+            coupling_data_from_box.coupling_tilde_tau.end());
+    REQUIRE(
+        coupling_data_from_box.coupling_tilde_rho_ye.find(east_neighbor_id) !=
+        coupling_data_from_box.coupling_tilde_rho_ye.end());
+    REQUIRE(coupling_data_from_box.coupling_tilde_s.find(east_neighbor_id) !=
+            coupling_data_from_box.coupling_tilde_s.end());
+
+    const size_t number_of_east_points =
+        east_ghost_cells_post.size() / (2 + Dim);
+    const DataVector coupling_tilde_tau_view{east_ghost_cells_post.data(),
+                                             number_of_east_points};
+    const DataVector coupling_tilde_rho_ye_view{
+        east_ghost_cells_post.data() + number_of_east_points,
+        number_of_east_points};
+    CHECK(coupling_data_from_box.coupling_tilde_tau.find(east_neighbor_id)
+              ->second == coupling_tilde_tau_view);
+    CHECK(coupling_data_from_box.coupling_tilde_rho_ye.find(east_neighbor_id)
+              ->second == coupling_tilde_rho_ye_view);
+    for (size_t d = 0; d < Dim; d++) {
+      const DataVector coupling_tilde_s_d_view{
+          east_ghost_cells_post.data() + number_of_east_points * (2 + d),
+          number_of_east_points};
+      CHECK(coupling_data_from_box.coupling_tilde_s.find(east_neighbor_id)
+                ->second.value()
+                .get(d) == coupling_tilde_s_d_view);
+    }
+  }
+  if constexpr (Dim > 1) {
+    const DirectionalId<Dim> south_neighbor_id{Direction<Dim>::lower_eta(),
+                                               south_id};
+    REQUIRE(coupling_data_from_box.coupling_tilde_tau.find(south_neighbor_id) !=
+            coupling_data_from_box.coupling_tilde_tau.end());
+    REQUIRE(
+        coupling_data_from_box.coupling_tilde_rho_ye.find(south_neighbor_id) !=
+        coupling_data_from_box.coupling_tilde_rho_ye.end());
+    REQUIRE(coupling_data_from_box.coupling_tilde_s.find(south_neighbor_id) !=
+            coupling_data_from_box.coupling_tilde_s.end());
+
+    const size_t number_of_south_points =
+        south_ghost_cells_post.size() / (2 + Dim);
+    const DataVector coupling_tilde_tau_view{south_ghost_cells_post.data(),
+                                             number_of_south_points};
+    const DataVector coupling_tilde_rho_ye_view{
+        south_ghost_cells_post.data() + number_of_south_points,
+        number_of_south_points};
+    CHECK(coupling_data_from_box.coupling_tilde_tau.find(south_neighbor_id)
+              ->second == coupling_tilde_tau_view);
+    CHECK(coupling_data_from_box.coupling_tilde_rho_ye.find(south_neighbor_id)
+              ->second == coupling_tilde_rho_ye_view);
+    for (size_t d = 0; d < Dim; d++) {
+      const DataVector coupling_tilde_s_d_view{
+          south_ghost_cells_post.data() + number_of_south_points * (2 + d),
+          number_of_south_points};
+      CHECK(coupling_data_from_box.coupling_tilde_s.find(south_neighbor_id)
+                ->second.value()
+                .get(d) == coupling_tilde_s_d_view);
+    }
+  }
   // We should now have 3 packets (2 for Dim=1)
   {
     const auto& packets_from_box =

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_TakeTimeStep.cpp
@@ -9,6 +9,7 @@
 #include "Evolution/Particles/MonteCarlo/EvolvePackets.hpp"
 #include "Evolution/Particles/MonteCarlo/NeutrinoInteractionTable.hpp"
 #include "Evolution/Particles/MonteCarlo/Packet.hpp"
+#include "Evolution/Particles/MonteCarlo/Tags.hpp"
 #include "Evolution/Particles/MonteCarlo/TemplatedLocalFunctions.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp"
@@ -121,11 +122,12 @@ void test_flat_space_time_step() {
   CHECK(packet.momentum_upper_t == 1.0);
 
   Scalar<DataVector> coupling_tilde_tau =
-      make_with_value<Scalar<DataVector>>(zero_dv, 0.0);
-  Scalar<DataVector> coupling_rho_ye =
-      make_with_value<Scalar<DataVector>>(zero_dv, 0.0);
+      make_with_value<Scalar<DataVector>>(zero_dv_with_ghost, 0.0);
+  Scalar<DataVector> coupling_tilde_rho_ye =
+      make_with_value<Scalar<DataVector>>(zero_dv_with_ghost, 0.0);
   tnsr::i<DataVector, 3, Frame::Inertial> coupling_tilde_s =
-      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(zero_dv, 0.0);
+      make_with_value<tnsr::i<DataVector, 3, Frame::Inertial>>(
+          zero_dv_with_ghost, 0.0);
 
   std::vector<Particles::MonteCarlo::Packet> packets{packet};
   Particles::MonteCarlo::TemplatedLocalFunctions<NeutrinoEnergies,
@@ -233,7 +235,8 @@ void test_flat_space_time_step() {
   double current_time = start_time;
   while (current_time < final_time) {
     MonteCarloStruct.take_time_step_on_element(
-        &packets, &generator, &single_packet_energy, current_time,
+        &packets, &coupling_tilde_tau, &coupling_tilde_rho_ye,
+        &coupling_tilde_s, &generator, &single_packet_energy, current_time,
         current_time + time_step, equation_of_state, interaction_table,
         electron_fraction, baryon_density, temperature, lorentz_factor,
         lower_spatial_four_velocity, lapse, shift, d_lapse, d_shift,

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_TimeStepAction.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_TimeStepAction.cpp
@@ -79,6 +79,9 @@ struct component {
       hydro::Tags::ElectronFraction<DataVector>,
       hydro::Tags::Temperature<DataVector>,
       Particles::MonteCarlo::Tags::CellLightCrossingTime<DataVector>,
+      Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
+      Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
+      Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, Dim>,
       domain::Tags::NeighborMesh<Dim>,
       Particles::MonteCarlo::Tags::DesiredPacketEnergyAtEmission<3>,
       hydro::Tags::LowerSpatialFourVelocity<DataVector, Dim, Frame::Inertial>,
@@ -88,8 +91,8 @@ struct component {
                   Frame::Inertial>,
       Tags::deriv<gr::Tags::Shift<DataVector, Dim>, tmpl::size_t<Dim>,
                   Frame::Inertial>,
-      Tags::deriv<gr::Tags::SpatialMetric<DataVector, Dim>,
-                  tmpl::size_t<Dim>, Frame::Inertial>,
+      Tags::deriv<gr::Tags::SpatialMetric<DataVector, Dim>, tmpl::size_t<Dim>,
+                  Frame::Inertial>,
       gr::Tags::SpatialMetric<DataVector, Dim, Frame::Inertial>,
       gr::Tags::InverseSpatialMetric<DataVector, Dim, Frame::Inertial>,
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
@@ -210,8 +213,23 @@ void test_advance_packets() {
   gsl::at(single_packet_energy, 2) = 1.0;
   get(cell_light_crossing_time) = 1.0;
 
+  // Coupling data
+  const auto& subcell_extents = subcell_mesh.extents();
+  const size_t num_ghost_zones = 1;
+  size_t mesh_size_with_ghost = 1;
+  for (size_t d = 0; d < Dim; d++) {
+    mesh_size_with_ghost *= subcell_extents[d] + 2 * num_ghost_zones;
+  }
+  const DataVector zero_dv_with_ghost(mesh_size_with_ghost, 0.0);
+  Scalar<DataVector> coupling_tilde_tau =
+      make_with_value<Scalar<DataVector>>(zero_dv_with_ghost, 0.0);
+  Scalar<DataVector> coupling_tilde_rho_ye =
+      make_with_value<Scalar<DataVector>>(zero_dv_with_ghost, 0.0);
+  tnsr::i<DataVector, Dim> coupling_tilde_s =
+      make_with_value<tnsr::i<DataVector, Dim>>(zero_dv_with_ghost, 0.0);
+
   // Grid coordinates on subcell mesh
-  const size_t mesh_size = subcell_mesh.extents()[0];
+  const size_t mesh_size = subcell_extents[0];
   CHECK(subcell_mesh.extents()[1] == mesh_size);
   CHECK(subcell_mesh.extents()[2] == mesh_size);
   tnsr::I<DataVector, 3, Frame::ElementLogical> mesh_coordinates =
@@ -306,6 +324,9 @@ void test_advance_packets() {
        electron_fraction,
        temperature,
        cell_light_crossing_time,
+       coupling_tilde_tau,
+       coupling_tilde_rho_ye,
+       coupling_tilde_s,
        typename domain::Tags::NeighborMesh<Dim>::type{},
        single_packet_energy,
        lower_spatial_four_velocity,


### PR DESCRIPTION
## Proposed changes

Add capability for the Monte Carlo code to gather the contribution of the MC packets to the evolution of the fluid, and communicate interactions happening in ghost zones back to the live points evolving the fluid.
This PR does NOT use the communicated data yet (we do not have a fully coupled MC+fluid executable yet).

Test_CommunicationTags include tests of this infrastructure.

### Upgrade instructions

NA

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.