### PR TITLE
Update create_initial_element for a Domain with non-conforming Blocks

### DIFF
--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -25,9 +25,11 @@
 namespace domain::Initialization {
 template <size_t VolumeDim>
 Element<VolumeDim> create_initial_element(
-    const ElementId<VolumeDim>& element_id, const Block<VolumeDim>& block,
+    const ElementId<VolumeDim>& element_id,
+    const std::vector<Block<VolumeDim>>& blocks,
     const std::vector<std::array<size_t, VolumeDim>>&
         initial_refinement_levels) {
+  const auto& block = blocks[element_id.block_id()];
   const auto& neighbors_of_block = block.neighbors();
   const auto segment_ids = element_id.segment_ids();
 
@@ -187,10 +189,10 @@ Element<VolumeDim> create_initial_element(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                 \
-  template Element<DIM(data)>                                \
-  domain::Initialization::create_initial_element<DIM(data)>( \
-      const ElementId<DIM(data)>&, const Block<DIM(data)>&,  \
+#define INSTANTIATE(_, data)                                             \
+  template Element<DIM(data)>                                            \
+  domain::Initialization::create_initial_element<DIM(data)>(             \
+      const ElementId<DIM(data)>&, const std::vector<Block<DIM(data)>>&, \
       const std::vector<std::array<size_t, DIM(data)>>&);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -12,6 +12,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/NeighborIsConforming.hpp"
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/SegmentId.hpp"
@@ -21,6 +22,83 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+
+namespace {
+SegmentId boundary_segment_id(const size_t refinement_level, const Side side) {
+  if (side == Side::Lower) {
+    return {refinement_level, 0_st};
+  }
+  ASSERT(side == Side::Upper, "Invalid side: " << side);
+  return {refinement_level, two_to_the(refinement_level) - 1};
+}
+
+std::vector<SegmentId> valid_transverse_ids_conforming(
+    const SegmentId& oriented_self_id, const size_t neighbor_refinement_level,
+    const size_t self_block_id, const size_t neighbor_block_id) {
+  const size_t self_refinement_level = oriented_self_id.refinement_level();
+  if (self_refinement_level == neighbor_refinement_level) {
+    return std::vector{oriented_self_id};
+  }
+  if (self_refinement_level == neighbor_refinement_level + 1) {
+    return std::vector{oriented_self_id.id_of_parent()};
+  }
+  if (self_refinement_level + 1 != neighbor_refinement_level) {
+    ERROR("Block " << self_block_id << " with refinement level "
+                   << self_refinement_level << " and neighbor block "
+                   << neighbor_block_id << " with refinement level "
+                   << neighbor_refinement_level << " differ by more than one.");
+  }
+  return std::vector{oriented_self_id.id_of_child(Side::Lower),
+                     oriented_self_id.id_of_child(Side::Upper)};
+}
+
+std::vector<SegmentId> valid_transverse_ids_nonconforming(
+    const size_t neighbor_refinement_level) {
+  std::vector<SegmentId> result(two_to_the(neighbor_refinement_level));
+  for (size_t i = 0; i < result.size(); ++i) {
+    result[i] = SegmentId(neighbor_refinement_level, i);
+  }
+  return result;
+}
+
+std::unordered_set<ElementId<1>> neighbor_ids(
+    const std::array<std::vector<SegmentId>, 1>& valid_segment_ids,
+    const size_t neighbor_block_id, const size_t grid_index) {
+  ASSERT(valid_segment_ids[0].size() == 1,
+         "Cannot have more than one neighbor in one dimension.");
+  return std::unordered_set{ElementId<1>{
+      neighbor_block_id, std::array{valid_segment_ids[0][0]}, grid_index}};
+}
+
+std::unordered_set<ElementId<2>> neighbor_ids(
+    const std::array<std::vector<SegmentId>, 2>& valid_segment_ids,
+    const size_t neighbor_block_id, const size_t grid_index) {
+  std::unordered_set<ElementId<2>> result;
+  for (const auto& xi_segment : valid_segment_ids[0]) {
+    for (const auto& eta_segment : valid_segment_ids[1]) {
+      result.emplace(neighbor_block_id, std::array{xi_segment, eta_segment},
+                     grid_index);
+    }
+  }
+  return result;
+}
+
+std::unordered_set<ElementId<3>> neighbor_ids(
+    const std::array<std::vector<SegmentId>, 3>& valid_segment_ids,
+    const size_t neighbor_block_id, const size_t grid_index) {
+  std::unordered_set<ElementId<3>> result;
+  for (const auto& xi_segment : valid_segment_ids[0]) {
+    for (const auto& eta_segment : valid_segment_ids[1]) {
+      for (const auto& zeta_segment : valid_segment_ids[2]) {
+        result.emplace(neighbor_block_id,
+                       std::array{xi_segment, eta_segment, zeta_segment},
+                       grid_index);
+      }
+    }
+  }
+  return result;
+}
+}  // namespace
 
 namespace domain::Initialization {
 template <size_t VolumeDim>
@@ -33,109 +111,70 @@ Element<VolumeDim> create_initial_element(
   const auto& neighbors_of_block = block.neighbors();
   const auto segment_ids = element_id.segment_ids();
 
-  // Declare two helper lambdas for setting the neighbors of an element
-  const auto compute_element_neighbor_in_other_block =
-      [&block, &initial_refinement_levels, &neighbors_of_block, &segment_ids,
-       grid_index =
-           element_id.grid_index()](const Direction<VolumeDim>& direction) {
-        const auto& block_neighbor = neighbors_of_block.at(direction);
-        const auto& orientation = block_neighbor.orientation();
-        const auto direction_in_neighbor = orientation(direction);
+  const auto compute_element_neighbors_in_other_block =
+      [&block, &blocks, &initial_refinement_levels, &neighbors_of_block,
+       &segment_ids, grid_index = element_id.grid_index()](
+          const Direction<VolumeDim>& direction) {
+        const auto& block_neighbors = neighbors_of_block.at(direction);
+        const auto& orientation = block_neighbors.orientation();
+        const auto direction_from_neighbor = orientation(direction).opposite();
+        Neighbors<VolumeDim> element_neighbors{
+            std::unordered_set<ElementId<VolumeDim>>{}, orientation};
 
-        // SegmentIds of the current element using the neighbor's axes.
-        auto segment_ids_of_unrefined_neighbor = orientation(segment_ids);
-        ASSERT(block_neighbor.size() == 1,
-               "Multiple block neighbors not supported by this function.");
-        const auto& refinement_of_neighbor =
-            initial_refinement_levels[*block_neighbor.begin()];
-
-        // Check whether each dimension will have multiple neighbors
-        // because the neighboring block is more refined.  For dimensions
-        // that have only one neighbor, adjust the SegmentId to that of
-        // the neighbor if necessary.
-        auto neighbor_is_refined = make_array<VolumeDim>(false);
-        for (size_t d = 0; d < VolumeDim; ++d) {
-          // The refinement difference perpendicular to the interface is
-          // not restricted.
-          if (d == direction_in_neighbor.dimension()) {
-            continue;
-          }
-          switch (static_cast<int>(gsl::at(refinement_of_neighbor, d)) -
-                  static_cast<int>(gsl::at(segment_ids_of_unrefined_neighbor, d)
-                                       .refinement_level())) {
-            case 0:
-              break;
-            case 1:
-              gsl::at(neighbor_is_refined, d) = true;
-              break;
-            case -1:
-              gsl::at(segment_ids_of_unrefined_neighbor, d) =
-                  gsl::at(segment_ids_of_unrefined_neighbor, d).id_of_parent();
-              break;
-            default:
-              ERROR("Refinement levels "
-                    << gsl::at(refinement_of_neighbor, d) << " and "
-                    << gsl::at(segment_ids_of_unrefined_neighbor, d)
-                           .refinement_level()
-                    << " in blocks " << *block_neighbor.begin() << " and "
-                    << block.id() << " differ by more than one.");
-          }
-        }
-
-        // Set the segment in the perpendicular dimension to the segment
-        // of the neighboring elements, which must be at one end of the
-        // interval.  This sort of refinement never produces multiple
-        // neighbors, so we do not set neighbor_is_refined[...].
-        {
-          auto& perpendicular_segment =
-              gsl::at(segment_ids_of_unrefined_neighbor,
-                      direction_in_neighbor.dimension());
-          const size_t neighbor_refinement = gsl::at(
-              refinement_of_neighbor, direction_in_neighbor.dimension());
-          // direction_in_neighbor points into the element, so we want the
-          // segment on the side it is pointing away from.
-          if (direction_in_neighbor.side() == Side::Upper) {
-            perpendicular_segment = SegmentId(neighbor_refinement, 0);
-          } else {
-            perpendicular_segment = SegmentId(
-                neighbor_refinement, two_to_the(neighbor_refinement) - 1);
-          }
-        }
-
-        // Consider all possible neighbors by looping over all elements of
-        // the product set {Lower, Upper}^VolumeDim, checking whether each
-        // actually describes a neighbor.  For dimensions where the
-        // interface is not split, we arbitrarily call all neighbors Lower
-        // and consider any Upper neighbors invalid.
-        std::unordered_set<ElementId<VolumeDim>> neighbor_ids;
-        for (IndexIterator<VolumeDim> index(Index<VolumeDim>(2)); index;
-             ++index) {
-          std::array<SegmentId, VolumeDim> segment_ids_of_neighbor{};
-          for (size_t d = 0; d < VolumeDim; ++d) {
-            const auto& unrefined_segment =
-                gsl::at(segment_ids_of_unrefined_neighbor, d);
-            auto& segment = gsl::at(segment_ids_of_neighbor, d);
-            if (not gsl::at(neighbor_is_refined, d)) {
-              if ((*index)[d] == 0) {
-                segment = unrefined_segment;
+        if (block_neighbors.size() == 1) {
+          const size_t neighbor_block_id = *(block_neighbors.begin());
+          std::array<std::vector<SegmentId>, VolumeDim> valid_segment_ids;
+          if (neighbor_is_conforming(block.topologies(),
+                                     blocks[neighbor_block_id].topologies(),
+                                     direction, orientation)) {
+            const auto oriented_segment_ids = orientation(segment_ids);
+            for (size_t d = 0; d < VolumeDim; ++d) {
+              const size_t level =
+                  gsl::at(initial_refinement_levels[neighbor_block_id], d);
+              if (d == direction_from_neighbor.dimension()) {
+                gsl::at(valid_segment_ids, d) = std::vector{
+                    boundary_segment_id(level, direction_from_neighbor.side())};
               } else {
-                goto next_index;
+                gsl::at(valid_segment_ids, d) = valid_transverse_ids_conforming(
+                    gsl::at(oriented_segment_ids, d), level, block.id(),
+                    neighbor_block_id);
               }
-            } else {
-              if ((*index)[d] == 0) {
-                segment = unrefined_segment.id_of_child(Side::Lower);
+            }
+          } else {
+            for (size_t d = 0; d < VolumeDim; ++d) {
+              const size_t level =
+                  gsl::at(initial_refinement_levels[neighbor_block_id], d);
+              if (d == direction_from_neighbor.dimension()) {
+                gsl::at(valid_segment_ids, d) = std::vector{
+                    boundary_segment_id(level, direction_from_neighbor.side())};
               } else {
-                segment = unrefined_segment.id_of_child(Side::Upper);
+                gsl::at(valid_segment_ids, d) =
+                    valid_transverse_ids_nonconforming(level);
               }
             }
           }
-          neighbor_ids.insert(
-              {*block_neighbor.begin(), segment_ids_of_neighbor, grid_index});
-        next_index:;
+          element_neighbors.add_ids(
+              neighbor_ids(valid_segment_ids, neighbor_block_id, grid_index));
+        } else {
+          for (const auto& block_id : block_neighbors.ids()) {
+            std::array<std::vector<SegmentId>, VolumeDim> valid_segment_ids;
+            for (size_t d = 0; d < VolumeDim; ++d) {
+              const size_t level =
+                  gsl::at(initial_refinement_levels[block_id], d);
+              if (d == direction_from_neighbor.dimension()) {
+                gsl::at(valid_segment_ids, d) = std::vector{
+                    boundary_segment_id(level, direction_from_neighbor.side())};
+              } else {
+                gsl::at(valid_segment_ids, d) =
+                    valid_transverse_ids_nonconforming(level);
+              }
+            }
+            element_neighbors.add_ids(
+                neighbor_ids(valid_segment_ids, block_id, grid_index));
+          }
         }
-        return std::make_pair(
-            direction,
-            Neighbors<VolumeDim>(std::move(neighbor_ids), orientation));
+
+        return std::make_pair(direction, std::move(element_neighbors));
       };
 
   const auto compute_element_neighbor_in_same_block = [&element_id,
@@ -165,7 +204,7 @@ Element<VolumeDim> create_initial_element(
     const auto lower_direction = Direction<VolumeDim>{d, Side::Lower};
     if (0 == index and 1 == neighbors_of_block.count(lower_direction)) {
       neighbors_of_element.emplace(
-          compute_element_neighbor_in_other_block(lower_direction));
+          compute_element_neighbors_in_other_block(lower_direction));
     } else if (0 != index) {
       neighbors_of_element.emplace(
           compute_element_neighbor_in_same_block(lower_direction));
@@ -175,7 +214,7 @@ Element<VolumeDim> create_initial_element(
     if (index == two_to_the(gsl::at(segment_ids, d).refinement_level()) - 1 and
         1 == neighbors_of_block.count(upper_direction)) {
       neighbors_of_element.emplace(
-          compute_element_neighbor_in_other_block(upper_direction));
+          compute_element_neighbors_in_other_block(upper_direction));
     } else if (index !=
                two_to_the(gsl::at(segment_ids, d).refinement_level()) - 1) {
       neighbors_of_element.emplace(
@@ -183,7 +222,8 @@ Element<VolumeDim> create_initial_element(
     }
   }
   return Element<VolumeDim>(ElementId<VolumeDim>(element_id),
-                            std::move(neighbors_of_element));
+                            std::move(neighbors_of_element),
+                            block.topologies());
 }
 }  // namespace domain::Initialization
 

--- a/src/Domain/CreateInitialElement.hpp
+++ b/src/Domain/CreateInitialElement.hpp
@@ -23,13 +23,14 @@ namespace Initialization {
  * \brief Creates an initial element of a Block.
  *
  * \details This function creates an element at the refinement level and
- * position specified by the `element_id` within the `block`. It assumes
+ * position specified by the `element_id` within the `blocks`. It assumes
  * that all elements in a given block have the same refinement level,
  * given in `initial_refinement_levels`.
  */
 template <size_t VolumeDim>
 Element<VolumeDim> create_initial_element(
-    const ElementId<VolumeDim>& element_id, const Block<VolumeDim>& block,
+    const ElementId<VolumeDim>& element_id,
+    const std::vector<Block<VolumeDim>>& blocks,
     const std::vector<std::array<size_t, VolumeDim>>&
         initial_refinement_levels);
 }  // namespace Initialization

--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -57,15 +57,16 @@ namespace {
 // local time stepping.
 template <size_t Dim>
 double get_num_points_and_grid_spacing_cost(
-    const ElementId<Dim>& element_id, const Block<Dim>& block,
+    const ElementId<Dim>& element_id, const std::vector<Block<Dim>>& blocks,
     const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Spectral::Quadrature quadrature) {
   Element<Dim> element = ::domain::Initialization::create_initial_element(
-      element_id, block, initial_refinement_levels);
+      element_id, blocks, initial_refinement_levels);
   const Mesh<Dim> mesh = ::domain::Initialization::create_initial_mesh(
       initial_extents, element, quadrature);
-  const ElementMap<Dim, Frame::Grid> element_map{element_id, block};
+  const ElementMap<Dim, Frame::Grid> element_map{element_id,
+                                                 blocks[element_id.block_id()]};
   const tnsr::I<DataVector, Dim, Frame::ElementLogical> logical_coords =
       logical_coordinates(mesh);
   const tnsr::I<DataVector, Dim, Frame::Grid> grid_coords =
@@ -122,7 +123,7 @@ std::unordered_map<ElementId<Dim>, double> get_element_costs(
 
         element_costs.insert(
             {element_id, get_num_points_and_grid_spacing_cost(
-                             element_id, block, initial_refinement_levels,
+                             element_id, blocks, initial_refinement_levels,
                              initial_extents, quadrature.value())});
       }
     }
@@ -323,7 +324,7 @@ size_t BlockZCurveProcDistribution<Dim>::get_proc_for_element(
   template class BlockZCurveProcDistribution<GET_DIM(data)>;                 \
   double get_num_points_and_grid_spacing_cost(                               \
       const ElementId<GET_DIM(data)>& element_id,                            \
-      const Block<GET_DIM(data)>& block,                                     \
+      const std::vector<Block<GET_DIM(data)>>& blocks,                       \
       const std::vector<std::array<size_t, GET_DIM(data)>>&                  \
           initial_refinement_levels,                                         \
       const std::vector<std::array<size_t, GET_DIM(data)>>& initial_extents, \

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_sources(
   HasBoundary.cpp
   Hypercube.cpp
   InitialElementIds.cpp
+  NeighborIsConforming.cpp
   Neighbors.cpp
   ObjectLabel.cpp
   OrientationMap.cpp
@@ -49,6 +50,7 @@ spectre_target_headers(
   IndexToSliceAt.hpp
   InitialElementIds.hpp
   MaxNumberOfNeighbors.hpp
+  NeighborIsConforming.hpp
   Neighbors.hpp
   ObjectLabel.hpp
   OrientationMap.hpp

--- a/src/Domain/Structure/Direction.cpp
+++ b/src/Domain/Structure/Direction.cpp
@@ -82,10 +82,24 @@ Direction<VolumeDim>::Direction(const size_t dimension, const Side side)
 template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os,
                          const Direction<VolumeDim>& direction) {
-  if (-1.0 == direction.sign()) {
-    os << "-";
-  } else {
-    os << "+";
+  switch (direction.side()) {
+    case Side::Uninitialized:
+      os << "Uninitialized";
+      return os;
+    case Side::Self:
+      os << "Self";
+      return os;
+    case Side::Lower:
+      os << '-';
+      break;
+    case Side::Upper:
+      os << '+';
+      break;
+    default:  // LCOV_EXCL_LINE
+      ERROR(
+          "A direction with an unknown Side was passed to the stream "
+          "operator.");
+      // LCOV_EXCL_STOP
   }
   os << direction.dimension();
   return os;

--- a/src/Domain/Structure/Direction.hpp
+++ b/src/Domain/Structure/Direction.hpp
@@ -45,10 +45,16 @@ class Direction {
   static Direction<VolumeDim> self();
 
   /// The dimension of the Direction
-  size_t dimension() const { return static_cast<uint8_t>(axis()); }
+  size_t dimension() const {
+    ASSERT(bit_field_ != 0, "Cannot use an uninitialized Direction");
+    return static_cast<uint8_t>(axis());
+  }
 
   /// The Axis of the Direction
-  Axis axis() const { return static_cast<Axis>(bit_field_ bitand axis_mask); }
+  Axis axis() const {
+    ASSERT(bit_field_ != 0, "Cannot use an uninitialized Direction");
+    return static_cast<Axis>(bit_field_ bitand axis_mask);
+  }
 
   /// The side of the Direction
   Side side() const { return static_cast<Side>(bit_field_ bitand side_mask); }
@@ -165,6 +171,7 @@ inline Direction<VolumeDim> Direction<VolumeDim>::upper_zeta() {
 
 template <size_t VolumeDim>
 inline Direction<VolumeDim> Direction<VolumeDim>::opposite() const {
+  ASSERT(bit_field_ != 0, "Cannot use an uninitialized Direction");
   return Direction<VolumeDim>(axis(), ::opposite(side()));
 }
 

--- a/src/Domain/Structure/Element.cpp
+++ b/src/Domain/Structure/Element.cpp
@@ -43,7 +43,8 @@ Element<VolumeDim>::Element(ElementId<VolumeDim> id, Neighbors_t neighbors,
     }
   }
   // Assuming a maximum 2-to-1 refinement between neighboring elements:
-  ASSERT(number_of_neighbors_ <= maximum_number_of_neighbors(VolumeDim),
+  ASSERT(number_of_neighbors_ <= maximum_number_of_neighbors(VolumeDim) or
+             topologies_ != domain::topologies::hypercube<VolumeDim>,
          "Can't have " << number_of_neighbors_ << " neighbors in " << VolumeDim
                        << " dimensions");
 }

--- a/src/Domain/Structure/NeighborIsConforming.cpp
+++ b/src/Domain/Structure/NeighborIsConforming.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/NeighborIsConforming.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/HasBoundary.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/Topology.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace {
+template <size_t VolumeDim>
+std::array<domain::Topology, VolumeDim - 1> boundary_topologies(
+    const std::array<domain::Topology, VolumeDim>& topologies,
+    const Direction<VolumeDim>& direction) {
+  const size_t dim = direction.dimension();
+  ASSERT(domain::has_boundary(gsl::at(topologies, dim), direction.side()),
+         "There is no boundary for topologies "
+             << topologies << " in the direction " << direction);
+  auto result = all_but_specified_element_of(topologies, dim);
+  if (gsl::at(topologies, dim) == domain::Topology::B2Radial) {
+    for (size_t d = 0; d < VolumeDim - 1; ++d) {
+      if (gsl::at(result, d) == domain::Topology::B2Angular) {
+        gsl::at(result, d) = domain::Topology::S1;
+      }
+    }
+  }
+  return result;
+}
+}  // namespace
+
+namespace domain {
+template <size_t VolumeDim>
+bool neighbor_is_conforming(
+    const std::array<Topology, VolumeDim>& self_topologies,
+    const std::array<Topology, VolumeDim>& neighbor_topologies,
+    const Direction<VolumeDim>& direction_to_neighbor,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor) {
+  if constexpr (VolumeDim > 1) {
+    const auto self_boundary_topologies =
+        boundary_topologies(self_topologies, direction_to_neighbor);
+    if (orientation_of_neighbor.is_aligned()) {
+      const auto neighbor_boundary_topologies = boundary_topologies(
+          neighbor_topologies, direction_to_neighbor.opposite());
+      return self_boundary_topologies == neighbor_boundary_topologies;
+    } else {
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        if (d == direction_to_neighbor.dimension()) {
+          continue;
+        }
+        if (orientation_of_neighbor(Direction<VolumeDim>{d, Side::Upper}) ==
+            Direction<VolumeDim>::self()) {
+          return false;
+        }
+      }
+      const auto neighbor_boundary_topologies = boundary_topologies(
+          orientation_of_neighbor.permute_from_neighbor(neighbor_topologies),
+          direction_to_neighbor);
+      return self_boundary_topologies == neighbor_boundary_topologies;
+    }
+  }
+  return true;
+}
+
+template bool neighbor_is_conforming(
+    const std::array<Topology, 1>& self_topologies,
+    const std::array<Topology, 1>& neighbor_topologies,
+    const Direction<1>& direction_to_neighbor,
+    const OrientationMap<1>& orientation_of_neighbor);
+template bool neighbor_is_conforming(
+    const std::array<Topology, 2>& self_topologies,
+    const std::array<Topology, 2>& neighbor_topologies,
+    const Direction<2>& direction_to_neighbor,
+    const OrientationMap<2>& orientation_of_neighbor);
+template bool neighbor_is_conforming(
+    const std::array<Topology, 3>& self_topologies,
+    const std::array<Topology, 3>& neighbor_topologies,
+    const Direction<3>& direction_to_neighbor,
+    const OrientationMap<3>& orientation_of_neighbor);
+}  // namespace domain

--- a/src/Domain/Structure/NeighborIsConforming.hpp
+++ b/src/Domain/Structure/NeighborIsConforming.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+/// \cond
+template <size_t VolumeDim>
+class Direction;
+template <size_t VolumeDim>
+class OrientationMap;
+namespace domain {
+enum class Topology : uint8_t;
+}  // namespace domain
+/// \endcond
+
+namespace domain {
+/// \ingroup ComputationalDomainGroup
+/// \brief Returns whether or not neighboring Blocks (or Elements) have
+/// conforming block logical coordinates on their interface
+///
+/// \details Block logical coordinates are considered to be conforming if they
+/// are identical or related by a discrete rotation (i.e. a valid non-aligned
+/// OrientationMap).  It is a requirement that neighboring Blocks be conforming
+/// if their oriented topologies are the same in the interface dimensions.
+///
+/// \note If the neighbors are conforming, they can exchange boundary data via
+/// copy or projection, taking into account the discrete rotation if necessary.
+/// If the neighbors are not conforming, boundary data will need to be
+/// interpolated.
+template <size_t VolumeDim>
+bool neighbor_is_conforming(
+    const std::array<Topology, VolumeDim>& self_topologies,
+    const std::array<Topology, VolumeDim>& neighbor_topologies,
+    const Direction<VolumeDim>& direction_to_neighbor,
+    const OrientationMap<VolumeDim>& orientation_of_neighbor);
+}  // namespace domain

--- a/src/Domain/Structure/Neighbors.cpp
+++ b/src/Domain/Structure/Neighbors.cpp
@@ -8,7 +8,6 @@
 #include <pup_stl.h>
 
 #include "Domain/Structure/ElementId.hpp"
-#include "Domain/Structure/MaxNumberOfNeighbors.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -17,10 +16,6 @@ template <size_t VolumeDim, typename IdType>
 Neighbors<VolumeDim, IdType>::Neighbors(std::unordered_set<IdType> ids,
                                         OrientationMap<VolumeDim> orientation)
     : ids_(std::move(ids)), orientation_(std::move(orientation)) {
-  // Assuming a maximum 2-to-1 refinement between neighboring elements:
-  ASSERT(ids_.size() <= maximum_number_of_neighbors_per_direction(VolumeDim),
-         "Can't have " << ids_.size() << " neighbors in " << VolumeDim
-                       << " dimensions");
   ASSERT(orientation_ != OrientationMap<VolumeDim>{},
          "Cannot use a default-constructed OrientationMap in Neighbors.");
 }
@@ -36,10 +31,6 @@ void Neighbors<VolumeDim, IdType>::add_ids(
   for (const auto& id : additional_ids) {
     ids_.insert(id);
   }
-  // Assuming a maximum 2-to-1 refinement between neighboring elements:
-  ASSERT(ids_.size() <= maximum_number_of_neighbors_per_direction(VolumeDim),
-         "Can't have " << ids_.size() << " neighbors in " << VolumeDim
-                       << " dimensions");
 }
 
 template <size_t VolumeDim, typename IdType>

--- a/src/Domain/Structure/OrientationMap.cpp
+++ b/src/Domain/Structure/OrientationMap.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/SegmentId.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -21,7 +22,9 @@ std::set<size_t> set_of_dimensions(
     const std::array<Direction<VolumeDim>, VolumeDim>& directions) {
   std::set<size_t> set_of_dims;
   for (size_t j = 0; j < VolumeDim; j++) {
-    set_of_dims.insert(gsl::at(directions, j).dimension());
+    if (gsl::at(directions, j) != Direction<VolumeDim>::self()) {
+      set_of_dims.insert(gsl::at(directions, j).dimension());
+    }
   }
   return set_of_dims;
 }
@@ -51,8 +54,13 @@ OrientationMap<VolumeDim>::OrientationMap(
       set_aligned(false);
     }
   }
-  ASSERT(set_of_dimensions().size() == VolumeDim,
-         "This OrientationMap fails to map Directions one-to-one.");
+  ASSERT(static_cast<size_t>(
+             alg::count(mapped_directions, Direction<VolumeDim>::self())) +
+                 set_of_dimensions().size() ==
+             VolumeDim,
+         "This OrientationMap fails to map Directions one-to-one.\n"
+         "Mapped directions = "
+             << mapped_directions);
 }
 
 template <size_t VolumeDim>
@@ -69,9 +77,16 @@ OrientationMap<VolumeDim>::OrientationMap(
     }
   }
   ASSERT(::set_of_dimensions(directions_in_host).size() == VolumeDim,
-         "This OrientationMap fails to map Directions one-to-one.");
-  ASSERT(::set_of_dimensions(directions_in_neighbor).size() == VolumeDim,
-         "This OrientationMap fails to map Directions one-to-one.");
+         "This OrientationMap fails to map Directions one-to-one."
+         "directions_in_host = "
+             << directions_in_host);
+  ASSERT(::set_of_dimensions(directions_in_neighbor).size() +
+                 static_cast<size_t>(alg::count(
+                     directions_in_neighbor, Direction<VolumeDim>::self())) ==
+             VolumeDim,
+         "This OrientationMap fails to map Directions one-to-one."
+         "directions_in_neighbor = "
+             << directions_in_neighbor);
 }
 
 template <size_t VolumeDim>
@@ -81,7 +96,10 @@ std::array<SegmentId, VolumeDim> OrientationMap<VolumeDim>::operator()(
          "Cannot use a default-constructed OrientationMap");
   std::array<SegmentId, VolumeDim> result = segmentIds;
   for (size_t d = 0; d < VolumeDim; d++) {
-    gsl::at(result, get_direction(d).dimension()) =
+    const auto neighbor_direction = get_direction(d);
+    ASSERT(neighbor_direction.side() != Side::Self,
+           "Cannot re-orient all SegmentIds for this Orientation");
+    gsl::at(result, neighbor_direction.dimension()) =
         get_direction(d).side() == Side::Upper
             ? gsl::at(segmentIds, d)
             : gsl::at(segmentIds, d).id_if_flipped();
@@ -103,8 +121,11 @@ template <size_t VolumeDim>
 OrientationMap<VolumeDim> OrientationMap<VolumeDim>::inverse_map() const {
   ASSERT(bit_field_ != static_cast<uint16_t>(0b1 << 15),
          "Cannot use a default-constructed OrientationMap");
-  std::array<Direction<VolumeDim>, VolumeDim> result;
+  auto result = make_array<VolumeDim>(Direction<VolumeDim>::self());
   for (size_t i = 0; i < VolumeDim; i++) {
+    if (get_direction(i).side() == Side::Self) {
+      continue;
+    }
     gsl::at(result, get_direction(i).dimension()) =
         Direction<VolumeDim>(i, get_direction(i).side());
   }
@@ -187,7 +208,9 @@ template <size_t VolumeDim>
 std::set<size_t> OrientationMap<VolumeDim>::set_of_dimensions() const {
   std::set<size_t> set_of_dims;
   for (size_t j = 0; j < VolumeDim; j++) {
-    set_of_dims.insert(get_direction(j).dimension());
+    if (get_direction(j) != Direction<VolumeDim>::self()) {
+      set_of_dims.insert(get_direction(j).dimension());
+    }
   }
   return set_of_dims;
 }
@@ -224,6 +247,8 @@ std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> discrete_rotation(
   std::array<ReturnType, VolumeDim> new_coords{};
   for (size_t i = 0; i < VolumeDim; i++) {
     const auto new_direction = rotation(Direction<VolumeDim>(i, Side::Upper));
+    ASSERT(new_direction.side() != Side::Self,
+           "Cannot define discrete rotation for this OrientationMap");
     gsl::at(new_coords, i) =
         std::move(gsl::at(source_coords, new_direction.dimension()));
     if (new_direction.side() != Side::Upper) {
@@ -240,6 +265,8 @@ tnsr::Ij<double, VolumeDim, Frame::NoFrame> discrete_rotation_jacobian(
   for (size_t d = 0; d < VolumeDim; d++) {
     const auto new_direction =
         orientation(Direction<VolumeDim>(d, Side::Upper));
+    ASSERT(new_direction.side() != Side::Self,
+           "Cannot define discrete rotation for this OrientationMap");
     jacobian_matrix.get(d, orientation(d)) =
         new_direction.side() == Side::Upper ? 1.0 : -1.0;
   }
@@ -253,6 +280,8 @@ tnsr::Ij<double, VolumeDim, Frame::NoFrame> discrete_rotation_inverse_jacobian(
   for (size_t d = 0; d < VolumeDim; d++) {
     const auto new_direction =
         orientation(Direction<VolumeDim>(d, Side::Upper));
+    ASSERT(new_direction.side() != Side::Self,
+           "Cannot define discrete rotation for this OrientationMap");
     inverse_jacobian_matrix.get(orientation(d), d) =
         new_direction.side() == Side::Upper ? 1.0 : -1.0;
   }

--- a/src/Domain/Structure/OrientationMap.hpp
+++ b/src/Domain/Structure/OrientationMap.hpp
@@ -31,6 +31,11 @@ class er;
  *
  * See the [tutorial](@ref tutorial_orientations) for information on how
  * OrientationMaps are used and constructed.
+ *
+ * \note If there is no discrete rotation between logical coordinates (e.g. the
+ * angular coordinates of a spherical shell abutting a wedge of a cubed sphere)
+ * specify Direction<VolumeDim>::self() as the mapped direction
+ *
  */
 template <size_t VolumeDim>
 class OrientationMap {
@@ -72,7 +77,10 @@ class OrientationMap {
   size_t operator()(const size_t dim) const {
     ASSERT(bit_field_ != static_cast<uint16_t>(0b1 << 15),
            "Cannot use a default-constructed OrientationMap");
-    return get_direction(dim).dimension();
+    const auto neighbor_direction = get_direction(dim);
+    ASSERT(neighbor_direction.side() != Side::Self,
+           "There is no corresponding dimension");
+    return neighbor_direction.dimension();
   }
 
   /// The corresponding direction in the neighbor.

--- a/src/Domain/Structure/Side.cpp
+++ b/src/Domain/Structure/Side.cpp
@@ -7,6 +7,23 @@
 
 #include "Utilities/ErrorHandling/Error.hpp"
 
+Side opposite(const Side side) {
+  switch (side) {
+    case (Side::Uninitialized):
+      ERROR("Cannot get the opposite of Side::Uninitialized");
+    case (Side::Lower):
+      return Side::Upper;
+    case (Side::Upper):
+      return Side::Lower;
+    case (Side::Self):
+      return Side::Self;
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("An unknown Side was passed to Side::opposite()");
+      // LCOV_EXCL_STOP
+  }
+}
+
 std::ostream& operator<<(std::ostream& os, const Side& side) {
   switch (side) {
     case Side::Uninitialized:

--- a/src/Domain/Structure/Side.hpp
+++ b/src/Domain/Structure/Side.hpp
@@ -30,10 +30,8 @@ enum class Side : uint8_t {
   Self = 3 << detail::side_shift
 };
 
-/// The opposite side
-constexpr inline Side opposite(const Side side) {
-  return (Side::Lower == side ? Side::Upper : Side::Lower);
-}
+/// The opposite side (Side::Self is its own opposite)
+Side opposite(Side side);
 
 /// Output operator for a Side.
 std::ostream& operator<<(std::ostream& os, const Side& side);

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -103,10 +103,9 @@ void InitializeGeometry<Dim>::apply(
          "The elliptic DG scheme supports Gauss and Gauss-Lobatto "
          "grids, but the chosen quadrature is: "
              << quadrature);
-  const auto& block = domain.blocks()[element_id.block_id()];
   // Element
-  *element = domain::Initialization::create_initial_element(element_id, block,
-                                                            initial_refinement);
+  *element = domain::Initialization::create_initial_element(
+      element_id, domain.blocks(), initial_refinement);
   *mesh = domain::Initialization::create_initial_mesh(initial_extents, *element,
                                                       quadrature);
   // Neighbor meshes
@@ -120,6 +119,7 @@ void InitializeGeometry<Dim>::apply(
     }
   }
   // Element map
+  const auto& block = domain.blocks()[element_id.block_id()];
   *element_map = ElementMap<Dim, Frame::Inertial>{element_id, block};
   // Coordinates and Jacobians
   detail::initialize_coords_and_jacobians(

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -143,11 +143,11 @@ struct Domain {
       const std::vector<std::array<size_t, Dim>>& initial_refinement,
       const Spectral::Quadrature& quadrature,
       const ElementId<Dim>& element_id) {
-    const auto& my_block = domain.blocks()[element_id.block_id()];
     *element = ::domain::Initialization::create_initial_element(
-        element_id, my_block, initial_refinement);
+        element_id, domain.blocks(), initial_refinement);
     *mesh = ::domain::Initialization::create_initial_mesh(initial_extents,
                                                           *element, quadrature);
+    const auto& my_block = domain.blocks()[element_id.block_id()];
     *element_map = ElementMap<Dim, Frame::Grid>{element_id, my_block};
 
     if (my_block.is_time_dependent()) {

--- a/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
+++ b/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
@@ -63,9 +63,8 @@ struct Domain {
       const std::vector<std::array<size_t, Dim>>& initial_refinement,
       const Spectral::Quadrature& quadrature,
       const ElementId<Dim>& element_id) {
-    const auto& my_block = domain.blocks()[element_id.block_id()];
     *element = ::domain::Initialization::create_initial_element(
-        element_id, my_block, initial_refinement);
+        element_id, domain.blocks(), initial_refinement);
     *mesh = ::domain::Initialization::create_initial_mesh(initial_extents,
                                                           *element, quadrature);
   }

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_Hypercube.cpp
   Test_IndexToSliceAt.cpp
   Test_InitialElementIds.cpp
+  Test_NeighborIsConforming.cpp
   Test_Neighbors.cpp
   Test_ObjectLabel.cpp
   Test_OrientationMap.cpp

--- a/tests/Unit/Domain/Structure/Test_Direction.cpp
+++ b/tests/Unit/Domain/Structure/Test_Direction.cpp
@@ -139,17 +139,6 @@ void test_helper_functions() {
   auto lower_zeta_3 = Direction<3>::lower_zeta();
   CHECK(lower_zeta_3.axis() == Direction<3>::Axis::Zeta);
   CHECK(lower_zeta_3.side() == Side::Lower);
-
-#ifdef SPECTRE_DEBUG
-  CHECK_THROWS_WITH(
-      Direction<3>(0, Side::Uninitialized).sign(),
-      Catch::Matchers::ContainsSubstring(
-          "sign() is only defined for Side::Lower and Side::Upper"));
-  CHECK_THROWS_WITH(
-      Direction<3>(0, Side::Self).sign(),
-      Catch::Matchers::ContainsSubstring(
-          "sign() is only defined for Side::Lower and Side::Upper"));
-#endif
 }
 
 void test_std_hash() {
@@ -240,6 +229,48 @@ void test_output() {
   auto lower_zeta_3 = Direction<3>(2, Side::Lower);
   CHECK(get_output(lower_zeta_3) == "-2");
 }
+
+template <size_t Dim>
+void test_uninitialized() {
+  const Direction<Dim> uninitialized{};
+  CHECK(uninitialized.side() == Side::Uninitialized);
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(uninitialized.dimension(),
+                    Catch::Matchers::ContainsSubstring(
+                        "Cannot use an uninitialized Direction"));
+  CHECK_THROWS_WITH(uninitialized.axis(),
+                    Catch::Matchers::ContainsSubstring(
+                        "Cannot use an uninitialized Direction"));
+  CHECK_THROWS_WITH(
+      uninitialized.sign(),
+      Catch::Matchers::ContainsSubstring(
+          "sign() is only defined for Side::Lower and Side::Upper"));
+  CHECK_THROWS_WITH(uninitialized.opposite(),
+                    Catch::Matchers::ContainsSubstring(
+                        "Cannot use an uninitialized Direction"));
+#endif  // SPECTRE_DEBUG
+  CHECK(uninitialized.bits() == 0);
+  test_serialization(uninitialized);
+  CHECK(get_output(uninitialized) == "Uninitialized");
+}
+
+template <size_t Dim>
+void test_self() {
+  const Direction<Dim> self = Direction<Dim>::self();
+  CHECK(self.dimension() == 0);
+  CHECK(self.axis() == Direction<Dim>::Axis::Xi);
+  CHECK(self.side() == Side::Self);
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      self.sign(),
+      Catch::Matchers::ContainsSubstring(
+          "sign() is only defined for Side::Lower and Side::Upper"));
+#endif  // SPECTRE_DEBUG
+  CHECK(self.opposite() == self);
+  CHECK(self.bits() == 0b00001100);
+  test_serialization(self);
+  CHECK(get_output(self) == "Self");
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Structure.Direction", "[Domain][Unit]") {
@@ -251,6 +282,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Direction", "[Domain][Unit]") {
   test_std_hash();
   test_direction_hash();
   test_output();
+  test_uninitialized<1>();
+  test_uninitialized<2>();
+  test_uninitialized<3>();
+  test_self<1>();
+  test_self<2>();
+  test_self<3>();
 
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(

--- a/tests/Unit/Domain/Structure/Test_NeighborIsConforming.cpp
+++ b/tests/Unit/Domain/Structure/Test_NeighborIsConforming.cpp
@@ -1,0 +1,199 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/NeighborIsConforming.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/Topology.hpp"
+
+namespace {
+void test_1d() {
+  for (const auto& direction : Direction<1>::all_directions()) {
+    for (const auto& orientation :
+         std::array{OrientationMap<1>::create_aligned(),
+                    OrientationMap<1>(std::array{Direction<1>::lower_xi()})}) {
+      CHECK(neighbor_is_conforming(std::array{domain::Topology::I1},
+                                   std::array{domain::Topology::I1}, direction,
+                                   orientation));
+    }
+  }
+}
+
+void test_2d() {
+  const OrientationMap<2> aligned = OrientationMap<2>::create_aligned();
+  const OrientationMap<2> quarter_turn_ccw(std::array<Direction<2>, 2>{
+      {Direction<2>::lower_eta(), Direction<2>::upper_xi()}});
+  const OrientationMap<2> half_turn(std::array<Direction<2>, 2>{
+      {Direction<2>::lower_xi(), Direction<2>::lower_eta()}});
+  const OrientationMap<2> quarter_turn_cw(std::array<Direction<2>, 2>{
+      {Direction<2>::upper_eta(), Direction<2>::lower_xi()}});
+
+  for (const auto& direction : Direction<2>::all_directions()) {
+    for (const auto& orientation :
+         std::array{aligned, quarter_turn_ccw, half_turn, quarter_turn_cw}) {
+      CHECK(neighbor_is_conforming(domain::topologies::hypercube<2>,
+                                   domain::topologies::hypercube<2>, direction,
+                                   orientation));
+    }
+  }
+
+  CHECK(neighbor_is_conforming(domain::topologies::disk,
+                               domain::topologies::annulus,
+                               Direction<2>::upper_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::annulus,
+                               domain::topologies::disk,
+                               Direction<2>::lower_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::annulus,
+                               domain::topologies::annulus,
+                               Direction<2>::lower_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::annulus,
+                               domain::topologies::annulus,
+                               Direction<2>::upper_xi(), aligned));
+
+  for (const auto& orientation :
+       std::array{aligned, quarter_turn_ccw, half_turn, quarter_turn_cw}) {
+    CHECK_FALSE(neighbor_is_conforming(domain::topologies::disk,
+                                       domain::topologies::hypercube<2>,
+                                       Direction<2>::upper_xi(), orientation));
+    CHECK_FALSE(neighbor_is_conforming(domain::topologies::annulus,
+                                       domain::topologies::hypercube<2>,
+                                       Direction<2>::lower_xi(), orientation));
+    CHECK_FALSE(neighbor_is_conforming(domain::topologies::annulus,
+                                       domain::topologies::hypercube<2>,
+                                       Direction<2>::upper_xi(), orientation));
+  }
+}
+
+void test_3d() {
+  const OrientationMap<3> aligned = OrientationMap<3>::create_aligned();
+  CHECK(neighbor_is_conforming(domain::topologies::spherical_shell,
+                               domain::topologies::spherical_shell,
+                               Direction<3>::lower_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::spherical_shell,
+                               domain::topologies::spherical_shell,
+                               Direction<3>::upper_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::full_cylinder,
+                               domain::topologies::full_cylinder,
+                               Direction<3>::lower_zeta(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::full_cylinder,
+                               domain::topologies::full_cylinder,
+                               Direction<3>::upper_zeta(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                               domain::topologies::cylindrical_shell,
+                               Direction<3>::lower_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                               domain::topologies::cylindrical_shell,
+                               Direction<3>::upper_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                               domain::topologies::cylindrical_shell,
+                               Direction<3>::lower_zeta(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                               domain::topologies::cylindrical_shell,
+                               Direction<3>::upper_zeta(), aligned));
+
+  const OrientationMap<3> radial_xi_to_zeta(std::array<Direction<3>, 3>{
+      Direction<3>::upper_zeta(), Direction<3>::self(), Direction<3>::self()});
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::spherical_shell, domain::topologies::hypercube<3>,
+      Direction<3>::lower_xi(), radial_xi_to_zeta));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::spherical_shell, domain::topologies::hypercube<3>,
+      Direction<3>::upper_xi(), radial_xi_to_zeta));
+
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::spherical_shell, domain::topologies::full_cylinder,
+      Direction<3>::lower_xi(), radial_xi_to_zeta));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::spherical_shell, domain::topologies::full_cylinder,
+      Direction<3>::upper_xi(), radial_xi_to_zeta));
+
+  const OrientationMap<3> radial_aligned(std::array<Direction<3>, 3>{
+      Direction<3>::upper_xi(), Direction<3>::self(), Direction<3>::self()});
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::spherical_shell,
+                                     domain::topologies::cylindrical_shell,
+                                     Direction<3>::lower_xi(), radial_aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::spherical_shell,
+                                     domain::topologies::cylindrical_shell,
+                                     Direction<3>::upper_xi(), radial_aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::spherical_shell,
+                                     domain::topologies::cylindrical_shell,
+                                     Direction<3>::lower_xi(),
+                                     radial_xi_to_zeta));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::spherical_shell,
+                                     domain::topologies::cylindrical_shell,
+                                     Direction<3>::upper_xi(),
+                                     radial_xi_to_zeta));
+
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::full_cylinder,
+                                     domain::topologies::hypercube<3>,
+                                     Direction<3>::upper_xi(), aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::full_cylinder,
+                                     domain::topologies::hypercube<3>,
+                                     Direction<3>::lower_zeta(), aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::full_cylinder,
+                                     domain::topologies::hypercube<3>,
+                                     Direction<3>::upper_zeta(), aligned));
+  const OrientationMap<3> radial_zeta_to_xi(std::array<Direction<3>, 3>{
+      Direction<3>::self(), Direction<3>::self(), Direction<3>::upper_xi()});
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::full_cylinder, domain::topologies::spherical_shell,
+      Direction<3>::lower_zeta(), radial_zeta_to_xi));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::full_cylinder, domain::topologies::spherical_shell,
+      Direction<3>::upper_zeta(), radial_zeta_to_xi));
+  CHECK(neighbor_is_conforming(domain::topologies::full_cylinder,
+                               domain::topologies::cylindrical_shell,
+                               Direction<3>::upper_xi(), aligned));
+  const OrientationMap<3> full_to_shell(std::array<Direction<3>, 3>{
+      Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+      Direction<3>::upper_xi()});
+  CHECK(neighbor_is_conforming(domain::topologies::full_cylinder,
+                               domain::topologies::cylindrical_shell,
+                               Direction<3>::upper_xi(), full_to_shell));
+
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::hypercube<3>,
+                                     Direction<3>::lower_xi(), aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::hypercube<3>,
+                                     Direction<3>::upper_xi(), aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::hypercube<3>,
+                                     Direction<3>::lower_zeta(), aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::hypercube<3>,
+                                     Direction<3>::upper_zeta(), aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::spherical_shell,
+                                     Direction<3>::lower_xi(), radial_aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::spherical_shell,
+                                     Direction<3>::upper_xi(), radial_aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::spherical_shell,
+                                     Direction<3>::lower_zeta(),
+                                     radial_zeta_to_xi));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::spherical_shell,
+                                     Direction<3>::upper_zeta(),
+                                     radial_zeta_to_xi));
+  CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                               domain::topologies::full_cylinder,
+                               Direction<3>::lower_xi(), aligned));
+  const OrientationMap<3> shell_to_full(std::array<Direction<3>, 3>{
+      Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+      Direction<3>::lower_xi()});
+  CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                               domain::topologies::full_cylinder,
+                               Direction<3>::upper_zeta(), shell_to_full));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.NeighborIsConforming",
+                  "[Domain][Unit]") {
+  test_1d();
+  test_2d();
+  test_3d();
+}

--- a/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Structure/Test_OrientationMap.cpp
@@ -486,6 +486,71 @@ void test_reference_wrapper() {
   CHECK(test_points[1].get() == y_points_proof);
   CHECK(test_points[2].get() == z_points_proof);
 }
+
+void test_only_radial_orientation() {
+  const OrientationMap<3> shell_to_wedge(std::array<Direction<3>, 3>{
+      Direction<3>::upper_zeta(), Direction<3>::self(), Direction<3>::self()});
+  const OrientationMap<3> wedge_to_shell(std::array<Direction<3>, 3>{
+      Direction<3>::self(), Direction<3>::self(), Direction<3>::upper_xi()});
+  const OrientationMap<3> radially_aligned(std::array<Direction<3>, 3>{
+      Direction<3>::upper_xi(), Direction<3>::self(), Direction<3>::self()});
+  CHECK_FALSE(shell_to_wedge.is_aligned());
+  CHECK_FALSE(wedge_to_shell.is_aligned());
+  CHECK_FALSE(radially_aligned.is_aligned());
+  CHECK(shell_to_wedge(0) == 2);
+  CHECK(wedge_to_shell(2) == 0);
+  CHECK(radially_aligned(0) == 0);
+  CHECK(shell_to_wedge(Direction<3>::upper_xi()) == Direction<3>::upper_zeta());
+  CHECK(shell_to_wedge(Direction<3>::lower_xi()) == Direction<3>::lower_zeta());
+  CHECK(shell_to_wedge(Direction<3>::lower_eta()) == Direction<3>::self());
+  CHECK(wedge_to_shell(Direction<3>::upper_zeta()) == Direction<3>::upper_xi());
+  CHECK(wedge_to_shell(Direction<3>::lower_zeta()) == Direction<3>::lower_xi());
+  CHECK(radially_aligned(Direction<3>::upper_xi()) == Direction<3>::upper_xi());
+  CHECK(radially_aligned(Direction<3>::lower_xi()) == Direction<3>::lower_xi());
+  CHECK(shell_to_wedge.inverse_map() == wedge_to_shell);
+  CHECK(shell_to_wedge == wedge_to_shell.inverse_map());
+  CHECK(radially_aligned.inverse_map() == radially_aligned);
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(shell_to_wedge(1),
+                    Catch::Matchers::ContainsSubstring(
+                        "There is no corresponding dimension"));
+
+  CHECK_THROWS_WITH(
+      shell_to_wedge(
+          std::array{SegmentId{1, 0}, SegmentId{2, 1}, SegmentId{3, 2}}),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot re-orient all SegmentIds for this Orientation"));
+  CHECK_THROWS_WITH(
+      shell_to_wedge(Mesh<3>{
+          {4, 5, 9},
+          {Spectral::Basis::Chebyshev, Spectral::Basis::SphericalHarmonic,
+           Spectral::Basis::SphericalHarmonic},
+          {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+           Spectral::Quadrature::Equiangular}}),
+      Catch::Matchers::ContainsSubstring(
+          "There is no corresponding dimension"));
+  CHECK_THROWS_WITH(
+      shell_to_wedge.permute_to_neighbor(std::array{1.0, 2.0, 3.0}),
+      Catch::Matchers::ContainsSubstring(
+          "There is no corresponding dimension"));
+  CHECK_THROWS_WITH(
+      shell_to_wedge.permute_from_neighbor(std::array{1.0, 2.0, 3.0}),
+      Catch::Matchers::ContainsSubstring(
+          "There is no corresponding dimension"));
+  CHECK_THROWS_WITH(
+      discrete_rotation(shell_to_wedge, std::array{1.0, 2.0, 3.0}),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot define discrete rotation for this OrientationMap"));
+  CHECK_THROWS_WITH(
+      discrete_rotation_jacobian(shell_to_wedge),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot define discrete rotation for this OrientationMap"));
+  CHECK_THROWS_WITH(
+      discrete_rotation_inverse_jacobian(shell_to_wedge),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot define discrete rotation for this OrientationMap"));
+#endif  // SPECTRE_DEBUG
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap", "[Domain][Unit]") {
@@ -497,5 +562,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.OrientationMap", "[Domain][Unit]") {
   test_rotation();
   test_reference_wrapper();
 
+  test_only_radial_orientation();
   test_errors();
 }

--- a/tests/Unit/Domain/Structure/Test_Side.cpp
+++ b/tests/Unit/Domain/Structure/Test_Side.cpp
@@ -12,6 +12,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Side", "[Domain][Unit]") {
   Side side_lower = Side::Lower;
   CHECK(opposite(side_lower) == Side::Upper);
   CHECK(opposite(opposite(side_lower)) == Side::Lower);
+  CHECK(opposite(Side::Self) == Side::Self);
   CHECK(get_output(side_lower) == "Lower");
   CHECK(get_output(Side::Upper) == "Upper");
+  CHECK(get_output(Side::Uninitialized) == "Uninitialized");
+  CHECK(get_output(Side::Self) == "Self");
+  CHECK_THROWS_WITH(opposite(Side::Uninitialized),
+                    Catch::Matchers::ContainsSubstring(
+                        "Cannot get the opposite of Side::Uninitialized"));
 }

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -34,11 +34,11 @@
 
 namespace {
 void test_create_initial_element(
-    const ElementId<2>& element_id, const Block<2>& block,
+    const ElementId<2>& element_id, const std::vector<Block<2>>& blocks,
     const std::vector<std::array<size_t, 2>>& refinement_levels,
     const DirectionMap<2, Neighbors<2>>& expected_neighbors) {
   const auto created_element = domain::Initialization::create_initial_element(
-      element_id, block, refinement_levels);
+      element_id, blocks, refinement_levels);
   const Element<2> expected_element{element_id, expected_neighbors};
   CHECK(created_element == expected_element);
 }
@@ -52,16 +52,17 @@ void test_h_refinement() {
                const std::unordered_set<ElementId<3>>& expected_neighbors) {
       CAPTURE(neighbor_orientation);
       CAPTURE(neighbor_refinement);
-      const Block<3> self_block(
-          domain::make_coordinate_map_base<Frame::BlockLogical,
-                                           Frame::Inertial>(
-              domain::CoordinateMaps::Identity<3>{}),
-          0, {{neighbor_direction, {1, neighbor_orientation}}});
+      std::vector<Block<3>> blocks;
+      blocks.emplace_back(
+          Block<3>(domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                    Frame::Inertial>(
+                       domain::CoordinateMaps::Identity<3>{}),
+                   0, {{neighbor_direction, {1, neighbor_orientation}}}));
       const std::vector<std::array<size_t, 3>> refinement_levels{
           {{1, 1, 1}}, neighbor_refinement};
 
       const auto refined_neighbors =
-          domain::Initialization::create_initial_element(self_id, self_block,
+          domain::Initialization::create_initial_element(self_id, blocks,
                                                          refinement_levels)
               .neighbors()
               .at(neighbor_direction)
@@ -398,18 +399,18 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
       make_array(Direction<2>::upper_xi(), Direction<2>::upper_eta()));
   OrientationMap<2> unaligned(
       make_array(Direction<2>::lower_eta(), Direction<2>::upper_xi()));
-  Block<2> test_block(
+  std::vector<Block<2>> blocks;
+  blocks.emplace_back(Block<2>(
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           domain::CoordinateMaps::Identity<2>{}),
       0,
       {{Direction<2>::upper_xi(), BlockNeighbors<2>{1, aligned}},
-       {Direction<2>::upper_eta(), BlockNeighbors<2>{2, unaligned}}});
+       {Direction<2>::upper_eta(), BlockNeighbors<2>{2, unaligned}}}));
   std::vector<std::array<size_t, 2>> refinement{{{2, 3}}, {{2, 3}}, {{3, 2}}};
 
   // interior element
   test_create_initial_element(
-      ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 4}}}}, test_block,
-      refinement,
+      ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 4}}}}, blocks, refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 4}}}}},
                      aligned}},
