### PR TITLE
Factor out enum ChildSize and rename it SegmentSize

### DIFF
--- a/src/Domain/Structure/ChildSize.cpp
+++ b/src/Domain/Structure/ChildSize.cpp
@@ -10,32 +10,32 @@
 
 #include "Domain/Structure/SegmentId.hpp"
 #include "Domain/Structure/Side.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace domain {
 
-Spectral::ChildSize child_size(const SegmentId& child_segment_id,
-                               const SegmentId& parent_segment_id) {
+Spectral::SegmentSize child_size(const SegmentId& child_segment_id,
+                                 const SegmentId& parent_segment_id) {
   if (child_segment_id == parent_segment_id) {
-    return Spectral::ChildSize::Full;
+    return Spectral::SegmentSize::Full;
   } else {
     ASSERT(child_segment_id.id_of_parent() == parent_segment_id,
            "Segment id '" << parent_segment_id << "' is not the parent of '"
                           << child_segment_id << "'.");
     return parent_segment_id.id_of_child(Side::Lower) == child_segment_id
-               ? Spectral::ChildSize::LowerHalf
-               : Spectral::ChildSize::UpperHalf;
+               ? Spectral::SegmentSize::LowerHalf
+               : Spectral::SegmentSize::UpperHalf;
   }
 }
 
 template <size_t Dim>
-std::array<Spectral::ChildSize, Dim> child_size(
+std::array<Spectral::SegmentSize, Dim> child_size(
     const std::array<SegmentId, Dim>& child_segment_ids,
     const std::array<SegmentId, Dim>& parent_segment_ids) {
-  std::array<Spectral::ChildSize, Dim> result{};
+  std::array<Spectral::SegmentSize, Dim> result{};
   for (size_t d = 0; d < Dim; ++d) {
     gsl::at(result, d) = child_size(gsl::at(child_segment_ids, d),
                                     gsl::at(parent_segment_ids, d));
@@ -45,9 +45,9 @@ std::array<Spectral::ChildSize, Dim> child_size(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                      \
-  template std::array<Spectral::ChildSize, DIM(data)> child_size( \
-      const std::array<SegmentId, DIM(data)>& child_segment_ids,  \
+#define INSTANTIATE(_, data)                                        \
+  template std::array<Spectral::SegmentSize, DIM(data)> child_size( \
+      const std::array<SegmentId, DIM(data)>& child_segment_ids,    \
       const std::array<SegmentId, DIM(data)>& parent_segment_ids);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/Domain/Structure/ChildSize.hpp
+++ b/src/Domain/Structure/ChildSize.hpp
@@ -7,7 +7,7 @@
 #include <cstddef>
 
 #include "Domain/Structure/SegmentId.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 
 namespace domain {
 /// @{
@@ -17,11 +17,11 @@ namespace domain {
  * Determines which part of the `parent_segment_id` is covered by the
  * `child_segment_id`: The full segment, its lower half or its upper half.
  */
-Spectral::ChildSize child_size(const SegmentId& child_segment_id,
-                               const SegmentId& parent_segment_id);
+Spectral::SegmentSize child_size(const SegmentId& child_segment_id,
+                                 const SegmentId& parent_segment_id);
 
 template <size_t Dim>
-std::array<Spectral::ChildSize, Dim> child_size(
+std::array<Spectral::SegmentSize, Dim> child_size(
     const std::array<SegmentId, Dim>& child_segment_ids,
     const std::array<SegmentId, Dim>& parent_segment_ids);
 /// @}

--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -37,8 +37,8 @@
 #include "NumericalAlgorithms/LinearOperators/WeakDivergence.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -235,7 +235,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
   };
 
   static constexpr auto full_mortar_size =
-      make_array<Dim - 1>(Spectral::MortarSize::Full);
+      make_array<Dim - 1>(Spectral::SegmentSize::Full);
 
   template <bool AllDataIsZero, typename... DerivTags, typename... PrimalVars,
             typename... PrimalFluxesVars, typename... PrimalMortarVars,

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -27,8 +27,8 @@
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -172,10 +172,10 @@ tnsr::I<DataVector, Dim, Frame::ElementLogical> mortar_logical_coordinates(
     if (d == direction.dimension()) {
       continue;
     }
-    if (mortar_size.at(d_m) == Spectral::MortarSize::LowerHalf) {
+    if (mortar_size.at(d_m) == Spectral::SegmentSize::LowerHalf) {
       mortar_logical_coords.get(d) -= 1.;
       mortar_logical_coords.get(d) *= 0.5;
-    } else if (mortar_size.at(d_m) == Spectral::MortarSize::UpperHalf) {
+    } else if (mortar_size.at(d_m) == Spectral::SegmentSize::UpperHalf) {
       mortar_logical_coords.get(d) += 1.;
       mortar_logical_coords.get(d) *= 0.5;
     }
@@ -200,7 +200,7 @@ void mortar_jacobian(
                                                     functions_of_time));
   // These factors of two account for the mortar size
   for (const auto& mortar_size_i : mortar_size) {
-    if (mortar_size_i != Spectral::MortarSize::Full) {
+    if (mortar_size_i != Spectral::SegmentSize::Full) {
       get(*mortar_jacobian) *= 0.5;
     }
   }

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
@@ -43,8 +43,8 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Utilities/Algorithm.hpp"
@@ -549,7 +549,7 @@ struct InitializeFacesAndMortars : tt::ConformsTo<::amr::protocols::Projector> {
           DirectionalId<Dim>{direction, ElementId<Dim>::external_boundary_id()};
       mortar_meshes->emplace(mortar_id, face_mesh);
       mortar_sizes->emplace(mortar_id,
-                            make_array<Dim - 1>(Spectral::MortarSize::Full));
+                            make_array<Dim - 1>(Spectral::SegmentSize::Full));
       penalty_factors->emplace(
           mortar_id,
           elliptic::dg::penalty(2. / get(face_normal_magnitudes->at(direction)),

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -41,8 +41,8 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags/Formulation.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
@@ -890,7 +890,7 @@ struct ApplyBoundaryCorrections {
                   *typed_boundary_correction, dg_formulation, volume_args_tuple,
                   typename BcType::dg_boundary_terms_volume_tags{});
 
-              const std::array<Spectral::MortarSize, volume_dim - 1>&
+              const std::array<Spectral::SegmentSize, volume_dim - 1>&
                   mortar_size = mortar_sizes.at(mortar_id);
 
               // This cannot reuse an allocation because it is initialized

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -30,7 +30,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -66,7 +66,7 @@ void internal_mortar_data_impl(
         volume_primitive_variables,
     const Element<Dim>& element, const Mesh<Dim>& volume_mesh,
     const DirectionalIdMap<Dim, Mesh<Dim - 1>>& mortar_meshes,
-    const DirectionalIdMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>&
+    const DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
         mortar_sizes,
     const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
         moving_mesh_map,

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -16,8 +16,8 @@
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -30,7 +30,7 @@ using MortarMap = DirectionalIdMap<Dim, MappedType>;
 template <size_t Dim>
 std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>,
            DirectionalIdMap<Dim, Mesh<Dim - 1>>,
-           DirectionalIdMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>,
+           DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>,
            DirectionalIdMap<Dim, TimeStepId>,
            DirectionMap<Dim, std::optional<Variables<tmpl::list<
                                  evolution::dg::Tags::MagnitudeOfNormal,
@@ -43,7 +43,7 @@ mortars_apply_impl(const Domain<Dim>& domain,
                    const Mesh<Dim>& volume_mesh) {
   MortarMap<evolution::dg::MortarDataHolder<Dim>, Dim> mortar_data{};
   MortarMap<Mesh<Dim - 1>, Dim> mortar_meshes{};
-  MortarMap<std::array<Spectral::MortarSize, Dim - 1>, Dim> mortar_sizes{};
+  MortarMap<std::array<Spectral::SegmentSize, Dim - 1>, Dim> mortar_sizes{};
   MortarMap<TimeStepId, Dim> mortar_next_temporal_ids{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
@@ -90,7 +90,7 @@ mortars_apply_impl(const Domain<Dim>& domain,
       DirectionalIdMap<DIM(data), evolution::dg::MortarDataHolder<DIM(data)>>, \
       DirectionalIdMap<DIM(data), Mesh<DIM(data) - 1>>,                        \
       DirectionalIdMap<DIM(data),                                              \
-                       std::array<Spectral::MortarSize, DIM(data) - 1>>,       \
+                       std::array<Spectral::SegmentSize, DIM(data) - 1>>,      \
       DirectionalIdMap<DIM(data), TimeStepId>,                                 \
       DirectionMap<DIM(data),                                                  \
                    std::optional<Variables<tmpl::list<                         \

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -48,9 +48,8 @@ template <typename Metavariables>
 class GlobalCache;
 }  // namespace Parallel
 namespace Spectral {
-enum class ChildSize : uint8_t;
-using MortarSize = ChildSize;
 enum class Quadrature : uint8_t;
+enum class SegmentSize : uint8_t;
 }  // namespace Spectral
 namespace Tags {
 struct TimeStepId;
@@ -66,7 +65,7 @@ namespace detail {
 template <size_t Dim>
 std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>,
            DirectionalIdMap<Dim, Mesh<Dim - 1>>,
-           DirectionalIdMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>,
+           DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>,
            DirectionalIdMap<Dim, TimeStepId>,
            DirectionMap<Dim, std::optional<Variables<tmpl::list<
                                  evolution::dg::Tags::MagnitudeOfNormal,
@@ -84,7 +83,7 @@ void p_project(
     /* mortar_data */,
     const gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_mesh,
     const gsl::not_null<
-        ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>*>
+        ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>*>
     /* mortar_size */,
     const gsl::not_null<::dg::MortarMap<Dim, TimeStepId>*>
     /* mortar_next_temporal_id */,
@@ -298,7 +297,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
           mortar_data,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> mortar_mesh,
       const gsl::not_null<
-          ::dg::MortarMap<dim, std::array<Spectral::MortarSize, dim - 1>>*>
+          ::dg::MortarMap<dim, std::array<Spectral::SegmentSize, dim - 1>>*>
           mortar_size,
       const gsl::not_null<::dg::MortarMap<dim, TimeStepId>*>
           mortar_next_temporal_id,
@@ -323,7 +322,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
       /*mortar_data*/,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> /*mortar_mesh*/,
       const gsl::not_null<
-          ::dg::MortarMap<dim, std::array<Spectral::MortarSize, dim - 1>>*>
+          ::dg::MortarMap<dim, std::array<Spectral::SegmentSize, dim - 1>>*>
       /*mortar_size*/,
       const gsl::not_null<
           ::dg::MortarMap<dim, TimeStepId>*> /*mortar_next_temporal_id*/,
@@ -347,7 +346,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
       /*mortar_data*/,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> /*mortar_mesh*/,
       const gsl::not_null<
-          ::dg::MortarMap<dim, std::array<Spectral::MortarSize, dim - 1>>*>
+          ::dg::MortarMap<dim, std::array<Spectral::SegmentSize, dim - 1>>*>
       /*mortar_size*/,
       const gsl::not_null<
           ::dg::MortarMap<dim, TimeStepId>*> /*mortar_next_temporal_id*/,

--- a/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
@@ -22,8 +22,7 @@ template <size_t Dim>
 class MortarDataHolder;
 }  // namespace evolution::dg
 namespace Spectral {
-enum class ChildSize : uint8_t;
-using MortarSize = ChildSize;
+enum class SegmentSize : uint8_t;
 }  // namespace Spectral
 class TimeStepId;
 namespace TimeSteppers {
@@ -73,7 +72,8 @@ struct MortarMesh : db::SimpleTag {
 /// The `Dim` is the volume dimension, not the face dimension.
 template <size_t Dim>
 struct MortarSize : db::SimpleTag {
-  using type = DirectionalIdMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>;
+  using type =
+      DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>;
 };
 
 /// The next temporal id at which to receive data on the specified mortar.

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
@@ -11,8 +11,8 @@
 #include "Domain/Structure/Side.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
@@ -48,7 +48,7 @@ Mesh<Dim> mortar_mesh(const Mesh<Dim>& face_mesh1,
 }
 
 template <size_t Dim>
-std::array<Spectral::MortarSize, Dim - 1> mortar_size(
+std::array<Spectral::SegmentSize, Dim - 1> mortar_size(
     const ElementId<Dim>& self, const ElementId<Dim>& neighbor,
     const size_t dimension, const OrientationMap<Dim>& orientation) {
   const auto self_segments =
@@ -56,20 +56,20 @@ std::array<Spectral::MortarSize, Dim - 1> mortar_size(
   const auto neighbor_segments = all_but_specified_element_of(
       orientation.inverse_map()(neighbor.segment_ids()), dimension);
 
-  std::array<Spectral::MortarSize, Dim - 1> result{};
+  std::array<Spectral::SegmentSize, Dim - 1> result{};
   for (size_t d = 0; d < Dim - 1; ++d) {
     const auto& self_segment = gsl::at(self_segments, d);
     const auto& neighbor_segment = gsl::at(neighbor_segments, d);
     if (neighbor_segment == self_segment.id_of_child(Side::Lower)) {
-      gsl::at(result, d) = Spectral::MortarSize::LowerHalf;
+      gsl::at(result, d) = Spectral::SegmentSize::LowerHalf;
     } else if (neighbor_segment == self_segment.id_of_child(Side::Upper)) {
-      gsl::at(result, d) = Spectral::MortarSize::UpperHalf;
+      gsl::at(result, d) = Spectral::SegmentSize::UpperHalf;
     } else {
       ASSERT(neighbor_segment == self_segment or
              neighbor_segment == self_segment.id_of_parent(),
              "Neighbor elements do not overlap 1:1 or 2:1: " << self_segment
              << " " << neighbor_segment);
-      gsl::at(result, d) = Spectral::MortarSize::Full;
+      gsl::at(result, d) = Spectral::SegmentSize::Full;
     }
   }
   return result;
@@ -79,7 +79,7 @@ std::array<Spectral::MortarSize, Dim - 1> mortar_size(
 #define INSTANTIATE(_, data)                                               \
   template Mesh<DIM(data)> mortar_mesh(const Mesh<DIM(data)>& face_mesh1,  \
                                        const Mesh<DIM(data)>& face_mesh2); \
-  template std::array<Spectral::MortarSize, DIM(data)> mortar_size(        \
+  template std::array<Spectral::SegmentSize, DIM(data)> mortar_size(       \
       const ElementId<DIM(data) + 1>& self,                                \
       const ElementId<DIM(data) + 1>& neighbor, size_t dimension,          \
       const OrientationMap<DIM(data) + 1>& orientation);

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -23,6 +23,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -42,7 +43,7 @@ namespace dg {
 template <size_t VolumeDim>
 using MortarId = DirectionalId<VolumeDim>;
 template <size_t MortarDim>
-using MortarSize = std::array<Spectral::MortarSize, MortarDim>;
+using MortarSize = std::array<Spectral::SegmentSize, MortarDim>;
 template <size_t VolumeDim, typename ValueType>
 using MortarMap = DirectionalIdMap<VolumeDim, ValueType>;
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -12,7 +12,7 @@
 #include "DataStructures/DataBox/TagName.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleMortarData.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Options/String.hpp"
 #include "Utilities/PrettyType.hpp"
 
@@ -35,7 +35,7 @@ struct Mortars : db::PrefixTag, db::SimpleTag {
 /// of the face that it covers.
 template <size_t Dim>
 struct MortarSize : db::SimpleTag {
-  using type = std::array<Spectral::MortarSize, Dim>;
+  using type = std::array<Spectral::SegmentSize, Dim>;
 };
 }  // namespace Tags
 

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -17,6 +17,7 @@ spectre_target_sources(
   Mesh.cpp
   Projection.cpp
   Quadrature.cpp
+  SegmentSize.cpp
   Spectral.cpp
   )
 
@@ -31,6 +32,7 @@ spectre_target_headers(
   Mesh.hpp
   Projection.hpp
   Quadrature.hpp
+  SegmentSize.hpp
   Spectral.hpp
   )
 

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -25,37 +25,20 @@
 
 namespace Spectral {
 
-std::ostream& operator<<(std::ostream& os, ChildSize mortar_size) {
-  switch (mortar_size) {
-    case ChildSize::Uninitialized:
-      return os << "Uninitialized";
-    case ChildSize::Full:
-      return os << "Full";
-    case ChildSize::UpperHalf:
-      return os << "UpperHalf";
-    case ChildSize::LowerHalf:
-      return os << "LowerHalf";
-    default:
-      ERROR(
-          "Invalid ChildSize. Expected one of: 'Full', 'UpperHalf', "
-          "'LowerHalf'");
-  }
-}
-
 template <size_t Dim>
 bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
-                      const std::array<ChildSize, Dim>& child_sizes) {
+                      const std::array<SegmentSize, Dim>& child_sizes) {
   return mesh1 != mesh2 or
-         alg::any_of(child_sizes, [](const Spectral::MortarSize child_size) {
-           ASSERT(child_size != Spectral::ChildSize::Uninitialized,
+         alg::any_of(child_sizes, [](const Spectral::SegmentSize child_size) {
+           ASSERT(child_size != Spectral::SegmentSize::Uninitialized,
                   "Received uninitialized child_size.");
-           return child_size != Spectral::ChildSize::Full;
+           return child_size != Spectral::SegmentSize::Full;
          });
 }
 
 const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                                                 const Mesh<1>& parent_mesh,
-                                                const ChildSize size,
+                                                const SegmentSize size,
                                                 const bool operand_is_massive) {
   constexpr size_t max_points = maximum_number_of_points<Basis::Legendre>;
   ASSERT(parent_mesh.basis(0) == Basis::Legendre and
@@ -79,11 +62,11 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
         CacheEnumeration<Quadrature, Quadrature::Gauss,
                          Quadrature::GaussLobatto>,
         CacheRange<2_st, max_points + 1>,
-        CacheEnumeration<ChildSize, ChildSize::Full, ChildSize::UpperHalf,
-                         ChildSize::LowerHalf>>(
+        CacheEnumeration<SegmentSize, SegmentSize::Full, SegmentSize::UpperHalf,
+                         SegmentSize::LowerHalf>>(
         [](const Quadrature child_quadrature, const size_t child_extent,
            const Quadrature parent_quadrature, const size_t parent_extent,
-           const ChildSize local_child_size) -> Matrix {
+           const SegmentSize local_child_size) -> Matrix {
           const auto& prolongation_operator = projection_matrix_parent_to_child(
               {parent_extent, Spectral::Basis::Legendre, parent_quadrature},
               {child_extent, Spectral::Basis::Legendre, child_quadrature},
@@ -95,7 +78,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
   }
 
   switch (size) {
-    case ChildSize::Full: {
+    case SegmentSize::Full: {
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
@@ -137,88 +120,88 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                    child_mesh.quadrature(0), child_mesh.extents(0));
     }
 
-    case ChildSize::UpperHalf: {
+    case SegmentSize::UpperHalf: {
       const static auto cache = make_static_cache<
           CacheEnumeration<Quadrature, Quadrature::Gauss,
                            Quadrature::GaussLobatto>,
           CacheRange<2_st, max_points + 1>,
           CacheEnumeration<Quadrature, Quadrature::Gauss,
                            Quadrature::GaussLobatto>,
-          CacheRange<2_st,
-                     max_points + 1>>([](const Quadrature quadrature_element,
-                                         const size_t extents_element,
-                                         const Quadrature quadrature_mortar,
-                                         const size_t extents_mortar) {
-        if (extents_element > extents_mortar) {
-          return Matrix{};
-        }
-        const Mesh<1> mesh_element(extents_element, Basis::Legendre,
-                                   quadrature_element);
-        const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
-                                  quadrature_mortar);
+          CacheRange<2_st, max_points + 1>>(
+          [](const Quadrature quadrature_element, const size_t extents_element,
+             const Quadrature quadrature_mortar, const size_t extents_mortar) {
+            if (extents_element > extents_mortar) {
+              return Matrix{};
+            }
+            const Mesh<1> mesh_element(extents_element, Basis::Legendre,
+                                       quadrature_element);
+            const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
+                                      quadrature_mortar);
 
-        // The transformation from the small interval to the large
-        // interval in spectral space.  This is a rearranged
-        // version of the equation given in the header.  This form
-        // was easier to code.
-        const auto spectral_transformation = [](const size_t large_index,
-                                                const size_t small_index) {
-          ASSERT(large_index >= small_index,
-                 "Above-diagonal entries are zero.  Don't use them.");
-          double result = 1.;
-          for (size_t i = (large_index - small_index) / 2; i > 0; --i) {
-            result = 1 - result *
-                             static_cast<double>(
-                                 (large_index + small_index + 3 - 2 * i) *
-                                 (large_index + small_index + 2 - 2 * i) *
-                                 (large_index - small_index + 2 - 2 * i) *
-                                 (large_index - small_index + 1 - 2 * i)) /
-                             static_cast<double>(2 * i *
-                                                 (2 * large_index + 1 - 2 * i) *
-                                                 (large_index + 2 - 2 * i) *
-                                                 (large_index + 1 - 2 * i));
-          }
+            // The transformation from the small interval to the large
+            // interval in spectral space.  This is a rearranged
+            // version of the equation given in the header.  This form
+            // was easier to code.
+            const auto spectral_transformation = [](const size_t large_index,
+                                                    const size_t small_index) {
+              ASSERT(large_index >= small_index,
+                     "Above-diagonal entries are zero.  Don't use them.");
+              double result = 1.;
+              for (size_t i = (large_index - small_index) / 2; i > 0; --i) {
+                result = 1 - result *
+                                 static_cast<double>(
+                                     (large_index + small_index + 3 - 2 * i) *
+                                     (large_index + small_index + 2 - 2 * i) *
+                                     (large_index - small_index + 2 - 2 * i) *
+                                     (large_index - small_index + 1 - 2 * i)) /
+                                 static_cast<double>(
+                                     2 * i * (2 * large_index + 1 - 2 * i) *
+                                     (large_index + 2 - 2 * i) *
+                                     (large_index + 1 - 2 * i));
+              }
 
-          for (size_t i = 1; i <= large_index - small_index; ++i) {
-            result *=
-                1. + static_cast<double>(large_index + small_index + 1) / i;
-          }
-          result /= pow(2., static_cast<int>(large_index) + 1);
-          return result;
-        };
+              for (size_t i = 1; i <= large_index - small_index; ++i) {
+                result *=
+                    1. + static_cast<double>(large_index + small_index + 1) / i;
+              }
+              result /= pow(2., static_cast<int>(large_index) + 1);
+              return result;
+            };
 
-        const auto& spectral_to_grid_element =
-            modal_to_nodal_matrix(mesh_element);
-        const auto& grid_to_spectral_mortar =
-            nodal_to_modal_matrix(mesh_mortar);
+            const auto& spectral_to_grid_element =
+                modal_to_nodal_matrix(mesh_element);
+            const auto& grid_to_spectral_mortar =
+                nodal_to_modal_matrix(mesh_mortar);
 
-        Matrix temp(extents_element, extents_element, 0.);
-        for (size_t j = 0; j < extents_element; ++j) {
-          for (size_t k = j; k < extents_element; ++k) {
-            const double transformation_entry = spectral_transformation(k, j);
+            Matrix temp(extents_element, extents_element, 0.);
+            for (size_t j = 0; j < extents_element; ++j) {
+              for (size_t k = j; k < extents_element; ++k) {
+                const double transformation_entry =
+                    spectral_transformation(k, j);
+                for (size_t i = 0; i < extents_element; ++i) {
+                  temp(i, j) +=
+                      spectral_to_grid_element(i, k) * transformation_entry;
+                }
+              }
+            }
+
+            Matrix projection(extents_element, extents_mortar, 0.);
             for (size_t i = 0; i < extents_element; ++i) {
-              temp(i, j) +=
-                  spectral_to_grid_element(i, k) * transformation_entry;
+              for (size_t j = 0; j < extents_mortar; ++j) {
+                for (size_t k = 0; k < extents_element; ++k) {
+                  projection(i, j) +=
+                      temp(i, k) * grid_to_spectral_mortar(k, j);
+                }
+              }
             }
-          }
-        }
 
-        Matrix projection(extents_element, extents_mortar, 0.);
-        for (size_t i = 0; i < extents_element; ++i) {
-          for (size_t j = 0; j < extents_mortar; ++j) {
-            for (size_t k = 0; k < extents_element; ++k) {
-              projection(i, j) += temp(i, k) * grid_to_spectral_mortar(k, j);
-            }
-          }
-        }
-
-        return projection;
-      });
+            return projection;
+          });
       return cache(parent_mesh.quadrature(0), parent_mesh.extents(0),
                    child_mesh.quadrature(0), child_mesh.extents(0));
     }
 
-    case ChildSize::LowerHalf: {
+    case SegmentSize::LowerHalf: {
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
@@ -242,7 +225,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                 // matrices using symmetry.
                 const auto& projection_upper_half =
                     projection_matrix_child_to_parent(mesh_mortar, mesh_element,
-                                                      ChildSize::UpperHalf);
+                                                      SegmentSize::UpperHalf);
 
                 Matrix projection_lower_half(extents_element, extents_mortar);
                 for (size_t i = 0; i < extents_element; ++i) {
@@ -259,16 +242,16 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
     }
 
     default:
-      ERROR("Invalid ChildSize");
+      ERROR("Invalid SegmentSize");
   }
 }
 
 template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim>
-projection_matrix_child_to_parent(const Mesh<Dim>& child_mesh,
-                                  const Mesh<Dim>& parent_mesh,
-                                  const std::array<ChildSize, Dim>& child_sizes,
-                                  const bool operand_is_massive) {
+projection_matrix_child_to_parent(
+    const Mesh<Dim>& child_mesh, const Mesh<Dim>& parent_mesh,
+    const std::array<SegmentSize, Dim>& child_sizes,
+    const bool operand_is_massive) {
   static const Matrix identity{};
   auto projection_matrix = make_array<Dim>(std::cref(identity));
   const auto child_mesh_slices = child_mesh.slices();
@@ -277,7 +260,7 @@ projection_matrix_child_to_parent(const Mesh<Dim>& child_mesh,
     const auto child_mesh_slice = gsl::at(child_mesh_slices, d);
     const auto parent_mesh_slice = gsl::at(parent_mesh_slices, d);
     const auto child_size = gsl::at(child_sizes, d);
-    if (child_size == ChildSize::Full and
+    if (child_size == SegmentSize::Full and
         child_mesh_slice == parent_mesh_slice) {
       // No projection necessary, keep matrix the identity in this dimension
       continue;
@@ -290,7 +273,7 @@ projection_matrix_child_to_parent(const Mesh<Dim>& child_mesh,
 
 const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
                                                 const Mesh<1>& child_mesh,
-                                                const ChildSize size) {
+                                                const SegmentSize size) {
   constexpr size_t max_points = maximum_number_of_points<Basis::Legendre>;
   ASSERT(child_mesh.basis(0) == Basis::Legendre and
              parent_mesh.basis(0) == Basis::Legendre,
@@ -325,7 +308,7 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
   };
 
   switch (size) {
-    case ChildSize::Full: {
+    case SegmentSize::Full: {
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
@@ -338,7 +321,7 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
                    parent_mesh.quadrature(0), parent_mesh.extents(0));
     }
 
-    case ChildSize::UpperHalf: {
+    case SegmentSize::UpperHalf: {
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
@@ -353,7 +336,7 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
                    parent_mesh.quadrature(0), parent_mesh.extents(0));
     }
 
-    case ChildSize::LowerHalf: {
+    case SegmentSize::LowerHalf: {
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
@@ -369,7 +352,7 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
     }
 
     default:
-      ERROR("Invalid ChildSize");
+      ERROR("Invalid SegmentSize");
   }
 }
 
@@ -377,7 +360,7 @@ template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim>
 projection_matrix_parent_to_child(
     const Mesh<Dim>& parent_mesh, const Mesh<Dim>& child_mesh,
-    const std::array<ChildSize, Dim>& child_sizes) {
+    const std::array<SegmentSize, Dim>& child_sizes) {
   static const Matrix identity{};
   auto projection_matrix = make_array<Dim>(std::cref(identity));
   const auto child_mesh_slices = child_mesh.slices();
@@ -386,7 +369,7 @@ projection_matrix_parent_to_child(
     const auto child_mesh_slice = gsl::at(child_mesh_slices, d);
     const auto parent_mesh_slice = gsl::at(parent_mesh_slices, d);
     const auto child_size = gsl::at(child_sizes, d);
-    if (child_size == ChildSize::Full and
+    if (child_size == SegmentSize::Full and
         child_mesh_slice == parent_mesh_slice) {
       // No projection necessary, keep matrix the identity in this dimension
       continue;
@@ -411,26 +394,26 @@ std::array<std::reference_wrapper<const Matrix>, Dim> p_projection_matrices(
       // No projection necessary, keep matrix the identity in this dimension
     } else if (source_mesh_slice.extents(0) <= target_mesh_slice.extents(0)) {
       gsl::at(projection_matrices, d) = projection_matrix_parent_to_child(
-          source_mesh_slice, target_mesh_slice, ChildSize::Full);
+          source_mesh_slice, target_mesh_slice, SegmentSize::Full);
     } else {
       gsl::at(projection_matrices, d) = projection_matrix_child_to_parent(
-          source_mesh_slice, target_mesh_slice, ChildSize::Full);
+          source_mesh_slice, target_mesh_slice, SegmentSize::Full);
     }
   }
   return projection_matrices;
 }
 
 template <size_t DimMinusOne>
-size_t hash(const std::array<Spectral::ChildSize, DimMinusOne>& mortar_size) {
+size_t hash(const std::array<Spectral::SegmentSize, DimMinusOne>& mortar_size) {
   if constexpr (DimMinusOne == 2) {
-    ASSERT(mortar_size[0] != Spectral::ChildSize::Uninitialized and
-               mortar_size[1] != Spectral::ChildSize::Uninitialized,
+    ASSERT(mortar_size[0] != Spectral::SegmentSize::Uninitialized and
+               mortar_size[1] != Spectral::SegmentSize::Uninitialized,
            "Cannot hash an uninitialized mortar_size: " << mortar_size[0] << " "
                                                         << mortar_size[1]);
     return (static_cast<size_t>(mortar_size[0]) - 1) % 2 +
            2 * ((static_cast<size_t>(mortar_size[1]) - 1) % 2);
   } else if constexpr (DimMinusOne == 1) {
-    ASSERT(mortar_size[0] != Spectral::ChildSize::Uninitialized,
+    ASSERT(mortar_size[0] != Spectral::SegmentSize::Uninitialized,
            "Cannot hash an uninitialized mortar_size: " << mortar_size[0]);
     return (static_cast<size_t>(mortar_size[0]) - 1) % 2;
   } else if constexpr (DimMinusOne == 0) {
@@ -443,7 +426,7 @@ size_t hash(const std::array<Spectral::ChildSize, DimMinusOne>& mortar_size) {
 
 template <size_t Dim>
 size_t MortarSizeHash<Dim>::operator()(
-    const std::array<Spectral::ChildSize, Dim - 1>& mortar_size) {
+    const std::array<Spectral::SegmentSize, Dim - 1>& mortar_size) {
   return hash(mortar_size);
 }
 
@@ -451,16 +434,16 @@ size_t MortarSizeHash<Dim>::operator()(
 #define INSTANTIATE(r, data)                                                 \
   template bool needs_projection(                                            \
       const Mesh<DIM(data)>& mesh1, const Mesh<DIM(data)>& mesh2,            \
-      const std::array<ChildSize, DIM(data)>& child_sizes);                  \
+      const std::array<SegmentSize, DIM(data)>& child_sizes);                \
   template std::array<std::reference_wrapper<const Matrix>, DIM(data)>       \
   projection_matrix_child_to_parent(                                         \
       const Mesh<DIM(data)>& child_mesh, const Mesh<DIM(data)>& parent_mesh, \
-      const std::array<ChildSize, DIM(data)>& child_sizes,                   \
+      const std::array<SegmentSize, DIM(data)>& child_sizes,                 \
       bool operand_is_massive);                                              \
   template std::array<std::reference_wrapper<const Matrix>, DIM(data)>       \
   projection_matrix_parent_to_child(                                         \
       const Mesh<DIM(data)>& parent_mesh, const Mesh<DIM(data)>& child_mesh, \
-      const std::array<ChildSize, DIM(data)>& child_sizes);                  \
+      const std::array<SegmentSize, DIM(data)>& child_sizes);                \
   template std::array<std::reference_wrapper<const Matrix>, DIM(data)>       \
   p_projection_matrices(const Mesh<DIM(data)>& source_mesh,                  \
                         const Mesh<DIM(data)>& target_mesh);
@@ -474,7 +457,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 
 #define INSTANTIATE(r, data)       \
   template size_t hash<DIM(data)>( \
-      const std::array<Spectral::ChildSize, DIM(data)>& mortar_size);
+      const std::array<Spectral::SegmentSize, DIM(data)>& mortar_size);
 GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2))
 #undef INSTANTIATE
 

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <ostream>
 
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
 /// \cond
@@ -17,20 +18,6 @@ class Mesh;
 /// \endcond
 
 namespace Spectral {
-
-/// The portion of a mesh covered by a child mesh.
-enum class ChildSize : uint8_t {
-  Uninitialized = 0,
-  Full = 1,
-  UpperHalf = 2,
-  LowerHalf = 3
-};
-
-/// The portion of an element covered by a mortar.
-using MortarSize = ChildSize;
-
-std::ostream& operator<<(std::ostream& os, ChildSize mortar_size);
-
 /// Determine whether data needs to be projected between a child mesh and its
 /// parent mesh. If no projection is necessary the data may be used as-is.
 /// Projection is necessary if the child is either p-refined or h-refined
@@ -38,7 +25,7 @@ std::ostream& operator<<(std::ostream& os, ChildSize mortar_size);
 /// irrelevant in which order the child and the parent mesh are passed in.
 template <size_t Dim>
 bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
-                      const std::array<ChildSize, Dim>& child_sizes);
+                      const std::array<SegmentSize, Dim>& child_sizes);
 
 /*!
  * \brief The projection matrix from a child mesh to its parent.
@@ -82,23 +69,23 @@ bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
  * \f}
  */
 const Matrix& projection_matrix_child_to_parent(
-    const Mesh<1>& child_mesh, const Mesh<1>& parent_mesh, ChildSize size,
+    const Mesh<1>& child_mesh, const Mesh<1>& parent_mesh, SegmentSize size,
     bool operand_is_massive = false);
 
 /// The projection matrix from a child mesh to its parent, in `Dim` dimensions.
 template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim>
-projection_matrix_child_to_parent(const Mesh<Dim>& child_mesh,
-                                  const Mesh<Dim>& parent_mesh,
-                                  const std::array<ChildSize, Dim>& child_sizes,
-                                  bool operand_is_massive = false);
+projection_matrix_child_to_parent(
+    const Mesh<Dim>& child_mesh, const Mesh<Dim>& parent_mesh,
+    const std::array<SegmentSize, Dim>& child_sizes,
+    bool operand_is_massive = false);
 
 /// The projection matrix from a parent mesh to one of its children.
 ///
 /// \see projection_matrix_child_to_parent()
 const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
                                                 const Mesh<1>& child_mesh,
-                                                ChildSize size);
+                                                SegmentSize size);
 
 /// The projection matrix from a parent mesh to one of its children, in `Dim`
 /// dimensions
@@ -106,7 +93,7 @@ template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim>
 projection_matrix_parent_to_child(
     const Mesh<Dim>& parent_mesh, const Mesh<Dim>& child_mesh,
-    const std::array<ChildSize, Dim>& child_sizes);
+    const std::array<SegmentSize, Dim>& child_sizes);
 
 /// The projection matrices from a source mesh to a target mesh where the
 /// meshes cover the same physical volume
@@ -121,7 +108,7 @@ std::array<std::reference_wrapper<const Matrix>, Dim> p_projection_matrices(
 /// This is particularly useful when hashing into statically-sized maps based
 /// on the number of dimensions.
 template <size_t DimMinusOne>
-size_t hash(const std::array<Spectral::ChildSize, DimMinusOne>& mortar_size);
+size_t hash(const std::array<Spectral::SegmentSize, DimMinusOne>& mortar_size);
 
 template <size_t Dim>
 struct MortarSizeHash {
@@ -129,7 +116,7 @@ struct MortarSizeHash {
   static constexpr bool is_perfect = MaxSize == two_to_the(Dim);
 
   size_t operator()(
-      const std::array<Spectral::ChildSize, Dim - 1>& mortar_size);
+      const std::array<Spectral::SegmentSize, Dim - 1>& mortar_size);
 };
 /// @}
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
@@ -28,19 +28,19 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
         py::arg("mesh"), py::arg("number_of_modes_to_zero"),
         py::return_value_policy::reference);
   // Projection
-  py::enum_<Spectral::ChildSize>(m, "ChildSize")
-      .value("Uninitialized", Spectral::ChildSize::Uninitialized)
-      .value("Full", Spectral::ChildSize::Full)
-      .value("UpperHalf", Spectral::ChildSize::UpperHalf)
-      .value("LowerHalf", Spectral::ChildSize::LowerHalf);
+  py::enum_<Spectral::SegmentSize>(m, "SegmentSize")
+      .value("Uninitialized", Spectral::SegmentSize::Uninitialized)
+      .value("Full", Spectral::SegmentSize::Full)
+      .value("UpperHalf", Spectral::SegmentSize::UpperHalf)
+      .value("LowerHalf", Spectral::SegmentSize::LowerHalf);
   m.def("projection_matrix_parent_to_child",
         static_cast<const Matrix& (*)(const Mesh<1>&, const Mesh<1>&,
-                                      Spectral::ChildSize)>(
+                                      Spectral::SegmentSize)>(
             &Spectral::projection_matrix_parent_to_child),
         py::arg("parent_mesh"), py::arg("child_mesh"), py::arg("size"));
   m.def("projection_matrix_child_to_parent",
         static_cast<const Matrix& (*)(const Mesh<1>&, const Mesh<1>&,
-                                      Spectral::ChildSize, bool)>(
+                                      Spectral::SegmentSize, bool)>(
             &Spectral::projection_matrix_child_to_parent),
         py::arg("child_mesh"), py::arg("parent_mesh"), py::arg("size"),
         py::arg("operand_is_massive"));

--- a/src/NumericalAlgorithms/Spectral/SegmentSize.cpp
+++ b/src/NumericalAlgorithms/Spectral/SegmentSize.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+#include <ostream>
+
+namespace Spectral {
+
+std::ostream& operator<<(std::ostream& os, SegmentSize segment_size) {
+  switch (segment_size) {
+    case SegmentSize::Uninitialized:
+      return os << "Uninitialized";
+    case SegmentSize::Full:
+      return os << "Full";
+    case SegmentSize::UpperHalf:
+      return os << "UpperHalf";
+    case SegmentSize::LowerHalf:
+      return os << "LowerHalf";
+    default:
+      ERROR(
+          "Invalid SegmentSize. Expected one of: 'Uninitialized', 'Full', "
+          "'UpperHalf', 'LowerHalf'");
+  }
+}
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SegmentSize.hpp
+++ b/src/NumericalAlgorithms/Spectral/SegmentSize.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdint>
+#include <iosfwd>
+
+namespace Spectral {
+
+/// \brief The portion of a Segment (or the interval \f$[-1, 1]\f$)
+/// covered by a mesh.
+///
+/// \details SegmentSize is used to denote the relationship between two meshes
+/// (in each dimension) such as:
+/// - a face mesh and a mortar mesh when computing boundary corrections on the
+///   mortars between neighboring elements.  In this case the face mesh will
+///   always have SegmentSize::Full, and the mortar mesh can have any value.
+/// - a parent mesh and a child mesh in a h-refinement hierarchy.  In this case
+///   the parent mesh will have SegmentSize::Full, while the child mesh will
+///   have either SegmentSize::UpperHalf or SegmentSize::LowerHalf.
+/// - for p-preojection, the source and target meshes should use
+///   SegmentSize::Full
+enum class SegmentSize : uint8_t {
+  Uninitialized = 0,
+  Full = 1,
+  UpperHalf = 2,
+  LowerHalf = 3
+};
+
+std::ostream& operator<<(std::ostream& os, SegmentSize segment_size);
+}  // namespace Spectral

--- a/src/ParallelAlgorithms/Amr/Projectors/Variables.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/Variables.hpp
@@ -14,6 +14,7 @@
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -62,16 +63,16 @@ struct ProjectVariables : tt::ConformsTo<amr::protocols::Projector> {
     const auto& element_id = element.id();
     const auto& parent_id = get<domain::Tags::Element<Dim>>(parent_items).id();
     const auto& parent_mesh = get<domain::Tags::Mesh<Dim>>(parent_items);
-    std::array<Spectral::ChildSize, Dim> child_sizes{};
+    std::array<Spectral::SegmentSize, Dim> child_sizes{};
     for (size_t d = 0; d < Dim; ++d) {
       if (parent_id.segment_id(d) == element_id.segment_id(d)) {
-        gsl::at(child_sizes, d) = Spectral::ChildSize::Full;
+        gsl::at(child_sizes, d) = Spectral::SegmentSize::Full;
       } else if (parent_id.segment_id(d).id_of_child(Side::Lower) ==
                  element_id.segment_id(d)) {
-        gsl::at(child_sizes, d) = Spectral::ChildSize::LowerHalf;
+        gsl::at(child_sizes, d) = Spectral::SegmentSize::LowerHalf;
       } else if (parent_id.segment_id(d).id_of_child(Side::Upper) ==
                  element_id.segment_id(d)) {
-        gsl::at(child_sizes, d) = Spectral::ChildSize::UpperHalf;
+        gsl::at(child_sizes, d) = Spectral::SegmentSize::UpperHalf;
       } else {
         ERROR("Parent element " << parent_id << " is not a parent of element "
                                 << element_id << ". Please report this bug.");

--- a/tests/Unit/Domain/Structure/Test_ChildSize.cpp
+++ b/tests/Unit/Domain/Structure/Test_ChildSize.cpp
@@ -5,24 +5,25 @@
 
 #include "Domain/Structure/ChildSize.hpp"
 #include "Domain/Structure/SegmentId.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 
 namespace domain {
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.ChildSize", "[Domain][Unit]") {
-  CHECK(child_size({0, 0}, {0, 0}) == Spectral::ChildSize::Full);
-  CHECK(child_size({1, 0}, {0, 0}) == Spectral::ChildSize::LowerHalf);
-  CHECK(child_size({1, 1}, {0, 0}) == Spectral::ChildSize::UpperHalf);
-  CHECK(child_size({1, 1}, {1, 1}) == Spectral::ChildSize::Full);
-  CHECK(child_size<1>({{{2, 3}}}, {{{1, 1}}}) ==
-        std::array<Spectral::ChildSize, 1>{{Spectral::ChildSize::UpperHalf}});
+SPECTRE_TEST_CASE("Unit.Domain.Structure.SegmentSize", "[Domain][Unit]") {
+  CHECK(child_size({0, 0}, {0, 0}) == Spectral::SegmentSize::Full);
+  CHECK(child_size({1, 0}, {0, 0}) == Spectral::SegmentSize::LowerHalf);
+  CHECK(child_size({1, 1}, {0, 0}) == Spectral::SegmentSize::UpperHalf);
+  CHECK(child_size({1, 1}, {1, 1}) == Spectral::SegmentSize::Full);
+  CHECK(
+      child_size<1>({{{2, 3}}}, {{{1, 1}}}) ==
+      std::array<Spectral::SegmentSize, 1>{{Spectral::SegmentSize::UpperHalf}});
   CHECK(child_size<2>({{{0, 0}, {1, 0}}}, {{{0, 0}, {0, 0}}}) ==
-        std::array<Spectral::ChildSize, 2>{
-            {Spectral::ChildSize::Full, Spectral::ChildSize::LowerHalf}});
+        std::array<Spectral::SegmentSize, 2>{
+            {Spectral::SegmentSize::Full, Spectral::SegmentSize::LowerHalf}});
   CHECK(child_size<3>({{{1, 1}, {1, 1}, {2, 2}}}, {{{0, 0}, {1, 1}, {1, 1}}}) ==
-        std::array<Spectral::ChildSize, 3>{{Spectral::ChildSize::UpperHalf,
-                                            Spectral::ChildSize::Full,
-                                            Spectral::ChildSize::LowerHalf}});
+        std::array<Spectral::SegmentSize, 3>{
+            {Spectral::SegmentSize::UpperHalf, Spectral::SegmentSize::Full,
+             Spectral::SegmentSize::LowerHalf}});
 
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH((child_size({1, 1}, {1, 0})),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -853,7 +853,7 @@ void test_impl(const Spectral::Quadrature quadrature,
         dg_formulation, 10);
 
     // Project the boundary terms from the mortar to the face
-    const std::array<Spectral::MortarSize, Dim - 1>& mortar_size =
+    const std::array<Spectral::SegmentSize, Dim - 1>& mortar_size =
         mortar_sizes.at(mortar_id);
     const Mesh<Dim - 1> face_mesh = mesh.slice_away(dimension);
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -33,8 +33,8 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Time/Slab.hpp"
@@ -112,7 +112,7 @@ void test_impl(
     const Element<Dim>& element, const TimeStepId& time_step_id,
     const TimeStepId& next_time_step_id, const Spectral::Quadrature quadrature,
     const ::dg::MortarMap<Dim, Mesh<Dim - 1>>& expected_mortar_meshes,
-    const ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>&
+    const ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
         expected_mortar_sizes,
     const DirectionMap<Dim, std::optional<Variables<tmpl::list<
                                 evolution::dg::Tags::MagnitudeOfNormal,
@@ -213,7 +213,7 @@ struct Test<1, LocalTimeStepping> {
                                                east_id};
     const ::dg::MortarMap<1, Mesh<0>> expected_mortar_meshes{
         {interface_mortar_id, {}}};
-    const ::dg::MortarMap<1, std::array<Spectral::MortarSize, 0>>
+    const ::dg::MortarMap<1, std::array<Spectral::SegmentSize, 0>>
         expected_mortar_sizes{{interface_mortar_id, {}}};
 
     const DirectionMap<
@@ -271,11 +271,11 @@ struct Test<2, LocalTimeStepping> {
          Mesh<1>(2, Spectral::Basis::Legendre, quadrature)},
         {interface_mortar_id_south,
          Mesh<1>(3, Spectral::Basis::Legendre, quadrature)}};
-    ::dg::MortarMap<2, std::array<Spectral::MortarSize, 1>>
+    ::dg::MortarMap<2, std::array<Spectral::SegmentSize, 1>>
         expected_mortar_sizes{};
     for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
       expected_mortar_sizes[mortar_id_and_mesh.first] = {
-          {Spectral::MortarSize::Full}};
+          {Spectral::SegmentSize::Full}};
     }
 
     const DirectionMap<
@@ -341,11 +341,11 @@ struct Test<3, LocalTimeStepping> {
          Mesh<2>({{2, 4}}, Spectral::Basis::Legendre, quadrature)},
         {interface_mortar_id_top,
          Mesh<2>({{2, 3}}, Spectral::Basis::Legendre, quadrature)}};
-    ::dg::MortarMap<3, std::array<Spectral::MortarSize, 2>>
+    ::dg::MortarMap<3, std::array<Spectral::SegmentSize, 2>>
         expected_mortar_sizes{};
     for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
       expected_mortar_sizes[mortar_id_and_mesh.first] = {
-          {Spectral::MortarSize::Full, Spectral::MortarSize::Full}};
+          {Spectral::SegmentSize::Full, Spectral::SegmentSize::Full}};
     }
 
     const DirectionMap<
@@ -400,7 +400,7 @@ template <size_t Dim, bool UsingLts>
 void test_p_refine(
     ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>& mortar_data,
     ::dg::MortarMap<Dim, Mesh<Dim - 1>>& mortar_mesh,
-    ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>&
+    ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
         mortar_size,
     ::dg::MortarMap<Dim, TimeStepId>& mortar_next_temporal_id,
     DirectionMap<Dim, std::optional<Variables<tmpl::list<
@@ -414,7 +414,7 @@ void test_p_refine(
     const ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>&
         expected_mortar_data,
     const ::dg::MortarMap<Dim, Mesh<Dim - 1>>& expected_mortar_mesh,
-    const ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>&
+    const ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
         expected_mortar_size,
     const ::dg::MortarMap<Dim, TimeStepId>& expected_mortar_next_temporal_id,
     const DirectionMap<Dim, std::optional<Variables<tmpl::list<
@@ -533,7 +533,8 @@ void test_p_refine_gts() {
 
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>> mortar_size{};
+  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
+      mortar_size{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
                                    evolution::dg::Tags::NormalCovector<Dim>>>>>
@@ -565,7 +566,7 @@ void test_p_refine_gts() {
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>
       expected_mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> expected_mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>
+  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
       expected_mortar_size{};
   ::dg::MortarMap<Dim, TimeStepId> expected_mortar_next_temporal_ids{};
   DirectionMap<Dim, std::optional<Variables<
@@ -653,7 +654,8 @@ void test_p_refine_lts() {
 
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>> mortar_size{};
+  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
+      mortar_size{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
                                    evolution::dg::Tags::NormalCovector<Dim>>>>>
@@ -700,7 +702,7 @@ void test_p_refine_lts() {
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>
       expected_mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> expected_mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::MortarSize, Dim - 1>>
+  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
       expected_mortar_size{};
   ::dg::MortarMap<Dim, TimeStepId> expected_mortar_next_temporal_ids{};
   DirectionMap<Dim, std::optional<Variables<

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
@@ -25,6 +25,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
@@ -50,22 +51,23 @@ void test_mortar_size() {
   CHECK(dg::mortar_size(ElementId<1>(0, {{{0, 0}}}),
                         ElementId<1>(0, {{{5, 2}}}), 0,
                         OrientationMap<1>::create_aligned()) ==
-        std::array<Spectral::MortarSize, 0>{});
+        std::array<Spectral::SegmentSize, 0>{});
 
   // Check the root segment to make sure the code doesn't try to get
   // its parent.
   CHECK(dg::mortar_size(ElementId<2>(0, {{{0, 0}, {0, 0}}}),
                         ElementId<2>(1, {{{0, 0}, {0, 0}}}), 1,
                         OrientationMap<2>::create_aligned()) ==
-        std::array<Spectral::MortarSize, 1>{{Spectral::MortarSize::Full}});
+        std::array<Spectral::SegmentSize, 1>{{Spectral::SegmentSize::Full}});
   CHECK(dg::mortar_size(ElementId<2>(0, {{{1, 0}, {0, 0}}}),
                         ElementId<2>(1, {{{0, 0}, {0, 0}}}), 1,
                         OrientationMap<2>::create_aligned()) ==
-        std::array<Spectral::MortarSize, 1>{{Spectral::MortarSize::Full}});
-  CHECK(dg::mortar_size(ElementId<2>(0, {{{0, 0}, {0, 0}}}),
-                        ElementId<2>(1, {{{1, 0}, {0, 0}}}), 1,
-                        OrientationMap<2>::create_aligned()) ==
-        std::array<Spectral::MortarSize, 1>{{Spectral::MortarSize::LowerHalf}});
+        std::array<Spectral::SegmentSize, 1>{{Spectral::SegmentSize::Full}});
+  CHECK(
+      dg::mortar_size(ElementId<2>(0, {{{0, 0}, {0, 0}}}),
+                      ElementId<2>(1, {{{1, 0}, {0, 0}}}), 1,
+                      OrientationMap<2>::create_aligned()) ==
+      std::array<Spectral::SegmentSize, 1>{{Spectral::SegmentSize::LowerHalf}});
 
   // Check all the aligned cases in 3D
   const auto test_segment = [](const SegmentId& base, const size_t test) {
@@ -86,11 +88,11 @@ void test_mortar_size() {
     switch (test) {
       case 0:
       case 1:
-        return Spectral::MortarSize::Full;
+        return Spectral::SegmentSize::Full;
       case 2:
-        return Spectral::MortarSize::LowerHalf;
+        return Spectral::SegmentSize::LowerHalf;
       case 3:
-        return Spectral::MortarSize::UpperHalf;
+        return Spectral::SegmentSize::UpperHalf;
       default:
         ERROR("Test logic error");
     }
@@ -117,7 +119,7 @@ void test_mortar_size() {
                                         test_segment(segment1, test1)}},
                               dimension, perp1));
         CAPTURE(neighbor);
-        const std::array<Spectral::MortarSize, 2> expected{
+        const std::array<Spectral::SegmentSize, 2> expected{
             {expected_size(test0), expected_size(test1)}};
         CHECK(dg::mortar_size(self, neighbor, dimension,
                               OrientationMap<3>::create_aligned()) == expected);
@@ -131,8 +133,8 @@ void test_mortar_size() {
                         OrientationMap<3>{{{Direction<3>::upper_eta(),
                                             Direction<3>::upper_zeta(),
                                             Direction<3>::lower_xi()}}}) ==
-        std::array<Spectral::MortarSize, 2>{
-            {Spectral::MortarSize::UpperHalf, Spectral::MortarSize::Full}});
+        std::array<Spectral::SegmentSize, 2>{
+            {Spectral::SegmentSize::UpperHalf, Spectral::SegmentSize::Full}});
 }
 
 struct Var : db::SimpleTag {
@@ -143,13 +145,13 @@ struct Var : db::SimpleTag {
 template <size_t Dim>
 tnsr::I<DataVector, Dim, Frame::ElementLogical> scaled_coords(
     tnsr::I<DataVector, Dim, Frame::ElementLogical> coords,
-    const std::array<Spectral::MortarSize, Dim>& mortar_size) {
+    const std::array<Spectral::SegmentSize, Dim>& mortar_size) {
   for (size_t d = 0; d < Dim; ++d) {
     switch (gsl::at(mortar_size, d)) {
-      case Spectral::MortarSize::LowerHalf:
+      case Spectral::SegmentSize::LowerHalf:
         coords.get(d) = 0.5 * (coords.get(d) - 1.);
         break;
-      case Spectral::MortarSize::UpperHalf:
+      case Spectral::SegmentSize::UpperHalf:
         coords.get(d) = 0.5 * (coords.get(d) + 1.);
         break;
       default:
@@ -173,9 +175,9 @@ DataVector basis6(const DataVector& coords) {
 }
 
 void test_projections() {
-  using Spectral::MortarSize;
-  const auto all_mortar_sizes = {MortarSize::Full, MortarSize::LowerHalf,
-                                 MortarSize::UpperHalf};
+  const auto all_mortar_sizes = {Spectral::SegmentSize::Full,
+                                 Spectral::SegmentSize::LowerHalf,
+                                 Spectral::SegmentSize::UpperHalf};
   // Check 0D
   {
     Variables<tmpl::list<Var>> vars(1);
@@ -195,7 +197,7 @@ void test_projections() {
       const auto face_coords = logical_coordinates(face_mesh);
       // face -> mortar
       for (const auto& slice_size : all_mortar_sizes) {
-        const std::array<MortarSize, 1> mortar_size{{slice_size}};
+        const std::array<Spectral::SegmentSize, 1> mortar_size{{slice_size}};
         CAPTURE(mortar_size);
         Variables<tmpl::list<Var>> vars(face_mesh.number_of_grid_points());
         get(get<Var>(vars)) = func(face_coords);
@@ -205,8 +207,8 @@ void test_projections() {
       }
 
       const auto make_mortar_data =
-          [&face_mesh, &func, &mortar_coords,
-           &mortar_mesh](const std::array<MortarSize, 1>& mortar_size) {
+          [&face_mesh, &func, &mortar_coords, &mortar_mesh](
+              const std::array<Spectral::SegmentSize, 1>& mortar_size) {
             Variables<tmpl::list<Var>> vars(
                 mortar_mesh.number_of_grid_points());
             get(get<Var>(vars)) =
@@ -222,7 +224,8 @@ void test_projections() {
 
       // full mortar -> face
       if (face_mesh != mortar_mesh) {
-        const std::array<MortarSize, 1> mortar_size{{MortarSize::Full}};
+        const std::array<Spectral::SegmentSize, 1> mortar_size{
+            {Spectral::SegmentSize::Full}};
         CAPTURE(mortar_size);
         const auto vars = make_mortar_data(mortar_size);
         CHECK_ITERABLE_APPROX(get(get<Var>(dg::project_from_mortar(
@@ -231,15 +234,17 @@ void test_projections() {
       }
       // half mortar -> face
       {
-        const auto vars_lo = make_mortar_data({{MortarSize::LowerHalf}});
-        const auto vars_hi = make_mortar_data({{MortarSize::UpperHalf}});
-        CHECK_ITERABLE_APPROX(
-            get(get<Var>(dg::project_from_mortar(
-                vars_lo, face_mesh, mortar_mesh, {{MortarSize::LowerHalf}}))) +
-                get(get<Var>(
-                    dg::project_from_mortar(vars_hi, face_mesh, mortar_mesh,
-                                            {{MortarSize::UpperHalf}}))),
-            func(face_coords));
+        const auto vars_lo =
+            make_mortar_data({{Spectral::SegmentSize::LowerHalf}});
+        const auto vars_hi =
+            make_mortar_data({{Spectral::SegmentSize::UpperHalf}});
+        CHECK_ITERABLE_APPROX(get(get<Var>(dg::project_from_mortar(
+                                  vars_lo, face_mesh, mortar_mesh,
+                                  {{Spectral::SegmentSize::LowerHalf}}))) +
+                                  get(get<Var>(dg::project_from_mortar(
+                                      vars_hi, face_mesh, mortar_mesh,
+                                      {{Spectral::SegmentSize::UpperHalf}}))),
+                              func(face_coords));
       }
     }
   }
@@ -260,7 +265,7 @@ void test_projections() {
       // face -> mortar
       for (const auto& slice_size0 : all_mortar_sizes) {
         for (const auto& slice_size1 : all_mortar_sizes) {
-          const std::array<MortarSize, 2> mortar_size{
+          const std::array<Spectral::SegmentSize, 2> mortar_size{
               {slice_size0, slice_size1}};
           CAPTURE(mortar_size);
           Variables<tmpl::list<Var>> vars(face_mesh.number_of_grid_points());
@@ -273,8 +278,8 @@ void test_projections() {
       }
 
       const auto make_mortar_data =
-          [&face_mesh, &func, &mortar_coords,
-           &mortar_mesh](const std::array<MortarSize, 2>& mortar_size) {
+          [&face_mesh, &func, &mortar_coords, &mortar_mesh](
+              const std::array<Spectral::SegmentSize, 2>& mortar_size) {
             Variables<tmpl::list<Var>> vars(
                 mortar_mesh.number_of_grid_points());
             get(get<Var>(vars)) =
@@ -293,8 +298,8 @@ void test_projections() {
 
       // full mortar -> face
       if (face_mesh != mortar_mesh) {
-        const std::array<MortarSize, 2> mortar_size{
-            {MortarSize::Full, MortarSize::Full}};
+        const std::array<Spectral::SegmentSize, 2> mortar_size{
+            {Spectral::SegmentSize::Full, Spectral::SegmentSize::Full}};
         const auto vars = make_mortar_data(mortar_size);
         CHECK_ITERABLE_APPROX(get(get<Var>(dg::project_from_mortar(
                                   vars, face_mesh, mortar_mesh, mortar_size))),
@@ -304,18 +309,19 @@ void test_projections() {
       // mortar -> face from a mortar long in one direction and short
       // in the other
       {
-        const auto vars_lo =
-            make_mortar_data({{MortarSize::Full, MortarSize::LowerHalf}});
-        const auto vars_hi =
-            make_mortar_data({{MortarSize::Full, MortarSize::UpperHalf}});
-        CHECK_ITERABLE_APPROX(
-            get(get<Var>(dg::project_from_mortar(
-                vars_lo, face_mesh, mortar_mesh,
-                {{MortarSize::Full, MortarSize::LowerHalf}}))) +
-                get(get<Var>(dg::project_from_mortar(
-                    vars_hi, face_mesh, mortar_mesh,
-                    {{MortarSize::Full, MortarSize::UpperHalf}}))),
-            func(face_coords));
+        const auto vars_lo = make_mortar_data(
+            {{Spectral::SegmentSize::Full, Spectral::SegmentSize::LowerHalf}});
+        const auto vars_hi = make_mortar_data(
+            {{Spectral::SegmentSize::Full, Spectral::SegmentSize::UpperHalf}});
+        CHECK_ITERABLE_APPROX(get(get<Var>(dg::project_from_mortar(
+                                  vars_lo, face_mesh, mortar_mesh,
+                                  {{Spectral::SegmentSize::Full,
+                                    Spectral::SegmentSize::LowerHalf}}))) +
+                                  get(get<Var>(dg::project_from_mortar(
+                                      vars_hi, face_mesh, mortar_mesh,
+                                      {{Spectral::SegmentSize::Full,
+                                        Spectral::SegmentSize::UpperHalf}}))),
+                              func(face_coords));
       }
     }
   }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
@@ -16,8 +16,8 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 
 namespace {
 
@@ -49,8 +49,8 @@ SPECTRE_TEST_CASE("Unit.DG.SimpleBoundaryData", "[Unit][NumericalAlgorithms]") {
                           Spectral::Quadrature::GaussLobatto};
   const Mesh<1> mortar_mesh{num_points + 1, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto};
-  const std::array<Spectral::MortarSize, 1> mortar_size{
-      {Spectral::MortarSize::UpperHalf}};
+  const std::array<Spectral::SegmentSize, 1> mortar_size{
+      {Spectral::SegmentSize::UpperHalf}};
   const auto projected_data =
       data.project_to_mortar(face_mesh, mortar_mesh, mortar_size);
   CHECK(projected_data.field_data ==

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_LogicalCoordinates.cpp
   Test_Mesh.cpp
   Test_Projection.cpp
+  Test_SegmentSize.cpp
   Test_Spectral.cpp
   )
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -14,6 +14,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -37,9 +38,9 @@ DataVector apply_matrix(const Matrix& m, const DataVector& v) {
 }
 
 void test_mortar_size() {
-  CHECK(get_output(Spectral::MortarSize::Full) == "Full");
-  CHECK(get_output(Spectral::MortarSize::UpperHalf) == "UpperHalf");
-  CHECK(get_output(Spectral::MortarSize::LowerHalf) == "LowerHalf");
+  CHECK(get_output(Spectral::SegmentSize::Full) == "Full");
+  CHECK(get_output(Spectral::SegmentSize::UpperHalf) == "UpperHalf");
+  CHECK(get_output(Spectral::SegmentSize::LowerHalf) == "LowerHalf");
 }
 
 void test_needs_projection() {
@@ -48,31 +49,31 @@ void test_needs_projection() {
   CHECK_FALSE(
       needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
                           {3, Basis::Legendre, Quadrature::GaussLobatto},
-                          make_array<1>(ChildSize::Full)));
+                          make_array<1>(SegmentSize::Full)));
   CHECK_FALSE(
       needs_projection<2>({3, Basis::Legendre, Quadrature::GaussLobatto},
                           {3, Basis::Legendre, Quadrature::GaussLobatto},
-                          make_array<2>(ChildSize::Full)));
+                          make_array<2>(SegmentSize::Full)));
   CHECK_FALSE(
       needs_projection<3>({3, Basis::Legendre, Quadrature::GaussLobatto},
                           {3, Basis::Legendre, Quadrature::GaussLobatto},
-                          make_array<3>(ChildSize::Full)));
+                          make_array<3>(SegmentSize::Full)));
   CHECK(needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
                             {4, Basis::Legendre, Quadrature::GaussLobatto},
-                            make_array<1>(ChildSize::Full)));
+                            make_array<1>(SegmentSize::Full)));
   CHECK(needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
                             {3, Basis::Legendre, Quadrature::Gauss},
-                            make_array<1>(ChildSize::Full)));
+                            make_array<1>(SegmentSize::Full)));
   CHECK(needs_projection<1>({3, Basis::Legendre, Quadrature::GaussLobatto},
                             {3, Basis::Legendre, Quadrature::GaussLobatto},
-                            {{ChildSize::LowerHalf}}));
+                            {{SegmentSize::LowerHalf}}));
   CHECK(needs_projection<2>({3, Basis::Legendre, Quadrature::GaussLobatto},
                             {3, Basis::Legendre, Quadrature::GaussLobatto},
-                            {{ChildSize::Full, ChildSize::LowerHalf}}));
+                            {{SegmentSize::Full, SegmentSize::LowerHalf}}));
   CHECK(needs_projection<3>(
       {3, Basis::Legendre, Quadrature::GaussLobatto},
       {3, Basis::Legendre, Quadrature::GaussLobatto},
-      {{ChildSize::Full, ChildSize::Full, ChildSize::UpperHalf}}));
+      {{SegmentSize::Full, SegmentSize::Full, SegmentSize::UpperHalf}}));
 }
 
 void test_p_mortar_to_element() {
@@ -80,7 +81,7 @@ void test_p_mortar_to_element() {
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
-             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
@@ -88,16 +89,15 @@ void test_p_mortar_to_element() {
       for (const auto& quadrature_source : quadratures) {
         for (size_t num_points_source = num_points_dest;
              num_points_source <=
-                 Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
              ++num_points_source) {
           const Mesh<1> mesh_source(
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
           CAPTURE(mesh_source);
           const auto& points_source = Spectral::collocation_points(mesh_source);
           const auto& projection = projection_matrix_child_to_parent(
-              mesh_source, mesh_dest, Spectral::MortarSize::Full);
-          for (size_t test_order = 0;
-               test_order < num_points_source;
+              mesh_source, mesh_dest, Spectral::SegmentSize::Full);
+          for (size_t test_order = 0; test_order < num_points_source;
                ++test_order) {
             CAPTURE(test_order);
             const DataVector source_data = pow(points_source, test_order);
@@ -134,24 +134,22 @@ void test_p_element_to_mortar() {
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
-             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
       CAPTURE(mesh_dest);
       const auto& points_dest = Spectral::collocation_points(mesh_dest);
       for (const auto& quadrature_source : quadratures) {
-        for (size_t num_points_source = 2;
-             num_points_source <= num_points_dest;
+        for (size_t num_points_source = 2; num_points_source <= num_points_dest;
              ++num_points_source) {
           const Mesh<1> mesh_source(
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
           CAPTURE(mesh_source);
           const auto& points_source = Spectral::collocation_points(mesh_source);
           const auto& projection = projection_matrix_parent_to_child(
-              mesh_source, mesh_dest, Spectral::MortarSize::Full);
-          for (size_t test_order = 0;
-               test_order < num_points_source;
+              mesh_source, mesh_dest, Spectral::SegmentSize::Full);
+          for (size_t test_order = 0; test_order < num_points_source;
                ++test_order) {
             CAPTURE(test_order);
             const DataVector source_data = pow(points_source, test_order);
@@ -175,7 +173,7 @@ DataVector to_lower_half(const DataVector& p) { return 0.5 * (p - 1.); }
 // [-1,1] interval to the half that we are (are not) interpolating
 // from.
 template <typename F1, typename F2>
-void check_mortar_to_element_projection(const Spectral::MortarSize mortar_size,
+void check_mortar_to_element_projection(const Spectral::SegmentSize mortar_size,
                                         const Mesh<1>& mesh_element,
                                         const Mesh<1>& mesh_self_mortar,
                                         F1&& to_element_self,
@@ -194,8 +192,7 @@ void check_mortar_to_element_projection(const Spectral::MortarSize mortar_size,
   const auto& points_self_mortar =
       Spectral::collocation_points(mesh_self_mortar);
 
-  for (size_t test_order = 0;
-       test_order < num_points_self_mortar;
+  for (size_t test_order = 0; test_order < num_points_self_mortar;
        ++test_order) {
     CAPTURE(test_order);
     const auto test_func_self_mortar = [test_order](const auto& x) {
@@ -266,7 +263,7 @@ void test_h_mortar_to_element() {
     for (size_t num_points_dest = 2;
          // We need one extra point to do the quadrature later.
          num_points_dest <=
-             Spectral::maximum_number_of_points<Spectral::Basis::Legendre> - 1;
+         Spectral::maximum_number_of_points<Spectral::Basis::Legendre> - 1;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
@@ -274,16 +271,15 @@ void test_h_mortar_to_element() {
       for (const auto& quadrature_source : quadratures) {
         for (size_t num_points_source = num_points_dest;
              num_points_source <=
-                 Spectral::maximum_number_of_points<Spectral::Basis::Legendre> -
-                 1;
+             Spectral::maximum_number_of_points<Spectral::Basis::Legendre> - 1;
              ++num_points_source) {
           const Mesh<1> mesh_source(
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
           CAPTURE(mesh_source);
-          check_mortar_to_element_projection(Spectral::MortarSize::UpperHalf,
+          check_mortar_to_element_projection(Spectral::SegmentSize::UpperHalf,
                                              mesh_dest, mesh_source,
                                              to_upper_half, to_lower_half);
-          check_mortar_to_element_projection(Spectral::MortarSize::LowerHalf,
+          check_mortar_to_element_projection(Spectral::SegmentSize::LowerHalf,
                                              mesh_dest, mesh_source,
                                              to_lower_half, to_upper_half);
         }
@@ -297,22 +293,20 @@ void test_h_element_to_mortar() {
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
-             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
       CAPTURE(mesh_dest);
       const auto& points_dest = Spectral::collocation_points(mesh_dest);
       for (const auto& quadrature_source : quadratures) {
-        for (size_t num_points_source = 2;
-             num_points_source <= num_points_dest;
+        for (size_t num_points_source = 2; num_points_source <= num_points_dest;
              ++num_points_source) {
           const Mesh<1> mesh_source(
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
           CAPTURE(mesh_source);
           const auto& points_source = Spectral::collocation_points(mesh_source);
-          for (size_t test_order = 0;
-               test_order < num_points_source;
+          for (size_t test_order = 0; test_order < num_points_source;
                ++test_order) {
             CAPTURE(test_order);
             const DataVector source_data = pow(points_source, test_order);
@@ -321,7 +315,7 @@ void test_h_element_to_mortar() {
             // projection should not alter it.
             {
               const auto& projection = projection_matrix_parent_to_child(
-                  mesh_source, mesh_dest, Spectral::MortarSize::UpperHalf);
+                  mesh_source, mesh_dest, Spectral::SegmentSize::UpperHalf);
               const DataVector projected_data =
                   apply_matrix(projection, source_data);
               CHECK_ITERABLE_APPROX(
@@ -329,7 +323,7 @@ void test_h_element_to_mortar() {
             }
             {
               const auto& projection = projection_matrix_parent_to_child(
-                  mesh_source, mesh_dest, Spectral::MortarSize::LowerHalf);
+                  mesh_source, mesh_dest, Spectral::SegmentSize::LowerHalf);
               const DataVector projected_data =
                   apply_matrix(projection, source_data);
               CHECK_ITERABLE_APPROX(
@@ -359,8 +353,8 @@ void test_massive_restriction(const size_t parent_num_points,
                            Spectral::Quadrature::Gauss};
   const auto& x_child = Spectral::collocation_points(child_mesh);
   DataVector child_data = square(x_child) + x_child + 1.;
-  for (const ChildSize child_size :
-       {ChildSize::Full, ChildSize::LowerHalf, ChildSize::UpperHalf}) {
+  for (const SegmentSize child_size :
+       {SegmentSize::Full, SegmentSize::LowerHalf, SegmentSize::UpperHalf}) {
     CAPTURE(child_size);
     // Check R = M_coarse^-1 * I^T * M_fine and R_massive = I^T
     // => M_coarse * R * f = R_massive * M_fine * f
@@ -372,7 +366,7 @@ void test_massive_restriction(const size_t parent_num_points,
     ::dg::apply_mass_matrix(make_not_null(&lhs), parent_mesh);
     // (ii) Compute r.h.s.
     auto massive_child_data = child_data;
-    if (child_size != ChildSize::Full) {
+    if (child_size != SegmentSize::Full) {
       // This is the Jacobian from logical to inertial coordinates (we take the
       // parent logical coordinates as inertial so don't have to apply a
       // Jacobian above). The `apply_mass_matrix` function requires
@@ -411,9 +405,9 @@ void test_exact_restriction() {
 
   // Restrict function values
   const auto& restriction_operator_left = projection_matrix_child_to_parent(
-      child_mesh, parent_mesh, ChildSize::LowerHalf);
+      child_mesh, parent_mesh, SegmentSize::LowerHalf);
   const auto& restriction_operator_right = projection_matrix_child_to_parent(
-      child_mesh, parent_mesh, ChildSize::UpperHalf);
+      child_mesh, parent_mesh, SegmentSize::UpperHalf);
   auto restricted_data =
       apply_matrix(restriction_operator_left, child_data_left);
   restricted_data += apply_matrix(restriction_operator_right, child_data_right);
@@ -431,10 +425,10 @@ void test_exact_restriction() {
   ::dg::apply_mass_matrix(make_not_null(&child_data_right), child_mesh);
   const auto& restriction_operator_left_massive =
       projection_matrix_child_to_parent(child_mesh, parent_mesh,
-                                        ChildSize::LowerHalf, true);
+                                        SegmentSize::LowerHalf, true);
   const auto& restriction_operator_right_massive =
       projection_matrix_child_to_parent(child_mesh, parent_mesh,
-                                        ChildSize::UpperHalf, true);
+                                        SegmentSize::UpperHalf, true);
   restricted_data =
       apply_matrix(restriction_operator_left_massive, child_data_left);
   restricted_data +=
@@ -456,12 +450,12 @@ void test_higher_dimensions() {
     const auto restriction_identity =
         Spectral::projection_matrix_child_to_parent(
             {3, basis, quadrature}, {3, basis, quadrature},
-            make_array<Dim>(Spectral::ChildSize::Full));
+            make_array<Dim>(Spectral::SegmentSize::Full));
     const auto prolongation_identity =
         Spectral::projection_matrix_parent_to_child(
             {3, basis, quadrature}, {3, basis, quadrature},
-            make_array<Dim>(Spectral::ChildSize::Full));
-    for (size_t d = 0; d < Dim;++d) {
+            make_array<Dim>(Spectral::SegmentSize::Full));
+    for (size_t d = 0; d < Dim; ++d) {
       CHECK(gsl::at(restriction_identity, d).get() == Matrix{});
       CHECK(gsl::at(prolongation_identity, d).get() == Matrix{});
     }
@@ -470,9 +464,9 @@ void test_higher_dimensions() {
     const size_t parent_extents = 3;
     std::array<size_t, Dim> child_extents{};
     std::iota(child_extents.begin(), child_extents.end(), size_t{3});
-    auto child_sizes = make_array<Dim>(Spectral::ChildSize::Full);
+    auto child_sizes = make_array<Dim>(Spectral::SegmentSize::Full);
     if constexpr (Dim > 1) {
-      child_sizes[1] = Spectral::ChildSize::UpperHalf;
+      child_sizes[1] = Spectral::SegmentSize::UpperHalf;
     }
     const auto projection_matrix = Spectral::projection_matrix_child_to_parent(
         {child_extents, basis, quadrature}, {parent_extents, basis, quadrature},
@@ -482,13 +476,13 @@ void test_higher_dimensions() {
       CHECK(&projection_matrix[1].get() ==
             &Spectral::projection_matrix_child_to_parent(
                 {4, basis, quadrature}, {3, basis, quadrature},
-                Spectral::ChildSize::UpperHalf));
+                Spectral::SegmentSize::UpperHalf));
     }
     if constexpr (Dim > 2) {
       CHECK(&projection_matrix[2].get() ==
             &Spectral::projection_matrix_child_to_parent(
                 {5, basis, quadrature}, {3, basis, quadrature},
-                Spectral::ChildSize::Full));
+                Spectral::SegmentSize::Full));
     }
   }
 }
@@ -520,7 +514,7 @@ void test_p_projection_matrices() {
     CHECK(&projection_matrix[0].get() ==
           &Spectral::projection_matrix_child_to_parent(
               {4, basis, quadrature}, {3, basis, quadrature},
-              Spectral::ChildSize::Full));
+              Spectral::SegmentSize::Full));
     if constexpr (Dim > 1) {
       CHECK(projection_matrix[1].get() == Matrix{});
     }
@@ -528,7 +522,7 @@ void test_p_projection_matrices() {
       CHECK(&projection_matrix[2].get() ==
             &Spectral::projection_matrix_parent_to_child(
                 {4, basis, quadrature}, {5, basis, quadrature},
-                Spectral::ChildSize::Full));
+                Spectral::SegmentSize::Full));
     }
   }
 }
@@ -536,30 +530,30 @@ void test_p_projection_matrices() {
 void test_hash() {
   CHECK(Spectral::MortarSizeHash<1>{}({}) == 0);
 
-  CHECK(Spectral::MortarSizeHash<2>{}({Spectral::ChildSize::LowerHalf}) == 0);
-  CHECK(Spectral::MortarSizeHash<2>{}({Spectral::ChildSize::Full}) == 0);
-  CHECK(Spectral::MortarSizeHash<2>{}({Spectral::ChildSize::UpperHalf}) == 1);
+  CHECK(Spectral::MortarSizeHash<2>{}({Spectral::SegmentSize::LowerHalf}) == 0);
+  CHECK(Spectral::MortarSizeHash<2>{}({Spectral::SegmentSize::Full}) == 0);
+  CHECK(Spectral::MortarSizeHash<2>{}({Spectral::SegmentSize::UpperHalf}) == 1);
 
-  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::ChildSize::LowerHalf,
-                                       Spectral::ChildSize::LowerHalf}) == 0);
-  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::ChildSize::UpperHalf,
-                                       Spectral::ChildSize::LowerHalf}) == 1);
-  CHECK(Spectral::MortarSizeHash<3>{}(
-            {Spectral::ChildSize::Full, Spectral::ChildSize::LowerHalf}) == 0);
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::LowerHalf,
+                                       Spectral::SegmentSize::LowerHalf}) == 0);
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::UpperHalf,
+                                       Spectral::SegmentSize::LowerHalf}) == 1);
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::Full,
+                                       Spectral::SegmentSize::LowerHalf}) == 0);
 
-  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::ChildSize::LowerHalf,
-                                       Spectral::ChildSize::UpperHalf}) == 2);
-  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::ChildSize::UpperHalf,
-                                       Spectral::ChildSize::UpperHalf}) == 3);
-  CHECK(Spectral::MortarSizeHash<3>{}(
-            {Spectral::ChildSize::Full, Spectral::ChildSize::UpperHalf}) == 2);
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::LowerHalf,
+                                       Spectral::SegmentSize::UpperHalf}) == 2);
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::UpperHalf,
+                                       Spectral::SegmentSize::UpperHalf}) == 3);
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::Full,
+                                       Spectral::SegmentSize::UpperHalf}) == 2);
 
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::LowerHalf,
+                                       Spectral::SegmentSize::Full}) == 0);
+  CHECK(Spectral::MortarSizeHash<3>{}({Spectral::SegmentSize::UpperHalf,
+                                       Spectral::SegmentSize::Full}) == 1);
   CHECK(Spectral::MortarSizeHash<3>{}(
-            {Spectral::ChildSize::LowerHalf, Spectral::ChildSize::Full}) == 0);
-  CHECK(Spectral::MortarSizeHash<3>{}(
-            {Spectral::ChildSize::UpperHalf, Spectral::ChildSize::Full}) == 1);
-  CHECK(Spectral::MortarSizeHash<3>{}(
-            {Spectral::ChildSize::Full, Spectral::ChildSize::Full}) == 0);
+            {Spectral::SegmentSize::Full, Spectral::SegmentSize::Full}) == 0);
 }
 }  // namespace
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SegmentSize.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SegmentSize.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Spectral.SegmentSize", "[NumericalAlgorithms][Unit]") {
+  CHECK(get_output(Spectral::SegmentSize::Uninitialized) == "Uninitialized");
+  CHECK(get_output(Spectral::SegmentSize::Full) == "Full");
+  CHECK(get_output(Spectral::SegmentSize::UpperHalf) == "UpperHalf");
+  CHECK(get_output(Spectral::SegmentSize::LowerHalf) == "LowerHalf");
+}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
@@ -24,6 +24,7 @@
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
@@ -183,11 +184,11 @@ SPECTRE_TEST_CASE("Unit.ParallelMultigrid.Action.RestrictFields",
     const DataVector coarse_data =
         apply_matrices(
             make_array<1>(Spectral::projection_matrix_child_to_parent(
-                fine_mesh, coarse_mesh, Spectral::ChildSize::LowerHalf)),
+                fine_mesh, coarse_mesh, Spectral::SegmentSize::LowerHalf)),
             fine_data_left, Index<1>{4}) +
         apply_matrices(
             make_array<1>(Spectral::projection_matrix_child_to_parent(
-                fine_mesh, coarse_mesh, Spectral::ChildSize::UpperHalf)),
+                fine_mesh, coarse_mesh, Spectral::SegmentSize::UpperHalf)),
             fine_data_right, Index<1>{4});
     test_restrict_fields<void>(fine_mesh, coarse_mesh, fine_data_left,
                                fine_data_right, coarse_data);
@@ -198,11 +199,13 @@ SPECTRE_TEST_CASE("Unit.ParallelMultigrid.Action.RestrictFields",
     const DataVector coarse_data =
         apply_matrices(
             make_array<1>(Spectral::projection_matrix_child_to_parent(
-                fine_mesh, coarse_mesh, Spectral::ChildSize::LowerHalf, true)),
+                fine_mesh, coarse_mesh, Spectral::SegmentSize::LowerHalf,
+                true)),
             fine_data_left, Index<1>{4}) +
         apply_matrices(
             make_array<1>(Spectral::projection_matrix_child_to_parent(
-                fine_mesh, coarse_mesh, Spectral::ChildSize::UpperHalf, true)),
+                fine_mesh, coarse_mesh, Spectral::SegmentSize::UpperHalf,
+                true)),
             fine_data_right, Index<1>{4});
     test_restrict_fields<MassiveTag>(fine_mesh, coarse_mesh, fine_data_left,
                                      fine_data_right, coarse_data, true);


### PR DESCRIPTION
- Factor out enum ChildSize from src/NumericalAlgorithms/Spectral/Projection.hpp
- Rename it to SegmentSize as it a more appropriate name for its two common use cases
- Remove type alias MortarSize as type aliases for enums are annoying.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
