### PR TITLE
Modify the initial setup of Fishbone-Moncrief Disk

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -43,7 +43,10 @@ FishboneMoncriefDisk::FishboneMoncriefDisk(const double bh_mass,
       noise_(noise),
       equation_of_state_{polytropic_constant_, polytropic_exponent_},
       background_spacetime_{
-          bh_mass_, {{0.0, 0.0, bh_dimless_spin}}, {{0.0, 0.0, 0.0}}} {
+          bh_mass_, {{0.0, 0.0, bh_dimless_spin}}, {{0.0, 0.0, 0.0}}},
+      background_pressure_(background_density_ * background_temperature_),
+      background_specific_internal_energy_(background_temperature_ /
+                                           (polytropic_exponent_ - 1.)) {
   const double sqrt_m = sqrt(bh_mass_);
   const double a_sqrt_m = bh_spin_a_ * sqrt_m;
   const double& rmax = max_pressure_radius_;
@@ -82,6 +85,10 @@ void FishboneMoncriefDisk::pup(PUP::er& p) {
   p | noise_;
   p | equation_of_state_;
   p | background_spacetime_;
+  p | background_density_;
+  p | background_temperature_;
+  p | background_pressure_;
+  p | background_specific_internal_energy_;
 }
 // Sigma in Fishbone&Moncrief eqn (3.5)
 template <typename DataType>
@@ -148,13 +155,16 @@ FishboneMoncriefDisk::variables(
   const auto specific_enthalpy =
       get<hydro::Tags::SpecificEnthalpy<DataType>>(variables(
           x, tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>>{}, vars));
-  auto rest_mass_density = make_with_value<Scalar<DataType>>(x, 0.0);
+  auto rest_mass_density =
+      make_with_value<Scalar<DataType>>(x, background_density_);
   variables_impl(vars, [&rest_mass_density, &specific_enthalpy, this](
                            const size_t s, const double /*potential_at_s*/) {
+    using std::max;
     get_element(get(rest_mass_density), s) =
-        (1 / rho_max_) *
-        get(equation_of_state_.rest_mass_density_from_enthalpy(
-            Scalar<double>{get_element(get(specific_enthalpy), s)}));
+        max((1 / rho_max_) *
+                get(equation_of_state_.rest_mass_density_from_enthalpy(
+                    Scalar<double>{get_element(get(specific_enthalpy), s)})),
+            background_density_);
   });
   return {std::move(rest_mass_density)};
 }
@@ -201,13 +211,15 @@ FishboneMoncriefDisk::variables(
   std::uniform_real_distribution<> dis(-noise_, noise_);
   const auto rest_mass_density = get<hydro::Tags::RestMassDensity<DataType>>(
       variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{}, vars));
-  auto pressure = make_with_value<Scalar<DataType>>(x, 0.0);
+  auto pressure = make_with_value<Scalar<DataType>>(x, background_pressure_);
   variables_impl(vars, [&pressure, &rest_mass_density, &gen, &dis, this](
                            const size_t s, const double /*potential_at_s*/) {
+    using std::max;
     get_element(get(pressure), s) =
-        (1 / rho_max_) * (1 + dis(gen)) *
-        get(equation_of_state_.pressure_from_density(
-            Scalar<double>{rho_max_ * get_element(get(rest_mass_density), s)}));
+        max((1 / rho_max_) * (1 + dis(gen)) *
+                get(equation_of_state_.pressure_from_density(Scalar<double>{
+                    rho_max_ * get_element(get(rest_mass_density), s)})),
+            background_pressure_);
   });
   return {std::move(pressure)};
 }
@@ -220,12 +232,15 @@ FishboneMoncriefDisk::variables(
     gsl::not_null<IntermediateVariables<DataType>*> vars) const {
   const auto rest_mass_density = get<hydro::Tags::RestMassDensity<DataType>>(
       variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{}, vars));
-  auto specific_internal_energy = make_with_value<Scalar<DataType>>(x, 0.0);
+  auto specific_internal_energy = make_with_value<Scalar<DataType>>(
+      x, background_specific_internal_energy_);
   variables_impl(vars, [&specific_internal_energy, &rest_mass_density, this](
                            const size_t s, const double /*potential_at_s*/) {
-    get_element(get(specific_internal_energy), s) =
+    using std::max;
+    get_element(get(specific_internal_energy), s) = max(
         get(equation_of_state_.specific_internal_energy_from_density(
-            Scalar<double>{rho_max_ * get_element(get(rest_mass_density), s)}));
+            Scalar<double>{rho_max_ * get_element(get(rest_mass_density), s)})),
+        background_specific_internal_energy_);
   });
   return {std::move(specific_internal_energy)};
 }
@@ -240,12 +255,15 @@ FishboneMoncriefDisk::variables(
       get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
           x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{},
           vars));
