### PR TITLE
Retry AH interpolation with new surface after failure

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -57,12 +58,16 @@ struct ErrorOnFailedApparentHorizon {
         }
         ERROR("Apparent horizon finder "
               << pretty_type::name<InterpolationTargetTag>()
-              << " failed, reason = " << failure_reason << os.str());
+              << " failed. Number of interpolation retries: "
+              << db::get<ah::Tags::FailedInterpolationIterations>(box)
+              << ", reason = " << failure_reason << os.str());
       }
     }
     ERROR("Apparent horizon finder "
           << pretty_type::name<InterpolationTargetTag>()
-          << " failed, reason = " << failure_reason << " at time "
+          << " failed. Number of interpolation retries: "
+          << db::get<ah::Tags::FailedInterpolationIterations>(box)
+          << ", reason = " << failure_reason << " at time "
           << InterpolationTarget_detail::get_temporal_id_value(temporal_id));
   }
 };

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -162,12 +162,21 @@ struct FindApparentHorizon
       // search, because only now do we know the temporal_id of this horizon
       // search.
       db::mutate<ylm::Tags::Strahlkorper<Frame>,
-                 ylm::Tags::PreviousStrahlkorpers<Frame>>(
+                 ylm::Tags::PreviousStrahlkorpers<Frame>,
+                 ah::Tags::PreviousIterationStrahlkorper<Frame>,
+                 ah::Tags::FailedInterpolationIterations>(
           [&temporal_id](
               const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
               const gsl::not_null<
                   std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>*>
-                  previous_strahlkorpers) {
+                  previous_strahlkorpers,
+              const gsl::not_null<ylm::Strahlkorper<Frame>*>
+                  previous_fast_flow_strahlkorper,
+              const gsl::not_null<size_t*> failed_interpolation_iterations) {
+            // Reset to zero. Will only be used starting from the second
+            // iteration
+            *failed_interpolation_iterations = 0;
+
             // If we have zero previous_strahlkorpers, then the
             // initial guess is already in strahlkorper, so do
             // nothing.
@@ -234,6 +243,9 @@ struct FindApparentHorizon
                     fac_1 * (*previous_strahlkorpers)[1].second.coefficients();
               }
             }
+
+            // First iteration the previous is just the initial guess
+            (*previous_fast_flow_strahlkorper) = *strahlkorper;
           },
           box);
     }
@@ -263,10 +275,17 @@ struct FindApparentHorizon
       std::pair<FastFlow::Status, FastFlow::IterInfo> status_and_info;
 
       // Do a FastFlow iteration.
