### PR TITLE
Add more docs and fix typo in TimeDerivative.hpp/cpp in the CCZ4 system

### DIFF
--- a/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.cpp
@@ -186,7 +186,7 @@ void TimeDerivative<Dim>::apply(
   } else if (slicing_condition_type == SlicingConditionType::Log) {
     ASSERT(min(get(*lapse)) > 0.0,
            "The lapse must be positive when using "
-           "Ccz4::SlicingConditionType::Harmonic.");
+           "Ccz4::SlicingConditionType::Log.");
 
     // g(\alpha) == 2 / \alpha
     get(*slicing_condition) = 2.0 / get(*lapse);

--- a/src/Evolution/Systems/Ccz4/TimeDerivative.hpp
+++ b/src/Evolution/Systems/Ccz4/TimeDerivative.hpp
@@ -17,6 +17,9 @@ class not_null;
 }  // namespace gsl
 /// \endcond
 
+/*!
+* \brief The namespace for the first and second-order Ccz4 evolution system.
+*/
 namespace Ccz4 {
 /*!
  * \brief Indicates whether or not to evolve the shift in a system evolved using
@@ -38,9 +41,9 @@ enum class EvolveShift : bool { False = false, True = true };
 enum class SlicingConditionType : char { Harmonic, Log };
 
 /*!
- * \brief Compute the RHS of the first order CCZ4 formulation of Einstein's
- * equations \cite Dumbser2017okk
- *
+ * \brief Compute the RHS of the first-order CCZ4 formulation of Einstein's
+ * equations with discontinuous Galerkin method. See equations 12a-12m of
+ * \cite Dumbser2017okk.
  * \details We define \f$\phi = (\det(\gamma_{ij}))^{-1/6}\f$ as the conformal
  * factor, \f$\alpha\f$ as the lapse, \f$\beta^i\f$ as the shift, \f$K_{ij}\f$
  * as the extrinsic curvature, and \f$Z_{a}\f$ as the Z4 constraint.


### PR DESCRIPTION
## Proposed changes
Add more docs to the existing `TimeDerivative.hpp` file to emphasize it is used for the first-order CCZ4 system with discontinuous Galerkin method, as opposed to the second-order CCZ4 system with finite difference. Also fix a typo in the existing `TimeDerivative.cpp` file.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
