### PR TITLE
Exporter: add PointwiseInterpolator, interpolation in grid frame

### DIFF
--- a/src/IO/Exporter/Exporter.cpp
+++ b/src/IO/Exporter/Exporter.cpp
@@ -15,7 +15,7 @@ std::vector<std::vector<double>> interpolate_to_points(
     const std::string& subfile_name, const ObservationVariant& observation,
     const std::vector<std::string>& tensor_components,
     const std::array<std::vector<double>, Dim>& target_points,
-    const bool extrapolate_into_excisions,
+    const bool extrapolate_into_excisions, const bool error_on_missing_points,
     const std::optional<size_t> num_threads) {
   tnsr::I<DataVector, Dim, Frame::Inertial> target_points_dv{};
   for (size_t d = 0; d < Dim; ++d) {
@@ -28,7 +28,7 @@ std::vector<std::vector<double>> interpolate_to_points(
   interpolate_to_points(make_not_null(&result), volume_files_or_glob,
                         subfile_name, observation, tensor_components,
                         target_points_dv, extrapolate_into_excisions,
-                        num_threads);
+                        error_on_missing_points, num_threads);
   return result;
 }
 
@@ -43,7 +43,8 @@ std::vector<std::vector<double>> interpolate_to_points(
       const std::string& subfile_name, const ObservationVariant& observation, \
       const std::vector<std::string>& tensor_components,                      \
       const std::array<std::vector<double>, DIM(data)>& target_points,        \
-      bool extrapolate_into_excisions, std::optional<size_t> num_threads);
+      bool extrapolate_into_excisions, bool error_on_missing_points,          \
+      std::optional<size_t> num_threads);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/IO/Exporter/Exporter.hpp
+++ b/src/IO/Exporter/Exporter.hpp
@@ -58,6 +58,9 @@ using ObservationVariant = std::variant<ObservationId, ObservationStep, double>;
  * grid frame (where the excision is spherical), then map the anchor points to
  * the distorted frame (where we have the target point) and do a 7th order
  * polynomial extrapolation into the excision region.
+ * \param error_on_missing_points If `true`, an error will be thrown if any of
+ * the target points are outside the domain. If `false`, the result will be
+ * filled with NaNs for points outside the domain (default is `false`).
  * \param num_threads The number of threads to use if OpenMP is linked in. If
  * not specified, OpenMP will determine the number of threads automatically.
  * It's also possible to set the number of threads using the environment
@@ -75,6 +78,7 @@ std::vector<std::vector<double>> interpolate_to_points(
     const std::vector<std::string>& tensor_components,
     const std::array<std::vector<double>, Dim>& target_points,
     bool extrapolate_into_excisions = false,
+    bool error_on_missing_points = false,
     std::optional<size_t> num_threads = std::nullopt);
 
 }  // namespace spectre::Exporter

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -395,10 +395,11 @@ auto parse_volume_files(const std::variant<std::vector<std::string>,
                          std::move(domain), std::move(time_and_fot.second));
 }
 
