### PR TITLE
Add pybinding for find_observation_id

### DIFF
--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -34,6 +34,9 @@ void bind_h5vol(py::module& m) {
       .def("list_observation_ids", &h5::VolumeData::list_observation_ids)
       .def("get_observation_value", &h5::VolumeData::get_observation_value,
            py::arg("observation_id"))
+      .def("find_observation_id", &h5::VolumeData::find_observation_id,
+           py::arg("observation_value"),
+           py::arg("observation_value_epsilon") = std::nullopt)
       .def("get_grid_names", &h5::VolumeData::get_grid_names,
            py::arg("observation_id"))
       .def("list_tensor_components", &h5::VolumeData::list_tensor_components,


### PR DESCRIPTION
-------

## Proposed changes

There was no pybinding for h5::VolumeData::find_observation_id; add it.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->