### PR TITLE
Fix possible small memory leak in interpolator

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp
@@ -16,6 +16,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
@@ -87,6 +88,17 @@ struct ReceivePoints {
       std::vector<BlockLogicalCoords<VolumeDim>>&& block_logical_coords,
       const size_t iteration = 0_st,
       const size_t reinterpolation_iteration = 0_st) {
+    const auto& finished_ids =
+        get<intrp::Vars::HolderTag<InterpolationTargetTag, Metavariables>>(
+            get<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(box))
+            .temporal_ids_when_data_has_been_interpolated;
+
+    // If we are receiving points from a target after the interpolation has
+    // finished, we discard the points and don't do anything
+    if (alg::found(finished_ids, temporal_id)) {
+      return;
+    }
+
     db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         [&temporal_id, &block_logical_coords, &iteration,
          &reinterpolation_iteration](

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -571,5 +571,40 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
         make_not_null(&runner), 0_st);
     CHECK(num_calls_of_target_receive_vars == 2);
   }
+
+  // Add temporal id to the finished ids
+  {
+    auto& intrp_box = ActionTesting::get_databox<interp_component>(
+        make_not_null(&runner), 0_st);
+
+    db::mutate<intrp::Tags::InterpolatedVarsHolders<metavars>>(
+        [&temporal_id](
+            const gsl::not_null<
+                typename intrp::Tags::InterpolatedVarsHolders<metavars>::type*>
+                vars_holders) {
+          auto& finished_ids =
+              get<intrp::Vars::HolderTag<target_tag, metavars>>(*vars_holders)
+                  .temporal_ids_when_data_has_been_interpolated;
+          finished_ids.push_back(temporal_id);
+        },
+        make_not_null(&intrp_box));
+  }
+
+  // Send points to first interpolator core again to test that we ignore the
+  // points now that the interpolation is finished
+  runner.simple_action<interp_component, intrp::Actions::ReceivePoints<
+                                             metavars::InterpolationTargetA>>(
+      0_st, temporal_id, block_logical_coords, 0_st);
+
+  {
+    INFO("Element 7 ignore finished temporal id");
+    const auto& holder = get_holder(0_st);
+    CHECK_FALSE(holder.temporal_ids_when_data_has_been_interpolated.empty());
+    CHECK(holder.infos.empty());
+
+    // There should be no queued actions and no extra calls to
+    // target_receive_vars
+    CHECK(runner.is_simple_action_queue_empty<target_component>(0_st));
+  }
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Points received after an interpolation has finished were still
accepted and stored. For a single time this probably isn't a lot
of data, but could build up over the course of a simulation

~Dependent on #6595 just because it edits the same files so it makes rebasing easier~

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