-      db::mutate<::ah::Tags::FastFlow, ylm::Tags::Strahlkorper<Frame>>(
+      db::mutate<::ah::Tags::FastFlow, ylm::Tags::Strahlkorper<Frame>,
+                 ah::Tags::PreviousIterationStrahlkorper<Frame>>(
           [&inv_g, &ex_curv, &christoffel, &status_and_info](
               const gsl::not_null<::FastFlow*> fast_flow,
-              const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper) {
+              const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
+              const gsl::not_null<ylm::Strahlkorper<Frame>*>
+                  previous_fast_flow_strahlkorper) {
+            // Set this before we iterate the fast flow. Note that this will
+            // have to be updated once we have adaptive horizon finding
+            (*previous_fast_flow_strahlkorper) = *strahlkorper;
+
             status_and_info = fast_flow->template iterate_horizon_finder<Frame>(
                 strahlkorper, inv_g, ex_curv, christoffel);
           },

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -22,6 +22,7 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Printf/Printf.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
@@ -153,7 +154,10 @@ struct FindApparentHorizon
       const TemporalId& temporal_id) {
     bool horizon_finder_failed = false;
 
-    if (get<::ah::Tags::FastFlow>(*box).current_iteration() == 0) {
+    const size_t current_iteration =
+        get<::ah::Tags::FastFlow>(*box).current_iteration();
+
+    if (current_iteration == 0) {
       // If we get here, we are in a new apparent horizon search, as
       // opposed to a subsequent iteration of the same horizon search.
       //
@@ -254,13 +258,55 @@ struct FindApparentHorizon
     // outside of the Domain.
     const auto& indices_of_invalid_pts =
         db::get<Tags::IndicesOfInvalidInterpPoints<TemporalId>>(*box);
+    size_t& failed_interpolation_iterations =
+        db::get_mutable_reference<ah::Tags::FailedInterpolationIterations>(box);
     if (indices_of_invalid_pts.count(temporal_id) > 0 and
         not indices_of_invalid_pts.at(temporal_id).empty()) {
-      InterpolationTargetTag::horizon_find_failure_callback::template apply<
-          InterpolationTargetTag>(*box, *cache, temporal_id,
-                                  FastFlow::Status::InterpolationFailure);
-      horizon_finder_failed = true;
+      ++failed_interpolation_iterations;
+
+      const auto& options = Parallel::get<
+          intrp::Tags::ApparentHorizon<InterpolationTargetTag, Frame>>(*cache);
+
+      // Can't recover from the first iteration or if we've exceeded our number
+      // of attempts
+      if (current_iteration > 0 and failed_interpolation_iterations <=
+                                        options.max_interpolation_retries) {
+        // Move the new trial surface halfway between the current surface and
+        // the previous surface
+        db::mutate<ylm::Tags::Strahlkorper<Frame>>(
+            [](const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
+               const ylm::Strahlkorper<Frame>&
+                   previous_strahlkorper_iteration) {
+              strahlkorper->coefficients() +=
+                  0.5 * (previous_strahlkorper_iteration.coefficients() -
+                         strahlkorper->coefficients());
+            },
+            box, db::get<ah::Tags::PreviousIterationStrahlkorper<Frame>>(*box));
+
+        // Resend the new coords at the same time and iteration. Use 0 for the
+        // array index because it's always 0 due to the targets being
+        // singletons. No need to worry about the invalid points since those get
+        // reset within SendPointsToInterpolator
+        Actions::SendPointsToInterpolator<InterpolationTargetTag>::
+            template apply<::intrp::InterpolationTarget<
+                Metavariables, InterpolationTargetTag>>(
+                *box, *cache, 0, temporal_id, current_iteration,
+                failed_interpolation_iterations);
+
+        // We return false because we don't want this iteration to clean
+        // up the volume data, since we still need it.
+        return false;
+      } else {
+        InterpolationTargetTag::horizon_find_failure_callback::template apply<
+            InterpolationTargetTag>(*box, *cache, temporal_id,
+                                    FastFlow::Status::InterpolationFailure);
+        horizon_finder_failed = true;
+      }
     }
+
+    // Reset now that we were able to interpolate (or if we are abandoning this
+    // horizon find)
+    failed_interpolation_iterations = 0;
 
     if (not horizon_finder_failed) {
       const auto& verbosity =

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp
@@ -7,6 +7,8 @@
 #include "IO/Logging/Verbosity.hpp"
 #include "Parallel/Printf/Printf.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "Utilities/PrettyType.hpp"
 
 /// \cond
@@ -30,14 +32,46 @@ struct IgnoreFailedApparentHorizon {
             typename Metavariables, typename TemporalId>
   static void apply(const db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const TemporalId& /*temporal_id*/,
+                    const TemporalId& temporal_id,
                     const FastFlow::Status failure_reason) {
     const auto& verbosity =
         db::get<logging::Tags::Verbosity<InterpolationTargetTag>>(box);
     if (verbosity >= ::Verbosity::Quiet) {
-      Parallel::printf("Remark: Horizon finder %s failed, reason = %s\n",
-                       pretty_type::name<InterpolationTargetTag>(),
-                       failure_reason);
+      const auto& invalid_indices =
+          db::get<::intrp::Tags::IndicesOfInvalidInterpPoints<TemporalId>>(box);
+      std::ostringstream os;
+      if (invalid_indices.contains(temporal_id) and
+          not invalid_indices.at(temporal_id).empty()) {
+        // There are invalid points (i.e. points that could not be
+        // interpolated). Print info about those points.
+
+        // First get the actual points
+        const auto coords =
+            InterpolationTargetTag::compute_target_points::points(
+                box, tmpl::type_<Metavariables>{}, temporal_id);
+
+        const auto& fast_flow = db::get<::ah::Tags::FastFlow>(box);
+
+        // Now output some information about them
+        os << "Invalid points (in "
+           << pretty_type::name<typename InterpolationTargetTag::
+                                    compute_target_points::frame>()
+           << " frame) at time "
+           << InterpolationTarget_detail::get_temporal_id_value(temporal_id)
+           << " at fast-flow iteration " << fast_flow.current_iteration()
+           << " are:\n";
+        for (const auto index : invalid_indices.at(temporal_id)) {
+          os << " (" << get<0>(coords)[index] << "," << get<1>(coords)[index]
+             << "," << get<2>(coords)[index] << ")\n";
+        }
+      }
+
+      Parallel::printf(
+          "Remark: Horizon finder %s failed. Number of interpolation retries: "
+          "%u, reason = %s\n%s",
+          pretty_type::name<InterpolationTargetTag>(),
+          db::get<ah::Tags::FailedInterpolationIterations>(box), failure_reason,
+          os.str());
     }
   }
 };

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.cpp
@@ -4,6 +4,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 
 #include <algorithm>
+#include <cstddef>
 
 #include "IO/Logging/Verbosity.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -16,10 +17,11 @@ namespace intrp::OptionHolders {
 template <typename Frame>
 ApparentHorizon<Frame>::ApparentHorizon(
     ylm::Strahlkorper<Frame> initial_guess_in, ::FastFlow fast_flow_in,
-    ::Verbosity verbosity_in)
+    ::Verbosity verbosity_in, const size_t max_interpolation_retries_in)
     : initial_guess(std::move(initial_guess_in)),
-      fast_flow(std::move(fast_flow_in)),    // NOLINT
-      verbosity(std::move(verbosity_in)) {}  // NOLINT
+      fast_flow(std::move(fast_flow_in)),  // NOLINT
+      verbosity(std::move(verbosity_in)),  // NOLINT
+      max_interpolation_retries(max_interpolation_retries_in) {}
 // clang-tidy std::move of trivially copyable type.
 
 template <typename Frame>
@@ -27,13 +29,15 @@ void ApparentHorizon<Frame>::pup(PUP::er& p) {
   p | initial_guess;
   p | fast_flow;
   p | verbosity;
+  p | max_interpolation_retries;
 }
 
 template <typename Frame>
 bool operator==(const ApparentHorizon<Frame>& lhs,
                 const ApparentHorizon<Frame>& rhs) {
   return lhs.initial_guess == rhs.initial_guess and
-         lhs.fast_flow == rhs.fast_flow and lhs.verbosity == rhs.verbosity;
+         lhs.fast_flow == rhs.fast_flow and lhs.verbosity == rhs.verbosity and
+         lhs.max_interpolation_retries == rhs.max_interpolation_retries;
 }
 
 template <typename Frame>

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
@@ -69,14 +69,22 @@ struct ApparentHorizon {
     static constexpr Options::String help = {"Verbosity"};
     using type = ::Verbosity;
   };
-  using options = tmpl::list<InitialGuess, FastFlow, Verbosity>;
+  struct MaxInterpolationRetries {
+    static constexpr Options::String help = {
+        "Number of times to retry the interpolation where, with each retry, "
+        "the two previous surfaces are averaged and that new surface is used."};
+    using type = size_t;
+  };
+  using options =
+      tmpl::list<InitialGuess, FastFlow, Verbosity, MaxInterpolationRetries>;
   static constexpr Options::String help = {
       "Provide an initial guess for the apparent horizon surface\n"
       "(Strahlkorper) and apparent-horizon-finding-algorithm (FastFlow)\n"
       "options."};
 
   ApparentHorizon(ylm::Strahlkorper<Frame> initial_guess_in,
-                  ::FastFlow fast_flow_in, ::Verbosity verbosity_in);
+                  ::FastFlow fast_flow_in, ::Verbosity verbosity_in,
+                  size_t max_interpolation_retries_in);
 
   ApparentHorizon() = default;
   ApparentHorizon(const ApparentHorizon& /*rhs*/) = default;
@@ -91,6 +99,7 @@ struct ApparentHorizon {
   ylm::Strahlkorper<Frame> initial_guess{};
   ::FastFlow fast_flow{};
   ::Verbosity verbosity{::Verbosity::Quiet};
+  size_t max_interpolation_retries{};
 };
 
 template <typename Frame>

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
@@ -154,7 +154,9 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   using common_tags =
       tmpl::push_back<ylm::Tags::items_tags<Frame>, ::ah::Tags::FastFlow,
                       logging::Tags::Verbosity<InterpolationTargetTag>,
-                      ylm::Tags::PreviousStrahlkorpers<Frame>>;
+                      ylm::Tags::PreviousStrahlkorpers<Frame>,
+                      ::ah::Tags::PreviousIterationStrahlkorper<Frame>,
+                      ::ah::Tags::FailedInterpolationIterations>;
   using simple_tags = tmpl::append<
       common_tags,
       tmpl::conditional_t<
@@ -186,7 +188,8 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
     Initialization::mutate_assign<common_tags>(
         box, options.initial_guess, options.fast_flow, options.verbosity,
         std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>{std::make_pair(
-            std::numeric_limits<double>::quiet_NaN(), options.initial_guess)});
+            std::numeric_limits<double>::quiet_NaN(), options.initial_guess)},
+        options.initial_guess, 0_st);
   }
 
   template <typename Metavariables, typename DbTags, typename TemporalId>

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -7,6 +7,10 @@
 
 /// \cond
 class FastFlow;
