### PR TITLE
Generalize DerivChristoffel in the CCZ4 system to allow more tensor symmetry types

### DIFF
--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -424,6 +424,13 @@ using iJkk = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
                                SpatialIndex<SpatialDim, UpLo::Lo, Fr>>>;
 
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using iijj = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 2, 1, 1>,
+                    index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>>>;
+
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using iiJJ = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 2, 1, 1>,
                     index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
                                SpatialIndex<SpatialDim, UpLo::Lo, Fr>,

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
 
 #include <cstddef>
+#include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -11,46 +12,61 @@
 #include "Utilities/Gsl.hpp"
 
 namespace Ccz4 {
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 void deriv_conformal_christoffel_second_kind(
     const gsl::not_null<tnsr::iJkk<DataType, Dim, Frame>*> result,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
-    const tnsr::ijj<DataType, Dim, Frame>& field_d,
-    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d, const TensorType& d_field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up) {
-  for (size_t i = 0; i < Dim; ++i) {
-    for (size_t j = i; j < Dim; ++j) {
-      for (size_t k = 0; k < Dim; ++k) {
-        for (size_t m = 0; m < Dim; ++m) {
-          (*result).get(k, m, i, j) =
-              -2.0 * field_d_up.get(k, m, 0) *
-                  (field_d.get(i, j, 0) + field_d.get(j, i, 0) -
-                   field_d.get(0, i, j)) +
-              0.5 * inverse_conformal_spatial_metric.get(m, 0) *
-                  (d_field_d.get(k, i, j, 0) + d_field_d.get(i, k, j, 0) +
-                   d_field_d.get(k, j, i, 0) + d_field_d.get(j, k, i, 0) -
-                   d_field_d.get(k, 0, i, j) - d_field_d.get(0, k, i, j));
-          for (size_t l = 1; l < Dim; ++l) {
-            (*result).get(k, m, i, j) +=
-                -2.0 * field_d_up.get(k, m, l) *
-                    (field_d.get(i, j, l) + field_d.get(j, i, l) -
-                     field_d.get(l, i, j)) +
-                0.5 * inverse_conformal_spatial_metric.get(m, l) *
-                    (d_field_d.get(k, i, j, l) + d_field_d.get(i, k, j, l) +
-                     d_field_d.get(k, j, i, l) + d_field_d.get(j, k, i, l) -
-                     d_field_d.get(k, l, i, j) - d_field_d.get(l, k, i, j));
+  // We keep this for loop specialization for faster speed when no symmetry
+  // of d_field_d is present.
+  if constexpr (std::is_same_v<TensorType, tnsr::ijkk<DataType, Dim, Frame>>) {
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = i; j < Dim; ++j) {
+        for (size_t k = 0; k < Dim; ++k) {
+          for (size_t m = 0; m < Dim; ++m) {
+            (*result).get(k, m, i, j) =
+                -2.0 * field_d_up.get(k, m, 0) *
+                    (field_d.get(i, j, 0) + field_d.get(j, i, 0) -
+                     field_d.get(0, i, j)) +
+                0.5 * inverse_conformal_spatial_metric.get(m, 0) *
+                    (d_field_d.get(k, i, j, 0) + d_field_d.get(i, k, j, 0) +
+                     d_field_d.get(k, j, i, 0) + d_field_d.get(j, k, i, 0) -
+                     d_field_d.get(k, 0, i, j) - d_field_d.get(0, k, i, j));
+            for (size_t l = 1; l < Dim; ++l) {
+              (*result).get(k, m, i, j) +=
+                  -2.0 * field_d_up.get(k, m, l) *
+                      (field_d.get(i, j, l) + field_d.get(j, i, l) -
+                       field_d.get(l, i, j)) +
+                  0.5 * inverse_conformal_spatial_metric.get(m, l) *
+                      (d_field_d.get(k, i, j, l) + d_field_d.get(i, k, j, l) +
+                       d_field_d.get(k, j, i, l) + d_field_d.get(j, k, i, l) -
+                       d_field_d.get(k, l, i, j) - d_field_d.get(l, k, i, j));
+            }
           }
         }
       }
     }
+  } else {
+    ::tenex::evaluate<ti::k, ti::M, ti::i, ti::j>(
+        result,
+        -2.0 * field_d_up(ti::k, ti::M, ti::L) *
+                (field_d(ti::i, ti::j, ti::l) + field_d(ti::j, ti::i, ti::l) -
+                 field_d(ti::l, ti::i, ti::j)) +
+            inverse_conformal_spatial_metric(ti::M, ti::L) * 0.5 *
+                (d_field_d(ti::k, ti::i, ti::j, ti::l) +
+                 d_field_d(ti::i, ti::k, ti::j, ti::l) +
+                 d_field_d(ti::k, ti::j, ti::i, ti::l) +
+                 d_field_d(ti::j, ti::k, ti::i, ti::l) -
+                 d_field_d(ti::k, ti::l, ti::i, ti::j) -
+                 d_field_d(ti::l, ti::k, ti::i, ti::j)));
   }
 }
 
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 tnsr::iJkk<DataType, Dim, Frame> deriv_conformal_christoffel_second_kind(
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
-    const tnsr::ijj<DataType, Dim, Frame>& field_d,
-    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d, const TensorType& d_field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up) {
   tnsr::iJkk<DataType, Dim, Frame> result{};
   deriv_conformal_christoffel_second_kind(make_not_null(&result),
@@ -94,47 +110,57 @@ deriv_contracted_conformal_christoffel_second_kind(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define TTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
 
-#define INSTANTIATE(_, data)                                                \
+#define INSTANTIATE_CONFORMAL_CHRISTOFFEL(_, data)                          \
   template void Ccz4::deriv_conformal_christoffel_second_kind(              \
       const gsl::not_null<tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>*> \
           result,                                                           \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
           inverse_conformal_spatial_metric,                                 \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,        \
-      const tnsr::ijkk<DTYPE(data), DIM(data), FRAME(data)>& d_field_d,     \
+      const TTYPE(data) < DTYPE(data), DIM(data), FRAME(data) > &d_field_d, \
       const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up);    \
   template tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>                  \
   Ccz4::deriv_conformal_christoffel_second_kind(                            \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
           inverse_conformal_spatial_metric,                                 \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& field_d,        \
-      const tnsr::ijkk<DTYPE(data), DIM(data), FRAME(data)>& d_field_d,     \
-      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up);    \
-  template void Ccz4::deriv_contracted_conformal_christoffel_second_kind(   \
-      const gsl::not_null<tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>*>   \
-          result,                                                           \
-      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          inverse_conformal_spatial_metric,                                 \
-      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,     \
-      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                 \
-          conformal_christoffel_second_kind,                                \
-      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&                \
-          d_conformal_christoffel_second_kind);                             \
-  template tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>                    \
-  Ccz4::deriv_contracted_conformal_christoffel_second_kind(                 \
-      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                  \
-          inverse_conformal_spatial_metric,                                 \
-      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,     \
-      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                 \
-          conformal_christoffel_second_kind,                                \
-      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&                \
+      const TTYPE(data) < DTYPE(data), DIM(data), FRAME(data) > &d_field_d, \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_CONFORMAL_CHRISTOFFEL, (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial), (double, DataVector),
+                        (tnsr::iijj, tnsr::ijkk))
+
+#undef INSTANTIATE_CONFORMAL_CHRISTOFFEL
+#undef TTYPE
+
+#define INSTANTIATE_CONTRACTED_CHRISTOFFEL(_, data)                       \
+  template void Ccz4::deriv_contracted_conformal_christoffel_second_kind( \
+      const gsl::not_null<tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>*> \
+          result,                                                         \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_conformal_spatial_metric,                               \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,   \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          conformal_christoffel_second_kind,                              \
+      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&              \
+          d_conformal_christoffel_second_kind);                           \
+  template tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>                  \
+  Ccz4::deriv_contracted_conformal_christoffel_second_kind(               \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+          inverse_conformal_spatial_metric,                               \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>& field_d_up,   \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
+          conformal_christoffel_second_kind,                              \
+      const tnsr::iJkk<DTYPE(data), DIM(data), FRAME(data)>&              \
           d_conformal_christoffel_second_kind);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Grid, Frame::Inertial),
-                        (double, DataVector))
+GENERATE_INSTANTIATIONS(INSTANTIATE_CONTRACTED_CHRISTOFFEL, (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial), (double, DataVector))
 
-#undef INSTANTIATE
+#undef INSTANTIATE_CONTRACTED_CHRISTOFFEL
 #undef DTYPE
 #undef FRAME
 #undef DIM

--- a/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
+++ b/src/Evolution/Systems/Ccz4/DerivChristoffel.hpp
@@ -26,21 +26,25 @@ namespace Ccz4 {
  * `Ccz4::Tags::InverseConformalMetric`, the CCZ4 auxiliary variable defined by
  * `Ccz4::Tags::FieldD`, its spatial derivative, and the CCZ4 identity defined
  * by `Ccz4::Tags::FieldDUp`.
+ * \note In second-order Ccz4, we impose symmetry of index k and l
+ * in \f$ \partial_l D_{kij}=\frac{1}{2}\partial_l \partial_k
+ * \tilde{\gamma}_{ij} \f$, because partial derivatives commute and to use
+ * `second_partial_derivatives()`. \f$ D_{kij} \f$ is evolved in
+ * the first-order system so no such symmetry is imposed.
  */
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 void deriv_conformal_christoffel_second_kind(
     const gsl::not_null<tnsr::iJkk<DataType, Dim, Frame>*> result,
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
-    const tnsr::ijj<DataType, Dim, Frame>& field_d,
-    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d, const TensorType& d_field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up);
 
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 tnsr::iJkk<DataType, Dim, Frame> deriv_conformal_christoffel_second_kind(
     const tnsr::II<DataType, Dim, Frame>& inverse_conformal_spatial_metric,
-    const tnsr::ijj<DataType, Dim, Frame>& field_d,
-    const tnsr::ijkk<DataType, Dim, Frame>& d_field_d,
+    const tnsr::ijj<DataType, Dim, Frame>& field_d, const TensorType& d_field_d,
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up);
+
 /// @}
 
 /// @{

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_DerivChristoffel.cpp
@@ -27,6 +27,16 @@ void test_compute_deriv_conformal_christoffel_second_kind(
                                                          Frame::Inertial>),
       "DerivChristoffel", "deriv_conformal_christoffel_second_kind",
       {{{-1., 1.}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::iJkk<DataType, Dim, Frame::Inertial> (*)(
+          const tnsr::II<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iijj<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJJ<DataType, Dim, Frame::Inertial>&)>(
+          &Ccz4::deriv_conformal_christoffel_second_kind<DataType, Dim,
+                                                         Frame::Inertial>),
+      "DerivChristoffel", "deriv_conformal_christoffel_second_kind",
+      {{{-1., 1.}}}, used_for_size);
 }
 
 template <size_t Dim, typename DataType>


### PR DESCRIPTION
Generalize `DerivChristoffel` in the CCZ4 system to allow tensor symmetry types used in the second-order CCZ4 system.

In the first-order CCZ4 system, $D_{kij}=\frac{1}{2}\partial_k \tilde{\gamma}\_{ij}$ is an evolved field, so $\partial_l D_{kij}$ has no symmetry. However, in the second-order CCZ4 system, $\partial_l D_{kij}=\frac{1}{2}\partial_l \partial_k \tilde{\gamma}\_{ij}$ is not evolved; it should have symmetry in k and l, since second partial derivatives commute for $C^2$ functions. This is also required to use `second_partial_derivatives()` in `SecondPartialDerivatives.hpp`. Hence, we generalize the `deriv_conformal_christoffel_second_kind()` within `DerivChristoffel.hpp` to allow for symmetric $\partial_l D_{kij}$ in the indices k and l.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
