### PR TITLE
Add a minimum temperature option in Ideal Fluid

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
@@ -12,8 +12,9 @@
 
 namespace EquationsOfState {
 template <bool IsRelativistic>
-IdealFluid<IsRelativistic>::IdealFluid(const double adiabatic_index)
-    : adiabatic_index_(adiabatic_index) {}
+IdealFluid<IsRelativistic>::IdealFluid(const double adiabatic_index,
+                                       const double min_temperature)
+    : adiabatic_index_(adiabatic_index), min_temperature_(min_temperature) {}
 
 EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
                                      IdealFluid<IsRelativistic>, double, 2)
@@ -44,7 +45,8 @@ bool IdealFluid<IsRelativistic>::is_equal(
 template <bool IsRelativistic>
 bool IdealFluid<IsRelativistic>::operator==(
     const IdealFluid<IsRelativistic>& rhs) const {
-  return adiabatic_index_ == rhs.adiabatic_index_;
+  return (adiabatic_index_ == rhs.adiabatic_index_) and
+         (min_temperature_ == rhs.min_temperature_);
 }
 
 template <bool IsRelativistic>
@@ -61,6 +63,7 @@ template <bool IsRelativistic>
 void IdealFluid<IsRelativistic>::pup(PUP::er& p) {
   EquationOfState<IsRelativistic, 2>::pup(p);
   p | adiabatic_index_;
+  p | min_temperature_;
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -55,15 +55,23 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
     static constexpr Options::String help = {"Adiabatic index gamma"};
   };
 
+  struct MinTemperature {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "Minimum temperature. "
+        "This value must be non-negative."};
+  };
+
   static constexpr Options::String help = {
       "An ideal fluid equation of state.\n"
       "The pressure is related to the rest mass density by p = rho * epsilon * "
       "(gamma - 1), where p is the pressure, rho is the rest mass density, "
       "epsilon is the specific internal energy, and gamma is the adiabatic "
       "index.\n"
-      "The temperature T is defined as T=epsilon."};
+      "The temperature T is defined as T=(gamma-1) * epsilon."};
 
-  using options = tmpl::list<AdiabaticIndex>;
+  using options = tmpl::list<AdiabaticIndex, MinTemperature>;
 
   IdealFluid() = default;
   IdealFluid(const IdealFluid&) = default;
@@ -72,7 +80,7 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
   IdealFluid& operator=(IdealFluid&&) = default;
   ~IdealFluid() override = default;
 
-  explicit IdealFluid(double adiabatic_index);
+  explicit IdealFluid(double adiabatic_index, double min_temperature = 0.0);
 
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(IdealFluid, 2)
 
@@ -104,9 +112,11 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
 
   /// The lower bound of the specific internal energy that is valid for this EOS
   /// at the given rest mass density \f$\rho\f$
+  /// If non-zero lower bound for temperature is provided, then the lower bound
+  /// for specific internal energy is also non-zero accordingly.
   double specific_internal_energy_lower_bound(
       const double /* rest_mass_density */) const override {
-    return 0.0;
+    return (min_temperature_) / (adiabatic_index_ - 1.0);
   }
 
   /// The upper bound of the specific internal energy that is valid for this EOS
@@ -115,9 +125,19 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
       double rest_mass_density) const override;
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
+  /// If non-zero lower bound for temperature is provided, then the lower bound
+  /// for specific internal enthalpy is also non-zero accordingly.
   double specific_enthalpy_lower_bound() const override {
-    return IsRelativistic ? 1.0 : 0.0;
+    return IsRelativistic ? 1.0 + (adiabatic_index_ * min_temperature_) /
+                                      (adiabatic_index_ - 1.0)
+                          : (adiabatic_index_ * min_temperature_) /
+                                (adiabatic_index_ - 1.0);
   }
+
+  /// The lower bound of the temperature that is valid for this EOS.
+  /// Non-zero lower bound could be set to impose floor on the specific
+  /// internal energy.
+  double temperature_lower_bound() const override { return min_temperature_; }
 
   /// The vacuum baryon mass for this EoS
   double baryon_mass() const override {
@@ -128,6 +148,7 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
 
   double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  double min_temperature_ = std::numeric_limits<double>::signaling_NaN();
 };
 
 /// \cond

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -25,6 +25,7 @@ PhaseChangeAndTriggers:
 EquationOfState:
   IdealFluid:
     AdiabaticIndex: 1.4
+    MinTemperature: 0.0
 
 InitialData: &InitialData
   RiemannProblem:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -25,6 +25,7 @@ PhaseChangeAndTriggers:
 EquationOfState:
   IdealFluid:
     AdiabaticIndex: 1.4
+    MinTemperature: 0.0
 
 InitialData: &InitialData
   RiemannProblem:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -25,6 +25,7 @@ PhaseChangeAndTriggers:
 EquationOfState:
   IdealFluid:
     AdiabaticIndex: 1.4
