### PR TITLE
Generalize spatial_ricci_tensor() for second-order CCZ4

### DIFF
--- a/src/Evolution/Systems/Ccz4/Ricci.hpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.hpp
@@ -81,8 +81,14 @@ namespace Ccz4 {
  * \f$\partial_m \tilde{\Gamma}^m_{ij} - \partial_j \tilde{\Gamma}^m_{im}\f$
  * term, and the argument `contracted_field_d_up` corresponds to the
  * \f$D_m{}^{ml}\f$ term.
+ *
+ * \note In second-order Ccz4, we impose symmetry of index i and j
+ * in \f$ \partial_i P_j=\partial_i \partial_j \ln \phi \f$,
+ * because partial derivatives commute and to use
+ * `second_partial_derivatives()`. \f$ P_i \f$ is evolved in
+ * the first-order system so no such symmetry is imposed.
  */
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 void spatial_ricci_tensor(
     const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
@@ -95,9 +101,9 @@ void spatial_ricci_tensor(
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
     const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_p);
+    const TensorType& d_field_p);
 
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
     const tnsr::i<DataType, Dim, Frame>& contracted_christoffel_second_kind,
@@ -109,6 +115,6 @@ tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
     const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_p);
+    const TensorType& d_field_p);
 /// @}
 }  // namespace Ccz4

--- a/src/Evolution/Systems/Ccz4/Ricci.tpp
+++ b/src/Evolution/Systems/Ccz4/Ricci.tpp
@@ -3,17 +3,16 @@
 
 #pragma once
 
-#include "Evolution/Systems/Ccz4/Ricci.hpp"
-
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/Ricci.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace Ccz4 {
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 void spatial_ricci_tensor(
     const gsl::not_null<tnsr::ii<DataType, Dim, Frame>*> result,
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
@@ -26,7 +25,7 @@ void spatial_ricci_tensor(
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
     const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_p) {
+    const TensorType& d_field_p) {
   tenex::evaluate<ti::i, ti::j>(
       result,
       contracted_d_conformal_christoffel_difference(ti::i, ti::j) +
@@ -69,7 +68,7 @@ void spatial_ricci_tensor(
               christoffel_second_kind(ti::M, ti::l, ti::j));
 }
 
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame, typename TensorType>
 tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
     const tnsr::Ijj<DataType, Dim, Frame>& christoffel_second_kind,
     const tnsr::i<DataType, Dim, Frame>& contracted_christoffel_second_kind,
@@ -81,7 +80,7 @@ tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
     const tnsr::iJJ<DataType, Dim, Frame>& field_d_up,
     const tnsr::I<DataType, Dim, Frame>& contracted_field_d_up,
     const tnsr::i<DataType, Dim, Frame>& field_p,
-    const tnsr::ij<DataType, Dim, Frame>& d_field_p) {
+    const TensorType& d_field_p) {
   tnsr::ii<DataType, Dim, Frame> result{};
   spatial_ricci_tensor(make_not_null(&result), christoffel_second_kind,
                        contracted_christoffel_second_kind,
@@ -96,6 +95,7 @@ tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define TTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
 
 #define INSTANTIATE(_, data)                                              \
   template void Ccz4::spatial_ricci_tensor(                               \
@@ -116,7 +116,7 @@ tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                 \
           contracted_field_d_up,                                          \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,        \
-      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);    \
+      const TTYPE(data)<DTYPE(data), DIM(data), FRAME(data)>& d_field_p); \
   template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                  \
   Ccz4::spatial_ricci_tensor(                                             \
       const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&               \
@@ -134,7 +134,7 @@ tnsr::ii<DataType, Dim, Frame> spatial_ricci_tensor(
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                 \
           contracted_field_d_up,                                          \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& field_p,        \
-      const tnsr::ij<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);
+      const TTYPE(data)<DTYPE(data), DIM(data), FRAME(data)>& d_field_p);
 
 // Instantiations are split into several compilation units to reduce
 // compiler memory consumption.

--- a/src/Evolution/Systems/Ccz4/Ricci1.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci1.cpp
@@ -4,4 +4,4 @@
 #include "Evolution/Systems/Ccz4/Ricci.tpp"
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1), (Frame::Grid, Frame::Inertial),
-                        (double, DataVector))
+                        (double, DataVector), (tnsr::ij, tnsr::ii))