@@ -425,8 +426,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
 
   // element on external boundary
   test_create_initial_element(
-      ElementId<2>{0, {{SegmentId{2, 0}, SegmentId{3, 0}}}}, test_block,
-      refinement,
+      ElementId<2>{0, {{SegmentId{2, 0}, SegmentId{3, 0}}}}, blocks, refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 1}, SegmentId{3, 0}}}}},
                      aligned}},
@@ -436,8 +436,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
 
   // element bounding aligned neighbor block
   test_create_initial_element(
-      ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 4}}}}, test_block,
-      refinement,
+      ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 4}}}}, blocks, refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{3, 4}}}}},
                      aligned}},
@@ -453,8 +452,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
 
   // element bounding unaligned neighbor block
   test_create_initial_element(
-      ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 7}}}}, test_block,
-      refinement,
+      ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 7}}}}, blocks, refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 7}}}}},
                      aligned}},
@@ -470,8 +468,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
 
   // element bounding both neighbor blocks
   test_create_initial_element(
-      ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 7}}}}, test_block,
-      refinement,
+      ElementId<2>{0, {{SegmentId{2, 3}, SegmentId{3, 7}}}}, blocks, refinement,
       {{Direction<2>::upper_xi(),
         Neighbors<2>{{ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{3, 7}}}}},
                      aligned}},
