### PR TITLE
Generalize neighbors for nonconforming blocks

### DIFF
--- a/src/Domain/Amr/NeighborsOfChild.cpp
+++ b/src/Domain/Amr/NeighborsOfChild.cpp
@@ -65,7 +65,8 @@ neighbors_of_child(
 
       result.first.emplace(
           direction,
-          Neighbors<VolumeDim>{new_neighbor_ids, old_neighbors.orientation()});
+          Neighbors<VolumeDim>{new_neighbor_ids, old_neighbors.orientations(),
+                               old_neighbors.are_conforming()});
     }
   }
 

--- a/src/Domain/Amr/NeighborsOfParent.cpp
+++ b/src/Domain/Amr/NeighborsOfParent.cpp
@@ -67,7 +67,8 @@ neighbors_of_parent(
       if (0 == result.first.count(direction)) {
         result.first.emplace(
             direction, Neighbors<VolumeDim>{new_neighbor_ids,
-                                            child_neighbors.orientation()});
+                                            child_neighbors.orientations(),
+                                            child_neighbors.are_conforming()});
       } else {
         result.first.at(direction).add_ids(new_neighbor_ids);
       }

--- a/src/Domain/Amr/NewNeighborIds.cpp
+++ b/src/Domain/Amr/NewNeighborIds.cpp
@@ -48,15 +48,15 @@ std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>> new_neighbor_ids(
   std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>>
       new_neighbors_in_direction;
 
-  const OrientationMap<VolumeDim>& orientation_map_from_me_to_neighbors =
-      previous_neighbors_in_direction.orientation();
-  const Direction<VolumeDim> direction_to_me_in_neighbor_frame =
-      orientation_map_from_me_to_neighbors(direction.opposite());
-
   // Only one neighbor in 1D in a given direction
   if constexpr (VolumeDim == 1) {
     const ElementId<1>& previous_neighbor_id =
         *(previous_neighbors_in_direction.ids().begin());
+    const OrientationMap<VolumeDim>& orientation_map_from_me_to_neighbors =
+        previous_neighbors_in_direction.orientation(previous_neighbor_id);
+    const Direction<VolumeDim> direction_to_me_in_neighbor_frame =
+        orientation_map_from_me_to_neighbors(direction.opposite());
+
     const amr::Flag neighbor_flag =
         previous_neighbors_amr_info.at(previous_neighbor_id).flags[0];
     SegmentId previous_segment_id = previous_neighbor_id.segment_ids()[0];
@@ -74,13 +74,17 @@ std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>> new_neighbor_ids(
     return new_neighbors_in_direction;
   }
 
-  const size_t dim_of_direction_to_me_in_neighbor_frame =
-      direction_to_me_in_neighbor_frame.dimension();
-  const std::array<SegmentId, VolumeDim> my_segment_ids_in_neighbor_frame =
-      orientation_map_from_me_to_neighbors(my_id.segment_ids());
-
   for (const auto& previous_neighbor_id :
        previous_neighbors_in_direction.ids()) {
+    const OrientationMap<VolumeDim>& orientation_map_from_me_to_neighbors =
+        previous_neighbors_in_direction.orientation(previous_neighbor_id);
+    const Direction<VolumeDim> direction_to_me_in_neighbor_frame =
+        orientation_map_from_me_to_neighbors(direction.opposite());
+    const size_t dim_of_direction_to_me_in_neighbor_frame =
+        direction_to_me_in_neighbor_frame.dimension();
+    const std::array<SegmentId, VolumeDim> my_segment_ids_in_neighbor_frame =
+        orientation_map_from_me_to_neighbors(my_id.segment_ids());
+
     // a neighbor_segment_id is valid if it touches me in the normal direction
     // (which is in dim_of_direction_to_me_in_neighbor_frame) or overlaps with
     // me in the transverse directions

--- a/src/Domain/Amr/UpdateAmrDecision.cpp
+++ b/src/Domain/Amr/UpdateAmrDecision.cpp
@@ -40,7 +40,7 @@ bool update_amr_decision(
       const Direction<VolumeDim> direction_to_neighbor =
           direction_neighbors.first;
       const OrientationMap<VolumeDim>& orientation_of_neighbor =
-          neighbors_in_dir.orientation();
+          neighbors_in_dir.orientation(neighbor_id);
       const std::array<size_t, VolumeDim> neighbor_desired_levels =
           desired_refinement_levels_of_neighbor(
               neighbor_id, neighbor_amr_flags, orientation_of_neighbor);

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -116,13 +116,16 @@ Element<VolumeDim> create_initial_element(
        &segment_ids, grid_index = element_id.grid_index()](
           const Direction<VolumeDim>& direction) {
         const auto& block_neighbors = neighbors_of_block.at(direction);
-        const auto& orientation = block_neighbors.orientation();
-        const auto direction_from_neighbor = orientation(direction).opposite();
         Neighbors<VolumeDim> element_neighbors{
-            std::unordered_set<ElementId<VolumeDim>>{}, orientation};
+            std::unordered_set<ElementId<VolumeDim>>{},
+            block_neighbors.orientations(), block_neighbors.are_conforming()};
 
         if (block_neighbors.size() == 1) {
           const size_t neighbor_block_id = *(block_neighbors.begin());
+          const auto& orientation =
+              block_neighbors.orientation(neighbor_block_id);
+          const auto direction_from_neighbor =
+              orientation(direction).opposite();
           std::array<std::vector<SegmentId>, VolumeDim> valid_segment_ids;
           if (neighbor_is_conforming(block.topologies(),
                                      blocks[neighbor_block_id].topologies(),
@@ -156,11 +159,15 @@ Element<VolumeDim> create_initial_element(
           element_neighbors.add_ids(
               neighbor_ids(valid_segment_ids, neighbor_block_id, grid_index));
         } else {
-          for (const auto& block_id : block_neighbors.ids()) {
+          for (const auto& neighbor_block_id : block_neighbors.ids()) {
+            const auto& orientation =
+                block_neighbors.orientation(neighbor_block_id);
+            const auto direction_from_neighbor =
+                orientation(direction).opposite();
             std::array<std::vector<SegmentId>, VolumeDim> valid_segment_ids;
             for (size_t d = 0; d < VolumeDim; ++d) {
               const size_t level =
-                  gsl::at(initial_refinement_levels[block_id], d);
+                  gsl::at(initial_refinement_levels[neighbor_block_id], d);
               if (d == direction_from_neighbor.dimension()) {
                 gsl::at(valid_segment_ids, d) = std::vector{
                     boundary_segment_id(level, direction_from_neighbor.side())};
@@ -170,7 +177,7 @@ Element<VolumeDim> create_initial_element(
               }
             }
             element_neighbors.add_ids(
-                neighbor_ids(valid_segment_ids, block_id, grid_index));
+                neighbor_ids(valid_segment_ids, neighbor_block_id, grid_index));
           }
         }
 

--- a/src/Domain/Structure/Neighbors.cpp
+++ b/src/Domain/Structure/Neighbors.cpp
@@ -3,21 +3,75 @@
 
 #include "Domain/Structure/Neighbors.hpp"
 
+#include <algorithm>
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
 
 #include "Domain/Structure/ElementId.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"
 
+namespace {
+template <size_t VolumeDim>
+bool ids_and_orientations_are_consistent(
+    const std::unordered_set<size_t>& block_ids,
+    const std::unordered_map<size_t, OrientationMap<VolumeDim>>& orientations) {
+  return alg::none_of(block_ids, [&orientations](size_t block_id) {
+    return orientations.count(block_id) == 0;
+  });
+}
+
+template <size_t VolumeDim>
+bool ids_and_orientations_are_consistent(
+    const std::unordered_set<ElementId<VolumeDim>>& element_ids,
+    const std::unordered_map<size_t, OrientationMap<VolumeDim>>& orientations) {
+  return alg::none_of(element_ids,
+                      [&orientations](const ElementId<VolumeDim>& element_id) {
+                        return orientations.count(element_id.block_id()) == 0;
+                      });
+}
+}  // namespace
+
+template <size_t VolumeDim, typename IdType>
+Neighbors<VolumeDim, IdType>::Neighbors(
+    std::unordered_set<IdType> ids,
+    std::unordered_map<size_t, OrientationMap<VolumeDim>> orientations,
+    const bool are_conforming)
+    : ids_(std::move(ids)),
+      orientations_(std::move(orientations)),
+      are_conforming_(are_conforming) {
+  ASSERT(alg::none_of(orientations_,
+                      [](const auto& orientation) {
+                        return orientation.second ==
+                               OrientationMap<VolumeDim>{};
+                      }),
+         "Cannot use a default-constructed OrientationMap in Neighbors.");
+  ASSERT(orientations_.size() == 1 or not are_conforming_,
+         "Conforming neighbors must all be in the same block, but multiple "
+         "orientations were specified "
+             << orientations_);
+  ASSERT(ids_and_orientations_are_consistent(ids_, orientations_),
+         "Not all Ids " << ids_ << " have orientations " << orientations_);
+}
+
 template <size_t VolumeDim, typename IdType>
 Neighbors<VolumeDim, IdType>::Neighbors(std::unordered_set<IdType> ids,
                                         OrientationMap<VolumeDim> orientation)
-    : ids_(std::move(ids)), orientation_(std::move(orientation)) {
-  ASSERT(orientation_ != OrientationMap<VolumeDim>{},
+    : ids_(std::move(ids)) {
+  ASSERT(orientation != OrientationMap<VolumeDim>{},
          "Cannot use a default-constructed OrientationMap in Neighbors.");
+  if constexpr (std::is_same_v<size_t, IdType>) {
+    orientations_.emplace(*ids_.begin(), std::move(orientation));
+  } else {
+    orientations_.emplace(ids_.begin()->block_id(), std::move(orientation));
+  }
+  ASSERT(ids_and_orientations_are_consistent(ids_, orientations_),
+         "Conforming neighbors must all be in the same block, but the "
+         "following Ids were specified: "
+             << ids_);
 }
 
 template <size_t VolumeDim, typename IdType>
@@ -26,25 +80,52 @@ Neighbors<VolumeDim, IdType>::Neighbors(const IdType id,
     : Neighbors(std::unordered_set{std::move(id)}, std::move(orientation)) {}
 
 template <size_t VolumeDim, typename IdType>
-void Neighbors<VolumeDim, IdType>::add_ids(
-    const std::unordered_set<IdType>& additional_ids) {
-  for (const auto& id : additional_ids) {
-    ids_.insert(id);
+const OrientationMap<VolumeDim>& Neighbors<VolumeDim, IdType>::orientation(
+    const IdType& id) const {
+  if constexpr (std::is_same_v<size_t, IdType>) {
+    return orientations_.at(id);
+  } else {
+    return orientations_.at(id.block_id());
   }
+}
+
+template <size_t VolumeDim, typename IdType>
+void Neighbors<VolumeDim, IdType>::set_ids_to(
+    const std::unordered_set<IdType> new_ids) {
+  ids_ = std::move(new_ids);
+  ASSERT(ids_and_orientations_are_consistent(ids_, orientations_),
+         "Some of the Ids " << ids_
+                            << "passed to set_ids_to are from different blocks "
+                               "than the current orientations "
+                            << orientations_);
+}
+
+template <size_t VolumeDim, typename IdType>
+void Neighbors<VolumeDim, IdType>::add_ids(
+    std::unordered_set<IdType> additional_ids) {
+  ids_.merge(additional_ids);
+  ASSERT(ids_and_orientations_are_consistent(ids_, orientations_),
+         "Some of the added Ids "
+             << additional_ids
+             << " are from different blocks than the current orientations "
+             << orientations_);
 }
 
 template <size_t VolumeDim, typename IdType>
 std::ostream& operator<<(std::ostream& os,
                          const Neighbors<VolumeDim, IdType>& neighbors) {
   os << "Ids = " << neighbors.ids()
-     << "; orientation = " << neighbors.orientation();
+     << "; orientations = " << neighbors.orientations()
+     << "; conforming = " << std::boolalpha << neighbors.are_conforming();
   return os;
 }
 
 template <size_t VolumeDim, typename IdType>
 bool operator==(const Neighbors<VolumeDim, IdType>& lhs,
                 const Neighbors<VolumeDim, IdType>& rhs) {
-  return (lhs.ids() == rhs.ids() and lhs.orientation() == rhs.orientation());
+  return (lhs.ids() == rhs.ids() and
+          lhs.orientations() == rhs.orientations() and
+          lhs.are_conforming() == rhs.are_conforming());
 }
 
 template <size_t VolumeDim, typename IdType>
@@ -56,7 +137,7 @@ bool operator!=(const Neighbors<VolumeDim, IdType>& lhs,
 template <size_t VolumeDim, typename IdType>
 void Neighbors<VolumeDim, IdType>::pup(PUP::er& p) {
   if constexpr (std::is_same_v<IdType, size_t>) {
-    size_t version = 1;
+    size_t version = 2;
     p | version;
     if (version == 0) {
       // Deserialize old BlockNeighbor class
@@ -64,13 +145,28 @@ void Neighbors<VolumeDim, IdType>::pup(PUP::er& p) {
       p | id;
       ids_.clear();
       ids_.emplace(id);
-    } else {
+      OrientationMap<VolumeDim> orientation;
+      p | orientation;
+      orientations_.clear();
+      orientations_.emplace(id, orientation);
+      are_conforming_ = true;
+    } else if (version == 1) {
       p | ids_;
+      OrientationMap<VolumeDim> orientation;
+      p | orientation;
+      orientations_.clear();
+      orientations_.emplace(*(ids_.begin()), orientation);
+      are_conforming_ = true;
+    } else {
+      ASSERT(version == 2, "Unknonwn version " << version);
+      p | ids_;
+      p | orientations_;
+      p | are_conforming_;
     }
-    p | orientation_;
   } else {
     p | ids_;
-    p | orientation_;
+    p | orientations_;
+    p | are_conforming_;
   }
 }
 

--- a/src/Domain/Structure/Neighbors.hpp
+++ b/src/Domain/Structure/Neighbors.hpp
@@ -31,8 +31,23 @@ class Neighbors {
                 std::is_same_v<IdType, ElementId<VolumeDim>>);
 
  public:
+  /// Construct with the ids, the orientation of the neighbors relative to the
+  /// host, and whether the neighbors are conforming.
+  ///
+  /// \param ids the ids of the neighbors.
+  /// \param orientations An OrientationMap (which takes objects in the logical
+  /// coordinate frame of the host and maps them to the logical coordinate frame
+  /// of the neighbor) for each neighboring Block (Elements within a Block share
+  /// the same orientation).  The key of the unordered map is the Block ID.
+  /// \param are_conforming whether or not the block logical coordinates of the
+  /// neighbors conform to those of the host (see
+  /// domain::neighbor_is_conforming)
+  Neighbors(std::unordered_set<IdType> ids,
+            std::unordered_map<size_t, OrientationMap<VolumeDim>> orientations,
+            bool are_conforming);
+
   /// Construct with the ids and orientation of the neighbors relative to the
-  /// host.
+  /// host, assuming the neighbors are conforming.
   ///
   /// \param ids the ids of the neighbors.
   /// \param orientation This OrientationMap takes objects in the logical
@@ -42,7 +57,7 @@ class Neighbors {
             OrientationMap<VolumeDim> orientation);
 
   /// Construct with the id and orientation of a single neighbor relative to the
-  /// host.
+  /// host, assuming the neighbor is conforming.
   ///
   /// \param id the id of the neighbors.
   /// \param orientation This OrientationMap takes objects in the logical
@@ -60,16 +75,33 @@ class Neighbors {
 
   const std::unordered_set<IdType>& ids() const { return ids_; }
 
-  const OrientationMap<VolumeDim>& orientation() const { return orientation_; }
-
-  /// Reset the ids of the neighbors.
-  void set_ids_to(const std::unordered_set<IdType> new_ids) {
-    ids_ = std::move(new_ids);
+  /// The orientations of the neighbors for each neighboring Block.
+  ///
+  /// \note All Elements within a Block share the same orientation.
+  const std::unordered_map<size_t, OrientationMap<VolumeDim>>& orientations()
+      const {
+    return orientations_;
   }
 
+  /// Whether or not the block logical coordinates of the neighbors conform to
+  /// those of the host (see domain::neighbor_is_conforming)
+  bool are_conforming() const { return are_conforming_; }
+
+  /// The orientation of a particular neighbor.
+  const OrientationMap<VolumeDim>& orientation(const IdType& id) const;
+
+  /// Reset the ids of the neighbors.
+  ///
+  /// \note This should only be called to reset Element Neighbors after
+  /// h-refinement
+  void set_ids_to(std::unordered_set<IdType> new_ids);
+
   /// Add ids of neighbors.
-  /// Adding an existing neighbor is allowed.
-  void add_ids(const std::unordered_set<IdType>& additional_ids);
+  ///
+  /// \note Adding an existing neighbor is allowed.
+  /// \note The additional ids must be from Blocks with the existing
+  /// orientations.
+  void add_ids(std::unordered_set<IdType> additional_ids);
 
   /// Serialization for Charm++
   // NOLINTNEXTLINE(google-runtime-references)
@@ -99,8 +131,9 @@ class Neighbors {
   }
 
  private:
-  std::unordered_set<IdType> ids_;
-  OrientationMap<VolumeDim> orientation_;
+  std::unordered_set<IdType> ids_{};
+  std::unordered_map<size_t, OrientationMap<VolumeDim>> orientations_{};
+  bool are_conforming_{true};
 };
 
 /// Output operator for Neighbors.

--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -257,9 +257,9 @@ struct PrepareAndSendMortarData<
         Parallel::get_parallel_component<ParallelComponent>(cache);
     for (const auto& [direction, neighbors] : element.neighbors()) {
       const size_t dimension = direction.dimension();
-      const auto& orientation = neighbors.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const auto& neighbor_id : neighbors) {
+        const auto& orientation = neighbors.orientation(neighbor_id);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
         // Make a copy of the local boundary data on the mortar to send to the
         // neighbor

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
@@ -463,8 +463,8 @@ struct InitializeFacesAndMortars : tt::ConformsTo<::amr::protocols::Projector> {
     const auto& element_id = element.id();
     for (const auto& [direction, neighbors] : element.neighbors()) {
       const auto face_mesh = mesh.slice_away(direction.dimension());
-      const auto& orientation = neighbors.orientation();
       for (const auto& neighbor_id : neighbors) {
+        const auto& orientation = neighbors.orientation(neighbor_id);
         const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
         const auto& neighbor_mesh = neighbor_meshes.at(mortar_id);
         mortar_meshes->emplace(

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.cpp
@@ -39,11 +39,11 @@ void InitializeOverlapGeometry<Dim>::operator()(
   // this setup is a possible optimization. The computational cost and memory
   // usage is probably irrelevant though.
   for (const auto& [direction, neighbors] : element.neighbors()) {
-    const auto& orientation = neighbors.orientation();
-    const auto direction_from_neighbor = orientation(direction.opposite());
-    const auto reoriented_face_mesh =
-        orientation(mesh).slice_away(direction_from_neighbor.dimension());
     for (const auto& neighbor_id : neighbors) {
+      const auto& orientation = neighbors.orientation(neighbor_id);
+      const auto direction_from_neighbor = orientation(direction.opposite());
+      const auto reoriented_face_mesh =
+          orientation(mesh).slice_away(direction_from_neighbor.dimension());
       const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
       const auto& neighbor_mesh = neighbor_meshes.at(mortar_id);
       const auto neighbor_face_mesh =
@@ -56,7 +56,7 @@ void InitializeOverlapGeometry<Dim>::operator()(
                                        direction_from_neighbor.dimension(),
                                        orientation.inverse_map()));
     }  // neighbors
-  }    // internal directions
+  }  // internal directions
 }
 
 template class InitializeOverlapGeometry<1>;

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
@@ -198,9 +198,9 @@ struct InitializeSubdomain {
       const ParallelComponent* const /*meta*/) {
     const auto& element = db::get<domain::Tags::Element<Dim>>(box);
     for (const auto& [direction, neighbors] : element.neighbors()) {
-      const auto& orientation = neighbors.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const auto& neighbor_id : neighbors) {
+        const auto& orientation = neighbors.orientation(neighbor_id);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         const LinearSolver::Schwarz::OverlapId<Dim> overlap_id{direction,
                                                                neighbor_id};
         // Initialize background-agnostic geometry on overlaps
@@ -335,9 +335,9 @@ struct InitializeSubdomain {
         db::get<overlaps_tag<domain::Tags::NeighborMesh<Dim>>>(*box).at(
             overlap_id);
     for (const auto& [direction, neighbors] : element.neighbors()) {
-      const auto& orientation = neighbors.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const auto& neighbor_id : neighbors) {
+        const auto& orientation = neighbors.orientation(neighbor_id);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};
         const auto neighbor_face_mesh =
             neighbor_meshes.at(mortar_id).slice_away(

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -420,9 +420,9 @@ struct SubdomainOperator
         data_is_zero);
     // Prepare neighbors
     for (const auto& [direction, neighbors] : central_element.neighbors()) {
-      const auto& orientation = neighbors.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const auto& neighbor_id : neighbors) {
+        const auto& orientation = neighbors.orientation(neighbor_id);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         const LinearSolver::Schwarz::OverlapId<Dim> overlap_id{direction,
                                                                neighbor_id};
         const auto& overlap_extent = all_overlap_extents.at(overlap_id);
@@ -520,7 +520,9 @@ struct SubdomainOperator
             continue;
           }
           const auto& neighbor_orientation =
-              neighbor.neighbors().at(neighbor_direction).orientation();
+              neighbor.neighbors()
+                  .at(neighbor_direction)
+                  .orientation(neighbors_neighbor_id);
           const auto neighbors_neighbor_direction =
               neighbor_orientation(neighbor_direction.opposite());
           const ::dg::MortarId<Dim> mortar_id_from_neighbors_neighbor{
@@ -624,9 +626,9 @@ struct SubdomainOperator
         box, temporal_id, fluxes_args_on_faces, sources_args, data_is_zero);
     // Apply on neighbors
     for (const auto& [direction, neighbors] : central_element.neighbors()) {
-      const auto& orientation = neighbors.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const auto& neighbor_id : neighbors) {
+        const auto& orientation = neighbors.orientation(neighbor_id);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         const LinearSolver::Schwarz::OverlapId<Dim> overlap_id{direction,
                                                                neighbor_id};
         const auto& overlap_extent = all_overlap_extents.at(overlap_id);

--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -295,9 +295,9 @@ struct SetAndCommunicateInitialRdmpData {
     auto& receiver_proxy =
         Parallel::get_parallel_component<ParallelComponent>(cache);
     for (const auto& [direction, neighbors] : element.neighbors()) {
-      const auto& orientation = neighbors.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const auto& neighbor : neighbors) {
+        const auto& orientation = neighbors.orientation(neighbor);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         evolution::dg::subcell::InitialTciData data{{}, rdmp_data};
         // We use temporal ID 0 for sending RDMP data
         const int temporal_id = 0;
@@ -429,9 +429,10 @@ struct ComputeAndSendTciOnInitialGrid {
       auto& receiver_proxy =
           Parallel::get_parallel_component<ParallelComponent>(cache);
       for (const auto& [direction, neighbors] : element.neighbors()) {
-        const auto& orientation = neighbors.orientation();
-        const auto direction_from_neighbor = orientation(direction.opposite());
         for (const auto& neighbor : neighbors) {
+          const auto& orientation = neighbors.orientation(neighbor);
+          const auto direction_from_neighbor =
+              orientation(direction.opposite());
           evolution::dg::subcell::InitialTciData data{tci_decision, {}};
           // We use temporal ID 1 for ending the TCI decision.
           const int temporal_id = 1;

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -208,14 +208,14 @@ struct SendDataForReconstruction {
     // Compute and send actual variables
     for (const auto& [direction, neighbors_in_direction] :
          element.neighbors()) {
-      const auto& orientation = neighbors_in_direction.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       ASSERT(neighbors_in_direction.size() == 1,
              "AMR is not yet supported when using DG-subcell. Note that this "
              "condition could be relaxed to support AMR only where the "
              "evolution is using DG without any changes to subcell.");
 
       for (const ElementId<Dim>& neighbor : neighbors_in_direction) {
+        const auto& orientation = neighbors_in_direction.orientation(neighbor);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         const size_t rdmp_size = rdmp_tci_data.max_variables_values.size() +
                                  rdmp_tci_data.min_variables_values.size();
         const auto& sliced_data_in_direction = all_sliced_data.at(direction);

--- a/src/Evolution/DgSubcell/SetInterpolators.hpp
+++ b/src/Evolution/DgSubcell/SetInterpolators.hpp
@@ -97,9 +97,10 @@ struct SetInterpolators {
       const auto& direction = direction_neighbors_in_direction.first;
       const auto& neighbors_in_direction =
           direction_neighbors_in_direction.second;
-      const auto& orientation = neighbors_in_direction.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const ElementId<Dim>& neighbor_id : neighbors_in_direction) {
+        const auto& orientation =
+            neighbors_in_direction.orientation(neighbor_id);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         const size_t neighbor_block_id = neighbor_id.block_id();
         if (neighbor_block_id == my_block_id) {
           continue;

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -692,9 +692,6 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
   }
 
   for (const auto& [direction, neighbors] : element.neighbors()) {
-    const auto& orientation = neighbors.orientation();
-    const auto direction_from_neighbor = orientation(direction.opposite());
-
     DataVector ghost_and_subcell_data{};
     if constexpr (using_subcell_v<Metavariables>) {
       ASSERT(all_neighbor_data_for_reconstruction.has_value(),
@@ -707,6 +704,8 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
     const size_t total_neighbors = neighbors.size();
     size_t neighbor_count = 1;
     for (const auto& neighbor : neighbors) {
+      const auto& orientation = neighbors.orientation(neighbor);
+      const auto direction_from_neighbor = orientation(direction.opposite());
       const DirectionalId<Dim> mortar_id{direction, neighbor};
 
       const Mesh<Dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -60,13 +60,14 @@ mortars_apply_impl(const Domain<Dim>& domain,
           ::dg::mortar_mesh(
               volume_mesh.slice_away(direction.dimension()),
               neighbors
-                  .orientation()(::domain::Initialization::create_initial_mesh(
+                  .orientation(
+                      neighbor)(::domain::Initialization::create_initial_mesh(
                       initial_extents, neighbor_block, neighbor, quadrature))
                   .slice_away(direction.dimension())));
       mortar_sizes.emplace(
           mortar_id,
           ::dg::mortar_size(element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation()));
+                            neighbors.orientation(neighbor)));
       // Since no communication needs to happen for boundary conditions
       // the temporal id is not advanced on the boundary, so we only need to
       // initialize it on internal boundaries

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -116,7 +116,7 @@ void p_project(
       const DirectionalId<Dim> mortar_id{direction, neighbor};
       if (mortar_mesh->contains(mortar_id)) {
         const auto new_neighbor_mesh =
-            have_neighbor_info ? neighbors.orientation().inverse_map()(
+            have_neighbor_info ? neighbors.orientation(neighbor).inverse_map()(
                                      neighbor_info.at(neighbor).new_mesh)
                                : neighbor_mesh.at(mortar_id);
         const auto& old_mortar_mesh = mortar_mesh->at(mortar_id);

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoGridHelpers.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoGridHelpers.cpp
@@ -26,8 +26,9 @@ bool check_element_has_one_similar_neighbor_in_direction(
     // More than one neighbor
     return false;
   } else {
-    const auto& orientation_map = neighbors.orientation();
-    const auto neighbor_segment_ids = neighbors.ids().cbegin()->segment_ids();
+    const auto& neighbor_id = *(neighbors.ids().cbegin());
+    const auto& orientation_map = neighbors.orientation(neighbor_id);
+    const auto neighbor_segment_ids = neighbor_id.segment_ids();
     const auto reoriented_neighbor_segment_ids =
         orientation_map.inverse_map()(neighbor_segment_ids);
     for (size_t d = 0; d < VolumeDim; ++d) {

--- a/src/Evolution/Particles/MonteCarlo/GhostZoneCommunication.hpp
+++ b/src/Evolution/Particles/MonteCarlo/GhostZoneCommunication.hpp
@@ -376,9 +376,9 @@ struct SendDataForMcCommunication {
 
     for (const auto& [direction, neighbors_in_direction] :
          element.neighbors()) {
-      const auto& orientation = neighbors_in_direction.orientation();
-      const auto direction_from_neighbor = orientation(direction.opposite());
       for (const ElementId<Dim>& neighbor : neighbors_in_direction) {
+        const auto& orientation = neighbors_in_direction.orientation(neighbor);
+        const auto direction_from_neighbor = orientation(direction.opposite());
         std::optional<std::vector<Particles::MonteCarlo::Packet>>
             packets_to_send = std::nullopt;
         DataVector subcell_data_to_send{};

--- a/src/ParallelAlgorithms/Actions/LimiterActions.hpp
+++ b/src/ParallelAlgorithms/Actions/LimiterActions.hpp
@@ -167,7 +167,8 @@ struct SendData {
                  << direction << "\nDimension: " << dimension
                  << "\nNeighbors:\n"
                  << neighbors_in_direction);
-      const auto& orientation = neighbors_in_direction.orientation();
+      const auto& neighbor_id = *(neighbors_in_direction.cbegin());
+      const auto& orientation = neighbors_in_direction.orientation(neighbor_id);
       const auto direction_from_neighbor = orientation(direction.opposite());
 
       using argument_tags =

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Actions/CommunicateOverlapFields.hpp
@@ -143,10 +143,10 @@ struct SendOverlapFields<tmpl::list<OverlapFields...>, OptionsGroup,
       }
       ();
       // Copy data to send to neighbors, but move it for the last one
-      const auto direction_from_neighbor =
-          neighbors.orientation()(direction.opposite());
       for (auto neighbor = neighbors.begin(); neighbor != neighbors.end();
            ++neighbor) {
+        const auto direction_from_neighbor =
+            neighbors.orientation(*neighbor)(direction.opposite());
         Parallel::receive_data<detail::OverlapFieldsTag<
             Dim, tmpl::list<OverlapFields...>, OptionsGroup>>(
             receiver_proxy[*neighbor], iteration_id,

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -475,7 +475,7 @@ struct SolveSubdomain {
         const auto& direction = overlap_id.direction();
         const auto& neighbor_id = overlap_id.id();
         const auto& orientation =
-            element.neighbors().at(direction).orientation();
+            element.neighbors().at(direction).orientation(neighbor_id);
         const auto direction_from_neighbor = orientation(direction.opposite());
         Parallel::receive_data<overlap_solution_inbox_tag>(
             receiver_proxy[neighbor_id], iteration_id,

--- a/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
+++ b/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
@@ -93,7 +93,8 @@ void test(const gsl::not_null<std::mt19937*> generator) {
                 new_neighbor_ids.insert(id);
               }
               const auto new_neighbors = Neighbors<Dim>{
-                  std::move(new_neighbor_ids), neighbors.orientation()};
+                  std::move(new_neighbor_ids), neighbors.orientations(),
+                  neighbors.are_conforming()};
               CAPTURE(new_neighbors);
               TestHelpers::domain::check_neighbors(new_neighbors, element_id,
                                                    direction);
@@ -122,7 +123,8 @@ void test(const gsl::not_null<std::mt19937*> generator) {
               new_neighbor_ids.insert(id);
             }
             const auto new_neighbors =
-                Neighbors<Dim>{new_neighbor_ids, neighbors.orientation()};
+                Neighbors<Dim>{new_neighbor_ids, neighbors.orientations(),
+                               neighbors.are_conforming()};
             CAPTURE(new_neighbors);
             TestHelpers::domain::check_neighbors(new_neighbors, element_id,
                                                  direction);

--- a/tests/Unit/Domain/Structure/Test_BlockNeighbors.cpp
+++ b/tests/Unit/Domain/Structure/Test_BlockNeighbors.cpp
@@ -26,15 +26,16 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.BlockNeighbors", "[Domain][Unit]") {
        Direction<3>::upper_xi()}});
   BlockNeighbors<3> custom_neighbor(0, custom_orientation);
   CHECK(*(custom_neighbor.begin()) == 0);
-  CHECK(custom_neighbor.orientation()(Direction<3>::upper_xi()) ==
+  CHECK(custom_neighbor.orientation(0)(Direction<3>::upper_xi()) ==
         Direction<3>::upper_eta());
-  CHECK(custom_neighbor.orientation()(Direction<3>::upper_eta()) ==
+  CHECK(custom_neighbor.orientation(0)(Direction<3>::upper_eta()) ==
         Direction<3>::upper_zeta());
-  CHECK(custom_neighbor.orientation()(Direction<3>::upper_zeta()) ==
+  CHECK(custom_neighbor.orientation(0)(Direction<3>::upper_zeta()) ==
         Direction<3>::upper_xi());
 
   // Test output operator:
-  CHECK(get_output(custom_neighbor) == "Ids = (0); orientation = (+1, +2, +0)");
+  CHECK(get_output(custom_neighbor) ==
+        "Ids = (0); orientations = ([0,(+1, +2, +0)]); conforming = true");
 
   // Test comparison operator:
   CHECK(test_block_neighbor != custom_neighbor);

--- a/tests/Unit/Domain/Structure/Test_Element.cpp
+++ b/tests/Unit/Domain/Structure/Test_Element.cpp
@@ -87,11 +87,20 @@ void check_element_1d() {
 }
 
 void check_element_2d() {
+  const SegmentId root_segment{0, 0};
   const Neighbors<2> neighbors_lower_eta(
-      std::unordered_set<ElementId<2>>{ElementId<2>(7), ElementId<2>(4)},
+      std::unordered_set<ElementId<2>>{
+          ElementId<2>(7,
+                       {{root_segment.id_of_child(Side::Lower), root_segment}}),
+          ElementId<2>(
+              7, {{root_segment.id_of_child(Side::Upper), root_segment}})},
       OrientationMap<2>::create_aligned());
   const Neighbors<2> neighbors_upper_eta(
-      std::unordered_set<ElementId<2>>{ElementId<2>(7), ElementId<2>(4)},
+      std::unordered_set<ElementId<2>>{
+          ElementId<2>(8,
+                       {{root_segment.id_of_child(Side::Lower), root_segment}}),
+          ElementId<2>(
+              8, {{root_segment.id_of_child(Side::Upper), root_segment}})},
       OrientationMap<2>::create_aligned());
   const typename Element<2>::Neighbors_t eta_neighbors{
       {Direction<2>::lower_eta(), neighbors_lower_eta},
@@ -100,13 +109,36 @@ void check_element_2d() {
 }
 
 void check_element_3d() {
+  const SegmentId root_segment{0, 0};
   const Neighbors<3> neighbors_lower_zeta(
-      std::unordered_set<ElementId<3>>{ElementId<3>(7), ElementId<3>(4),
-                                       ElementId<3>(9), ElementId<3>(2)},
+      std::unordered_set<ElementId<3>>{
+          ElementId<3>(7,
+                       {{root_segment.id_of_child(Side::Lower),
+                         root_segment.id_of_child(Side::Lower), root_segment}}),
+          ElementId<3>(7,
+                       {{root_segment.id_of_child(Side::Lower),
+                         root_segment.id_of_child(Side::Upper), root_segment}}),
+          ElementId<3>(7,
+                       {{root_segment.id_of_child(Side::Upper),
+                         root_segment.id_of_child(Side::Lower), root_segment}}),
+          ElementId<3>(
+              7, {{root_segment.id_of_child(Side::Upper),
+                   root_segment.id_of_child(Side::Upper), root_segment}})},
       OrientationMap<3>::create_aligned());
   const Neighbors<3> neighbors_upper_zeta(
-      std::unordered_set<ElementId<3>>{ElementId<3>(7), ElementId<3>(4),
-                                       ElementId<3>(9), ElementId<3>(2)},
+      std::unordered_set<ElementId<3>>{
+          ElementId<3>(8,
+                       {{root_segment.id_of_child(Side::Lower),
+                         root_segment.id_of_child(Side::Lower), root_segment}}),
+          ElementId<3>(8,
+                       {{root_segment.id_of_child(Side::Lower),
+                         root_segment.id_of_child(Side::Upper), root_segment}}),
+          ElementId<3>(8,
+                       {{root_segment.id_of_child(Side::Upper),
+                         root_segment.id_of_child(Side::Lower), root_segment}}),
+          ElementId<3>(
+              8, {{root_segment.id_of_child(Side::Upper),
+                   root_segment.id_of_child(Side::Upper), root_segment}})},
       OrientationMap<3>::create_aligned());
   const typename Element<3>::Neighbors_t zeta_neighbors{
       {Direction<3>::lower_zeta(), neighbors_lower_zeta},

--- a/tests/Unit/Domain/Structure/Test_Neighbors.cpp
+++ b/tests/Unit/Domain/Structure/Test_Neighbors.cpp
@@ -17,7 +17,8 @@
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/GetOutput.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.1d", "[Domain][Unit]") {
+namespace {
+void check_neighbors_1d() {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<1> test_neighbors;
@@ -32,18 +33,32 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.1d", "[Domain][Unit]") {
   // Test size
   CHECK(custom_neighbors.size() == 1);
 
-  // In 1D, cannot have more than 1 neighbor.
-  // Test add_ids using an empty default-constructed Neighbors object:
-  Neighbors<1> empty_neighbors;
+  // Test add_ids
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([&test_neighbors, &custom_id]() {
+        test_neighbors.add_ids(custom_id);
+      }()),
+      Catch::Matchers::ContainsSubstring("Some of the added Ids"));
+#endif
+  Neighbors<1> empty_neighbors{{}, {{2, custom_orientation}}, true};
   CHECK(empty_neighbors.size() == 0);
   empty_neighbors.add_ids(custom_id);
   CHECK(empty_neighbors.size() == 1);
 
   // Test set_ids_to:
   const std::unordered_set<ElementId<1>> other_custom_id{
-      ElementId<1>(0, {{SegmentId(2, 1)}})};
+      ElementId<1>(2, {{SegmentId(1, 1)}})};
   custom_neighbors.set_ids_to(other_custom_id);
   CHECK(custom_neighbors.size() == 1);
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(([&custom_neighbors]() {
+                      const std::unordered_set<ElementId<1>> wrong_block_id{
+                          ElementId<1>(0, {{SegmentId(2, 1)}})};
+                      custom_neighbors.set_ids_to(wrong_block_id);
+                    }()),
+                    Catch::Matchers::ContainsSubstring("Some of the Ids"));
+#endif
 
   // Test serialization:
   test_serialization(custom_neighbors);
@@ -57,7 +72,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.1d", "[Domain][Unit]") {
   test_iterators(custom_neighbors);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.2d", "[Domain][Unit]") {
+void check_neighbors_2d() {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<2> test_neighbors;
@@ -74,7 +89,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.2d", "[Domain][Unit]") {
 
   // Test add_ids:
   const std::unordered_set<ElementId<2>> other_custom_id{
-      ElementId<2>(0, {{SegmentId(2, 3), SegmentId(1, 0)}})};
+      ElementId<2>(2, {{SegmentId(2, 2), SegmentId(1, 0)}})};
   custom_neighbors.add_ids(other_custom_id);
   CHECK(custom_neighbors.size() == 2);
 
@@ -99,7 +114,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.2d", "[Domain][Unit]") {
   test_move_semantics(std::move(custom_neighbors), custom_copy);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.3d", "[Domain][Unit]") {
+void check_neighbors_3d() {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<3> test_neighbors;
@@ -110,8 +125,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.3d", "[Domain][Unit]") {
        Direction<3>::upper_xi()}});
   const std::unordered_set<ElementId<3>> custom_ids{
       ElementId<3>(2, {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(1, 1)}}),
-      ElementId<3>(3, {{SegmentId(2, 2), SegmentId(1, 1), SegmentId(1, 0)}}),
-      ElementId<3>(1, {{SegmentId(2, 1), SegmentId(1, 0), SegmentId(1, 1)}})};
+      ElementId<3>(2, {{SegmentId(2, 2), SegmentId(1, 1), SegmentId(1, 0)}}),
+      ElementId<3>(2, {{SegmentId(2, 1), SegmentId(1, 0), SegmentId(1, 1)}})};
   Neighbors<3> custom_neighbors(custom_ids, custom_orientation);
 
   // Test size
@@ -120,20 +135,20 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.3d", "[Domain][Unit]") {
   // Test output
   CHECK(get_output(custom_neighbors) ==
         "Ids = "
-        "([B1,(L2I1,L1I0,L1I1)],[B2,(L2I3,L1I0,L1I1)],[B3,(L2I2,L1I1,L1I0)]); "
-        "orientation = (+1, +2, +0)");
+        "([B2,(L2I1,L1I0,L1I1)],[B2,(L2I2,L1I1,L1I0)],[B2,(L2I3,L1I0,L1I1)]); "
+        "orientations = ([2,(+1, +2, +0)]); conforming = true");
 
   // Test add_ids
   const std::unordered_set<ElementId<3>> other_custom_id{
-      ElementId<3>(0, {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(1, 1)}})};
+      ElementId<3>(2, {{SegmentId(2, 3), SegmentId(1, 1), SegmentId(1, 1)}})};
   custom_neighbors.add_ids(other_custom_id);
   CHECK(custom_neighbors.size() == 4);
 
   CHECK(get_output(custom_neighbors) ==
         "Ids = "
-        "([B0,(L2I3,L1I0,L1I1)],[B1,(L2I1,L1I0,L1I1)],[B2,(L2I3,L1I0,L1I1)],"
-        "[B3,(L2I2,L1I1,L1I0)]); "
-        "orientation = (+1, +2, +0)");
+        "([B2,(L2I1,L1I0,L1I1)],[B2,(L2I2,L1I1,L1I0)],[B2,(L2I3,L1I0,L1I1)],["
+        "B2,(L2I3,L1I1,L1I1)]); "
+        "orientations = ([2,(+1, +2, +0)]); conforming = true");
 
   // Test set_ids_to:
   custom_neighbors.set_ids_to(custom_ids);
@@ -141,8 +156,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.3d", "[Domain][Unit]") {
 
   CHECK(get_output(custom_neighbors) ==
         "Ids = "
-        "([B1,(L2I1,L1I0,L1I1)],[B2,(L2I3,L1I0,L1I1)],[B3,(L2I2,L1I1,L1I0)]); "
-        "orientation = (+1, +2, +0)");
+        "([B2,(L2I1,L1I0,L1I1)],[B2,(L2I2,L1I1,L1I0)],[B2,(L2I3,L1I0,L1I1)]); "
+        "orientations = ([2,(+1, +2, +0)]); conforming = true");
 
   // Test serialization:
   test_serialization(custom_neighbors);
@@ -159,4 +174,11 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors.3d", "[Domain][Unit]") {
   const auto custom_copy = custom_neighbors;
   test_copy_semantics(test_neighbors);
   test_move_semantics(std::move(custom_neighbors), custom_copy);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.Neighbors", "[Domain][Unit]") {
+  check_neighbors_1d();
+  check_neighbors_2d();
+  check_neighbors_3d();
 }

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -399,8 +399,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
         "Block 3 (Identity):\n"
         "Topology: (I1,I1)\n"
         "Neighbors: "
-        "([+0,Ids = (1); orientation = (+0, +1)],"
-        "[-1,Ids = (2); orientation = (-0, +1)])\n"
+        "([+0,Ids = (1); orientations = ([1,(+0, +1)]); conforming = true],"
+        "[-1,Ids = (2); orientations = ([2,(-0, +1)]); conforming = true])\n"
         "External boundaries: (+1,-0)\n"
         "Is time dependent: false");
 

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -409,7 +409,11 @@ void test_nonconforming_blocks() {
   blocks.emplace_back(
       nullptr, 0,
       DirectionMap<2, BlockNeighbors<2>>{
-          {Direction<2>::upper_xi(), BlockNeighbors<2>{{1, 2, 3, 4}, aligned}}},
+          {Direction<2>::upper_xi(),
+           BlockNeighbors<2>{
+               {1, 2, 3, 4},
+               {{1, aligned}, {2, aligned}, {3, aligned}, {4, aligned}},
+               false}}},
       "Annulus", std::array{domain::Topology::I1, domain::Topology::S1});
   blocks.emplace_back(
       nullptr, 1,
@@ -458,7 +462,8 @@ void test_nonconforming_blocks() {
        {Direction<2>::upper_xi(),
         Neighbors<2>{{north_l, north_u, east_l, east_u, south_l, south_u,
                       west_l, west_u},
-                     aligned}}},
+                     {{1, aligned}, {2, aligned}, {3, aligned}, {4, aligned}},
+                     false}}},
       domain::topologies::annulus);
   test_create_initial_element(
       north_l, blocks, initial_refinement_levels,

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -47,16 +47,20 @@ void test_periodic_same_block() {
   set_internal_boundaries<3>(&neighbors_of_all_blocks, corners_of_all_blocks);
 
   const OrientationMap<3> aligned = OrientationMap<3>::create_aligned();
-  CHECK(neighbors_of_all_blocks[0][Direction<3>::lower_zeta()].orientation() ==
-        aligned);
+  for (const auto& [_, orientation] :
+       neighbors_of_all_blocks[0][Direction<3>::lower_zeta()].orientations()) {
+    CHECK(orientation == aligned);
+  }
 
   const PairOfFaces x_faces{{1, 3, 5, 7}, {0, 2, 4, 6}};
 
   const std::vector<PairOfFaces> identifications{x_faces};
   set_identified_boundaries<3>(identifications, corners_of_all_blocks,
                                &neighbors_of_all_blocks);
-  CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
-        aligned);
+  for (const auto& [_, orientation] :
+       neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientations()) {
+    CHECK(orientation == aligned);
+  }
 
   const std::vector<DirectionMap<3, BlockNeighbors<3>>>
       expected_block_neighbors{{{Direction<3>::upper_xi(), {0, aligned}},
@@ -74,16 +78,20 @@ void test_periodic_different_blocks() {
   set_internal_boundaries<3>(&neighbors_of_all_blocks, corners_of_all_blocks);
 
   const OrientationMap<3> aligned = OrientationMap<3>::create_aligned();
-  CHECK(neighbors_of_all_blocks[0][Direction<3>::lower_zeta()].orientation() ==
-        aligned);
+  for (const auto& [_, orientation] :
+       neighbors_of_all_blocks[0][Direction<3>::lower_zeta()].orientations()) {
+    CHECK(orientation == aligned);
+  }
 
   const PairOfFaces x_faces_on_different_blocks{{1, 3, 5, 7}, {8, 10, 0, 2}};
 
   const std::vector<PairOfFaces> identifications{x_faces_on_different_blocks};
   set_identified_boundaries<3>(identifications, corners_of_all_blocks,
                                &neighbors_of_all_blocks);
-  CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
-        aligned);
+  for (const auto& [_, orientation] :
+       neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientations()) {
+    CHECK(orientation == aligned);
+  }
   const std::vector<DirectionMap<3, BlockNeighbors<3>>>
       expected_block_neighbors{{{Direction<3>::upper_xi(), {1, aligned}},
                                 {Direction<3>::lower_zeta(), {1, aligned}}},

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -175,8 +175,8 @@ struct InitializeRandomSubdomainData {
                   make_not_null(&gen), make_not_null(&dist),
                   mesh.number_of_grid_points());
           for (const auto& [direction, neighbors] : element.neighbors()) {
-            const auto& orientation = neighbors.orientation();
             for (const auto& neighbor_id : neighbors) {
+              const auto& orientation = neighbors.orientation(neighbor_id);
               const auto overlap_id =
                   DirectionalId<Dim>{direction, neighbor_id};
               const size_t overlap_extent = all_overlap_extents.at(overlap_id);
@@ -682,8 +682,8 @@ void test_subdomain_operator(
           const auto& direction = overlap_id.direction();
           const auto& neighbor_id = overlap_id.id();
           const auto direction_from_neighbor =
-              central_element.neighbors().at(direction).orientation()(
-                  direction.opposite());
+              central_element.neighbors().at(direction).orientation(
+                  neighbor_id)(direction.opposite());
           set_tag(
               neighbor_id, fields_tag{},
               LinearSolver::Schwarz::extended_overlap_data(
@@ -738,8 +738,8 @@ void test_subdomain_operator(
           const auto& direction = overlap_id.direction();
           const auto& neighbor_id = overlap_id.id();
           const auto direction_from_neighbor =
-              central_element.neighbors().at(direction).orientation()(
-                  direction.opposite());
+              central_element.neighbors().at(direction).orientation(
+                  neighbor_id)(direction.opposite());
           const auto expected_overlap_result =
               LinearSolver::Schwarz::data_on_overlap(
                   get_tag(neighbor_id, operator_applied_to_fields_tag{}),

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
@@ -97,7 +97,7 @@ void test() {
   Interps neighbor_dg_to_fd_interpolants{};
   {
     const auto& orientation_map =
-        neighbors.at(lower_xi_id.direction()).orientation();
+        neighbors.at(lower_xi_id.direction()).orientation(lower_xi_id.id());
     tnsr::I<DataVector, Dim, Frame::ElementLogical> oriented_logical_coords{};
     for (size_t i = 0; i < Dim; ++i) {
       oriented_logical_coords.get(i) = orient_variables(
@@ -113,7 +113,7 @@ void test() {
     const DirectionalId<Dim> lower_zeta_id{Direction<Dim>::lower_zeta(),
                                            ElementId<Dim>{4}};
     const auto& orientation_map =
-        neighbors.at(lower_zeta_id.direction()).orientation();
+        neighbors.at(lower_zeta_id.direction()).orientation(lower_zeta_id.id());
     tnsr::I<DataVector, Dim, Frame::ElementLogical> oriented_logical_coords{};
     for (size_t i = 0; i < Dim; ++i) {
       oriented_logical_coords.get(i) = orient_variables(
@@ -143,16 +143,19 @@ void test() {
   const DataVector expected_neighbor_data_from_lower_xi = [&dg_mesh, &neighbors,
                                                            &number_of_rdmp_vars,
                                                            &received_dg_data,
-                                                           &subcell_mesh]() {
+                                                           &subcell_mesh,
+                                                           &lower_xi_id]() {
     (void)number_of_rdmp_vars;  // workaround clang bug unused warning
     // Need the view so the size is correct
     const DataVector view_received_data(
         received_dg_data.data(),
         received_dg_data.size() - 2 * number_of_rdmp_vars);
     DataVector oriented_data{view_received_data.size()};
-    orient_variables(
-        make_not_null(&oriented_data), view_received_data, dg_mesh.extents(),
-        neighbors.at(Direction<Dim>::lower_xi()).orientation().inverse_map());
+    orient_variables(make_not_null(&oriented_data), view_received_data,
+                     dg_mesh.extents(),
+                     neighbors.at(Direction<Dim>::lower_xi())
+                         .orientation(lower_xi_id.id())
+                         .inverse_map());
     // We've now got the data in the local orientation, so now we need to
     // project it to the ghost cells.
     // Note: assume isotropic meshes
@@ -351,10 +354,11 @@ void test() {
             number_of_ghost_zones, Side::Upper));
 
     DataVector oriented_data{unaligned_received_dg_data.size()};
-    orient_variables(
-        make_not_null(&oriented_data), unaligned_received_dg_data,
-        dg_mesh.extents(),
-        neighbors.at(Direction<Dim>::lower_zeta()).orientation().inverse_map());
+    orient_variables(make_not_null(&oriented_data), unaligned_received_dg_data,
+                     dg_mesh.extents(),
+                     neighbors.at(Direction<Dim>::lower_zeta())
+                         .orientation(lower_zeta_id.id())
+                         .inverse_map());
     apply_matrices(make_not_null(&expected_data), projection_matrices,
                    oriented_data, dg_mesh.extents());
     CHECK_ITERABLE_APPROX(get_neighbor_data(lower_zeta_id), expected_data);

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -220,10 +220,10 @@ void test(const bool all_neighbors_are_doing_dg,
   Interps dg_to_fd_neighbor_interpolants{};
   if constexpr (Dim == 3) {
     const auto direction = expected_neighbor_directions<Dim>()[1];
-    const auto& orientation_map =
-        element.neighbors().at(direction).orientation();
     const auto& neighbor_element_id =
         *element.neighbors().at(direction).begin();
+    const auto& orientation_map =
+        element.neighbors().at(direction).orientation(neighbor_element_id);
     const auto logical_fd_coords = logical_coordinates(subcell_mesh);
     tnsr::I<DataVector, Dim, Frame::ElementLogical> oriented_logical_coords{};
     for (size_t i = 0; i < Dim; ++i) {
@@ -333,9 +333,11 @@ void test(const bool all_neighbors_are_doing_dg,
       const auto direction = expected_neighbor_directions<Dim>()[1];
       Index<Dim> slice_extents = subcell_mesh.extents();
       slice_extents[direction.dimension()] = ghost_zone_size;
-      expected_neighbor_data.at(direction) =
-          orient_variables(expected_neighbor_data.at(direction), slice_extents,
-                           element.neighbors().at(direction).orientation());
+      const auto& neighbor_element_id =
+          *element.neighbors().at(direction).begin();
+      expected_neighbor_data.at(direction) = orient_variables(
+          expected_neighbor_data.at(direction), slice_extents,
+          element.neighbors().at(direction).orientation(neighbor_element_id));
     }
   }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -555,7 +555,7 @@ void test_p_refine_gts() {
       mortar_size.emplace(
           mortar_id,
           ::dg::mortar_size(old_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation()));
+                            neighbors.orientation(neighbor)));
       mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
       neighbor_info.emplace(
           neighbor,
@@ -587,7 +587,7 @@ void test_p_refine_gts() {
       expected_mortar_size.emplace(
           mortar_id,
           ::dg::mortar_size(new_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation()));
+                            neighbors.orientation(neighbor)));
       expected_mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
     }
   }
@@ -675,7 +675,7 @@ void test_p_refine_lts() {
       mortar_size.emplace(
           mortar_id,
           ::dg::mortar_size(old_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation()));
+                            neighbors.orientation(neighbor)));
       mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
       neighbor_info.emplace(
           neighbor,
@@ -723,7 +723,7 @@ void test_p_refine_lts() {
       expected_mortar_size.emplace(
           mortar_id,
           ::dg::mortar_size(new_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation()));
+                            neighbors.orientation(neighbor)));
       expected_mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
       expected_mortar_data_history.emplace(mortar_id,
                                            boundary_history_type<Dim>{});

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Minmod.cpp
@@ -1123,11 +1123,16 @@ void test_minmod_impl_limits_in_x_only(
 // limiting operation.
 void test_minmod_impl_two_lower_xi_neighbors() {
   INFO("Testing minmod_impl in 2D with two neighbors in one direction");
+  const SegmentId root_segment{0, 0};
   const auto element = Element<2>{
       ElementId<2>{0},
       Element<2>::Neighbors_t{
           {Direction<2>::lower_xi(),
-           {std::unordered_set<ElementId<2>>{ElementId<2>(1), ElementId<2>(7)},
+           {std::unordered_set<ElementId<2>>{
+                ElementId<2>(
+                    1, {{root_segment, root_segment.id_of_child(Side::Lower)}}),
+                ElementId<2>(1, {{root_segment,
+                                  root_segment.id_of_child(Side::Upper)}})},
             OrientationMap<2>::create_aligned()}},
           {Direction<2>::upper_xi(),
            TestHelpers::Limiters::make_neighbor_with_id<2>(2)}}};
@@ -1144,17 +1149,24 @@ void test_minmod_impl_two_lower_xi_neighbors() {
   };
   const auto input = ScalarTag::type(func(logical_coords));
 
-  const auto make_neighbors = [&dx](const double left1, const double left2,
-                                    const double right, const double left1_size,
-                                    const double left2_size) {
+  const auto make_neighbors =
+    [&dx,&root_segment](const double left1, const double left2,
+                        const double right, const double left1_size,
+                        const double left2_size) {
     using Pack = Limiters::Minmod<2, tmpl::list<ScalarTag>>::PackagedData;
     return std::unordered_map<DirectionalId<2>, Pack,
                               boost::hash<DirectionalId<2>>>{
         std::make_pair(
-            DirectionalId<2>{Direction<2>::lower_xi(), ElementId<2>(1)},
+            DirectionalId<2>{
+                Direction<2>::lower_xi(),
+                ElementId<2>(1, {{root_segment,
+                                  root_segment.id_of_child(Side::Lower)}})},
             Pack{Scalar<double>(left1), make_array(left1_size, dx)}),
         std::make_pair(
-            DirectionalId<2>{Direction<2>::lower_xi(), ElementId<2>(7)},
+            DirectionalId<2>{
+                Direction<2>::lower_xi(),
+                ElementId<2>(1, {{root_segment,
+                                  root_segment.id_of_child(Side::Upper)}})},
             Pack{Scalar<double>(left2), make_array(left2_size, dx)}),
         std::make_pair(
             DirectionalId<2>{Direction<2>::upper_xi(), ElementId<2>(2)},
@@ -1270,16 +1282,27 @@ void test_minmod_impl_3d_work(const Spectral::Quadrature quadrature) {
 // Similar to the 2D case, but in 3D and with 4 upper_xi neighbors
 void test_minmod_impl_four_upper_xi_neighbors() {
   INFO("Testing minmod_impl in 3D with four neighbors in one direction");
+  const SegmentId root_segment{0, 0};
   const auto element = Element<3>{
       ElementId<3>{0},
       Element<3>::Neighbors_t{
           {Direction<3>::lower_xi(),
            TestHelpers::Limiters::make_neighbor_with_id<3>(1)},
           {Direction<3>::upper_xi(),
-           {std::unordered_set<ElementId<3>>{ElementId<3>(2), ElementId<3>(7),
-                                             ElementId<3>(8), ElementId<3>(9)},
-            OrientationMap<3>::create_aligned()}},
-      }};
+           {std::unordered_set<ElementId<3>>{
+                ElementId<3>(
+                    2, {root_segment, root_segment.id_of_child(Side::Lower),
+                        root_segment.id_of_child(Side::Lower)}),
+                ElementId<3>(
+                    2, {root_segment, root_segment.id_of_child(Side::Lower),
+                        root_segment.id_of_child(Side::Upper)}),
+                ElementId<3>(
+                    2, {root_segment, root_segment.id_of_child(Side::Upper),
+                        root_segment.id_of_child(Side::Lower)}),
+                ElementId<3>(
+                    2, {root_segment, root_segment.id_of_child(Side::Upper),
+                        root_segment.id_of_child(Side::Upper)})},
+            OrientationMap<3>::create_aligned()}}}};
   const auto mesh =
       Mesh<3>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
@@ -1294,10 +1317,11 @@ void test_minmod_impl_four_upper_xi_neighbors() {
   const auto input = ScalarTag::type(func(logical_coords));
 
   const auto make_neighbors =
-      [&dx](const double left, const double right1, const double right2,
-            const double right3, const double right4, const double right1_size,
-            const double right2_size, const double right3_size,
-            const double right4_size) {
+    [&dx, &root_segment](const double left, const double right1,
+                         const double right2, const double right3,
+                         const double right4, const double right1_size,
+                         const double right2_size, const double right3_size,
+                         const double right4_size) {
         using Pack = Limiters::Minmod<3, tmpl::list<ScalarTag>>::PackagedData;
         return std::unordered_map<DirectionalId<3>, Pack,
                                   boost::hash<DirectionalId<3>>>{
@@ -1305,16 +1329,32 @@ void test_minmod_impl_four_upper_xi_neighbors() {
                 DirectionalId<3>{Direction<3>::lower_xi(), ElementId<3>(1)},
                 Pack{Scalar<double>(left), make_array<3>(dx)}),
             std::make_pair(
-                DirectionalId<3>{Direction<3>::upper_xi(), ElementId<3>(2)},
+                DirectionalId<3>{
+                    Direction<3>::upper_xi(),
+                    ElementId<3>(
+                        2, {root_segment, root_segment.id_of_child(Side::Lower),
+                            root_segment.id_of_child(Side::Lower)})},
                 Pack{Scalar<double>(right1), make_array(right1_size, dx, dx)}),
             std::make_pair(
-                DirectionalId<3>{Direction<3>::upper_xi(), ElementId<3>(7)},
+                DirectionalId<3>{
+                    Direction<3>::upper_xi(),
+                    ElementId<3>(
+                        2, {root_segment, root_segment.id_of_child(Side::Lower),
+                            root_segment.id_of_child(Side::Upper)})},
                 Pack{Scalar<double>(right2), make_array(right2_size, dx, dx)}),
             std::make_pair(
-                DirectionalId<3>{Direction<3>::upper_xi(), ElementId<3>(8)},
+                DirectionalId<3>{
+                    Direction<3>::upper_xi(),
+                    ElementId<3>(
+                        2, {root_segment, root_segment.id_of_child(Side::Upper),
+                            root_segment.id_of_child(Side::Lower)})},
                 Pack{Scalar<double>(right3), make_array(right3_size, dx, dx)}),
             std::make_pair(
-                DirectionalId<3>{Direction<3>::upper_xi(), ElementId<3>(9)},
+                DirectionalId<3>{
+                    Direction<3>::upper_xi(),
+                    ElementId<3>(
+                        2, {root_segment, root_segment.id_of_child(Side::Upper),
+                            root_segment.id_of_child(Side::Upper)})},
                 Pack{Scalar<double>(right4), make_array(right4_size, dx, dx)}),
         };
       };

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoGridHelpers.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_WenoGridHelpers.cpp
@@ -34,8 +34,8 @@ void test_check_element_no_href() {
   const ElementId<2> self_id(0, {{{3, 7}, {4, 2}}});
   const ElementId<2> lower_xi_id(1, {{{3, 5}, {4, 11}}});
   const ElementId<2> upper_xi_id(2, {{{4, 7}, {3, 0}}});
-  const ElementId<2> lower_eta_id_1(3, {{{3, 7}, {4, 2}}});
-  const ElementId<2> lower_eta_id_2(4, {{{3, 7}, {4, 2}}});
+  const ElementId<2> lower_eta_id_1(3, {{{4, 14}, {4, 2}}});
+  const ElementId<2> lower_eta_id_2(3, {{{4, 15}, {4, 2}}});
   const ElementId<2> upper_eta_id(5, {{{3, 7}, {3, 2}}});
 
   const Neighbors<2> lower_xi_neighbors({lower_xi_id},

--- a/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Amr/NeighborFlagHelpers.cpp
@@ -145,11 +145,13 @@ valid_info_t<Dim> valid_neighbor_info(
   valid_info_t<Dim> result{};
   Mesh<Dim> mesh{5, Spectral::Basis::Legendre,
                  Spectral::Quadrature::GaussLobatto};
-  const auto& orientation_of_neighbors = neighbors.orientation();
   const auto& first_neighbor_id = *(neighbors.begin());
+  const auto& orientation_of_first_neighbor =
+      neighbors.orientation(first_neighbor_id);
   for (const auto& neighbor_flags : amr_flags<Dim>()) {
     if (are_valid_neighbor_flags(element_id, element_flags, first_neighbor_id,
-                                 neighbor_flags, orientation_of_neighbors)) {
+                                 neighbor_flags,
+                                 orientation_of_first_neighbor)) {
       result.emplace_back(neighbor_info_t<Dim>{
           {first_neighbor_id, ::amr::Info<Dim>{neighbor_flags, mesh}}});
     }
@@ -159,10 +161,11 @@ valid_info_t<Dim> valid_neighbor_info(
     valid_info_t<Dim> prev_result{};
     std::swap(result, prev_result);
     const auto& neighbor_id = *it;
+    const auto& orientation_of_neighbor = neighbors.orientation(neighbor_id);
     for (const auto& neighbor_flags : amr_flags<Dim>()) {
       if (not are_valid_neighbor_flags(element_id, element_flags, neighbor_id,
                                        neighbor_flags,
-                                       orientation_of_neighbors)) {
+                                       orientation_of_neighbor)) {
         // neighbor_flags conflicts with element
         continue;
       }

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -107,9 +107,9 @@ void test_domain_connectivity(
     for (const auto& direction_neighbors : element.neighbors()) {
       const auto& direction = direction_neighbors.first;
       const auto& neighbors = direction_neighbors.second;
-      const auto& direction_to_me_in_neighbor =
-          neighbors.orientation()(direction.opposite());
       for (const auto& neighbor_id : neighbors.ids()) {
+        const auto& direction_to_me_in_neighbor =
+            neighbors.orientation(neighbor_id)(direction.opposite());
         CHECK(is_a_neighbor_of_my_neighbor_me(
             element_id, elements_in_domain.at(neighbor_id),
             direction_to_me_in_neighbor));
@@ -166,16 +166,16 @@ void test_refinement_levels_of_neighbors(
     const auto& element = key_value.second;
     for (const auto& direction_neighbors : element.neighbors()) {
       const auto& neighbors = direction_neighbors.second;
-      const auto& orientation = neighbors.orientation();
       for (size_t d = 0; d < VolumeDim; ++d) {
         // No restriction on perpendicular refinement.
         if (d == direction_neighbors.first.dimension()) {
           continue;
         }
 
-        const size_t my_dim_in_neighbor = orientation(d);
         const size_t my_level = element_id.segment_id(d).refinement_level();
         for (const auto neighbor_id : neighbors.ids()) {
+          const auto& orientation = neighbors.orientation(neighbor_id);
+          const size_t my_dim_in_neighbor = orientation(d);
           const size_t neighbor_level =
               neighbor_id.segment_id(my_dim_in_neighbor).refinement_level();
           check_if_levels_are_within<AllowedTangentialDifference>(
@@ -202,7 +202,7 @@ OrientationMap<VolumeDim> find_neighbor_orientation(
     const Block<VolumeDim>& neighbor_block) {
   for (const auto& neighbor : host_block.neighbors()) {
     if (neighbor.second.ids().contains(neighbor_block.id())) {
-      return neighbor.second.orientation();
+      return neighbor.second.orientation(neighbor_block.id());
     }
   }
   ERROR("The Block `neighbor_block` is not a neighbor of `host_block`.");

--- a/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
@@ -525,9 +525,10 @@ void check_neighbors(const Neighbors<Dim>& neighbors,
   const size_t dim_normal_to_face = direction.dimension();
   const Side neighbor_side = direction.side();
   const Side element_side = opposite(neighbor_side);
-  const OrientationMap<Dim>& orientation_map = neighbors.orientation();
   double surface_area_covered = 0.0;
   for (const auto& neighbor : neighbors) {
+    const OrientationMap<Dim>& orientation_map =
+        neighbors.orientation(neighbor);
     double neighbor_overlap_area = 1.0;
     const std::array<SegmentId, Dim> neighbor_segment_ids =
         orientation_map.is_aligned()

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1079,6 +1079,7 @@ void test_impl(const Spectral::Quadrature quadrature,
   ElementId<Dim> self_id{};
   ElementId<Dim> east_id{};
   ElementId<Dim> south_id{};  // not used in 1d
+  OrientationMap<Dim> south_orientation{};
 
   if constexpr (Dim == 1) {
     self_id = ElementId<Dim>{0, {{{1, 0}}}};
@@ -1089,24 +1090,24 @@ void test_impl(const Spectral::Quadrature quadrature,
     self_id = ElementId<Dim>{0, {{{1, 0}, {0, 0}}}};
     east_id = ElementId<Dim>{0, {{{1, 1}, {0, 0}}}};
     south_id = ElementId<Dim>{1, {{{0, 0}, {0, 0}}}};
+    south_orientation = OrientationMap<Dim>{
+        std::array{Direction<Dim>::lower_xi(), Direction<Dim>::lower_eta()}};
     neighbors[Direction<Dim>::upper_xi()] =
         Neighbors<Dim>{{east_id}, OrientationMap<Dim>::create_aligned()};
-    neighbors[Direction<Dim>::lower_eta()] = Neighbors<Dim>{
-        {south_id},
-        OrientationMap<Dim>{std::array{Direction<Dim>::lower_xi(),
-                                       Direction<Dim>::lower_eta()}}};
+    neighbors[Direction<Dim>::lower_eta()] =
+        Neighbors<Dim>{{south_id}, south_orientation};
   } else {
     static_assert(Dim == 3, "Only implemented tests in 1, 2, and 3d");
     self_id = ElementId<Dim>{0, {{{1, 0}, {0, 0}, {0, 0}}}};
     east_id = ElementId<Dim>{0, {{{1, 1}, {0, 0}, {0, 0}}}};
     south_id = ElementId<Dim>{1, {{{0, 0}, {0, 0}, {0, 0}}}};
+    south_orientation = OrientationMap<Dim>{
+        std::array{Direction<Dim>::lower_xi(), Direction<Dim>::lower_eta(),
+                   Direction<Dim>::upper_zeta()}};
     neighbors[Direction<Dim>::upper_xi()] =
         Neighbors<Dim>{{east_id}, OrientationMap<Dim>::create_aligned()};
-    neighbors[Direction<Dim>::lower_eta()] = Neighbors<Dim>{
-        {south_id},
-        OrientationMap<Dim>{std::array{Direction<Dim>::lower_xi(),
-                                       Direction<Dim>::lower_eta(),
-                                       Direction<Dim>::upper_zeta()}}};
+    neighbors[Direction<Dim>::lower_eta()] =
+        Neighbors<Dim>{{south_id}, south_orientation};
   }
 
   const auto grid_to_inertial_map =
@@ -1114,7 +1115,7 @@ void test_impl(const Spectral::Quadrature quadrature,
           domain::CoordinateMaps::Identity<Dim>{});
 
   const Element<Dim> element{self_id, neighbors};
-  MockRuntimeSystem runner = [&dg_formulation, &element,
+  MockRuntimeSystem runner = [&dg_formulation, &south_orientation,
                               &grid_to_inertial_map]() {
     std::vector<DirectionMap<
         Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
@@ -1123,29 +1124,22 @@ void test_impl(const Spectral::Quadrature quadrature,
     DirectionMap<Dim, BlockNeighbors<Dim>> neighbors_block0{};
     DirectionMap<Dim, BlockNeighbors<Dim>> neighbors_block1{};
     if constexpr (Dim > 1) {
-      neighbors_block0[Direction<Dim>::lower_eta()] = BlockNeighbors<Dim>{
-          1, element.neighbors().at(Direction<Dim>::lower_eta()).orientation()};
-      neighbors_block1[element.neighbors()
-                           .at(Direction<Dim>::lower_eta())
-                           .orientation()(Direction<Dim>::lower_eta())] =
-          BlockNeighbors<Dim>{0, element.neighbors()
-                                    .at(Direction<Dim>::lower_eta())
-                                    .orientation()
-                                    .inverse_map()};
+      neighbors_block0[Direction<Dim>::lower_eta()] =
+          BlockNeighbors<Dim>{1, south_orientation};
+      neighbors_block1[south_orientation(Direction<Dim>::lower_eta())] =
+          BlockNeighbors<Dim>{0, south_orientation.inverse_map()};
       for (const auto& direction : Direction<Dim>::all_directions()) {
         if (direction != Direction<Dim>::lower_eta()) {
           boundary_conditions[0][direction] =
               std::make_unique<DemandOutgoingCharSpeeds<Dim>>();
         }
-        if (direction != element.neighbors()
-                             .at(Direction<Dim>::lower_eta())
-                             .orientation()(Direction<Dim>::lower_eta())) {
+        if (direction != south_orientation(Direction<Dim>::lower_eta())) {
           boundary_conditions[1][direction] =
               std::make_unique<DemandOutgoingCharSpeeds<Dim>>();
         }
       }
     } else {
-      (void)element;
+      (void)south_orientation;
       for (const auto& direction : Direction<Dim>::all_directions()) {
         boundary_conditions[0][direction] =
             std::make_unique<DemandOutgoingCharSpeeds<Dim>>();
@@ -1805,8 +1799,9 @@ void test_impl(const Spectral::Quadrature quadrature,
           expected_data = packaged_data_buffer;
         }
 
-        const auto& orientation =
-            element.neighbors().at(local_direction).orientation();
+        const auto& orientation = element.neighbors()
+                                      .at(local_direction)
+                                      .orientation(local_neighbor_id);
         DataVector oriented_variables =
             orient_variables_on_slice(expected_data, mortar_mesh.extents(),
                                       local_direction.dimension(), orientation);
@@ -1896,7 +1891,8 @@ void test_impl(const Spectral::Quadrature quadrature,
            .at(DirectionalId<Dim>{
                element.neighbors()
                    .at(mortar_id_east.direction())
-                   .orientation()(mortar_id_east.direction().opposite()),
+                   .orientation(mortar_id_east.id())(
+                       mortar_id_east.direction().opposite()),
                element.id()})
            .boundary_correction_data.value()),
       compute_expected_mortar_data(mortar_id_east.direction(),
@@ -1910,7 +1906,8 @@ void test_impl(const Spectral::Quadrature quadrature,
              .at(DirectionalId<Dim>{
                  element.neighbors()
                      .at(mortar_id_east.direction())
-                     .orientation()(mortar_id_east.direction().opposite()),
+                     .orientation(mortar_id_east.id())(
+                         mortar_id_east.direction().opposite()),
                  element.id()})
              .validity_range) ==
         (LocalTimeStepping ? next_time_step_id : time_step_id));
@@ -1926,7 +1923,8 @@ void test_impl(const Spectral::Quadrature quadrature,
                .at(DirectionalId<Dim>{
                    element.neighbors()
                        .at(mortar_id_south.direction())
-                       .orientation()(mortar_id_south.direction().opposite()),
+                       .orientation(mortar_id_south.id())(
+                           mortar_id_south.direction().opposite()),
                    element.id()})
                .validity_range) ==
           (LocalTimeStepping ? next_time_step_id : time_step_id));
@@ -1961,7 +1959,8 @@ void test_impl(const Spectral::Quadrature quadrature,
              .at(DirectionalId<Dim>{
                  element.neighbors()
                      .at(mortar_id_south.direction())
-                     .orientation()(mortar_id_south.direction().opposite()),
+                     .orientation(mortar_id_south.id())(
+                         mortar_id_south.direction().opposite()),
                  element.id()})
              .boundary_correction_data.value()),
         compute_expected_mortar_data(mortar_id_south.direction(),

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_CommunicateOverlapFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Actions/Test_CommunicateOverlapFields.cpp
@@ -75,6 +75,36 @@ struct Metavariables {
   using component_list = tmpl::list<element_array>;
 };
 
+template <size_t Dim>
+ElementId<Dim> make_element_id_2() {
+  const SegmentId root_segment{0, 0};
+  if constexpr (Dim == 1) {
+    return ElementId<1>{1, {{root_segment}}};
+  } else if constexpr (Dim == 2) {
+    return ElementId<2>{
+        1, {{root_segment, root_segment.id_of_child(Side::Lower)}}};
+  } else {
+    return ElementId<3>{
+        1,
+        {{root_segment, root_segment.id_of_child(Side::Lower), root_segment}}};
+  }
+}
+
+template <size_t Dim>
+ElementId<Dim> make_element_id_3() {
+  const SegmentId root_segment{0, 0};
+  if constexpr (Dim == 1) {
+    return ElementId<1>{2, {{root_segment}}};
+  } else if constexpr (Dim == 2) {
+    return ElementId<2>{
+        1, {{root_segment, root_segment.id_of_child(Side::Upper)}}};
+  } else {
+    return ElementId<3>{
+        1,
+        {{root_segment, root_segment.id_of_child(Side::Upper), root_segment}}};
+  }
+}
+
 template <size_t Dim, bool RestrictToOverlap>
 void test_communicate_overlap_fields(const size_t num_points_per_dim,
                                      const size_t overlap,
@@ -108,8 +138,8 @@ void test_communicate_overlap_fields(const size_t num_points_per_dim,
          LinearSolver::Schwarz::OverlapMap<Dim, typename fields_tag::type>{}});
   };
   const ElementId<Dim> first_element_id{0};
-  const ElementId<Dim> second_element_id{1};
-  const ElementId<Dim> third_element_id{2};
+  const ElementId<Dim> second_element_id = make_element_id_2<Dim>();
+  const ElementId<Dim> third_element_id = make_element_id_3<Dim>();
   // We can only have multiple face-neighbors in >1 dimensions
   if constexpr (Dim > 1) {
     add_element({first_element_id,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
@@ -107,13 +107,20 @@ void test_weights_conservation(const Element<Dim>& element,
 template <size_t Dim>
 void test_weights(const Mesh<Dim>& mesh, const size_t max_overlap) {
   typename Element<Dim>::Neighbors_t neighbors{};
+  std::unordered_map<size_t, OrientationMap<Dim>> orientations{};
+  for (size_t i = 0; i < two_to_the(Dim - 1); ++i) {
+    orientations.emplace(i + 1, OrientationMap<Dim>::create_aligned());
+  }
   for (size_t d = 0; d < Dim; ++d) {
     for (const auto& side : std::array<Side, 2>{{Side::Lower, Side::Upper}}) {
+      // This test as written uses Neighbors that are in different Blocks which
+      // are now by definition non-conforming.  LK has chosen to mark them as
+      // non-conforming instead of generating Elements that would be conforming
       auto& direction_neighbors =
           neighbors
               .emplace(Direction<Dim>{d, side},
                        Neighbors<Dim>{std::unordered_set<ElementId<Dim>>{},
-                                      OrientationMap<Dim>::create_aligned()})
+                                      orientations, false})
               .first->second;
       for (size_t i = 0; i < two_to_the(Dim - 1); ++i) {
         direction_neighbors.add_ids({ElementId<Dim>{i + 1}});


### PR DESCRIPTION
## Proposed changes

With non-conforming Blocks, a Block may have multiple neighbors in a direction, and those neighbors need not share a common Orientation.  Thus store an OrientationMap indexed by the id of the Block.  This is sufficient for Elements as well since all Elements in a given Block are aligned with each other.

Note this requires a block id to be passed to fetch the correct OrientationMap from the Neighbors.

Also, for convenience, store a boolean on whether or not the neighbors are conforming to the host.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
You must pass the ID of the Block or Neighbor to the orientation member function of BlockNeighbors or Neighbors.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
