### PR TITLE
Fix reported link time

### DIFF
--- a/src/Informer/InfoAtLink.cpp
+++ b/src/Informer/InfoAtLink.cpp
@@ -10,7 +10,7 @@
 #include <boost/preprocessor.hpp>
 #include <string>
 
-std::string link_date() { return std::string(__TIMESTAMP__); }
+std::string link_date() { return std::string(BOOST_PP_STRINGIZE(LINK_TIME)); }
 
 std::string executable_name() {
   return std::string(BOOST_PP_STRINGIZE(EXECUTABLE_NAME));

--- a/src/Informer/InfoAtLink.cpp
+++ b/src/Informer/InfoAtLink.cpp
@@ -10,14 +10,10 @@
 #include <boost/preprocessor.hpp>
 #include <string>
 
-std::string link_date() { return std::string(BOOST_PP_STRINGIZE(LINK_TIME)); }
+std::string link_date() { return BOOST_PP_STRINGIZE(LINK_TIME); }
 
-std::string executable_name() {
-  return std::string(BOOST_PP_STRINGIZE(EXECUTABLE_NAME));
-}
+std::string executable_name() { return BOOST_PP_STRINGIZE(EXECUTABLE_NAME); }
 
-std::string git_description() {
-  return std::string(BOOST_PP_STRINGIZE(GIT_DESCRIPTION));
-}
+std::string git_description() { return BOOST_PP_STRINGIZE(GIT_DESCRIPTION); }
 
-std::string git_branch() { return std::string(BOOST_PP_STRINGIZE(GIT_BRANCH)); }
+std::string git_branch() { return BOOST_PP_STRINGIZE(GIT_BRANCH); }

--- a/tools/WrapExecutableLinker.sh
+++ b/tools/WrapExecutableLinker.sh
@@ -41,11 +41,12 @@ if [ -f @CMAKE_BINARY_DIR@/tmp/Formaline.sh ]; then
     . @CMAKE_BINARY_DIR@/tmp/Formaline.sh $(basename "${!oindex}")
     temp_files+=("${formaline_output}" "${formaline_object_output}")
     "$@" -DGIT_DESCRIPTION=$git_description -DGIT_BRANCH=$git_branch \
-         ${InfoAtLink_flags} "${InfoAtLink_file}" "${formaline_output}" \
-         ${formaline_object_output}
+         -DLINK_TIME="$(date -u -Iseconds)" ${InfoAtLink_flags} \
+         "${InfoAtLink_file}" "${formaline_output}" ${formaline_object_output}
 else
     "$@" -DGIT_DESCRIPTION=$git_description -DGIT_BRANCH=$git_branch \
-         ${InfoAtLink_flags} "${InfoAtLink_file}"
+         -DLINK_TIME="$(date -u -Iseconds)" ${InfoAtLink_flags} \
+         "${InfoAtLink_file}"
 fi
 
 if @WRAP_EXECUTABLE_LINKER_USE_STUB_OBJECT_FILES@; then


### PR DESCRIPTION
__TIMESTAMP__ is the modification date of the file, not the current date.  That probably worked back when we made a separate copy of the file for each executable, but we stopped doing that a while ago.

Fixes #6558 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