@@ -490,7 +487,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
     const size_t grid_index = 3;
     test_create_initial_element(
         ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{3, 4}}}, grid_index},
-        test_block, refinement,
+        blocks, refinement,
         {{Direction<2>::upper_xi(),
           Neighbors<2>{
               {ElementId<2>{

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -28,6 +28,7 @@
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -36,10 +37,12 @@ namespace {
 void test_create_initial_element(
     const ElementId<2>& element_id, const std::vector<Block<2>>& blocks,
     const std::vector<std::array<size_t, 2>>& refinement_levels,
-    const DirectionMap<2, Neighbors<2>>& expected_neighbors) {
+    const DirectionMap<2, Neighbors<2>>& expected_neighbors,
+    const std::array<domain::Topology, 2>& topologies =
+        domain::topologies::hypercube<2>) {
   const auto created_element = domain::Initialization::create_initial_element(
       element_id, blocks, refinement_levels);
-  const Element<2> expected_element{element_id, expected_neighbors};
+  const Element<2> expected_element{element_id, expected_neighbors, topologies};
   CHECK(created_element == expected_element);
 }
 
@@ -58,6 +61,13 @@ void test_h_refinement() {
                                                     Frame::Inertial>(
                        domain::CoordinateMaps::Identity<3>{}),
                    0, {{neighbor_direction, {1, neighbor_orientation}}}));
+      blocks.emplace_back(
+          Block<3>(domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                    Frame::Inertial>(
+                       domain::CoordinateMaps::Identity<3>{}),
+                   1,
+                   {{neighbor_orientation(neighbor_direction).opposite(),
+                     {1, neighbor_orientation.inverse_map()}}}));
       const std::vector<std::array<size_t, 3>> refinement_levels{
           {{1, 1, 1}}, neighbor_refinement};
 
@@ -392,6 +402,71 @@ void test_h_refinement() {
   check_perpendicular_refinement_lower(reflected, {{5, 0, 0}},
                                        {{1, {{{5, 0}, {0, 0}, {0, 0}}}}});
 }
+
+void test_nonconforming_blocks() {
+  const OrientationMap<2> aligned = OrientationMap<2>::create_aligned();
+  std::vector<Block<2>> blocks;
+  blocks.emplace_back(
+      nullptr, 0,
+      DirectionMap<2, BlockNeighbors<2>>{
+          {Direction<2>::upper_xi(), BlockNeighbors<2>{{1, 2, 3, 4}, aligned}}},
+      "Annulus", std::array{domain::Topology::I1, domain::Topology::S1});
+  blocks.emplace_back(
+      nullptr, 1,
+      DirectionMap<2, BlockNeighbors<2>>{
+          {Direction<2>::lower_xi(), BlockNeighbors<2>{0, aligned}},
+          {Direction<2>::lower_eta(), BlockNeighbors<2>{2, aligned}},
+          {Direction<2>::upper_eta(), BlockNeighbors<2>{4, aligned}}},
+      "North", std::array{domain::Topology::I1, domain::Topology::I1});
+  blocks.emplace_back(
+      nullptr, 2,
+      DirectionMap<2, BlockNeighbors<2>>{
+          {Direction<2>::lower_xi(), BlockNeighbors<2>{0, aligned}},
+          {Direction<2>::lower_eta(), BlockNeighbors<2>{3, aligned}},
+          {Direction<2>::upper_eta(), BlockNeighbors<2>{1, aligned}}},
+      "East", std::array{domain::Topology::I1, domain::Topology::I1});
+  blocks.emplace_back(
+      nullptr, 3,
+      DirectionMap<2, BlockNeighbors<2>>{
+          {Direction<2>::lower_xi(), BlockNeighbors<2>{0, aligned}},
+          {Direction<2>::lower_eta(), BlockNeighbors<2>{4, aligned}},
+          {Direction<2>::upper_eta(), BlockNeighbors<2>{2, aligned}}},
+      "South", std::array{domain::Topology::I1, domain::Topology::I1});
+  blocks.emplace_back(
+      nullptr, 4,
+      DirectionMap<2, BlockNeighbors<2>>{
+          {Direction<2>::lower_xi(), BlockNeighbors<2>{0, aligned}},
+          {Direction<2>::lower_eta(), BlockNeighbors<2>{1, aligned}},
+          {Direction<2>::upper_eta(), BlockNeighbors<2>{3, aligned}}},
+      "West", std::array{domain::Topology::I1, domain::Topology::I1});
+  const std::vector<std::array<size_t, 2>> initial_refinement_levels{
+      std::array{2_st, 0_st}, std::array{0_st, 1_st}, std::array{0_st, 1_st},
+      std::array{0_st, 1_st}, std::array{0_st, 1_st}};
+  const ElementId<2> annulus_u{0, std::array{SegmentId{2, 3}, SegmentId{0, 0}}};
+  const ElementId<2> annulus_m{0, std::array{SegmentId{2, 2}, SegmentId{0, 0}}};
+  const ElementId<2> north_l{1, std::array{SegmentId{0, 0}, SegmentId{1, 0}}};
+  const ElementId<2> north_u{1, std::array{SegmentId{0, 0}, SegmentId{1, 1}}};
+  const ElementId<2> east_l{2, std::array{SegmentId{0, 0}, SegmentId{1, 0}}};
+  const ElementId<2> east_u{2, std::array{SegmentId{0, 0}, SegmentId{1, 1}}};
+  const ElementId<2> south_l{3, std::array{SegmentId{0, 0}, SegmentId{1, 0}}};
+  const ElementId<2> south_u{3, std::array{SegmentId{0, 0}, SegmentId{1, 1}}};
+  const ElementId<2> west_l{4, std::array{SegmentId{0, 0}, SegmentId{1, 0}}};
+  const ElementId<2> west_u{4, std::array{SegmentId{0, 0}, SegmentId{1, 1}}};
+  test_create_initial_element(
+      annulus_u, blocks, initial_refinement_levels,
+      {{Direction<2>::lower_xi(), Neighbors<2>{annulus_m, aligned}},
+       {Direction<2>::upper_xi(),
+        Neighbors<2>{{north_l, north_u, east_l, east_u, south_l, south_u,
+                      west_l, west_u},
+                     aligned}}},
+      domain::topologies::annulus);
+  test_create_initial_element(
+      north_l, blocks, initial_refinement_levels,
+      {{Direction<2>::lower_xi(), Neighbors<2>{annulus_u, aligned}},
+       {Direction<2>::lower_eta(), Neighbors<2>{east_u, aligned}},
+       {Direction<2>::upper_eta(), Neighbors<2>{north_u, aligned}}},
+      domain::topologies::hypercube<2>);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
@@ -406,6 +481,16 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
       0,
       {{Direction<2>::upper_xi(), BlockNeighbors<2>{1, aligned}},
        {Direction<2>::upper_eta(), BlockNeighbors<2>{2, unaligned}}}));
+  blocks.emplace_back(Block<2>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<2>{}),
+      1, {{Direction<2>::lower_xi(), BlockNeighbors<2>{0, aligned}}}));
+  blocks.emplace_back(Block<2>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<2>{}),
+      2,
+      {{Direction<2>::lower_xi(),
+        BlockNeighbors<2>{0, unaligned.inverse_map()}}}));
   std::vector<std::array<size_t, 2>> refinement{{{2, 3}}, {{2, 3}}, {{3, 2}}};
 
   // interior element
