### PR TITLE
Exporter: add SpacetimeInterpolator

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -316,6 +316,21 @@ eprint = {https://doi.org/10.1137/0916035}
   year          = {2014}
 }
 
+@article{Bohn:2016afc,
+  author        = {Bohn, Andy and Kidder, Lawrence E. and Teukolsky, Saul A.},
+  title         = {Parallel adaptive event horizon finder for numerical
+                   relativity},
+  eprint        = {1606.00437},
+  archiveprefix = {arXiv},
+  primaryclass  = {gr-qc},
+  doi           = {10.1103/PhysRevD.94.064008},
+  journal       = {Phys. Rev. D},
+  volume        = {94},
+  number        = {6},
+  pages         = {064008},
+  year          = {2016}
+}
+
 @article{Borges20083191,
   title =   {An improved weighted essentially non-oscillatory scheme for
              hyperbolic conservation laws},

--- a/src/IO/Exporter/CMakeLists.txt
+++ b/src/IO/Exporter/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_sources(
   Exporter.cpp
   PointwiseInterpolator.cpp
   SelectObservation.cpp
+  SpacetimeInterpolator.cpp
   )
 
 spectre_target_headers(
@@ -26,6 +27,7 @@ spectre_target_headers(
   Exporter.hpp
   PointwiseInterpolator.hpp
   SelectObservation.hpp
+  SpacetimeInterpolator.hpp
   )
 
 target_link_libraries(

--- a/src/IO/Exporter/Exporter.hpp
+++ b/src/IO/Exporter/Exporter.hpp
@@ -21,6 +21,7 @@ namespace spectre::Exporter {
 
 /// Identifies an observation by its ID in the volume data file.
 struct ObservationId {
+  ObservationId() = default;
   explicit ObservationId(size_t local_value) : value(local_value) {}
   size_t value;
 };
@@ -28,6 +29,7 @@ struct ObservationId {
 /// Identifies an observation by its index in the ordered list of observations.
 /// Negative indices are counted from the end of the list.
 struct ObservationStep {
+  ObservationStep() = default;
   explicit ObservationStep(int local_value) : value(local_value) {}
   int value;
 };

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -394,22 +394,20 @@ auto parse_volume_files(const std::variant<std::vector<std::string>,
   // `Visualization.ReadH5:select_observation` and possibly move it to C++.
   const size_t obs_id =
       std::visit(SelectObservation{first_volfile}, observation);
-  // Get domain, time, functions of time
+  const double time = first_volfile.get_observation_value(obs_id);
+  // Get domain, functions of time
   auto domain =
       deserialize<Domain<Dim>>(first_volfile.get_domain(obs_id)->data());
-  auto time_and_fot = [&first_volfile, &obs_id, &domain]() {
-    if (domain.is_time_dependent()) {
-      return std::make_pair(
-          first_volfile.get_observation_value(obs_id),
-          deserialize<domain::FunctionsOfTimeMap>(
-              first_volfile.get_functions_of_time(obs_id)->data()));
-    } else {
-      return std::make_pair(0., domain::FunctionsOfTimeMap{});
+  auto functions_of_time = [&first_volfile, &obs_id]() {
+    const auto serialized_fot = first_volfile.get_functions_of_time(obs_id);
+    if (not serialized_fot.has_value()) {
+      return domain::FunctionsOfTimeMap{};
     }
+    return deserialize<domain::FunctionsOfTimeMap>(serialized_fot->data());
   }();
   first_h5file.close();
-  return std::make_tuple(std::move(filenames), obs_id, time_and_fot.first,
-                         std::move(domain), std::move(time_and_fot.second));
+  return std::make_tuple(std::move(filenames), obs_id, time, std::move(domain),
+                         std::move(functions_of_time));
 }
 
 template <typename DataType, size_t Dim, typename Frame>

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -700,7 +700,14 @@ void PointwiseInterpolator<Dim, Frame>::interpolate_to_points(
     // Clear the anchor points from the result
     for (size_t i = 0; i < result->size(); ++i) {
       DataVector& component = (*result)[i];
-      component.destructive_resize(num_target_points);
+      // Can't use `destructive_resize` because we want to preserve the
+      // leading elements of the DataVector
+      DataVector new_component(num_target_points);
+      std::copy(
+          component.begin(),
+          component.begin() + static_cast<std::ptrdiff_t>(num_target_points),
+          new_component.begin());
+      component = std::move(new_component);
     }
   }
 }

--- a/src/IO/Exporter/Python/Bindings.cpp
+++ b/src/IO/Exporter/Python/Bindings.cpp
@@ -7,6 +7,8 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "IO/Exporter/PointwiseInterpolator.hpp"
+#include "IO/Exporter/SpacetimeInterpolator.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -25,11 +27,70 @@ void bind_interpolate_to_points_impl(py::module& m) {
             const tnsr::I<DataVector, Dim, Frame>&, bool, bool,
             std::optional<size_t>>(
             &spectre::Exporter::interpolate_to_points<Dim, Frame>),
-      py::arg("volume_files_or_glob"), py::arg("subfile_name"),
+        py::arg("volume_files_or_glob"), py::arg("subfile_name"),
         py::arg("observation"), py::arg("tensor_components"),
-      py::arg("target_points"), py::arg("extrapolate_into_excisions") = false,
-      py::arg("error_on_missing_points") = false,
-      py::arg("num_threads") = std::nullopt);
+        py::arg("target_points"), py::arg("extrapolate_into_excisions") = false,
+        py::arg("error_on_missing_points") = false,
+        py::arg("num_threads") = std::nullopt);
+}
+
+template <size_t Dim, typename Frame>
+void bind_pointwise_interpolator_impl(py::module& m) {
+  using PointwiseInterpolator =
+      spectre::Exporter::PointwiseInterpolator<Dim, Frame>;
+  py::class_<PointwiseInterpolator>(
+      m, ("PointwiseInterpolator" + std::to_string(Dim) + "D" +
+          get_output(Frame{}))
+             .c_str())
+      .def(py::init<const std::variant<std::vector<std::string>, std::string>&,
+                    const std::string&,
+                    const spectre::Exporter::ObservationVariant&,
+                    const std::vector<std::string>&>(),
+           py::arg("volume_files_or_glob"), py::arg("subfile_name"),
+           py::arg("observation"), py::arg("tensor_components"))
+      .def("obs_id", &PointwiseInterpolator::obs_id)
+      .def("time", &PointwiseInterpolator::time)
+      .def("domain", &PointwiseInterpolator::domain)
+      .def("functions_of_time",
+           [](const PointwiseInterpolator& self) {
+             return clone_unique_ptrs(self.functions_of_time());
+           })
+      .def(
+          "interpolate_to_point",
+          [](const PointwiseInterpolator& self,
+             const tnsr::I<double, Dim, Frame>& target_point) {
+            std::vector<double> result{};
+            self.interpolate_to_point(make_not_null(&result), target_point);
+            return result;
+          },
+          py::arg("target_point"));
+}
+
+template <size_t Dim>
+void bind_spacetime_interpolator_impl(py::module& m) {
+  using SpacetimeInterpolator =
+      spectre::Exporter::SpacetimeInterpolator<Dim, Frame::Inertial>;
+  py::class_<SpacetimeInterpolator>(
+      m, ("SpacetimeInterpolator" + std::to_string(Dim) + "D").c_str())
+      .def(py::init<std::variant<std::vector<std::string>, std::string>,
+                    std::string, std::vector<std::string>>(),
+           py::arg("volume_files_or_glob"), py::arg("subfile_name"),
+           py::arg("tensor_components"))
+      .def("max_time_bounds", &SpacetimeInterpolator::max_time_bounds)
+      .def("load_time_bounds", &SpacetimeInterpolator::load_time_bounds,
+           py::arg("time_bounds"))
+      .def("time_bounds", &SpacetimeInterpolator::time_bounds)
+      .def(
+          "interpolate_to_point",
+          [](const SpacetimeInterpolator& self,
+             const tnsr::I<double, Dim, Frame::Inertial>& target_point,
+             const double time) {
+            std::vector<double> result{};
+            self.interpolate_to_point(make_not_null(&result), target_point,
+                                      time);
+            return result;
+          },
+          py::arg("target_point"), py::arg("time"));
 }
 
 }  // namespace
@@ -49,4 +110,13 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   bind_interpolate_to_points_impl<1, Frame::Inertial>(m);
   bind_interpolate_to_points_impl<2, Frame::Inertial>(m);
   bind_interpolate_to_points_impl<3, Frame::Inertial>(m);
+  bind_pointwise_interpolator_impl<1, Frame::Grid>(m);
+  bind_pointwise_interpolator_impl<2, Frame::Grid>(m);
+  bind_pointwise_interpolator_impl<3, Frame::Grid>(m);
+  bind_pointwise_interpolator_impl<1, Frame::Inertial>(m);
+  bind_pointwise_interpolator_impl<2, Frame::Inertial>(m);
+  bind_pointwise_interpolator_impl<3, Frame::Inertial>(m);
+  bind_spacetime_interpolator_impl<1>(m);
+  bind_spacetime_interpolator_impl<2>(m);
+  bind_spacetime_interpolator_impl<3>(m);
 }

--- a/src/IO/Exporter/Python/Bindings.cpp
+++ b/src/IO/Exporter/Python/Bindings.cpp
@@ -17,24 +17,16 @@ namespace {
 
 template <size_t Dim, typename Frame>
 void bind_interpolate_to_points_impl(py::module& m) {
-  m.def(
-      "interpolate_to_points",
-      [](const std::variant<std::vector<std::string>, std::string>&
-             volume_files_or_glob,
-         const std::string& subfile_name, const size_t observation_id,
-         const std::vector<std::string>& tensor_components,
-         const tnsr::I<DataVector, Dim, Frame>& target_points,
-         const bool extrapolate_into_excisions,
-         const bool error_on_missing_points,
-         const std::optional<size_t>& num_threads) {
-        return spectre::Exporter::interpolate_to_points(
-            volume_files_or_glob, subfile_name,
-            spectre::Exporter::ObservationId{observation_id}, tensor_components,
-            target_points, extrapolate_into_excisions, error_on_missing_points,
-            num_threads);
-      },
+  m.def("interpolate_to_points",
+        py::overload_cast<
+            const std::variant<std::vector<std::string>, std::string>&,
+            const std::string&, const spectre::Exporter::ObservationVariant&,
+            const std::vector<std::string>&,
+            const tnsr::I<DataVector, Dim, Frame>&, bool, bool,
+            std::optional<size_t>>(
+            &spectre::Exporter::interpolate_to_points<Dim, Frame>),
       py::arg("volume_files_or_glob"), py::arg("subfile_name"),
-      py::arg("observation_id"), py::arg("tensor_components"),
+        py::arg("observation"), py::arg("tensor_components"),
       py::arg("target_points"), py::arg("extrapolate_into_excisions") = false,
       py::arg("error_on_missing_points") = false,
       py::arg("num_threads") = std::nullopt);
@@ -45,6 +37,12 @@ void bind_interpolate_to_points_impl(py::module& m) {
 PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   enable_segfault_handler();
   py::module_::import("spectre.DataStructures.Tensor");
+  py::class_<spectre::Exporter::ObservationId>(m, "ObservationId")
+      .def(py::init<size_t>())
+      .def_readonly("value", &spectre::Exporter::ObservationId::value);
+  py::class_<spectre::Exporter::ObservationStep>(m, "ObservationStep")
+      .def(py::init<int>())
+      .def_readonly("value", &spectre::Exporter::ObservationStep::value);
   bind_interpolate_to_points_impl<1, Frame::Grid>(m);
   bind_interpolate_to_points_impl<2, Frame::Grid>(m);
   bind_interpolate_to_points_impl<3, Frame::Grid>(m);

--- a/src/IO/Exporter/Python/InterpolateToPoints.py
+++ b/src/IO/Exporter/Python/InterpolateToPoints.py
@@ -9,7 +9,7 @@ import rich
 
 import spectre.IO.H5 as spectre_h5
 from spectre.DataStructures.Tensor import DataVector, Frame, tnsr
-from spectre.IO.Exporter import interpolate_to_points
+from spectre.IO.Exporter import ObservationId, interpolate_to_points
 from spectre.Visualization.OpenVolfiles import (
     open_volfiles_command,
     parse_points,
@@ -114,7 +114,7 @@ def interpolate_to_points_command(
         interpolate_to_points(
             h5_files,
             subfile_name=subfile_name,
-            observation_id=obs_id,
+            observation=ObservationId(obs_id),
             tensor_components=vars,
             target_points=target_points,
             **kwargs,

--- a/src/IO/Exporter/Python/__init__.py
+++ b/src/IO/Exporter/Python/__init__.py
@@ -47,3 +47,10 @@ def interpolate_tensors_to_points(
             tensor[i] = DataVector(data[j])
             j += 1
     return list(tensors.values())
+
+
+SpacetimeInterpolator = {
+    1: SpacetimeInterpolator1D,
+    2: SpacetimeInterpolator2D,
+    3: SpacetimeInterpolator3D,
+}

--- a/src/IO/Exporter/SpacetimeInterpolator.cpp
+++ b/src/IO/Exporter/SpacetimeInterpolator.cpp
@@ -1,0 +1,293 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Exporter/SpacetimeInterpolator.hpp"
+
+#include <array>
+#include <cstddef>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "IO/Exporter/PointwiseInterpolator.hpp"
+#include "IO/Exporter/SelectObservation.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Interpolation/PolynomialInterpolation.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+
+namespace spectre::Exporter {
+
+namespace {
+
+auto load_observation_ids(const std::variant<std::vector<std::string>,
+                                             std::string>& volume_files_or_glob,
+                          const std::string& subfile_name) {
+  const std::vector<std::string> filenames =
+      std::visit(Overloader{[](const std::vector<std::string>& volume_files) {
+                              return volume_files;
+                            },
+                            [](const std::string& volume_files_glob) {
+                              return file_system::glob(volume_files_glob);
+                            }},
+                 volume_files_or_glob);
+  const h5::H5File<h5::AccessType::ReadOnly> first_h5file(filenames.front());
+  const auto& first_volfile = first_h5file.get<h5::VolumeData>(subfile_name);
+  const auto all_observation_ids = first_volfile.list_observation_ids();
+  std::vector<double> all_observation_values(all_observation_ids.size());
+  std::transform(all_observation_ids.begin(), all_observation_ids.end(),
+                 all_observation_values.begin(),
+                 [&first_volfile](const size_t obs_id) {
+                   return first_volfile.get_observation_value(obs_id);
+                 });
+  first_h5file.close();
+  return std::make_pair(all_observation_ids, all_observation_values);
+}
+
+}  // namespace
+
+template <size_t Dim, typename Frame>
+SpacetimeInterpolator<Dim, Frame>::SpacetimeInterpolator(
+    std::variant<std::vector<std::string>, std::string> volume_files_or_glob,
+    std::string subfile_name, std::vector<std::string> tensor_components)
+    : volume_files_or_glob_(std::move(volume_files_or_glob)),
+      subfile_name_(std::move(subfile_name)),
+      tensor_components_(std::move(tensor_components)) {
+  std::tie(all_observation_ids_, all_observation_values_) =
+      load_observation_ids(volume_files_or_glob_, subfile_name_);
+  if (all_observation_ids_.empty()) {
+    ERROR("No observation IDs found in the volume data files.");
+  }
+  if (all_observation_ids_.size() < time_interpolation_order_ + 1) {
+    ERROR(
+        "The number of available observations must be at least the time "
+        "interpolation order plus one (num observations >= "
+        << time_interpolation_order_ + 1 << "), but "
+        << all_observation_ids_.size() << " observations were found.");
+  }
+}
+
+template <size_t Dim, typename Frame>
+std::array<double, 2> SpacetimeInterpolator<Dim, Frame>::max_time_bounds()
+    const {
+  return {*(all_observation_values_.begin() + num_ghost_slices_),
+          *(all_observation_values_.end() - num_ghost_slices_ - 1)};
+}
+
+template <size_t Dim, typename Frame>
+void SpacetimeInterpolator<Dim, Frame>::load_time_bounds(
+    std::array<double, 2> time_bounds) {
+  ASSERT(time_bounds[0] < time_bounds[1],
+         "The lower time bound must be smaller than the upper time bound.");
+  ASSERT(time_bounds[0] >= max_time_bounds()[0] and
+             time_bounds[1] <= max_time_bounds()[1],
+         "The time bounds " << time_bounds
+                            << " must be within the maximum time bounds "
+                            << max_time_bounds() << ".");
+  // Collect all observations that we need to load
+  const auto lower_time =
+      std::lower_bound(all_observation_values_.begin(),
+                       all_observation_values_.end(), time_bounds[0],
+                       std::less_equal<double>{}) -
+      num_ghost_slices_ - 1;
+  const auto upper_time =
+      std::upper_bound(lower_time, all_observation_values_.end(),
+                       time_bounds[1], std::less_equal<double>{}) +
+      num_ghost_slices_ + 1;
+  time_bounds_[0] = *(lower_time + num_ghost_slices_);
+  time_bounds_[1] = *(upper_time - num_ghost_slices_ - 1);
+  const auto lower_id =
+      all_observation_ids_.begin() +
+      std::distance(all_observation_values_.begin(), lower_time);
+  const auto upper_id =
+      all_observation_ids_.begin() +
+      std::distance(all_observation_values_.begin(), upper_time);
+  const auto num_obs = static_cast<size_t>(std::distance(lower_id, upper_id));
+  ASSERT(num_obs >= time_interpolation_order_ + 1,
+         "The number of time slices must be at least the time interpolation "
+         "order plus one (NumTimeSlices >= "
+             << time_interpolation_order_ + 1 << ").");
+
+  if (interpolators_.empty()) {
+    // No need to lock because we are loading interpolators for the first time
+    // so no other thread can be accessing the data.
+    for (auto it = lower_id; it != upper_id; ++it) {
+      interpolators_.emplace_back(volume_files_or_glob_, subfile_name_,
+                                  ObservationId{*it}, tensor_components_);
+    }
+    return;
+  }
+
+  // Drop interpolators that are not needed anymore. Do this early to free up
+  // memory.
+  auto first_interpolator_obs_id_it =
+      std::find(all_observation_ids_.begin(), all_observation_ids_.end(),
+                interpolators_.front().obs_id());
+  ASSERT(first_interpolator_obs_id_it != all_observation_ids_.end(),
+         "The first interpolator is not in the list of observation IDs.");
+  const auto last_interpolator_obs_id_it =
+      first_interpolator_obs_id_it +
+      static_cast<std::ptrdiff_t>(interpolators_.size());
+  const auto num_erase_front =
+      std::distance(first_interpolator_obs_id_it, lower_id);
+  const auto num_erase_back =
+      std::distance(upper_id, last_interpolator_obs_id_it);
+  if (num_erase_front == 0 and num_erase_back == 0) {
+    // No need to drop or load interpolators
+    return;
+  }
+  if (num_erase_front >= static_cast<std::ptrdiff_t>(interpolators_.size()) or
+      num_erase_back >= static_cast<std::ptrdiff_t>(interpolators_.size())) {
+    // We are dropping all interpolators and loading new ones. No need to lock
+    // because there's no overlapping time range where old data can still be
+    // used.
+    interpolators_.clear();
+    for (auto it = lower_id; it != upper_id; ++it) {
+      interpolators_.emplace_back(volume_files_or_glob_, subfile_name_,
+                                  ObservationId{*it}, tensor_components_);
+    }
+    return;
+  }
+  {
+    // Lock while we are modifying the vector
+    const std::unique_lock lock(interpolators_mutex_);
+    if (num_erase_front > 0) {
+      interpolators_.erase(interpolators_.begin(),
+                           interpolators_.begin() + num_erase_front);
+    }
+    if (num_erase_back > 0) {
+      interpolators_.erase(interpolators_.end() - num_erase_back,
+                           interpolators_.end());
+    }
+  }
+
+  // Load new interpolators
+  std::vector<PointwiseInterpolator<Dim, ::Frame::Grid>>
+      new_interpolators_front;
+  std::vector<PointwiseInterpolator<Dim, ::Frame::Grid>> new_interpolators_back;
+  if (num_erase_front < 0) {
+    const auto num_add_front =
+        std::min(static_cast<size_t>(-num_erase_front), num_obs);
+    new_interpolators_front.reserve(num_add_front);
+    for (auto it = lower_id;
+         it != lower_id + static_cast<std::ptrdiff_t>(num_add_front); ++it) {
+      new_interpolators_front.emplace_back(volume_files_or_glob_, subfile_name_,
+                                           ObservationId{*it},
+                                           tensor_components_);
+    }
+  }
+  if (num_erase_back < 0) {
+    const auto num_add_back =
+        std::min(static_cast<size_t>(-num_erase_back),
+                 num_obs - new_interpolators_front.size());
+    new_interpolators_back.reserve(num_add_back);
+    for (auto it = upper_id - static_cast<std::ptrdiff_t>(num_add_back);
+         it != upper_id; ++it) {
+      new_interpolators_back.emplace_back(volume_files_or_glob_, subfile_name_,
+                                          ObservationId{*it},
+                                          tensor_components_);
+    }
+  }
+  {
+    // Lock while we are modifying the vector
+    const std::unique_lock lock(interpolators_mutex_);
+    interpolators_.insert(
+        interpolators_.begin(),
+        std::make_move_iterator(new_interpolators_front.begin()),
+        std::make_move_iterator(new_interpolators_front.end()));
+    interpolators_.insert(
+        interpolators_.end(),
+        std::make_move_iterator(new_interpolators_back.begin()),
+        std::make_move_iterator(new_interpolators_back.end()));
+  }
+}
+
+template <size_t Dim, typename Frame>
+void SpacetimeInterpolator<Dim, Frame>::interpolate_to_point(
+    const gsl::not_null<std::vector<double>*> result,
+    const tnsr::I<double, Dim, Frame>& target_point, const double time,
+    const std::optional<gsl::not_null<std::vector<size_t>*>> block_order)
+    const {
+  // Lock to ensure that the `interpolators_` vector is not being modified while
+  // we access it. Multiple threads can still read the data concurrently even
+  // while loeading new data, just the short amount of time when the vector is
+  // being modified is locked.
+  const std::shared_lock lock(interpolators_mutex_);
+  ASSERT(not interpolators_.empty(),
+         "SpacetimeInterpolator has not been initialized.");
+  // Find the time slice that contains the target time
+  ASSERT(time >= time_bounds_[0] and time <= time_bounds_[1],
+         "Requested time " << time << " is outside the time bounds.");
+  const auto lower =
+      std::lower_bound(interpolators_.begin() + num_ghost_slices_ + 1,
+                       interpolators_.end() - num_ghost_slices_ - 1, time,
+                       [](const auto& interpolator, const double t) {
+                         return interpolator.time() <= t;
+                       });
+  // Transform target point to block-logical frame
+  // NOTE: We assume here that the grid frame and even the block-logical frame
+  // is the same in all time slices. This is true while the domain stays the
+  // same (just functions of time values change to control the grid-to-inertial
+  // map), but won't be true in general (e.g. with AMR regrids or ringdown
+  // transitions). Then, we have to do the transformation for each time slice
+  // separately (see https://arxiv.org/abs/1606.00437). This is not implemented
+  // yet.
+  const auto& any_interpolator = *lower;
+  const auto block_logical_coords = block_logical_coordinates_single_point(
+      target_point, any_interpolator.domain(), time,
+      any_interpolator.functions_of_time(), block_order);
+  if (not block_logical_coords.has_value()) {
+    ERROR("Point is not in any block:\n" << target_point);
+  }
+  // Interpolate to the grid-frame target point in each time slice
+  std::array<std::vector<double>, time_interpolation_order_ + 1> data{};
+  std::array<double, time_interpolation_order_ + 1> times{};
+  const auto times_span = gsl::make_span(times);
+  for (size_t i = 0; i < time_interpolation_order_ + 1; ++i) {
+    const auto& interpolator =
+        *(lower - 1 - static_cast<std::ptrdiff_t>(num_ghost_slices_) +
+          static_cast<std::ptrdiff_t>(i));
+    interpolator.interpolate_to_point(make_not_null(&gsl::at(data, i)),
+                                      block_logical_coords.value());
+    gsl::at(times, i) = interpolator.time();
+  }
+  // Interpolate in time
+  const size_t num_components = tensor_components_.size();
+  result->resize(num_components);
+  std::array<double, time_interpolation_order_ + 1> values{};
+  const auto values_span = gsl::make_span(values);
+  double interpolation_error = 0.;
+  for (size_t j = 0; j < num_components; ++j) {
+    for (size_t k = 0; k < time_interpolation_order_ + 1; ++k) {
+      gsl::at(values, k) = gsl::at(data, k)[j];
+    }
+    intrp::polynomial_interpolation<time_interpolation_order_>(
+        make_not_null(&(*result)[j]), make_not_null(&interpolation_error), time,
+        values_span, times_span);
+  }
+}
+
+// Generate instantiations
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data) \
+  template class SpacetimeInterpolator<DIM(data), FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial))
+
+#undef INSTANTIATE
+#undef DIM
+#undef FRAME
+
+}  // namespace spectre::Exporter

--- a/src/IO/Exporter/SpacetimeInterpolator.hpp
+++ b/src/IO/Exporter/SpacetimeInterpolator.hpp
@@ -1,0 +1,142 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "IO/Exporter/PointwiseInterpolator.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace spectre::Exporter {
+
+/*!
+ * \brief Interpolates data in volume files in both space and time
+ *
+ * This class reads the volume data at multiple time steps into memory and can
+ * then interpolate it to any number of target points at any time within the
+ * time bounds of the loaded data.
+ *
+ * \details The interpolation is first done in space and then in time. For the
+ * interpolation in space, the PointwiseInterpolator class is used, which does
+ * spectral interpolation within the elements. For the interpolation in time, a
+ * polynomial interpolation with fixed order is used (currently third order,
+ * meaning four time slices are used).
+ *
+ * \par Coordinate frames
+ * The target points are given in the `Frame` specified as template parameter
+ * (defaults to `Frame::Inertial`). However, the interpolation is done in the
+ * grid frame, which is time-independent and therefore best suitable for
+ * interpolation in time. Details of this idea can be found in
+ * \cite Bohn:2016afc .
+ *
+ * \par Thread safety
+ * Loading volume data from H5 files on multiple threads at once is not
+ * generally thread safe, so `load_time_bounds` may only be called on a single
+ * thread. However, once the data is loaded, the `interpolate_to_point` function
+ * is thread safe. This means the volume data can be loaded once in a single
+ * thread and then used by multiple threads to interpolate to different points
+ * in parallel. Also, `load_time_bounds` can be called again to load new data
+ * while other threads are still accessing the old data, as long as they only
+ * request data within both the old and the new time bounds.
+ */
+template <size_t Dim, typename Frame = ::Frame::Inertial>
+struct SpacetimeInterpolator {
+  SpacetimeInterpolator() = default;
+
+  /*!
+   * \brief Construct the interpolator without loading any volume data
+   *
+   * \param volume_files_or_glob The list of H5 files, or a glob pattern
+   * \param subfile_name The name of the subfile in the H5 files containing the
+   * volume data
+   * \param tensor_components The tensor components to interpolate. The order of
+   * the components in the vector is the order in which they will be returned.
+   */
+  SpacetimeInterpolator(
+      std::variant<std::vector<std::string>, std::string> volume_files_or_glob,
+      std::string subfile_name, std::vector<std::string> tensor_components);
+
+  /// The maximum time bounds available in the volume data files (taking into
+  /// account the number of ghost slices needed for interpolation). Only time
+  /// bounds in this (inclusive) range can be requested with the
+  /// `load_time_bounds()` function.
+  std::array<double, 2> max_time_bounds() const;
+
+  /*!
+   * \brief Load volume data into memory such that the given time bounds are
+   * covered.
+   *
+   * The given time bounds must be within the `max_time_bounds()` (inclusive).
+   *
+   * Previously loaded volume data slices outside the given time bounds will be
+   * dropped and new ones loaded.
+   *
+   * \par Thread safety
+   * This function is not generally thread safe, as it loads data from H5 files.
+   * It should be called from a single thread only. It is safe to keep calling
+   * interpolation routines from other threads while this function is running,
+   * as long as they are requesting data within both the old and the new time
+   * bounds.
+   */
+  void load_time_bounds(std::array<double, 2> time_bounds);
+
+  /// The time bounds of the loaded data (inclusive). It is an error to call the
+  /// interpolation routines outside these bounds.
+  std::array<double, 2> time_bounds() const { return time_bounds_; }
+
+  /// The number of loaded time slices.
+  size_t num_loaded_slices() const { return interpolators_.size(); }
+
+  /*!
+   * \brief Interpolate to a single point
+   *
+   * This function is thread safe, so the interpolator can be constructed to
+   * load the volume data once and then used by multiple threads to interpolate
+   * to different points in parallel. Note that updating the `block_order` (if
+   * provided) is not thread safe, so each thread should manage a separate
+   * `block_order`.
+   *
+   * \param result the interpolated data at the target point. The vector is over
+   * the number of components. Will be resized automatically.
+   * \param target_point the point to interpolate to.
+   * \param time the time to interpolate to. Must be within the `time_bounds()`.
+   * \param block_order an optional priority order to search for the block
+   * containing the target point. Will be updated when the point is found.
+   * See `block_logical_coordinates_single_point` for more details.
+   */
+  void interpolate_to_point(gsl::not_null<std::vector<double>*> result,
+                            const tnsr::I<double, Dim, Frame>& target_point,
+                            double time,
+                            std::optional<gsl::not_null<std::vector<size_t>*>>
+                                block_order = std::nullopt) const;
+
+ private:
+  std::variant<std::vector<std::string>, std::string> volume_files_or_glob_;
+  std::string subfile_name_;
+  std::vector<std::string> tensor_components_;
+  constexpr static size_t time_interpolation_order_ = 3;  // must be odd
+  constexpr static size_t num_ghost_slices_ =
+      (time_interpolation_order_ + 1) / 2 - 1;
+  // Metadata collected from data files
+  std::vector<size_t> all_observation_ids_;
+  std::vector<double> all_observation_values_;
+  // State
+  std::array<double, 2> time_bounds_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  // Loaded from data files
+  std::vector<PointwiseInterpolator<Dim, ::Frame::Grid>> interpolators_{};
+  // Mutex to protect other threads from accessing the `interpolators_` vector
+  // while it is being modified
+  mutable std::shared_mutex interpolators_mutex_;  // NOLINT(spectre-mutable)
+};
+
+}  // namespace spectre::Exporter

--- a/src/Visualization/Python/PlotAlongLine.py
+++ b/src/Visualization/Python/PlotAlongLine.py
@@ -11,7 +11,7 @@ import matplotlib.animation
 import matplotlib.pyplot as plt
 import numpy as np
 
-from spectre.IO.Exporter import interpolate_to_points
+from spectre.IO.Exporter import ObservationId, interpolate_to_points
 from spectre.Visualization.OpenVolfiles import (
     open_volfiles,
     open_volfiles_command,
@@ -145,7 +145,7 @@ def plot_along_line(
         vars_on_line = interpolate_to_points(
             h5_files,
             subfile_name=subfile_name,
-            observation_id=obs_id,
+            observation=ObservationId(obs_id),
             tensor_components=vars,
             target_points=target_coords,
             extrapolate_into_excisions=extrapolate_into_excisions,

--- a/src/Visualization/Python/PlotSlice.py
+++ b/src/Visualization/Python/PlotSlice.py
@@ -14,7 +14,7 @@ import numpy as np
 import rich
 
 import spectre.IO.H5 as spectre_h5
-from spectre.IO.Exporter import interpolate_to_points
+from spectre.IO.Exporter import ObservationId, interpolate_to_points
 from spectre.Visualization.OpenVolfiles import (
     open_volfiles,
     open_volfiles_command,
@@ -198,7 +198,7 @@ def plot_slice(
             interpolate_to_points(
                 h5_files,
                 subfile_name=subfile_name,
-                observation_id=obs_id,
+                observation=ObservationId(obs_id),
                 tensor_components=[var_name],
                 target_points=target_coords.reshape(3, np.prod(num_samples)),
                 extrapolate_into_excisions=extrapolate_into_excisions,

--- a/support/Pipelines/Bbh/FindHorizon.py
+++ b/support/Pipelines/Bbh/FindHorizon.py
@@ -12,7 +12,7 @@ import spectre.IO.H5 as spectre_h5
 from spectre.ApparentHorizonFinder import FastFlow, FlowType, Status
 from spectre.DataStructures import DataVector
 from spectre.DataStructures.Tensor import tnsr
-from spectre.IO.Exporter import interpolate_tensors_to_points
+from spectre.IO.Exporter import ObservationId, interpolate_tensors_to_points
 from spectre.PointwiseFunctions.GeneralRelativity.Surfaces import (
     horizon_quantities,
 )
@@ -174,7 +174,7 @@ def find_horizon(
         ) = interpolate_tensors_to_points(
             h5_files,
             subfile_name,
-            observation_id=obs_id,
+            observation=ObservationId(obs_id),
             target_points=cartesian_coords(prolonged_strahlkorper),
             tensor_names=tensor_names[1:4],
             tensor_types=[
@@ -219,7 +219,7 @@ def find_horizon(
     ) = interpolate_tensors_to_points(
         h5_files,
         subfile_name,
-        observation_id=obs_id,
+        observation=ObservationId(obs_id),
         target_points=cartesian_coords(strahlkorper),
         tensor_names=tensor_names,
         tensor_types=[

--- a/tests/Unit/IO/Exporter/CMakeLists.txt
+++ b/tests/Unit/IO/Exporter/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Exporter")
 
 set(LIBRARY_SOURCES
   Test_Exporter.cpp
+  Test_SpacetimeInterpolator.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/IO/Exporter/Python/CMakeLists.txt
+++ b/tests/Unit/IO/Exporter/Python/CMakeLists.txt
@@ -6,3 +6,9 @@ spectre_add_python_bindings_test(
   Test_InterpolateToPoints.py
   "unit;python"
   PyExporter)
+
+spectre_add_python_bindings_test(
+  "Unit.IO.Exporter.Python.SpacetimeInterpolator"
+  Test_SpacetimeInterpolator.py
+  "unit;python"
+  PyExporter)

--- a/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
+++ b/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 from spectre.DataStructures import DataVector
 from spectre.DataStructures.Tensor import Frame, Scalar, tnsr
 from spectre.Informer import unit_test_build_path, unit_test_src_path
-from spectre.IO.Exporter import interpolate_tensors_to_points
+from spectre.IO.Exporter import ObservationId, interpolate_tensors_to_points
 from spectre.IO.Exporter.InterpolateToPoints import (
     interpolate_to_points_command,
 )
@@ -38,13 +38,13 @@ class TestInterpolateToPoints(unittest.TestCase):
             open_volfiles([self.h5_filename], "/element_data")
         )[0][0]
         for frame in [Frame.Grid, Frame.Inertial]:
-            coords = tnsr.I[DataVector, 3](
+            coords = tnsr.I[DataVector, 3, frame](
                 np.array([3 * [0.0], 3 * [2 * np.pi]]).T
             )
             (psi,) = interpolate_tensors_to_points(
                 self.h5_filename,
                 "element_data",
-                observation_id=obs_id,
+                observation=ObservationId(obs_id),
                 tensor_names=["Psi"],
                 tensor_types=[Scalar[DataVector]],
                 target_points=coords,

--- a/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
+++ b/tests/Unit/IO/Exporter/Python/Test_InterpolateToPoints.py
@@ -12,7 +12,11 @@ from click.testing import CliRunner
 from spectre.DataStructures import DataVector
 from spectre.DataStructures.Tensor import Frame, Scalar, tnsr
 from spectre.Informer import unit_test_build_path, unit_test_src_path
-from spectre.IO.Exporter import ObservationId, interpolate_tensors_to_points
+from spectre.IO.Exporter import (
+    ObservationId,
+    PointwiseInterpolator3DInertial,
+    interpolate_tensors_to_points,
+)
 from spectre.IO.Exporter.InterpolateToPoints import (
     interpolate_to_points_command,
 )
@@ -50,6 +54,16 @@ class TestInterpolateToPoints(unittest.TestCase):
                 target_points=coords,
             )
             self.assertAlmostEqual(psi.get()[0], -0.07059806932542323)
+        interpolator = PointwiseInterpolator3DInertial(
+            self.h5_filename,
+            subfile_name="element_data",
+            observation=ObservationId(obs_id),
+            tensor_components=["Psi"],
+        )
+        self.assertAlmostEqual(
+            interpolator.interpolate_to_point(np.zeros(3))[0],
+            -0.07059806932542323,
+        )
 
     def test_cli(self):
         runner = CliRunner()

--- a/tests/Unit/IO/Exporter/Python/Test_SpacetimeInterpolator.py
+++ b/tests/Unit/IO/Exporter/Python/Test_SpacetimeInterpolator.py
@@ -1,0 +1,74 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import os
+import shutil
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from click.testing import CliRunner
+
+import spectre.IO.H5 as spectre_h5
+from spectre.DataStructures import DataVector
+from spectre.DataStructures.Tensor import Frame, Scalar, tnsr
+from spectre.Domain import ElementId, serialize_domain
+from spectre.Domain.Creators import Brick
+from spectre.Informer import unit_test_build_path, unit_test_src_path
+from spectre.IO.Exporter import ObservationStep, SpacetimeInterpolator
+from spectre.IO.H5 import ElementVolumeData, TensorComponent
+from spectre.Spectral import Basis, Mesh, Quadrature
+
+
+class TestSpacetimeInterpolator(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.join(
+            unit_test_build_path(), "IO/Exporter/SpacetimeInterpolator"
+        )
+        self.h5_filename = os.path.join(self.test_dir, "VolumeData.h5")
+        os.makedirs(self.test_dir, exist_ok=True)
+
+        # Write some volume data
+        domain = Brick(
+            lower_bounds=[0.0, 0.0, 0.0],
+            upper_bounds=[1.0, 1.0, 1.0],
+            initial_refinement_levels=[0, 0, 0],
+            initial_num_points=[4, 4, 4],
+            is_periodic=[False, False, False],
+        ).create_domain()
+        serialized_domain = serialize_domain(domain)
+        mesh = Mesh[3](4, Basis.Legendre, Quadrature.GaussLobatto)
+        with spectre_h5.H5File(self.h5_filename, "w") as open_h5file:
+            volfile = open_h5file.insert_vol("/VolumeData", version=0)
+            for i in range(5):
+                volfile.write_volume_data(
+                    observation_id=i,
+                    observation_value=i,
+                    elements=[
+                        ElementVolumeData(
+                            ElementId[3]("[B0,(L0I0,L0I0,L0I0)]"),
+                            [TensorComponent("Psi", np.ones(4**3) * i)],
+                            mesh,
+                        ),
+                    ],
+                    serialized_domain=serialized_domain,
+                )
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_spacetime_interpolator(self):
+        interpolator = SpacetimeInterpolator[3](
+            self.h5_filename,
+            subfile_name="VolumeData",
+            tensor_components=["Psi"],
+        )
+        self.assertEqual(interpolator.max_time_bounds(), [1, 3])
+        interpolator.load_time_bounds([1.5, 3])
+        self.assertEqual(interpolator.time_bounds(), [1, 3])
+        (psi,) = interpolator.interpolate_to_point(np.zeros(3), time=2.5)
+        self.assertAlmostEqual(psi, 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -83,6 +83,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
         "element_data",
         ObservationStep{0},
         {"Psi", "Phi_x", "Phi_y", "Phi_z"}};
+    CHECK(interpolator.time() == approx(0.04));
     {
       INFO("Multiple points");
       std::vector<DataVector> interpolated_data{};

--- a/tests/Unit/IO/Exporter/Test_SpacetimeInterpolator.cpp
+++ b/tests/Unit/IO/Exporter/Test_SpacetimeInterpolator.cpp
@@ -1,0 +1,198 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Creators/Rectilinear.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "IO/Exporter/Exporter.hpp"
+#include "IO/Exporter/SpacetimeInterpolator.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace spectre::Exporter {
+
+namespace {
+
+void write_data_to_file(const std::string& h5_file_name) {
+  // Create a domain
+  const std::array<double, 3> velocity{{1.0, 0.0, 0.0}};
+  const domain::creators::time_dependence::UniformTranslation<3, 0>
+      time_dependence{0.0, velocity};
+  const domain::creators::Sphere domain_creator{
+      1.0,
+      3.0,
+      domain::creators::Sphere::Excision{},
+      1_st,
+      6_st,
+      true,
+      {},
+      {},
+      domain::CoordinateMaps::Distribution::Linear,
+      ShellWedges::All,
+      time_dependence.get_clone()};
+  const auto domain = domain_creator.create_domain();
+  const auto functions_of_time = domain_creator.functions_of_time();
+
+  // Generate some volume data in the grid frame
+  const auto element_ids =
+      initial_element_ids(domain_creator.initial_refinement_levels());
+  const Mesh<3> mesh{6, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const auto xi = logical_coordinates(mesh);
+  std::vector<ElementVolumeData> element_volume_data{};
+  const auto func = [](const auto& x) { return get(magnitude(x)); };
+  for (const auto& element_id : element_ids) {
+    const ElementMap<3, Frame::Grid> element_map{
+        element_id, domain.blocks()[element_id.block_id()]};
+    const auto x = element_map(xi);
+    DataVector psi = func(x);
+    element_volume_data.push_back(ElementVolumeData{
+        element_id, {TensorComponent{"Psi", std::move(psi)}}, mesh});
+  }
+
+  // Write grid-frame data to file at multiple times. This means the data is
+  // moving with the grid, but since the SpacetimeInterpolator works in the
+  // grid frame the time interpolation should be exact.
+  const size_t num_times = 10;
+  std::vector<double> times(num_times);
+  std::iota(times.begin(), times.end(), 0.0);
+  h5::H5File<h5::AccessType::ReadWrite> h5_file(h5_file_name);
+  auto& volfile = h5_file.insert<h5::VolumeData>("/VolumeData", 0);
+  size_t obs_id = 0;
+  for (const double time : times) {
+    volfile.write_volume_data(obs_id, time, element_volume_data,
+                              serialize(domain), serialize(functions_of_time));
+    ++obs_id;
+  }
+}
+
+void test_time_interpolation(
+    const SpacetimeInterpolator<3, Frame::Inertial>& interpolator) {
+  auto [tmin, tmax] = interpolator.time_bounds();
+  CHECK(tmin < tmax);
+  std::vector<double> interpolated_data{};
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      interpolator.interpolate_to_point(make_not_null(&interpolated_data),
+                                        tnsr::I<double, 3>{{0.0, 0.0, 0.0}},
+                                        tmin - 0.1),
+      Catch::Matchers::ContainsSubstring("outside the time bounds."));
+#endif  // SPECTRE_DEBUG
+  for (const double time : {tmin, tmin + 0.1, tmin + 1.0,
+                            tmin + 0.5 * (tmax - tmin), tmax - 0.1, tmax}) {
+    CAPTURE(time);
+    interpolator.interpolate_to_point(
+        make_not_null(&interpolated_data),
+        tnsr::I<double, 3>{{time + 1.0, 0.0, 0.0}}, time);
+    CHECK(interpolated_data[0] == approx(1.0));
+  }
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      interpolator.interpolate_to_point(make_not_null(&interpolated_data),
+                                        tnsr::I<double, 3>{{0.0, 0.0, 0.0}},
+                                        tmax + 0.1),
+      Catch::Matchers::ContainsSubstring("outside the time bounds."));
+#endif  // SPECTRE_DEBUG
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.IO.Exporter.SpacetimeInterpolator", "[Unit]") {
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  // Write sample data to file
+  const std::string h5_file_name{"Unit.IO.Exporter.SpacetimeInterpolator.h5"};
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+  write_data_to_file(h5_file_name);
+
+  {
+    SpacetimeInterpolator<3, Frame::Inertial> interpolator{
+        h5_file_name, "VolumeData", {"Psi"}};
+    CHECK(interpolator.max_time_bounds() == std::array<double, 2>{{1.0, 8.0}});
+    interpolator.load_time_bounds({{1.0, 4.0}});
+    CHECK(interpolator.num_loaded_slices() == 6);
+    CHECK(interpolator.time_bounds() == std::array<double, 2>{{1.0, 4.0}});
+    // Load some time bounds that are already loaded
+    interpolator.load_time_bounds({{1.5, 4.0}});
+    CHECK(interpolator.num_loaded_slices() == 6);
+    CHECK(interpolator.time_bounds() == std::array<double, 2>{{1.0, 4.0}});
+    interpolator.load_time_bounds({{2.5, 4.0}});
+    CHECK(interpolator.num_loaded_slices() == 5);
+    CHECK(interpolator.time_bounds() == std::array<double, 2>{{2.0, 4.0}});
+    // Load some time bounds that don't overlap with the current bounds
+    interpolator.load_time_bounds({{7.5, 8.0}});
+    CHECK(interpolator.num_loaded_slices() == 4);
+    CHECK(interpolator.time_bounds() == std::array<double, 2>{{7.0, 8.0}});
+    // Interpolate
+    interpolator.load_time_bounds({{1.0, 4.0}});
+    CHECK(interpolator.num_loaded_slices() == 6);
+    CHECK(interpolator.time_bounds() == std::array<double, 2>{{1.0, 4.0}});
+    test_time_interpolation(interpolator);
+    interpolator.load_time_bounds({{4.0, 7.0}});
+    CHECK(interpolator.time_bounds() == std::array<double, 2>{{4.0, 7.0}});
+    test_time_interpolation(interpolator);
+  }
+
+  // Delete the test file
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  {
+    INFO("Test with time-independent domain");
+    const auto domain = domain::creators::Brick{
+        {{0.0, 0.0, 0.0}},
+        {{1.0, 1.0, 1.0}},
+        {{0, 0, 0}},
+        {{4, 4, 4}}}.create_domain();
+    const Mesh<3> mesh{4, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+
+    h5::H5File<h5::AccessType::ReadWrite> h5_file{h5_file_name};
+    auto& volfile = h5_file.insert<h5::VolumeData>("/VolumeData", 0);
+    for (size_t i = 0; i < 5; ++i) {
+      const double t = 1.0 * static_cast<double>(i);
+      ElementVolumeData element_volume_data{
+          ElementId<3>{0}, {TensorComponent{"Psi", DataVector(64, t)}}, mesh};
+      volfile.write_volume_data(i, t, {std::move(element_volume_data)},
+                                serialize(domain));
+    }
+
+    SpacetimeInterpolator<3> interpolator{h5_file_name, "VolumeData", {"Psi"}};
+    interpolator.load_time_bounds({{1.5, 3}});
+    std::vector<double> result{};
+    interpolator.interpolate_to_point(
+        make_not_null(&result), tnsr::I<double, 3, Frame::Inertial>{{0, 0, 0}},
+        2.5);
+    CHECK(result[0] == approx(2.5));
+
+    if (file_system::check_if_file_exists(h5_file_name)) {
+      file_system::rm(h5_file_name, true);
+    }
+  }
+}
+
+}  // namespace spectre::Exporter


### PR DESCRIPTION
## Proposed changes

Adds the `SpacetimeInterpolator` class that can load multiple slices of volume data and then interpolate to arbitrary points in both space and time within this time range. The time range can be advanced sequentially. This is useful for ray tracing.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
