### PR TITLE
Only interpolate for horizon finds from certain blocks

### DIFF
--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -60,6 +60,17 @@ Disk::Disk(typename InnerRadius::type inner_radius,
   if (boundary_condition_ != nullptr and is_periodic(boundary_condition_)) {
     PARSE_ERROR(context, "Cannot have periodic boundary conditions on a disk.");
   }
+
+  block_groups_["Shell0"];
+  block_names_.reserve(5);
+  const std::array<std::string, 4> wedge_directions{"UpperX", "UpperY",
+                                                    "LowerX", "LowerY"};
+  for (const std::string& name : wedge_directions) {
+    block_names_.emplace_back(name);
+    block_groups_["Shell0"].insert(name);
+  }
+  block_names_.emplace_back("CenterSquare");
+  block_groups_["CenterSquare"].insert("CenterSquare");
 }
 
 Domain<2> Disk::create_domain() const {
@@ -131,7 +142,8 @@ Domain<2> Disk::create_domain() const {
     boundary_conditions_all_blocks.emplace_back();
   }
 
-  return Domain<2>{std::move(coord_maps), corners};
+  return Domain<2>{std::move(coord_maps), corners,      {}, {},
+                   block_names_,          block_groups_};
 }
 
 std::vector<DirectionMap<

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -6,6 +6,9 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
@@ -138,6 +141,13 @@ class Disk : public DomainCreator<2> {
 
   std::vector<std::array<size_t, 2>> initial_refinement_levels() const override;
 
+  std::vector<std::string> block_names() const override { return block_names_; }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const override {
+    return block_groups_;
+  }
+
  private:
   typename InnerRadius::type inner_radius_{};
   typename OuterRadius::type outer_radius_{};
@@ -146,6 +156,9 @@ class Disk : public DomainCreator<2> {
   typename UseEquiangularMap::type use_equiangular_map_{false};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       boundary_condition_;
+  std::vector<std::string> block_names_;
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      block_groups_;
 };
 }  // namespace creators
 }  // namespace domain

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -180,7 +180,8 @@ Domain<Dim> Rectilinear<Dim>::create_domain() const {
       {std::move(block_corners)},
       std::move(identifications),
       {},
-      block_names_};
+      block_names(),
+      block_groups()};
 
   if (not time_dependence_->is_none()) {
     domain.inject_time_dependent_map_for_block(

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
@@ -246,6 +247,11 @@ class Rectilinear : public DomainCreator<Dim> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
   std::vector<std::string> block_names() const override { return block_names_; }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const override {
+    return {{name(), {name()}}};
+  }
 
   // Transforms from option-created boundary conditions to the type used in the
   // constructor

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
@@ -24,10 +24,10 @@ template <bool UseControlSystems, typename... InterpolationTargetTags>
 struct EvolutionMetavars
     : public GhValenciaDivCleanTemplateBase<
           EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>,
-          true, UseControlSystems> {
+          true, UseControlSystems, false> {
   using base = GhValenciaDivCleanTemplateBase<
       EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>, true,
-      UseControlSystems>;
+      UseControlSystems, false>;
   using const_global_cache_tags = typename base::const_global_cache_tags;
   using observed_reduction_data_tags =
       typename base::observed_reduction_data_tags;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -43,14 +43,14 @@ template <bool UseControlSystems, typename... InterpolationTargetTags>
 struct EvolutionMetavars
     : public GhValenciaDivCleanTemplateBase<
           EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>,
-          false, false> {
+          false, false, true> {
   static_assert(not UseControlSystems,
                 "GhValenciaWithHorizon doesn't support control systems yet.");
   static constexpr bool use_dg_subcell = false;
 
   using defaults = GhValenciaDivCleanDefaults<use_dg_subcell>;
   using base = GhValenciaDivCleanTemplateBase<EvolutionMetavars, use_dg_subcell,
-                                              UseControlSystems>;
+                                              UseControlSystems, true>;
   static constexpr size_t volume_dim = defaults::volume_dim;
   using domain_frame = typename defaults::domain_frame;
   static constexpr bool use_damped_harmonic_rollon =

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -337,15 +337,15 @@ struct GhValenciaDivCleanDefaults {
 };
 
 template <typename EvolutionMetavarsDerived, bool UseDgSubcell,
-          bool UseControlSystems>
+          bool UseControlSystems, bool WithHorizon>
 struct GhValenciaDivCleanTemplateBase;
 
-template <bool UseDgSubcell, bool UseControlSystems,
+template <bool UseDgSubcell, bool UseControlSystems, bool WithHorizon,
           template <bool, typename...> class EvolutionMetavarsDerived,
           typename... InterpolationTargetTags>
 struct GhValenciaDivCleanTemplateBase<
     EvolutionMetavarsDerived<UseControlSystems, InterpolationTargetTags...>,
-    UseDgSubcell, UseControlSystems>
+    UseDgSubcell, UseControlSystems, WithHorizon>
     : public virtual GhValenciaDivCleanDefaults<UseDgSubcell> {
   using derived_metavars =
       EvolutionMetavarsDerived<UseControlSystems, InterpolationTargetTags...>;
@@ -690,9 +690,11 @@ struct GhValenciaDivCleanTemplateBase<
       gh::ConstraintDamping::Tags::DampingFunctionGamma2<volume_dim,
                                                          Frame::Grid>>>;
 
-  using dg_registration_list =
-      tmpl::list<intrp::Actions::RegisterElementWithInterpolator,
-                 observers::Actions::RegisterEventsWithObservers>;
+  using dg_registration_list = tmpl::flatten<tmpl::list<
+      tmpl::conditional_t<WithHorizon,
+                          intrp::Actions::RegisterElementWithInterpolator,
+                          tmpl::list<>>,
+      observers::Actions::RegisterEventsWithObservers>>;
 
   static constexpr auto default_phase_order = std::array<Parallel::Phase, 8>{
       {Parallel::Phase::Initialization,
@@ -928,7 +930,8 @@ struct GhValenciaDivCleanTemplateBase<
       observers::ObserverWriter<derived_metavars>,
       importers::ElementDataReader<derived_metavars>,
       control_system::control_components<derived_metavars, control_systems>,
-      intrp::Interpolator<derived_metavars>,
+      tmpl::conditional_t<WithHorizon, intrp::Interpolator<derived_metavars>,
+                          tmpl::list<>>,
       intrp::InterpolationTarget<derived_metavars, InterpolationTargetTags>...,
       dg_element_array_component>>;
 };

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -118,19 +118,12 @@
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
-#include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
-#include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp"
-#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp"
-#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp"
-#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
-#include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
-#include "ParallelAlgorithms/Interpolation/Interpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/KerrHorizon.hpp"
@@ -515,8 +508,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                           dg_step_actions>;
 
   using dg_registration_list =
-      tmpl::list<intrp::Actions::RegisterElementWithInterpolator,
-                 observers::Actions::RegisterEventsWithObservers>;
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<
@@ -613,7 +605,6 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
   using component_list = tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
-      intrp::Interpolator<EvolutionMetavars>,
       intrp::InterpolationTarget<EvolutionMetavars, InterpolationTargetTags>...,
       dg_element_array_component>;
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.cpp
@@ -5,8 +5,10 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <unordered_set>
 
 #include "IO/Logging/Verbosity.hpp"
+#include "Options/Context.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace Frame {
@@ -17,11 +19,13 @@ namespace intrp::OptionHolders {
 template <typename Frame>
 ApparentHorizon<Frame>::ApparentHorizon(
     ylm::Strahlkorper<Frame> initial_guess_in, ::FastFlow fast_flow_in,
-    ::Verbosity verbosity_in, const size_t max_interpolation_retries_in)
+    ::Verbosity verbosity_in, const size_t max_interpolation_retries_in,
+    std::optional<std::vector<std::string>> blocks_for_interpolation_in)
     : initial_guess(std::move(initial_guess_in)),
       fast_flow(std::move(fast_flow_in)),  // NOLINT
       verbosity(std::move(verbosity_in)),  // NOLINT
-      max_interpolation_retries(max_interpolation_retries_in) {}
+      max_interpolation_retries(max_interpolation_retries_in),
+      blocks_for_interpolation(std::move(blocks_for_interpolation_in)) {}
 // clang-tidy std::move of trivially copyable type.
 
 template <typename Frame>
@@ -30,6 +34,7 @@ void ApparentHorizon<Frame>::pup(PUP::er& p) {
   p | fast_flow;
   p | verbosity;
   p | max_interpolation_retries;
+  p | blocks_for_interpolation;
 }
 
 template <typename Frame>
@@ -37,7 +42,8 @@ bool operator==(const ApparentHorizon<Frame>& lhs,
                 const ApparentHorizon<Frame>& rhs) {
   return lhs.initial_guess == rhs.initial_guess and
          lhs.fast_flow == rhs.fast_flow and lhs.verbosity == rhs.verbosity and
-         lhs.max_interpolation_retries == rhs.max_interpolation_retries;
+         lhs.max_interpolation_retries == rhs.max_interpolation_retries and
+         lhs.blocks_for_interpolation == rhs.blocks_for_interpolation;
 }
 
 template <typename Frame>

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
@@ -4,24 +4,36 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
 #include "IO/Logging/Tags.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Requires.hpp"
@@ -39,6 +51,8 @@ template <typename TagsList>
 class DataBox;
 }  // namespace db
 namespace intrp {
+template <class Metavariables, typename InterpolationTargetTag>
+struct InterpolationTarget;
 namespace Tags {
 template <typename TemporalId>
 struct TemporalIds;
@@ -55,6 +69,10 @@ namespace OptionHolders {
 /// Options for finding an apparent horizon.
 template <typename Frame>
 struct ApparentHorizon {
+ private:
+  struct All {};
+
+ public:
   /// See Strahlkorper for suboptions.
   struct InitialGuess {
     static constexpr Options::String help = {"Initial guess"};
@@ -75,16 +93,23 @@ struct ApparentHorizon {
         "the two previous surfaces are averaged and that new surface is used."};
     using type = size_t;
   };
-  using options =
-      tmpl::list<InitialGuess, FastFlow, Verbosity, MaxInterpolationRetries>;
+  struct BlocksForInterpolation {
+    static constexpr Options::String help = {
+        "Volume data will be sent to the interpolator for these block group "
+        "names. Set to 'All' to send volume data from the entire domain."};
+    using type = Options::Auto<std::vector<std::string>, All>;
+  };
+  using options = tmpl::list<InitialGuess, FastFlow, Verbosity,
+                             MaxInterpolationRetries, BlocksForInterpolation>;
   static constexpr Options::String help = {
       "Provide an initial guess for the apparent horizon surface\n"
       "(Strahlkorper) and apparent-horizon-finding-algorithm (FastFlow)\n"
       "options."};
 
-  ApparentHorizon(ylm::Strahlkorper<Frame> initial_guess_in,
-                  ::FastFlow fast_flow_in, ::Verbosity verbosity_in,
-                  size_t max_interpolation_retries_in);
+  ApparentHorizon(
+      ylm::Strahlkorper<Frame> initial_guess_in, ::FastFlow fast_flow_in,
+      ::Verbosity verbosity_in, size_t max_interpolation_retries_in,
+      std::optional<std::vector<std::string>> blocks_for_interpolation_in);
 
   ApparentHorizon() = default;
   ApparentHorizon(const ApparentHorizon& /*rhs*/) = default;
@@ -100,6 +125,7 @@ struct ApparentHorizon {
   ::FastFlow fast_flow{};
   ::Verbosity verbosity{::Verbosity::Quiet};
   size_t max_interpolation_retries{};
+  std::optional<std::vector<std::string>> blocks_for_interpolation;
 };
 
 template <typename Frame>
@@ -138,6 +164,83 @@ struct ApparentHorizon : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& option) { return option; }
 };
+
+namespace detail {
+template <typename InterpolationTargetTags>
+struct get_horizon_options;
+
+template <typename... InterpolationTargetTags>
+struct get_horizon_options<tmpl::list<InterpolationTargetTags...>> {
+  using type = tmpl::list<OptionTags::ApparentHorizon<
+      InterpolationTargetTags,
+      typename InterpolationTargetTags::compute_target_points::frame>...>;
+};
+
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(component_being_mocked)
+}  // namespace detail
+
+/*!
+ * \brief Holds a map between interpolation target tag name (aka a horizon) and
+ * a set of block names that should be used for interpolation for that target.
+ */
+struct BlocksForInterpolation : db::SimpleTag, BlocksForInterpolationBase {
+  using type = std::unordered_map<std::string, std::unordered_set<std::string>>;
+  template <typename Metavariables>
+  using option_tags = tmpl::push_front<
+      typename detail::get_horizon_options<
+          InterpolationTarget_detail::get_sequential_target_tags<
+              Metavariables>>::type,
+      ::domain::OptionTags::DomainCreator<Metavariables::volume_dim>>;
+
+  static constexpr bool pass_metavariables = true;
+  template <typename Metavariables, typename... HorizonOptions>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const HorizonOptions&... all_horizon_options) {
+    return create_from_options_impl<Metavariables>(
+        domain_creator, std::forward_as_tuple(all_horizon_options...),
+        std::make_index_sequence<sizeof...(HorizonOptions)>{});
+  }
+
+ private:
+  // Need the names of the target tags which are in the option tags, but not the
+  // horizon options themselves. This just expands a tuple to be able to index
+  // the `option_tags` type alias so we can get the name of the target horizon
+  template <typename Metavariables, typename HorizonOptionsTuple, size_t... Is>
+  static type create_from_options_impl(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const HorizonOptionsTuple& all_horizon_options,
+      const std::index_sequence<Is...>& /*index_sequence*/
+  ) {
+    std::unordered_map<std::string, std::unordered_set<std::string>> result{};
+
+    const auto block_names = domain_creator->block_names();
+    const auto block_groups = domain_creator->block_groups();
+
+    const auto append_to_result = [&](const std::string& name,
+                                      const auto& horizon_options) {
+      if (horizon_options.blocks_for_interpolation.has_value()) {
+        result[name] = domain::expand_block_groups_to_block_names(
+            horizon_options.blocks_for_interpolation.value(), block_names,
+            block_groups);
+      } else {
+        // Insert all blocks
+        result[name].insert(block_names.begin(), block_names.end());
+      }
+
+      // Needed for the expand_pack below
+      return 0;
+    };
+
+    expand_pack(
+        append_to_result(tmpl::at_c<option_tags<Metavariables>, Is + 1>::name(),
+                         std::get<Is>(all_horizon_options))...);
+
+    return result;
+  }
+};
 }  // namespace Tags
 
 namespace TargetPoints {
@@ -156,7 +259,8 @@ namespace TargetPoints {
 template <typename InterpolationTargetTag, typename Frame>
 struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   using const_global_cache_tags =
-      tmpl::list<Tags::ApparentHorizon<InterpolationTargetTag, Frame>>;
+      tmpl::list<Tags::BlocksForInterpolation,
+                 Tags::ApparentHorizon<InterpolationTargetTag, Frame>>;
   using is_sequential = std::true_type;
   using frame = Frame;
 

--- a/src/ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp
@@ -10,9 +10,12 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -69,8 +72,21 @@ struct InitializeInterpolator {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    Initialization::mutate_assign<tmpl::list<Tags::NumberOfElements<Dim>>>(
-        make_not_null(&box), std::unordered_set<ElementId<Dim>>{});
+    using sequential_targets =
+        intrp::InterpolationTarget_detail::get_sequential_target_tags<
+            Metavariables>;
+    db::mutate<Tags::NumberOfElements<Dim>>(
+        [](const gsl::not_null<std::unordered_map<
+               std::string, std::unordered_set<ElementId<Dim>>>*>
+               num_elements) {
+          tmpl::for_each<sequential_targets>([&](auto target_v) {
+            using target = tmpl::type_from<decltype(target_v)>;
+            const std::string& target_name = pretty_type::name<target>();
+
+            (*num_elements)[target_name] = std::unordered_set<ElementId<Dim>>{};
+          });
+        },
+        make_not_null(&box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -15,10 +16,14 @@
 #include "Parallel/Local.hpp"
 #include "Parallel/Protocols/ElementRegistrar.hpp"
 #include "ParallelAlgorithms/Actions/GetItemFromDistributedObject.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
@@ -57,16 +62,40 @@ struct RegisterElement {
                     const Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
                     const ElementId<Metavariables::volume_dim>& element_id) {
+    using sequential_targets =
+        intrp::InterpolationTarget_detail::get_sequential_target_tags<
+            Metavariables>;
+    const auto& blocks_to_interpolate =
+        Parallel::get<intrp::Tags::BlocksForInterpolationBase>(cache);
+    const auto& blocks =
+        Parallel::get<domain::Tags::Domain<Metavariables::volume_dim>>(cache)
+            .blocks();
     db::mutate<Tags::NumberOfElements<Metavariables::volume_dim>>(
-        [&](const gsl::not_null<
-            std::unordered_set<ElementId<Metavariables::volume_dim>>*>
+        [&](const gsl::not_null<std::unordered_map<
+                std::string,
+                std::unordered_set<ElementId<Metavariables::volume_dim>>>*>
                 num_elements) {
-          auto inserted = num_elements->insert(element_id);
-          if (not inserted.second) {
-            ERROR("Unable to insert element "
-                  << element_id << " into interpolator core "
-                  << Parallel::my_proc<size_t>(cache));
-          }
+          const auto& block_name = blocks[element_id.block_id()].name();
+
+          tmpl::for_each<sequential_targets>([&](auto target_v) {
+            using target = tmpl::type_from<decltype(target_v)>;
+            const std::string& target_name = pretty_type::name<target>();
+            if (not blocks_to_interpolate.contains(target_name)) {
+              ERROR("Target " << target_name
+                              << " not in blocks to interpolate: "
+                              << keys_of(blocks_to_interpolate));
+            }
+
+            if (blocks_to_interpolate.at(target_name).contains(block_name)) {
+              auto inserted = (*num_elements)[target_name].insert(element_id);
+              if (not inserted.second) {
+                ERROR("Unable to insert element "
+                      << element_id << " into interpolator core "
+                      << Parallel::my_proc<size_t>(cache) << " for target "
+                      << target_name);
+              }
+            }
+          });
         },
         make_not_null(&box));
   }
@@ -94,16 +123,45 @@ struct DeregisterElement {
                     const Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
                     const ElementId<Metavariables::volume_dim>& element_id) {
+    using sequential_targets =
+        intrp::InterpolationTarget_detail::get_sequential_target_tags<
+            Metavariables>;
+    const auto& blocks_to_interpolate =
+        Parallel::get<intrp::Tags::BlocksForInterpolationBase>(cache);
+    const auto& blocks =
+        Parallel::get<domain::Tags::Domain<Metavariables::volume_dim>>(cache)
+            .blocks();
     db::mutate<Tags::NumberOfElements<Metavariables::volume_dim>>(
-        [&](const gsl::not_null<
-            std::unordered_set<ElementId<Metavariables::volume_dim>>*>
+        [&](const gsl::not_null<std::unordered_map<
+                std::string,
+                std::unordered_set<ElementId<Metavariables::volume_dim>>>*>
                 num_elements) {
-          const size_t num_elements_removed = num_elements->erase(element_id);
-          if (num_elements_removed == 0) {
-            ERROR("Unable to remove element "
-                  << element_id << " from interpolator core "
-                  << Parallel::my_proc<size_t>(cache));
-          }
+          const auto& block_name = blocks[element_id.block_id()].name();
+
+          tmpl::for_each<sequential_targets>([&](auto target_v) {
+            using target = tmpl::type_from<decltype(target_v)>;
+            const std::string& target_name = pretty_type::name<target>();
+            if (not blocks_to_interpolate.contains(target_name)) {
+              ERROR("Target " << target_name
+                              << " not in blocks to interpolate: "
+                              << keys_of(blocks_to_interpolate));
+            }
+
+            if (blocks_to_interpolate.at(target_name).contains(block_name)) {
+              const size_t num_elements_removed =
+                  (*num_elements)[target_name].erase(element_id);
+              if (num_elements_removed == 0) {
+                ERROR("Unable to remove element "
+                      << element_id << " from interpolator core "
+                      << Parallel::my_proc<size_t>(cache) << " for target "
+                      << target_name);
+              }
+
+              if (num_elements->at(target_name).empty()) {
+                num_elements->erase(target_name);
+              }
+            }
+          });
         },
         make_not_null(&box));
   }

--- a/src/ParallelAlgorithms/Interpolation/Actions/PrintInterpolatorForDeadlock.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/PrintInterpolatorForDeadlock.hpp
@@ -48,11 +48,12 @@ struct PrintInterpolator {
 
     tmpl::for_each<target_tags>([&](const auto tag_v) {
       using target_tag = tmpl::type_from<decltype(tag_v)>;
+      const std::string& target_name = pretty_type::name<target_tag>();
 
       // Only need to print the sequential targets (aka horizons)
       if constexpr (target_tag::compute_target_points::is_sequential::value) {
         const std::string file_name =
-            intrp_deadlock_dir + "/" + pretty_type::name<target_tag>() + ".out";
+            intrp_deadlock_dir + "/" + target_name + ".out";
 
         const auto& holders =
             db::get<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(box);
@@ -79,12 +80,13 @@ struct PrintInterpolator {
         for (const auto& [temporal_id, info] : vars_infos) {
           ss << "Temporal id " << temporal_id << ": "
              << "Iteration " << info.iteration << ", expecting data from "
-             << num_elements.size() << " elements, but only received "
+             << num_elements.at(target_name).size()
+             << " elements, but only received "
              << info.interpolation_is_done_for_these_elements.size()
              << ". Missing these elements: ";
 
           std::unordered_set<ElementId<Metavariables::volume_dim>> difference{};
-          for (const auto& element : num_elements) {
+          for (const auto& element : num_elements.at(target_name)) {
             if (not info.interpolation_is_done_for_these_elements.contains(
                     element)) {
               difference.insert(element);

--- a/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
@@ -17,12 +17,15 @@
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Printf/Printf.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -198,16 +201,25 @@ void try_to_interpolate(
 
   // Send interpolated data only if interpolation has been done on all
   // of the local elements.
-  const auto& num_elements =
+  const auto all_num_elements =
       db::get<Tags::NumberOfElements<Metavariables::volume_dim>>(*box);
-  if (vars_infos.at(temporal_id)
-          .interpolation_is_done_for_these_elements.size() ==
-      num_elements.size()) {
+  const std::string& target_name = pretty_type::name<InterpolationTargetTag>();
+  if (not all_num_elements.contains(target_name)) {
+    ERROR("Target name " << target_name << " not in NumberOfElements: "
+                         << keys_of(all_num_elements));
+  }
+  const auto& num_elements = all_num_elements.at(target_name);
+  // Since some targets may not need all elements, we must specifically check if
+  // we have all the necessary elements
+  if (alg::all_of(num_elements, [&](const auto& element) {
+        return vars_infos.at(temporal_id)
+            .interpolation_is_done_for_these_elements.contains(element);
+      })) {
     // Send data to InterpolationTarget, but only if the list of points is
     // non-empty.
     if (debug_print) {
-      ss << "finished interpolation on all " << num_elements
-         << " elements on core " << sys::my_proc();
+      ss << "finished interpolation on all " << num_elements.size()
+         << " elements on core " << Parallel::my_proc<int>(*cache);
     }
 
     if (not vars_infos.at(temporal_id).global_offsets.empty()) {
@@ -238,7 +250,8 @@ void try_to_interpolate(
         box);
   } else if (debug_print) {
     ss << "interpolation not finished on all local elements of core "
-       << sys::my_proc() << ". Expected " << num_elements << ", received "
+       << Parallel::my_proc<int>(*cache) << ". Expected " << num_elements.size()
+       << ", received "
        << vars_infos.at(temporal_id)
               .interpolation_is_done_for_these_elements.size();
   }

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -17,6 +17,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/GetComputeItemsOnSource.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -90,6 +91,22 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
     static_assert(
         std::is_same_v<typename Metavariables::interpolator_source_vars,
                        tmpl::list<InterpolatorSourceVarTags...>>);
+
+    const auto& blocks_to_interpolate =
+        Parallel::get<intrp::Tags::BlocksForInterpolationBase>(cache);
+    ASSERT(blocks_to_interpolate.contains(name()),
+           "Blocks to interpolate doesn't contain target " << name());
+    const auto& blocks_to_interpolate_for_this_target =
+        blocks_to_interpolate.at(name());
+    const auto& blocks =
+        Parallel::get<domain::Tags::Domain<VolumeDim>>(cache).blocks();
+    const auto& block_name = blocks[array_index.block_id()].name();
+
+    // Only send data if this target needs this blocks data
+    if (not blocks_to_interpolate_for_this_target.contains(block_name)) {
+      return;
+    }
+
     if constexpr (Parallel::is_dg_element_collection_v<ParallelComponent>) {
       const auto core_id = static_cast<int>(
           Parallel::local_synchronous_action<

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -380,6 +380,7 @@ void clean_up_interpolation_target(
       box);
 }
 
+struct HaveDataAtAllPoints {};
 /// Returns true if this InterpolationTarget has received data
 /// at all its points.
 ///
@@ -414,7 +415,6 @@ bool have_data_at_all_points(
           .at(temporal_id)
           .number_of_grid_points();
   if (verbosity >= ::Verbosity::Debug) {
-    struct HaveDataAtAllPoints {};
     Parallel::printf(
         "%s, Total expected points = %d, valid points received = %d, "
         "invalid points received = %d\n",

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -88,6 +88,27 @@ struct Variables;
 /// \endcond
 
 namespace intrp::InterpolationTarget_detail {
+template <typename InterpolationTarget>
+struct get_interpolation_target_tag {
+  using type = typename InterpolationTarget::interpolation_target_tag;
+};
+
+template <typename InterpolationTargetTag>
+struct is_sequential
+    : InterpolationTargetTag::compute_target_points::is_sequential {};
+
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(component_being_mocked)
+
+template <typename Metavariables>
+using get_sequential_target_tags = tmpl::filter<
+    tmpl::transform<
+        tmpl::filter<tmpl::transform<typename Metavariables::component_list,
+                                     get_component_being_mocked_or_default<
+                                         tmpl::_1, tmpl::_1>>,
+                     tt::is_a<intrp::InterpolationTarget, tmpl::_1>>,
+        get_interpolation_target_tag<tmpl::_1>>,
+    is_sequential<tmpl::_1>>;
+
 CREATE_IS_CALLABLE(substep_time)
 CREATE_IS_CALLABLE_V(substep_time)
 template <typename T>

--- a/src/ParallelAlgorithms/Interpolation/Tags.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Tags.hpp
@@ -208,10 +208,12 @@ struct InterpolatedVarsHolders : db::SimpleTag {
       typename Metavariables::interpolation_target_tags, Metavariables>>;
 };
 
-/// Unordered set of element ids on each interpolator core.
+/// Map between interpolation target name and an unordered set of element ids on
+/// each interpolator core that will participate for that target.
 template <size_t Dim>
 struct NumberOfElements : db::SimpleTag {
-  using type = std::unordered_set<ElementId<Dim>>;
+  using type =
+      std::unordered_map<std::string, std::unordered_set<ElementId<Dim>>>;
 };
 
 /*!

--- a/src/ParallelAlgorithms/Interpolation/Tags.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Tags.hpp
@@ -214,5 +214,13 @@ struct NumberOfElements : db::SimpleTag {
   using type = std::unordered_set<ElementId<Dim>>;
 };
 
+/*!
+ * \brief Base tag that holds a map between interpolation target tag name (aka a
+ * horizon) and a set of block names that should be used for interpolation for
+ * that target.
+ */
+struct BlocksForInterpolationBase : db::BaseTag {
+  using type = std::unordered_map<std::string, std::unordered_set<std::string>>;
+};
 }  // namespace Tags
 }  // namespace intrp

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -468,6 +468,7 @@ ApparentHorizons:
       MaxIts: 100
     Verbosity: Quiet
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: ["ObjectAShell", "ObjectACube"]
   ObservationAhB: &AhB
     InitialGuess:
       LMax: *ObsLMax
@@ -476,6 +477,7 @@ ApparentHorizons:
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: ["ObjectBShell", "ObjectBCube"]
   ObservationAhC:
     InitialGuess:
       LMax: 33
@@ -484,6 +486,12 @@ ApparentHorizons:
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
     MaxInterpolationRetries: 3
+    BlocksForInterpolation:
+      - "ObjectAShell"
+      - "ObjectACube"
+      - "ObjectBShell"
+      - "ObjectBCube"
+      - "Envelope"
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
   ControlSystemCharSpeedAhA: *AhA

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -306,6 +306,7 @@ ApparentHorizons:
       MaxIts: 100
     Verbosity: Quiet
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: ["Shell0"]
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -275,6 +275,7 @@ ApparentHorizons:
       MaxIts: 100
     Verbosity: Verbose
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: All
   ObservationAhB: &AhB
     InitialGuess:
       LMax: *LMax
@@ -283,6 +284,7 @@ ApparentHorizons:
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: All
   ObservationAhC:
     InitialGuess:
       LMax: 20
@@ -291,6 +293,7 @@ ApparentHorizons:
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: All
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
   ControlSystemCharSpeedAhA: *AhA

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -250,6 +250,7 @@ ApparentHorizons:
       MaxIts: 100
     Verbosity: Verbose
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: All
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -446,7 +446,6 @@ Observers:
   ReductionFileName: "GhMhdReductions"
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 EventsAndDenseTriggers:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -248,6 +248,7 @@ ApparentHorizons:
       MaxIts: 100
     Verbosity: Verbose
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: All
 
 InterpolationTargets:
   BondiSachsInterpolation:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -273,7 +273,6 @@ Observers:
   ReductionFileName: "GhMhdTovStarReductions"
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 EventsAndDenseTriggers:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -136,10 +136,6 @@ Observers:
   VolumeFileName: "ValenciaDivCleanBlastWaveVolume"
   ReductionFileName: "ValenciaDivCleanBlastWaveReductions"
 
-Interpolator:
-  DumpVolumeDataOnFailure: false
-  Verbosity: Silent
-
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -186,7 +186,6 @@ Observers:
   ReductionFileName: "ValenciaDivCleanFishboneMoncriefDiskReductions"
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 InterpolationTargets:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -222,6 +222,7 @@ ApparentHorizons:
       MaxIts: 100
     Verbosity: Verbose
     MaxInterpolationRetries: 3
+    BlocksForInterpolation: All
   ControlSystemSingleAh: *AhA
 
 InterpolationTargets:

--- a/tests/Unit/Domain/Creators/Python/Test_Brick.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Brick.py
@@ -18,7 +18,7 @@ class TestBrick(unittest.TestCase):
         domain = brick.create_domain()
         self.assertFalse(domain.is_time_dependent())
         self.assertEqual(brick.block_names(), ["Brick"])
-        self.assertEqual(brick.block_groups(), {})
+        self.assertEqual(brick.block_groups(), {"Brick": {"Brick"}})
         self.assertEqual(brick.initial_extents(), [[3, 4, 2]])
         self.assertEqual(brick.initial_refinement_levels(), [[1, 0, 1]])
         self.assertEqual(brick.functions_of_time(), {})

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -71,7 +71,9 @@ void test_brick_construction(
   CHECK(brick.initial_extents() == expected_extents);
   CHECK(brick.initial_refinement_levels() == expected_refinement_level);
   CHECK(brick.block_names() == std::vector<std::string>{"Brick"});
-  CHECK(brick.block_groups().empty());
+  const auto block_groups = brick.block_groups();
+  CHECK(block_groups.contains("Brick"));
+  CHECK(block_groups.at("Brick") == std::unordered_set<std::string>{"Brick"});
 
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -48,6 +48,15 @@ void test_disk_construction(
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       disk, expect_boundary_conditions);
   CHECK(disk.grid_anchors().empty());
+  CHECK(disk.block_names() == std::vector<std::string>{"UpperX", "UpperY",
+                                                       "LowerX", "LowerY",
+                                                       "CenterSquare"});
+  const auto block_groups = disk.block_groups();
+  CHECK(block_groups.contains("Shell0"));
+  CHECK(block_groups.contains("CenterSquare"));
+  CHECK(
+      block_groups.at("Shell0") ==
+      std::unordered_set<std::string>{"UpperX", "UpperY", "LowerX", "LowerY"});
 
   const OrientationMap<2> aligned_orientation =
       OrientationMap<2>::create_aligned();

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -44,7 +44,11 @@ void test_interval_construction(const creators::Interval& domain_creator,
   CHECK(domain_creator.grid_anchors().empty());
 
   // Interval-specific tests
-  CHECK(domain.block_groups().empty());
+  CHECK(domain_creator.block_names() == std::vector<std::string>{"Interval"});
+  const auto block_groups = domain_creator.block_groups();
+  CHECK(block_groups.contains("Interval"));
+  CHECK(block_groups.at("Interval") ==
+        std::unordered_set<std::string>{"Interval"});
   const auto& blocks = domain.blocks();
   CHECK(blocks.size() == 1);
   CHECK(domain.excision_spheres().empty());

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -69,6 +69,12 @@ void test_rectangle_construction(
       rectangle, expect_boundary_conditions);
   CHECK(rectangle.grid_anchors().empty());
 
+  CHECK(rectangle.block_names() == std::vector<std::string>{"Rectangle"});
+  const auto block_groups = rectangle.block_groups();
+  CHECK(block_groups.contains("Rectangle"));
+  CHECK(block_groups.at("Rectangle") ==
+        std::unordered_set<std::string>{"Rectangle"});
+
   CHECK(rectangle.initial_extents() == expected_extents);
   CHECK(rectangle.initial_refinement_levels() == expected_refinement_level);
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Creators/Tags/Domain.hpp"
@@ -28,6 +29,7 @@
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
@@ -55,6 +57,19 @@ struct NumberOfElements;
 /// \endcond
 
 namespace InterpTargetTestHelpers {
+namespace Tags {
+// Tag used for tests that will never be created from options, but will be
+// created in a mock runtime system
+struct BlocksForInterpolation : db::SimpleTag,
+                                intrp::Tags::BlocksForInterpolationBase {
+  using type = std::unordered_map<std::string, std::unordered_set<std::string>>;
+
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return {}; }
+};
+}  // namespace Tags
 
 enum class ValidPoints { All, None, Some };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -25,6 +25,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/SendPointsToInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -148,10 +149,12 @@ struct MockMetavars {
 };
 
 template <typename InterpolationTargetTag, size_t Dim,
-          typename InterpolationTargetOptionTag, typename BlockCoordHolder>
+          typename InterpolationTargetOptionTag, typename BlockCoordHolder,
+          typename... ExtraCacheObjects>
 void test_interpolation_target(
     typename InterpolationTargetOptionTag::type options,
-    const BlockCoordHolder& expected_block_coord_holders) {
+    const BlockCoordHolder& expected_block_coord_holders,
+    const ExtraCacheObjects&... extra_cache_objects) {
   using metavars = MockMetavars<InterpolationTargetTag, Dim>;
   using target_component =
       mock_interpolation_target<metavars, InterpolationTargetTag>;
@@ -161,8 +164,8 @@ void test_interpolation_target(
                 intrp::protocols::ComputeTargetPoints>);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {std::move(options), Domain<metavars::volume_dim>{},
-       ::Verbosity::Silent}};
+      {extra_cache_objects..., std::move(options),
+       Domain<metavars::volume_dim>{}, ::Verbosity::Silent}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_component<target_component>(&runner, 0);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -321,7 +321,8 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   std::unique_ptr<DomainCreator<3>> domain_creator;
   std::unique_ptr<ActionTesting::MockRuntimeSystem<metavars>> runner_ptr{};
   std::unordered_map<std::string, std::unordered_set<std::string>>
-      blocks_for_interpolation{{"AhA", {"Shell0"}}};
+      blocks_for_interpolation{};
+  blocks_for_interpolation["AhA"];
 
   // The test finds an apparent horizon for a Schwarzschild or Kerr
   // metric with M=1.  We choose a spherical shell domain extending
@@ -355,6 +356,9 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
         1.9, 2.9, domain::creators::Sphere::Excision{}, 1_st,
         grid_points_each_dimension, false, std::nullopt, radial_partitioning,
         radial_distribution, ShellWedges::All, std::move(time_dependence));
+    const auto block_names = domain_creator->block_names();
+    blocks_for_interpolation.at("AhA").insert(block_names.begin(),
+                                              block_names.end());
     tuples::TaggedTuple<
         domain::Tags::Domain<3>, intrp::Tags::BlocksForInterpolation,
         typename ::intrp::Tags::ApparentHorizon<typename metavars::AhA, Frame>,
@@ -369,6 +373,9 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
     domain_creator = std::make_unique<domain::creators::Sphere>(
         1.9, 2.9, domain::creators::Sphere::Excision{}, 1_st,
         grid_points_each_dimension, false);
+    const auto block_names = domain_creator->block_names();
+    blocks_for_interpolation.at("AhA").insert(block_names.begin(),
+                                              block_names.end());
 
     tuples::TaggedTuple<
         domain::Tags::Domain<3>, intrp::Tags::BlocksForInterpolation,

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -316,10 +316,12 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
       ylm::Strahlkorper<Frame>{l_max, 2.8, {{0.0, 0.0, 0.0}}},
       FastFlow{FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5,
                max_its},
-      Verbosity::Verbose, 3_st);
+      Verbosity::Verbose, 3_st, std::nullopt);
 
   std::unique_ptr<DomainCreator<3>> domain_creator;
   std::unique_ptr<ActionTesting::MockRuntimeSystem<metavars>> runner_ptr{};
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      blocks_for_interpolation{{"AhA", {"Shell0"}}};
 
   // The test finds an apparent horizon for a Schwarzschild or Kerr
   // metric with M=1.  We choose a spherical shell domain extending
@@ -354,10 +356,11 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
         grid_points_each_dimension, false, std::nullopt, radial_partitioning,
         radial_distribution, ShellWedges::All, std::move(time_dependence));
     tuples::TaggedTuple<
-        domain::Tags::Domain<3>,
+        domain::Tags::Domain<3>, intrp::Tags::BlocksForInterpolation,
         typename ::intrp::Tags::ApparentHorizon<typename metavars::AhA, Frame>,
         intrp::Tags::Verbosity>
         tuple_of_opts{std::move(domain_creator->create_domain()),
+                      std::move(blocks_for_interpolation),
                       std::move(apparent_horizon_opts), ::Verbosity::Silent};
     runner_ptr = std::make_unique<ActionTesting::MockRuntimeSystem<metavars>>(
         std::move(tuple_of_opts), domain_creator->functions_of_time(),
@@ -368,10 +371,11 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
         grid_points_each_dimension, false);
 
     tuples::TaggedTuple<
-        domain::Tags::Domain<3>,
+        domain::Tags::Domain<3>, intrp::Tags::BlocksForInterpolation,
         typename ::intrp::Tags::ApparentHorizon<typename metavars::AhA, Frame>,
         intrp::Tags::Verbosity>
         tuple_of_opts{std::move(domain_creator->create_domain()),
+                      std::move(blocks_for_interpolation),
                       std::move(apparent_horizon_opts), ::Verbosity::Silent};
 
     runner_ptr = std::make_unique<ActionTesting::MockRuntimeSystem<metavars>>(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
@@ -7,11 +7,15 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Domain.hpp"
@@ -59,7 +63,7 @@ SPECTRE_TEST_CASE(
   // Options for ApparentHorizon
   intrp::OptionHolders::ApparentHorizon<Frame::Inertial> apparent_horizon_opts(
       ylm::Strahlkorper<Frame::Inertial>{l_max, radius, center}, FastFlow{},
-      Verbosity::Verbose, 3_st);
+      Verbosity::Verbose, 3_st, std::nullopt);
 
   // Test creation of options
   const auto created_opts = TestHelpers::test_creation<
@@ -78,7 +82,8 @@ SPECTRE_TEST_CASE(
       "  Center: [0.05, 0.06, 0.07]\n"
       "  Radius: 2.0\n"
       "  LMax: 12\n"
-      "MaxInterpolationRetries: 3");
+      "MaxInterpolationRetries: 3\n"
+      "BlocksForInterpolation: All");
   CHECK(created_opts == apparent_horizon_opts);
 
   const auto domain_creator = domain::creators::Sphere(
@@ -125,5 +130,57 @@ SPECTRE_TEST_CASE(
 
   InterpTargetTestHelpers::test_interpolation_target<
       HorizonTag, 3, intrp::Tags::ApparentHorizon<HorizonTag, Frame::Inertial>>(
-      apparent_horizon_opts, expected_block_coord_holders);
+      apparent_horizon_opts, expected_block_coord_holders,
+      std::unordered_map<std::string, std::unordered_set<std::string>>{});
+
+  TestHelpers::db::test_simple_tag<intrp::Tags::BlocksForInterpolation>(
+      "BlocksForInterpolation");
+
+  {
+    const auto blocks_for_interpolation =
+        intrp::Tags::BlocksForInterpolation::create_from_options<
+            InterpTargetTestHelpers::MockMetavars<HorizonTag, 3>>(
+            std::make_unique<domain::creators::Sphere>(
+                1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st,
+                false),
+            created_opts);
+    REQUIRE(blocks_for_interpolation.contains("HorizonTag"));
+    const auto block_names = domain_creator.block_names();
+    CHECK(blocks_for_interpolation.at("HorizonTag") ==
+          std::unordered_set<std::string>{block_names.begin(),
+                                          block_names.end()});
+  }
+  {
+    const auto new_created_opts = TestHelpers::test_creation<
+        intrp::OptionHolders::ApparentHorizon<Frame::Inertial>>(
+        "FastFlow:\n"
+        "  Flow: Fast\n"
+        "  Alpha: 1.0\n"
+        "  Beta: 0.5\n"
+        "  AbsTol: 1e-12\n"
+        "  TruncationTol: 1e-2\n"
+        "  DivergenceTol: 1.2\n"
+        "  DivergenceIter: 5\n"
+        "  MaxIts: 100\n"
+        "Verbosity: Verbose\n"
+        "InitialGuess:\n"
+        "  Center: [0.05, 0.06, 0.07]\n"
+        "  Radius: 2.0\n"
+        "  LMax: 12\n"
+        "MaxInterpolationRetries: 3\n"
+        "BlocksForInterpolation: [Shell0]");
+    const auto blocks_for_interpolation =
+        intrp::Tags::BlocksForInterpolation::create_from_options<
+            InterpTargetTestHelpers::MockMetavars<HorizonTag, 3>>(
+            std::make_unique<domain::creators::Sphere>(
+                1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st,
+                false, std::nullopt, std::vector{2.0}),
+            new_created_opts);
+    REQUIRE(blocks_for_interpolation.contains("HorizonTag"));
+    const auto block_names = domain_creator.block_names();
+    CHECK(blocks_for_interpolation.at("HorizonTag") ==
+          std::unordered_set<std::string>{"Shell0UpperZ", "Shell0LowerZ",
+                                          "Shell0UpperY", "Shell0LowerY",
+                                          "Shell0UpperX", "Shell0LowerX"});
+  }
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -141,7 +141,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
   ActionTesting::MockRuntimeSystem<metavars> runner{{::Verbosity::Silent}};
   ActionTesting::emplace_component_and_initialize<interp_component>(
       &runner, 0,
-      {std::unordered_set<ElementId<metavars::volume_dim>>{},
+      {std::unordered_map<
+           std::string, std::unordered_set<ElementId<metavars::volume_dim>>>{},
        typename intrp::Tags::VolumeVarsInfo<metavars, ::Tags::TimeStepId>::type{
            std::move(volume_vars_info_bc)},
        typename intrp::Tags::VolumeVarsInfo<metavars, ::Tags::Time>::type{

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -16,6 +16,8 @@
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
@@ -32,12 +34,14 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp"
 #include "Time/Slab.hpp"
@@ -151,6 +155,10 @@ struct mock_interpolation_target {
   using array_index = size_t;
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
+  using const_global_cache_tags = tmpl::flatten<tmpl::append<
+      Parallel::get_const_global_cache_tags_from_actions<
+          tmpl::list<typename InterpolationTargetTag::compute_target_points>>,
+      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
@@ -182,8 +190,8 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Lapse>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        ::intrp::TargetPoints::LineSegment<InterpolatorTargetA, 3,
-                                           Frame::Inertial>;
+        ::intrp::TargetPoints::ApparentHorizon<InterpolatorTargetA,
+                                               Frame::Inertial>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
             tmpl::list<>, InterpolatorTargetA>>;
@@ -209,6 +217,7 @@ struct MockMetavariables {
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
                   "[Unit]") {
   ::domain::FunctionsOfTime::register_derived_with_charm();
+  ::domain::creators::register_derived_with_charm();
   using metavars = MockMetavariables;
   const ElementId<metavars::volume_dim> element_id(2);
   const ElementId<metavars::volume_dim> array_index(element_id);
@@ -226,8 +235,15 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
           0.0, std::array<DataVector, 1>{{DataVector{1, 0.0}}},
           initial_expr_time);
+  const auto domain_creator = domain::creators::Sphere(
+      1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
+  const auto block_names = domain_creator.block_names();
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {::Verbosity::Silent}, {std::move(functions_of_time)}};
+      {std::unordered_map<std::string, std::unordered_set<std::string>>{
+           {"InterpolatorTargetA", {block_names.begin(), block_names.end()}}},
+       intrp::OptionHolders::ApparentHorizon<Frame::Inertial>{},
+       domain_creator.create_domain(), ::Verbosity::Silent},
+      {std::move(functions_of_time)}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_group_component<interp_component>(&runner);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -39,6 +39,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolationTargetReceiveVars.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceivePoints.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
@@ -119,10 +120,12 @@ struct MockCleanUpInterpolator {
     // this function was called.  This isn't the usual usage of
     // NumberOfElements.
     db::mutate<intrp::Tags::NumberOfElements<Metavariables::volume_dim>>(
-        [](const gsl::not_null<
-            std::unordered_set<ElementId<Metavariables::volume_dim>>*>
+        [](const gsl::not_null<std::unordered_map<
+               std::string,
+               std::unordered_set<ElementId<Metavariables::volume_dim>>>*>
                number_of_elements) {
-          number_of_elements->insert(ElementId<Metavariables::volume_dim>{0});
+          (*number_of_elements)["InterpolationTargetA"].insert(
+              ElementId<Metavariables::volume_dim>{0});
         },
         make_not_null(&box));
   }
@@ -194,12 +197,10 @@ void callback_impl(const db::DataBox<DbTags>& box,
 
 struct MockPostInterpolationCallback
     : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
-  template <typename DbTags, typename Metavariables>
-  static void apply(
-      const db::DataBox<DbTags>& box,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const typename Metavariables::InterpolationTargetA::temporal_id::type&
-          temporal_id) {
+  template <typename DbTags, typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const TemporalId& temporal_id) {
     callback_impl(box, temporal_id);
   }
 };
@@ -211,12 +212,11 @@ struct MockPostInterpolationCallback
 //  but this is a more direct test.
 struct MockPostInterpolationCallbackNoCleanup
     : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
-  template <typename DbTags, typename Metavariables>
+  template <typename DbTags, typename Metavariables, typename TemporalId>
   static bool apply(
       const gsl::not_null<db::DataBox<DbTags>*> box,
       const gsl::not_null<Parallel::GlobalCache<Metavariables>*> /*cache*/,
-      const typename Metavariables::InterpolationTargetA::temporal_id::type&
-          temporal_id) {
+      const TemporalId& temporal_id) {
     callback_impl(*box, temporal_id);
     return false;
   }
@@ -226,12 +226,10 @@ template <size_t NumberOfInvalidInterpolationPoints>
 struct MockPostInterpolationCallbackWithInvalidPoints
     : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
   static constexpr double fill_invalid_points_with = 15.0;
-  template <typename DbTags, typename Metavariables>
-  static void apply(
-      const db::DataBox<DbTags>& box,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const typename Metavariables::InterpolationTargetA::temporal_id::type&
-          temporal_id) {
+  template <typename DbTags, typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const TemporalId& temporal_id) {
     CHECK(temporal_id.id == 13.0 / 16.0);
 
     // The result should be the square of the first 10 integers, in
@@ -486,10 +484,12 @@ void test_interpolation_target_receive_vars() {
 
     // Check that MockCleanUpInterpolator was NOT called.  If called, it resets
     // the (fake) number of elements, specifically so we can test it here.
-    CHECK(ActionTesting::get_databox_tag<interp_component,
-                                         intrp::Tags::NumberOfElements<Dim>>(
-              runner, 0)
-              .empty());
+    const auto& number_of_elements =
+        ActionTesting::get_databox_tag<interp_component,
+                                       intrp::Tags::NumberOfElements<Dim>>(
+            runner, 0);
+    REQUIRE(number_of_elements.contains("InterpolationTargetA"));
+    CHECK(number_of_elements.at("InterpolationTargetA").empty());
 
     // Also, there should still be the same number of TemporalIds left
     // because we did not clean them up.
@@ -555,10 +555,12 @@ void test_interpolation_target_receive_vars() {
 
     // Check that MockCleanUpInterpolator was called.  It resets the
     // (fake) number of elements, specifically so we can test it here.
-    CHECK(ActionTesting::get_databox_tag<interp_component,
-                                         intrp::Tags::NumberOfElements<Dim>>(
-              runner, 0)
-              .size() == 1);
+    const auto& number_of_elements =
+        ActionTesting::get_databox_tag<interp_component,
+                                       intrp::Tags::NumberOfElements<Dim>>(
+            runner, 0);
+    REQUIRE(number_of_elements.contains("InterpolationTargetA"));
+    CHECK(number_of_elements.at("InterpolationTargetA").size() == 1);
 
     if constexpr (IsTimeDependent::value) {
       // There should be zero TemporalIds left, but one PendingTemporalId,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
@@ -33,6 +33,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/VolumeData.hpp"
@@ -53,6 +54,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -248,7 +250,8 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
+      tmpl::list<InterpTargetTestHelpers::Tags::BlocksForInterpolation,
+                 domain::Tags::Domain<Metavariables::volume_dim>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -412,6 +415,7 @@ void test(const bool dump_vol_data) {
   const auto domain_creator = domain::creators::Sphere(
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false);
   const auto domain = domain_creator.create_domain();
+  const auto block_names = domain_creator.block_names();
   Slab slab(0.0, 1.0);
   TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
   auto vars_holders = [&domain, &temporal_id]() {
@@ -444,11 +448,14 @@ void test(const bool dump_vol_data) {
   }
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(), dump_vol_data, ::Verbosity::Silent,
+      {std::unordered_map<std::string, std::unordered_set<std::string>>{
+           {"InterpolationTargetA", {block_names.begin(), block_names.end()}},
+           {"InterpolationTargetB", {block_names.begin(), block_names.end()}}},
+       domain_creator.create_domain(), dump_vol_data, ::Verbosity::Silent,
        filename}};
   ActionTesting::emplace_group_component_and_initialize<interp_component>(
       &runner,
-      {std::unordered_set<ElementId<3>>{},
+      {std::unordered_map<std::string, std::unordered_set<ElementId<3>>>{},
        typename intrp::Tags::VolumeVarsInfo<
            metavars,
            typename metavars::InterpolationTargetA::temporal_id>::type{},

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -23,6 +23,7 @@
 #include "Domain/Structure/BlockId.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -34,6 +35,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -169,7 +171,8 @@ struct mock_interpolation_target {
   using component_being_mocked =
       intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
   using const_global_cache_tags =
-      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>;
+      tmpl::list<InterpTargetTestHelpers::Tags::BlocksForInterpolation,
+                 domain::Tags::Domain<Metavariables::volume_dim>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
@@ -239,9 +242,12 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
       std::array{1_st, 2_st, 0_st}, std::array{2_st, 2_st, 2_st},
       std::array{false, false, false}};
   const Domain<3> domain = domain_creator.create_domain();
+  const auto block_names = domain_creator.block_names();
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(), ::Verbosity::Silent},
+      {std::unordered_map<std::string, std::unordered_set<std::string>>{
+           {"InterpolationTargetA", {block_names.begin(), block_names.end()}}},
+       domain_creator.create_domain(), ::Verbosity::Silent},
       {},
       std::vector<std::size_t>{2_st}};
   ActionTesting::set_phase(make_not_null(&runner),
@@ -291,7 +297,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
   for (size_t array_index = 0; array_index < 2; array_index++) {
     for (size_t num_elements = 0; num_elements < 4; num_elements++) {
       runner.simple_action<interp_component, ::intrp::Actions::RegisterElement>(
-          array_index, element_ids[array_index + num_elements * 2]);
+          array_index, element_ids[num_elements + array_index * 4]);
     }
   }
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -5,11 +5,15 @@
 
 #include <cstddef>
 
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolatedVars.hpp"
@@ -26,12 +30,22 @@ struct NumberOfElements;
 }  // namespace intrp::Tags
 
 namespace {
+struct MockTargetTag
+    : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  using temporal_id = ::Tags::TimeStepId;
+  using vars_to_interpolate_to_target = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using compute_items_on_target = tmpl::list<>;
+  using compute_target_points =
+      ::intrp::TargetPoints::ApparentHorizon<MockTargetTag, ::Frame::Inertial>;
+  using post_interpolation_callbacks = tmpl::list<>;
+};
 
 template <typename Metavariables>
 struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockGroupChare;
   using array_index = size_t;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
@@ -73,17 +87,27 @@ struct MockMetavariables {
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
 
-  using component_list = tmpl::list<mock_interpolator<MockMetavariables>,
-                                    mock_element<MockMetavariables>>;
+  using component_list = tmpl::list<
+      InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables,
+                                                         MockTargetTag>,
+      mock_interpolator<MockMetavariables>, mock_element<MockMetavariables>>;
 };
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
                   "[Unit]") {
+  domain::creators::register_derived_with_charm();
   using metavars = MockMetavariables;
   constexpr size_t Dim = metavars::volume_dim;
   using interp_component = mock_interpolator<metavars>;
   using elem_component = mock_element<metavars>;
-  ActionTesting::MockRuntimeSystem<metavars> runner{{::Verbosity::Silent}};
+  const auto domain_creator = domain::creators::Sphere(
+      1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
+  const auto block_names = domain_creator.block_names();
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {std::unordered_map<std::string, std::unordered_set<std::string>>{
+           {"MockTargetTag", {block_names.begin(), block_names.end()}}},
+       intrp::OptionHolders::ApparentHorizon<Frame::Inertial>{},
+       domain_creator.create_domain(), ::Verbosity::Silent}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_group_component<interp_component>(&runner);
@@ -105,19 +129,22 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
                                      ::intrp::Tags::NumberOfElements<Dim>>(
           runner, 0);
 
-  CHECK(number_of_elements.empty());
+  const std::string target_name = pretty_type::name<MockTargetTag>();
+  REQUIRE(number_of_elements.contains(target_name));
 
   runner.simple_action<interp_component, ::intrp::Actions::RegisterElement>(
       0, id_0);
 
-  CHECK(number_of_elements.size() == 1);
-  CHECK(number_of_elements.contains(id_0));
+  CHECK(number_of_elements.contains(target_name));
+  CHECK(number_of_elements.at(target_name).size() == 1);
+  CHECK(number_of_elements.at(target_name).contains(id_0));
 
   runner.simple_action<interp_component, ::intrp::Actions::RegisterElement>(
       0, id_1);
 
-  CHECK(number_of_elements.size() == 2);
-  CHECK(number_of_elements.contains(id_1));
+  CHECK(number_of_elements.contains(target_name));
+  CHECK(number_of_elements.at(target_name).size() == 2);
+  CHECK(number_of_elements.at(target_name).contains(id_1));
 
   // Call RegisterElementWithInterpolator from element, check if
   // it gets registered.
@@ -126,8 +153,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
 
   runner.invoke_queued_simple_action<interp_component>(0);
 
-  CHECK(number_of_elements.size() == 3);
-  CHECK(number_of_elements.contains(id_2));
+  CHECK(number_of_elements.contains(target_name));
+  CHECK(number_of_elements.at(target_name).size() == 3);
+  CHECK(number_of_elements.at(target_name).contains(id_2));
 
   // No more queued simple actions.
   CHECK(runner.is_simple_action_queue_empty<interp_component>(0));
@@ -146,12 +174,14 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
     CHECK(runner.is_simple_action_queue_empty<interp_component>(0));
     CHECK(runner.is_simple_action_queue_empty<elem_component>(id_0));
 
-    CHECK(number_of_elements.size() == 2);
-    CHECK_FALSE(number_of_elements.contains(id_0));
+    CHECK(number_of_elements.contains(target_name));
+    CHECK(number_of_elements.at(target_name).size() == 2);
+    CHECK_FALSE(number_of_elements.at(target_name).contains(id_0));
     runner.simple_action<interp_component, ::intrp::Actions::DeregisterElement>(
         0, id_1);
-    CHECK(number_of_elements.size() == 1);
-    CHECK_FALSE(number_of_elements.contains(id_1));
+    CHECK(number_of_elements.contains(target_name));
+    CHECK(number_of_elements.at(target_name).size() == 1);
+    CHECK_FALSE(number_of_elements.at(target_name).contains(id_1));
     runner.simple_action<interp_component, ::intrp::Actions::DeregisterElement>(
         0, id_2);
     CHECK(number_of_elements.empty());

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -33,6 +33,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/IO/VolumeData.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/Dat.hpp"
 #include "IO/H5/File.hpp"
@@ -58,6 +59,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Callbacks/ObserveLineSegment.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/LineSegment.hpp"
@@ -131,7 +133,8 @@ struct MockInterpolationTarget {
           tmpl::flatten<tmpl::list<
               typename InterpolationTargetTag::compute_target_points,
               typename InterpolationTargetTag::post_interpolation_callbacks>>>,
-      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
+      tmpl::list<InterpTargetTestHelpers::Tags::BlocksForInterpolation,
+                 domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
@@ -269,12 +272,22 @@ void run_test(gsl::not_null<Generator*> generator,
       MockInterpolationTarget<metavars, typename metavars::LineB>;
   using obs_writer = MockObserverWriter<metavars>;
 
+  const auto block_names = domain_creator.block_names();
   tuples::TaggedTuple<observers::Tags::ReductionFileName,
                       ::intrp::Tags::LineSegment<typename metavars::LineA, Dim>,
                       ::intrp::Tags::LineSegment<typename metavars::LineB, Dim>,
-                      ::intrp::Tags::Verbosity, domain::Tags::Domain<Dim>>
-      tuple_of_opts{h5_file_prefix, line_segment_opts_A, line_segment_opts_B,
-                    ::Verbosity::Silent, domain_creator.create_domain()};
+                      ::intrp::Tags::Verbosity,
+                      InterpTargetTestHelpers::Tags::BlocksForInterpolation,
+                      domain::Tags::Domain<Dim>>
+      tuple_of_opts{
+          h5_file_prefix,
+          line_segment_opts_A,
+          line_segment_opts_B,
+          ::Verbosity::Silent,
+          std::unordered_map<std::string, std::unordered_set<std::string>>{
+              {"LineA", {block_names.begin(), block_names.end()}},
+              {"LineB", {block_names.begin(), block_names.end()}}},
+          domain_creator.create_domain()};
 
   // Three mock nodes, with 2, 1, and 4 mock cores.
   ActionTesting::MockRuntimeSystem<metavars> runner{
@@ -413,6 +426,8 @@ void run_test(gsl::not_null<Generator*> generator,
   }
   // There should be 2 more threaded actions, so invoke them and check
   // that there are no more.  They should all be on node zero.
+  REQUIRE(ActionTesting::number_of_queued_threaded_actions<obs_writer>(runner,
+                                                                       0) == 2);
   ActionTesting::invoke_queued_threaded_action<obs_writer>(
       make_not_null(&runner), 0);
   ActionTesting::invoke_queued_threaded_action<obs_writer>(
@@ -424,60 +439,61 @@ void run_test(gsl::not_null<Generator*> generator,
 
   const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
 
-  auto check_file_contents = [&file, &spacetime](const std::string& group_name,
-                                                 const tnsr::I<DataVector, Dim>&
-                                                     interpolated_coords) {
-    file.close_current_object();
-    const auto& vol_file = file.get<h5::VolumeData>(group_name);
-    const auto& obs_ids = vol_file.list_observation_ids();
-    CHECK(obs_ids.size() == 1);
-    const auto& obs_value = vol_file.get_observation_value(obs_ids.at(0));
-    CHECK(obs_value == 0.);
+  auto check_file_contents =
+      [&file, &spacetime](const std::string& group_name,
+                          const tnsr::I<DataVector, Dim>& interpolated_coords) {
+        file.close_current_object();
+        const auto& vol_file = file.get<h5::VolumeData>(group_name);
+        const auto& obs_ids = vol_file.list_observation_ids();
+        CHECK(obs_ids.size() == 1);
+        const auto& obs_value = vol_file.get_observation_value(obs_ids.at(0));
+        CHECK(obs_value == 0.);
 
-    // error due to low resolution of domain
-    Approx custom_approx = Approx::custom().epsilon(1.e-4).scale(1.0);
+        // error due to low resolution of domain
+        Approx custom_approx = Approx::custom().epsilon(1.e-4).scale(1.0);
 
-    for (size_t i = 0; i < interpolated_coords.size(); ++i) {
-      const auto& written_component = vol_file.get_tensor_component(
-          obs_ids.at(0),
-          "InertialCoordinates" + interpolated_coords.component_suffix(i));
-      const auto& written_dv = std::get<DataVector>(written_component.data);
-      CHECK_ITERABLE_CUSTOM_APPROX(written_dv, interpolated_coords.get(i),
-                                   custom_approx);
-    }
+        for (size_t i = 0; i < interpolated_coords.size(); ++i) {
+          const auto& written_component = vol_file.get_tensor_component(
+              obs_ids.at(0),
+              "InertialCoordinates" + interpolated_coords.component_suffix(i));
+          const auto& written_dv = std::get<DataVector>(written_component.data);
+          CHECK_ITERABLE_CUSTOM_APPROX(written_dv, interpolated_coords.get(i),
+                                       custom_approx);
+        }
 
-    const auto interpolated_metric =
-        get<gr::Tags::SpatialMetric<DataVector, Dim>>(spacetime.variables(
-            interpolated_coords, 0.0,
-            tmpl::list<gr::Tags::SpatialMetric<DataVector, Dim>>{}));
-    for (size_t i = 0; i < interpolated_metric.size(); ++i) {
-      const auto& written_component = vol_file.get_tensor_component(
-          obs_ids.at(0),
-          "SpatialMetric" + interpolated_metric.component_suffix(i));
-      const auto& written_dv = std::get<DataVector>(written_component.data);
-      CHECK_ITERABLE_CUSTOM_APPROX(written_dv, interpolated_metric[i],
-                                   custom_approx);
-    }
+        const auto interpolated_metric =
+            get<gr::Tags::SpatialMetric<DataVector, Dim>>(spacetime.variables(
+                interpolated_coords, 0.0,
+                tmpl::list<gr::Tags::SpatialMetric<DataVector, Dim>>{}));
+        for (size_t i = 0; i < interpolated_metric.size(); ++i) {
+          const auto& written_component = vol_file.get_tensor_component(
+              obs_ids.at(0),
+              "SpatialMetric" + interpolated_metric.component_suffix(i));
+          const auto& written_dv = std::get<DataVector>(written_component.data);
+          CHECK_ITERABLE_CUSTOM_APPROX(written_dv, interpolated_metric[i],
+                                       custom_approx);
+        }
 
-    const auto interpolated_test_solution = test_function(interpolated_coords);
+        const auto interpolated_test_solution =
+            test_function(interpolated_coords);
 
-    const auto& written_test_solution_component =
-        vol_file.get_tensor_component(obs_ids.at(0), "TestSolution");
-    const auto& written_test_solution_dv =
-        std::get<DataVector>(written_test_solution_component.data);
+        const auto& written_test_solution_component =
+            vol_file.get_tensor_component(obs_ids.at(0), "TestSolution");
+        const auto& written_test_solution_dv =
+            std::get<DataVector>(written_test_solution_component.data);
 
-    CHECK_ITERABLE_CUSTOM_APPROX(written_test_solution_dv,
-                                 interpolated_test_solution, custom_approx);
+        CHECK_ITERABLE_CUSTOM_APPROX(written_test_solution_dv,
+                                     interpolated_test_solution, custom_approx);
 
-    const auto interpolated_square = square(interpolated_test_solution);
-    const auto& written_square_component =
-        vol_file.get_tensor_component(obs_ids.at(0), "Square");
-    const auto& written_square_dv =
-        std::get<DataVector>(written_square_component.data);
+        const auto interpolated_square = square(interpolated_test_solution);
+        const auto& written_square_component =
+            vol_file.get_tensor_component(obs_ids.at(0), "Square");
+        const auto& written_square_dv =
+            std::get<DataVector>(written_square_component.data);
 
-    CHECK_ITERABLE_CUSTOM_APPROX(written_square_dv, interpolated_square,
-                                 custom_approx);
-  };
+        CHECK_ITERABLE_CUSTOM_APPROX(written_square_dv, interpolated_square,
+                                     custom_approx);
+      };
 
   auto check_file_contents_are_nans =
       [&file](const std::string& group_name,

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -390,7 +390,8 @@ struct MockInterpolationTarget {
           tmpl::flatten<tmpl::list<
               typename InterpolationTargetTag::compute_target_points,
               typename InterpolationTargetTag::post_interpolation_callbacks>>>,
-      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
+      tmpl::list<InterpTargetTestHelpers::Tags::BlocksForInterpolation,
+                 domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
@@ -604,18 +605,31 @@ void run_test() {
       3, {{0.04, 0.05, 0.06}}, 1.1, {{1.0, 0.0, 0.0}},
       ylm::AngularOrdering::Strahlkorper);
   const auto domain_creator = make_sphere<ValidPoints>();
+  const auto block_names = domain_creator.block_names();
   tuples::TaggedTuple<
       observers::Tags::ReductionFileName, observers::Tags::SurfaceFileName,
-      ::intrp::Tags::KerrHorizon<metavars::SurfaceA>, domain::Tags::Domain<3>,
-      ::intrp::Tags::KerrHorizon<metavars::SurfaceB>,
+      ::intrp::Tags::KerrHorizon<metavars::SurfaceA>,
+      InterpTargetTestHelpers::Tags::BlocksForInterpolation,
+      domain::Tags::Domain<3>, ::intrp::Tags::KerrHorizon<metavars::SurfaceB>,
       ::intrp::Tags::KerrHorizon<metavars::SurfaceC>,
       ::intrp::Tags::KerrHorizon<metavars::SurfaceD>,
       ::intrp::Tags::KerrHorizon<metavars::SurfaceE>, ::intrp::Tags::Verbosity>
-      tuple_of_opts{h5_file_prefix,      surfaces_file_prefix,
-                    kerr_horizon_opts_A, domain_creator.create_domain(),
-                    kerr_horizon_opts_B, kerr_horizon_opts_C,
-                    kerr_horizon_opts_D, kerr_horizon_opts_E,
-                    ::Verbosity::Silent};
+      tuple_of_opts{
+          h5_file_prefix,
+          surfaces_file_prefix,
+          kerr_horizon_opts_A,
+          std::unordered_map<std::string, std::unordered_set<std::string>>{
+              {"SurfaceA", {block_names.begin(), block_names.end()}},
+              {"SurfaceB", {block_names.begin(), block_names.end()}},
+              {"SurfaceC", {block_names.begin(), block_names.end()}},
+              {"SurfaceD", {block_names.begin(), block_names.end()}},
+              {"SurfaceE", {block_names.begin(), block_names.end()}}},
+          domain_creator.create_domain(),
+          kerr_horizon_opts_B,
+          kerr_horizon_opts_C,
+          kerr_horizon_opts_D,
+          kerr_horizon_opts_E,
+          ::Verbosity::Silent};
 
   // Three mock nodes, with 2, 1, and 4 mock cores.
   ActionTesting::MockRuntimeSystem<metavars> runner{

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -28,6 +28,7 @@
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -45,6 +46,7 @@
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorReceiveVolumeData.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
@@ -201,7 +203,8 @@ struct mock_interpolation_target {
   using const_global_cache_tags = tmpl::flatten<tmpl::append<
       Parallel::get_const_global_cache_tags_from_actions<
           tmpl::list<typename InterpolationTargetTag::compute_target_points>>,
-      tmpl::list<domain::Tags::Domain<Metavariables::volume_dim>>>>;
+      tmpl::list<InterpTargetTestHelpers::Tags::BlocksForInterpolation,
+                 domain::Tags::Domain<Metavariables::volume_dim>>>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
@@ -312,18 +315,32 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(
       10, {{0.0, 0.0, 0.0}}, 1.0, {{0.0, 0.0, 0.0}},
       ylm::AngularOrdering::Strahlkorper);
-  const auto domain_creator = domain::creators::Sphere(
-      0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
+  // The radial partition is chosen specially for this test to include all
+  // points for targets A&C in the first shell, but points for B are in both
+  // shells.
+  const auto domain_creator =
+      domain::creators::Sphere(0.9, 4.9, domain::creators::Sphere::Excision{},
+                               1_st, 5_st, false, std::nullopt, {4.2});
+  const auto block_names = domain_creator.block_names();
+  const auto block_groups = domain_creator.block_groups();
   tuples::TaggedTuple<
       intrp::Tags::LineSegment<metavars::InterpolationTargetA, 3>,
+      InterpTargetTestHelpers::Tags::BlocksForInterpolation,
       domain::Tags::Domain<3>,
       intrp::Tags::LineSegment<metavars::InterpolationTargetB, 3>,
       intrp::Tags::KerrHorizon<metavars::InterpolationTargetC>,
       intrp::Tags::Verbosity>
-      tuple_of_opts(std::move(line_segment_opts_A),
-                    domain_creator.create_domain(),
-                    std::move(line_segment_opts_B), kerr_horizon_opts_C,
-                    ::Verbosity::Silent);
+      tuple_of_opts(
+          std::move(line_segment_opts_A),
+          std::unordered_map<std::string, std::unordered_set<std::string>>{
+              // Target A only receives data from elements in Shell0
+              {"InterpolationTargetA", block_groups.at("Shell0")},
+              {"InterpolationTargetB",
+               {block_names.begin(), block_names.end()}},
+              {"InterpolationTargetC",
+               {block_names.begin(), block_names.end()}}},
+          domain_creator.create_domain(), std::move(line_segment_opts_B),
+          kerr_horizon_opts_C, ::Verbosity::Silent);
 
   // 3 mock nodes, with 2, 3, and 1 mocked core respectively.
   ActionTesting::MockRuntimeSystem<metavars> runner{


### PR DESCRIPTION
## Proposed changes

These are currently taken as options from the input file. Eventually
we could have this be more automatic, e.g. the domain creators know
which blocks could potentially hold a horizon, but that would be
a future optimization.

This is the first step in a lot of backend work to combine the horizon finders and get rid of the interpolator group component.

I've tested this on a single BH while interpolating only some blocks and all blocks. And also tried on a BBH

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Each entry under the `ApparentHorizons:` block of the input file gets a new option `BlocksForInterpolation:`. This could either be a list of block groups or `All` to indicate all blocks in the doman.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