@@ -511,4 +596,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
   }
 
   test_h_refinement();
+  test_nonconforming_blocks();
 }

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -237,11 +237,11 @@ auto make_databox_with_boundary_conditions() {
   const ElementId<Dim> right_element_id{0, {{{2, 1}, {0, 0}}}};
   const ElementId<Dim> bottom_element_id{1, {{{1, 0}, {1, 1}}}};
   Element<Dim> central_element = domain::Initialization::create_initial_element(
-      central_element_id, domain.blocks()[0], refinement);
+      central_element_id, domain.blocks(), refinement);
   Element<Dim> right_element = domain::Initialization::create_initial_element(
-      right_element_id, domain.blocks()[0], refinement);
+      right_element_id, domain.blocks(), refinement);
   Element<Dim> bottom_element = domain::Initialization::create_initial_element(
-      bottom_element_id, domain.blocks()[1], refinement);
+      bottom_element_id, domain.blocks(), refinement);
   // Subdomain
   LinearSolver::Schwarz::OverlapMap<Dim, Element<Dim>> overlap_elements{
       {{Direction<Dim>::upper_xi(), right_element_id},
@@ -269,9 +269,9 @@ auto make_databox_without_boundary_conditions() {
   const ElementId<Dim> central_element_id{0, {{{2, 1}, {2, 1}}}};
   const ElementId<Dim> right_element_id{0, {{{2, 2}, {2, 1}}}};
   Element<Dim> central_element = domain::Initialization::create_initial_element(
-      central_element_id, domain.blocks()[0], refinement);
+      central_element_id, domain.blocks(), refinement);
   Element<Dim> right_element = domain::Initialization::create_initial_element(
-      right_element_id, domain.blocks()[0], refinement);
+      right_element_id, domain.blocks(), refinement);
   LinearSolver::Schwarz::OverlapMap<Dim, Element<Dim>> overlap_elements{
       {{Direction<Dim>::upper_xi(), right_element_id},
        std::move(right_element)}};

--- a/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
@@ -103,9 +103,9 @@ void test_local_adm_integrals(const double& distance,
   // Compute integral by summing over each element.
   for (const auto& element_id : element_ids) {
     // Get element information.
-    const auto& current_block = blocks.at(element_id.block_id());
     const auto current_element = domain::Initialization::create_initial_element(
-        element_id, current_block, initial_ref_levels);
+        element_id, blocks, initial_ref_levels);
+    const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
 

--- a/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
@@ -167,7 +167,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const bool did_rollback) {
   const auto domain = brick.create_domain();
   const auto element_id = ElementId<3>{0};
   Element<3> element = domain::Initialization::create_initial_element(
-      element_id, domain.blocks().at(0),
+      element_id, domain.blocks(),
       std::vector<std::array<size_t, 3>>{{0, 0, 0}});
 
   const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_MinmodTci.cpp
@@ -240,7 +240,7 @@ void test_tci_at_boundary(const size_t number_of_grid_points,
   const auto element_with_no_neighbors = TestHelpers::Limiters::make_element<1>(
       {{Direction<1>::lower_xi(), Direction<1>::upper_xi()}});
   test_tci_detection(false, tvb_constant, input, mesh,
-                     element_with_no_neighbors, element_size, {{}}, {{}});
+                     element_with_no_neighbors, element_size, {}, {});
 }
 
 void test_tci_with_different_size_neighbor(

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BackgroundGrVars.cpp
@@ -132,7 +132,7 @@ void test(const gsl::not_null<std::mt19937*> gen) {
   const auto domain = brick.create_domain();
   const auto element_id = ElementId<3>{0};
   Element<3> element = domain::Initialization::create_initial_element(
-      element_id, domain.blocks().at(0),
+      element_id, domain.blocks(),
       std::vector<std::array<size_t, 3>>{{0, 0, 0}});
 
   const Mesh<3> mesh{num_dg_pts, Spectral::Basis::Legendre,

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -95,7 +95,7 @@ void test(const BoundaryConditionType& boundary_condition) {
   auto domain = interval.create_domain();
   auto boundary_conditions = interval.external_boundary_conditions();
   const auto element = domain::Initialization::create_initial_element(
-      ElementId<1>{0, {SegmentId{0, 0}}}, domain.blocks().at(0),
+      ElementId<1>{0, {SegmentId{0, 0}}}, domain.blocks(),
       std::vector<std::array<size_t, 1>>{{refinement_level_x}});
 
   // Mesh and coordinates

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
@@ -211,11 +211,11 @@ void test_iterations(const size_t max_iterations) {
     std::vector<ElementId<Dim>> non_abutting_element_ids{};
 
     for (const auto& element_id : element_ids) {
-      const auto& my_block = blocks.at(element_id.block_id());
       auto element = domain::Initialization::create_initial_element(
-          element_id, my_block, initial_refinements);
+          element_id, blocks, initial_refinements);
       auto mesh = domain::Initialization::create_initial_mesh(
           initial_extents, element, quadrature);
+      const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(element_id,
                                    my_block.stationary_map().get_clone());
       const auto logical_coords = logical_coordinates(mesh);

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -169,9 +169,8 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
         make_not_null(&element_faces_grid_coords), initial_extents,
         initial_refinements, quadrature, shell_domain, excision_sphere);
     for (const auto& element_id : element_ids) {
-      const auto& my_block = blocks.at(element_id.block_id());
       auto element = domain::Initialization::create_initial_element(
-          element_id, my_block, initial_refinements);
+          element_id, blocks, initial_refinements);
       auto mesh = domain::Initialization::create_initial_mesh(
           initial_extents, element, quadrature);
       const size_t grid_size = mesh.number_of_grid_points();

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -214,11 +214,11 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
     const std::array<tnsr::I<double, Dim>, 2> particle_pos_vel{
         {std::move(particle_position), std::move(particle_velocity)}};
     for (const auto& element_id : element_ids) {
-      const auto& my_block = blocks.at(element_id.block_id());
       auto element = domain::Initialization::create_initial_element(
-          element_id, my_block, initial_refinements);
+          element_id, blocks, initial_refinements);
       auto mesh = domain::Initialization::create_initial_mesh(
           initial_extents, element, quadrature);
+      const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(element_id,
                                    my_block.stationary_map().get_clone());
       const auto logical_coords = logical_coordinates(mesh);

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -138,9 +138,9 @@ void test_compute_face_coordinates_grid() {
         initial_refinements, quadrature, domain, excision_sphere);
 
     for (const auto& element_id : element_ids) {
-      const auto& my_block = blocks.at(element_id.block_id());
       const auto element = domain::Initialization::create_initial_element(
-          element_id, my_block, initial_refinements);
+          element_id, blocks, initial_refinements);
+      const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(
           element_id, my_block.stationary_map().get_to_grid_frame());
       const auto mesh_1 = domain::Initialization::create_initial_mesh(
@@ -212,11 +212,11 @@ void test_compute_face_coordinates() {
       make_not_null(&all_faces_grid_coords), initial_extents,
       initial_refinements, quadrature, domain, excision_sphere);
   for (const auto& element_id : element_ids) {
-    const auto& my_block = blocks.at(element_id.block_id());
     const auto element = domain::Initialization::create_initial_element(
-        element_id, my_block, initial_refinements);
+        element_id, blocks, initial_refinements);
     const auto mesh = domain::Initialization::create_initial_mesh(
         initial_extents, element, quadrature);
+    const auto& my_block = blocks.at(element_id.block_id());
     const ElementMap element_map(
         element_id,
         my_block.moving_mesh_logical_to_grid_map().get_to_grid_frame());
@@ -552,11 +552,11 @@ void test_face_quantities_compute() {
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
 
   for (const auto& element_id : element_ids) {
-    const auto& my_block = blocks.at(element_id.block_id());
     const auto element = domain::Initialization::create_initial_element(
-        element_id, my_block, initial_refinements);
+        element_id, blocks, initial_refinements);
     const auto mesh = domain::Initialization::create_initial_mesh(
         initial_extents, element, quadrature);
+    const auto& my_block = blocks.at(element_id.block_id());
     const ElementMap element_map(element_id,
                                  my_block.stationary_map().get_clone());
     const auto logical_coords = logical_coordinates(mesh);

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -106,8 +106,7 @@ void test(const BoundaryConditionType& boundary_condition,
   auto boundary_conditions = brick.external_boundary_conditions();
   const auto element = domain::Initialization::create_initial_element(
       ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},
-      domain.blocks().at(0),
-      std::vector<std::array<size_t, 3>>{{refinement_levels}});
+      domain.blocks(), std::vector<std::array<size_t, 3>>{{refinement_levels}});
 
   // Mesh and coordinates
   const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -94,17 +94,19 @@ double test(const size_t num_dg_pts) {
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
-  Block<3> block{
+  std::vector<Block<3>> blocks;
+  blocks.emplace_back(Block<3>{
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{affine_map, affine_map, affine_map}),
       0,
-      {}};
+      {}});
+  const auto& block = blocks[0];
   ElementMap<3, Frame::Grid> element_map{
       element_id, block.is_time_dependent()
                       ? block.moving_mesh_logical_to_grid_map().get_clone()
                       : block.stationary_map().get_to_grid_frame()};
   const auto element = domain::Initialization::create_initial_element(
-      element_id, block,
+      element_id, blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 
   const auto moving_mesh_map =

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -133,15 +133,18 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
                 ::RelativisticEuler::Solutions::TovStar>>(soln))
             .get_clone();
   }
-  Block<3> block{test_non_diagonal_jacobian
-                     ? domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                        Frame::Inertial>(
-                           ::domain::CoordinateMaps::Rotation<3>(0.7, 0, 0.))
-                     : domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                        Frame::Inertial>(
-                           Affine3D{affine_map, affine_map, affine_map}),
-                 0,
-                 {}};
+  std::vector<Block<3>> blocks;
+  blocks.emplace_back(
+      Block<3>{test_non_diagonal_jacobian
+                   ? domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                      Frame::Inertial>(
+                         ::domain::CoordinateMaps::Rotation<3>(0.7, 0, 0.))
+                   : domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                      Frame::Inertial>(
+                         Affine3D{affine_map, affine_map, affine_map}),
+               0,
+               {}});
+  const auto& block = blocks[0];
 
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -155,7 +158,7 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
       ::domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           ::domain::CoordinateMaps::Identity<3>{});
   const auto element = domain::Initialization::create_initial_element(
-      element_id, block,
+      element_id, blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 
   const double time = 0.0;
@@ -308,8 +311,6 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
         neighbor_data_in_direction;
   }
 
-  std::vector<Block<3>> blocks{};
-  blocks.push_back(std::move(block));
   Domain<3> domain{std::move(blocks)};
 
   const auto gamma1 =  // Gamma1, taken from SpEC BNS

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -106,8 +106,7 @@ void test(const BoundaryConditionType& boundary_condition,
   auto boundary_conditions = brick.external_boundary_conditions();
   const auto element = domain::Initialization::create_initial_element(
       ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},
-      domain.blocks().at(0),
-      std::vector<std::array<size_t, 3>>{{refinement_levels}});
+      domain.blocks(), std::vector<std::array<size_t, 3>>{{refinement_levels}});
 
   // Mesh and coordinates
   const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -104,17 +104,18 @@ double test(const size_t num_dg_pts) {
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
-  Block<3> block{
+  std::vector<Block<3>> blocks;
+  blocks.emplace_back(Block<3>(
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{affine_map, affine_map, affine_map}),
-      0,
-      {}};
+      0, {}));
+  const auto& block = blocks[0];
   ElementMap<3, Frame::Grid> element_map{
       element_id, block.is_time_dependent()
                       ? block.moving_mesh_logical_to_grid_map().get_clone()
                       : block.stationary_map().get_to_grid_frame()};
   const auto element = domain::Initialization::create_initial_element(
-      element_id, block,
+      element_id, blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 
   const auto moving_mesh_map =

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -139,13 +139,14 @@ std::array<double, 5> test(const size_t num_dg_pts,
   using Affine3D =
       domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const Affine affine_map{-1.0, 1.0, 1.0, 15.0};
+  std::vector<Block<3>> blocks;
+  blocks.emplace_back(Block<3>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Affine3D{affine_map, affine_map, affine_map}),
+      0, {}));
   const auto element = domain::Initialization::create_initial_element(
       ElementId<3>{0, {SegmentId{2, 2}, SegmentId{2, 2}, SegmentId{2, 2}}},
-      Block<3>{domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Inertial>(
-                   Affine3D{affine_map, affine_map, affine_map}),
-               0,
-               {}},
+      blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
   const ElementMap<3, Frame::Grid> element_map{
       element.id(),

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -102,38 +102,40 @@ auto make_element();
 template <>
 auto make_element<1>() {
   Affine affine_map{-1.0, 1.0, 2.0, 3.0};
+  std::vector<Block<1>> blocks;
+  blocks.emplace_back(Block<1>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          affine_map),
+      0, {}));
   return domain::Initialization::create_initial_element(
-      ElementId<1>{0, {SegmentId{3, 4}}},
-      Block<1>{domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Inertial>(affine_map),
-               0,
-               {}},
+      ElementId<1>{0, {SegmentId{3, 4}}}, blocks,
       std::vector<std::array<size_t, 1>>{std::array<size_t, 1>{{3}}});
 }
 
 template <>
 auto make_element<2>() {
   Affine affine_map{-1.0, 1.0, 2.0, 3.0};
+  std::vector<Block<2>> blocks;
+  blocks.emplace_back(Block<2>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Affine2D{affine_map, affine_map}),
+      0, {}));
   return domain::Initialization::create_initial_element(
-      ElementId<2>{0, {SegmentId{3, 4}, SegmentId{3, 4}}},
-      Block<2>{domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Inertial>(
-                   Affine2D{affine_map, affine_map}),
-               0,
-               {}},
+      ElementId<2>{0, {SegmentId{3, 4}, SegmentId{3, 4}}}, blocks,
       std::vector<std::array<size_t, 2>>{std::array<size_t, 2>{{3, 3}}});
 }
 
 template <>
 auto make_element<3>() {
   Affine affine_map{-1.0, 1.0, 2.0, 3.0};
+  std::vector<Block<3>> blocks;
+  blocks.emplace_back(Block<3>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Affine3D{affine_map, affine_map, affine_map}),
+      0, {}));
   return domain::Initialization::create_initial_element(
       ElementId<3>{0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}},
