### PR TITLE
Docfix ComputeBondiIntegrand<Tags::PoleOfIntegrand<Tags::BondiH>>

### DIFF
--- a/src/Evolution/Systems/Cce/Equations.hpp
+++ b/src/Evolution/Systems/Cce/Equations.hpp
@@ -589,7 +589,7 @@ struct ComputeBondiIntegrand<Tags::RegularIntegrand<Tags::BondiW>> {
  * We write the equations of motion in the compactified coordinate \f$ y \equiv
  * 1 - 2 R/ r\f$, where \f$r(u, \theta, \phi)\f$ is the Bondi radius of the
  * \f$y=\f$ constant surface and \f$R(u,\theta,\phi)\f$ is the Bondi radius of
- * the worldtube. The equation which determines \f$W\f$ on a surface of constant
+ * the worldtube. The equation which determines \f$H\f$ on a surface of constant
  * \f$u\f$ given \f$J\f$,\f$\beta\f$, \f$Q\f$, \f$U\f$, and \f$W\f$ on the same
  * surface is written as
  * \f[(1 - y) \partial_y H + H + (1 - y)(\mathcal{D}_J H


### PR DESCRIPTION
-------

## Proposed changes

The documentation for ComputeBondiIntegrand<Tags::PoleOfIntegrand<Tags::BondiH>>
had a one-character typo, where W should have been H.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->