### PR TITLE
Change observed CCE volume data format.

### DIFF
--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -450,6 +450,11 @@ a bit on why we chose some of those parameters.
   we also recommend running CCE over several worldtube radii and checking which
   is the best based on the Bianchi identity violations. There isn't necessarily
   a "best radius" to extract waveforms at.
+- Most users will not need it, but if you want to dump data from the volume
+  (instead of only on future null infinity), this is possible with the
+  `ObserveFields` option to `Events` within `EventsAndTriggersAtSlabs` in the
+  input file. See the input file referenced above for a (commented-out) example,
+  and the documentation of the class `Cce::Events::ObserveFields` for details.
 
 ### Initial data on the null hypersurface
 

--- a/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
+++ b/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
@@ -23,6 +23,7 @@
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/VolumeActions.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCoefficients.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp"
@@ -99,18 +100,41 @@ std::string name() {
  * data and decompose in spherical harmonics before writing. This means
  * our typical way of writing/storing volume data won't work.
  *
- * This event writes its data in the following structure in the H5 file:
- * `/Cce/VolumeData/TagName/CompactifiedRadius_X.dat`. Every field that is
- * observed will get its own subgroup called `TagName`. In this subgroup, there
- * will be N files corresponding to N radial grid points named
- * `CompactifiedRadius_X.dat` where `X` here will range from 0 to `N-1`. We call
- * these compactified radii because for a more "physical" radius, it goes to
- * infinity at future-null infinity and we can't write that in a file. Instead,
- * these N files will correspond to the compactified coordinate $y = 1 - 2R/r$
- * where $r$ is your coordinate radius and $R$ is the coordinate radius of your
- * worldtube. Each file will hold the modal data for that radial grid point. It
- * is recommended to always dump the quantity `Cce::Tags::OneMinusY` so the
- * values of the compactified coordinates are available as well.
+ * All data will be written into the `observers::OptionTags::VolumeFileName`
+ * file. If CCE is run on a single core, then this will write the volume data
+ * immediately (synchronously) instead of sending it to the ObserverWriter to be
+ * written asynchronously.  The option `SubgroupName` controls the name of the
+ * H5 group where this volume data is written. For example, if `SubgroupName` is
+ * "CceVolumeData", then the volume file will contain
+ * `/CceVolumeData/VolumeData.vol` for most fields; it would contain
+ * `/CceVolumeData/InertialRetardedTime.vol` for the inertial retarded time; and
+ * it would contain `/CceVolumeData/OneMinusY.vol` for the compactified radial
+ * coordinate. The structure of the .vol subfiles is the same as that for DG
+ * volume data. However, the extents of the three different volume files are all
+ * different, and for modal directions, they take the values l_max in both of
+ * the two extent slots corresponding to angular modes. This  also means that
+ * complex modal data (which has real/imag parts interleaved, as described
+ * below) has twice as much data as the products of the extents suggests.
+ *
+ * The formats for `Cce::Tags::ComplexInertialRetardedTime` and
+ * `Cce::Tags::OneMinusY` are special and are described below. Every other field
+ * follows the same format. Each ObservationId contains one time slice. Within
+ * an ObservationId, each field is an unraveled vector of complex modal
+ * coefficients at compactified radial slices (the compactified coordinate is $y
+ * = 1 - 2R/r$ where $r$ is your coordinate radius and $R$ is the coordinate
+ * radius of your worldtube; it is recommended to always dump the quantity
+ * `Cce::Tags::OneMinusY` so the values of the compactified coordinates are
+ * available as well). The ordering of the coefficients for a field $f$ at
+ * constant observation event are, for example:
+ * Re f_{0,0}(1-y_0), Im f_{0,0}(1-y_0), Re f_{1,-1}(1-y_0), Im f_{1,-1}(1-y_0),
+ * Re f_{1,0}(1-y_0), Im f_{1,0}(1-y_0), ...
+ * Re f_{l_{max},l_{max}}(1-y_0), Im f_{l_{max},l_{max}}(1-y_0),
+ * Re f_{0,0}(1-y_1), Im f_{0,0}(1-y_1), ...
+ * Re f_{l_{max},l_{max}}(1-y_{max)), Im f_{l_{max},l_{max}}(1-y_{max}).
+ * That is, the radial slice indexes the slowest, followed by the $\ell$ number
+ * (always starting at 0, even for s≠0), followed by the azimuthal m number
+ * (from $-\ell$ to $+\ell$ inclusive), followed by interleaving real and
+ * imaginary parts of the complex field.
  *
  * There are two notable exceptions to this format. One is
  * `Cce::Tags::ComplexInertialRetardedTime`. The quantity we are actually
@@ -118,24 +142,16 @@ std::string name() {
  * defined once for every direction $\theta,\phi$ (meaning it does not have
  * different values at the different radial grid points). However, we use
  * `Cce::Tags::ComplexInertialRetardedTime` because it has the same data type as
- * the other tags which makes the internals of the class simpler. The imaginary
- * part of this `ComplexDataVector` is set to zero. This quantity will be stored
- * in a subfile named `/Cce/VolumeData/InertialRetardedTime.dat` as a single
- * modal set of data so we don't repeat it N times.
+ * the other tags which makes the internals of the class simpler. This quantity
+ * is stored in `/<SubgroupName>/InertialRetardedTime.vol`.
  *
- * The second is `Cce::Tags::OneMinusY`. Even though this quantity is stored
- * as a `Scalar<SpinWeighted<ComplexDataVector, 0>>` like the others, there is
- * only one meaningful value per radial grid point. All angular grid points for
- * a given radius are set to this value, namely $1-y$. Thus we only need to
- * write this value once for each radial grid point. We do this in a subfile
- * `/Cce/VolumeData/OneMinusY.dat` where the columns are named
- * `CompactifiedRadius_X` corresponding to the radial subfiles written for the
- * spin weighted quantities above (and time as the first column).
- *
- * All data will be written into the `observers::OptionTags::ReductionFileName`
- * file. If CCE is run on a single core, then this will write the volume data
- * immediately (synchronously) instead of sending it to the ObserverWriter to be
- * written asynchronously.
+ * The second is `Cce::Tags::OneMinusY`. Even though this quantity is stored as
+ * a `Scalar<SpinWeighted<ComplexDataVector, 0>>` like the others, there is only
+ * one meaningful value per radial grid point. All angular grid points for a
+ * given radius are set to this value, namely $1-y$. Thus we only need to write
+ * this value once for each radial grid point. We do this in a volume subfile
+ * `/<SubgroupName>/OneMinusY.vol` with the elements in the same order as the
+ * radial index order for the spin weighted quantities above.
  */
 class ObserveFields : public Event {
   template <typename Tag, bool IncludeSecondDeriv = true>
@@ -172,22 +188,33 @@ class ObserveFields : public Event {
   WRAPPED_PUPable_decl_template(ObserveFields);  // NOLINT
   /// \endcond
 
+  /// The name of the subgroup inside the HDF5 file
+  struct SubgroupName {
+    using type = std::string;
+    static constexpr Options::String help = {
+      "The name of the subgroup inside the HDF5 file without an extension and "
+      "without a preceding '/'."};
+  };
+
   struct VariablesToObserve {
     static constexpr Options::String help = "Subset of variables to observe";
     using type = std::vector<std::string>;
     static size_t lower_bound_on_size() { return 1; }
   };
 
-  using options = tmpl::list<VariablesToObserve>;
+  using options = tmpl::list<SubgroupName, VariablesToObserve>;
 
   static constexpr Options::String help =
       "Observe volume tensor fields on the characteristic grid. Writes volume "
       "quantities from the tensors listed in the 'VariablesToObserve' "
-      "option to the `/Cce/VolumeData` subfile of the reduction h5 file.\n";
+      "option to volume subfiles in the subgroup named by the option "
+      "'SubgroupName', into the volume h5 file named by the option "
+      "'VolumeFileName' of Observers.\n";
 
   ObserveFields() = default;
 
-  ObserveFields(const std::vector<std::string>& variables_to_observe,
+  ObserveFields(const std::string& subgroup_name,
+                const std::vector<std::string>& variables_to_observe,
                 const Options::Context& context = {});
 
   using compute_tags_for_observation_box =
@@ -215,22 +242,6 @@ class ObserveFields : public Event {
     const size_t number_of_radial_grid_points =
         get<Tags::NumberOfRadialPoints>(box);
 
-    // Buffers/views
-    std::vector<double> data_to_write(2 * l_max_plus_one_squared + 1);
-    ComplexModalVector goldberg_mode_buffer{l_max_plus_one_squared};
-    ComplexDataVector spin_weighted_data_view{};
-
-    // Legend
-    std::vector<std::string> file_legend;
-    file_legend.reserve(2 * l_max_plus_one_squared + 1);
-    file_legend.emplace_back("time");
-    for (int i = 0; i <= static_cast<int>(l_max); ++i) {
-      for (int j = -i; j <= i; ++j) {
-        file_legend.push_back(MakeString{} << "Real Y_" << i << "," << j);
-        file_legend.push_back(MakeString{} << "Imag Y_" << i << "," << j);
-      }
-    }
-
     // Time
     const double time = get<::Tags::Time>(box);
 
@@ -238,166 +249,156 @@ class ObserveFields : public Event {
     auto observer_proxy = Parallel::get_parallel_component<
         ::observers::ObserverWriter<Metavariables>>(cache)[0];
 
-    // Actual work to transform nodal data to modal data. Places result in
-    // data_to_write (but starts placing data in the 1st, not 0th, element
-    // because the 0th element is time). Also makes use of the
-    // spin_weighted_data_view and goldberg_mode_buffer
-    const auto transform_to_modal =
-        [&spin_weighted_data_view, &goldberg_mode_buffer, &box, &l_max,
-         &number_of_angular_points, &l_max_plus_one_squared,
-         &data_to_write](auto tag_v, const auto& spin_weighted_transform,
-                         auto& goldberg_modes, const size_t radial_index) {
-          using tag = std::decay_t<decltype(tag_v)>;
-
-          // Get ComplexDataVector out of SpinWeighted out of databox tag
-          const ComplexDataVector& tensor = get(get<tag>(box)).data();
-
-          // Make non-owning ComplexDataVector to angular data corresponding to
-          // this radial index
-          // NOLINTBEGIN
-          spin_weighted_data_view.set_data_ref(
-              const_cast<ComplexDataVector&>(tensor).data() +
-                  radial_index * number_of_angular_points,
-              number_of_angular_points);
-          // NOLINTEND
-
-          // swsh_transform requires a SpinWeighted<ComplexDataVector>. It's
-          // easier to make a const-view from a ComplexDataVector that is
-          // already the proper size (spin_weighted_data_view) than it is to try
-          // and do all the indexing into the big block of memory here in this
-          // call. That is why we have spin_weighted_data_view above.
-          make_const_view(make_not_null(&spin_weighted_transform.data()),
-                          spin_weighted_data_view, 0,
-                          spin_weighted_data_view.size());
-
-          // libsharp_to_goldberg_modes expects
-          // SpinWeighted<ComplexModalVector>, but we don't know the spin until
-          // we loop over tensors, so we have goldberg_mode_buffer (a
-          // ComplexModalVector) allocated properly above and just point into it
-          // here.
-          goldberg_modes.set_data_ref(make_not_null(&goldberg_mode_buffer));
-
-          // Transform nodal data to modal data
-          Spectral::Swsh::libsharp_to_goldberg_modes(
-              make_not_null(&goldberg_modes),
-              Spectral::Swsh::swsh_transform(l_max, 1, spin_weighted_transform),
-              l_max);
-
-          // Copy data into std::vector for writing (remember 0th component is
-          // time and was written above).
-          for (size_t i = 0; i < l_max_plus_one_squared; ++i) {
-            data_to_write[2 * i + 1] = real(goldberg_modes.data()[i]);
-            data_to_write[2 * i + 2] = imag(goldberg_modes.data()[i]);
-          }
-        };
-
+    ////////////////////////////////////////////////////////////
     // The inertial retarded time is special because it's stored as a
     // Scalar<DataVector> because it's only real and only has one set of angular
-    // points worth of data to write. However, all the machinery above is for a
+    // points worth of data to write. However, all the machinery is for a
     // SpinWeighted<ComplexDataVector>. Luckily there is a
     // ComplexInertialRetardedTime where the real part is the
-    // InertialRetardedTime and the imaginary part is 0, so we use that instead
-    // swapping the names and legend where necessary
+    // InertialRetardedTime and the imaginary part is 0, so we use that instead,
+    // swapping the names where necessary.
+    // Put into volume subfile named /<SubgroupName>/InertialRetardedTime.vol
     const std::string inertial_retarded_time_name =
         detail::name<Tags::ComplexInertialRetardedTime>();
     if (variables_to_observe_.count(inertial_retarded_time_name) == 1) {
-      const std::string subfile_name =
-          "/Cce/VolumeData/" + inertial_retarded_time_name;
+      const std::string subfile_name = subgroup_path_
+                                       + "/" + inertial_retarded_time_name;
+      const observers::ObservationId observation_id{time,
+        subfile_name + ".vol"};
+      const std::vector<size_t> extents_vector{{l_max, l_max}};
+      const std::vector<Spectral::Basis> bases_vector{
+        {Spectral::Basis::SphericalHarmonic,
+         Spectral::Basis::SphericalHarmonic}};
+      const std::vector<Spectral::Quadrature> quadratures_vector{
+        {Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
 
-      // Legend
-      std::vector<std::string> inertial_retarded_time_legend;
-      inertial_retarded_time_legend.reserve(l_max_plus_one_squared + 1);
-      inertial_retarded_time_legend.emplace_back("time");
-      for (int i = 0; i <= static_cast<int>(l_max); ++i) {
-        for (int j = -i; j <= i; ++j) {
-          inertial_retarded_time_legend.push_back(MakeString{} << "Y_" << i
-                                                               << "," << j);
-        }
-      }
+      const SpinWeighted<ComplexDataVector, 0>& complex_inertial_retarded_time =
+          get(get<Tags::ComplexInertialRetardedTime>(box));
 
-      // These have to be here because of the spin template
-      const SpinWeighted<ComplexDataVector, 0> spin_weighted_transform{};
-      SpinWeighted<ComplexModalVector, 0> goldberg_modes{};
+      // Allocate a buffer to receive the transformed data, since
+      // WriteVolumeData only understands DataVectors, not
+      // ComplexDataVectors.
+      DataVector goldberg_modes_interleaved_dv(2 * l_max_plus_one_squared);
 
-      // Actually transform the time to complex modal data. Radial index 0
-      // because this isn't volume data. It only holds one shell of data.
-      transform_to_modal(Tags::ComplexInertialRetardedTime{},
-                         spin_weighted_transform, goldberg_modes, 0);
+      // A non-owning view of goldberg_modes_interleaved_dv,
+      // with the correct spin
+      SpinWeighted<ComplexModalVector, 0> goldberg_mode_view;
+      goldberg_mode_view.set_data_ref(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<std::complex<double>*>(
+          goldberg_modes_interleaved_dv.data()),
+        l_max_plus_one_squared);
 
-      // Buffer to write
-      std::vector<double> inertial_retarded_time_to_write(
-          l_max_plus_one_squared + 1);
+      Spectral::Swsh::libsharp_to_goldberg_modes(
+          make_not_null(&goldberg_mode_view),
+          Spectral::Swsh::swsh_transform(
+              l_max, 1, complex_inertial_retarded_time),
+          l_max);
 
-      inertial_retarded_time_to_write[0] = time;
-      // Only copy real data
-      for (size_t i = 0; i < l_max_plus_one_squared; ++i) {
-        inertial_retarded_time_to_write[i + 1] = data_to_write[2 * i + 1];
-      }
+      const std::vector<TensorComponent> tensor_components{
+        {inertial_retarded_time_name, goldberg_modes_interleaved_dv}};
 
       if (write_synchronously) {
         Parallel::local_synchronous_action<
-            observers::ThreadedActions::WriteReductionDataRow>(
-            observer_proxy, cache, subfile_name, inertial_retarded_time_legend,
-            std::make_tuple(std::move(inertial_retarded_time_to_write)));
+          observers::ThreadedActions::WriteVolumeData>(
+              observer_proxy, cache,
+              Parallel::get<observers::Tags::VolumeFileName>(cache),
+              subfile_name, observation_id,
+              std::vector<ElementVolumeData>{
+                {inertial_retarded_time_name, tensor_components,
+                 extents_vector, bases_vector,
+                 quadratures_vector}});
       } else {
         // Send to observer writer
         Parallel::threaded_action<
-            observers::ThreadedActions::WriteReductionDataRow>(
-            observer_proxy, subfile_name, inertial_retarded_time_legend,
-            std::make_tuple(std::move(inertial_retarded_time_to_write)));
+          observers::ThreadedActions::WriteVolumeData>(
+              observer_proxy,
+              Parallel::get<observers::Tags::VolumeFileName>(cache),
+              subfile_name, observation_id,
+              std::vector<ElementVolumeData>{
+                {inertial_retarded_time_name, tensor_components,
+                 extents_vector, bases_vector,
+                 quadratures_vector}});
       }
     }
 
+    ////////////////////////////////////////////////////////////
     // One minus y is also special because every angular grid point for a given
     // radius holds the same value. Thus we only need to write one double per
-    // radial grid point corresponding to 1 - y. The subfile name is just the
-    // name of the tag, and the column names correspond to the names of the
-    // radial subfiles for the spin weighted quantities
+    // radial grid point corresponding to 1 - y. Put into volume subfile named
+    // /<SubgroupName>/OneMinusY.vol
     const std::string one_minus_y_name = detail::name<Tags::OneMinusY>();
     if (variables_to_observe_.count(one_minus_y_name) == 1) {
-      const std::string subfile_name = "/Cce/VolumeData/" + one_minus_y_name;
-      std::vector<double> one_minus_y_to_write;
-      std::vector<std::string> one_minus_y_legend;
-      one_minus_y_to_write.reserve(number_of_radial_grid_points + 1);
-      one_minus_y_legend.reserve(number_of_radial_grid_points + 1);
-      one_minus_y_to_write.emplace_back(time);
-      one_minus_y_legend.emplace_back("time");
+      const std::string subfile_name = subgroup_path_ + "/" + one_minus_y_name;
+      const observers::ObservationId observation_id{time,
+        subfile_name + ".vol"};
+      const std::vector<size_t> extents_vector{number_of_radial_grid_points};
+      const std::vector<Spectral::Basis> bases_vector{
+        Spectral::Basis::Legendre};
+      const std::vector<Spectral::Quadrature> quadratures_vector{
+        Spectral::Quadrature::GaussLobatto};
 
       const ComplexDataVector& one_minus_y =
           get(get<Tags::OneMinusY>(box)).data();
 
-      // All nodal data for each radius are the same value so we just take the
-      // first one
+      DataVector one_minus_y_to_write(number_of_radial_grid_points);
+
       for (size_t radial_index = 0; radial_index < number_of_radial_grid_points;
            radial_index++) {
-        one_minus_y_to_write.emplace_back(
-            real(one_minus_y[radial_index * number_of_angular_points]));
-        one_minus_y_legend.emplace_back("CompactifiedRadius_" +
-                                        std::to_string(radial_index));
+        one_minus_y_to_write[radial_index] =
+            real(one_minus_y[radial_index * number_of_angular_points]);
       }
+
+      const std::vector<TensorComponent> tensor_components{
+        {one_minus_y_name, one_minus_y_to_write}};
 
       if (write_synchronously) {
         Parallel::local_synchronous_action<
-            observers::ThreadedActions::WriteReductionDataRow>(
-            observer_proxy, cache, subfile_name, one_minus_y_legend,
-            std::make_tuple(std::move(one_minus_y_to_write)));
+          observers::ThreadedActions::WriteVolumeData>(
+              observer_proxy, cache,
+              Parallel::get<observers::Tags::VolumeFileName>(cache),
+              subfile_name, observation_id,
+              std::vector<ElementVolumeData>{
+                {one_minus_y_name, tensor_components,
+                 extents_vector, bases_vector,
+                 quadratures_vector}});
       } else {
         // Send to observer writer
         Parallel::threaded_action<
-            observers::ThreadedActions::WriteReductionDataRow>(
-            observer_proxy, subfile_name, one_minus_y_legend,
-            std::make_tuple(std::move(one_minus_y_to_write)));
+          observers::ThreadedActions::WriteVolumeData>(
+              observer_proxy,
+              Parallel::get<observers::Tags::VolumeFileName>(cache),
+              subfile_name, observation_id,
+              std::vector<ElementVolumeData>{
+                {one_minus_y_name, tensor_components,
+                 extents_vector, bases_vector,
+                 quadratures_vector}});
       }
     }
 
-    // Everything needs the same time so we just write it once here. We use the
-    // code time because the inertial retarded time is specified over the whole
-    // sphere and is written above (as a function of the code time as well)
-    data_to_write[0] = time;
+    ////////////////////////////////////////////////////////////
+    // Everything else gets written together into the volume subfile named
+    // /<SubgroupName>/VolumeData.vol
 
-    // Loop over all available spin weighted tags and check if we are observing
-    // this tag. We just capture everything in the scope because we need a
-    // majority of the variables anyways
+    // Field-independent info for writing into volume data file
+    const std::string subfile_name = subgroup_path_ + "/VolumeData";
+    const observers::ObservationId observation_id{time,
+      subfile_name + ".vol"};
+    const std::vector<size_t> extents_vector{
+      {number_of_radial_grid_points, l_max, l_max}};
+    const std::vector<Spectral::Basis> bases_vector{
+      {Spectral::Basis::Legendre,
+       Spectral::Basis::SphericalHarmonic,
+       Spectral::Basis::SphericalHarmonic}};
+    const std::vector<Spectral::Quadrature> quadratures_vector{
+      {Spectral::Quadrature::GaussLobatto,
+       Spectral::Quadrature::Gauss,
+       Spectral::Quadrature::Equiangular}};
+
+    // Create tensor_components by looping over all available spin
+    // weighted tags and checking if we are observing this tag.
+    std::vector<TensorComponent> tensor_components;
     tmpl::for_each<spin_weighted_tags_to_observe>([&](auto tag_v) {
       using tag = tmpl::type_from<decltype(tag_v)>;
       constexpr int spin = tag::type::type::spin;
@@ -408,36 +409,56 @@ class ObserveFields : public Event {
         return;
       }
 
-      // These have to be here because of the spin template
-      const SpinWeighted<ComplexDataVector, spin> spin_weighted_transform{};
-      SpinWeighted<ComplexModalVector, spin> goldberg_modes{};
+      const SpinWeighted<ComplexDataVector, spin>& field =
+        get(get<tag>(box));
 
-      // If we are observing this tag, loop over all radii and write data to
-      // separate subfiles for each radius
-      for (size_t radial_index = 0; radial_index < number_of_radial_grid_points;
-           radial_index++) {
-        const std::string subfile_name = "/Cce/VolumeData/" + name +
-                                         "/CompactifiedRadius_" +
-                                         std::to_string(radial_index);
+      // Allocate a buffer to receive the transformed data, since
+      // WriteVolumeData only understands DataVectors, not
+      // ComplexDataVectors.
+      DataVector goldberg_modes_interleaved_dv(2 *
+        l_max_plus_one_squared * number_of_radial_grid_points);
 
-        // Actually transform the time to complex modal data.
-        transform_to_modal(tag{}, spin_weighted_transform, goldberg_modes,
-                           radial_index);
+      // A non-owning view of goldberg_modes_interleaved_dv,
+      // with the correct spin
+      SpinWeighted<ComplexModalVector, spin> goldberg_mode_view;
+      goldberg_mode_view.set_data_ref(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<std::complex<double>*>(
+          goldberg_modes_interleaved_dv.data()),
+        l_max_plus_one_squared * number_of_radial_grid_points);
 
-        if (write_synchronously) {
-          Parallel::local_synchronous_action<
-              observers::ThreadedActions::WriteReductionDataRow>(
-              observer_proxy, cache, subfile_name, file_legend,
-              std::make_tuple(data_to_write));
-        } else {
-          // Send to observer writer
-          Parallel::threaded_action<
-              observers::ThreadedActions::WriteReductionDataRow>(
-              observer_proxy, subfile_name, file_legend,
-              std::make_tuple(data_to_write));
-        }
-      }
+      Spectral::Swsh::libsharp_to_goldberg_modes(
+        make_not_null(&goldberg_mode_view),
+        Spectral::Swsh::swsh_transform(l_max,
+          number_of_radial_grid_points, field), l_max);
+
+      tensor_components.emplace_back(
+        name, std::move(goldberg_modes_interleaved_dv));
+
     });
+
+    if (write_synchronously) {
+      Parallel::local_synchronous_action<
+        observers::ThreadedActions::WriteVolumeData>(
+        observer_proxy, cache,
+        Parallel::get<observers::Tags::VolumeFileName>(cache),
+        subfile_name, observation_id,
+        std::vector<ElementVolumeData>{
+          {"VolumeData", tensor_components,
+           extents_vector, bases_vector,
+           quadratures_vector}});
+    } else {
+      // Send to observer writer
+      Parallel::threaded_action<
+        observers::ThreadedActions::WriteVolumeData>(
+        observer_proxy,
+        Parallel::get<observers::Tags::VolumeFileName>(cache),
+        subfile_name, observation_id,
+        std::vector<ElementVolumeData>{
+          {"VolumeData", tensor_components,
+           extents_vector, bases_vector,
+           quadratures_vector}});
+    }
   }
 
   using is_ready_argument_tags = tmpl::list<>;
@@ -454,17 +475,21 @@ class ObserveFields : public Event {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override {
     Event::pup(p);
+    p | subgroup_path_;
     p | variables_to_observe_;
   }
 
  private:
+  std::string subgroup_path_;
   std::unordered_set<std::string> variables_to_observe_;
 };
 
 ObserveFields::ObserveFields(
+    const std::string& subgroup_name,
     const std::vector<std::string>& variables_to_observe,
     const Options::Context& context)
-    : variables_to_observe_([&context, &variables_to_observe]() {
+    : subgroup_path_("/" + subgroup_name),
+      variables_to_observe_([&context, &variables_to_observe]() {
         std::unordered_set<std::string> result{};
         for (const auto& tensor : variables_to_observe) {
           if (result.contains(tensor)) {

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -439,6 +439,30 @@ struct WriteVolumeData {
         h5_file_name, observers::input_source_from_cache(cache), subfile_path,
         observation_id, std::move(volume_data));
   }
+
+  // For a local synchronous action
+  using return_type = void;
+
+  /// \brief The apply call for the local synchronous action
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename... Ts,
+            typename DataBox = db::DataBox<DbTagsList>>
+  static return_type apply(
+      db::DataBox<DbTagsList>& box,
+      const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const std::string& h5_file_name,
+      const std::string& subfile_path,
+      const observers::ObservationId& observation_id,
+      std::vector<ElementVolumeData>&& volume_data) {
+    auto& volume_file_lock =
+        db::get_mutable_reference<Tags::H5FileLock>(
+            make_not_null(&box));
+    const std::lock_guard hold_lock(volume_file_lock);
+    VolumeActions_detail::write_data(
+        h5_file_name, observers::input_source_from_cache(cache),
+        subfile_path, observation_id, std::move(volume_data));
+  }
 };
 }  // namespace ThreadedActions
 }  // namespace observers

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -7,43 +7,16 @@ Testing:
   Timeout: 20
   Priority: High
 ExpectedOutput:
-  - CharacteristicExtractReduction.h5
+  - CharacteristicExtractVolume.h5
 OutputFileChecks:
-  # Redo this when we change the CCE volume format
-  - Label: "check_psi0_r2"
-    Subfile: "/Cce/VolumeData/Psi0/CompactifiedRadius_2.dat"
-    FileGlob: "CharacteristicExtractReduction.h5"
-    SkipColumns: [0] # Don't look at the time column
+  - Label: "check_psi0"
+    Subfile: "/CceVolumeData/VolumeData.vol/ObservationId.*/Psi0"
+    FileGlob: "CharacteristicExtractVolume.h5"
     # By not specifying an expected value, we test against 0
     AbsoluteTolerance: 1e-8
-  - Label: "check_psi0_r3"
-    Subfile: "/Cce/VolumeData/Psi0/CompactifiedRadius_3.dat"
-    FileGlob: "CharacteristicExtractReduction.h5"
-    SkipColumns: [0] # Don't look at the time column
-    # By not specifying an expected value, we test against 0
-    AbsoluteTolerance: 1e-8
-  - Label: "check_psi0_r4"
-    Subfile: "/Cce/VolumeData/Psi0/CompactifiedRadius_4.dat"
-    FileGlob: "CharacteristicExtractReduction.h5"
-    SkipColumns: [0] # Don't look at the time column
-    # By not specifying an expected value, we test against 0
-    AbsoluteTolerance: 1e-8
-  - Label: "check_psi1_r4"
-    Subfile: "/Cce/VolumeData/Psi1/CompactifiedRadius_4.dat"
-    FileGlob: "CharacteristicExtractReduction.h5"
-    SkipColumns: [0] # Don't look at the time column
-    # By not specifying an expected value, we test against 0
-    AbsoluteTolerance: 1e-8
-  - Label: "check_psi1_r5"
-    Subfile: "/Cce/VolumeData/Psi1/CompactifiedRadius_5.dat"
-    FileGlob: "CharacteristicExtractReduction.h5"
-    SkipColumns: [0] # Don't look at the time column
-    # By not specifying an expected value, we test against 0
-    AbsoluteTolerance: 1e-8
-  - Label: "check_psi1_r6"
-    Subfile: "/Cce/VolumeData/Psi1/CompactifiedRadius_6.dat"
-    FileGlob: "CharacteristicExtractReduction.h5"
-    SkipColumns: [0] # Don't look at the time column
+  - Label: "check_psi1"
+    Subfile: "/CceVolumeData/VolumeData.vol/ObservationId.*/Psi1"
+    FileGlob: "CharacteristicExtractVolume.h5"
     # By not specifying an expected value, we test against 0
     AbsoluteTolerance: 1e-8
 
@@ -65,7 +38,7 @@ ResourceInfo:
       Exclusive: false
 
 Observers:
-  VolumeFileName: "CharacteristicExtractUnusedVolume"
+  VolumeFileName: "CharacteristicExtractVolume"
   ReductionFileName: "CharacteristicExtractReduction"
 
 EventsAndTriggersAtSlabs:
@@ -79,7 +52,10 @@ EventsAndTriggersAtSlabs:
           SubfileName: CceTimeStep
           PrintTimeToTerminal: false
       - ObserveFields:
+          SubgroupName: "CceVolumeData"
           VariablesToObserve:
+            - OneMinusY
+            - InertialRetardedTime
             - Psi0
             - Psi1
 

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -25,11 +25,15 @@ ResourceInfo:
   Singletons: Auto
 
 Observers:
-  VolumeFileName: "CharacteristicExtractUnusedVolume"
-  # The reduction file is where the CCE output will be written.
+  # The reduction file is where to write the CCE output of quantities at future
+  # null infinity.
   # Specifically, it will be in a `/SpectreRXXXX.cce` where the number is the
   # ExtractionRadius specified below.
   ReductionFileName: "CharacteristicExtractReduction"
+  # The volume file is where to write the quantities from the bulk of the
+  # spacetime. The fields to extract can be specified in the section
+  # EventsAndTriggersAtSlabs.Events.ObserveFields below.
+  VolumeFileName: "CharacteristicExtractVolume"
 
 EventsAndTriggersAtSlabs:
   # Write the CCE time step every Slab. A Slab is a fixed length of simulation
@@ -45,6 +49,23 @@ EventsAndTriggersAtSlabs:
           # "/SubfileName.dat"
           SubfileName: CceTimeStep
           PrintTimeToTerminal: true
+      # # If you want to dump volume data into VolumeFileName (specified above),
+      # # you can uncomment the ObserveFields option here:
+      # - ObserveFields:
+      #     # Data will be written in the group named by SubgroupName inside the
+      #     # h5 file specified by VolumeFileName. If dumping any volume data,
+      #     # it is recommended to also output OneMinusY and
+      #     # InertialRetardedTime so as to conveniently provide the
+      #     # coordinates. See the documentation of
+      #     # src/Evolution/Systems/Cce/Events/ObserveFields.hpp for details of
+      #     # the Cce volume format.
+      #     SubgroupName: "CceVolumeData"
+      #     VariablesToObserve:
+      #       - OneMinusY
+      #       - InertialRetardedTime
+      #       - J
+      #       - Psi0
+      #       - Psi1
 
 EventsAndTriggersAtSteps:
 

--- a/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
@@ -40,33 +40,33 @@ constexpr size_t num_volume_grid_points =
     num_radial_grid_points * num_angular_grid_points;
 constexpr double time = 1.3;
 
-struct MockWriteReductionDataRow {
+struct MockWriteVolumeData {
   template <typename ParallelComponent, typename DbTagsList,
-            typename Metavariables, typename ArrayIndex>
+            typename Metavariables, typename ArrayIndex,
+            typename DataBox = db::DataBox<DbTagsList>>
   static void apply(db::DataBox<DbTagsList>& /*box*/,
-                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
-                    const std::string& subfile_name,
-                    const std::vector<std::string>& file_legend,
-                    const std::tuple<std::vector<double>>& data_row) {
+                    const std::string& /*h5_file_name*/,
+                    const std::string& subfile_path,
+                    const observers::ObservationId& /*observation_id*/,
+                    std::vector<ElementVolumeData>&& volume_data) {
     // If we were to have made the data non-zero values, the event does too many
     // transformations for us to calculate what the result would be by hand, so
     // we just check that the sizes are correct, and that the (code) time is
     // correct
     const size_t l_plus_one_squared = square(l_max + 1);
-    if (subfile_name.find("InertialRetardedTime") != std::string::npos) {
-      CHECK(file_legend.size() == l_plus_one_squared + 1);
-      CHECK(std::get<0>(data_row).size() == l_plus_one_squared + 1);
-    } else if (subfile_name.find("OneMinusY") != std::string::npos) {
-      CHECK(file_legend.size() == num_radial_grid_points + 1);
-      CHECK(std::get<0>(data_row).size() == num_radial_grid_points + 1);
+    const DataVector& data_v =
+        std::get<DataVector>(volume_data[0].tensor_components[0].data);
+    if (subfile_path.find("InertialRetardedTime") != std::string::npos) {
+      CHECK(data_v.size() == 2 * l_plus_one_squared);
+    } else if (subfile_path.find("OneMinusY") != std::string::npos) {
+      CHECK(data_v.size() == num_radial_grid_points);
     } else {
-      CHECK(subfile_name.find("CompactifiedRadius") != std::string::npos);
-      CHECK(file_legend.size() == 2 * l_plus_one_squared + 1);
-      CHECK(std::get<0>(data_row).size() == 2 * l_plus_one_squared + 1);
+      CHECK(data_v.size() ==
+            2 * l_plus_one_squared * num_radial_grid_points);
     }
-    CHECK(std::get<0>(data_row)[0] == time);
   }
 };
 
@@ -74,24 +74,48 @@ void check_h5_file(const std::string& filename_prefix) {
   const h5::H5File<h5::AccessType::ReadOnly> h5_file{filename_prefix + ".h5"};
   const size_t l_plus_one_squared = square(l_max + 1);
   {
-    const auto& cce_subfile =
-        h5_file.get<h5::Dat>("/Cce/VolumeData/InertialRetardedTime.dat");
-    CHECK(cce_subfile.get_legend().size() == l_plus_one_squared + 1);
-    CHECK(cce_subfile.get_data()(0, 0) == time);
+    const auto& u_volume_data =
+        h5_file.get<h5::VolumeData>("/CceVolumeData/InertialRetardedTime");
+    const size_t observation_id = u_volume_data.find_observation_id(time);
+
+    const TensorComponent inertial_retarded_time_component =
+        u_volume_data.get_tensor_component(observation_id,
+                                           "InertialRetardedTime");
+
+    const DataVector inertial_retarded_time =
+        std::get<DataVector>(inertial_retarded_time_component.data);
+
+    CHECK(inertial_retarded_time.size() == 2 * l_plus_one_squared);
     h5_file.close_current_object();
   }
   {
-    const auto& cce_subfile =
-        h5_file.get<h5::Dat>("/Cce/VolumeData/OneMinusY.dat");
-    CHECK(cce_subfile.get_legend().size() == num_radial_grid_points + 1);
-    CHECK(cce_subfile.get_data()(0, 0) == time);
+    const auto& one_minus_y_volume_data =
+        h5_file.get<h5::VolumeData>("/CceVolumeData/OneMinusY");
+    const size_t observation_id =
+        one_minus_y_volume_data.find_observation_id(time);
+
+    const TensorComponent one_minus_y_component =
+        one_minus_y_volume_data.get_tensor_component(observation_id,
+                                           "OneMinusY");
+
+    const DataVector one_minus_y =
+        std::get<DataVector>(one_minus_y_component.data);
+
+    CHECK(one_minus_y.size() == num_radial_grid_points);
     h5_file.close_current_object();
   }
   {
-    const auto& cce_subfile =
-        h5_file.get<h5::Dat>("/Cce/VolumeData/J/CompactifiedRadius_0.dat");
-    CHECK(cce_subfile.get_legend().size() == 2 * l_plus_one_squared + 1);
-    CHECK(cce_subfile.get_data()(0, 0) == time);
+    const auto& volume_data =
+        h5_file.get<h5::VolumeData>("/CceVolumeData/VolumeData");
+    const size_t observation_id = volume_data.find_observation_id(time);
+
+    const TensorComponent J_component =
+        volume_data.get_tensor_component(observation_id, "J");
+
+    const DataVector J_interleaved =
+        std::get<DataVector>(J_component.data);
+    CHECK(J_interleaved.size() ==
+          2 * l_plus_one_squared * num_radial_grid_points);
     h5_file.close_current_object();
   }
 }
@@ -106,12 +130,12 @@ struct MockObserverWriter {
                              tmpl::list<ActionTesting::InitializeDataBox<
                                  tmpl::list<observers::Tags::H5FileLock>>>>>;
   using const_global_cache_tags =
-      tmpl::list<observers::Tags::ReductionFileName>;
+      tmpl::list<observers::Tags::VolumeFileName>;
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
 
   using replace_these_threaded_actions =
-      tmpl::list<observers::ThreadedActions::WriteReductionDataRow>;
-  using with_these_threaded_actions = tmpl::list<MockWriteReductionDataRow>;
+      tmpl::list<observers::ThreadedActions::WriteVolumeData>;
+  using with_these_threaded_actions = tmpl::list<MockWriteVolumeData>;
 };
 
 template <typename Metavariables>
@@ -145,19 +169,21 @@ void test(const bool write_synchronously) {
   using obs_writer = MockObserverWriter<metavars>;
   using element = MockElement<metavars>;
 
-  const Cce::Events::ObserveFields fields{std::vector<std::string>{
-      "InertialRetardedTime", "J", "Psi0", "Psi1", "Dy(H)", "OneMinusY"}};
+  const std::vector<std::string> observe_field_names{
+    "InertialRetardedTime", "J", "Psi0", "Psi1", "Dy(H)", "OneMinusY"};
+  const std::string subgroup_name{"CceVolumeData"};
+  const Cce::Events::ObserveFields fields{subgroup_name, observe_field_names};
   const Cce::Events::ObserveFields serialized_fields =
       serialize_and_deserialize(fields);
 
-  const std::string filename_prefix{"PineTree"};
-  if (file_system::check_if_file_exists(filename_prefix + ".h5")) {
-    file_system::rm(filename_prefix + ".h5", true);
+  const std::string volume_filename_prefix{"PineTree"};
+  if (file_system::check_if_file_exists(volume_filename_prefix + ".h5")) {
+    file_system::rm(volume_filename_prefix + ".h5", true);
   }
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {filename_prefix},
+      {volume_filename_prefix},
       {},
       std::vector<size_t>{write_synchronously ? 1_st : 2_st}};
   ActionTesting::emplace_nodegroup_component_and_initialize<obs_writer>(
@@ -217,10 +243,11 @@ void test(const bool write_synchronously) {
   serialized_fields(obs_box, cache, array_index, component, observation_value);
 
   if (write_synchronously) {
-    check_h5_file(filename_prefix);
+    check_h5_file(volume_filename_prefix);
   } else {
-    // 1 for InertialRetardedTime and OneMinusY and 2 for each other tag
-    const size_t expected_number_of_actions = 10;
+    // 1 each for InertialRetardedTime, OneMinusY, and 1 for all the rest of the
+    // volume fields together.
+    const size_t expected_number_of_actions = 3;
     CHECK(ActionTesting::number_of_queued_threaded_actions<obs_writer>(
               runner, 0) == expected_number_of_actions);
     for (size_t i = 0; i < expected_number_of_actions; i++) {
@@ -231,13 +258,14 @@ void test(const bool write_synchronously) {
 }
 
 void test_errors() {
-  CHECK_THROWS_WITH((Cce::Events::ObserveFields{std::vector<std::string>{
-                        "Unique", "Duplicate", "Duplicate"}}),
+  CHECK_THROWS_WITH((Cce::Events::ObserveFields{"CceVolumeData",
+        std::vector<std::string>{"Unique", "Duplicate", "Duplicate"}}),
                     Catch::Matchers::ContainsSubstring(
                         "more than once in list of variables to observe"));
 
   CHECK_THROWS_WITH(
-      (Cce::Events::ObserveFields{std::vector<std::string>{"MisspelledTag"}}),
+      (Cce::Events::ObserveFields{"CceVolumeData",
+         std::vector<std::string>{"MisspelledTag"}}),
       Catch::Matchers::ContainsSubstring(
           "MisspelledTag is not an available variable. Available variables:"));
 }

--- a/tools/CheckOutputFiles.py
+++ b/tools/CheckOutputFiles.py
@@ -14,6 +14,17 @@ import numpy.testing as npt
 import yaml
 
 
+def enumerate_h5_datasets(obj):
+    """
+    Iterate through structure of an h5 file and yield all paths to dataset
+    """
+    if type(obj) in [h5py.Group, h5py.File]:
+        for key in obj.keys():
+            yield from enumerate_h5_datasets(obj[key])
+    elif type(obj) == h5py.Dataset:
+        yield obj.name
+
+
 class H5Check:
     """Describes a particular comparison between H5 datasets or groups
 
@@ -25,12 +36,17 @@ class H5Check:
         unit_test: The `unittest.testcase` object, used to invoke asserts
         label: An identifier string for the test
         file_glob: The shell glob matching the h5 files to test
-        subfile: The h5 path for the group or dataset to check
+        subfile: The h5 path for the group or dataset to check. This is allowed
+          to be a python regex but only the first matching dataset is checked.
+        absolute_tolerance: The absolute tolerance for approximation checks
+        relative_tolerance: The relative tolerance for approximation checks
         expected_data_subfile: The h5 path for the expected group or dataset
         expected_data: The expected data to compare with directly. Mutually
           exclusive with `expected_data_subfile`.
-        absolute_tolerance: The absolute tolerance for approximation checks
-        relative_tolerance: The relative tolerance for approximation checks
+        skip_columns: Which "columns" of the data to skip when checking. Here
+          column means the last index of a dataset of any shape. If the dataset
+          is rank 1, these are the indices to skip; if the dataset is rank 2,
+          with indices (row, column), then these are the columns to skip; etc.
     """
 
     def __init__(
@@ -94,7 +110,7 @@ class H5Check:
                 test_data = h5_file[test_entity][()]
                 column_mask = [
                     x not in self.skip_columns
-                    for x in range(test_data.shape[1])
+                    for x in range(test_data.shape[-1])
                 ]
                 if self.expected_h5_entity is not None:
                     expected_data = h5_file[expected_entity][()]
@@ -120,8 +136,8 @@ class H5Check:
                         # the error and print the arrays to full precision
                         try:
                             npt.assert_allclose(
-                                test_data[:, column_mask],
-                                expected_data[:, column_mask],
+                                test_data[..., column_mask],
+                                expected_data[..., column_mask],
                                 rtol=self.relative_tolerance,
                                 atol=self.absolute_tolerance,
                             )
@@ -129,10 +145,11 @@ class H5Check:
                             np.set_printoptions(precision=16)
                             print(
                                 "DESIRED:"
-                                f" {np.array(expected_data[:, column_mask])}"
+                                f" {np.array(expected_data[..., column_mask])}"
                             )
                             print(
-                                f"ACTUAL: {np.array(test_data[:, column_mask])}"
+                                "ACTUAL:"
+                                f" {np.array(test_data[..., column_mask])}"
                             )
                             raise AssertionError(
                                 "Test data is not equal to the expected data"
@@ -146,7 +163,7 @@ class H5Check:
                         # the error and print the arrays to full precision
                         try:
                             npt.assert_allclose(
-                                test_data[:, column_mask],
+                                test_data[..., column_mask],
                                 self.expected_data or 0.0,
                                 rtol=self.relative_tolerance,
                                 atol=self.absolute_tolerance,
@@ -157,7 +174,7 @@ class H5Check:
                             if self.expected_data:
                                 print(
                                     "ACTUAL:"
-                                    f" {np.array(test_data[:, column_mask])}"
+                                    f" {np.array(test_data[..., column_mask])}"
                                 )
                             else:
                                 print("ACTUAL: 0.0")
@@ -218,10 +235,31 @@ class H5Check:
         logging.info(
             "Performing checks: " + os.path.join(run_directory, self.h5_glob)
         )
+        test_h5_entity_pat = re.compile(self.test_h5_entity)
         for filename in glob.glob(os.path.join(run_directory, self.h5_glob)):
             logging.info("Checking file: " + filename)
             with self.unit_test.subTest(filename=filename):
                 with h5py.File(filename, "r") as check_h5:
+                    dataset_paths = enumerate_h5_datasets(check_h5)
+                    matched_paths = [
+                        path
+                        for path in dataset_paths
+                        if test_h5_entity_pat.match(path)
+                    ]
+
+                    if len(matched_paths) > 1:
+                        logging.warn(
+                            "Found more than 1 subfile path matching pattern '"
+                            + self.test_h5_entity
+                            + "'. Going to use first match. The matches were:\n"
+                            + "\n".join(matched_paths)
+                        )
+                        test_h5_entity = matched_paths[0]
+                    elif len(matched_paths) == 1:
+                        test_h5_entity = matched_paths[0]
+                    else:
+                        test_h5_entity = self.test_h5_entity
+
                     files_and_entities = (
                         files_and_entities
                         + filename
@@ -230,27 +268,25 @@ class H5Check:
                         + "\n"
                     )
                     found_test_entity = found_test_entity or (
-                        self.test_h5_entity in check_h5
+                        test_h5_entity in check_h5
                     )
                     found_expected_entity = found_expected_entity or (
                         self.expected_h5_entity is not None
                         and self.expected_h5_entity in check_h5
                     )
 
-                    if self.test_h5_entity in check_h5 or (
+                    if test_h5_entity in check_h5 or (
                         self.expected_h5_entity is not None
                         and self.expected_h5_entity in check_h5
                     ):
-                        self.unit_test.assertTrue(
-                            self.test_h5_entity in check_h5
-                        )
+                        self.unit_test.assertTrue(test_h5_entity in check_h5)
                         self.unit_test.assertTrue(
                             self.expected_h5_entity is None
                             or self.expected_h5_entity in check_h5
                         )
                         self.check_h5_file(
                             check_h5,
-                            self.test_h5_entity,
+                            test_h5_entity,
                             self.expected_h5_entity,
                         )
         self.unit_test.assertTrue(


### PR DESCRIPTION

## Proposed changes

Rather than putting each radial shell into its own subgroup, each complex field is unraveled into a single complex vector. At each observation event, we have a complex vector where compactified radius indexes the slowest, followed by \ell number, followed by azimuthal m number, followed by real/imaginary parts interleaved.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