-      Block<3>{domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Inertial>(
-                   Affine3D{affine_map, affine_map, affine_map}),
-               0,
-               {}},
+      blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 }
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -95,38 +95,40 @@ auto make_element();
 template <>
 auto make_element<1>() {
   Affine affine_map{-1.0, 1.0, 2.0, 3.0};
+  std::vector<Block<1>> blocks;
+  blocks.emplace_back(Block<1>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          affine_map),
+      0, {}));
   return domain::Initialization::create_initial_element(
-      ElementId<1>{0, {SegmentId{2, 2}}},
-      Block<1>{domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Inertial>(affine_map),
-               0,
-               {}},
+      ElementId<1>{0, {SegmentId{2, 2}}}, blocks,
       std::vector<std::array<size_t, 1>>{std::array<size_t, 1>{{3}}});
 }
 
 template <>
 auto make_element<2>() {
   Affine affine_map{-1.0, 1.0, 2.0, 3.0};
+  std::vector<Block<2>> blocks;
+  blocks.emplace_back(Block<2>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Affine2D{affine_map, affine_map}),
+      0, {}));
   return domain::Initialization::create_initial_element(
-      ElementId<2>{0, {SegmentId{2, 2}, SegmentId{2, 2}}},
-      Block<2>{domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Inertial>(
-                   Affine2D{affine_map, affine_map}),
-               0,
-               {}},
+      ElementId<2>{0, {SegmentId{2, 2}, SegmentId{2, 2}}}, blocks,
       std::vector<std::array<size_t, 2>>{std::array<size_t, 2>{{3, 3}}});
 }
 
 template <>
 auto make_element<3>() {
   Affine affine_map{-1.0, 1.0, 2.0, 3.0};
+  std::vector<Block<3>> blocks;
+  blocks.emplace_back(Block<3>(
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          Affine3D{affine_map, affine_map, affine_map}),
+      0, {}));
   return domain::Initialization::create_initial_element(
       ElementId<3>{0, {SegmentId{2, 2}, SegmentId{2, 2}, SegmentId{2, 2}}},
-      Block<3>{domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Inertial>(
-                   Affine3D{affine_map, affine_map, affine_map}),
-               0,
-               {}},
+      blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 }
 

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -580,8 +580,7 @@ void test_initial_domain(const Domain<VolumeDim>& domain,
   for (const auto& element_id : element_ids) {
     elements.emplace(element_id,
                      domain::Initialization::create_initial_element(
-                         element_id, blocks[element_id.block_id()],
-                         initial_refinement_levels));
+                         element_id, blocks, initial_refinement_levels));
   }
   domain::test_domain_connectivity(domain, elements);
   domain::test_refinement_levels_of_neighbors<1>(elements);

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -285,9 +285,8 @@ struct InitializeElement {
     const auto& initial_extents = db::get<domain::Tags::InitialExtents<1>>(box);
     const auto& initial_refinement =
         db::get<domain::Tags::InitialRefinementLevels<1>>(box);
-    const auto& block = domain.blocks()[element_id.block_id()];
     auto element = domain::Initialization::create_initial_element(
-        element_id, block, initial_refinement);
+        element_id, domain.blocks(), initial_refinement);
     auto mesh = domain::Initialization::create_initial_mesh(
         initial_extents, element,
         Parallel::get<elliptic::dg::Tags::Quadrature>(cache));

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
@@ -67,9 +67,9 @@ void test_infinite_surface_integral(const double distance, const double mass,
     }
 
     // Get element information
