### PR TITLE
Improve documentation and fix Lorentz factor–velocity inconsistency in PrimitiveRecovery.cpp

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -256,19 +256,27 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
 
     if (primitive_data.has_value()) {
       get(*rest_mass_density)[s] = primitive_data.value().rest_mass_density;
-      const double coefficient_of_b =
-          get(momentum_density_dot_magnetic_field)[s] /
-          (primitive_data.value().rho_h_w_squared *
-           (primitive_data.value().rho_h_w_squared +
-            get(magnetic_field_squared)[s]));
-      const double coefficient_of_s =
-          1.0 / (get(sqrt_det_spatial_metric)[s] *
-                 (primitive_data.value().rho_h_w_squared +
-                  get(magnetic_field_squared)[s]));
-      for (size_t i = 0; i < 3; ++i) {
-        spatial_velocity->get(i)[s] =
-            coefficient_of_b * magnetic_field->get(i)[s] +
-            coefficient_of_s * tilde_s_upper.get(i)[s];
+      // if we set the Lorentz factor to 1.0 in atmosphere, then
+      // we also need to set the spatial_velocity accordingly.
+      if (primitive_data.value().lorentz_factor == 1.0) {
+        for (size_t i = 0; i < 3; ++i) {
+          spatial_velocity->get(i)[s] = 0.0;
+        }
+      } else {
+        const double coefficient_of_b =
+            get(momentum_density_dot_magnetic_field)[s] /
+            (primitive_data.value().rho_h_w_squared *
+             (primitive_data.value().rho_h_w_squared +
+              get(magnetic_field_squared)[s]));
+        const double coefficient_of_s =
+            1.0 / (get(sqrt_det_spatial_metric)[s] *
+                   (primitive_data.value().rho_h_w_squared +
+                    get(magnetic_field_squared)[s]));
+        for (size_t i = 0; i < 3; ++i) {
+          spatial_velocity->get(i)[s] =
+              coefficient_of_b * magnetic_field->get(i)[s] +
+              coefficient_of_s * tilde_s_upper.get(i)[s];
+        }
       }
       get(*lorentz_factor)[s] = primitive_data.value().lorentz_factor;
       get(*pressure)[s] = primitive_data.value().pressure;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -41,6 +41,33 @@ namespace ValenciaDivClean {
  * If `EnforcePhysicality` is `false` then the hydrodynamic inversion will
  * return with an error if the input conservatives are unphysical, i.e., if no
  * solution exits. The exact behavior is governed by `ErrorOnFailure`.
+ *
+ * \note
+ * Here, we outline the algebra for computing the spatial velocity
+ * \f$ v^i \f$:
+ *
+ * We start from definition of the momentum density \f$ S_i \f$:
+ * \f[
+ * \begin{aligned}
+ * S_i &= (\rho h)^* W^2 v_i - \alpha b^0 b_i \\
+ *     &= \left(\rho h + \frac{B^2}{W^2} + (v \cdot B)^2\right) W^2 v_i
+ *        - \alpha \left(\frac{W}{\alpha}(v \cdot B)\right)
+ *        \left(\frac{B_i}{W} + (v \cdot B) W v_i\right) \\
+ *     &= \left(\rho h + \frac{B^2}{W^2}\right) W^2 v_i - (v \cdot B) B_i
+ * \end{aligned}
+ * \f]
+ *
+ * From the above, we obtain:
+ * \f[
+ * \begin{aligned}
+ * S^i &= \left(\rho h + \frac{B^2}{W^2}\right) W^2 v^i - (v \cdot B) B^i \\
+ * S \cdot B &= \left(\rho h + \frac{B^2}{W^2}\right) W^2 (v \cdot B)
+ *              - (v \cdot B) B^2 \\
+ *          &= \rho h W^2 (v \cdot B) \\
+ * v^i &= \frac{1}{\sqrt{\gamma} (\rho h W^2 + B^2)} \tilde{S}^i
+ *       + \frac{S \cdot B}{\rho h W^2 (\rho h W^2 + B^2)} B^i
+ * \end{aligned}
+ * \f]
  */
 template <typename OrderedListOfPrimitiveRecoverySchemes,
           bool ErrorOnFailure = true>


### PR DESCRIPTION
## Proposed changes

1. Add documentation detailing the algebra for recovering spatial velocity from the conserved variables and the PrimitiveRecoveryData returned by the recovery schemes.
2. Fix a bug where, for D < D_cutoff, the Lorentz factor is set to 1.0 but the velocity is not reset to zero, leading to inconsistency.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
