### PR TITLE
PySphericalHarmonics: instantiate another transform function

### DIFF
--- a/src/Domain/Python/StrahlkorperTransformations.cpp
+++ b/src/Domain/Python/StrahlkorperTransformations.cpp
@@ -16,32 +16,53 @@ namespace py = pybind11;
 
 namespace domain::py_bindings {
 namespace {
+
+using PyFunctionsOfTimeMap =
+    std::unordered_map<std::string,
+                       const domain::FunctionsOfTime::FunctionOfTime&>;
+
+// Transform functions-of-time map to unique_ptrs because pybind11
+// can't handle them easily as function arguments (it's hard to
+// transfer ownership of a Python object to C++)
+domain::FunctionsOfTimeMap transform_functions_of_time(
+    const std::optional<PyFunctionsOfTimeMap>& functions_of_time) {
+  domain::FunctionsOfTimeMap functions_of_time_ptrs{};
+  if (functions_of_time.has_value()) {
+    for (const auto& [name, fot] : *functions_of_time) {
+      functions_of_time_ptrs[name] = fot.get_clone();
+    }
+  }
+  return functions_of_time_ptrs;
+}
+
 template <typename SrcFrame, typename DestFrame>
 void bind_strahlkorper_transformations_impl(py::module& m) {  // NOLINT
   m.def(
       "strahlkorper_in_inertial_frame",
       [](const ylm::Strahlkorper<SrcFrame>& strahlkorper,
          const Domain<3>& domain,
-         const std::optional<std::unordered_map<
-             std::string, const domain::FunctionsOfTime::FunctionOfTime&>>&
-             functions_of_time,
+         const std::optional<PyFunctionsOfTimeMap>& functions_of_time,
          const std::optional<double>& time) {
-        // Transform functions-of-time map to unique_ptrs because pybind11 can't
-        // handle unique_ptrs easily as function arguments (it's hard to
-        // transfer ownership of a Python object to C++)
-        std::unordered_map<
-            std::string,
-            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-            functions_of_time_ptrs{};
-        if (functions_of_time.has_value()) {
-          for (const auto& [name, fot] : *functions_of_time) {
-            functions_of_time_ptrs[name] = fot.get_clone();
-          }
-        }
         ylm::Strahlkorper<DestFrame> result{};
         strahlkorper_in_different_frame<SrcFrame, DestFrame>(
             make_not_null(&result), strahlkorper, domain,
-            functions_of_time_ptrs,
+            transform_functions_of_time(functions_of_time),
+            time.value_or(std::numeric_limits<double>::signaling_NaN()));
+        return result;
+      },
+      py::arg("strahlkorper"), py::arg("domain"),
+      py::arg("functions_of_time") = std::nullopt,
+      py::arg("time") = std::nullopt);
+  m.def(
+      "strahlkorper_in_inertial_frame_aligned",
+      [](const ylm::Strahlkorper<SrcFrame>& strahlkorper,
+         const Domain<3>& domain,
+         const std::optional<PyFunctionsOfTimeMap>& functions_of_time,
+         const std::optional<double>& time) {
+        ylm::Strahlkorper<DestFrame> result{};
+        strahlkorper_in_different_frame_aligned<SrcFrame, DestFrame>(
+            make_not_null(&result), strahlkorper, domain,
+            transform_functions_of_time(functions_of_time),
             time.value_or(std::numeric_limits<double>::signaling_NaN()));
         return result;
       },
@@ -52,9 +73,9 @@ void bind_strahlkorper_transformations_impl(py::module& m) {  // NOLINT
 }  // namespace
 
 void bind_strahlkorper_transformations(py::module& m) {  // NOLINT
+  // Only instantiating for Grid->Inertial because the Py functions are
+  // currently named like that
   bind_strahlkorper_transformations_impl<Frame::Grid, Frame::Inertial>(m);
-  bind_strahlkorper_transformations_impl<Frame::Inertial, Frame::Grid>(m);
-  bind_strahlkorper_transformations_impl<Frame::Inertial, Frame::Distorted>(m);
 }
 
 }  // namespace domain::py_bindings

--- a/tests/Unit/Domain/Python/Test_StrahlkorperTransformations.py
+++ b/tests/Unit/Domain/Python/Test_StrahlkorperTransformations.py
@@ -37,6 +37,13 @@ class TestStrahlkorperTransformations(unittest.TestCase):
             time=0.0,
         )
         self.assertAlmostEqual(strahlkorper_inertial.average_radius, 0.5)
+        strahlkorper_inertial = strahlkorper_in_inertial_frame_aligned(
+            strahlkorper_grid,
+            domain=domain,
+            functions_of_time=functions_of_time,
+            time=0.0,
+        )
+        self.assertAlmostEqual(strahlkorper_inertial.average_radius, 0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

Need this `_aligned` function for interpolating to excisions in initial data.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