--- a/src/Evolution/Systems/Ccz4/Ricci2.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci2.cpp
@@ -4,4 +4,4 @@
 #include "Evolution/Systems/Ccz4/Ricci.tpp"
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (2), (Frame::Grid, Frame::Inertial),
-                        (double, DataVector))
+                        (double, DataVector), (tnsr::ij, tnsr::ii))

--- a/src/Evolution/Systems/Ccz4/Ricci3.cpp
+++ b/src/Evolution/Systems/Ccz4/Ricci3.cpp
@@ -4,4 +4,4 @@
 #include "Evolution/Systems/Ccz4/Ricci.tpp"
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (Frame::Grid, Frame::Inertial),
-                        (double, DataVector))
+                        (double, DataVector), (tnsr::ij, tnsr::ii))

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Ricci.cpp
@@ -142,6 +142,14 @@ void test_compute_spatial_ricci_tensor(
 
   const auto d_field_p =
       partial_derivative(field_p, mesh, coord_map.inv_jacobian(x_logical));
+  // testing spatial_ricci_tensor() with a symmetric d_field_p
+  tnsr::ii<DataVector, SpatialDim, Frame::Inertial> d_field_p_symm{};
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = i; j < SpatialDim; j++) {
+        d_field_p_symm.get(i, j) = d_field_p.get(i, j);
+    }
+  }
+
   const auto conformal_christoffel_second_kind =
       Ccz4::conformal_christoffel_second_kind(inverse_conformal_spatial_metric,
                                               field_d);
@@ -166,6 +174,12 @@ void test_compute_spatial_ricci_tensor(
           d_conformal_christoffel_second_kind, conformal_spatial_metric,
           inverse_conformal_spatial_metric, field_d, field_d_up, field_p,
           d_field_p)};
+  const auto expected_py_ricci_tensor_with_symmetric_d_field_p{
+      pypp::call<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+          "Ricci", "spatial_ricci_tensor", christoffel_second_kind,
+          d_conformal_christoffel_second_kind, conformal_spatial_metric,
+          inverse_conformal_spatial_metric, field_d, field_d_up, field_p,
+          d_field_p_symm)};
 
   const auto expected_cpp_ricci_tensor =
       gr::ricci_tensor(christoffel_second_kind, d_christoffel_second_kind);
@@ -175,14 +189,25 @@ void test_compute_spatial_ricci_tensor(
       contracted_d_conformal_christoffel_difference, conformal_spatial_metric,
       inverse_conformal_spatial_metric, field_d, field_d_up,
       contracted_field_d_up, field_p, d_field_p);
+  const auto actual_cpp_ricci_tensor_with_symmetric_d_field_p
+    = Ccz4::spatial_ricci_tensor(
+        christoffel_second_kind, contracted_christoffel_second_kind,
+        contracted_d_conformal_christoffel_difference, conformal_spatial_metric,
+        inverse_conformal_spatial_metric, field_d, field_d_up,
+        contracted_field_d_up, field_p, d_field_p_symm);
 
   CHECK_ITERABLE_APPROX(expected_py_ricci_tensor, actual_cpp_ricci_tensor);
+  CHECK_ITERABLE_APPROX(expected_py_ricci_tensor_with_symmetric_d_field_p,
+    actual_cpp_ricci_tensor_with_symmetric_d_field_p);
   // A custom epsilon is used here because the Legendre polynomials don't fit
   // the derivative of 1 / r well. This was looked at for various box sizes and
   // number of 1D grid points.
   Approx approx = Approx::custom().epsilon(1e-11).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(expected_cpp_ricci_tensor,
                                actual_cpp_ricci_tensor, approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_cpp_ricci_tensor,
+                               actual_cpp_ricci_tensor_with_symmetric_d_field_p,
+                               approx);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes
Generalize `spatial_ricci_tensor()` in CCZ4 to take in symmetric tensor parameter `d_field_p`.

In the first-order CCZ4 system, `field_p`, or $P_i=\partial_i \ln\phi$, is an evolved field, so `d_field_p`, or $\partial_i P_j$, has no symmetry. However, in the second-order CCZ4 system, $\partial_i P_j=\partial_i \partial_j \ln\phi$ is not evolved; it should have symmetry in i and j, since second partial derivatives commute for $C^2$ functions. This is also required to use `second_partial_derivatives()` in `SecondPartialDerivatives.hpp` to calculate $\partial_i \partial_j \ln\phi$, as symmetry in i, j is expected there. Hence, we generalize the `spatial_ricci_tensor()` within `Ricci.hpp` to allow for symmetric $\partial_i P_j$.
 
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