+namespace ylm {
+template <typename Frame>
+class Strahlkorper;
+}  // namespace ylm
 /// \endcond
 
 /*!
@@ -15,6 +19,23 @@ class FastFlow;
 namespace ah::Tags {
 struct FastFlow : db::SimpleTag {
   using type = ::FastFlow;
+};
+
+/*!
+ * \brief Tag that holds the strahlkorper of the previous FastFlow iteration
+ * (not the strahlkorper of the entire previous horizon find.)
+ */
+template <typename Frame>
+struct PreviousIterationStrahlkorper : db::SimpleTag {
+  using type = ylm::Strahlkorper<Frame>;
+};
+
+/*!
+ * \brief Tag to hold the number of failed interpolations to a surface during
+ * iterations of the FastFlow algorithm.
+ */
+struct FailedInterpolationIterations : db::SimpleTag {
+  using type = size_t;
 };
 
 /// Base tag for whether or not to write the centers of the horizons to disk.

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
@@ -85,9 +85,11 @@ struct ReceivePoints {
       const ArrayIndex& /*array_index*/,
       const typename InterpolationTargetTag::temporal_id::type& temporal_id,
       std::vector<BlockLogicalCoords<VolumeDim>>&& block_logical_coords,
-      const size_t iteration = 0_st) {
+      const size_t iteration = 0_st,
+      const size_t reinterpolation_iteration = 0_st) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
-        [&temporal_id, &block_logical_coords, &iteration](
+        [&temporal_id, &block_logical_coords, &iteration,
+         &reinterpolation_iteration](
             const gsl::not_null<typename intrp::Tags::InterpolatedVarsHolders<
                 Metavariables>::type*>
                 vars_holders) {
@@ -97,37 +99,52 @@ struct ReceivePoints {
                   .infos;
 
           // Add the new target interpolation points at this temporal_id. There
-          // are two conditions that allow us to overwrite the current target
-          // points. Either
+          // are three conditions that allow us to overwrite the current target
+          // points:
           //
           //  1. There are no current target points at the temporal_id, OR
           //  2. There are target points already at this temporal_id, but the
           //     iteration of the new target points is greater than the
-          //     iteration of the current target points.
+          //     iteration of the current target points (even if we are retrying
+          //     interpolation).
+          //  3. There are target points already at this temporal_id, but the
+          //     iteration of the new target points is equal to the iteration of
+          //     the current target points, and the incoming reinterpolation
+          //     iteration is greater than the current reinterpolation
+          //     iteration.
           //
           // If we already have target points and the iteration of the new
           // points is less than or equal to the iteration of the current target
-          // points, then we ignore the new points. The new points are outdated
-          // and we definitely didn't have any of the new target points in our
-          // element by the fact that we have already received the next
-          // iteration of points.
+          // points (and we aren't retrying an interpolation with new points),
+          // then we ignore the new points. The new points are outdated and we
+          // definitely didn't have any of the new target points in our element
+          // by the fact that we have already received the next iteration of
+          // points.
+          //
+          // However, it occasionally happens where interpolation fails at some
+          // iteration, and the horizon finder is able to send a new set of
+          // points to try for the same iteration.
           //
           // Whenever we overwrite the target points, we also empty the
           // `interpolation_is_done_for_these_elements` (by virtue of a default
           // constructed `intrp::Vars::Info`) so that we always check every
           // element for this new set of target points.
           if (vars_infos.count(temporal_id) == 0 or
-              vars_infos.at(temporal_id).iteration < iteration) {
+              vars_infos.at(temporal_id).iteration < iteration or
+              (vars_infos.at(temporal_id).iteration == iteration and
+               vars_infos.at(temporal_id).reinterpolation_iteration <
+                   reinterpolation_iteration)) {
             vars_infos.insert_or_assign(
                 temporal_id,
                 intrp::Vars::Info<VolumeDim, typename InterpolationTargetTag::
                                                  vars_to_interpolate_to_target>{
                     std::move(block_logical_coords), iteration});
-          } else if (vars_infos.at(temporal_id).iteration == iteration) {
-            ERROR(
-                "Interpolator received target points at iteration "
-                << iteration
-                << " twice. Only one set of points per iteration is allowed.");
+          } else if (vars_infos.at(temporal_id).iteration == iteration and
+                     vars_infos.at(temporal_id).reinterpolation_iteration ==
+                         reinterpolation_iteration) {
+            ERROR("Interpolator received target points at iteration "
+                  << iteration << " (and reinterpolation iteration "
+                  << reinterpolation_iteration << ") twice.");
           }
         },
         make_not_null(&box));

--- a/src/ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp
@@ -60,7 +60,8 @@ struct SendPointsToInterpolator {
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index,
                     const TemporalId& temporal_id,
-                    const size_t iteration = 0_st) {
+                    const size_t iteration = 0_st,
+                    const size_t reinterpolation_iteration = 0_st) {
     auto coords = InterpolationTarget_detail::block_logical_coords<
         InterpolationTargetTag>(box, cache, temporal_id);
     InterpolationTarget_detail::set_up_interpolation<InterpolationTargetTag>(
@@ -86,7 +87,8 @@ struct SendPointsToInterpolator {
     auto& receiver_proxy =
         Parallel::get_parallel_component<Interpolator<Metavariables>>(cache);
     Parallel::simple_action<Actions::ReceivePoints<InterpolationTargetTag>>(
-        receiver_proxy, temporal_id, std::move(coords), iteration);
+        receiver_proxy, temporal_id, std::move(coords), iteration,
+        reinterpolation_iteration);
     if (Parallel::get<intrp::Tags::Verbosity>(cache) >= ::Verbosity::Debug) {
       Parallel::printf(
           "%s, Sending points to interpolator.\n",

--- a/src/ParallelAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -47,6 +47,11 @@ struct Info {
   /// along which iteration the `block_coord_holders` are for. That way they can
   /// be properly ordered in the Interpolator.
   size_t iteration{0_st};
+  /// Sometimes during a single iteration, we are unable to interpolate, but the
+  /// target has a method of retrying the interpolation for the same overall
+  /// iteration. This keeps track of how many times we've tried to reinterpolate
+  /// for a given iteration.
+  size_t reinterpolation_iteration{0_st};
   /// `vars` holds the interpolated `Variables` on some subset of the
   /// points in `block_coord_holders`.  The grid points inside vars
   /// are indexed according to `global_offsets` below.  The size of

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -467,6 +467,7 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Quiet
+    MaxInterpolationRetries: 3
   ObservationAhB: &AhB
     InitialGuess:
       LMax: *ObsLMax
@@ -474,6 +475,7 @@ ApparentHorizons:
       Center: [*XCoordB, *YOffset, *ZOffset]
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
+    MaxInterpolationRetries: 3
   ObservationAhC:
     InitialGuess:
       LMax: 33
@@ -481,6 +483,7 @@ ApparentHorizons:
       Center: [0.0, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
+    MaxInterpolationRetries: 3
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
   ControlSystemCharSpeedAhA: *AhA

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -305,6 +305,7 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Quiet
+    MaxInterpolationRetries: 3
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -274,6 +274,7 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
+    MaxInterpolationRetries: 3
   ObservationAhB: &AhB
     InitialGuess:
       LMax: *LMax
@@ -281,6 +282,7 @@ ApparentHorizons:
       Center: [*XCoordB, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
+    MaxInterpolationRetries: 3
   ObservationAhC:
     InitialGuess:
       LMax: 20
@@ -288,6 +290,7 @@ ApparentHorizons:
       Center: [0.0, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
+    MaxInterpolationRetries: 3
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
   ControlSystemCharSpeedAhA: *AhA

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -249,6 +249,7 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
+    MaxInterpolationRetries: 3
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -247,6 +247,7 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
+    MaxInterpolationRetries: 3
 
 InterpolationTargets:
   BondiSachsInterpolation:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -221,6 +221,7 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
+    MaxInterpolationRetries: 3
   ControlSystemSingleAh: *AhA
 
 InterpolationTargets:

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -90,7 +90,8 @@ struct MockReceivePoints {
       const ArrayIndex& /*array_index*/,
       const typename InterpolationTargetTag::temporal_id::type& temporal_id,
       std::vector<BlockLogicalCoords<VolumeDim>>&& block_coord_holders,
-      const size_t iteration = 0_st) {
+      const size_t iteration = 0_st,
+      const size_t /*reinterpolation_iteration*/ = 0_st) {
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         [&temporal_id, &block_coord_holders, &iteration](
             const gsl::not_null<typename intrp::Tags::InterpolatedVarsHolders<

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -316,7 +316,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
       ylm::Strahlkorper<Frame>{l_max, 2.8, {{0.0, 0.0, 0.0}}},
       FastFlow{FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5,
                max_its},
-      Verbosity::Verbose);
+      Verbosity::Verbose, 3_st);
 
   std::unique_ptr<DomainCreator<3>> domain_creator;
   std::unique_ptr<ActionTesting::MockRuntimeSystem<metavars>> runner_ptr{};

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
@@ -59,7 +59,7 @@ SPECTRE_TEST_CASE(
   // Options for ApparentHorizon
   intrp::OptionHolders::ApparentHorizon<Frame::Inertial> apparent_horizon_opts(
       ylm::Strahlkorper<Frame::Inertial>{l_max, radius, center}, FastFlow{},
-      Verbosity::Verbose);
+      Verbosity::Verbose, 3_st);
 
   // Test creation of options
   const auto created_opts = TestHelpers::test_creation<
@@ -77,7 +77,8 @@ SPECTRE_TEST_CASE(
       "InitialGuess:\n"
       "  Center: [0.05, 0.06, 0.07]\n"
       "  Radius: 2.0\n"
-      "  LMax: 12");
+      "  LMax: 12\n"
+      "MaxInterpolationRetries: 3");
   CHECK(created_opts == apparent_horizon_opts);
 
   const auto domain_creator = domain::creators::Sphere(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
@@ -205,6 +205,11 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.StrahlkorperDataBox",
   test_dimensionful_spin_vector_compute_tag();
   test_dimensionless_spin_magnitude_compute_tag();
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
+  TestHelpers::db::test_simple_tag<
+      ah::Tags::PreviousIterationStrahlkorper<::Frame::Distorted>>(
+      "PreviousIterationStrahlkorper");
+  TestHelpers::db::test_simple_tag<ah::Tags::FailedInterpolationIterations>(
+      "FailedInterpolationIterations");
   TestHelpers::db::test_base_tag<ah::Tags::ObserveCentersBase>(
       "ObserveCentersBase");
   TestHelpers::db::test_simple_tag<ah::Tags::ObserveCenters>("ObserveCenters");

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -502,7 +502,13 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
           intrp::Actions::ReceivePoints<metavars::InterpolationTargetA>>(
           1_st, temporal_id, block_logical_coords, 1_st)),
       Catch::Matchers::ContainsSubstring(
-          "Interpolator received target points at iteration 1 twice."));
+          "Interpolator received target points at iteration 1 (and "
+          "reinterpolation iteration 0) twice"));
+  // However if on core 1 we reinterpolate at the same iteration, there
+  // shouldn't be an error
+  runner.simple_action<interp_component, intrp::Actions::ReceivePoints<
+                                             metavars::InterpolationTargetA>>(
+      1_st, temporal_id, block_logical_coords, 1_st, 1_st);
 
   // Now send with iteration 2. These points should overwrite the previous ones
   // and an interpolation should happen


### PR DESCRIPTION
## Proposed changes

If the iterations of a horizon find move the surface such that it's within an excision, this will now retry the interpolation at a surface half the distance between the current failing one and the previous successful one for a certain number of retries.

Unfortunately the test for the horizon finder just does a full horizon find and invokes actions in a random order so it's not straightforward to check that reinterpolation happened for a specific iteration. However, I have tested this on a BBH run and it does work.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