-template <typename DataType, size_t Dim>
+template <typename DataType, size_t Dim, typename Frame>
 auto block_logical_coordinates(
-    const tnsr::I<DataType, Dim>& target_points, const Domain<Dim>& domain,
-    const double time, const domain::FunctionsOfTimeMap& functions_of_time,
+    const tnsr::I<DataType, Dim, Frame>& target_points,
+    const Domain<Dim>& domain, const double time,
+    const domain::FunctionsOfTimeMap& functions_of_time,
     const bool extrapolate_into_excisions,
     [[maybe_unused]] const size_t resolved_num_threads) {
   const size_t num_target_points = get_size(get<0>(target_points));
@@ -410,13 +411,20 @@ auto block_logical_coordinates(
   // added to the `block_logical_coords` and additional information is collected
   // in `extrapolation_info` for later extrapolation.
   constexpr size_t num_extrapolation_anchors = 8;
-  const double extrapolation_spacing = 0.3;
+  [[maybe_unused]] const double extrapolation_spacing = 0.3;
   std::vector<ExtrapolationInfo<num_extrapolation_anchors>>
       extrapolation_info{};
+  if constexpr (not std::is_same_v<Frame, ::Frame::Inertial>) {
+    if (extrapolate_into_excisions) {
+      ERROR(
+          "Extrapolation into excisions is only supported in the inertial "
+          "frame at the moment.");
+    }
+  }
 #pragma omp parallel num_threads(resolved_num_threads)
   {
     // Set up thread-local variables
-    tnsr::I<double, Dim, Frame::Inertial> target_point{};
+    tnsr::I<double, Dim, Frame> target_point{};
     std::vector<BlockLogicalCoords<Dim>> extra_block_logical_coords{};
     std::vector<ExtrapolationInfo<num_extrapolation_anchors>>
         extra_extrapolation_info{};
@@ -439,14 +447,16 @@ auto block_logical_coordinates(
       }
       // The point wasn't found in any block. Check if it's in an excision and
       // set up extrapolation if requested.
-      for (const auto& [name, excision_sphere] : domain.excision_spheres()) {
-        if (add_extrapolation_anchors(
-                make_not_null(&extra_block_logical_coords),
-                make_not_null(&extra_extrapolation_info), excision_sphere,
-                domain, target_point, time, functions_of_time,
-                extrapolation_spacing)) {
-          extra_extrapolation_info.back().target_index = s;
-          break;
+      if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
+        for (const auto& [name, excision_sphere] : domain.excision_spheres()) {
+          if (add_extrapolation_anchors(
+                  make_not_null(&extra_block_logical_coords),
+                  make_not_null(&extra_extrapolation_info), excision_sphere,
+                  domain, target_point, time, functions_of_time,
+                  extrapolation_spacing)) {
+            extra_extrapolation_info.back().target_index = s;
+            break;
+          }
         }
       }
     }  // omp for target points
@@ -473,14 +483,14 @@ auto block_logical_coordinates(
 
 }  // namespace
 
-template <typename ResultDataType, size_t Dim>
+template <typename ResultDataType, size_t Dim, typename Frame>
 void interpolate_to_points(
     const gsl::not_null<std::vector<ResultDataType>*> result,
     const std::variant<std::vector<std::string>, std::string>&
         volume_files_or_glob,
     const std::string& subfile_name, const ObservationVariant& observation,
     const std::vector<std::string>& tensor_components,
-    const tnsr::I<DataVector, Dim>& target_points,
+    const tnsr::I<DataVector, Dim, Frame>& target_points,
     const bool extrapolate_into_excisions,
     const std::optional<size_t> num_threads) {
   const size_t num_target_points = get<0>(target_points).size();
@@ -562,23 +572,25 @@ void interpolate_to_points(
 // Generate instantiations
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
 
 #define INSTANTIATE(_, data)                                                  \
-  template void interpolate_to_points<DTYPE(data), DIM(data)>(                \
+  template void interpolate_to_points<DTYPE(data), DIM(data), FRAME(data)>(   \
       gsl::not_null<std::vector<DTYPE(data)>*> result,                        \
       const std::variant<std::vector<std::string>, std::string>&              \
           volume_files_or_glob,                                               \
       const std::string& subfile_name, const ObservationVariant& observation, \
       const std::vector<std::string>& tensor_components,                      \
-      const tnsr::I<DataVector, DIM(data)>& target_points,                    \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& target_points,       \
       bool extrapolate_into_excisions, std::optional<size_t> num_threads);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
                         (DataVector, std::vector<double>))
 
 #undef INSTANTIATE
 #undef DIM
+#undef FRAME
 #undef DTYPE
 
 }  // namespace spectre::Exporter

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -400,7 +400,7 @@ auto block_logical_coordinates(
     const tnsr::I<DataType, Dim, Frame>& target_points,
     const Domain<Dim>& domain, const double time,
     const domain::FunctionsOfTimeMap& functions_of_time,
-    const bool extrapolate_into_excisions,
+    const bool extrapolate_into_excisions, const bool error_on_missing_points,
     [[maybe_unused]] const size_t resolved_num_threads) {
   const size_t num_target_points = get_size(get<0>(target_points));
   // Look up block logical coordinates for all target points by mapping them
@@ -441,13 +441,22 @@ auto block_logical_coordinates(
       block_logical_coords[s] = block_logical_coordinates_single_point(
           target_point, domain, time, functions_of_time,
           make_not_null(&block_order));
-      if (block_logical_coords[s].has_value() or
-          not extrapolate_into_excisions) {
+      if (block_logical_coords[s].has_value()) {
         continue;
+      }
+      if (not extrapolate_into_excisions) {
+        // The point wasn't found in any block and we're not extrapolating.
+        // Check if we should throw an error or just skip this point.
+        if (error_on_missing_points) {
+          ERROR("Point is not in any block:\n" << target_point);
+        } else {
+          continue;
+        }
       }
       // The point wasn't found in any block. Check if it's in an excision and
       // set up extrapolation if requested.
       if constexpr (std::is_same_v<Frame, ::Frame::Inertial>) {
+        bool found_in_excision = false;
         for (const auto& [name, excision_sphere] : domain.excision_spheres()) {
           if (add_extrapolation_anchors(
                   make_not_null(&extra_block_logical_coords),
@@ -455,8 +464,12 @@ auto block_logical_coordinates(
                   domain, target_point, time, functions_of_time,
                   extrapolation_spacing)) {
             extra_extrapolation_info.back().target_index = s;
+            found_in_excision = true;
             break;
           }
+        }
+        if (not found_in_excision and error_on_missing_points) {
+          ERROR("Point is not in any block or excision:\n" << target_point);
         }
       }
     }  // omp for target points
@@ -491,7 +504,7 @@ void interpolate_to_points(
     const std::string& subfile_name, const ObservationVariant& observation,
     const std::vector<std::string>& tensor_components,
     const tnsr::I<DataVector, Dim, Frame>& target_points,
-    const bool extrapolate_into_excisions,
+    const bool extrapolate_into_excisions, const bool error_on_missing_points,
     const std::optional<size_t> num_threads) {
   const size_t num_target_points = get<0>(target_points).size();
   const auto [filenames, obs_id, time, domain, functions_of_time] =
@@ -502,7 +515,7 @@ void interpolate_to_points(
   const auto [block_logical_coords, extrapolation_info] =
       block_logical_coordinates(target_points, domain, time, functions_of_time,
                                 extrapolate_into_excisions,
-                                resolved_num_threads);
+                                error_on_missing_points, resolved_num_threads);
   const size_t num_interpolation_points = block_logical_coords.size();
 
   // Allocate memory for result
@@ -583,7 +596,8 @@ void interpolate_to_points(
       const std::string& subfile_name, const ObservationVariant& observation, \
       const std::vector<std::string>& tensor_components,                      \
       const tnsr::I<DataVector, DIM(data), FRAME(data)>& target_points,       \
-      bool extrapolate_into_excisions, std::optional<size_t> num_threads);
+      bool extrapolate_into_excisions, bool error_on_missing_points,          \
+      std::optional<size_t> num_threads);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
                         (DataVector, std::vector<double>))

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -149,6 +149,23 @@ void interpolate_to_points_impl(
   }  // omp parallel
 }
 
+template <size_t Dim>
+void interpolate_to_point_impl(
+    const gsl::not_null<std::vector<double>*> result,
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& x_element_logical,
+    const Mesh<Dim>& mesh, const size_t offset, const size_t length,
+    const std::vector<DataVector>& tensor_data) {
+  const intrp::Irregular<Dim> interpolant(mesh, x_element_logical);
+  const size_t num_components = tensor_data.size();
+  result->resize(num_components);
+  for (size_t i = 0; i < num_components; ++i) {
+    auto output_data = gsl::make_span(&(*result)[i], 1);
+    const auto input_data =
+        gsl::make_span(tensor_data[i].data() + offset, length);
+    interpolant.interpolate(make_not_null(&output_data), input_data);
+  }
+}
+
 // Data structure for extrapolation of tensor components into excisions
 template <size_t NumExtrapolationAnchors>
 struct ExtrapolationInfo {
@@ -582,6 +599,136 @@ void interpolate_to_points(
   }
 }
 
+template <size_t Dim, typename Frame>
+PointwiseInterpolator<Dim, Frame>::PointwiseInterpolator(
+    const std::variant<std::vector<std::string>, std::string>&
+        volume_files_or_glob,
+    const std::string& subfile_name, const ObservationVariant& observation,
+    const std::vector<std::string>& tensor_components) {
+  auto bindings =
+      parse_volume_files<Dim>(volume_files_or_glob, subfile_name, observation);
+  const auto& filenames = std::get<0>(bindings);
+  obs_id_ = std::get<1>(bindings);
+  time_ = std::get<2>(bindings);
+  domain_ = std::move(std::get<3>(bindings));
+  functions_of_time_ = std::move(std::get<4>(bindings));
+
+  // Load tensor data into memory
+  element_ids_.reserve(filenames.size());
+  meshes_.reserve(filenames.size());
+  tensor_data_.reserve(filenames.size());
+  for (const auto& filename : filenames) {
+    const h5::H5File<h5::AccessType::ReadOnly> h5file(filename);
+    const auto& volfile = h5file.get<h5::VolumeData>(subfile_name);
+    const auto [element_ids, meshes] = load_grids<Dim>(volfile, obs_id_);
+    element_ids_.push_back(std::move(element_ids));
+    meshes_.push_back(std::move(meshes));
+    tensor_data_.push_back(
+        load_tensor_data(volfile, obs_id_, tensor_components));
+    h5file.close();
+  }
+}
+
+template <size_t Dim, typename Frame>
+void PointwiseInterpolator<Dim, Frame>::interpolate_to_points(
+    const gsl::not_null<std::vector<DataVector>*> result,
+    const tnsr::I<DataVector, Dim, Frame>& target_points,
+    const bool extrapolate_into_excisions, const bool error_on_missing_points,
+    const std::optional<size_t> num_threads) const {
+  ASSERT(not tensor_data_.empty(),
+         "PointwiseInterpolator has not been initialized with tensor data.");
+  const size_t resolved_num_threads = resolve_num_threads(num_threads);
+  const size_t num_target_points = get<0>(target_points).size();
+
+  // Map the target points through the domain
+  const auto [block_logical_coords, extrapolation_info] =
+      block_logical_coordinates(target_points, domain_, time_,
+                                functions_of_time_, extrapolate_into_excisions,
+                                error_on_missing_points, resolved_num_threads);
+  const size_t num_interpolation_points = block_logical_coords.size();
+
+  // Allocate memory for result
+  const size_t num_components = tensor_data_.front().size();
+  result->resize(num_components);
+  for (size_t i = 0; i < num_components; ++i) {
+    DataVector& component = (*result)[i];
+    component.destructive_resize(num_interpolation_points);
+    std::fill(component.begin(), component.end(),
+              std::numeric_limits<double>::signaling_NaN());
+  }
+  std::vector<bool> filled_data(num_interpolation_points, false);
+
+  // Process all volume files in serial
+  for (size_t file_id = 0; file_id < element_ids_.size(); ++file_id) {
+    const auto& element_ids = element_ids_[file_id];
+    const auto& meshes = meshes_[file_id];
+    const auto& tensor_data = tensor_data_[file_id];
+
+    // Map the target points to element-logical coordinates. This selects the
+    // subset of target points that are in the volume data file's elements.
+    const auto element_logical_coords =
+        element_logical_coordinates(element_ids, block_logical_coords);
+    if (element_logical_coords.empty()) {
+      continue;
+    }
+
+    // Interpolate the tensor data to the target points
+    interpolate_to_points_impl(result, make_not_null(&filled_data),
+                               element_logical_coords, element_ids, meshes,
+                               tensor_data, resolved_num_threads);
+
+    // Terminate early if all data has been filled
+    if (std::all_of(filled_data.begin(), filled_data.end(),
+                    [](const bool filled) { return filled; })) {
+      break;
+    }
+  }
+
+  if (extrapolate_into_excisions) {
+    extrapolate_into_excisions_impl(result, extrapolation_info,
+                                    resolved_num_threads);
+    // Clear the anchor points from the result
+    for (size_t i = 0; i < result->size(); ++i) {
+      DataVector& component = (*result)[i];
+      component.destructive_resize(num_target_points);
+    }
+  }
+}
+
+template <size_t Dim, typename Frame>
+void PointwiseInterpolator<Dim, Frame>::interpolate_to_point(
+    const gsl::not_null<std::vector<double>*> result,
+    const tnsr::I<double, Dim, Frame>& target_point,
+    const std::optional<gsl::not_null<std::vector<size_t>*>> block_order)
+    const {
+  ASSERT(not tensor_data_.empty(),
+         "PointwiseInterpolator has not been initialized with tensor data.");
+  const auto block_logical_coords = block_logical_coordinates_single_point(
+      target_point, domain_, time_, functions_of_time_, block_order);
+  if (not block_logical_coords.has_value()) {
+    ERROR("Point is not in any block:\n" << target_point);
+  }
+  // Process all volume files in serial
+  for (size_t file_id = 0; file_id < element_ids_.size(); ++file_id) {
+    const auto& element_ids = element_ids_[file_id];
+    const auto& meshes = meshes_[file_id];
+    const auto& tensor_data = tensor_data_[file_id];
+    const auto element_logical_coords =
+        element_logical_coordinates(element_ids, {block_logical_coords});
+    if (element_logical_coords.empty()) {
+      continue;
+    }
+    const auto& element_id = element_logical_coords.begin()->first;
+    const auto& x_element_logical =
+        element_logical_coords.begin()->second.element_logical_coords;
+    const auto& mesh_offset_length = meshes.at(element_id);
+    interpolate_to_point_impl(
+        result, x_element_logical, get<0>(mesh_offset_length),
+        get<1>(mesh_offset_length), get<2>(mesh_offset_length), tensor_data);
+    break;
+  }
+}
+
 // Generate instantiations
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -599,10 +746,16 @@ void interpolate_to_points(
       bool extrapolate_into_excisions, bool error_on_missing_points,          \
       std::optional<size_t> num_threads);
 
+#define INSTANTIATE_CLASSES(_, data) \
+  template class PointwiseInterpolator<DIM(data), FRAME(data)>;
+
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
                         (DataVector, std::vector<double>))
+GENERATE_INSTANTIATIONS(INSTANTIATE_CLASSES, (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial))
 
 #undef INSTANTIATE
+#undef INSTANTIATE_CLASSES
 #undef DIM
 #undef FRAME
 #undef DTYPE

--- a/src/IO/Exporter/PointwiseInterpolator.hpp
+++ b/src/IO/Exporter/PointwiseInterpolator.hpp
@@ -75,6 +75,7 @@ void interpolate_to_points(
     const std::vector<std::string>& tensor_components,
     const tnsr::I<DataVector, Dim, Frame>& target_points,
     bool extrapolate_into_excisions = false,
+    bool error_on_missing_points = false,
     std::optional<size_t> num_threads = std::nullopt);
 
 template <size_t Dim, typename Frame>
@@ -85,11 +86,13 @@ std::vector<DataVector> interpolate_to_points(
     const std::vector<std::string>& tensor_components,
     const tnsr::I<DataVector, Dim, Frame>& target_points,
     bool extrapolate_into_excisions = false,
+    bool error_on_missing_points = false,
     std::optional<size_t> num_threads = std::nullopt) {
   std::vector<DataVector> interpolated_data{};
   interpolate_to_points(make_not_null(&interpolated_data), volume_files_or_glob,
                         subfile_name, observation, tensor_components,
-                        target_points, extrapolate_into_excisions, num_threads);
+                        target_points, extrapolate_into_excisions,
+                        error_on_missing_points, num_threads);
   return interpolated_data;
 }
 
@@ -100,11 +103,12 @@ tuples::tagged_tuple_from_typelist<Tags> interpolate_to_points(
     const std::string& subfile_name, const ObservationVariant& observation,
     const tnsr::I<DataVector, Dim, Frame>& target_points,
     bool extrapolate_into_excisions = false,
+    const bool error_on_missing_points = false,
     std::optional<size_t> num_threads = std::nullopt) {
-  return make_tagged_tuple<Tags>(
-      interpolate_to_points(volume_files_or_glob, subfile_name, observation,
-                            get_tensor_components<Tags>(), target_points,
-                            extrapolate_into_excisions, num_threads));
+  return make_tagged_tuple<Tags>(interpolate_to_points(
+      volume_files_or_glob, subfile_name, observation,
+      get_tensor_components<Tags>(), target_points, extrapolate_into_excisions,
+      error_on_missing_points, num_threads));
 }
 /// @}
 

--- a/src/IO/Exporter/PointwiseInterpolator.hpp
+++ b/src/IO/Exporter/PointwiseInterpolator.hpp
@@ -7,11 +7,13 @@
 #include <cstddef>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Domain.hpp"
 #include "IO/Exporter/Exporter.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -111,5 +113,94 @@ tuples::tagged_tuple_from_typelist<Tags> interpolate_to_points(
       error_on_missing_points, num_threads));
 }
 /// @}
