### PR TITLE
Generalize DerivLapse in the CCZ4 system to allow more tensor symmetry

### DIFF
--- a/src/Evolution/Systems/Ccz4/DerivLapse.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.cpp
@@ -22,7 +22,7 @@ void grad_grad_lapse(
     const tnsr::i<DataType, Dim, Frame>& field_a, const TensorType& d_field_a) {
   if constexpr (std::is_same_v<TensorType, tnsr::ij<DataType, Dim, Frame>>) {
     // We keep this for loop specialization for faster speed when no symmetry
-    // of field_a is present.
+    // of d_field_a is present.
     for (size_t i = 0; i < Dim; ++i) {
       for (size_t j = 0; j < Dim; ++j) {
         result->get(i, j) = field_a.get(i) * field_a.get(j) +

--- a/src/Evolution/Systems/Ccz4/DerivLapse.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/Ccz4/DerivLapse.hpp"
 
 #include <cstddef>
+#include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -13,32 +14,41 @@
 #include "Utilities/SetNumberOfGridPoints.hpp"
 
 namespace Ccz4 {
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 void grad_grad_lapse(
     const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> result,
     const Scalar<DataType>& lapse,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::i<DataType, Dim, Frame>& field_a,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_a) {
-  for (size_t i = 0; i < Dim; ++i) {
-    for (size_t j = 0; j < Dim; ++j) {
-      result->get(i, j) = field_a.get(i) * field_a.get(j) +
-                          0.5 * (d_field_a.get(i, j) + d_field_a.get(j, i));
-      for (size_t k = 0; k < Dim; ++k) {
-        result->get(i, j) -=
-            christoffel_second_kind.get(k, i, j) * field_a.get(k);
+    const tnsr::i<DataType, Dim, Frame>& field_a, const TensorType& d_field_a) {
+  if constexpr (std::is_same_v<TensorType, tnsr::ij<DataType, Dim, Frame>>) {
+    // We keep this for loop specialization for faster speed when no symmetry
+    // of field_a is present.
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = 0; j < Dim; ++j) {
+        result->get(i, j) = field_a.get(i) * field_a.get(j) +
+                            0.5 * (d_field_a.get(i, j) + d_field_a.get(j, i));
+        for (size_t k = 0; k < Dim; ++k) {
+          result->get(i, j) -=
+              christoffel_second_kind.get(k, i, j) * field_a.get(k);
+        }
+        result->get(i, j) *= get(lapse);
       }
-      result->get(i, j) *= get(lapse);
     }
+  } else {
+    ::tenex::evaluate<ti::i, ti::j>(
+        result, lapse() * field_a(ti::i) * field_a(ti::j) -
+                    lapse() * christoffel_second_kind(ti::K, ti::i, ti::j) *
+                        field_a(ti::k) +
+                    lapse() * 0.5 *
+                        (d_field_a(ti::i, ti::j) + d_field_a(ti::j, ti::i)));
   }
 }
 
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 tnsr::ij<DataType, Dim, Frame> grad_grad_lapse(
     const Scalar<DataType>& lapse,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::i<DataType, Dim, Frame>& field_a,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_a) {
+    const tnsr::i<DataType, Dim, Frame>& field_a, const TensorType& d_field_a) {
   tnsr::ij<DataType, Dim, Frame> result{};
   grad_grad_lapse(make_not_null(&result), lapse, christoffel_second_kind,
                   field_a, d_field_a);
@@ -78,8 +88,9 @@ Scalar<DataType> divergence_lapse(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define TTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
 
-#define INSTANTIATE(_, data)                                                 \
+#define INSTANTIATE_GRAD_GRAD_LAPSE(_, data)                                 \
   template void Ccz4::grad_grad_lapse(                                       \
       const gsl::not_null<tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>*>    \
           result,                                                            \
@@ -87,14 +98,23 @@ Scalar<DataType> divergence_lapse(
       const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                  \
           christoffel_second_kind,                                           \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_a,           \
-      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_a);       \
+      const TTYPE(data) < DTYPE(data), DIM(data), FRAME(data) > &d_field_a); \
   template tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>                     \
   Ccz4::grad_grad_lapse(                                                     \
       const Scalar<DTYPE(data)>& lapse,                                      \
       const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                  \
           christoffel_second_kind,                                           \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_a,           \
-      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_a);       \
+      const TTYPE(data) < DTYPE(data), DIM(data), FRAME(data) > &d_field_a);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_GRAD_GRAD_LAPSE, (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial), (double, DataVector),
+                        (tnsr::ii, tnsr::ij))
+
+#undef INSTANTIATE_GRAD_GRAD_LAPSE
+#undef TTYPE
+
+#define INSTANTIATE_DIV_LAPSE(_, data)                                       \
   template void Ccz4::divergence_lapse(                                      \
       const gsl::not_null<Scalar<DTYPE(data)>*> result,                      \
       const Scalar<DTYPE(data)>& conformal_factor_squared,                   \
@@ -107,10 +127,10 @@ Scalar<DataType> divergence_lapse(
           inverse_conformal_metric,                                          \
       const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& grad_grad_lapse);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
-                        (double, DataVector))
+GENERATE_INSTANTIATIONS(INSTANTIATE_DIV_LAPSE, (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial), (double, DataVector))
 
-#undef INSTANTIATE
+#undef INSTANTIATE_GRAD_GRAD_LAPSE
 #undef DTYPE
 #undef FRAME
 #undef DIM

--- a/src/Evolution/Systems/Ccz4/DerivLapse.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivLapse.hpp
@@ -22,21 +22,26 @@ namespace Ccz4 {
  * \f$\partial_j A_i\f$ are the lapse, spatial christoffel symbols of the second
  * kind, the CCZ4 auxiliary variable defined by `Ccz4::Tags::FieldA`, and its
  * spatial derivative, respectively.
+ *
+ * \note In second-order Ccz4, we impose symmetry of index i and j
+ * in \f$ \partial_i A_j=\partial_i \partial_j \ln \alpha \f$,
+ * because partial derivatives commute and to use
+ * `second_partial_derivatives()`. \f$ A_i \f$ is evolved in
+ * the first-order system so no such symmetry is imposed.
  */
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 void grad_grad_lapse(
     const gsl::not_null<tnsr::ij<DataType, Dim, Frame>*> result,
     const Scalar<DataType>& lapse,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::i<DataType, Dim, Frame>& field_a,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_a);
+    const tnsr::i<DataType, Dim, Frame>& field_a, const TensorType& d_field_a);
 
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 tnsr::ij<DataType, Dim, Frame> grad_grad_lapse(
     const Scalar<DataType>& lapse,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
-    const tnsr::i<DataType, Dim, Frame>& field_a,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_a);
+    const tnsr::i<DataType, Dim, Frame>& field_a, const TensorType& d_field_a);
+
 /// @}
 
 /// @{

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivLapse.cpp
@@ -26,6 +26,14 @@ void test_grad_grad_lapse(const DataType& used_for_size) {
           const tnsr::ij<DataType, Dim, Frame::Inertial>&)>(
           &::Ccz4::grad_grad_lapse<DataType, Dim, Frame::Inertial>),
       "DerivLapse", "grad_grad_lapse", {{{-1., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ij<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::Ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::i<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&)>(
+          &::Ccz4::grad_grad_lapse<DataType, Dim, Frame::Inertial>),
+      "DerivLapse", "grad_grad_lapse", {{{-1., 1.}}}, used_for_size);
 }
 
 template <size_t Dim, typename DataType>


### PR DESCRIPTION
Generalize DerivLapse in the CCZ4 system to allow tensor symmetry used in second-order CCZ4 system.

In the first-order CCZ4 system, $A_i=\partial_i \ln\alpha$ is an evolved field, so $\partial_i A_j$ has no symmetry. However, in the second-order CCZ4 system, $\partial_i A_j=\partial_i \partial_j \ln\alpha$ is not evolved; it should have symmetry in i and j, since second partial derivatives commute for $C^2$ functions. This is also required to use `second_partial_derivatives()` in `SecondPartialDerivatives.hpp`. Hence, we generalize the `grad_grad_lapse()` within `DerivLapse.hpp` to allow for symmetric $\partial_i A_j$.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
