### PR TITLE
Correct size of coupling tensors in MC initialization

### DIFF
--- a/src/Evolution/Particles/MonteCarlo/Actions/InitializeMonteCarlo.hpp
+++ b/src/Evolution/Particles/MonteCarlo/Actions/InitializeMonteCarlo.hpp
@@ -200,7 +200,8 @@ struct InitializeMCTags {
           mesh.slice_away(direction.dimension()).extents();
       size_t sliced_mesh_size_with_ghost_zone = 1;
       for (size_t d = 0; d < dim - 1; d++) {
-        sliced_mesh_size_with_ghost_zone *= sliced_mesh_extents[d];
+        sliced_mesh_size_with_ghost_zone *= ( sliced_mesh_extents[d]
+                                             + 2 * num_ghost_zones );
       }
       const DataVector zero_dv_ghost_zones(sliced_mesh_size_with_ghost_zone,
                                            0.0);


### PR DESCRIPTION
## Proposed changes

Correct the size of the tensors containing coupling terms in Monte Carlo

### Upgrade instructions

None

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

NA