-    const auto& current_block = blocks.at(element_id.block_id());
     const auto current_element = domain::Initialization::create_initial_element(
-        element_id, current_block, initial_ref_levels);
+        element_id, blocks, initial_ref_levels);
+    const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
 
@@ -187,9 +187,9 @@ void test_infinite_volume_integral(const double distance, const double mass,
   // Compute integrals by summing over each element
   for (const auto& element_id : element_ids) {
     // Get element information
-    const auto& current_block = blocks.at(element_id.block_id());
     const auto current_element = domain::Initialization::create_initial_element(
-        element_id, current_block, initial_ref_levels);
+        element_id, blocks, initial_ref_levels);
+    const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
 

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
@@ -74,9 +74,9 @@ void test_infinite_surface_integrals(const double distance, const double mass,
     }
 
     // Get element information
-    const auto& current_block = blocks.at(element_id.block_id());
     const auto current_element = domain::Initialization::create_initial_element(
-        element_id, current_block, initial_ref_levels);
+        element_id, blocks, initial_ref_levels);
+    const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
 
@@ -211,9 +211,9 @@ void test_infinite_volume_integral(const double distance, const double mass,
   // Compute integrals by summing over each element
   for (const auto& element_id : element_ids) {
     // Get element information
-    const auto& current_block = blocks.at(element_id.block_id());
     const auto current_element = domain::Initialization::create_initial_element(
-        element_id, current_block, initial_ref_levels);
+        element_id, blocks, initial_ref_levels);
+    const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
 

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
@@ -79,9 +79,9 @@ void test_infinite_surface_integral(const double distance,
     }
 
     // Get element information
-    const auto& current_block = blocks.at(element_id.block_id());
     const auto current_element = domain::Initialization::create_initial_element(
-        element_id, current_block, initial_ref_levels);
+        element_id, blocks, initial_ref_levels);
+    const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
 
@@ -167,9 +167,9 @@ void test_infinite_volume_integral(const double distance,
   // Compute integrals by summing over each element
   for (const auto& element_id : element_ids) {
     // Get element information
-    const auto& current_block = blocks.at(element_id.block_id());
     const auto current_element = domain::Initialization::create_initial_element(
-        element_id, current_block, initial_ref_levels);
+        element_id, blocks, initial_ref_levels);
+    const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
 


### PR DESCRIPTION
## Proposed changes

New logic is needed to determine the neighbors of an Element on the boundary of a Block if the Blocks of a Domain are non-conforming (i.e. the block logical coordinates on the interface of neighboring blocks are not related by a discrete rotation).

For an S2 boundary topology next to multiple wedges of a cubed sphere (which have boundary topology I1 x I1) there is no one-to-one mapping between the logical axes on the interface.  (There is a one-to-one mapping for the logical axis normal to the interface.)  In such a case the OrientationMap will use `Direction<Dim>::self()` as the angular mapped direction.

I do not allow arbitrary non-conforming Blocks.  It is a requirement that neighboring Blocks be conforming if their oriented topologies are the same in the interface dimensions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
