### PR TITLE
Add check for negative expansion boundary condition.

### DIFF
--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
@@ -253,6 +253,9 @@ void apparent_horizon_impl(
         make_not_null(&expansion_of_solution), make_not_null(&beta_orthogonal),
         *solution_for_negative_expansion, x, face_normal, face_normal_magnitude,
         deriv_unnormalized_face_normal);
+    ASSERT(max(get(expansion_of_solution)) <
+               100.0 * std::numeric_limits<double>::epsilon(),
+           "Expansion of solution is not negative everywhere.");
   }
 
   // Shift


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Check if the expansion at the excisions is negative. We found that this boundary condition is currently violated in two test initial data runs: high mass ratio ($q = 10$) and high spin ($\chi = 0.9999$).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
