### PR TITLE
Catch integer overflow in choose_lts_step_size

### DIFF
--- a/src/Time/ChangeStepSize.hpp
+++ b/src/Time/ChangeStepSize.hpp
@@ -130,19 +130,6 @@ bool change_step_size(const gsl::not_null<db::DataBox<DbTags>*> box) {
            "you are using DG.");
   }
 
-  constexpr double smallest_relative_step_size = 1.0 / (1 << 31);
-  if (abs(desired_step / current_step.slab().duration().value()) <
-      smallest_relative_step_size) {
-    ERROR_NO_TRACE(
-        "Chosen step "
-        << desired_step
-        << " cannot be represented as a fraction of a slab of size "
-        << current_step.slab().duration().value()
-        << " without integer overflow.  The smallest representable step is "
-        << smallest_relative_step_size * current_step.slab().duration().value()
-        << ".");
-  }
-
   const auto new_step =
       choose_lts_step_size(time_step_id.step_time(), desired_step);
   step_requests.error_on_hard_limit(

--- a/src/Time/ChooseLtsStepSize.cpp
+++ b/src/Time/ChooseLtsStepSize.cpp
@@ -27,6 +27,21 @@ TimeDelta choose_lts_step_size(const Time& time, const double desired_step) {
           : static_cast<size_t>(
                 std::ceil(std::log2(std::ceil(desired_step_count))));
 
+  const auto max_denominator =
+      std::numeric_limits<decltype(time.fraction().denominator())>::max() / 2 +
+      1;
+  ASSERT((max_denominator & (max_denominator - 1)) == 0,
+         "Calculated max denominator not a power of 2.");
+  if (two_to_the(desired_step_power) > static_cast<size_t>(max_denominator)) {
+    ERROR_NO_TRACE(
+        "Chosen step "
+        << desired_step
+        << " cannot be represented as a fraction of a slab of size "
+        << time.slab().duration().value()
+        << " without integer overflow.  The smallest representable step is "
+        << time.slab().duration().value() / max_denominator << ".");
+  }
+
   // Ensure we will hit the slab boundary if we continue taking
   // constant-sized steps.
   const auto step_count =

--- a/tests/Unit/Time/Test_ChooseLtsStepSize.cpp
+++ b/tests/Unit/Time/Test_ChooseLtsStepSize.cpp
@@ -23,6 +23,14 @@ SPECTRE_TEST_CASE("Unit.Time.ChooseLtsStepSize", "[Unit][Time]") {
                              std::numeric_limits<double>::infinity()) ==
         slab.duration());
 
+  CHECK(choose_lts_step_size(slab.start(),
+                             1.1 * slab.duration().value() / (1 << 30)) ==
+        slab.duration() / (1 << 30));
+  CHECK_THROWS_WITH(
+      choose_lts_step_size(slab.start(),
+                           0.9 * slab.duration().value() / (1 << 30)),
+      Catch::Matchers::ContainsSubstring("integer overflow"));
+
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       choose_lts_step_size(slab.start() + slab.duration() / 3, 1.),


### PR DESCRIPTION
This was checked in the main place that calls the function, but other uses could also hit the problem.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
