### PR TITLE
Add states DeltaRDriftInward, DeltaRNoDrift

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -12,6 +12,7 @@
 #include "ControlSystem/Averager.hpp"
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
@@ -45,9 +46,11 @@ Size<DerivOrder, Horizon>::Size(
     const int max_times, const double smooth_avg_timescale_frac,
     TimescaleTuner<true> smoother_tuner,
     std::unique_ptr<size::State> initial_state,
-    std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options)
+    std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options,
+    std::optional<DeltaRDriftInwardOptions> delta_r_drift_inward_options)
     : smoother_tuner_(std::move(smoother_tuner)),
-      delta_r_drift_outward_options_(delta_r_drift_outward_options) {
+      delta_r_drift_outward_options_(delta_r_drift_outward_options),
+      delta_r_drift_inward_options_(delta_r_drift_inward_options) {
   if (not smoother_tuner_.timescales_have_been_set()) {
     smoother_tuner_.resize_timescales(1);
   }
@@ -59,6 +62,10 @@ Size<DerivOrder, Horizon>::Size(
   comoving_char_speed_predictor_ =
       intrp::ZeroCrossingPredictor{3, max_times_size_t};
   delta_radius_predictor_ = intrp::ZeroCrossingPredictor{3, max_times_size_t};
+  drift_limit_char_speed_predictor_ =
+      intrp::ZeroCrossingPredictor{3, max_times_size_t};
+  drift_limit_delta_radius_predictor_ =
+      intrp::ZeroCrossingPredictor{3, max_times_size_t};
   state_history_ = size::StateHistory{DerivOrder + 1};
   legend_ = std::vector<std::string>{"Time",
                                      "ControlError",
@@ -143,10 +150,13 @@ void Size<DerivOrder, Horizon>::pup(PUP::er& p) {
   p | char_speed_predictor_;
   p | comoving_char_speed_predictor_;
   p | delta_radius_predictor_;
+  p | drift_limit_char_speed_predictor_;
+  p | drift_limit_delta_radius_predictor_;
   p | state_history_;
   p | legend_;
   p | subfile_name_;
   p | delta_r_drift_outward_options_;
+  p | delta_r_drift_inward_options_;
 }
 
 template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
@@ -166,6 +176,24 @@ void Size<DerivOrder, Horizon>::DeltaRDriftOutwardOptions::pup(PUP::er& p) {
   p | max_allowed_radial_distance;
   p | outward_drift_velocity;
   p | outward_drift_timescale;
+}
+
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+Size<DerivOrder,
+     Horizon>::DeltaRDriftInwardOptions::DeltaRDriftInwardOptions() = default;
+
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+Size<DerivOrder, Horizon>::DeltaRDriftInwardOptions::DeltaRDriftInwardOptions(
+    double min_allowed_radial_distance_in, double min_allowed_char_speed_in,
+    double inward_drift_velocity_in)
+    : min_allowed_radial_distance(min_allowed_radial_distance_in),
+      min_allowed_char_speed(min_allowed_char_speed_in),
+      inward_drift_velocity(inward_drift_velocity_in) {}
+template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
+void Size<DerivOrder, Horizon>::DeltaRDriftInwardOptions::pup(PUP::er& p) {
+  p | min_allowed_radial_distance;
+  p | min_allowed_char_speed;
+  p | inward_drift_velocity;
 }
 
 #define DERIV_ORDER(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -235,9 +235,47 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
     double outward_drift_timescale{};
   };
 
-  using options = tmpl::list<MaxNumTimesForZeroCrossingPredictor,
-                             SmoothAvgTimescaleFraction, SmootherTuner,
-                             InitialState, DeltaRDriftOutwardOptions>;
+  struct DeltaRDriftInwardOptions {
+    using type =
+        Options::Auto<DeltaRDriftInwardOptions, Options::AutoLabel::None>;
+    static constexpr Options::String help{
+        "Options for State DeltaRDriftInward. Specify 'None' to disable State "
+        "DeltaRDriftInward."};
+    struct MinAllowedRadialDistance {
+      using type = double;
+      static constexpr Options::String help{
+          "Drift excision boundary inward if distance from horizon to "
+          "excision is less than this."};
+    };
+    struct MinAllowedCharSpeed {
+      using type = double;
+      static constexpr Options::String help{
+          "Drift excision boundary inward if min char speed is less than "
+          "this."};
+    };
+    struct InwardDriftVelocity {
+      using type = double;
+      static constexpr Options::String help{
+          "Maximum value of drift velocity term, if State DeltaRDriftInward is "
+          "triggered by MinAllowedRadialDistance or MinAllowedCharSpeed."};
+    };
+    using options = tmpl::list<MinAllowedRadialDistance, MinAllowedCharSpeed,
+                               InwardDriftVelocity>;
+    DeltaRDriftInwardOptions();
+    DeltaRDriftInwardOptions(double min_allowed_radial_distance_in,
+                             double min_allowed_char_speed_in,
+                             double inward_drift_velocity_in);
+    void pup(PUP::er& p);
+
+    double min_allowed_radial_distance{};
+    double min_allowed_char_speed{};
+    double inward_drift_velocity{};
+  };
+
+  using options =
+      tmpl::list<MaxNumTimesForZeroCrossingPredictor,
+                 SmoothAvgTimescaleFraction, SmootherTuner, InitialState,
+                 DeltaRDriftOutwardOptions, DeltaRDriftInwardOptions>;
   static constexpr Options::String help{
       "Computes the control error for size control. Will also write a "
       "diagnostics file if the control systems are allowed to write data to "
@@ -265,7 +303,8 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
   Size(const int max_times, const double smooth_avg_timescale_frac,
        TimescaleTuner<true> smoother_tuner,
        std::unique_ptr<size::State> initial_state,
-       std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options);
+       std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options,
+       std::optional<DeltaRDriftInwardOptions> delta_r_drift_inward_options);
 
   /// Returns the internal `control_system::size::Info::suggested_time_scale`. A
   /// std::nullopt means that no timescale is suggested.
@@ -456,6 +495,21 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
                                         delta_r_drift_outward_options_.value()
                                             .outward_drift_timescale)
             : std::nullopt;
+    const std::optional<double> inward_drift_velocity =
+        delta_r_drift_inward_options_.has_value()
+            ? std::optional<double>(
+                  delta_r_drift_inward_options_.value().inward_drift_velocity)
+            : std::nullopt;
+    const std::optional<double> min_allowed_radial_distance =
+        delta_r_drift_inward_options_.has_value()
+            ? std::optional<double>(delta_r_drift_inward_options_.value()
+                                        .min_allowed_radial_distance)
+            : std::nullopt;
+    const std::optional<double> min_allowed_char_speed =
+        delta_r_drift_inward_options_.has_value()
+            ? std::optional<double>(
+                  delta_r_drift_inward_options_.value().min_allowed_char_speed)
+            : std::nullopt;
 
     // Currently we don't do anything with the derivative of the comoving char
     // speed. Eventually, we will pass it to the computation of the control
@@ -489,15 +543,18 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
     const size::ErrorDiagnostics error_diagnostics = size::control_error(
         make_not_null(&info_), make_not_null(&char_speed_predictor_),
         make_not_null(&comoving_char_speed_predictor_),
-        make_not_null(&delta_radius_predictor_), time, control_error_delta_r,
-        control_error_delta_r_outward,
+        make_not_null(&delta_radius_predictor_),
+        make_not_null(&drift_limit_char_speed_predictor_),
+        make_not_null(&drift_limit_delta_radius_predictor_), time,
+        control_error_delta_r, control_error_delta_r_outward,
         delta_r_drift_outward_options_.has_value()
             ? std::optional<double>(delta_r_drift_outward_options_.value()
                                         .max_allowed_radial_distance)
             : std::nullopt,
-        dt_lambda_00, apparent_horizon, excision_surface, lapse,
-        shifty_quantity, spatial_metric_on_excision,
-        inverse_spatial_metric_on_excision);
+        inward_drift_velocity, min_allowed_radial_distance,
+        min_allowed_char_speed, horizon_00, dt_lambda_00, apparent_horizon,
+        excision_surface, lapse, shifty_quantity, spatial_metric_on_excision,
+        inverse_spatial_metric_on_excision, deriv_comoving_char_speed);
 
     state_history_.store(time, info_, error_diagnostics.control_error_args);
 
@@ -555,10 +612,13 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
   intrp::ZeroCrossingPredictor char_speed_predictor_{};
   intrp::ZeroCrossingPredictor comoving_char_speed_predictor_{};
   intrp::ZeroCrossingPredictor delta_radius_predictor_{};
+  intrp::ZeroCrossingPredictor drift_limit_char_speed_predictor_{};
+  intrp::ZeroCrossingPredictor drift_limit_delta_radius_predictor_{};
   size::StateHistory state_history_{};
   std::vector<std::string> legend_{};
   std::string subfile_name_{};
   std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options_{};
+  std::optional<DeltaRDriftInwardOptions> delta_r_drift_inward_options_{};
   db::compute_databox_type<tmpl::list<
       gr::Tags::InverseSpatialMetric<DataVector, 3, Frame::Distorted>,
       ylm::Tags::Strahlkorper<Frame::Distorted>,

--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
@@ -9,6 +9,8 @@
 #include <string>
 
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "Utilities/StdHelpers.hpp"
 
 namespace control_system::size::States {
@@ -22,6 +24,12 @@ std::string AhSpeed::update(const gsl::not_null<Info*> info,
                             const CrossingTimeInfo& crossing_time_info) const {
   const double min_char_speed = update_args.min_char_speed;
   const double min_comoving_char_speed = update_args.min_comoving_char_speed;
+
+  // This factor is present in SpEC, and it is used to prevent
+  // oscillations between states.  The value was chosen in SpEC, but
+  // nothing should be sensitive to small changes in this value as
+  // long as it is slightly greater than unity.
+  constexpr double non_oscillation_drift_inward_factor = 1.1;
 
   // Note that delta_radius_is_in_danger and char_speed_is_in_danger
   // can be different for different States.
@@ -120,6 +128,16 @@ std::string AhSpeed::update(const gsl::not_null<Info*> info,
       }
       ss << " Target char speed = " << info->target_char_speed << "\n";
       ss << " Suggested timescale = " << info->suggested_time_scale;
+    } else if (should_activate_inward_drift(update_args)) {
+      info->discontinuous_change_has_occurred = true;
+      info->state = std::make_unique<States::DeltaRDriftInward>();
+      info->suggested_time_scale = crossing_time_info.t_delta_radius;
+      info->target_char_speed = target_speed_for_inward_drift(
+          update_args.avg_distorted_normal_dot_unit_coord_vector,
+          update_args.min_char_speed,
+          update_args.inward_drift_velocity.value());
+      ss << " Switching to DeltaRDriftInward.\n";
+      ss << " Suggested timescale = " << info->suggested_time_scale;
     } else {
       info->discontinuous_change_has_occurred = true;
       info->state = std::make_unique<States::DeltaR>();
@@ -127,7 +145,6 @@ std::string AhSpeed::update(const gsl::not_null<Info*> info,
       info->target_char_speed = 0.0;
       ss << " Switching to DeltaR.\n";
       ss << " Suggested timescale = " << info->suggested_time_scale;
-      // Here is where possible transition to State DeltaRDriftInward will go.
     }
   } else if (update_args.min_comoving_char_speed > 0.0 and
              update_args.min_char_speed > 0.0 and
@@ -138,10 +155,19 @@ std::string AhSpeed::update(const gsl::not_null<Info*> info,
                comoving_decreasing_slower_than_char_speeds)) and
              (update_args.min_char_speed >= info->target_char_speed or
               min_comoving_char_speed > min_char_speed)) {
+    const bool drift_inward = should_activate_inward_drift(update_args);
     info->discontinuous_change_has_occurred = true;
-    info->state = std::make_unique<States::DeltaR>();
-
-    ss << "Current state AhSpeed. Switching to DeltaR.\n";
+    if (drift_inward) {
+      info->state = std::make_unique<States::DeltaRDriftInward>();
+      info->target_char_speed = target_speed_for_inward_drift(
+          update_args.avg_distorted_normal_dot_unit_coord_vector,
+          update_args.min_char_speed,
+          update_args.inward_drift_velocity.value());
+    } else {
+      info->state = std::make_unique<States::DeltaR>();
+    }
+    ss << "Current state AhSpeed. Switching to "
+       << (drift_inward ? "DeltaRDriftInward" : "DeltaR") << ".\n";
     ss << " Min char speed " << update_args.min_char_speed << " > 0\n";
     ss << " Min comoving char speed " << update_args.min_comoving_char_speed
        << " > 0\n";
@@ -160,10 +186,19 @@ std::string AhSpeed::update(const gsl::not_null<Info*> info,
       ss << " Min char speed " << update_args.min_char_speed
          << " >= target char speed " << info->target_char_speed << "\n";
     }
-    // Must happen after we print the value above
-    info->target_char_speed = 0.0;
-    // Here is where possible transition to State DeltaRDriftInward
-    // will go.
+    if (not drift_inward) {  // Must happen after we print the value above
+      info->target_char_speed = 0.0;
+    }
+  } else if (update_args.average_radial_distance.has_value() and
+             update_args.average_radial_distance.value() >
+                 non_oscillation_drift_inward_factor *
+                     update_args.max_allowed_radial_distance.value_or(
+                         std::numeric_limits<double>::infinity()) and
+             not crossing_time_info.t_char_speed.has_value()) {
+    info->discontinuous_change_has_occurred = true;
+    ss << "Current state AhSpeed. We have drifted too far in, so "
+          "we are switching to DeltaRDriftOutward.\n";
+    info->state = std::make_unique<States::DeltaRDriftOutward>();
   } else {
     ss << "Current state AhSpeed. No change necessary. Staying in AhSpeed.";
   }

--- a/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
+++ b/src/ControlSystem/ControlErrors/Size/CMakeLists.txt
@@ -8,7 +8,9 @@ spectre_target_sources(
   Info.cpp
   AhSpeed.cpp
   DeltaR.cpp
+  DeltaRDriftInward.cpp
   DeltaRDriftOutward.cpp
+  DeltaRNoDrift.cpp
   Error.cpp
   Initial.cpp
   RegisterDerivedWithCharm.cpp
@@ -25,7 +27,9 @@ spectre_target_headers(
   StateHistory.hpp
   AhSpeed.hpp
   DeltaR.hpp
+  DeltaRDriftInward.hpp
   DeltaRDriftOutward.hpp
+  DeltaRNoDrift.hpp
   Error.hpp
   Factory.hpp
   Initial.hpp

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
@@ -107,7 +107,8 @@ std::string DeltaR::update(const gsl::not_null<Info*> info,
   } else if (update_args.average_radial_distance.has_value() and
              update_args.average_radial_distance.value() >
                  non_oscillation_drift_outward_factor *
-                     update_args.max_allowed_radial_distance.value()) {
+                     update_args.max_allowed_radial_distance.value_or(
+                         std::numeric_limits<double>::infinity())) {
     info->discontinuous_change_has_occurred = true;
     info->state = std::make_unique<States::DeltaRDriftOutward>();
     ss << "Current state DeltaR. "

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "Utilities/StdHelpers.hpp"
 
@@ -48,6 +49,18 @@ std::string DeltaR::update(const gsl::not_null<Info*> info,
       crossing_time_info.t_char_speed.value_or(
           std::numeric_limits<double>::infinity()) < info->damping_time and
       not delta_radius_is_in_danger;
+
+  // inward_drift_limit_in_danger means we are about
+  // to cross the maximum allowed deltaR, and we are not in
+  // the situation where we should exit state DeltaRNoDrift.
+  // (the latter is important because we don't want to keep entering
+  //  and exiting DeltaRNoDrift repeatedly)
+  // In SpEC this variable is called "State2MaxLimitInDanger".
+  const bool inward_drift_limit_in_danger =
+      crossing_time_info.t_drift_limit_delta_radius.value_or(
+          std::numeric_limits<double>::infinity()) < info->damping_time and
+      update_args.min_allowed_radial_distance.has_value() and
+      not ok_to_return_to_state_deltar(update_args);
 
   // This factor is present in SpEC, and it is used to prevent
   // oscillations between states.  The value was chosen in SpEC, but
@@ -104,6 +117,22 @@ std::string DeltaR::update(const gsl::not_null<Info*> info,
        << std::abs(update_args.control_error_delta_r) << " > threshold "
        << delta_r_control_error_threshold << ". Staying in DeltaR.\n";
     ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (should_transition_from_state_delta_r_to_inward_drift(
+                 crossing_time_info.t_drift_limit, info->damping_time,
+                 update_args)) {
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::DeltaRDriftInward>();
+    info->target_char_speed = target_speed_for_inward_drift(
+        update_args.avg_distorted_normal_dot_unit_coord_vector,
+        update_args.min_char_speed, update_args.inward_drift_velocity.value());
+    ss << "Current state DeltaR. "
+          "Horizon too close to excision boundary. Switching to "
+          "DeltaRDriftInward";
+  } else if (inward_drift_limit_in_danger) {
+    info->suggested_time_scale = crossing_time_info.t_drift_limit_delta_radius;
+    ss << "Current state DeltaR. Inward drift limit in danger. Staying "
+          "in DeltaR.\n";
+    ss << " Suggested timescale = " << info->suggested_time_scale;
   } else if (update_args.average_radial_distance.has_value() and
              update_args.average_radial_distance.value() >
                  non_oscillation_drift_outward_factor *
@@ -117,8 +146,6 @@ std::string DeltaR::update(const gsl::not_null<Info*> info,
   } else {
     ss << "Current state DeltaR. No change necessary. Staying in DeltaR.";
   }
-  // Here is where possible transitions to states DeltaRDriftInward and
-  // state DeltaRDriftOutward will go.
 
   return ss.str();
 }

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftInward.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftInward.cpp
@@ -1,0 +1,259 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
+
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace control_system::size::States {
+
+std::unique_ptr<State> DeltaRDriftInward::get_clone() const {
+  return std::make_unique<DeltaRDriftInward>(*this);
+}
+
+std::string DeltaRDriftInward::update(
+    const gsl::not_null<Info*> info, const StateUpdateArgs& update_args,
+    const CrossingTimeInfo& crossing_time_info) const {
+  const double Y00 = 0.25 * M_2_SQRTPI;
+
+  // This factor is present in SpEC, and it is used to prevent
+  // oscillations between states.  The value was chosen in SpEC, but
+  // nothing should be sensitive to small changes in this value as
+  // long as it is slightly greater than unity.
+  constexpr double non_oscillation_drift_inward_factor = 1.1;
+
+  // Note that delta_radius_is_in_danger and char_speed_is_in_danger
+  // can be different for different States.
+
+  // The value of 0.99 was chosen by trial and error in SpEC.
+  // It should be slightly less than unity but nothing should be
+  // sensitive to small changes in this value.
+  constexpr double time_tolerance_for_delta_r_in_danger = 0.99;
+  const bool delta_radius_is_in_danger =
+      crossing_time_info.horizon_will_hit_excision_boundary_first and
+      crossing_time_info.t_delta_radius.value_or(
+          std::numeric_limits<double>::infinity()) <
+          info->damping_time * time_tolerance_for_delta_r_in_danger;
+  const bool char_speed_is_in_danger =
+      crossing_time_info.char_speed_will_hit_zero_first and
+      crossing_time_info.t_char_speed.value_or(
+          std::numeric_limits<double>::infinity()) < info->damping_time and
+      not delta_radius_is_in_danger;
+
+  // spherepack_factor is needed because horizon_00 is a
+  // spherepack coefficient, not a spherical harmonic coefficient.
+  const double spherepack_factor = sqrt(0.5 * M_PI);
+
+  std::stringstream ss{};
+
+  if (char_speed_is_in_danger) {
+    ss << "Current state DeltaRDriftInward. Char speed in danger."
+       << " Switching to AhSpeed.\n";
+    // Switch to AhSpeed mode. Note that we don't check ComovingCharSpeed
+    // like we do in state DeltaR; this behavior agrees with SpEC.
+
+    // This factor prevents oscillations between
+    // DeltaR/DeltaRInward/DeltaRNoDrift/DeltaROutward and AhSpeed.
+    // It needs to be slightly greater than unity, but the control
+    // system should not be sensitive to the exact value. The value of
+    // 1.01 was chosen arbitrarily in SpEC and never needed to be
+    // changed.
+    constexpr double non_oscillation_factor = 1.01;
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::AhSpeed>();
+    info->target_char_speed =
+        update_args.min_char_speed * non_oscillation_factor;
+    ss << " Target char speed = " << info->target_char_speed << "\n";
+    // If the comoving char speed is positive and is not about to
+    // cross zero, staying in DeltaRDriftInward mode will rescue the
+    // speed automatically (since it drives char speed to comoving
+    // char speed, plus a small difference).  But we should decrease
+    // the timescale in any case.
+    info->suggested_time_scale = crossing_time_info.t_char_speed.value();
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (delta_radius_is_in_danger) {
+    info->suggested_time_scale = crossing_time_info.t_delta_radius.value();
+    ss << "Current state DeltaRDriftInward. Delta radius in danger. Staying "
+          "in DeltaRDriftInward.\n";
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (should_transition_from_state_inward_drift_to_delta_r_no_drift(
+                 crossing_time_info.t_drift_limit, info->damping_time,
+                 update_args)) {
+    ss << "Current state DeltaRDriftInward. Switching to DeltaRNoDrift.\n";
+    info->discontinuous_change_has_occurred = true;
+    info->state = std::make_unique<States::DeltaRNoDrift>();
+    info->suggested_time_scale = crossing_time_info.t_drift_limit;
+  } else if (crossing_time_info.t_delta_radius.has_value() and
+             info->damping_time >
+                 2.0 * spherepack_factor * update_args.horizon_00 * Y00) {
+    // Explaination of the above 'if':
+    //
+    // If crossing_time_info.t_delta_radius has a value, this means
+    // that delta_radius is decreasing.  But the entire point of state
+    // DeltaRDriftInward is to make delta_radius increase, not
+    // decrease.  So if we are in state DeltaRDriftInward and
+    // crossing_time_info.t_delta_radius has a value
+    // (i.e. delta_radius is decreasing), something is wrong.
+    //
+    // The thing that is usually wrong is that damping_time is too
+    // large, and hence DeltaRDriftInward doesn't have time to make
+    // delta_radius increase.  So the fix is to decrease the damping
+    // time (a.k.a. suggested_time_scale below).  But we stop
+    // decreasing the damping time if it is less than twice the
+    // average horizon radius, which is the same criterion SpEC
+    // uses. (Here we are assuming that timescales and length scales
+    // have the same units, which should be true for horizons).
+    ss << "Current state DeltaRDriftInward. RelativeDeltaR is decreasing, "
+          "which is probably because timescale is too big (DeltaRDriftInward "
+          "should be increasing RelativeDeltaR if control system is working "
+          "properly). Decreasing timescale and staying in DeltaRDriftInward.\n";
+    // delta_r_drift_inward_decrease_factor is an arbitrary factor
+    // chosen by trial and error in SpEC. If this factor is too close
+    // to 1, then the timescale does not decrease fast enough.  If
+    // this factor is too far from 1, then repeated calls of
+    // DeltaRDriftInward::update will decrease the timescale to
+    // 2*average_horizon_radius too quickly.
+    constexpr double delta_r_drift_inward_decrease_factor = 0.99;
+    info->suggested_time_scale =
+        info->damping_time * delta_r_drift_inward_decrease_factor;
+    info->target_char_speed = target_speed_for_inward_drift(
+        update_args.avg_distorted_normal_dot_unit_coord_vector,
+        update_args.min_char_speed, update_args.inward_drift_velocity.value());
+    ss << " Target char speed = " << info->target_char_speed << "\n";
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (update_args.average_radial_distance.has_value() and
+             update_args.average_radial_distance.value() >
+                 non_oscillation_drift_inward_factor *
+                     update_args.max_allowed_radial_distance.value_or(
+                         std::numeric_limits<double>::infinity())) {
+    info->discontinuous_change_has_occurred = true;
+    ss << "Current state DeltaRDriftInward. We have drifted too far, so "
+          "we are switching to DeltaRDriftOutward.\n";
+    info->state = std::make_unique<States::DeltaRDriftOutward>();
+  } else {
+    ss << "Current state DeltaRDriftInward. No change necessary. Staying in "
+          "DeltaRDriftInward.";
+  }
+
+  return ss.str();
+}
+
+double DeltaRDriftInward::control_error(
+    const Info& info, const ControlErrorArgs& control_error_args) const {
+  // We increase the control error by the target speed, so as to make
+  // control_error_delta_r more negative, which gives a negative velocity
+  // to delta_r (i.e. a positive velocity to the excision boundary).
+  return control_error_args.control_error_delta_r + info.target_char_speed;
+}
+
+// cppcoreguidelines-avoid-non-const-global-variables
+PUP::able::PUP_ID DeltaRDriftInward::my_PUP_ID = 0;  // NOLINT
+
+double target_speed_for_inward_drift(
+    const double avg_distorted_normal_dot_unit_coord_vector,
+    const double min_char_speed, const double inward_drift_velocity) {
+  // TargetSpeed should be > 0 (we want DeltaR to increase).  And
+  // TargetSpeed must be <
+  // min_char_speed/avg_distorted_normal_dot_unit_coord_vector, because
+  // going into DriftInward will make min_char_speed decrease by
+  // TargetSpeed*avg_distorted_normal_dot_unit_coord_vector. The time
+  // it takes v to cross zero (assuming v decreases linearly, only a
+  // rough approximation) is
+  // Tau*min_char_speed/avg_distorted_normal_dot_unit_coord_vector*TargetSpeed,
+  // where Tau is the damping timescale.  Therefore choosing
+  // TargetSpeed < fudge *
+  // min_char_speed/avg_distorted_normal_dot_unit_coord_vector should make
+  // v decrease only by a factor of fudge, and it should make the
+  // crossing time fudge*Tau.
+  constexpr double fudge = 0.5;
+  return std::min(
+      inward_drift_velocity,
+      fudge * min_char_speed / avg_distorted_normal_dot_unit_coord_vector);
+}
+
+bool should_transition_from_state_delta_r_to_inward_drift(
+    const std::optional<double>& crossing_time_drift_limit,
+    const double damping_time, const StateUpdateArgs& update_args) {
+  // This function is called ShouldEnterState3FromState2 in SpEC.
+  if (update_args.inward_drift_velocity.has_value() and
+      crossing_time_drift_limit.has_value() and
+      crossing_time_drift_limit.value() < damping_time) {
+    return false;
+  }
+  return should_activate_inward_drift(update_args);
+}
+
+bool should_transition_from_state_inward_drift_to_delta_r_no_drift(
+    const std::optional<double>& crossing_time_drift_limit,
+    const double damping_time, const StateUpdateArgs& update_args) {
+  return (not should_transition_from_state_delta_r_to_inward_drift(
+      crossing_time_drift_limit, damping_time, update_args));
+}
+
+bool should_activate_inward_drift(const StateUpdateArgs& update_args) {
+  // This function is called PreferState3OverState2 in SpEC.
+
+  // This drift factor was chosen in SpEC arbitrarily to be 0.9.
+  constexpr double inward_drift_limit_buffer_factor = 0.9;
+
+  // The idea of these variables is to check whether either DeltaR or
+  // char speed are close to going above the
+  // min_average_radial_distance or min_allowed_char_speed values.  If
+  // so, then we don't need state DeltaRDriftInward at the moment.
+  // For reference, in SpEC these variables are called
+  // "DeltaRAlmostAboveState3Limit" and
+  // "CharSpeedAlmostAboveState3Limit".
+  const bool delta_r_almost_above_inward_drift_limit =
+      update_args.min_allowed_radial_distance.has_value() and
+      update_args.average_radial_distance.value() >
+          inward_drift_limit_buffer_factor *
+              update_args.min_allowed_radial_distance.value();
+  const bool char_speed_almost_above_inward_drift_limit =
+      update_args.min_allowed_char_speed.has_value() and
+      update_args.min_char_speed >
+          inward_drift_limit_buffer_factor *
+              update_args.min_allowed_char_speed.value();
+
+  return (update_args.inward_drift_velocity.has_value() and
+          update_args.comoving_char_speed_increasing_inward and
+          (update_args.min_allowed_char_speed.has_value() or
+           update_args.min_allowed_radial_distance.has_value()) and
+          (not delta_r_almost_above_inward_drift_limit) and
+          (not char_speed_almost_above_inward_drift_limit));
+}
+
+bool ok_to_return_to_state_deltar(const StateUpdateArgs& update_args) {
+  // The purpose of delta_r_large_enough_to_stop_inward_drift and
+  // char_speed_large_enough_to_stop_inward_drift below is to stop
+  // the scenario in which either the CharSpeed or DeltaR approaches
+  // the limit "min_allowed_radial_distance" and the timescale gets
+  // cut down to a ridiculously small value.  When that scenario
+  // happens, we simply exit state DeltaRNoDrift and go back to DeltaR.
+  // These variables are called "DeltaRLargeEnoughToExitState4"
+  // and "CharSpeedLargeEnoughToExitState4" in SpEC.
+  constexpr double stop_inward_drift_buffer_factor = 0.99;
+  const bool delta_r_large_enough_to_stop_inward_drift =
+      update_args.min_allowed_radial_distance.has_value() and
+      update_args.average_radial_distance.value() >
+          stop_inward_drift_buffer_factor *
+              update_args.min_allowed_radial_distance.value();
+  const bool char_speed_large_enough_to_stop_inward_drift =
+      update_args.min_allowed_char_speed.has_value() and
+      update_args.min_char_speed >
+          stop_inward_drift_buffer_factor *
+              update_args.min_allowed_char_speed.value();
+  return delta_r_large_enough_to_stop_inward_drift or
+         char_speed_large_enough_to_stop_inward_drift;
+}
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace control_system::size::States {
+class DeltaRDriftInward : public State {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Controls the velocity of the excision surface to maintain a constant "
+      "separation between the excision surface and the horizon surface with a "
+      "small inward radial velocity. This is state 3 in SpEC."};
+  DeltaRDriftInward() = default;
+  std::string name() const override { return "DeltaRDriftInward"; }
+  size_t number() const override { return 3; }
+  std::unique_ptr<State> get_clone() const override;
+  std::string update(gsl::not_null<Info*> info,
+                     const StateUpdateArgs& update_args,
+                     const CrossingTimeInfo& crossing_time_info) const override;
+  /// The return value is Q from Eq. 96 of \cite Hemberger2012jz, plus
+  /// an inward velocity term.
+  double control_error(
+      const Info& info,
+      const ControlErrorArgs& control_error_args) const override;
+
+  WRAPPED_PUPable_decl_template(DeltaRDriftInward);  // NOLINT
+  explicit DeltaRDriftInward(CkMigrateMessage* const /*msg*/) {}
+};
+
+// The following are helper functions that are used in many
+// of the states, for transitions to/from DeltaRDriftInward.
+
+/// Value of target_char_speed when state DeltaRDriftInward is in effect.
+double target_speed_for_inward_drift(
+    double avg_distorted_normal_dot_unit_coord_vector, double min_char_speed,
+    double inward_drift_velocity);
+
+/// Returs true if we should transition from state DeltaR to state
+/// DeltaRDriftInward.
+bool should_transition_from_state_delta_r_to_inward_drift(
+    const std::optional<double>& crossing_time_drift_limit, double damping_time,
+    const StateUpdateArgs& update_args);
+
+/// Returns true if we should transition from state DeltaRDriftInward
+/// to state DeltaRNoDrift.
+bool should_transition_from_state_inward_drift_to_delta_r_no_drift(
+    const std::optional<double>& crossing_time_drift_limit, double damping_time,
+    const StateUpdateArgs& update_args);
+
+/// Returns true if we should transition to DeltaRDriftInward rather than
+/// to DeltaR.
+bool should_activate_inward_drift(const StateUpdateArgs& update_args);
+
+/// Returns true if either CharSpeed approaches min_allowed_char_speed
+/// or DeltaR approaches min_allowed_radial_distance close enough
+/// that it would be ok to turn off state DeltaRNoDrift.
+bool ok_to_return_to_state_deltar(const StateUpdateArgs& update_args);
+
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
@@ -48,11 +48,12 @@ std::string DeltaRDriftOutward::update(
     // Switch to AhSpeed mode. Note that we don't check ComovingCharSpeed
     // like we do in state DeltaR; this behavior agrees with SpEC.
 
-    // This factor prevents oscillating between states Initial and
-    // AhSpeed.  It needs to be slightly greater than unity, but the
-    // control system should not be sensitive to the exact
-    // value. The value of 1.01 was chosen arbitrarily in SpEC and
-    // never needed to be changed.
+    // This factor prevents oscillations between
+    // DeltaR/DeltaRInward/DeltaRNoDrift/DeltaROutward and AhSpeed.
+    // It needs to be slightly greater than unity, but the control
+    // system should not be sensitive to the exact value. The value of
+    // 1.01 was chosen arbitrarily in SpEC and never needed to be
+    // changed.
     constexpr double non_oscillation_factor = 1.01;
     info->discontinuous_change_has_occurred = true;
     info->state = std::make_unique<States::AhSpeed>();

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
@@ -72,7 +72,8 @@ std::string DeltaRDriftOutward::update(
     ss << " Suggested timescale = " << info->suggested_time_scale;
   } else if (update_args.average_radial_distance.has_value() and
              update_args.average_radial_distance.value() <
-                 update_args.max_allowed_radial_distance.value()) {
+                 update_args.max_allowed_radial_distance.value_or(
+                     std::numeric_limits<double>::infinity())) {
     ss << "Current state DeltaRDriftOutward. Switching to DeltaR.";
     info->discontinuous_change_has_occurred = true;
     info->state = std::make_unique<States::DeltaR>();

--- a/src/ControlSystem/ControlErrors/Size/DeltaRNoDrift.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRNoDrift.cpp
@@ -1,0 +1,125 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp"
+
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+
+#include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace control_system::size::States {
+
+std::unique_ptr<State> DeltaRNoDrift::get_clone() const {
+  return std::make_unique<DeltaRNoDrift>(*this);
+}
+
+std::string DeltaRNoDrift::update(
+    const gsl::not_null<Info*> info, const StateUpdateArgs& update_args,
+    const CrossingTimeInfo& crossing_time_info) const {
+  // This factor is present in SpEC, and it is used to prevent
+  // oscillations between states.  The value was chosen in SpEC, but
+  // nothing should be sensitive to small changes in this value as
+  // long as it is slightly greater than unity.
+  constexpr double non_oscillation_drift_inward_factor = 1.1;
+
+  // Note that delta_radius_is_in_danger and char_speed_is_in_danger
+  // can be different for different States.
+
+  // The value of 0.99 was chosen by trial and error in SpEC.
+  // It should be slightly less than unity but nothing should be
+  // sensitive to small changes in this value.
+  constexpr double time_tolerance_for_delta_r_in_danger = 0.99;
+  const bool delta_radius_is_in_danger =
+      crossing_time_info.horizon_will_hit_excision_boundary_first and
+      crossing_time_info.t_delta_radius.value_or(
+          std::numeric_limits<double>::infinity()) <
+          info->damping_time * time_tolerance_for_delta_r_in_danger;
+  const bool char_speed_is_in_danger =
+      crossing_time_info.char_speed_will_hit_zero_first and
+      crossing_time_info.t_char_speed.value_or(
+          std::numeric_limits<double>::infinity()) < info->damping_time and
+      not delta_radius_is_in_danger;
+
+  std::stringstream ss{};
+
+  if (char_speed_is_in_danger) {
+    ss << "Current state DeltaRNoDrift. Char speed in danger.";
+    if (crossing_time_info.t_comoving_char_speed.has_value() or
+        update_args.min_comoving_char_speed < 0.0) {
+      // Comoving char speed is negative or threatening to cross zero, so
+      // staying in DeltaRNoDrift mode will not work.  So switch to AhSpeed
+      // mode.
+
+      // This factor prevents oscillations between
+      // DeltaR/DeltaRInward/DeltaRNoDrift/DeltaROutward and AhSpeed.
+      // It needs to be slightly greater than unity, but the control
+      // system should not be sensitive to the exact value. The value of
+      // 1.01 was chosen arbitrarily in SpEC and never needed to be
+      // changed.
+      constexpr double non_oscillation_factor = 1.01;
+      info->discontinuous_change_has_occurred = true;
+      info->state = std::make_unique<States::AhSpeed>();
+      info->target_char_speed =
+          update_args.min_char_speed * non_oscillation_factor;
+      ss << " Switching to AhSpeed.\n";
+      ss << " Target char speed = " << info->target_char_speed << "\n";
+    } else {
+      ss << " Staying in DeltaRNoDrift.\n";
+    }
+    // If the comoving char speed is positive and is not about to
+    // cross zero, staying in DeltaRNoDrift mode will rescue the speed
+    // automatically (since it drives char speed to comoving char
+    // speed).  But we should decrease the timescale in any case.
+    info->suggested_time_scale = crossing_time_info.t_char_speed;
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (delta_radius_is_in_danger) {
+    info->suggested_time_scale = crossing_time_info.t_delta_radius;
+    ss << "Current state DeltaRNoDrift. Delta radius in danger. Staying in "
+          "DeltaRNoDrift.\n";
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if ((not crossing_time_info.t_drift_limit.has_value()) or
+             ok_to_return_to_state_deltar(update_args)) {
+    info->state = std::make_unique<States::DeltaR>();
+    ss << "Current state DeltaRNoDrift, but safe to exit. "
+          "Going to state DeltaR.\n";
+  } else if (crossing_time_info.t_drift_limit.value_or(
+                 std::numeric_limits<double>::infinity()) <
+                 info->damping_time and
+             (update_args.min_allowed_char_speed.has_value() or
+              update_args.min_allowed_radial_distance.has_value())) {
+    info->suggested_time_scale = crossing_time_info.t_drift_limit;
+    ss << "Current state DeltaRNoDrift. Inward drift limit in danger. Staying "
+          "in DeltaRNoDrift.\n";
+    ss << " Suggested timescale = " << info->suggested_time_scale;
+  } else if (update_args.average_radial_distance.has_value() and
+             update_args.average_radial_distance.value() >
+                 non_oscillation_drift_inward_factor *
+                     update_args.max_allowed_radial_distance.value_or(
+                         std::numeric_limits<double>::infinity())) {
+    info->discontinuous_change_has_occurred = true;
+    ss << "Current state DeltaRNoDrift. We have drifted too far, so "
+          "we are switching to DeltaRDriftOutward.\n";
+    info->state = std::make_unique<States::DeltaRDriftOutward>();
+  } else {
+    ss << "Current state DeltaRNoDrift. No change necessary. Staying in "
+          "DeltaRNoDrift.";
+  }
+
+  return ss.str();
+}
+
+double DeltaRNoDrift::control_error(
+    const Info& /*info*/, const ControlErrorArgs& control_error_args) const {
+  return control_error_args.control_error_delta_r;
+}
+
+// cppcoreguidelines-avoid-non-const-global-variables
+PUP::able::PUP_ID DeltaRNoDrift::my_PUP_ID = 0; // NOLINT
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+#include <string>
+
+#include "ControlSystem/ControlErrors/Size/Info.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace control_system::size::States {
+class DeltaRNoDrift : public State {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Controls the velocity of the excision surface to maintain a constant "
+      "separation between the excision surface and the horizon surface. "
+      "This is a transition from DeltaRDriftInward to DeltaR, and otherwise "
+      "acts very much like state DeltaR (e.g. it has the same control error). "
+      "This is state 4 in SpEC."};
+  DeltaRNoDrift() = default;
+  std::string name() const override { return "DeltaRNoDrift"; }
+  size_t number() const override { return 4; }
+  std::unique_ptr<State> get_clone() const override;
+  std::string update(gsl::not_null<Info*> info,
+                     const StateUpdateArgs& update_args,
+                     const CrossingTimeInfo& crossing_time_info) const override;
+  /// The return value is Q from Eq. 96 of \cite Hemberger2012jz.
+  double control_error(
+      const Info& info,
+      const ControlErrorArgs& control_error_args) const override;
+
+  WRAPPED_PUPable_decl_template(DeltaRNoDrift);  // NOLINT
+  explicit DeltaRNoDrift(CkMigrateMessage* const /*msg*/) {}
+};
+}  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -37,16 +37,24 @@ ErrorDiagnostics control_error(
     const gsl::not_null<intrp::ZeroCrossingPredictor*>
         predictor_comoving_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_delta_radius,
+    const gsl::not_null<intrp::ZeroCrossingPredictor*>
+        predictor_drift_limit_char_speed,
+    const gsl::not_null<intrp::ZeroCrossingPredictor*>
+        predictor_drift_limit_delta_radius,
     const double time, const double control_error_delta_r,
     const std::optional<double> control_error_delta_r_outward,
     const std::optional<double> max_allowed_radial_distance,
+    const std::optional<double> inward_drift_velocity,
+    const std::optional<double> min_allowed_radial_distance,
+    const std::optional<double> min_allowed_char_speed, const double horizon_00,
     const double dt_lambda_00, const ylm::Strahlkorper<Frame>& apparent_horizon,
     const ylm::Strahlkorper<Frame>& excision_boundary,
     const Scalar<DataVector>& lapse_on_excision_boundary,
     const tnsr::I<DataVector, 3, Frame>& frame_components_of_grid_shift,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric_on_excision_boundary,
     const tnsr::II<DataVector, 3, Frame>&
-        inverse_spatial_metric_on_excision_boundary) {
+        inverse_spatial_metric_on_excision_boundary,
+    const Scalar<DataVector>& deriv_comoving_char_speed) {
   const double Y00 = 0.25 * M_2_SQRTPI;
 
   // Define various quantities on excision boundary.
@@ -126,6 +134,8 @@ ErrorDiagnostics control_error(
   //
   // Minus sign is because we want the normal pointing into the hole,
   // not out of the hole.
+  //
+  // Note that distorted_normal_dot_unit_coord_vector is negative.
   get(distorted_normal_dot_unit_coord_vector) =
       -get<0>(excision_normal_one_form) * get<0>(excision_rhat);
   for (size_t i = 1; i < 3; ++i) {
@@ -137,6 +147,8 @@ ErrorDiagnostics control_error(
 
   // Average value of distorted_normal_dot_unit_coord_vector on the excision
   // boundary.  Compute the average by integrating.
+  //
+  // Note that avg_distorted_normal_dot_unit_coord_vector is negative.
   get(unity) = 1.0;
   const double avg_distorted_normal_dot_unit_coord_vector =
       gr::surfaces::surface_integral_of_scalar(
@@ -146,6 +158,10 @@ ErrorDiagnostics control_error(
                                                excision_boundary);
 
   // Compute char speed on excision boundary, Eq. 87 in ArXiv:1211.6079
+  //
+  // Note that characteristic_speed_on_excision_boundary should normally
+  // be positive, and one of the control system states (AhSpeed) is designed
+  // to keep it positive.
   get(characteristic_speed_on_excision_boundary) =
       -get(lapse_on_excision_boundary);
   for (size_t i = 0; i < 3; ++i) {
@@ -169,6 +185,9 @@ ErrorDiagnostics control_error(
   // Minimum of the comoving char speed on the excision boundary.
   const double min_comoving_char_speed = min(get(comoving_char_speed));
 
+  const bool comoving_char_speed_increasing_inward =
+      min(get(deriv_comoving_char_speed)) > 0.0;
+
   // Difference between horizon and excision boundary.
   gr::surfaces::radial_distance(make_not_null(&radial_distance),
                                 apparent_horizon, excision_boundary);
@@ -178,6 +197,15 @@ ErrorDiagnostics control_error(
                             get(characteristic_speed_on_excision_boundary));
   predictor_comoving_char_speed->add(time, get(comoving_char_speed));
   predictor_delta_radius->add(time, get(radial_distance));
+  if (min_allowed_char_speed.has_value()) {
+    predictor_drift_limit_char_speed->add(
+        time, min_allowed_char_speed.value() -
+                  get(characteristic_speed_on_excision_boundary));
+  }
+  if (min_allowed_radial_distance.has_value()) {
+    predictor_drift_limit_delta_radius->add(
+        time, min_allowed_radial_distance.value() - get(radial_distance));
+  }
 
   // Compute crossing times for state-change logic.
   const std::optional<double> char_speed_crossing_time =
@@ -186,10 +214,32 @@ ErrorDiagnostics control_error(
       predictor_comoving_char_speed->min_positive_zero_crossing_time(time);
   const std::optional<double> delta_radius_crossing_time =
       predictor_delta_radius->min_positive_zero_crossing_time(time);
+  const std::optional<double> drift_limit_delta_radius_crossing_time =
+      min_allowed_radial_distance.has_value()
+          ? predictor_drift_limit_delta_radius->min_positive_zero_crossing_time(
+                time)
+          : std::nullopt;
+  const std::optional<double> drift_limit_char_speed_crossing_time =
+      min_allowed_char_speed.has_value()
+          ? predictor_drift_limit_char_speed->min_positive_zero_crossing_time(
+                time)
+          : std::nullopt;
 
   // Compute average radial distance for state DeltaRDriftOutward.
+  // NOTE: This choice corresponds to SpEC's "DeltaRPolicy=Absolute"
+  // and SpEC's "FunctionVsTimeMinDeltaRNoLam00=<NONE>".
+  // However, the default in SpEC is "DeltaRPolicy=Relative" and
+  // "FunctionVsTimeMinDeltaRNoLam00" being an actual FunctionOfTime.
+  //
+  // If we were to make this change here, it means reinterpreting the
+  // meaning of max_allowed_radial_distance and
+  // min_allowed_radial_distance and using a different formula for
+  // average_radial_distance, but all the logic other than those
+  // changes remains unchanged.
+  // Such a change is possible to make, but we do not (yet) make it here.
   const std::optional<double> average_radial_distance =
-      max_allowed_radial_distance.has_value()
+      (max_allowed_radial_distance.has_value() or
+       min_allowed_radial_distance.has_value())
           ? std::optional<double>(
                 gr::surfaces::surface_integral_of_scalar(
                     area_element, radial_distance, excision_boundary) /
@@ -200,12 +250,17 @@ ErrorDiagnostics control_error(
   // Update the info, possibly changing the state inside of info.
   std::string update_message = info->state->get_clone()->update(
       info,
-      StateUpdateArgs{min_char_speed, min_comoving_char_speed,
+      StateUpdateArgs{min_char_speed, min_comoving_char_speed, horizon_00,
                       control_error_delta_r, average_radial_distance,
-                      max_allowed_radial_distance},
-      CrossingTimeInfo{char_speed_crossing_time,
-                       comoving_char_speed_crossing_time,
-                       delta_radius_crossing_time});
+                      max_allowed_radial_distance,
+                      avg_distorted_normal_dot_unit_coord_vector,
+                      inward_drift_velocity, min_allowed_radial_distance,
+                      min_allowed_char_speed,
+                      comoving_char_speed_increasing_inward},
+      CrossingTimeInfo{
+          char_speed_crossing_time, comoving_char_speed_crossing_time,
+          delta_radius_crossing_time, drift_limit_char_speed_crossing_time,
+          drift_limit_delta_radius_crossing_time});
 
   const ControlErrorArgs control_error_args{
       min_char_speed, control_error_delta_r, control_error_delta_r_outward,
@@ -243,9 +298,17 @@ ErrorDiagnostics control_error(
           predictor_comoving_char_speed,                                       \
       const gsl::not_null<intrp::ZeroCrossingPredictor*>                       \
           predictor_delta_radius,                                              \
+      const gsl::not_null<intrp::ZeroCrossingPredictor*>                       \
+          predictor_drift_limit_char_speed,                                    \
+      const gsl::not_null<intrp::ZeroCrossingPredictor*>                       \
+          predictor_drift_limit_delta_radius,                                  \
       double time, double control_error_delta_r,                               \
       std::optional<double> control_error_delta_r_outward,                     \
-      std::optional<double> max_allowed_radial_distance, double dt_lambda_00,  \
+      std::optional<double> max_allowed_radial_distance,                       \
+      std::optional<double> inward_drift_velocity,                             \
+      std::optional<double> min_allowed_radial_distance,                       \
+      std::optional<double> min_allowed_char_speed, double horizon_00,         \
+      double dt_lambda_00,                                                     \
       const ylm::Strahlkorper<FRAME(data)>& apparent_horizon,                  \
       const ylm::Strahlkorper<FRAME(data)>& excision_boundary,                 \
       const Scalar<DataVector>& lapse_on_excision_boundary,                    \
@@ -254,7 +317,8 @@ ErrorDiagnostics control_error(
       const tnsr::ii<DataVector, 3, FRAME(data)>&                              \
           spatial_metric_on_excision_boundary,                                 \
       const tnsr::II<DataVector, 3, FRAME(data)>&                              \
-          inverse_spatial_metric_on_excision_boundary);
+          inverse_spatial_metric_on_excision_boundary,                         \
+      const Scalar<DataVector>& deriv_comoving_char_speed);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Distorted, ::Frame::Inertial))
 

--- a/src/ControlSystem/ControlErrors/Size/Error.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.hpp
@@ -62,6 +62,11 @@ struct ErrorDiagnostics {
  *        comoving characteristic speed.
  * \param predictor_delta_radius ZeroCrossingPredictor for the difference
  *        in radius between the horizon and the excision boundary.
+ * \param predictor_drift_limit_char_speed ZeroCrossingPredictor for the
+ *        difference between the characteristic speed and
+ *        min_allowed_char_speed.
+ * \param predictor_drift_limit_delta_radius ZeroCrossingPredictor for the
+ *        difference between delta_radius and min_allowed_radial_distance.
  * \param time the current time.
  * \param control_error_delta_r the control error for the DeltaR state. This is
  *        used in other states as well.
@@ -72,6 +77,20 @@ struct ErrorDiagnostics {
  *        between the horizon and the excision boundary that is allowed without
  *        triggering the DeltaRDriftOutward state.  If std::nullopt, then
  *        DeltaRDriftOutward will not be used.
+ * \param inward_drift_velocity a velocity that determines how fast the
+ *        excision boundary drifts inward in state DeltaRDriftInward. If
+ *        std::nullopt, then DeltaRDriftInward will not be used.
+ * \param min_allowed_radial_distance the minimum average radial distance
+ *        between the horizon and the excision boundary that is allowed without
+ *        triggering the DeltaRDriftInward state.  If std::nullopt, then
+ *        DeltaRDriftInward will not be used.
+ * \param min_allowed_char_speed the minimum characteristic speed on the
+ *        excision boundary that is allowed without triggering the
+ *        DeltaRDriftInward state.  If std::nullopt, then
+ *        DeltaRDriftInward will not be used.
+ * \param horizon_00 The l=0,m=0 component of the spherepack decomposition
+ *        of the apparent horizon.  This is passed separately from the
+ *        full apparent_horizon below because horizon_00 is time-averaged.
  * \param dt_lambda_00 the time derivative of the map parameter lambda_00
  * \param apparent_horizon the current horizon in frame Frame.
  * \param excision_boundary a Strahlkorper representing the excision
@@ -84,6 +103,8 @@ struct ErrorDiagnostics {
  *        Frame.
  * \param spatial_metric_on_excision_boundary metric in frame Frame.
  * \param inverse_spatial_metric_on_excision_boundary metric in frame Frame.
+ * \param deriv_comoving_char_speed the derivative of the comoving char
+ *        speed with respect to the map parameter lambda_00.
  * \return Returns an `ErrorDiagnostics` object which, in addition to the actual
  *         control error, holds a lot of diagnostic information about how the
  *         control error was calculated. This information could be used to print
@@ -138,20 +159,28 @@ struct ErrorDiagnostics {
  */
 template <typename Frame>
 ErrorDiagnostics control_error(
-    const gsl::not_null<Info*> info,
-    const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed,
-    const gsl::not_null<intrp::ZeroCrossingPredictor*>
+    gsl::not_null<Info*> info,
+    gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed,
+    gsl::not_null<intrp::ZeroCrossingPredictor*>
         predictor_comoving_char_speed,
-    const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_delta_radius,
+    gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_delta_radius,
+    gsl::not_null<intrp::ZeroCrossingPredictor*>
+        predictor_drift_limit_char_speed,
+    gsl::not_null<intrp::ZeroCrossingPredictor*>
+        predictor_drift_limit_delta_radius,
     double time, double control_error_delta_r,
     std::optional<double> control_error_delta_r_outward,
-    std::optional<double> max_allowed_radial_distance, double dt_lambda_00,
-    const ylm::Strahlkorper<Frame>& apparent_horizon,
+    std::optional<double> max_allowed_radial_distance,
+    std::optional<double> inward_drift_velocity,
+    std::optional<double> min_allowed_radial_distance,
+    std::optional<double> min_allowed_char_speed, double horizon_00,
+    double dt_lambda_00, const ylm::Strahlkorper<Frame>& apparent_horizon,
     const ylm::Strahlkorper<Frame>& excision_boundary,
     const Scalar<DataVector>& lapse_on_excision_boundary,
     const tnsr::I<DataVector, 3, Frame>& frame_components_of_grid_shift,
     const tnsr::ii<DataVector, 3, Frame>& spatial_metric_on_excision_boundary,
     const tnsr::II<DataVector, 3, Frame>&
-        inverse_spatial_metric_on_excision_boundary);
+        inverse_spatial_metric_on_excision_boundary,
+    const Scalar<DataVector>& deriv_comoving_char_speed);
 
 }  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/Factory.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Factory.hpp
@@ -5,11 +5,14 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace control_system::size::States {
 using factory_creatable_states =
-    tmpl::list<AhSpeed, DeltaR, DeltaRDriftOutward, Initial>;
+    tmpl::list<AhSpeed, DeltaR, DeltaRDriftInward, DeltaRDriftOutward,
+               DeltaRNoDrift, Initial>;
 }  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/Info.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.cpp
@@ -3,6 +3,7 @@
 
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 
+#include <limits>
 #include <optional>
 #include <pup.h>
 #include <pup_stl.h>
@@ -63,10 +64,21 @@ void Info::set_all_but_state(const Info& info) {
 CrossingTimeInfo::CrossingTimeInfo(
     const std::optional<double>& char_speed_crossing_time,
     const std::optional<double>& comoving_char_speed_crossing_time,
-    const std::optional<double>& delta_radius_crossing_time)
+    const std::optional<double>& delta_radius_crossing_time,
+    const std::optional<double>& drift_limit_char_speed_crossing_time,
+    const std::optional<double>& drift_limit_delta_radius_crossing_time)
     : t_char_speed(char_speed_crossing_time),
       t_comoving_char_speed(comoving_char_speed_crossing_time),
-      t_delta_radius(delta_radius_crossing_time) {
+      t_delta_radius(delta_radius_crossing_time),
+      t_drift_limit_delta_radius(drift_limit_delta_radius_crossing_time),
+      t_drift_limit((drift_limit_char_speed_crossing_time.has_value() or
+                     drift_limit_delta_radius_crossing_time.has_value())
+                        ? std::optional<double>(std::min(
+                              drift_limit_char_speed_crossing_time.value_or(
+                                  std::numeric_limits<double>::max()),
+                              drift_limit_delta_radius_crossing_time.value_or(
+                                  std::numeric_limits<double>::max())))
+                        : std::nullopt) {
   if (t_char_speed.value_or(-1.0) > 0.0) {
     if (t_delta_radius.value_or(-1.0) > 0.0 and
         t_delta_radius.value() <= t_char_speed.value()) {

--- a/src/ControlSystem/ControlErrors/Size/Info.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.hpp
@@ -65,7 +65,9 @@ struct CrossingTimeInfo {
   CrossingTimeInfo(
       const std::optional<double>& char_speed_crossing_time,
       const std::optional<double>& comoving_char_speed_crossing_time,
-      const std::optional<double>& delta_radius_crossing_time);
+      const std::optional<double>& delta_radius_crossing_time,
+      const std::optional<double>& drift_limit_char_speed_crossing_time,
+      const std::optional<double>& drift_limit_delta_radius_crossing_time);
   /// t_char_speed is the time (relative to the current time) when the
   /// minimum characteristic speed is predicted to cross zero (or nullopt if
   /// the minimum characteristic speed is increasing).
@@ -79,6 +81,18 @@ struct CrossingTimeInfo {
   /// predicted to cross zero (or nullopt if the minimum distance is
   /// increasing).
   std::optional<double> t_delta_radius;
+  /// t_drift_limit_delta_radius is the time (relative to the current time) when
+  /// the minimum distance between the horizon and the excision boundary is
+  /// predicted to cross the min_allowed_radial_distance associated with the
+  /// state DeltaRDriftInward (or nullopt if the minimum distance is
+  /// decreasing).
+  /// In SpEC this quantity is called MaxDeltaRXTime
+  std::optional<double> t_drift_limit_delta_radius;
+  /// t_drift_limit is a convenient variable that is
+  /// the minimum of t_drift_limit_delta_radius and t_drift_limit_char_speed,
+  /// or nullopt if both drift limits are nullopt.
+  /// In SpEC this quantity is called State3XTime
+  std::optional<double> t_drift_limit;
   /// Extra variables to simplify the logic; these indicate whether
   /// the characteristic speed or the excision boundary (or neither) are
   /// expected to cross zero soon.

--- a/src/ControlSystem/ControlErrors/Size/Initial.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.cpp
@@ -10,6 +10,7 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "Utilities/StdHelpers.hpp"
 
@@ -59,21 +60,28 @@ std::string Initial::update(const gsl::not_null<Info*> info,
           "AhSpeed.\n";
     ss << " Target char speed = " << info->target_char_speed << "\n";
     ss << " Suggested timescale = " << info->suggested_time_scale;
-  } else if (delta_radius_is_in_danger) {
+  } else if (delta_radius_is_in_danger
+             or update_args.min_comoving_char_speed > 0.0) {
     info->discontinuous_change_has_occurred = true;
-    info->state = std::make_unique<States::DeltaR>();
-    info->suggested_time_scale = crossing_time_info.t_delta_radius;
-    ss << "Current state Initial. Delta radius in danger. Switching to "
-          "DeltaR.\n";
-    ss << " Suggested timescale = " << info->suggested_time_scale;
-    // Here is where transition to State DeltaRDriftInward will go.
-  } else if (update_args.min_comoving_char_speed > 0.0) {
-    // Here the comoving speed is positive, so prefer DeltaR control.
-    info->discontinuous_change_has_occurred = true;
-    info->state = std::make_unique<States::DeltaR>();
-    ss << "Current state Initial. Comoving char speed positive. Switching to "
-          "DeltaR.";
-    // Here is where transition to State DeltaRDriftInward will go.
+    if (delta_radius_is_in_danger) {
+      info->suggested_time_scale = crossing_time_info.t_delta_radius;
+    }
+    const bool drift_inward = should_activate_inward_drift(update_args);
+    if (drift_inward) {
+      info->state = std::make_unique<States::DeltaRDriftInward>();
+      info->target_char_speed = target_speed_for_inward_drift(
+          update_args.avg_distorted_normal_dot_unit_coord_vector,
+          update_args.min_char_speed,
+          update_args.inward_drift_velocity.value());
+    } else {
+      info->state = std::make_unique<States::DeltaR>();
+    }
+    ss << "Current state Initial. "
+       << (delta_radius_is_in_danger ? "DeltaR is in danger"
+                                     : "Comoving char speed positive")
+       << ". Switching to " << (drift_inward ? "DeltaRDriftInward." : "DeltaR.")
+       << "\n";
+    ss << " Target char speed = " << info->target_char_speed;
   } else if (update_args.average_radial_distance.has_value() and
              update_args.average_radial_distance.value() >
                  non_oscillation_drift_outward_factor *

--- a/src/ControlSystem/ControlErrors/Size/Initial.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.cpp
@@ -77,7 +77,8 @@ std::string Initial::update(const gsl::not_null<Info*> info,
   } else if (update_args.average_radial_distance.has_value() and
              update_args.average_radial_distance.value() >
                  non_oscillation_drift_outward_factor *
-                     update_args.max_allowed_radial_distance.value()) {
+                     update_args.max_allowed_radial_distance.value_or(
+                         std::numeric_limits<double>::infinity())) {
     info->discontinuous_change_has_occurred = true;
     info->state = std::make_unique<States::DeltaRDriftOutward>();
     ss << "Current state Initial. "

--- a/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
+++ b/src/ControlSystem/ControlErrors/Size/RegisterDerivedWithCharm.cpp
@@ -8,13 +8,16 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace control_system::size {
 void register_derived_with_charm() {
   register_classes_with_charm<States::Initial, States::AhSpeed, States::DeltaR,
+                              States::DeltaRDriftInward, States::DeltaRNoDrift,
                               States::DeltaRDriftOutward>();
 }
 }  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/State.hpp
+++ b/src/ControlSystem/ControlErrors/Size/State.hpp
@@ -31,6 +31,9 @@ struct StateUpdateArgs {
   /// min_comoving_char_speed is the minimum over the excision boundary
   /// of Eq. 28 of \cite Hemberger2012jz.
   double min_comoving_char_speed;
+  /// horizon_00 is the spherepack coefficient of the apparent
+  /// horizon.
+  double horizon_00;
   /// control_error_delta_r is the control error when the control system
   /// is in state Label::DeltaR.
   /// This is Q in Eq. 96 of \cite Hemberger2012jz.
@@ -44,6 +47,26 @@ struct StateUpdateArgs {
   /// Label::DeltaRDriftOutward.  If std::nullopt, then DeltaRDriftOutward
   /// will never be triggered.
   std::optional<double> max_allowed_radial_distance;
+  /// avg_distorted_normal_dot_unit_coord_vector is the same quantity as
+  /// ControlErrorArgs::avg_distorted_normal_dot_unit_coord_vector.
+  double avg_distorted_normal_dot_unit_coord_vector;
+  /// inward_drift_velocity is a positive quantity that represents how
+  /// fast the horizon and the excision boundary move apart in state
+  /// DeltaRDriftInward.  If std::nullopt, then DeltaRDriftInward will
+  /// never be triggered.
+  std::optional<double> inward_drift_velocity;
+  /// min_allowed_radial_distance is the minimum distance between the horizon
+  /// and the excision boundary that will trigger state
+  /// Label::DeltaRDriftInward.
+  std::optional<double> min_allowed_radial_distance;
+  /// min_allowed_char_speed is the minimum char speed that will
+  /// trigger state DeltaRDriftInward.  If both
+  /// min_allowed_radial_distance and min_allowed_char_speed are
+  /// std::nullopt, then DeltaRDriftInward will never be triggered.
+  std::optional<double> min_allowed_char_speed;
+  /// comoving_char_speed_increasing_inward is true if the comoving char speed
+  /// increases as the excision boundary is moved inward.
+  bool comoving_char_speed_increasing_inward;
 };
 
 /*!
@@ -120,16 +143,16 @@ struct ControlErrorArgs {
  * - DeltaRDriftOutward: Same as DeltaR but the excision boundary has a small
  *   velocity outward.  This state is triggered when it is deemed that the
  *   excision boundary and the horizon are too far apart.
- * - DeltaRTransition: Same as DeltaR except for the logic that
- *   determines how DeltaRTransition changes to other states.
- *   DeltaRTransition is allowed (under some circumstances) to change
+ * - DeltaRNoDrift: Same as DeltaR except for the logic that
+ *   determines how DeltaRNoDrift changes to other states.
+ *   DeltaRNoDrift is allowed (under some circumstances) to change
  *   to state DeltaR, but DeltaRDriftOutward and DeltaRDriftInward
  *   are never allowed to change to state DeltaR.  Instead
  *   DeltaRDriftOutward and DeltaRDriftInward are allowed (under
- *   some circumstances) to change to state DeltaRTransition.
+ *   some circumstances) to change to state DeltaRNoDrift.
  *
  * The reason that DeltaRDriftInward, DeltaRDriftOutward, and
- * DeltaRTransition are separate states is to simplify the logic.  In
+ * DeltaRNoDrift are separate states is to simplify the logic.  In
  * principle, all 3 of those states could be merged with state
  * DeltaR, because the control error is the same for all four states
  * (except for a velocity term that could be set to zero).  But if that

--- a/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
+++ b/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
@@ -12,7 +12,9 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
@@ -30,6 +32,8 @@ void StateHistory::initialize_stored_control_errors() {
   stored_control_errors_[States::Initial{}.number()];
   stored_control_errors_[States::DeltaR{}.number()];
   stored_control_errors_[States::AhSpeed{}.number()];
+  stored_control_errors_[States::DeltaRDriftInward{}.number()];
+  stored_control_errors_[States::DeltaRNoDrift{}.number()];
   stored_control_errors_[States::DeltaRDriftOutward{}.number()];
 }
 
@@ -49,6 +53,8 @@ void StateHistory::store(double time, const Info& info,
   store_state(States::Initial{});
   store_state(States::DeltaR{});
   store_state(States::AhSpeed{});
+  store_state(States::DeltaRDriftInward{});
+  store_state(States::DeltaRNoDrift{});
   store_state(States::DeltaRDriftOutward{});
 }
 

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -582,6 +582,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      DeltaRDriftInwardOptions: None
       InitialState: Initial
       SmootherTuner:
         InitialTimescales: *SizeATimescale
@@ -604,6 +605,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      DeltaRDriftInwardOptions: None
       InitialState: Initial
       SmootherTuner:
         InitialTimescales: *SizeBTimescale

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -377,6 +377,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      DeltaRDriftInwardOptions: None
       InitialState: DeltaR
       SmootherTuner:
         InitialTimescales: [0.02]

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -386,6 +386,7 @@ ControlSystems:
       MaxNumTimesForZeroCrossingPredictor: 4
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
+      DeltaRDriftInwardOptions: None
       InitialState: Initial
       SmootherTuner:
         InitialTimescales: [0.2]

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -9,7 +9,9 @@
 
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRNoDrift.hpp"
 #include "ControlSystem/ControlErrors/Size/Factory.hpp"
 #include "ControlSystem/ControlErrors/Size/Info.hpp"
 #include "ControlSystem/ControlErrors/Size/Initial.hpp"
@@ -26,17 +28,29 @@ struct TestParams {
   // These are reasonable values for quantities that won't change in
   // the various logic tests.
   const double original_target_char_speed{0.011};
-  const double damping_time{0.1};
   const std::optional<double> average_radial_distance{
       0.01};  // This is what SpEC calls DeltaR.
+  // The following means that the excision boundary radius in the grid frame
+  // is 2.01.
+  // Recall that horizon_00 is a Spherepack coefficient and not a raw
+  // spherical harmonic coefficient.
+  double horizon_00{4.02 * sqrt(2.0)};
+  double avg_distorted_normal_dot_unit_coord_vector{1.0};
   // Defaults are values for quantities that we will vary so that the
   // logic makes different decisions.
+  double damping_time{0.1};
   double min_char_speed{0.01};
   double min_comoving_char_speed{-0.02};
   double control_err_delta_r{0.03};
   std::optional<double> max_allowed_radial_distance{1.e100};
+  // By default here we turn off state DeltaRDriftInward
+  // by setting the following two options to nullopt.
+  std::optional<double> min_allowed_radial_distance{std::nullopt};
+  std::optional<double> min_allowed_char_speed{std::nullopt};
+  std::optional<double> inward_drift_velocity{0.005};
+  bool comoving_char_speed_increasing_inward{false};
   control_system::size::CrossingTimeInfo crossing_time_info{
-      std::nullopt, std::nullopt, std::nullopt};
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt};
 };
 
 template <typename InitialState, typename FinalState>
@@ -56,13 +70,19 @@ void do_test(const TestParams& test_params,
   CAPTURE(test_params.min_char_speed);
   CAPTURE(test_params.min_comoving_char_speed);
   CAPTURE(test_params.control_err_delta_r);
+  CAPTURE(test_params.max_allowed_radial_distance);
+  CAPTURE(test_params.min_allowed_radial_distance);
+  CAPTURE(test_params.min_allowed_char_speed);
+  CAPTURE(test_params.inward_drift_velocity);
   CAPTURE(test_params.crossing_time_info.char_speed_will_hit_zero_first);
   CAPTURE(
       test_params.crossing_time_info.horizon_will_hit_excision_boundary_first);
   CAPTURE(test_params.crossing_time_info.t_char_speed);
   CAPTURE(test_params.crossing_time_info.t_comoving_char_speed);
   CAPTURE(test_params.crossing_time_info.t_delta_radius);
-
+  CAPTURE(test_params.crossing_time_info.t_drift_limit_delta_radius);
+  CAPTURE(test_params.crossing_time_info.t_drift_limit);
+  CAPTURE(test_params.comoving_char_speed_increasing_inward);
   // Set reasonable values for quantities that won't change in the various
   // logic tests.
   const double target_drift_velocity = 0.001;
@@ -70,9 +90,17 @@ void do_test(const TestParams& test_params,
   const bool original_discontinuous_change_has_occurred = false;
 
   const control_system::size::StateUpdateArgs update_args{
-      test_params.min_char_speed, test_params.min_comoving_char_speed,
-      test_params.control_err_delta_r, test_params.average_radial_distance,
-      test_params.max_allowed_radial_distance};
+      test_params.min_char_speed,
+      test_params.min_comoving_char_speed,
+      test_params.horizon_00,
+      test_params.control_err_delta_r,
+      test_params.average_radial_distance,
+      test_params.max_allowed_radial_distance,
+      test_params.avg_distorted_normal_dot_unit_coord_vector,
+      test_params.inward_drift_velocity,
+      test_params.min_allowed_radial_distance,
+      test_params.min_allowed_char_speed,
+      test_params.comoving_char_speed_increasing_inward};
   control_system::size::Info info{
       TestHelpers::test_factory_creation<control_system::size::State,
                                          InitialState>(initial_state),
@@ -101,13 +129,14 @@ void do_test(const TestParams& test_params,
   auto state = info.state->get_clone();
   const std::string update_message = state->update(
       make_not_null(&info), update_args, test_params.crossing_time_info);
+  CAPTURE(update_message);
 
   // These messages are hardcoded in the states
   CHECK(update_message.find("Current state " + initial_state) !=
         std::string::npos);
   CHECK(update_message.find_last_of(final_state) != std::string::npos);
 
-  CHECK(dynamic_cast<FinalState*>(info.state.get()) != nullptr);
+  CHECK(info.state.get()->number() == FinalState{}.number());
   CHECK(info.damping_time == test_params.damping_time);
   CHECK(info.target_char_speed == expected_target_char_speed);
   CHECK(info.target_drift_velocity == target_drift_velocity);
@@ -121,6 +150,99 @@ void do_test(const TestParams& test_params,
   CHECK(info.target_drift_velocity == target_drift_velocity);
   CHECK_FALSE(info.suggested_time_scale.has_value());
   CHECK_FALSE(info.discontinuous_change_has_occurred);
+}
+
+// For states X=Initial and X=AhSpeed, the logic for the transition
+// from state X to state DeltaR is almost the same as the logic to
+// transition from state X to state
+// DeltaRDriftInward. test_transition_to_delta_r_inward encodes the
+// differences between ending up in state DeltaR and ending up in
+// state DeltaRDriftInward.  Every test below that ends up in state
+// DeltaR from state Initial or from state AhSpeed should call
+// test_transition_to_delta_r_inward afterwards.
+template <typename InitialState>
+void test_transition_to_delta_r_inward(
+    TestParams test_params, const std::optional<double> suggested_time_scale,
+    const double target_char_speed) {
+  // Should_activate_inward_drift is true iff all of the following are true:
+  //  1. inward_drift_velocity has a value.
+  //  2. min_char_speed <= 0.9*min_allowed_char_speed or
+  //     min_allowed_char_speed has no value
+  //  3. avg_radial_distance <= 0.9*min_allowed_radial_distance or
+  //     min_allowed_radial_distance has no value
+  //  4. comoving_char_speed_increasing_inward is true
+  //  5. min_allowed_char_speed has a value or
+  //     min_allowed_radial_distance has a value
+  //
+  // should_transition_from_state_delta_r_to_inward_drift is true iff
+  // all of the following are true:
+  // A. should_activate_inward_drift is true
+  // B. t_drift_limit >= damping time or t_drift_limit has no value
+  //
+  // should_transition_from_state_inward_drift_to_delta_r_no_drift is
+  // true iff should_transition_from_state_delta_r_to_inward_drift is false.
+
+  // On entry to this function, 1, 2, and 3 above are true, but 4 and 5
+  // above are false.
+  // Also, on entry to this function, t_drift_limit has no value so B.
+  // is satisfied.
+
+  // Here we make 4 true, but 5 is still false.
+  // So 1,2,3,4 are true and 5 is false so we stay in state DeltaR.
+  test_params.comoving_char_speed_increasing_inward = true;
+  do_test<InitialState, control_system::size::States::DeltaR>(
+      test_params, true, suggested_time_scale, target_char_speed);
+
+  // Here we make 4 and 5 true, but 2 is now false (because limit is 0.9).
+  // So 1,3,4,5 are true and 2 is false so we stay in state DeltaR.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.91;
+  do_test<InitialState, control_system::size::States::DeltaR>(
+      test_params, true, suggested_time_scale, target_char_speed);
+
+  // Here we make 4 and 5 true, but 2 is now false (because limit is 0.9)
+  // and 3 is now false.
+  // So 1,4,5 are true and 2,3 false so we stay in state DeltaR.
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.91;
+  do_test<InitialState, control_system::size::States::DeltaR>(
+      test_params, true, suggested_time_scale, target_char_speed);
+
+  // Here 1,2,4,5 are true and 3 false so we stay in state DeltaR.
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.89;
+  do_test<InitialState, control_system::size::States::DeltaR>(
+      test_params, true, suggested_time_scale, target_char_speed);
+
+  // Now all 1,2,3,4,5 are true.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.89;
+  do_test<InitialState, control_system::size::States::DeltaRDriftInward>(
+      test_params, true, suggested_time_scale,
+      std::min(test_params.inward_drift_velocity.value(),
+               0.5 * test_params.min_char_speed /
+                   test_params.avg_distorted_normal_dot_unit_coord_vector));
+
+  // Now 4 above is false, even though 1,2,3,5 are true. So stay in State
+  // DeltaR.
+  test_params.comoving_char_speed_increasing_inward = false;
+  do_test<InitialState, control_system::size::States::DeltaR>(
+      test_params, true, suggested_time_scale, target_char_speed);
+  test_params.comoving_char_speed_increasing_inward = true;
+
+  // Now 1 above is false, even though 2,3,4,5 are true. So stay in State
+  // DeltaR.
+  test_params.inward_drift_velocity = std::nullopt;
+  do_test<InitialState, control_system::size::States::DeltaR>(
+      test_params, true, suggested_time_scale, target_char_speed);
+
+  // 1,2,3,4,5 are true, so go to state DeltaRDriftInward.  This is
+  // the same as the test above, but now the std::min in the last
+  // argument takes a different value.
+  test_params.inward_drift_velocity = 0.1;
+  do_test<InitialState, control_system::size::States::DeltaRDriftInward>(
+      test_params, true, suggested_time_scale,
+      std::min(test_params.inward_drift_velocity.value(),
+               0.5 * test_params.min_char_speed /
+                   test_params.avg_distorted_normal_dot_unit_coord_vector));
 }
 
 void test_size_control_update() {
@@ -146,44 +268,60 @@ void test_size_control_update() {
   do_test<control_system::size::States::Initial,
           control_system::size::States::DeltaR>(
       test_params, true, std::nullopt, test_params.original_target_char_speed);
+  test_transition_to_delta_r_inward<control_system::size::States::Initial>(
+      test_params, std::nullopt, test_params.original_target_char_speed);
 
   // Make deltar cross zero after damping time.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, 1.1 * test_params.damping_time);
+      std::nullopt, std::nullopt, 1.1 * test_params.damping_time, std::nullopt,
+      std::nullopt);
   do_test<control_system::size::States::Initial,
           control_system::size::States::DeltaR>(
       test_params, true, std::nullopt, test_params.original_target_char_speed);
+  test_transition_to_delta_r_inward<control_system::size::States::Initial>(
+      test_params, std::nullopt, test_params.original_target_char_speed);
 
   // Make deltar cross zero before damping time.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, 0.9 * test_params.damping_time);
+      std::nullopt, std::nullopt, 0.9 * test_params.damping_time, std::nullopt,
+      std::nullopt);
   do_test<control_system::size::States::Initial,
           control_system::size::States::DeltaR>(
       test_params, true, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
+  test_transition_to_delta_r_inward<control_system::size::States::Initial>(
+      test_params, 0.9 * test_params.damping_time,
       test_params.original_target_char_speed);
 
   // Make deltar cross zero before damping time, faster than char speed.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.91 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.899 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::Initial,
           control_system::size::States::DeltaR>(
-      test_params, true, 0.9 * test_params.damping_time,
+      test_params, true, 0.899 * test_params.damping_time,
+      test_params.original_target_char_speed);
+  test_transition_to_delta_r_inward<control_system::size::States::Initial>(
+      test_params, 0.899 * test_params.damping_time,
       test_params.original_target_char_speed);
 
   // Make deltar cross zero before damping time, same as char speed.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.9 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::Initial,
           control_system::size::States::DeltaR>(
       test_params, true, 0.9 * test_params.damping_time,
       test_params.original_target_char_speed);
+  test_transition_to_delta_r_inward<control_system::size::States::Initial>(
+      test_params, 0.9 * test_params.damping_time,
+      test_params.original_target_char_speed);
 
   // Make deltar cross zero before damping time, slower than char speed.
+  // Now it goes to state AhSpeed.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.89 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::Initial,
           control_system::size::States::AhSpeed>(
       test_params, true, 0.89 * test_params.damping_time,
@@ -193,24 +331,88 @@ void test_size_control_update() {
   test_params.max_allowed_radial_distance = 0.001;
   // Make sure nothing is in danger.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, std::nullopt);
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
   // Comoving speed should be <0 or else we get state DeltaR and not
   // DeltaRDriftOutward.
   test_params.min_comoving_char_speed = -0.02;
   do_test<control_system::size::States::Initial,
           control_system::size::States::DeltaRDriftOutward>(
       test_params, true, std::nullopt, test_params.original_target_char_speed);
-  test_params.max_allowed_radial_distance = 1.e100;
+  // Turn off DeltaRDriftOutward again.
+  test_params.max_allowed_radial_distance = std::nullopt;
 
   // Now do DeltaR tests
-  test_params.min_comoving_char_speed = -0.02;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, std::nullopt);
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
 
-  // Should do nothing
+  // Should stay in DeltaR.
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::DeltaR>(
       test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // Should stay in DeltaR but change suggested timescale
+  // because inward_drift_limit_in_danger.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+      0.95 * test_params.damping_time);
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.98;
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.98;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.95 * test_params.damping_time,
+      test_params.original_target_char_speed);
+
+  // Should stay in DeltaR because
+  // t_drift_limit is less than damping time.
+  test_params.comoving_char_speed_increasing_inward = true;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, 0.95 * test_params.damping_time,
+      std::nullopt);
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.89;
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.89;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // Exactly the same but now all the crossing times are null,
+  // so it should go to state DeltaRDriftInward with no change in timescale,
+  // but a change in target_char_speed.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaRDriftInward>(
+      test_params, true, std::nullopt,
+      std::min(test_params.inward_drift_velocity.value(),
+               0.5 * test_params.min_char_speed /
+                   test_params.avg_distorted_normal_dot_unit_coord_vector));
+
+  // Should stay in state DeltaR if either CharSpeed or DeltaR
+  // are above the min limits.
+  // So test both cases and then put back the previous values of the limits.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.91;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.89;
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.91;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.89;
+
+  // Should stay in DeltaR if comoving_char_speed_increasing_inward is false.
+  test_params.comoving_char_speed_increasing_inward = false;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // Turn off DeltaRDriftInward again.
+  test_params.min_allowed_char_speed = std::nullopt;
+  test_params.min_allowed_radial_distance = std::nullopt;
 
   // Should change suggested time scale
   test_params.min_comoving_char_speed = 0.02;
@@ -228,14 +430,16 @@ void test_size_control_update() {
   // Make deltar cross zero *slightly* before damping time; should do
   // nothing (depends on tolerance in control_system::size::StateDeltaR).
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, 0.999 * test_params.damping_time);
+      std::nullopt, std::nullopt, 0.999 * test_params.damping_time,
+      std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::DeltaR>(
       test_params, false, std::nullopt, test_params.original_target_char_speed);
 
   // Make deltar cross zero before damping time.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, 0.9 * test_params.damping_time);
+      std::nullopt, std::nullopt, 0.9 * test_params.damping_time, std::nullopt,
+      std::nullopt);
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::DeltaR>(
       test_params, false, 0.9 * test_params.damping_time,
@@ -244,7 +448,7 @@ void test_size_control_update() {
   // Make deltar cross zero before damping time, faster than char speed.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.91 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::DeltaR>(
       test_params, false, 0.9 * test_params.damping_time,
@@ -253,7 +457,7 @@ void test_size_control_update() {
   // Make deltar cross zero before damping time, same as char speed.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.9 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::DeltaR>(
       test_params, false, 0.9 * test_params.damping_time,
@@ -262,7 +466,7 @@ void test_size_control_update() {
   // Make deltar cross zero before damping time, slower than char speed.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.89 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::DeltaR>(
       test_params, false, 0.89 * test_params.damping_time,
@@ -279,7 +483,8 @@ void test_size_control_update() {
   // Same as 2 tests ago, but comoving_char_speed will cross zero far
   // in the future.  Should be same result as previous test.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      0.89 * test_params.damping_time, 1.e12, 0.9 * test_params.damping_time);
+      0.89 * test_params.damping_time, 1.e12, 0.9 * test_params.damping_time,
+      std::nullopt, std::nullopt);
   test_params.min_comoving_char_speed = 0.02;
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::AhSpeed>(
@@ -290,20 +495,22 @@ void test_size_control_update() {
   test_params.max_allowed_radial_distance = 0.001;
   // Make sure nothing is in danger.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, std::nullopt);
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
   // Comoving speed should be <0 or else we get state DeltaR and not
   // DeltaRDriftOutward.
   test_params.min_comoving_char_speed = -0.02;
   do_test<control_system::size::States::DeltaR,
           control_system::size::States::DeltaRDriftOutward>(
       test_params, true, std::nullopt, test_params.original_target_char_speed);
-  test_params.max_allowed_radial_distance = 1.e100;
+
+  // Turn off DeltaRDriftOutward
+  test_params.max_allowed_radial_distance = std::nullopt;
 
   // Now do AhSpeed tests
   test_params.min_comoving_char_speed = -0.02;
   test_params.control_err_delta_r = 0.03;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, std::nullopt);
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
 
   // Should do nothing.
   do_test<control_system::size::States::AhSpeed,
@@ -315,6 +522,8 @@ void test_size_control_update() {
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(test_params, true, std::nullopt,
                                                 0.0);
+  test_transition_to_delta_r_inward<control_system::size::States::AhSpeed>(
+      test_params, std::nullopt, 0.0);
 
   // Should do nothing because min_comoving_char_speed is smaller than
   // min_char_speed.
@@ -329,38 +538,45 @@ void test_size_control_update() {
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(test_params, true, std::nullopt,
                                                 0.0);
+  test_transition_to_delta_r_inward<control_system::size::States::AhSpeed>(
+      test_params, std::nullopt, 0.0);
 
   // Now it should do nothing because comoving crossing time is very small.
   test_params.min_char_speed = 0.01;
   test_params.min_comoving_char_speed = 0.02;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, 1.e-10, std::nullopt);
+      std::nullopt, 1.e-10, std::nullopt, std::nullopt, std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::AhSpeed>(
       test_params, false, std::nullopt, test_params.original_target_char_speed);
 
   // Now it should go to DeltaR because comoving crossing time is large.
-  test_params.crossing_time_info =
-      control_system::size::CrossingTimeInfo(std::nullopt, 100.0, std::nullopt);
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, 100.0, std::nullopt, std::nullopt, std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(test_params, true, std::nullopt,
                                                 0.0);
+  test_transition_to_delta_r_inward<control_system::size::States::AhSpeed>(
+      test_params, std::nullopt, 0.0);
 
   // Now it should do nothing because comoving is decreasing faster than
   // charspeeds.
-  test_params.crossing_time_info =
-      control_system::size::CrossingTimeInfo(1000.0, 100.0, std::nullopt);
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      1000.0, 100.0, std::nullopt, std::nullopt, std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::AhSpeed>(
       test_params, false, std::nullopt, test_params.original_target_char_speed);
 
   // Now it should think delta_r is in danger,
-  // and it should go to DeltaR state.
+  // and it should go to DeltaR state. And it should change the damping time.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, 19.0 * test_params.damping_time);
+      std::nullopt, std::nullopt, 19.0 * test_params.damping_time, std::nullopt,
+      std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(
       test_params, true, 19.0 * test_params.damping_time, 0.0);
+  test_transition_to_delta_r_inward<control_system::size::States::AhSpeed>(
+      test_params, 19.0 * test_params.damping_time, 0.0);
 
   // But now with comoving_char_speed negative it should stay in AhSpeed
   // state, but with a change in target speed.
@@ -374,7 +590,8 @@ void test_size_control_update() {
   // AhSpeed state if char_speed has a positive crossing time.
   test_params.min_comoving_char_speed = 0.02;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      1.e10, std::nullopt, 19.0 * test_params.damping_time);
+      1.e10, std::nullopt, 19.0 * test_params.damping_time, std::nullopt,
+      std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::AhSpeed>(
       test_params, true, test_params.damping_time,
@@ -382,17 +599,20 @@ void test_size_control_update() {
 
   // .. but not if the delta_r crossing time is small enough.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      1.e10, std::nullopt, 4.99 * test_params.damping_time);
+      1.e10, std::nullopt, 4.99 * test_params.damping_time, std::nullopt,
+      std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(
       test_params, true, 4.99 * test_params.damping_time, 0.0);
+  test_transition_to_delta_r_inward<control_system::size::States::AhSpeed>(
+      test_params, 4.99 * test_params.damping_time, 0.0);
 
   // If it thinks char speed is in danger, and the target char speed is
   // greater than the char speed, it changes the timescale and
   // nothing else.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.89 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::AhSpeed>(
       test_params, false, 0.89 * test_params.damping_time,
@@ -410,7 +630,7 @@ void test_size_control_update() {
   test_params.min_char_speed = test_params.original_target_char_speed * 1.09999;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.98999 * test_params.damping_time, std::nullopt,
-      0.99 * test_params.damping_time);
+      0.99 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::AhSpeed>(
       test_params, false, 0.98999 * test_params.damping_time,
@@ -422,22 +642,43 @@ void test_size_control_update() {
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(test_params, true, std::nullopt,
                                                 0.0);
+  test_transition_to_delta_r_inward<control_system::size::States::AhSpeed>(
+      test_params, std::nullopt, 0.0);
 
   // Again char speed is *barely not* in danger, but for a different reason.
   test_params.min_char_speed = test_params.original_target_char_speed * 1.09999;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.99001 * test_params.damping_time, std::nullopt,
-      0.992 * test_params.damping_time);
+      0.992 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::AhSpeed,
           control_system::size::States::DeltaR>(test_params, true, std::nullopt,
                                                 0.0);
+  test_transition_to_delta_r_inward<control_system::size::States::AhSpeed>(
+      test_params, std::nullopt, 0.0);
+
+  // Should go into state DeltaRDriftOutward.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+  test_params.min_comoving_char_speed = -0.02;
+  test_params.min_char_speed = -0.01;
+  test_params.max_allowed_radial_distance = 0.00069;
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::DeltaRDriftOutward>(
+      test_params, true, std::nullopt, test_params.original_target_char_speed);
+
+  // Should not go into state DeltaRDriftOutward because
+  // CharSpeed is not in danger and its crossing time is valid.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      100.0, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+  do_test<control_system::size::States::AhSpeed,
+          control_system::size::States::AhSpeed>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
 
   // Now do DeltaRDriftOutward tests
-  test_params.min_comoving_char_speed = -0.02;
-  test_params.control_err_delta_r = 0.03;
   test_params.max_allowed_radial_distance = 0.001;
+  test_params.min_char_speed = 0.01;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, std::nullopt);
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
 
   // Should do nothing.
   do_test<control_system::size::States::DeltaRDriftOutward,
@@ -447,7 +688,8 @@ void test_size_control_update() {
   // Make deltar cross zero *slightly* before damping time; it should still do
   // nothing (depends on tolerance in control_system::size::DeltaRDriftOutward).
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, 0.999 * test_params.damping_time);
+      std::nullopt, std::nullopt, 0.999 * test_params.damping_time,
+      std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaRDriftOutward,
           control_system::size::States::DeltaRDriftOutward>(
       test_params, false, std::nullopt, test_params.original_target_char_speed);
@@ -455,7 +697,8 @@ void test_size_control_update() {
   // Make charspeed cross zero slightly after damping time; it should
   // still do nothing.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      1.001 * test_params.damping_time, std::nullopt, std::nullopt);
+      1.001 * test_params.damping_time, std::nullopt, std::nullopt,
+      std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaRDriftOutward,
           control_system::size::States::DeltaRDriftOutward>(
       test_params, false, std::nullopt, test_params.original_target_char_speed);
@@ -463,7 +706,8 @@ void test_size_control_update() {
   // Make deltar cross zero before damping time. Now it should suggest
   // a new damping time.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, 0.9 * test_params.damping_time);
+      std::nullopt, std::nullopt, 0.9 * test_params.damping_time, std::nullopt,
+      std::nullopt);
   do_test<control_system::size::States::DeltaRDriftOutward,
           control_system::size::States::DeltaRDriftOutward>(
       test_params, false, 0.9 * test_params.damping_time,
@@ -473,7 +717,7 @@ void test_size_control_update() {
   // faster than char speed.  Should suggest new damping time.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.91 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaRDriftOutward,
           control_system::size::States::DeltaRDriftOutward>(
       test_params, false, 0.9 * test_params.damping_time,
@@ -483,7 +727,7 @@ void test_size_control_update() {
   // slower than char speed.  Should go to AhSpeed.
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
       0.89 * test_params.damping_time, std::nullopt,
-      0.9 * test_params.damping_time);
+      0.9 * test_params.damping_time, std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaRDriftOutward,
           control_system::size::States::AhSpeed>(
       test_params, true, 0.89 * test_params.damping_time,
@@ -492,9 +736,317 @@ void test_size_control_update() {
   // Should go to state DeltaR because distance < max_allowed_radial_distance.
   test_params.max_allowed_radial_distance = 1.e100;
   test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
-      std::nullopt, std::nullopt, std::nullopt);
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
   do_test<control_system::size::States::DeltaRDriftOutward,
           control_system::size::States::DeltaR>(
+      test_params, true, std::nullopt, test_params.original_target_char_speed);
+
+  // Tests for state DeltaRDriftInward.
+  // If CharSpeed not in danger and DeltaR not in danger, then we
+  // look at a few things.
+  // First we check if we should transition to state DeltaRNoDrift.  To
+  // transition to State DeltaRNoDrift, EITHER all of the following are true:
+  //  1. t_drift_limit < tdamp
+  //  2. t_drift_limit is valid
+  //  3. inward_drift_velocity is nonzero
+  // OR at least one of the following are true:
+  //  4. inward_drift_velocity is nullopt
+  //  5. min_char_speed > 0.9*min_allowed_char_speed and
+  //     min_allowed_char_speed is valid
+  //  6. avg_radial_distance > 0.9*min_allowed_radial_distance and
+  //     min_allowed_radial_distance is valid
+  //  7. comoving_char_speed_increasing_inward is false
+  //  8. min_allowed_char_speed is invalid and
+  //     min_allowed_radial_distance is invalid
+
+  // Here t_drift_limit is invalid, so 1+2+3 is false.
+  // But 8. above is true, so change to DeltaRNoDrift.
+  test_params.comoving_char_speed_increasing_inward = true;
+  test_params.min_allowed_radial_distance = std::nullopt;
+  test_params.min_allowed_char_speed = std::nullopt;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, true, std::nullopt, test_params.original_target_char_speed);
+
+  // No transition because 8 above is no longer true.
+  // (also 5 above is not true)
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.89;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRDriftInward>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // No transition because 8 above is no longer true.
+  // (also 6 above is not true)
+  test_params.min_allowed_char_speed = std::nullopt;
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.89;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRDriftInward>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // Change to state DeltaRNoDrift with a timescale for t_drift_limit,
+  // because t_drift_limit is now less than damping time.
+  // Happens because 1,2,3 above are all true.
+  // Note that 8 and 6 above are still false, i.e. all of 4 thru 8 are false.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+      0.95 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, true, test_params.crossing_time_info.t_drift_limit,
+      test_params.original_target_char_speed);
+
+  // Still change to State DeltaRNoDrift if CharSpeed is above the limit.
+  // Note that 1. above is false.  Now 5 is true.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+      1.2 * test_params.damping_time);
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.91;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, true, test_params.crossing_time_info.t_drift_limit,
+      test_params.original_target_char_speed);
+
+  // Still change to State DeltaRNoDrift if DeltaR is above the limit.
+  // Note that 1. above is false.  Now 5 and 6 are true.
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.91;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, true, test_params.crossing_time_info.t_drift_limit,
+      test_params.original_target_char_speed);
+
+  // Now put DeltaR below the limit. Still goes to state DeltaRNoDrift.
+  // Note that 1. above is false.  Now 6 is true, but the rest of 4-8 are false.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.89;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, true, test_params.crossing_time_info.t_drift_limit,
+      test_params.original_target_char_speed);
+
+  // Now put DeltaR below the limit.
+  // Now it doesn't transition because all of 4-8 are false,
+  // and 1 is still false.
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.89;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRDriftInward>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // Goes to DeltaRNoDrift because 4 above is true.
+  test_params.inward_drift_velocity = std::nullopt;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, true, test_params.crossing_time_info.t_drift_limit,
+      test_params.original_target_char_speed);
+
+  // Goes to DeltaRNoDrift because 7 above is true.
+  test_params.inward_drift_velocity = 0.005;
+  test_params.comoving_char_speed_increasing_inward = false;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, true, test_params.crossing_time_info.t_drift_limit,
+      test_params.original_target_char_speed);
+  test_params.comoving_char_speed_increasing_inward = true;
+
+  // Now put DeltaR below the DeltaRDriftOutward limit.
+  // Should go to DeltaRDriftOutward.
+  test_params.max_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 3.5;
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRDriftOutward>(
+      test_params, true, std::nullopt, test_params.original_target_char_speed);
+  test_params.max_allowed_radial_distance = std::nullopt;
+
+  // Now both CharSpeed and DeltaR are below the limit, but
+  // damping_time is large and t_drift_limit is active.  Now it should
+  // stay in State DeltaRDriftInward but change the timescale.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.89;
+  test_params.damping_time = 5.0;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, 20.0, std::nullopt,
+      1.1 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRDriftInward>(
+      test_params, false, 0.99 * test_params.damping_time,
+      std::min(test_params.inward_drift_velocity.value(),
+               0.5 * test_params.min_char_speed /
+                   test_params.avg_distorted_normal_dot_unit_coord_vector));
+  test_params.damping_time = 0.1;
+
+  // Now do DeltaRInDanger. Should stay in State DeltaRDriftInward but with
+  // different timescale.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, 0.9 * test_params.damping_time, std::nullopt,
+      1.1 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::DeltaRDriftInward>(
+      test_params, false, test_params.crossing_time_info.t_delta_radius,
+      test_params.original_target_char_speed);
+
+  // Now do CharSpeedInDanger. Should go to State AhSpeed with new
+  // damping time.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.89 * test_params.damping_time, std::nullopt,
+      0.9 * test_params.damping_time, std::nullopt,
+      1.1 * test_params.damping_time);
+  do_test<control_system::size::States::DeltaRDriftInward,
+          control_system::size::States::AhSpeed>(
+      test_params, true, test_params.crossing_time_info.t_char_speed,
+      test_params.min_char_speed * 1.01);
+
+  // The following tests start in state DeltaRNoDrift
+
+  // CharSpeed is in danger, but ComovingCharSpeed is positive, so
+  // stays in State DeltaRNoDrift with new timescale.
+  test_params.min_comoving_char_speed = 0.02;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.89 * test_params.damping_time, std::nullopt, std::nullopt, std::nullopt,
+      std::nullopt);
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, false, test_params.crossing_time_info.t_char_speed,
+      test_params.original_target_char_speed);
+
+  // CharSpeed is in danger, but ComovingCharSpeed is negative, so
+  // goes to State AhSpeed.
+  test_params.min_comoving_char_speed = -0.02;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::AhSpeed>(
+      test_params, true, test_params.crossing_time_info.t_char_speed,
+      test_params.min_char_speed * 1.01);
+
+  // CharSpeed is in danger, ComovingCharSpeed is positive,
+  // but ComovingCharSpeed is decreasing (i.e.
+  // its crossing time is positive), so
+  // goes to State AhSpeed.
+  test_params.min_comoving_char_speed = 0.02;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      0.89 * test_params.damping_time, 0.02, std::nullopt, std::nullopt,
+      std::nullopt);
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::AhSpeed>(
+      test_params, true, test_params.crossing_time_info.t_char_speed,
+      test_params.min_char_speed * 1.01);
+
+  // CharSpeed is in danger, ComovingCharSpeed negative,
+  // ComovingCharSpeed is decreasing (i.e.
+  // its crossing time is positive), so
+  // goes to State AhSpeed.
+  test_params.min_comoving_char_speed = -0.02;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::AhSpeed>(
+      test_params, true, test_params.crossing_time_info.t_char_speed,
+      test_params.min_char_speed * 1.01);
+
+  // DeltaRex is in danger, so stays in State DeltaRNoDrift with different
+  // timescale.
+  test_params.min_comoving_char_speed = 0.02;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, 0.7 * test_params.damping_time, std::nullopt,
+      std::nullopt);
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, false, test_params.crossing_time_info.t_delta_radius,
+      test_params.original_target_char_speed);
+
+  // To transition from DeltaRNoDrift to DeltaR, we require
+  // at least one of the following to be true:
+  // A. t_drift_limit = std::nullopt
+  // B. delta_r > 0.99 min_allowed_radial_distance
+  // C. char_speed > 0.99 min_allowed_char_speed
+  //
+  // If none of the above are true, then we stay in DeltaRNoDrift with
+  // a different timescale if both of the following are true:
+  // D. t_drift_limit < damping_time
+  // E. Either min_allowed_radial_distance or min_allowed_char_speed
+  //    has a value.
+  //
+  // If either D. or E. is false, then we stay in DeltaRNoDrift but
+  // keep the same timescale.
+
+  // A, B, and C above are false, and D. and E. are true.
+  // We stay in State DeltaRNoDrift with a different timescale.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, 0.3 * test_params.damping_time,
+      std::nullopt);
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.98;
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.98;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, false, test_params.crossing_time_info.t_drift_limit,
+      test_params.original_target_char_speed);
+
+  // A, B are false, C. is true. (D. and E. are true but do not matter here).
+  // We exit DeltaRNoDrift.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.991;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // A, C are false, B. is true. (D. and E. are true but do not matter here).
+  // We exit DeltaRNoDrift.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.98;
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.991;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // B, C are false, A. is true. (D. and E. are true but do not matter here).
+  // We exit DeltaRNoDrift.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.98;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // A, B are false, C true. (D. false and E. true).
+  // We exit DeltaRNoDrift.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.991;
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, 1.1 * test_params.damping_time,
+      std::nullopt);
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // A, C are false, B true. (D. false and E. true).
+  // We exit DeltaRNoDrift.
+  test_params.min_allowed_char_speed = test_params.min_char_speed / 0.98;
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.991;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaR>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // A, B, C are false. (D. false and E. true).
+  // We stay in State DeltaRNoDrift but with the same timescale.
+  test_params.min_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 0.98;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // A, B, C are false. (D. true and E. false).
+  // We stay in State DeltaRNoDrift but with the same timescale.
+  test_params.crossing_time_info = control_system::size::CrossingTimeInfo(
+      std::nullopt, std::nullopt, std::nullopt, 0.77 * test_params.damping_time,
+      std::nullopt);
+  test_params.min_allowed_char_speed = std::nullopt;
+  test_params.min_allowed_radial_distance = std::nullopt;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaRNoDrift>(
+      test_params, false, std::nullopt, test_params.original_target_char_speed);
+
+  // Here we want to enter state DeltaRDriftOutward.
+  test_params.max_allowed_radial_distance =
+      test_params.average_radial_distance.value() / 1.2;
+  do_test<control_system::size::States::DeltaRNoDrift,
+          control_system::size::States::DeltaRDriftOutward>(
       test_params, true, std::nullopt, test_params.original_target_char_speed);
 }
 
@@ -541,6 +1093,8 @@ void test_name_and_number() {
   const control_system::size::States::Initial initial{};
   const control_system::size::States::AhSpeed ah_speed{};
   const control_system::size::States::DeltaR delta_r{};
+  const control_system::size::States::DeltaRDriftInward delta_r_drift_inward{};
+  const control_system::size::States::DeltaRNoDrift delta_r_no_drift{};
   const control_system::size::States::DeltaRDriftOutward
       delta_r_drift_outward{};
 
@@ -550,6 +1104,10 @@ void test_name_and_number() {
   CHECK(ah_speed.number() == 1_st);
   CHECK(delta_r.name() == "DeltaR"s);
   CHECK(delta_r.number() == 2_st);
+  CHECK(delta_r_drift_inward.name() == "DeltaRDriftInward"s);
+  CHECK(delta_r_drift_inward.number() == 3_st);
+  CHECK(delta_r_no_drift.name() == "DeltaRNoDrift"s);
+  CHECK(delta_r_no_drift.number() == 4_st);
   CHECK(delta_r_drift_outward.name() == "DeltaRDriftOutward"s);
   CHECK(delta_r_drift_outward.number() == 5_st);
 }
@@ -563,6 +1121,9 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.SizeControlStates", "[Domain][Unit]") {
   test_clone_and_serialization<control_system::size::States::Initial>();
   test_clone_and_serialization<control_system::size::States::AhSpeed>();
   test_clone_and_serialization<control_system::size::States::DeltaR>();
+  test_clone_and_serialization<
+      control_system::size::States::DeltaRDriftInward>();
+  test_clone_and_serialization<control_system::size::States::DeltaRNoDrift>();
   test_clone_and_serialization<
       control_system::size::States::DeltaRDriftOutward>();
   test_name_and_number();

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -14,6 +14,7 @@
 #include "ControlSystem/ControlErrors/Size.hpp"
 #include "ControlSystem/ControlErrors/Size/AhSpeed.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaR.hpp"
+#include "ControlSystem/ControlErrors/Size/DeltaRDriftInward.hpp"
 #include "ControlSystem/ControlErrors/Size/DeltaRDriftOutward.hpp"
 #include "ControlSystem/ControlErrors/Size/Error.hpp"
 #include "ControlSystem/ControlErrors/Size/Factory.hpp"
@@ -95,6 +96,10 @@ void test_size_error_one_step(
     const gsl::not_null<intrp::ZeroCrossingPredictor*>
         predictor_comoving_char_speed,
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_delta_radius,
+    const gsl::not_null<intrp::ZeroCrossingPredictor*>
+        predictor_drift_limit_char_speed,
+    const gsl::not_null<intrp::ZeroCrossingPredictor*>
+        predictor_drift_limit_delta_radius,
     const double time, const double grid_excision_boundary_radius,
     const double distorted_excision_boundary_radius_initial,
     const double distorted_excision_boundary_velocity,
@@ -110,8 +115,26 @@ void test_size_error_one_step(
   const double initial_damping_time = 0.1;
   const double initial_target_drift_velocity = 0.0;
   const double initial_suggested_time_scale = 0.0;
-  // Set constants so that State::DeltaROutward is turned off.
-  const std::optional<double> max_allowed_radial_distance{};
+  // Set max_allowed_radial_distance so that State::DeltaRDriftOutward
+  // does not transition to DeltaR with the chosen radial_distance of 0.5
+  // below. This is fine-tuned.
+  const std::optional<double> max_allowed_radial_distance{0.049};
+  // The NOLINTs for these following 3 vars are because clang-tidy
+  // wants these to be const, but their values are changed (sometimes)
+  // by the if constexpr below.
+  std::optional<double> inward_drift_velocity{}; // NOLINT
+  std::optional<double> min_allowed_radial_distance{}; // NOLINT
+  std::optional<double> min_allowed_char_speed{}; // NOLINT
+  if constexpr (std::is_same_v<
+                    FinalState,
+                    control_system::size::States::DeltaRDriftInward>) {
+    // Set constants so that State::DeltaRDriftInward does not transition
+    // to DeltaRNoDrift for the chosen parameters in the test.
+    // This is fine-tuned.
+    min_allowed_radial_distance = 0.06;
+    inward_drift_velocity = 0.001;
+    min_allowed_char_speed = 0.068;
+  }
   control_system::size::Info info{std::make_unique<InitialState>(),
                                   initial_damping_time,
                                   target_char_speed,
@@ -135,7 +158,8 @@ void test_size_error_one_step(
       tmpl::list<::Tags::Tempi<0, 2, ::Frame::Spherical<Frame::Distorted>>,
                  ::Tags::Tempi<1, 3, Frame::Distorted>,
                  ::Tags::TempI<2, 3, Frame::Distorted>,
-                 ::Tags::TempI<3, 3, Frame::Distorted>, ::Tags::TempScalar<4>>>
+                 ::Tags::TempI<3, 3, Frame::Distorted>, ::Tags::TempScalar<4>,
+                 Tags::TempScalar<5>>>
       temp_buffer(excision_boundary.ylm_spherepack().physical_size());
   auto& theta_phi =
       get<::Tags::Tempi<0, 2, ::Frame::Spherical<Frame::Distorted>>>(
@@ -145,6 +169,7 @@ void test_size_error_one_step(
       get<Tags::TempI<2, 3, Frame::Distorted>>(temp_buffer);
   auto& shifty_quantity = get<Tags::TempI<3, 3, Frame::Distorted>>(temp_buffer);
   auto& radius = get<::Tags::TempScalar<4>>(temp_buffer);
+  auto& deriv_comoving_char_speed = get<::Tags::TempScalar<5>>(temp_buffer);
   ylm::Tags::ThetaPhiCompute<Frame::Distorted>::function(
       make_not_null(&theta_phi), excision_boundary);
   ylm::Tags::RhatCompute<Frame::Distorted>::function(make_not_null(&r_hat),
@@ -193,6 +218,12 @@ void test_size_error_one_step(
                            distorted_excision_boundary_radius_initial;
   }
 
+  // Here set deriv_comoving_char_speed to 1.0 artificially.
+  // deriv_comoving_char_speed is not used in the control error,
+  // except in determining which state to change to, in which case
+  // only the sign of deriv_comoving_char_speed matters.
+  get(deriv_comoving_char_speed) = 1.0;
+
   const auto lambda_dt_lambda = function_of_time->func_and_deriv(time);
   const double control_error_delta_r =
       control_system::size::control_error_delta_r(
@@ -212,10 +243,14 @@ void test_size_error_one_step(
 
   auto error = control_system::size::control_error(
       make_not_null(&info), predictor_char_speed, predictor_comoving_char_speed,
-      predictor_delta_radius, time, control_error_delta_r,
+      predictor_delta_radius, predictor_drift_limit_char_speed,
+      predictor_drift_limit_delta_radius, time, control_error_delta_r,
       control_error_delta_r_outward, max_allowed_radial_distance,
+      inward_drift_velocity, min_allowed_radial_distance,
+      min_allowed_char_speed, horizon.coefficients()[0],
       time_deriv_horizon.coefficients()[0], horizon, excision_boundary, lapse,
-      shifty_quantity, spatial_metric, inverse_spatial_metric);
+      shifty_quantity, spatial_metric, inverse_spatial_metric,
+      deriv_comoving_char_speed);
 
   // Check error and parts of info.
   //
@@ -225,7 +260,8 @@ void test_size_error_one_step(
   // main thing that happens inside of control_error.
   // Here we merely check that control_error does the correct
   // thing for a few cases.
-  CHECK(dynamic_cast<FinalState*>(info.state.get()) != nullptr);
+  CAPTURE(error.update_message);
+  CHECK(info.state.get()->number() == FinalState{}.number());
   CHECK(error.control_error == approx(expected_error));
 
   // Now check the control error class, but only if the initial state is Initial
@@ -242,6 +278,7 @@ void test_size_error_one_step(
         "MaxNumTimesForZeroCrossingPredictor: 4\n"
         "SmoothAvgTimescaleFraction: 0.25\n"
         "DeltaRDriftOutwardOptions: None\n"
+        "DeltaRDriftInwardOptions: None\n"
         "InitialState: Initial\n"
         "SmootherTuner:\n"
         "  InitialTimescales: 0.2\n"
@@ -366,11 +403,15 @@ void test_size_error(const double grid_excision_boundary_radius,
   intrp::ZeroCrossingPredictor predictor_char_speed;
   intrp::ZeroCrossingPredictor predictor_comoving_char_speed;
   intrp::ZeroCrossingPredictor predictor_delta_radius;
+  intrp::ZeroCrossingPredictor predictor_drift_limit_char_speed;
+  intrp::ZeroCrossingPredictor predictor_drift_limit_delta_radius;
 
   test_size_error_one_step<InitialState, FinalState>(
       make_not_null(&predictor_char_speed),
       make_not_null(&predictor_comoving_char_speed),
-      make_not_null(&predictor_delta_radius), initial_time,
+      make_not_null(&predictor_delta_radius),
+      make_not_null(&predictor_drift_limit_char_speed),
+      make_not_null(&predictor_drift_limit_delta_radius), initial_time,
       grid_excision_boundary_radius, distorted_excision_boundary_radius_initial,
       distorted_excision_boundary_velocity, distorted_horizon_radius,
       distorted_horizon_velocity, target_char_speed, function_of_time,
@@ -411,6 +452,20 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.SizeError", "[Domain][Unit]") {
         horizon_velocity, target_char_speed, expected_control_error);
   }
   {
+    // The following is computed by hand from arxiv:1211.6079 eq. 96.
+    const double horizon_distorted = 2.0;
+    const double excision_distorted = 1.98;
+    const double expected_control_error =
+        (-horizon_velocity * 0.5 * excision_distorted + excision_velocity) /
+        Y00;
+    // Should go to state DeltaR.
+    test_size_error<control_system::size::States::DeltaRNoDrift,
+                    control_system::size::States::DeltaR>(
+        excision_grid, excision_distorted, excision_velocity, horizon_distorted,
+        horizon_velocity, target_char_speed, expected_control_error);
+  }
+
+  {
     // The following is computed by hand from arxiv:1211.6079 eq. 97.
     const double horizon_distorted = 2.0;
     const double excision_distorted = 1.95;
@@ -422,6 +477,22 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.SizeError", "[Domain][Unit]") {
     // Should stay in state DeltaRDriftOutward.
     test_size_error<control_system::size::States::DeltaRDriftOutward,
                     control_system::size::States::DeltaRDriftOutward>(
+        excision_grid, excision_distorted, excision_velocity, horizon_distorted,
+        horizon_velocity, target_char_speed, expected_control_error);
+  }
+
+  {
+    // The following is computed by hand from arxiv:1211.6079 eq. 96 plus
+    // the target char speed.
+    const double horizon_distorted = 2.0;
+    const double excision_distorted = 1.95;
+    const double expected_control_error =
+        (-horizon_velocity * 0.5 * excision_distorted + excision_velocity) /
+            Y00 +
+        target_char_speed;
+    // Should stay in state DeltaRDriftInward.
+    test_size_error<control_system::size::States::DeltaRDriftInward,
+                    control_system::size::States::DeltaRDriftInward>(
         excision_grid, excision_distorted, excision_velocity, horizon_distorted,
         horizon_velocity, target_char_speed, expected_control_error);
   }

--- a/tests/Unit/ControlSystem/ControlErrors/Test_StateHistory.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_StateHistory.cpp
@@ -29,7 +29,7 @@ void test_state_history(const size_t num_times_to_store) {
   ControlErrorArgs control_error_args{1.0, 1.0, 1.0, 1.0, 1.0};
 
   StateHistory state_history{num_times_to_store};
-  const std::vector<size_t> states{0, 1, 2, 5};
+  const std::vector<size_t> states{0, 1, 2, 3, 4, 5};
 
   // Test that as we fill up the history, we have the expected number of stored
   // entries and that they are the correct values, for each state
@@ -55,6 +55,12 @@ void test_state_history(const size_t num_times_to_store) {
             CHECK(control_error == 0.0);
             break;
           case 2:
+            CHECK(control_error == 1.0);
+            break;
+          case 3:
+            CHECK(control_error == 2.0);
+            break;
+          case 4:
             CHECK(control_error == 1.0);
             break;
           case 5:


### PR DESCRIPTION
These correspond to State 3 and State 4 in
SpEC.  These states can prevent the excision
boundary from getting too close to the horizon.

This involves:
 - Adding the two new states.
 - Adding new options DeltaRDriftInwardOptions
 - Passing in a new quantity into control_error.
 - Changing the three current states to allow transitions into the new states.
 - Adding new tests to Test_SizeControlStates that mirror the same tests in SpEC that test the logic of transitioning between states.
 - Updating the other tests to handle the new states.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Add this option to your input file to have the DetalRDriftInward state disabled by default.
```yaml
ControlSystems:
  Size:
    ...
    DeltaRDriftInwardOptions: None
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
