### PR TITLE
Ghost zone comm mc sum fluid coupling

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/GhostZoneCommunication.hpp
+++ b/src/Evolution/Particles/MonteCarlo/GhostZoneCommunication.hpp
@@ -197,6 +197,103 @@ struct GhostDataMcPackets {
   }
 };
 
+// Take the data for coupling MC to hydro gathered from neighboring
+// ghost zones (stored after communication in GhostZoneCouplingDataTag)
+// and add them to the coupling terms in live zones. After calling this
+// action, the coupling terms CouplingTildeTau, CouplingTildeRhoYe,
+// CouplingTildeS should contain the changes to the energy, RhoYe, and
+// momentum of the fluid due to MC packets evolved locally and those
+// that evolved within ghost zones on neighboring elements.
+// THIS FUNCTION IS CURRENTLY ONLY IMPLENTED IN 3D!
+// As other parts of the MC communication, it is also incompatible with
+// mesh refinement.
+template <size_t Dim>
+struct CombineCouplingDataPostStep {
+  using return_tags =
+      tmpl::list<Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeRhoYe<DataVector>,
+                 Particles::MonteCarlo::Tags::CouplingTildeS<DataVector, Dim>>;
+  using argument_tags =
+      tmpl::list<Particles::MonteCarlo::Tags::GhostZoneCouplingDataTag<Dim>,
+                 ::domain::Tags::Element<Dim>,
+                 evolution::dg::subcell::Tags::Mesh<Dim>>;
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> coupling_tilde_tau,
+      gsl::not_null<Scalar<DataVector>*> coupling_tilde_rho_ye,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          coupling_tilde_s,
+      const Particles::MonteCarlo::GhostZoneCouplingData<Dim>& coupling_data,
+      const Element<Dim>& element, const Mesh<Dim>& subcell_mesh) {
+    // Check that we do not use this function for 1D/2D runs
+    ASSERT(Dim == 3, "CombineCouplingDataPostStep only coded in 3D so far");
+
+    const size_t num_ghost_zones = 1;
+    const Index<Dim> local_extents = subcell_mesh.extents();
+    Index<Dim> ghost_extents = local_extents;
+    for (size_t d = 0; d < 3; d++) {
+      ghost_extents[d] += 2 * num_ghost_zones;
+    }
+    // Loop over neighboring elements
+    for (const auto& [direction, neighbors_in_direction] :
+         element.neighbors()) {
+      for (const auto& neighbor : neighbors_in_direction) {
+        DirectionalId<Dim> directional_element_id{direction, neighbor};
+        if (coupling_data.coupling_tilde_tau.at(directional_element_id) ==
+            std::nullopt) {
+          continue;
+        }
+        const size_t dimension = directional_element_id.direction().dimension();
+        const Side side = directional_element_id.direction().side();
+        // Extents of coupling data: mesh with ghost points, sliced
+        // in direction 'dimension'
+        Index<Dim> ghost_zone_extents = ghost_extents;
+        ghost_zone_extents[dimension] = num_ghost_zones;
+        // These loops only work in 3D; needs fixing for other dimensions
+        for (size_t i = 0; i < ghost_zone_extents[0]; ++i) {
+          for (size_t j = 0; j < ghost_zone_extents[1]; ++j) {
+            for (size_t k = 0; k < ghost_zone_extents[2]; ++k) {
+              Index<Dim> index_3d{i, j, k};
+              // Index of point in ghost zone data
+              const size_t ghost_index =
+                  collapsed_index(index_3d, ghost_zone_extents);
+              // Index of corresponding live point within the full
+              // mesh, with ghost zones.
+              // For two ghost zones e.g., the 1d mesh looks like
+              //        x x o o o o o o x x
+              // with neighbors
+              //  o o o o o x x     x x o o o o o
+              // with x = GZ, o = live points. On the lower face,
+              // we thus add data from the first ghost point to
+              // index num_ghost_zones. On the upper face, the first
+              // ghost point goes to index local_extents (the size of
+              // the mesh without ghost zone).
+              index_3d[dimension] =
+                  (side == Side::Lower)
+                      ? index_3d[dimension] + num_ghost_zones
+                      : local_extents[dimension] + index_3d[dimension];
+              const size_t extended_index =
+                  collapsed_index(index_3d, ghost_extents);
+              // Add gathered data to existing coupling terms
+              coupling_tilde_tau->get()[extended_index] +=
+                  coupling_data.coupling_tilde_tau.at(directional_element_id)
+                      .value()[ghost_index];
+              coupling_tilde_rho_ye->get()[extended_index] +=
+                  coupling_data.coupling_tilde_rho_ye.at(directional_element_id)
+                      .value()[ghost_index];
+              for (size_t d = 0; d < Dim; d++) {
+                coupling_tilde_s->get(d)[extended_index] +=
+                    coupling_data.coupling_tilde_s.at(directional_element_id)
+                        .value()
+                        .get(d)[ghost_index];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
 /// Action responsible for the Send operation of ghost
 /// zone communication for Monte-Carlo transport.
 /// If CommStep == PreStep, this sends the fluid and
@@ -500,6 +597,12 @@ struct ReceiveDataForMcCommunication {
             }
           },
           make_not_null(&box));
+      // Combine ghost zone data with live points data. Currently only done in
+      // 3D
+      if constexpr (Dim == 3) {
+        db::mutate_apply(CombineCouplingDataPostStep<Dim>{},
+                         make_not_null(&box));
+      }
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/tests/Unit/Evolution/Particles/MonteCarlo/Test_CommunicationTags.cpp
+++ b/tests/Unit/Evolution/Particles/MonteCarlo/Test_CommunicationTags.cpp
@@ -6,6 +6,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -286,6 +287,8 @@ void test_send_receive_actions() {
       make_with_value<Scalar<DataVector>>(zero_dv_with_ghost, 0.0);
   tnsr::i<DataVector, Dim> coupling_tilde_s =
       make_with_value<tnsr::i<DataVector, Dim>>(zero_dv_with_ghost, 0.0);
+  alg::iota(get(coupling_tilde_tau), 1.0);
+  alg::iota(get(coupling_tilde_rho_ye), 2.0);
   Particles::MonteCarlo::GhostZoneCouplingData<Dim> coupling_data{};
   {
     const size_t number_of_points_in_ghost_zone =
@@ -305,6 +308,7 @@ void test_send_receive_actions() {
                                                south_id};
     coupling_data.coupling_tilde_tau[south_neighbor_id] =
         DataVector(number_of_points_in_ghost_zone, 0.1);
+    alg::iota(coupling_data.coupling_tilde_tau[south_neighbor_id].value(), 1.0);
     coupling_data.coupling_tilde_rho_ye[south_neighbor_id] =
         DataVector(number_of_points_in_ghost_zone, 0.1);
     coupling_data.coupling_tilde_s[south_neighbor_id] =
@@ -846,6 +850,49 @@ void test_send_receive_actions() {
     if constexpr (Dim > 1) {
       CHECK(packets_from_box[2] == packet_south);
     }
+  }
+  if constexpr (Dim == 3) {
+    // Check final values of coupling terms
+    // (1) Add values expected from east face
+    Index<2> extents_2d;
+    extents_2d[0] = extents_with_ghost[1];
+    extents_2d[1] = extents_with_ghost[2];
+    Index<3> index_volume_3d;
+    Index<2> index_slice_2d;
+    for (size_t i = 0; i < extents_with_ghost[1]; i++) {
+      for (size_t j = 0; j < extents_with_ghost[2]; j++) {
+        index_volume_3d[0] = extents_with_ghost[0] - 2;
+        index_volume_3d[1] = i;
+        index_volume_3d[2] = j;
+        index_slice_2d[0] = i;
+        index_slice_2d[1] = j;
+        const size_t index_volume =
+            collapsed_index(index_volume_3d, extents_with_ghost);
+        const size_t index_slice = collapsed_index(index_slice_2d, extents_2d);
+        get(coupling_tilde_tau)[index_volume] +=
+          (static_cast<double>(index_slice) + 2.0);
+      }
+    }
+    // South slice
+    extents_2d[0] = extents_with_ghost[0];
+    for (size_t i = 0; i < extents_with_ghost[0]; i++) {
+      for (size_t j = 0; j < extents_with_ghost[2]; j++) {
+        index_volume_3d[0] = i;
+        index_volume_3d[1] = 1;
+        index_volume_3d[2] = j;
+        index_slice_2d[0] = i;
+        index_slice_2d[1] = j;
+        const size_t index_volume =
+            collapsed_index(index_volume_3d, extents_with_ghost);
+        const size_t index_slice = collapsed_index(index_slice_2d, extents_2d);
+        get(coupling_tilde_tau)[index_volume] +=
+          (static_cast<double>(index_slice) + 2.0);
+      }
+    }
+    const auto& post_comm_coupling_tilde_tau = get_databox_tag<
+        comp, Particles::MonteCarlo::Tags::CouplingTildeTau<DataVector>>(
+        runner, self_id);
+    CHECK(post_comm_coupling_tilde_tau == coupling_tilde_tau);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

Add a mutator responsible for summing the contributions to the coupling between fluid and Monte-Carlo gathered from ghost zones to the values stored locally from the evolution of MC packets in live zones.

### Upgrade instructions

NA

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Depends on #6550 
