### PR TITLE
Whitespace deprecated after operator""

### DIFF
--- a/src/Utilities/Literals.hpp
+++ b/src/Utilities/Literals.hpp
@@ -12,6 +12,6 @@ using namespace std::literals::string_literals;  // NOLINT
 
 /// \ingroup UtilitiesGroup
 /// Defines the _st size_t suffix
-inline constexpr size_t operator"" _st(const unsigned long long n) {  // NOLINT
+inline constexpr size_t operator""_st(const unsigned long long n) {  // NOLINT
   return static_cast<size_t>(n);
 }


### PR DESCRIPTION
Whitespace deprecated after operator"".

Latest clang complains about this deprecation. See
https://cplusplus.github.io/CWG/issues/2521.html

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->