+    MinTemperature: 0.0
 
 InitialData: &InitialData
   RiemannProblem:

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
@@ -27,7 +27,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Equilibrium3D",
   const double ideal_adiabatic_index = 2.0;
   const double cold_polytropic_index = 2.0;
   const EoS::PolytropicFluid<true> cold_eos{100.0, cold_polytropic_index};
-  const EoS::IdealFluid<true> eos_ideal_fluid{ideal_adiabatic_index};
+  const EoS::IdealFluid<true> eos_ideal_fluid{ideal_adiabatic_index, 0.0};
 
   EoS::Equilibrium3D<EoS::IdealFluid<true>> eos_ideal_fluid_3d{eos_ideal_fluid};
   const EoS::HybridEos<EoS::PolytropicFluid<true>> underlying_eos{

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -43,15 +43,33 @@ void check_dominant_energy_condition_at_bound() {
   CHECK(approx(pressure) == energy_density);
 }
 
-template <bool IsRelativistic>
+template <bool IsRelativistic, bool NonZeroMinTemp>
 void check_bounds() {
-  const auto eos = EquationsOfState::IdealFluid<IsRelativistic>{1.5};
+  auto min_temperature = 0.0;
+  if constexpr (NonZeroMinTemp) {
+    const auto seed = std::random_device{}();
+    MAKE_GENERATOR(generator, seed);
+    CAPTURE(seed);
+    auto distribution = std::uniform_real_distribution<>{1.e-15, 1.e-5};
+    min_temperature = distribution(generator);
+  }
+
+  const auto adiabatic_index = 1.5;
+  const auto eos = EquationsOfState::IdealFluid<IsRelativistic>{
+      adiabatic_index, min_temperature};
+  CAPTURE(adiabatic_index);
+  CAPTURE(min_temperature);
+
   CHECK(0.0 == eos.rest_mass_density_lower_bound());
-  CHECK(0.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(min_temperature == eos.temperature_lower_bound());
+  CHECK(min_temperature / (adiabatic_index - 1) ==
+        eos.specific_internal_energy_lower_bound(1.0));
   if constexpr (IsRelativistic) {
-    CHECK(1.0 == eos.specific_enthalpy_lower_bound());
+    CHECK(1.0 + (adiabatic_index * min_temperature) / (adiabatic_index - 1.0) ==
+          eos.specific_enthalpy_lower_bound());
   } else {
-    CHECK(0.0 == eos.specific_enthalpy_lower_bound());
+    CHECK((adiabatic_index * min_temperature) / (adiabatic_index - 1.0) ==
+          eos.specific_enthalpy_lower_bound());
   }
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
@@ -59,7 +77,6 @@ void check_bounds() {
   CHECK(eos.baryon_mass() ==
         approx(hydro::units::geometric::default_baryon_mass));
 }
-
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
@@ -101,29 +118,35 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"IdealFluid:\n"
-           "  AdiabaticIndex: 1.6666666666666667\n"}),
+           "  AdiabaticIndex: 1.6666666666666667\n"
+           "  MinTemperature: 0.0\n"}),
       "IdealFluid", "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"IdealFluid:\n"
-           "  AdiabaticIndex: 1.3333333333333333\n"}),
+           "  AdiabaticIndex: 1.3333333333333333\n"
+           "  MinTemperature: 0.0\n"}),
       "IdealFluid", "ideal_fluid", dv_for_size, 4.0 / 3.0);
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<false, 2>>>(
           {"IdealFluid:\n"
-           "  AdiabaticIndex: 1.6666666666666667\n"}),
+           "  AdiabaticIndex: 1.6666666666666667\n"
+           "  MinTemperature: 0.0\n"}),
       "IdealFluid", "ideal_fluid", d_for_size, 5.0 / 3.0);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<false, 2>>>(
           {"IdealFluid:\n"
-           "  AdiabaticIndex: 1.3333333333333333\n"}),
+           "  AdiabaticIndex: 1.3333333333333333\n"
+           "  MinTemperature: 0.0\n"}),
       "IdealFluid", "ideal_fluid", dv_for_size, 4.0 / 3.0);
 
-  check_bounds<true>();
-  check_bounds<false>();
+  check_bounds<true, true>();
+  check_bounds<true, false>();
+  check_bounds<false, true>();
+  check_bounds<false, false>();
   check_dominant_energy_condition_at_bound();
 }


### PR DESCRIPTION
## Proposed changes

Add a minimum temperature option for the Ideal Fluid equation of state.
The lower bound of specific internal energy is currently determined from the lower bound of temperature, which defaults to 0 for the ideal fluid equation of state. This new option provides a simple way of enforcing a nonzero lower bound on the specific internal energy. 
For those who prefer the default lower bound on temperature, MinTemperature can be set to 0.0 in the input file. Additionally, using the single-argument constructor will set the minimum temperature to its default value of 0.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