+
+/*!
+ * \brief Interpolates data in volume files to target points by reading the
+ * volume data into memory
+ *
+ * This class reads the volume data at the requested time into memory and can
+ * then interpolate it to any number of target points.
+ *
+ * \par Thread safety
+ * Constructing the `PointwiseInterpolator` on multiple threads at once is not
+ * thread safe (unless HDF5 was built with thread-safety support) because the
+ * constructor opens the H5 files and reads in the data. However, once the data
+ * is loaded, the `interpolate_to_points` and `interpolate_to_point` functions
+ * are thread safe. This means the volume data can be loaded once in a single
+ * thread and then used by multiple threads to interpolate to different points
+ * in parallel.
+ */
+template <size_t Dim, typename Frame = ::Frame::Inertial>
+struct PointwiseInterpolator {
+  PointwiseInterpolator() = default;
+  PointwiseInterpolator(const std::variant<std::vector<std::string>,
+                                           std::string>& volume_files_or_glob,
+                        const std::string& subfile_name,
+                        const ObservationVariant& observation,
+                        const std::vector<std::string>& tensor_components);
+
+  /*!
+   * \brief Interpolate to many points
+   *
+   * \param result the interpolated data at the target points. The outer vector
+   * is the number of components and the inner vector is the number of target
+   * points. Will be resized automatically.
+   * \param target_points the points to interpolate to
+   * \param extrapolate_into_excisions whether to extrapolate into excised
+   * regions
+   * \param error_on_missing_points whether to throw an error if any of the
+   * target points are outside the domain
+   * \param num_threads the number of OpenMP threads to use to parallelize the
+   * interpolation over the target points. If not provided, the default number
+   * of threads will be used.
+   */
+  void interpolate_to_points(
+      gsl::not_null<std::vector<DataVector>*> result,
+      const tnsr::I<DataVector, Dim, Frame>& target_points,
+      bool extrapolate_into_excisions = false,
+      bool error_on_missing_points = false,
+      std::optional<size_t> num_threads = std::nullopt) const;
+
+  /*!
+   * \brief Interpolate to a single point
+   *
+   * This function is thread safe, so the interpolator can be constructed to
+   * load the volume data once and then used by multiple threads to interpolate
+   * to different points in parallel. Note that updating the `block_order` (if
+   * provided) is not thread safe, so each thread should manage a separate
+   * `block_order`.
+   *
+   * \param result the interpolated data at the target point. The vector is over
+   * the number of components. Will be resized automatically.
+   * \param target_point the point to interpolate to
+   * \param block_order an optional priority order to search for the block
+   * containing the target point. Will be updated when the point is found.
+   * See `block_logical_coordinates_single_point` for more details.
+   */
+  void interpolate_to_point(gsl::not_null<std::vector<double>*> result,
+                            const tnsr::I<double, Dim, Frame>& target_point,
+                            std::optional<gsl::not_null<std::vector<size_t>*>>
+                                block_order = std::nullopt) const;
+
+  size_t obs_id() const { return obs_id_; }
+  double time() const { return time_; }
+  const Domain<Dim>& domain() const { return domain_; }
+  const domain::FunctionsOfTimeMap& functions_of_time() const {
+    return functions_of_time_;
+  }
+
+ private:
+  // Loaded from data files
+  size_t obs_id_ = std::numeric_limits<size_t>::max();
+  double time_ = std::numeric_limits<double>::signaling_NaN();
+  Domain<Dim> domain_;
+  domain::FunctionsOfTimeMap functions_of_time_;
+  // Outer vector is the source data file
+  std::vector<std::vector<ElementId<Dim>>> element_ids_;
+  std::vector<
+      std::unordered_map<ElementId<Dim>, std::tuple<Mesh<Dim>, size_t, size_t>>>
+      meshes_;
+  std::vector<std::vector<DataVector>> tensor_data_;
+};
 
 }  // namespace spectre::Exporter

