### PR TITLE
Sort files before concatenating for eccentricity control

### DIFF
--- a/support/Pipelines/EccentricityControl/EccentricityControlParams.py
+++ b/support/Pipelines/EccentricityControl/EccentricityControlParams.py
@@ -104,6 +104,7 @@ def eccentricity_control_params(
     # Make sure h5_files is a sequence
     if isinstance(h5_files, str):
         h5_files = glob.glob(h5_files)
+        h5_files.sort()
     if isinstance(h5_files, Path):
         h5_files = [h5_files]
 


### PR DESCRIPTION
## Proposed changes

Sort h5 filenames before concatenating. This avoids errors in the spec performAllFits routine due to the time data not being monotonic.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
