### PR TITLE
Add enum InterfaceDataPolicy

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_headers(
   BoundaryData.hpp
   DgElementArray.hpp
   InboxTags.hpp
+  InterfaceDataPolicy.hpp
   MortarData.hpp
   MortarDataHolder.hpp
   MortarTags.hpp
@@ -23,6 +24,7 @@ spectre_target_sources(
   PRIVATE
   AtomicInboxBoundaryData.cpp
   BoundaryData.cpp
+  InterfaceDataPolicy.cpp
   MortarData.cpp
   MortarDataHolder.cpp
   )

--- a/src/Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp"
+
+#include <ostream>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace evolution::dg {
+std::ostream& operator<<(std::ostream& os, const InterfaceDataPolicy value) {
+  switch (value) {
+    case InterfaceDataPolicy::Uninitialized:
+      return os << "Uninitialized";
+    case InterfaceDataPolicy::CopyProject:
+      return os << "CopyProject";
+    case InterfaceDataPolicy::OrientCopyProject:
+      return os << "OrientCopyProject";
+    case InterfaceDataPolicy::NonconformingBothInterpolate:
+      return os << "NonconformingBothInterpolate";
+    case InterfaceDataPolicy::NonconformingSelfInterpolates:
+      return os << "NonconformingSelfInterpolates";
+    case InterfaceDataPolicy::NonconformingNeighborInterpolates:
+      return os << "NonconformingNeighborInterpolates";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR(
+          "An unknown value of InterfaceDataPolicy was passed to the stream "
+          "operator.");
+      // LCOV_EXCL_STOP
+  }
+}
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdint>
+#include <iosfwd>
+
+namespace evolution::dg {
+/// \brief Label for a neighboring Element (or Block) that determines how
+/// information is exchanged between neighboring Elements
+///
+/// \details The specific label is determined by the relationship between the
+/// block logical coordinates of the neighboring Elements (Blocks) for the
+/// points on the interface between them.  In two cases there is a simple
+/// relationship between the coordinates:
+/// - CopyProject: in this case the block logical coordinates are identical.
+///   Therefore a DataVector can be either copied (if the Mesh on each side of
+///   the interface are at the same points) or projected to the Mesh of the
+///   neighbor.
+/// - OrientCopyProject: in this case the block logical coordinates are related
+///   by a discrete rotation (represented by an OrientationMap). Therefore a
+///   DataVector can be reoriented (with the OrientationMap), and then either
+///   copied or projected to the Mesh of the neighbor.
+///
+/// In the following cases, there is no simple relationship between the block
+/// logical coordinates.  Therefore a DataVector must be interpolated to the
+/// points of the neighboring Mesh.  The cases differ in which Element does the
+/// interpolation:
+/// - NonconformingBothInterpolate:  in this case both the Element and its
+///   neighbor interpolate data to the grid points of each others Mesh.
+/// - NonconformingSelfInterpolates:  in this case the Element will receive the
+///   neighbor's boundary data and will interpolate it to the Mesh of the
+///   Element.  The Element will then need to send boundary correction data to
+///   the neighbor.
+/// - NonconformingNeighborInterpolates:  in this case the Element send its
+///   boundary data to the neighbor who will then interpolate it to its own
+///   Mesh. The neighbor will need to send boundary correction data back to the
+///   Element.
+///
+/// The Element and its neighbor will need to use consistent values of this
+/// enum:
+/// - In the cases CopyProject, OrientCopyProject, and
+///   NonconformingBothInterpolate, neighboring elements should agree on the
+///   values.
+/// - For NonconformingSelfInterpolates and NonconformingNeighborInterpolates
+///   neighboring elements should have different values.  These cases should be
+///   used when one Element has many neighboring Elements (e.g. when a single
+///   spherical shell abuts a cubes sphere).  In this case it should be more
+///   efficient for the single element to send its boundary data to its
+///   neighbors which then do the interpolation to their meshes.
+enum class InterfaceDataPolicy : uint8_t {
+  /// default value is uninitialized
+  Uninitialized = 0,
+  /// Boundary data can be copied or projected to Mesh of neighbor
+  CopyProject = 1,
+  /// Boundary data should be reoriented, and then copied or projected to Mesh
+  /// of neighbor
+  OrientCopyProject = 2,
+  /// Boundary data should be interpolated to Mesh of neighbor
+  NonconformingBothInterpolate = 3,
+  /// Neighbor will send boundary data to be interpolated onto the Mesh of this
+  /// Element.  Boundary correction data will then need to be sent to the
+  /// neighbor.
+  NonconformingSelfInterpolates = 4,
+  /// Boundary data should be sent to the neighbor, who will interpolate the
+  /// data to its own Mesh.  The neighbor will send boundary correction data
+  /// back.
+  NonconformingNeighborInterpolates = 5
+};
+
+/// Output operator for a InterfaceDataPolicy.
+std::ostream& operator<<(std::ostream& os, InterfaceDataPolicy value);
+}  // namespace evolution::dg

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_BackgroundGrVars.cpp
   Test_BoundaryCorrectionsHelper.cpp
   Test_BoundaryData.cpp
+  Test_InterfaceDataPolicy.cpp
   Test_MortarData.cpp
   Test_MortarDataHolder.cpp
   Test_MortarTags.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InterfaceDataPolicy.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InterfaceDataPolicy.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.InterfaceDataPolicy",
+                  "[Unit][Evolution]") {
+  CHECK(get_output(evolution::dg::InterfaceDataPolicy::Uninitialized) ==
+        "Uninitialized");
+  CHECK(get_output(evolution::dg::InterfaceDataPolicy::CopyProject) ==
+        "CopyProject");
+  CHECK(get_output(evolution::dg::InterfaceDataPolicy::OrientCopyProject) ==
+        "OrientCopyProject");
+  CHECK(get_output(
+            evolution::dg::InterfaceDataPolicy::NonconformingBothInterpolate) ==
+        "NonconformingBothInterpolate");
+  CHECK(
+      get_output(
+          evolution::dg::InterfaceDataPolicy::NonconformingSelfInterpolates) ==
+      "NonconformingSelfInterpolates");
+  CHECK(get_output(evolution::dg::InterfaceDataPolicy::
+                       NonconformingNeighborInterpolates) ==
+        "NonconformingNeighborInterpolates");
+}


### PR DESCRIPTION
## Proposed changes

Add enum InterfaceDataPolicy which will be used by evolution actions to do the appropriate thing at interfaces. 
I plan to store it in a struct (that I plan to name MortarInfo) that will generalize what is currently stored for Tags::MortarSize

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