-  auto temperature = make_with_value<Scalar<DataType>>(x, 0.0);
+  auto temperature =
+      make_with_value<Scalar<DataType>>(x, background_temperature_);
   variables_impl(vars, [&temperature, &specific_internal_energy, this](
                            const size_t s, const double /*potential_at_s*/) {
+    using std::max;
     get_element(get(temperature), s) =
-        (polytropic_exponent_ - 1.0) *
-        get_element(get(specific_internal_energy), s);
+        max((polytropic_exponent_ - 1.0) *
+                get_element(get(specific_internal_energy), s),
+            background_temperature_);
   });
   return {std::move(temperature)};
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -236,15 +236,16 @@ FishboneMoncriefDisk::variables(
     const tnsr::I<DataType, 3>& x,
     tmpl::list<hydro::Tags::Temperature<DataType>> /*meta*/,
     gsl::not_null<IntermediateVariables<DataType>*> vars) const {
-  const auto rest_mass_density = get<hydro::Tags::RestMassDensity<DataType>>(
-      variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{}, vars));
-
+  const auto specific_internal_energy =
+      get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
+          x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{},
+          vars));
   auto temperature = make_with_value<Scalar<DataType>>(x, 0.0);
-  variables_impl(vars, [&temperature, &rest_mass_density, this](
+  variables_impl(vars, [&temperature, &specific_internal_energy, this](
                            const size_t s, const double /*potential_at_s*/) {
     get_element(get(temperature), s) =
-        get(equation_of_state_.temperature_from_density(
-            Scalar<double>{get_element(get(rest_mass_density), s)}));
+        (polytropic_exponent_ - 1.0) *
+        get_element(get(specific_internal_energy), s);
   });
   return {std::move(temperature)};
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -428,6 +428,24 @@ class FishboneMoncriefDisk
   double noise_ = std::numeric_limits<double>::signaling_NaN();
   EquationsOfState::PolytropicFluid<true> equation_of_state_{};
   gr::Solutions::SphericalKerrSchild background_spacetime_{};
+
+  // Many of the codes on the EHT Code Comparison Project use flooring with
+  // density and pressure. However, in SpECTRE, floorings are applied on
+  // density and temperature.
+  // Previously, the background values outside of the torus were initialized
+  // to 0 and then subsequently modified based on the atmosphere treatment
+  // and flooring options.
+  // However, this meant that we need to apply higher than desired flooring
+  // level on temperature or density in order to match the radial
+  // profile of the pressure as used in the EHT Code Comparison project.
+  // Thus, we instead initialize the background values that most closely
+  // matches the radial profiles of EHT Code Comparison Project initial data
+  // without introducing any weird kinks.
+  double background_density_ = 1.e-7;
+  double background_temperature_ = 2.e-5;
+  double background_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double background_specific_internal_energy_ =
+      std::numeric_limits<double>::signaling_NaN();
 };
 
 bool operator!=(const FishboneMoncriefDisk& lhs,

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.py
@@ -3,6 +3,14 @@
 
 import numpy as np
 
+"""
+Background values (for density, temperature)
+For more details, check the the comments on the background_*
+member variables in FishboneMoncriefDisk.hpp.
+"""
+background_density_ = 1.0e-7
+background_temperature_ = 2.0e-5
+
 
 def rho_max(
     bh_mass,
@@ -262,24 +270,28 @@ def rest_mass_density(
         polytropic_constant,
         polytropic_exponent,
     )
-    return (1 / rho_max_) * np.power(
-        (polytropic_exponent - 1.0)
-        * (
-            specific_enthalpy(
-                x,
-                t,
-                bh_mass,
-                bh_dimless_a,
-                dimless_r_in,
-                dimless_r_max,
-                polytropic_constant,
-                polytropic_exponent,
-                noise,
+    return max(
+        (1 / rho_max_)
+        * np.power(
+            (polytropic_exponent - 1.0)
+            * (
+                specific_enthalpy(
+                    x,
+                    t,
+                    bh_mass,
+                    bh_dimless_a,
+                    dimless_r_in,
+                    dimless_r_max,
+                    polytropic_constant,
+                    polytropic_exponent,
+                    noise,
+                )
+                - 1.0
             )
-            - 1.0
-        )
-        / (polytropic_exponent * polytropic_constant),
-        1.0 / (polytropic_exponent - 1.0),
+            / (polytropic_exponent * polytropic_constant),
+            1.0 / (polytropic_exponent - 1.0),
+        ),
+        background_density_,
     )
 
 
@@ -302,7 +314,7 @@ def specific_internal_energy(
         polytropic_constant,
         polytropic_exponent,
     )
-    return (
+    return max(
         polytropic_constant
         * np.power(
             rho_max_
@@ -319,7 +331,8 @@ def specific_internal_energy(
             ),
             polytropic_exponent - 1.0,
         )
-        / (polytropic_exponent - 1.0)
+        / (polytropic_exponent - 1.0),
+        background_temperature_ / (polytropic_exponent - 1.0),
     )
 
 
@@ -342,7 +355,7 @@ def pressure(
         polytropic_constant,
         polytropic_exponent,
     )
-    return (
+    return max(
         (1 / rho_max_)
         * polytropic_constant
         * np.power(
@@ -359,7 +372,8 @@ def pressure(
                 noise,
             ),
             polytropic_exponent,
-        )
+        ),
+        background_density_ * background_temperature_,
     )
 
 


### PR DESCRIPTION
## Proposed changes
1. Change the temperature setup to match EHT Code Comparison Project results.
2. Set the background values (outside of torus) such that they most closely match the radial profile in EHT Code Comparison Project results.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