--- a/src/IO/Exporter/PointwiseInterpolator.hpp
+++ b/src/IO/Exporter/PointwiseInterpolator.hpp
@@ -66,24 +66,24 @@ auto make_tagged_tuple(std::vector<DataType> interpolated_data) {
  *
  * \snippet Test_Exporter.cpp interpolate_tensors_to_points_example
  */
-template <typename ResultDataType, size_t Dim>
+template <typename ResultDataType, size_t Dim, typename Frame>
 void interpolate_to_points(
     gsl::not_null<std::vector<ResultDataType>*> result,
     const std::variant<std::vector<std::string>, std::string>&
         volume_files_or_glob,
     const std::string& subfile_name, const ObservationVariant& observation,
     const std::vector<std::string>& tensor_components,
-    const tnsr::I<DataVector, Dim>& target_points,
+    const tnsr::I<DataVector, Dim, Frame>& target_points,
     bool extrapolate_into_excisions = false,
     std::optional<size_t> num_threads = std::nullopt);
 
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 std::vector<DataVector> interpolate_to_points(
     const std::variant<std::vector<std::string>, std::string>&
         volume_files_or_glob,
     const std::string& subfile_name, const ObservationVariant& observation,
     const std::vector<std::string>& tensor_components,
-    const tnsr::I<DataVector, Dim>& target_points,
+    const tnsr::I<DataVector, Dim, Frame>& target_points,
     bool extrapolate_into_excisions = false,
     std::optional<size_t> num_threads = std::nullopt) {
   std::vector<DataVector> interpolated_data{};
@@ -93,12 +93,12 @@ std::vector<DataVector> interpolate_to_points(
   return interpolated_data;
 }
 
-template <typename Tags, size_t Dim>
+template <typename Tags, size_t Dim, typename Frame>
 tuples::tagged_tuple_from_typelist<Tags> interpolate_to_points(
     const std::variant<std::vector<std::string>, std::string>&
         volume_files_or_glob,
     const std::string& subfile_name, const ObservationVariant& observation,
-    const tnsr::I<DataVector, Dim>& target_points,
+    const tnsr::I<DataVector, Dim, Frame>& target_points,
     bool extrapolate_into_excisions = false,
     std::optional<size_t> num_threads = std::nullopt) {
   return make_tagged_tuple<Tags>(

--- a/src/IO/Exporter/Python/Bindings.cpp
+++ b/src/IO/Exporter/Python/Bindings.cpp
@@ -25,15 +25,18 @@ void bind_interpolate_to_points_impl(py::module& m) {
          const std::vector<std::string>& tensor_components,
          const tnsr::I<DataVector, Dim, Frame>& target_points,
          const bool extrapolate_into_excisions,
+         const bool error_on_missing_points,
          const std::optional<size_t>& num_threads) {
         return spectre::Exporter::interpolate_to_points(
             volume_files_or_glob, subfile_name,
             spectre::Exporter::ObservationId{observation_id}, tensor_components,
-            target_points, extrapolate_into_excisions, num_threads);
+            target_points, extrapolate_into_excisions, error_on_missing_points,
+            num_threads);
       },
       py::arg("volume_files_or_glob"), py::arg("subfile_name"),
       py::arg("observation_id"), py::arg("tensor_components"),
       py::arg("target_points"), py::arg("extrapolate_into_excisions") = false,
+      py::arg("error_on_missing_points") = false,
       py::arg("num_threads") = std::nullopt);
 }
 

--- a/src/IO/Exporter/Python/Bindings.cpp
+++ b/src/IO/Exporter/Python/Bindings.cpp
@@ -5,51 +5,47 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "IO/Exporter/Exporter.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "IO/Exporter/PointwiseInterpolator.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MakeArray.hpp"
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
-  enable_segfault_handler();
+namespace {
+
+template <size_t Dim, typename Frame>
+void bind_interpolate_to_points_impl(py::module& m) {
   m.def(
       "interpolate_to_points",
       [](const std::variant<std::vector<std::string>, std::string>&
              volume_files_or_glob,
          const std::string& subfile_name, const size_t observation_id,
          const std::vector<std::string>& tensor_components,
-         std::vector<std::vector<double>> target_points,
-         bool extrapolate_into_excisions,
+         const tnsr::I<DataVector, Dim, Frame>& target_points,
+         const bool extrapolate_into_excisions,
          const std::optional<size_t>& num_threads) {
-        const size_t dim = target_points.size();
-        const spectre::Exporter::ObservationId obs_id{observation_id};
-        if (dim == 1) {
-          return spectre::Exporter::interpolate_to_points(
-              volume_files_or_glob, subfile_name, obs_id, tensor_components,
-              make_array<std::vector<double>, 1>(std::move(target_points)),
-              extrapolate_into_excisions, num_threads);
-        } else if (dim == 2) {
-          return spectre::Exporter::interpolate_to_points(
-              volume_files_or_glob, subfile_name, obs_id, tensor_components,
-              make_array<std::vector<double>, 2>(std::move(target_points)),
-              extrapolate_into_excisions, num_threads);
-        } else if (dim == 3) {
-          return spectre::Exporter::interpolate_to_points(
-              volume_files_or_glob, subfile_name, obs_id, tensor_components,
-              make_array<std::vector<double>, 3>(std::move(target_points)),
-              extrapolate_into_excisions, num_threads);
-        } else {
-          ERROR("Invalid dimension of target points: "
-                << dim
-                << ". Must be 1, 2, or 3. The first dimension of the "
-                   "target points must the spatial dimension of the volume "
-                   "data, and the second dimension is the number of points.");
-        }
+        return spectre::Exporter::interpolate_to_points(
+            volume_files_or_glob, subfile_name,
+            spectre::Exporter::ObservationId{observation_id}, tensor_components,
+            target_points, extrapolate_into_excisions, num_threads);
       },
       py::arg("volume_files_or_glob"), py::arg("subfile_name"),
       py::arg("observation_id"), py::arg("tensor_components"),
       py::arg("target_points"), py::arg("extrapolate_into_excisions") = false,
       py::arg("num_threads") = std::nullopt);
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
+  enable_segfault_handler();
+  py::module_::import("spectre.DataStructures.Tensor");
+  bind_interpolate_to_points_impl<1, Frame::Grid>(m);
+  bind_interpolate_to_points_impl<2, Frame::Grid>(m);
+  bind_interpolate_to_points_impl<3, Frame::Grid>(m);
+  bind_interpolate_to_points_impl<1, Frame::Inertial>(m);
+  bind_interpolate_to_points_impl<2, Frame::Inertial>(m);
+  bind_interpolate_to_points_impl<3, Frame::Inertial>(m);
 }

--- a/src/IO/Exporter/Python/CMakeLists.txt
+++ b/src/IO/Exporter/Python/CMakeLists.txt
@@ -17,8 +17,14 @@ spectre_python_add_module(
 spectre_python_link_libraries(
   ${LIBRARY}
   PRIVATE
+  DataStructures
   ErrorHandling
   Exporter
   pybind11::module
   Utilities
+  )
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyTensor
   )

--- a/src/IO/Exporter/Python/InterpolateToPoints.py
+++ b/src/IO/Exporter/Python/InterpolateToPoints.py
@@ -8,6 +8,7 @@ import numpy as np
 import rich
 
 import spectre.IO.H5 as spectre_h5
+from spectre.DataStructures.Tensor import DataVector, Frame, tnsr
 from spectre.IO.Exporter import interpolate_to_points
 from spectre.Visualization.OpenVolfiles import (
     open_volfiles_command,
@@ -40,6 +41,13 @@ logger = logging.getLogger(__name__)
         "Can be specified multiple times to quickly interpolate "
         "to a couple of target points."
     ),
+)
+@click.option(
+    "--frame",
+    type=click.Choice(Frame.__members__),
+    callback=lambda ctx, param, value: Frame.__members__[value],
+    default=Frame.Inertial.name,
+    help="Frame in which coordinates are specified.",
 )
 @click.option(
     "--extrapolate-into-excisions",
@@ -82,6 +90,7 @@ def interpolate_to_points_command(
     vars,
     target_coords,
     target_coords_file,
+    frame,
     output,
     delimiter,
     **kwargs,
@@ -98,6 +107,7 @@ def interpolate_to_points_command(
             target_coords_file, ndmin=2, delimiter=delimiter
         )
     dim = target_coords.shape[1]
+    target_points = tnsr.I[DataVector, dim, frame](target_coords.T)
 
     # Interpolate!
     interpolated_data = np.array(
@@ -106,7 +116,7 @@ def interpolate_to_points_command(
             subfile_name=subfile_name,
             observation_id=obs_id,
             tensor_components=vars,
-            target_points=target_coords.T,
+            target_points=target_points,
             **kwargs,
         )
     )

--- a/src/Visualization/Python/PlotAlongLine.py
+++ b/src/Visualization/Python/PlotAlongLine.py
@@ -152,7 +152,7 @@ def plot_along_line(
             num_threads=num_threads,
         )
         for y, var_name, line in zip(vars_on_line, vars, lines):
-            line.set_data(x, y)
+            line.set_data(x, np.asarray(y))
         time_label.set_text(f"t = {obs_time:g}")
         ax.relim()
         ax.autoscale_view()

--- a/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
+++ b/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
@@ -10,7 +10,7 @@ import numpy.testing as npt
 from click.testing import CliRunner
 
 from spectre.DataStructures import DataVector
-from spectre.DataStructures.Tensor import Scalar, tnsr
+from spectre.DataStructures.Tensor import Frame, Scalar, tnsr
 from spectre.Informer import unit_test_build_path, unit_test_src_path
 from spectre.IO.Exporter import interpolate_tensors_to_points
 from spectre.IO.Exporter.InterpolateToPoints import (
@@ -37,16 +37,19 @@ class TestInterpolateToPoints(unittest.TestCase):
         obs_id = list_observations(
             open_volfiles([self.h5_filename], "/element_data")
         )[0][0]
-        coords = tnsr.I[DataVector, 3](np.array([3 * [0.0], 3 * [2 * np.pi]]).T)
-        (psi,) = interpolate_tensors_to_points(
-            self.h5_filename,
-            "element_data",
-            observation_id=obs_id,
-            tensor_names=["Psi"],
-            tensor_types=[Scalar[DataVector]],
-            target_points=coords,
-        )
-        self.assertAlmostEqual(psi.get()[0], -0.07059806932542323)
+        for frame in [Frame.Grid, Frame.Inertial]:
+            coords = tnsr.I[DataVector, 3](
+                np.array([3 * [0.0], 3 * [2 * np.pi]]).T
+            )
+            (psi,) = interpolate_tensors_to_points(
+                self.h5_filename,
+                "element_data",
+                observation_id=obs_id,
+                tensor_names=["Psi"],
+                tensor_types=[Scalar[DataVector]],
+                target_points=coords,
+            )
+            self.assertAlmostEqual(psi.get()[0], -0.07059806932542323)
 
     def test_cli(self):
         runner = CliRunner()

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -36,12 +36,8 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
   // Disable OpenMP multithreading since multiple unit tests may run in parallel
   omp_set_num_threads(1);
 #endif
-  {
-    INFO("Bundled volume data files");
-    const auto interpolated_data = interpolate_to_points<3>(
-        unit_test_src_path() + "/Visualization/Python/VolTestData*.h5",
-        "element_data", ObservationStep{0}, {"Psi", "Phi_x", "Phi_y", "Phi_z"},
-        {{{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 0.0}}});
+
+  const auto check_scalar_data = [](const auto& interpolated_data) {
     const auto& psi = interpolated_data[0];
     CHECK(psi[0] == approx(-0.07059806932542323));
     CHECK(psi[1] == approx(0.7869554122196492));
@@ -50,6 +46,15 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
     CHECK(phi_y[0] == approx(1.0569673471948728));
     CHECK(phi_y[1] == approx(0.6741524090220188));
     CHECK(phi_y[2] == approx(0.2629752479142838));
+  };
+
+  {
+    INFO("Bundled volume data files");
+    const auto interpolated_data = interpolate_to_points<3>(
+        unit_test_src_path() + "/Visualization/Python/VolTestData*.h5",
+        "element_data", ObservationStep{0}, {"Psi", "Phi_x", "Phi_y", "Phi_z"},
+        {{{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 0.0}}});
+    check_scalar_data(interpolated_data);
   }
   {
     INFO("Tensor interface");
@@ -70,6 +75,31 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
     CHECK(phi_y[0] == approx(1.0569673471948728));
     CHECK(phi_y[1] == approx(0.6741524090220188));
     CHECK(phi_y[2] == approx(0.2629752479142838));
+  }
+  {
+    INFO("PointwiseInterpolator interface");
+    const PointwiseInterpolator<3, Frame::Inertial> interpolator{
+        unit_test_src_path() + "/Visualization/Python/VolTestData*.h5",
+        "element_data",
+        ObservationStep{0},
+        {"Psi", "Phi_x", "Phi_y", "Phi_z"}};
+    {
+      INFO("Multiple points");
+      std::vector<DataVector> interpolated_data{};
+      interpolator.interpolate_to_points(
+          make_not_null(&interpolated_data),
+          tnsr::I<DataVector, 3>{
+              {{{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 0.0, 0.0}}}});
+      check_scalar_data(interpolated_data);
+    }
+    {
+      INFO("Single point");
+      std::vector<double> interpolated_data{};
+      interpolator.interpolate_to_point(make_not_null(&interpolated_data),
+                                        tnsr::I<double, 3>{{0.0, 0.0, 0.0}});
+      CHECK(interpolated_data[0] == approx(-0.07059806932542323));
+      CHECK(interpolated_data[2] == approx(1.0569673471948728));
+    }
   }
   {
     INFO("Single-precision volume data");


### PR DESCRIPTION
## Proposed changes

Adds the `PointwiseInterpolator` interface to the exporter, which can hold volume data in memory to repeatedly interpolate to arbitrary points. It can also interpolate in the grid frame, which will be useful for time interpolation (next PR).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
