### PR TITLE
Fix error in frustum, use ZeroMhd for BNS, not not-BNS....

### DIFF
--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -746,21 +746,27 @@ std::vector<domain::CoordinateMaps::Frustum> frustum_coordinate_maps(
     const domain::CoordinateMaps::Distribution radial_distribution,
     const std::optional<double> distribution_value, const double sphericity,
     const double opening_angle) {
-  if (length_inner_cube >= 0.5 * length_outer_cube) {
-    ERROR("The outer cube (" << length_outer_cube
-                             << ") is too small! The inner cubes ("
-                             << length_inner_cube
-                             << ") will pierce the surface of the outer cube.");
+  if (sphericity != 0.0 and sphericity != 1.0) {
+    ERROR("Sphericity for Frusmtums must be either 0 or 1, not " << sphericity);
+  }
+  const double sphericity_factor = sphericity == 0.0 ? 1.0 : std::sqrt(3.0);
+  if (length_inner_cube >= 0.5 * sphericity_factor * length_outer_cube) {
+    ERROR("The outer cube ("
+          << length_outer_cube << ") is too small! The inner cubes ("
+          << (length_inner_cube * sphericity_factor)
+          << ") will pierce the surface of the outer cube. The sphericity is "
+          << sphericity);
   }
   if (not(abs(origin_preimage[0]) + length_inner_cube <
-              0.5 * length_outer_cube and
+              0.5 * sphericity_factor * length_outer_cube and
           abs(origin_preimage[1]) + length_inner_cube <
-              0.5 * length_outer_cube and
+              0.5 * sphericity_factor * length_outer_cube and
           abs(origin_preimage[2]) + 0.5 * length_inner_cube <
-              0.5 * length_outer_cube)) {
+              0.5 * sphericity_factor * length_outer_cube)) {
     ERROR(
         "The current choice for `origin_preimage` results in the inner cubes "
-        "piercing the surface of the outer cube.");
+        "piercing the surface of the outer cube. The sphericity is "
+        << sphericity);
   }
   const auto frustum_orientations = orientations_for_sphere_wrappings();
   const double lower = 0.5 * length_inner_cube;

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -196,6 +196,11 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
 /// surfaces: The inner surface is the surface of the two joined inner cubes
 /// enveloping the two compact objects, while the outer is the surface of the
 /// outer cube.
+///
+/// When the sphericity is 0, the \p length_inner_cube must be less than $1/2$
+/// \p length_outer_cube while when the sphericity is 1 it must be less than
+/// $\sqrt{3}/2$ \p length_outer_cube.
+///
 /// \param length_inner_cube The side length of the cubes enveloping the two
 /// shells.
 /// \param length_outer_cube The side length of the outer cube.

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -763,9 +763,10 @@ struct GhValenciaDivCleanTemplateBase<
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           system, volume_dim, false, use_dg_element_collection>,
       tmpl::conditional_t<
-          UseControlSystems, tmpl::list<>,
+          UseControlSystems,
           Actions::MutateApply<
-              grmhd::GhValenciaDivClean::subcell::ZeroMhdTimeDerivatives>>,
+              grmhd::GhValenciaDivClean::subcell::ZeroMhdTimeDerivatives>,
+          tmpl::list<>>,
       tmpl::conditional_t<
           local_time_stepping, tmpl::list<>,
           tmpl::list<Actions::RecordTimeStepperData<system>,


### PR DESCRIPTION
## Proposed changes

As far as I can tell, this is the last bit of code needed for running BNS on develop fairly robustly. I'll keep testing more, but this gets inspiral, merger, and post-merger (less accurate PM) working for equal mass. I have code for translation control using the global COM that I'll clean up and test, which will enable unequal mass.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
