### PR TITLE
Add ElementSearchTree, use to speed up PointwiseInterpolator

### DIFF
--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -4,7 +4,9 @@
 #include "Domain/ElementLogicalCoordinates.hpp"
 
 #include <array>
+#include <map>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -43,6 +45,30 @@ element_logical_coordinates(
         (2.0 * x_block_logical.get(d) - up - lo) / (up - lo);
   }
   return x_element_logical;
+}
+
+template <size_t Dim>
+std::optional<
+    std::pair<ElementId<Dim>, tnsr::I<double, Dim, Frame::ElementLogical>>>
+element_logical_coordinates(
+    const IdPair<domain::BlockId, tnsr::I<double, Dim, Frame::BlockLogical>>&
+        block_logical_coords,
+    const std::map<size_t, domain::ElementSearchTree<Dim>>& search_tree) {
+  const auto block_search_tree_it =
+      search_tree.find(block_logical_coords.id.get_index());
+  if (block_search_tree_it == search_tree.end()) {
+    return std::nullopt;
+  }
+  const auto& block_search_tree = block_search_tree_it->second;
+  const auto found_element_id = block_search_tree.qbegin(
+      boost::geometry::index::covers(block_logical_coords.data));
+  if (found_element_id == block_search_tree.qend()) {
+    return std::nullopt;
+  }
+  const auto& element_id = *found_element_id;
+  return std::make_pair(element_id, element_logical_coordinates(
+                                        block_logical_coords.data, element_id)
+                                        .value());
 }
 
 namespace {
@@ -152,6 +178,15 @@ element_logical_coordinates(
   element_logical_coordinates(                                                \
       const tnsr::I<double, DIM(data), Frame::BlockLogical>& x_block_logical, \
       const ElementId<DIM(data)>& element_id);                                \
+  template std::optional<                                                     \
+      std::pair<ElementId<DIM(data)>,                                         \
+                tnsr::I<double, DIM(data), Frame::ElementLogical>>>           \
+  element_logical_coordinates(                                                \
+      const IdPair<domain::BlockId,                                           \
+                   tnsr::I<double, DIM(data), Frame::BlockLogical>>&          \
+          block_logical_coords,                                               \
+      const std::map<size_t, domain::ElementSearchTree<DIM(data)>>&           \
+          search_tree);                                                       \
   template std::unordered_map<ElementId<DIM(data)>,                           \
                               ElementLogicalCoordHolder<DIM(data)>>           \
   element_logical_coordinates(                                                \

--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -4,12 +4,14 @@
 #pragma once
 
 #include <cstddef>
+#include <map>
 #include <optional>
 #include <unordered_map>
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Structure/ElementSearchTree.hpp"
 
 /// \cond
 namespace domain {
@@ -38,6 +40,29 @@ std::optional<tnsr::I<double, Dim, Frame::ElementLogical>>
 element_logical_coordinates(
     const tnsr::I<double, Dim, Frame::BlockLogical>& x_block_logical,
     const ElementId<Dim>& element_id);
+
+/*!
+ * \brief Map block logical coordinates to element logical coordinates using an
+ * indexed set of elements
+ *
+ * The indexing is done by the `domain::index_element_ids` function, which
+ * places element IDs into a search tree for fast lookup. If the point is on a
+ * shared element boundary then no guarantee is made which of the abutting
+ * element IDs is returned (the returned element ID is deterministic but depends
+ * on the order in which the elements were inserted into the search tree). See
+ * the other function overload for handling multiple points and disambiguating
+ * points on shared element boundaries.
+ *
+ * \param block_logical_coords the block logical coordinates of the point
+ * \param search_tree the result of `domain::index_element_ids`
+ */
+template <size_t Dim>
+std::optional<
+    std::pair<ElementId<Dim>, tnsr::I<double, Dim, Frame::ElementLogical>>>
+element_logical_coordinates(
+    const IdPair<domain::BlockId, tnsr::I<double, Dim, Frame::BlockLogical>>&
+        block_logical_coords,
+    const std::map<size_t, domain::ElementSearchTree<Dim>>& search_tree);
 
 /// \ingroup ComputationalDomainGroup
 ///

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -45,6 +45,7 @@ spectre_target_headers(
   DirectionMap.hpp
   Element.hpp
   ElementId.hpp
+  ElementSearchTree.hpp
   HasBoundary.hpp
   Hypercube.hpp
   IndexToSliceAt.hpp

--- a/src/Domain/Structure/ElementSearchTree.hpp
+++ b/src/Domain/Structure/ElementSearchTree.hpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#include <cstddef>
+#include <map>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+
+namespace boost::geometry::traits {
+// Make Tensor compatible with Boost.Geometry
+// This is needed to search for a block-logical coordinate given as a Tensor
+// in the `ElementSearchTree`.
+template <typename DataType, size_t Dim, typename Frame>
+struct tag<tnsr::I<DataType, Dim, Frame>> {
+  using type = boost::geometry::point_tag;
+};
+template <typename DataType, size_t Dim, typename Frame>
+struct coordinate_type<tnsr::I<DataType, Dim, Frame>> {
+  using type = DataType;
+};
+template <typename DataType, size_t Dim, typename Frame>
+struct coordinate_system<tnsr::I<DataType, Dim, Frame>> {
+  using type = boost::geometry::cs::cartesian;
+};
+template <typename DataType, size_t Dim, typename Frame>
+struct dimension<tnsr::I<DataType, Dim, Frame>>
+    : std::integral_constant<size_t, Dim> {};
+template <typename DataType, size_t Dim, typename Frame, size_t GetDimension>
+struct access<tnsr::I<DataType, Dim, Frame>, GetDimension> {
+  static constexpr DataType get(const tnsr::I<DataType, Dim, Frame>& point) {
+    return ::get<GetDimension>(point);
+  }
+  static void set(tnsr::I<DataType, Dim, Frame>& point, const DataType& value) {
+    ::get<GetDimension>(point) = value;
+  }
+};
+// Make ElementId compatible with Boost.Geometry
+// Each ElementId defines a bounding box in block-logical coordinates, which is
+// used to search for elements in the `ElementSearchTree`.
+template <size_t Dim>
+struct tag<ElementId<Dim>> {
+  using type = boost::geometry::box_tag;
+};
+template <size_t Dim>
+struct coordinate_type<ElementId<Dim>> {
+  using type = double;
+};
+template <size_t Dim>
+struct coordinate_system<ElementId<Dim>> {
+  using type = boost::geometry::cs::cartesian;
+};
+template <size_t Dim>
+struct dimension<ElementId<Dim>> : std::integral_constant<size_t, Dim> {};
+template <size_t Dim>
+struct point_type<ElementId<Dim>> {
+  using type = tnsr::I<double, Dim, ::Frame::BlockLogical>;
+};
+template <size_t Dim, size_t Index, size_t GetDimension>
+struct indexed_access<ElementId<Dim>, Index, GetDimension> {
+  static constexpr double get(const ElementId<Dim>& element_id) {
+    if constexpr (Index == 0) {
+      return element_id.segment_id(GetDimension).endpoint(Side::Lower);
+    } else {
+      return element_id.segment_id(GetDimension).endpoint(Side::Upper);
+    }
+  }
+};
+}  // namespace boost::geometry::traits
+
+namespace domain {
+
+/*!
+ * \brief Search tree for efficiently looking up elements by their bounding
+ * boxes in block-logical coordinates.
+ *
+ * The search tree is constructed from a list of `ElementId`s, which define
+ * bounding boxes in block-logical coordinates. All `ElementId`s must be in the
+ * same block. Then, the search tree can be used to efficiently search for the
+ * element that contains a given block-logical coordinate (see e.g.
+ * `element_logical_coordinates`).
+ *
+ * Example usage:
+ * \snippet Test_ElementSearchTree.cpp element_search_tree_example
+ *
+ * Use `domain::index_element_ids()` to create one search tree for each block in
+ * the domain given the full list of `ElementId`s.
+ *
+ * \details The search tree is a `boost::geometry::rtree` with a choice of
+ * quadratic splitting algorithm and a maximum of 16 elements per node. These
+ * choices work well, but haven't been extensively tuned.
+ */
+template <size_t Dim>
+using ElementSearchTree =
+    boost::geometry::index::rtree<ElementId<Dim>,
+                                  boost::geometry::index::quadratic<16>>;
+
+/*!
+ * \brief Sorts element IDs into one `ElementSearchTree` per block for efficient
+ * searching.
+ *
+ * Returns a map of search trees indexed by block ID. Each search tree contains
+ * all the `ElementId`s for that block.
+ *
+ * \see ElementSearchTree
+ */
+template <size_t Dim>
+std::map<size_t, ElementSearchTree<Dim>> index_element_ids(
+    const std::vector<ElementId<Dim>>& element_ids) {
+  std::map<size_t, ElementSearchTree<Dim>> trees{};
+  for (const auto& element_id : element_ids) {
+    trees[element_id.block_id()].insert(element_id);
+  }
+  return trees;
+}
+
+}  // namespace domain

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -708,13 +708,22 @@ void PointwiseInterpolator<Dim, Frame>::interpolate_to_point(
   if (not block_logical_coords.has_value()) {
     ERROR("Point is not in any block:\n" << target_point);
   }
-  // Process all volume files in serial
+  interpolate_to_point(result, block_logical_coords.value());
+}
+
+template <size_t Dim, typename Frame>
+void PointwiseInterpolator<Dim, Frame>::interpolate_to_point(
+    const gsl::not_null<std::vector<double>*> result,
+    const IdPair<domain::BlockId, tnsr::I<double, Dim, ::Frame::BlockLogical>>&
+        target_point) const {
+  ASSERT(not tensor_data_.empty(),
+         "PointwiseInterpolator has not been initialized with tensor data.");
   for (size_t file_id = 0; file_id < element_ids_.size(); ++file_id) {
     const auto& element_ids = element_ids_[file_id];
     const auto& meshes = meshes_[file_id];
     const auto& tensor_data = tensor_data_[file_id];
     const auto element_logical_coords =
-        element_logical_coordinates(element_ids, {block_logical_coords});
+        element_logical_coordinates(element_ids, {target_point});
     if (element_logical_coords.empty()) {
       continue;
     }

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -152,7 +152,7 @@ void interpolate_to_points_impl(
 template <size_t Dim>
 void interpolate_to_point_impl(
     const gsl::not_null<std::vector<double>*> result,
-    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& x_element_logical,
+    const tnsr::I<double, Dim, Frame::ElementLogical>& x_element_logical,
     const Mesh<Dim>& mesh, const size_t offset, const size_t length,
     const std::vector<DataVector>& tensor_data) {
   const intrp::Irregular<Dim> interpolant(mesh, x_element_logical);
@@ -622,6 +622,7 @@ PointwiseInterpolator<Dim, Frame>::PointwiseInterpolator(
 
   // Load tensor data into memory
   element_ids_.reserve(filenames.size());
+  element_search_trees_.reserve(filenames.size());
   meshes_.reserve(filenames.size());
   tensor_data_.reserve(filenames.size());
   for (const auto& filename : filenames) {
@@ -629,6 +630,8 @@ PointwiseInterpolator<Dim, Frame>::PointwiseInterpolator(
     const auto& volfile = h5file.get<h5::VolumeData>(subfile_name);
     const auto [element_ids, meshes] = load_grids<Dim>(volfile, obs_id_);
     element_ids_.push_back(std::move(element_ids));
+    element_search_trees_.push_back(
+        domain::index_element_ids(element_ids_.back()));
     meshes_.push_back(std::move(meshes));
     tensor_data_.push_back(
         load_tensor_data(volfile, obs_id_, tensor_components));
@@ -726,17 +729,16 @@ void PointwiseInterpolator<Dim, Frame>::interpolate_to_point(
   ASSERT(not tensor_data_.empty(),
          "PointwiseInterpolator has not been initialized with tensor data.");
   for (size_t file_id = 0; file_id < element_ids_.size(); ++file_id) {
-    const auto& element_ids = element_ids_[file_id];
+    const auto& element_search_tree = element_search_trees_[file_id];
     const auto& meshes = meshes_[file_id];
     const auto& tensor_data = tensor_data_[file_id];
     const auto element_logical_coords =
-        element_logical_coordinates(element_ids, {target_point});
-    if (element_logical_coords.empty()) {
+        element_logical_coordinates(target_point, element_search_tree);
+    if (not element_logical_coords.has_value()) {
       continue;
     }
-    const auto& element_id = element_logical_coords.begin()->first;
-    const auto& x_element_logical =
-        element_logical_coords.begin()->second.element_logical_coords;
+    const auto& element_id = element_logical_coords.value().first;
+    const auto& x_element_logical = element_logical_coords.value().second;
     const auto& mesh_offset_length = meshes.at(element_id);
     interpolate_to_point_impl(
         result, x_element_logical, get<0>(mesh_offset_length),

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -584,14 +584,21 @@ void interpolate_to_points(
     }
   }
 
-  if (extrapolate_into_excisions) {
+  if (extrapolate_into_excisions and not extrapolation_info.empty()) {
     extrapolate_into_excisions_impl(result, extrapolation_info,
                                     resolved_num_threads);
     // Clear the anchor points from the result
     for (size_t i = 0; i < result->size(); ++i) {
       ResultDataType& component = (*result)[i];
       if constexpr (std::is_same_v<ResultDataType, DataVector>) {
-        component.destructive_resize(num_target_points);
+        // Can't use `destructive_resize` because we want to preserve the
+        // leading elements of the DataVector
+        DataVector new_component(num_target_points);
+        std::copy(
+            component.begin(),
+            component.begin() + static_cast<std::ptrdiff_t>(num_target_points),
+            new_component.begin());
+        component = std::move(new_component);
       } else {
         component.resize(num_target_points);
       }

--- a/src/IO/Exporter/PointwiseInterpolator.hpp
+++ b/src/IO/Exporter/PointwiseInterpolator.hpp
@@ -13,6 +13,7 @@
 
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Domain.hpp"
 #include "IO/Exporter/Exporter.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -181,6 +182,20 @@ struct PointwiseInterpolator {
                             const tnsr::I<double, Dim, Frame>& target_point,
                             std::optional<gsl::not_null<std::vector<size_t>*>>
                                 block_order = std::nullopt) const;
+
+  /*!
+   * \brief Interpolate to a single point in block-logical coordinates
+   *
+   * \param result the interpolated data at the target point. The vector is over
+   * the number of components. Will be resized automatically.
+   * \param target_point the point to interpolate to in block-logical
+   * coordinates.
+   */
+  void interpolate_to_point(
+      gsl::not_null<std::vector<double>*> result,
+      const IdPair<domain::BlockId,
+                   tnsr::I<double, Dim, ::Frame::BlockLogical>>& target_point)
+      const;
 
   size_t obs_id() const { return obs_id_; }
   double time() const { return time_; }

--- a/src/IO/Exporter/PointwiseInterpolator.hpp
+++ b/src/IO/Exporter/PointwiseInterpolator.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Structure/ElementSearchTree.hpp"
 #include "IO/Exporter/Exporter.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -212,6 +213,8 @@ struct PointwiseInterpolator {
   domain::FunctionsOfTimeMap functions_of_time_;
   // Outer vector is the source data file
   std::vector<std::vector<ElementId<Dim>>> element_ids_;
+  std::vector<std::map<size_t, domain::ElementSearchTree<Dim>>>
+      element_search_trees_;
   std::vector<
       std::unordered_map<ElementId<Dim>, std::tuple<Mesh<Dim>, size_t, size_t>>>
       meshes_;

--- a/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.cpp
@@ -14,49 +14,52 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Blas.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace intrp {
-template <size_t Dim>
-Cardinal<Dim>::Cardinal(
+
+namespace {
+
+template <size_t Dim, typename DataType>
+std::array<Matrix, Dim> interpolation_matrices_impl(
     const Mesh<Dim>& source_mesh,
-    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points)
-    : n_target_points_(get<0>(target_points).size()),
-      source_mesh_(source_mesh) {
+    const tnsr::I<DataType, Dim, Frame::ElementLogical>& target_points) {
+  std::array<Matrix, Dim> interpolation_matrices{};
+  const size_t n_target_points = get_size(get<0>(target_points));
   for (size_t d = 0; d < Dim; ++d) {
-    switch (source_mesh_.basis(d)) {
+    switch (source_mesh.basis(d)) {
       case Spectral::Basis::Chebyshev:
         [[fallthrough]];
       case Spectral::Basis::Legendre: {
         const DataVector xi =
-            get<0>(logical_coordinates(source_mesh_.slice_through(d)));
-        gsl::at(interpolation_matrices_, d) =
+            get<0>(logical_coordinates(source_mesh.slice_through(d)));
+        gsl::at(interpolation_matrices, d) =
             fornberg_interpolation_matrix(target_points.get(d), xi);
         break;
       }
       case Spectral::Basis::SphericalHarmonic: {
-        using_spherical_harmonics_ = true;
-        switch (source_mesh_.quadrature(d)) {
+        switch (source_mesh.quadrature(d)) {
           case Spectral::Quadrature::Gauss: {
             const DataVector theta =
-                get<0>(logical_coordinates(source_mesh_.slice_through(d)));
+                get<0>(logical_coordinates(source_mesh.slice_through(d)));
             const DataVector cos_theta_source = cos(theta);
-            const DataVector cos_theta_target = cos(target_points.get(d));
+            const DataType cos_theta_target = cos(target_points.get(d));
             const Matrix theta_matrix = fornberg_interpolation_matrix(
                 cos_theta_target, cos_theta_source);
-            const size_t n_th = source_mesh_.extents(d);
-            gsl::at(interpolation_matrices_, d)
-                .resize(n_target_points_, 2 * n_th);
+            const size_t n_th = source_mesh.extents(d);
+            gsl::at(interpolation_matrices, d)
+                .resize(n_target_points, 2 * n_th);
             const DataVector csc_theta_source = 1.0 / sin(theta);
-            const DataVector sin_theta_target = sin(target_points.get(d));
-            for (size_t k = 0; k < n_target_points_; ++k) {
+            const DataType sin_theta_target = sin(target_points.get(d));
+            for (size_t k = 0; k < n_target_points; ++k) {
               for (size_t i_th = 0; i_th < n_th; ++i_th) {
-                const double factor =
-                    0.5 * sin_theta_target[k] * csc_theta_source[i_th];
-                gsl::at(interpolation_matrices_, d)(k, i_th) =
+                const double factor = 0.5 * get_element(sin_theta_target, k) *
+                                      csc_theta_source[i_th];
+                gsl::at(interpolation_matrices, d)(k, i_th) =
                     theta_matrix(k, i_th) * (0.5 + factor);
-                gsl::at(interpolation_matrices_, d)(k, n_th + i_th) =
+                gsl::at(interpolation_matrices, d)(k, n_th + i_th) =
                     theta_matrix(k, i_th) * (0.5 - factor);
               }
             }
@@ -64,31 +67,61 @@ Cardinal<Dim>::Cardinal(
           }
           case Spectral::Quadrature::Equiangular: {
             const DataVector phi =
-                get<0>(logical_coordinates(source_mesh_.slice_through(d)));
-            const DataVector& phi_target = target_points.get(d);
-            DataVector extended_phi_target{2 * n_target_points_};
-            for (size_t k = 0; k < n_target_points_; ++k) {
-              extended_phi_target[2 * k] = phi_target[k];
-              extended_phi_target[2 * k + 1] = phi_target[k] + M_PI;
+                get<0>(logical_coordinates(source_mesh.slice_through(d)));
+            const DataType& phi_target = target_points.get(d);
+            DataVector extended_phi_target{2 * n_target_points};
+            for (size_t k = 0; k < n_target_points; ++k) {
+              extended_phi_target[2 * k] = get_element(phi_target, k);
+              extended_phi_target[2 * k + 1] =
+                  get_element(phi_target, k) + M_PI;
             }
-            gsl::at(interpolation_matrices_, d) = fourier_interpolation_matrix(
-                extended_phi_target, source_mesh_.extents(d));
+            gsl::at(interpolation_matrices, d) = fourier_interpolation_matrix(
+                extended_phi_target, source_mesh.extents(d));
             break;
           }
           default:
             ERROR(
                 "Quadrature must be Gauss or Equiangular for Basis "
                 "SphericalHarmonic, not "
-                << source_mesh_.quadrature(d));
+                << source_mesh.quadrature(d));
         }
         break;
       }
       default:
-        ERROR("Basis " << source_mesh_.basis(d)
+        ERROR("Basis " << source_mesh.basis(d)
                        << " is not supported by the Cardinal interpolator.");
     }
   }
+  return interpolation_matrices;
 }
+
+}  // namespace
+
+template <size_t Dim>
+Cardinal<Dim>::Cardinal(
+    const Mesh<Dim>& source_mesh,
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points)
+    : n_target_points_(get<0>(target_points).size()),
+      source_mesh_(source_mesh),
+      interpolation_matrices_(
+          interpolation_matrices_impl(source_mesh_, target_points)),
+      using_spherical_harmonics_(
+          alg::any_of(source_mesh_.basis(), [](const Spectral::Basis basis) {
+            return basis == Spectral::Basis::SphericalHarmonic;
+          })) {}
+
+template <size_t Dim>
+Cardinal<Dim>::Cardinal(
+    const Mesh<Dim>& source_mesh,
+    const tnsr::I<double, Dim, Frame::ElementLogical>& target_point)
+    : n_target_points_(1),
+      source_mesh_(source_mesh),
+      interpolation_matrices_(
+          interpolation_matrices_impl(source_mesh_, target_point)),
+      using_spherical_harmonics_(
+          alg::any_of(source_mesh_.basis(), [](const Spectral::Basis basis) {
+            return basis == Spectral::Basis::SphericalHarmonic;
+          })) {}
 
 template <>
 DataVector Cardinal<1>::interpolate(const DataVector& f_source) const {

--- a/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp
@@ -40,6 +40,9 @@ class Cardinal {
   Cardinal(
       const Mesh<Dim>& source_mesh,
       const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points);
+  Cardinal(
+      const Mesh<Dim>& source_mesh,
+      const tnsr::I<double, Dim, Frame::ElementLogical>& target_point);
 
   Cardinal();
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationWeights.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationWeights.cpp
@@ -8,20 +8,23 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 
 namespace intrp {
-Matrix fornberg_interpolation_matrix(const DataVector& x_target,
+template <typename TargetDataType>
+Matrix fornberg_interpolation_matrix(const TargetDataType& x_target,
                                      const DataVector& x_source) {
-  Matrix result{x_target.size(), x_source.size()};
+  Matrix result{get_size(x_target), x_source.size()};
   const size_t n_source_pts = x_source.size();
-  for (size_t k = 0; k < x_target.size(); ++k) {
+  for (size_t k = 0; k < get_size(x_target); ++k) {
     double c1 = 1.0;
-    double c4 = x_source[0] - x_target[k];
+    double c4 = x_source[0] - get_element(x_target, k);
     result(k, 0) = 1.0;
     for (size_t i = 1; i < n_source_pts; ++i) {
       double c2 = 1.0;
       const double c5 = c4;
-      c4 = x_source[i] - x_target[k];
+      c4 = x_source[i] - get_element(x_target, k);
       for (size_t j = 0; j < i; ++j) {
         const double c3 = x_source[i] - x_source[j];
         c2 *= c3;
@@ -36,23 +39,24 @@ Matrix fornberg_interpolation_matrix(const DataVector& x_target,
   return result;
 }
 
-Matrix fourier_interpolation_matrix(const DataVector& x_target,
+template <typename TargetDataType>
+Matrix fourier_interpolation_matrix(const TargetDataType& x_target,
                                     const size_t n_source_points) {
   if (n_source_points == 1) {
-    return Matrix{x_target.size(), 1, 1.0};
+    return Matrix{get_size(x_target), 1, 1.0};
   }
   DataVector x_source{n_source_points,
                       2.0 * M_PI / static_cast<double>(n_source_points)};
   for (size_t i = 0; i < n_source_points; ++i) {
     x_source[i] *= static_cast<double>(i);
   }
-  Matrix result{x_target.size(), n_source_points,
+  Matrix result{get_size(x_target), n_source_points,
                 1.0 / static_cast<double>(n_source_points)};
   const bool n_source_points_is_even = n_source_points % 2 == 0;
-  for (size_t k = 0; k < x_target.size(); ++k) {
+  for (size_t k = 0; k < get_size(x_target); ++k) {
     for (size_t i = 0; i < n_source_points; ++i) {
       double c0 = 1.0;
-      double c1 = cos(x_target[k] - x_source[i]);
+      double c1 = cos(get_element(x_target, k) - x_source[i]);
       const double cdx2 = 2.0 * c1;
       double sum = c1;
       for (size_t j = 2; j <= n_source_points / 2; ++j) {
@@ -67,4 +71,20 @@ Matrix fourier_interpolation_matrix(const DataVector& x_target,
   }
   return result;
 }
+
+// Generate instantiations
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template Matrix fornberg_interpolation_matrix(const DTYPE(data) & x_target, \
+                                                const DataVector& x_source);  \
+  template Matrix fourier_interpolation_matrix(const DTYPE(data) & x_target,  \
+                                               const size_t n_source_points);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationWeights.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationWeights.hpp
@@ -24,7 +24,8 @@ namespace intrp {
  * distribution of the source points.  It is strongly suggested that you
  * carefully investigate the accuracy for your use case.
  */
-Matrix fornberg_interpolation_matrix(const DataVector& x_target,
+template <typename TargetDataType>
+Matrix fornberg_interpolation_matrix(const TargetDataType& x_target,
                                      const DataVector& x_source);
 
 /*!
@@ -41,6 +42,7 @@ Matrix fornberg_interpolation_matrix(const DataVector& x_target,
  * the term in brackets is evaluated only if \f$n\f$ is even.
  *
  */
-Matrix fourier_interpolation_matrix(const DataVector& x_target,
+template <typename TargetDataType>
+Matrix fourier_interpolation_matrix(const TargetDataType& x_target,
                                     size_t n_source_points);
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -14,6 +14,7 @@
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 
 namespace {
 
@@ -42,24 +43,24 @@ std::vector<double> fd_stencil(const DataVector& xi_source,
   return result;
 }
 
-template <size_t Dim>
+template <size_t Dim, typename DataType>
 Matrix interpolation_matrix(
     const Mesh<Dim>& mesh,
-    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& points);
+    const tnsr::I<DataType, Dim, Frame::ElementLogical>& points);
 
-template <>
+template <typename DataType>
 Matrix interpolation_matrix(
     const Mesh<1>& mesh,
-    const tnsr::I<DataVector, 1, Frame::ElementLogical>& points) {
+    const tnsr::I<DataType, 1, Frame::ElementLogical>& points) {
   if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
     auto source_xi = logical_coordinates(mesh);
     const auto number_of_source_points = mesh.number_of_grid_points();
     const DataVector xi_source(get<0>(source_xi).data(),
                                number_of_source_points);
-    const auto number_of_target_points = get<0>(points).size();
-    Matrix result(number_of_target_points, mesh.number_of_grid_points());
+    const size_t number_of_target_points = get_size(get<0>(points));
+    Matrix result(number_of_target_points, number_of_source_points);
     for (size_t p = 0; p < number_of_target_points; ++p) {
-      const double xi_target = get<0>(points)[p];
+      const double xi_target = get_element(get<0>(points), p);
       const auto stencil = fd_stencil(xi_source, xi_target);
       for (size_t i = 0; i < number_of_source_points; ++i) {
         result(p, i) = stencil[i];
@@ -72,11 +73,11 @@ Matrix interpolation_matrix(
   return Spectral::interpolation_matrix(mesh, get<0>(points));
 }
 
-template <>
+template <typename DataType>
 Matrix interpolation_matrix(
     const Mesh<2>& mesh,
-    const tnsr::I<DataVector, 2, Frame::ElementLogical>& points) {
-  const auto number_of_target_points = get<0>(points).size();
+    const tnsr::I<DataType, 2, Frame::ElementLogical>& points) {
+  const auto number_of_target_points = get_size(get<0>(points));
   Matrix result(number_of_target_points, mesh.number_of_grid_points());
 
   if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
@@ -94,8 +95,8 @@ Matrix interpolation_matrix(
       }
     }
     for (size_t p = 0; p < number_of_target_points; ++p) {
-      const double xi_target = get<0>(points)[p];
-      const double eta_target = get<1>(points)[p];
+      const double xi_target = get_element(get<0>(points), p);
+      const double eta_target = get_element(get<1>(points), p);
       const auto xi_stencil = fd_stencil(xi_source, xi_target);
       const auto eta_stencil = fd_stencil(eta_source, eta_target);
       for (size_t j = 0, s = 0; j < mesh.extents(1); ++j) {
@@ -142,11 +143,11 @@ Matrix interpolation_matrix(
   return result;
 }
 
-template <>
+template <typename DataType>
 Matrix interpolation_matrix(
     const Mesh<3>& mesh,
-    const tnsr::I<DataVector, 3, Frame::ElementLogical>& points) {
-  const auto number_of_target_points = get<0>(points).size();
+    const tnsr::I<DataType, 3, Frame::ElementLogical>& points) {
+  const auto number_of_target_points = get_size(get<0>(points));
   Matrix result(number_of_target_points, mesh.number_of_grid_points());
 
   if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
@@ -177,9 +178,9 @@ Matrix interpolation_matrix(
       }
     }
     for (size_t p = 0; p < number_of_target_points; ++p) {
-      const double xi_target = get<0>(points)[p];
-      const double eta_target = get<1>(points)[p];
-      const double zeta_target = get<2>(points)[p];
+      const double xi_target = get_element(get<0>(points), p);
+      const double eta_target = get_element(get<1>(points), p);
+      const double zeta_target = get_element(get<2>(points), p);
       const auto xi_stencil = fd_stencil(xi_source, xi_target);
       const auto eta_stencil = fd_stencil(eta_source, eta_target);
       const auto zeta_stencil = fd_stencil(zeta_source, zeta_target);
@@ -245,10 +246,16 @@ template <size_t Dim>
 Irregular<Dim>::Irregular() = default;
 
 template <size_t Dim>
-Irregular<Dim>::Irregular(const Mesh<Dim>& source_mesh,
-                          const tnsr::I<DataVector, Dim, Frame::ElementLogical>&
-                              target_points)
+Irregular<Dim>::Irregular(
+    const Mesh<Dim>& source_mesh,
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points)
     : interpolation_matrix_(interpolation_matrix(source_mesh, target_points)) {}
+
+template <size_t Dim>
+Irregular<Dim>::Irregular(
+    const Mesh<Dim>& source_mesh,
+    const tnsr::I<double, Dim, Frame::ElementLogical>& target_point)
+    : interpolation_matrix_(interpolation_matrix(source_mesh, target_point)) {}
 
 template <size_t Dim>
 void Irregular<Dim>::pup(PUP::er& p) {

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -39,6 +39,9 @@ class Irregular {
   Irregular(
       const Mesh<Dim>& source_mesh,
       const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points);
+  Irregular(
+      const Mesh<Dim>& source_mesh,
+      const tnsr::I<double, Dim, Frame::ElementLogical>& target_point);
   Irregular();
 
   /// Serialization for Charm++

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOURCES
   Test_ElementDistribution.cpp
   Test_ElementMap.cpp
   Test_ElementToBlockLogicalMap.cpp
+  Test_ElementSearchTree.cpp
   Test_ExcisionSphere.cpp
   Test_FaceNormal.cpp
   Test_FlatLogicalMetric.cpp

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -32,6 +32,7 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/Structure/BlockId.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/ElementSearchTree.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
@@ -71,6 +72,107 @@ void test_element_logical_coordinates() {
             tnsr::I<double, 3, Frame::BlockLogical>{{{0., 0.5, 1.}}},
             ElementId<3>{0, {{{1, 0}, {1, 1}, {1, 1}}}}) ==
         tnsr::I<double, 3, Frame::ElementLogical>{{{1., 0., 1.}}});
+
+  {
+    INFO("With ElementSearchTree");
+    const std::vector<ElementId<2>> element_ids{
+        // Element layout in block-logical coordinates:
+        //        xi -->
+        //        -1     0       1
+        // eta  -1  -------------
+        //  |      |  0  |   2   |
+        //  v    0 |-------------|
+        //         |  1  | 3 | 4 |
+        //       1  -------------
+        ElementId<2>{0, {{{1, 0}, {1, 0}}}},  // 0
+        ElementId<2>{0, {{{1, 0}, {1, 1}}}},  // 1
+        ElementId<2>{0, {{{1, 1}, {1, 0}}}},  // 2
+        ElementId<2>{0, {{{2, 2}, {1, 1}}}},  // 3
+        ElementId<2>{0, {{{2, 3}, {1, 1}}}},  // 4
+        // Other block
+        ElementId<2>{1, {{{1, 0}, {1, 0}}}}};
+    const auto search_tree = domain::index_element_ids(element_ids);
+    CHECK(element_logical_coordinates<2>(
+              {domain::BlockId{0},
+               tnsr::I<double, 2, Frame::BlockLogical>{{{0.25, 0.5}}}},
+              search_tree) ==
+          std::make_pair(
+              element_ids[3],
+              tnsr::I<double, 2, Frame::ElementLogical>{{{0.0, 0.0}}}));
+    CHECK(element_logical_coordinates<2>(
+              {domain::BlockId{0},
+               tnsr::I<double, 2, Frame::BlockLogical>{{{-0.5, 0.5}}}},
+              search_tree) ==
+          std::make_pair(
+              element_ids[1],
+              tnsr::I<double, 2, Frame::ElementLogical>{{{0.0, 0.0}}}));
+    CHECK(element_logical_coordinates<2>(
+              {domain::BlockId{1},
+               tnsr::I<double, 2, Frame::BlockLogical>{{{-0.5, -0.5}}}},
+              search_tree) ==
+          std::make_pair(
+              element_ids[5],
+              tnsr::I<double, 2, Frame::ElementLogical>{{{0.0, 0.0}}}));
+    CHECK(element_logical_coordinates<2>(
+              {domain::BlockId{0},
+               tnsr::I<double, 2, Frame::BlockLogical>{{{-1.0, -0.5}}}},
+              search_tree) ==
+          std::make_pair(
+              element_ids[0],
+              tnsr::I<double, 2, Frame::ElementLogical>{{{-1.0, 0.0}}}));
+    CHECK(element_logical_coordinates<2>(
+              {domain::BlockId{0},
+               tnsr::I<double, 2, Frame::BlockLogical>{{{0.0, 0.0}}}},
+              search_tree) ==
+          std::make_pair(
+              // Multiple matches, result should be the first one inserted
+              element_ids[0],
+              tnsr::I<double, 2, Frame::ElementLogical>{{{1.0, 1.0}}}));
+    CHECK_FALSE(element_logical_coordinates<2>(
+                    {domain::BlockId{1},
+                     tnsr::I<double, 2, Frame::BlockLogical>{{{0.5, 0.5}}}},
+                    search_tree)
+                    .has_value());
+    CHECK_FALSE(element_logical_coordinates<2>(
+                    {domain::BlockId{2},
+                     tnsr::I<double, 2, Frame::BlockLogical>{{{-0.5, -0.5}}}},
+                    search_tree)
+                    .has_value());
+  }
+
+  {
+    // Benchmark with and without search tree
+    // - Result on Apple M2 Pro chip (Nils Vu, May 2025):
+    //   4.7 ms without search tree vs 0.2 ms with search tree (mean time per
+    //   sample)
+    const auto element_ids =
+        initial_element_ids<3>({{{3, 3, 3}}, {{2, 2, 2}}, {{1, 1, 1}}});
+    const auto search_tree = domain::index_element_ids(element_ids);
+    const size_t num_points = 100;
+    std::vector<
+        IdPair<domain::BlockId, tnsr::I<double, 3, Frame::BlockLogical>>>
+        target_points;
+    target_points.reserve(num_points);
+    std::uniform_int_distribution<size_t> dist_blocks(0, 3);
+    std::uniform_real_distribution<double> dist_points(-1.0, 1.0);
+    MAKE_GENERATOR(gen);
+    for (size_t i = 0; i < num_points; ++i) {
+      target_points.push_back(
+          {domain::BlockId{dist_blocks(gen)},
+           tnsr::I<double, 3, Frame::BlockLogical>{
+               {dist_points(gen), dist_points(gen), dist_points(gen)}}});
+    }
+    BENCHMARK("element_logical_coordinates without search tree") {
+      for (const auto& target_point : target_points) {
+        element_logical_coordinates(element_ids, {target_point});
+      }
+    };
+    BENCHMARK("element_logical_coordinates with search tree") {
+      for (const auto& target_point : target_points) {
+        element_logical_coordinates(target_point, search_tree);
+      }
+    };
+  }
 }
 
 template <size_t Dim>

--- a/tests/Unit/Domain/Test_ElementSearchTree.cpp
+++ b/tests/Unit/Domain/Test_ElementSearchTree.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/ElementSearchTree.hpp"
+
+namespace domain {
+
+SPECTRE_TEST_CASE("Unit.Domain.ElementSearchTree", "[Domain][Unit]") {
+  // [element_search_tree_example]
+  const std::vector<ElementId<2>> element_ids{
+      // Element layout in block-logical coordinates:
+      //        xi -->
+      //        -1     0       1
+      // eta  -1  -------------
+      //  |      |  0  |   2   |
+      //  v    0 |-------------|
+      //         |  1  | 3 | 4 |
+      //       1  -------------
+      ElementId<2>{0, {{{1, 0}, {1, 0}}}},  // 0
+      ElementId<2>{0, {{{1, 0}, {1, 1}}}},  // 1
+      ElementId<2>{0, {{{1, 1}, {1, 0}}}},  // 2
+      ElementId<2>{0, {{{2, 2}, {1, 1}}}},  // 3
+      ElementId<2>{0, {{{2, 3}, {1, 1}}}}   // 4
+  };
+  const ElementSearchTree<2> search_tree(element_ids);
+  std::vector<ElementId<2>> search_result;
+  search_tree.query(boost::geometry::index::covers(
+                        tnsr::I<double, 2, Frame::BlockLogical>{{{0.5, -0.5}}}),
+                    std::back_inserter(search_result));
+  CHECK(search_result.size() == 1);
+  CHECK(search_result[0] == element_ids[2]);
+  // [element_search_tree_example]
+  search_result.clear();
+  search_tree.query(boost::geometry::index::covers(
+                        tnsr::I<double, 2, Frame::BlockLogical>{{{0.0, -0.5}}}),
+                    std::back_inserter(search_result));
+  CHECK(search_result.size() == 2);
+  CHECK(search_result[0] == element_ids[0]);
+  CHECK(search_result[1] == element_ids[2]);
+
+  {
+    INFO("Multiple blocks");
+    std::vector<ElementId<2>> more_element_ids(element_ids);
+    more_element_ids.push_back(ElementId<2>{1, {{{1, 0}, {1, 0}}}});
+    const auto search_trees = domain::index_element_ids<2>(more_element_ids);
+    CHECK(search_trees.size() == 2);
+    CHECK(search_trees.at(0).size() == 5);
+    CHECK(search_trees.at(1).size() == 1);
+    search_result.clear();
+    search_trees.at(0).query(
+        boost::geometry::index::covers(
+            tnsr::I<double, 2, Frame::BlockLogical>{{{0.5, -0.5}}}),
+        std::back_inserter(search_result));
+    CHECK(search_result.size() == 1);
+    CHECK(search_result[0] == element_ids[2]);
+    search_result.clear();
+    search_trees.at(1).query(
+        boost::geometry::index::covers(
+            tnsr::I<double, 2, Frame::BlockLogical>{{{-0.5, -0.5}}}),
+        std::back_inserter(search_result));
+    CHECK(search_result.size() == 1);
+    CHECK(search_result[0] == more_element_ids.back());
+    search_result.clear();
+    search_trees.at(1).query(
+        boost::geometry::index::covers(
+            tnsr::I<double, 2, Frame::BlockLogical>{{{0.5, -0.5}}}),
+        std::back_inserter(search_result));
+    CHECK(search_result.empty());
+  }
+}
+
+}  // namespace domain

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -231,6 +231,48 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
     // This point is interpolated
     Approx approx_interpolated = Approx::custom().epsilon(1.e-6).scale(1.0);
     CHECK(psi_interpolated[5] == approx_interpolated(psi_expected[5]));
+
+    // Do some benchmarks
+    // - Results ran on Apple M2 Pro chip (Nils Vu, May 2025)
+    // - First number is without h-refinement (as set in the domain creator
+    //   above so these tests run quickly). Second number is when setting the
+    //   h-refinement to 2.
+    // 9.5 ms / 576 ms
+    BENCHMARK("interpolate_to_points") {
+      return interpolate_to_points<3>(h5_file_name, "/VolumeData",
+                                      ObservationId{123}, {"Psi"},
+                                      target_points, true);
+    };
+    {
+      PointwiseInterpolator<3, Frame::Inertial> interpolator{
+          h5_file_name, "/VolumeData", ObservationId{123}, {"Psi"}};
+      // 3.1 ms / 3.4 ms
+      BENCHMARK("PointwiseInterpolator::interpolate_to_points") {
+        std::vector<DataVector> result{};
+        interpolator.interpolate_to_points(make_not_null(&result),
+                                           target_points, true);
+        return result;
+      };
+      // 152 us / 327 us
+      BENCHMARK("PointwiseInterpolator::interpolate_to_point") {
+        std::vector<double> result{};
+        interpolator.interpolate_to_point(make_not_null(&result),
+                                          tnsr::I<double, 3>{{10., 0., 0.}});
+        return result;
+      };
+      std::vector<size_t> block_order(domain.blocks().size());
+      std::iota(block_order.begin(), block_order.end(), 0);
+      // 139 us / 321 us
+      BENCHMARK(
+          "PointwiseInterpolator::interpolate_to_point with block order") {
+        std::vector<double> result{};
+        interpolator.interpolate_to_point(make_not_null(&result),
+                                          tnsr::I<double, 3>{{10., 0., 0.}},
+                                          make_not_null(&block_order));
+        return result;
+      };
+    }
+
     // Delete the test file
     if (file_system::check_if_file_exists(h5_file_name)) {
       file_system::rm(h5_file_name, true);

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -206,16 +206,9 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
                                            {0., 0., 0., 0., 0., 0.},
                                            {0., 0., 0., 0., 0., 0.}}}};
     const size_t num_target_points = get<0>(target_points).size();
-    std::array<std::vector<double>, 3> target_points_array{};
-    for (size_t d = 0; d < 3; ++d) {
-      gsl::at(target_points_array, d).resize(num_target_points);
-      for (size_t i = 0; i < num_target_points; ++i) {
-        gsl::at(target_points_array, d)[i] = target_points.get(d)[i];
-      }
-    }
     const auto interpolated_data = interpolate_to_points<3>(
-        h5_file_name, "/VolumeData", ObservationId{123}, {"Psi"},
-        target_points_array, true);
+        h5_file_name, "/VolumeData", ObservationId{123}, {"Psi"}, target_points,
+        true);
     CHECK(interpolated_data.size() == 1);
     CHECK(interpolated_data[0].size() == num_target_points);
     // Check result

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -253,7 +253,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
                                            target_points, true);
         return result;
       };
-      // 152 us / 327 us
+      // 147 us / 149 us
       BENCHMARK("PointwiseInterpolator::interpolate_to_point") {
         std::vector<double> result{};
         interpolator.interpolate_to_point(make_not_null(&result),
@@ -262,7 +262,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
       };
       std::vector<size_t> block_order(domain.blocks().size());
       std::iota(block_order.begin(), block_order.end(), 0);
-      // 139 us / 321 us
+      // 137 us / 143 us
       BENCHMARK(
           "PointwiseInterpolator::interpolate_to_point with block order") {
         std::vector<double> result{};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CardinalInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CardinalInterpolator.cpp
@@ -72,6 +72,8 @@ void test_1d(const gsl::not_null<std::mt19937*> generator) {
     const auto xi_target =
         make_with_random_values<tnsr::I<DataVector, 1, Frame::ElementLogical>>(
             generator, make_not_null(&xi_distribution), n_target_points);
+    const tnsr::I<double, 1, Frame::ElementLogical> xi_target_single{
+        {{get<0>(xi_target)[0]}}};
     for (const auto basis :
          std::array{Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
       for (const auto quadrature :
@@ -83,9 +85,20 @@ void test_1d(const gsl::not_null<std::mt19937*> generator) {
           const auto xi_source = logical_coordinates(source_mesh);
           const DataVector f_source = f(get<0>(xi_source));
           const DataVector f_expected = f(get<0>(xi_target));
-          const intrp::Cardinal<1> interpolator(source_mesh, xi_target);
-          const DataVector f_interpolated = interpolator.interpolate(f_source);
-          CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          {
+            const intrp::Cardinal<1> interpolator(source_mesh, xi_target);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          }
+          if (n_target_points == 1) {
+            const intrp::Cardinal<1> interpolator(source_mesh,
+                                                  xi_target_single);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK(f_interpolated.size() == 1);
+            CHECK(f_interpolated[0] == approx(f_expected[0]));
+          }
         }
       }
     }
@@ -103,6 +116,8 @@ void test_2d_cartesian(const gsl::not_null<std::mt19937*> generator) {
     const auto xi_target =
         make_with_random_values<tnsr::I<DataVector, 2, Frame::ElementLogical>>(
             generator, make_not_null(&xi_distribution), n_target_points);
+    const tnsr::I<double, 2, Frame::ElementLogical> xi_target_single{
+        {{get<0>(xi_target)[0], get<1>(xi_target)[0]}}};
     for (const auto xi_basis : bases) {
       for (const auto xi_quadrature : quadratures) {
         for (const auto eta_basis : bases) {
@@ -118,10 +133,20 @@ void test_2d_cartesian(const gsl::not_null<std::mt19937*> generator) {
                 const auto xi_source = logical_coordinates(source_mesh);
                 const DataVector f_source = f(xi_source);
                 const DataVector f_expected = f(xi_target);
-                const intrp::Cardinal<2> interpolator(source_mesh, xi_target);
-                const DataVector f_interpolated =
-                    interpolator.interpolate(f_source);
-                CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+                {
+                  const intrp::Cardinal<2> interpolator(source_mesh, xi_target);
+                  const DataVector f_interpolated =
+                      interpolator.interpolate(f_source);
+                  CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+                }
+                if (n_target_points == 1) {
+                  const intrp::Cardinal<2> interpolator(source_mesh,
+                                                        xi_target_single);
+                  const DataVector f_interpolated =
+                      interpolator.interpolate(f_source);
+                  CHECK(f_interpolated.size() == 1);
+                  CHECK(f_interpolated[0] == approx(f_expected[0]));
+                }
               }
             }
           }
@@ -141,6 +166,8 @@ void test_2d_spherical(const gsl::not_null<std::mt19937*> generator) {
         generator, make_not_null(&xi_distribution), xi_target));
     get<1>(xi_target) = make_with_random_values<DataVector>(
         generator, make_not_null(&phi_distribution), xi_target);
+    const tnsr::I<double, 2, Frame::ElementLogical> xi_target_single{
+        {{get<0>(xi_target)[0], get<1>(xi_target)[0]}}};
     for (size_t n_z = 0; n_z < 4; ++n_z) {
       for (size_t n_y = 0; n_y < 4; ++n_y) {
         for (size_t n_x = 0; n_x < 4; ++n_x) {
@@ -154,9 +181,20 @@ void test_2d_spherical(const gsl::not_null<std::mt19937*> generator) {
           const auto xi_source = logical_coordinates(source_mesh);
           const DataVector f_source = f(xi_source);
           const DataVector f_expected = f(xi_target);
-          const intrp::Cardinal<2> interpolator(source_mesh, xi_target);
-          const DataVector f_interpolated = interpolator.interpolate(f_source);
-          CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          {
+            const intrp::Cardinal<2> interpolator(source_mesh, xi_target);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          }
+          if (n_target_points == 1) {
+            const intrp::Cardinal<2> interpolator(source_mesh,
+                                                  xi_target_single);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK(f_interpolated.size() == 1);
+            CHECK(f_interpolated[0] == approx(f_expected[0]));
+          }
         }
       }
     }
@@ -170,6 +208,8 @@ void test_3d_cartesian(const gsl::not_null<std::mt19937*> generator) {
     const auto xi_target =
         make_with_random_values<tnsr::I<DataVector, 3, Frame::ElementLogical>>(
             generator, make_not_null(&xi_distribution), n_target_points);
+    const tnsr::I<double, 3, Frame::ElementLogical> xi_target_single{
+        {{get<0>(xi_target)[0], get<1>(xi_target)[0], get<2>(xi_target)[0]}}};
     for (size_t n_xi = 2; n_xi < 21; n_xi += 3) {
       for (size_t n_eta = 2; n_eta < 21; n_eta += 3) {
         for (size_t n_zeta = 2; n_zeta < 21; n_zeta += 3) {
@@ -182,9 +222,20 @@ void test_3d_cartesian(const gsl::not_null<std::mt19937*> generator) {
           const auto xi_source = logical_coordinates(source_mesh);
           const DataVector f_source = f(xi_source);
           const DataVector f_expected = f(xi_target);
-          const intrp::Cardinal<3> interpolator(source_mesh, xi_target);
-          const DataVector f_interpolated = interpolator.interpolate(f_source);
-          CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          {
+            const intrp::Cardinal<3> interpolator(source_mesh, xi_target);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+          }
+          if (n_target_points == 1) {
+            const intrp::Cardinal<3> interpolator(source_mesh,
+                                                  xi_target_single);
+            const DataVector f_interpolated =
+                interpolator.interpolate(f_source);
+            CHECK(f_interpolated.size() == 1);
+            CHECK(f_interpolated[0] == approx(f_expected[0]));
+          }
         }
       }
     }
@@ -203,6 +254,8 @@ void test_3d_spherical(const gsl::not_null<std::mt19937*> generator) {
         generator, make_not_null(&xi_distribution), xi_target));
     get<2>(xi_target) = make_with_random_values<DataVector>(
         generator, make_not_null(&phi_distribution), xi_target);
+    const tnsr::I<double, 3, Frame::ElementLogical> xi_target_single{
+        {{get<0>(xi_target)[0], get<1>(xi_target)[0], get<2>(xi_target)[0]}}};
     for (size_t n_r = 2; n_r < 4; ++n_r) {
       for (size_t n_z = 0; n_z < 4; ++n_z) {
         for (size_t n_y = 0; n_y < 4; ++n_y) {
@@ -224,10 +277,20 @@ void test_3d_spherical(const gsl::not_null<std::mt19937*> generator) {
             const DataVector f_expected =
                 f_r(get<0>(xi_target)) *
                 f_a(get<1>(xi_target), get<2>(xi_target));
-            const intrp::Cardinal<3> interpolator(source_mesh, xi_target);
-            const DataVector f_interpolated =
-                interpolator.interpolate(f_source);
-            CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+            {
+              const intrp::Cardinal<3> interpolator(source_mesh, xi_target);
+              const DataVector f_interpolated =
+                  interpolator.interpolate(f_source);
+              CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+            }
+            if (n_target_points == 1) {
+              const intrp::Cardinal<3> interpolator(source_mesh,
+                                                    xi_target_single);
+              const DataVector f_interpolated =
+                  interpolator.interpolate(f_source);
+              CHECK(f_interpolated.size() == 1);
+              CHECK(f_interpolated[0] == approx(f_expected[0]));
+            }
           }
         }
       }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationWeights.cpp
@@ -43,6 +43,10 @@ void test_fornberg_matrix(const gsl::not_null<std::mt19937*> generator) {
           CHECK(fornberg_matrix.rows() == n_target_points);
           CHECK(fornberg_matrix.columns() == n_source_points);
           CHECK(spectral_matrix == fornberg_matrix);
+          if (n_target_points == 1) {
+            CHECK(intrp::fornberg_interpolation_matrix(
+                      x_target[0], get<0>(xi)) == fornberg_matrix);
+          }
         }
       }
     }
@@ -70,6 +74,10 @@ void test_fourier_matrix(const gsl::not_null<std::mt19937*> generator) {
            n_target_points, f_source.data(), 1, 0.0, f_interp.data(), 1);
     for (size_t k = 0; k < n_target_points; ++k) {
       CHECK_THAT(f_interp[k], Catch::Matchers::WithinAbs(f_target[k], 1.e-13));
+    }
+    if (n_target_points == 1) {
+      CHECK(intrp::fourier_interpolation_matrix(x_target[0], n_source_points) ==
+            m);
     }
   }
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -177,6 +177,18 @@ void test_interpolate_to_points(const Mesh<Dim>& mesh) {
     CHECK(irregular_interpolant_new != irregular_interpolant);
   }
 
+  // ... and another to test the constructor from a single point
+  {
+    tnsr::I<double, Dim, Frame::ElementLogical> target_x_single{};
+    tnsr::I<DataVector, Dim, Frame::ElementLogical> target_x_single_dv(1_st);
+    for (size_t d = 0; d < Dim; ++d) {
+      target_x_single.get(d) = target_x.get(d)[0];
+      target_x_single_dv.get(d)[0] = target_x_single.get(d);
+    }
+    CHECK(intrp::Irregular<Dim>(mesh, target_x_single) ==
+          intrp::Irregular<Dim>(mesh, target_x_single_dv));
+  }
+
   // Coordinates on the grid
   const auto src_x = coordinate_map(logical_coordinates(mesh));
 


### PR DESCRIPTION
## Proposed changes

Uses a `boost::geometric::index::rtree` to speed up repeated interpolation to single points. This speeds up ray tracing through volume data by about a factor of 3.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
