### PR TITLE
Add MortarInfo

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -619,7 +619,7 @@ struct ApplyBoundaryCorrections {
       tmpl::flatten<tmpl::list<
           tmpl::conditional_t<DenseOutput, mortar_data_tag, tmpl::list<>>,
           domain::Tags::Mesh<volume_dim>, domain::Tags::Element<volume_dim>,
-          Tags::MortarMesh<volume_dim>, Tags::MortarSize<volume_dim>,
+          Tags::MortarMesh<volume_dim>, Tags::MortarInfo<volume_dim>,
           ::dg::Tags::Formulation,
           evolution::dg::Tags::NormalCovectorAndMagnitude<volume_dim>,
           ::Tags::TimeStepper<TimeStepperType>,
@@ -637,7 +637,7 @@ struct ApplyBoundaryCorrections {
       const gsl::not_null<MortarDataType*> mortar_data,
       const Mesh<volume_dim>& volume_mesh, const Element<volume_dim>& element,
       const typename Tags::MortarMesh<volume_dim>::type& mortar_meshes,
-      const typename Tags::MortarSize<volume_dim>::type& mortar_sizes,
+      const typename Tags::MortarInfo<volume_dim>::type& mortar_infos,
       const ::dg::Formulation dg_formulation,
       const DirectionMap<
           volume_dim, std::optional<Variables<tmpl::list<
@@ -650,7 +650,7 @@ struct ApplyBoundaryCorrections {
       const Scalar<DataVector>& gts_det_inv_jacobian,
       const VolumeArgs&... volume_args) {
     apply_impl(vars_to_update, mortar_data, volume_mesh, element, mortar_meshes,
-               mortar_sizes, dg_formulation, face_normal_covector_and_magnitude,
+               mortar_infos, dg_formulation, face_normal_covector_and_magnitude,
                time_stepper, boundary_correction, time_step,
                std::numeric_limits<double>::signaling_NaN(),
                gts_det_inv_jacobian, volume_args...);
@@ -662,7 +662,7 @@ struct ApplyBoundaryCorrections {
       const gsl::not_null<MortarDataType*> mortar_data,
       const Mesh<volume_dim>& volume_mesh, const Element<volume_dim>& element,
       const typename Tags::MortarMesh<volume_dim>::type& mortar_meshes,
-      const typename Tags::MortarSize<volume_dim>::type& mortar_sizes,
+      const typename Tags::MortarInfo<volume_dim>::type& mortar_infos,
       const ::dg::Formulation dg_formulation,
       const DirectionMap<
           volume_dim, std::optional<Variables<tmpl::list<
@@ -673,7 +673,7 @@ struct ApplyBoundaryCorrections {
       const typename system::boundary_correction_base& boundary_correction,
       const TimeDelta& time_step, const VolumeArgs&... volume_args) {
     apply_impl(vars_to_update, mortar_data, volume_mesh, element, mortar_meshes,
-               mortar_sizes, dg_formulation, face_normal_covector_and_magnitude,
+               mortar_infos, dg_formulation, face_normal_covector_and_magnitude,
                time_stepper, boundary_correction, time_step,
                std::numeric_limits<double>::signaling_NaN(), {},
                volume_args...);
@@ -686,7 +686,7 @@ struct ApplyBoundaryCorrections {
       const MortarDataType& mortar_data, const Mesh<volume_dim>& volume_mesh,
       const Element<volume_dim>& element,
       const typename Tags::MortarMesh<volume_dim>::type& mortar_meshes,
-      const typename Tags::MortarSize<volume_dim>::type& mortar_sizes,
+      const typename Tags::MortarInfo<volume_dim>::type& mortar_infos,
       const ::dg::Formulation dg_formulation,
       const DirectionMap<
           volume_dim, std::optional<Variables<tmpl::list<
@@ -697,7 +697,7 @@ struct ApplyBoundaryCorrections {
       const typename system::boundary_correction_base& boundary_correction,
       const double dense_output_time, const VolumeArgs&... volume_args) {
     apply_impl(vars_to_update, &mortar_data, volume_mesh, element,
-               mortar_meshes, mortar_sizes, dg_formulation,
+               mortar_meshes, mortar_infos, dg_formulation,
                face_normal_covector_and_magnitude, time_stepper,
                boundary_correction, TimeDelta{}, dense_output_time, {},
                volume_args...);
@@ -729,7 +729,7 @@ struct ApplyBoundaryCorrections {
       const gsl::not_null<MortarDataType*> mortar_data,
       const Mesh<volume_dim>& volume_mesh, const Element<volume_dim>& element,
       const typename Tags::MortarMesh<volume_dim>::type& mortar_meshes,
-      const typename Tags::MortarSize<volume_dim>::type& mortar_sizes,
+      const typename Tags::MortarInfo<volume_dim>::type& mortar_infos,
       const ::dg::Formulation dg_formulation,
       const DirectionMap<
           volume_dim, std::optional<Variables<tmpl::list<
@@ -777,7 +777,7 @@ struct ApplyBoundaryCorrections {
         &boundary_correction,
         [&dense_output_time, &dg_formulation,
          &face_normal_covector_and_magnitude, &mortar_data, &mortar_meshes,
-         &mortar_sizes, &time_step, &time_stepper, using_gauss_lobatto_points,
+         &mortar_infos, &time_step, &time_stepper, using_gauss_lobatto_points,
          &vars_to_update, &volume_args_tuple, &volume_det_jacobian,
          &volume_det_inv_jacobian,
          &volume_mesh](auto* typed_boundary_correction) {
@@ -823,7 +823,7 @@ struct ApplyBoundaryCorrections {
                  &dt_boundary_correction_on_mortar, &face_det_jacobian,
                  &face_mesh, &face_normal_covector_and_magnitude,
                  &local_data_on_mortar, &mortar_id, &mortar_meshes,
-                 &mortar_sizes, &neighbor_data_on_mortar,
+                 &mortar_infos, &neighbor_data_on_mortar,
                  using_gauss_lobatto_points, &volume_args_tuple,
                  &volume_det_jacobian, &volume_det_inv_jacobian,
                  &volume_dt_correction, &volume_mesh](
@@ -891,7 +891,7 @@ struct ApplyBoundaryCorrections {
                   typename BcType::dg_boundary_terms_volume_tags{});
 
               const std::array<Spectral::SegmentSize, volume_dim - 1>&
-                  mortar_size = mortar_sizes.at(mortar_id);
+                  mortar_size = mortar_infos.at(mortar_id).mortar_size();
 
               // This cannot reuse an allocation because it is initialized
               // via move-assignment.  (If it is used at all.)

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -317,7 +317,6 @@ struct get_primitive_tags_for_face {
  *   - `domain::Tags::Element<Dim>`
  *   - `domain::Tags::Mesh<Dim>`
  *   - `evolution::dg::Tags::MortarMesh<Dim>`
- *   - `evolution::dg::Tags::MortarSize<Dim>`
  *   - `evolution::dg::Tags::MortarData<Dim>`
  *   - `Tags::TimeStepId`
  *   - \code{.cpp}

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -66,8 +66,7 @@ void internal_mortar_data_impl(
         volume_primitive_variables,
     const Element<Dim>& element, const Mesh<Dim>& volume_mesh,
     const DirectionalIdMap<Dim, Mesh<Dim - 1>>& mortar_meshes,
-    const DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
-        mortar_sizes,
+    const DirectionalIdMap<Dim, MortarInfo<Dim>>& mortar_infos,
     const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, Dim>&
         moving_mesh_map,
     const std::optional<tnsr::I<DataVector, Dim>>& volume_mesh_velocity,
@@ -241,7 +240,7 @@ void internal_mortar_data_impl(
       const auto& neighbor = *neighbors_in_direction.begin();
       const auto mortar_id = DirectionalId<Dim>{direction, neighbor};
       const auto& mortar_mesh = mortar_meshes.at(mortar_id);
-      const auto& mortar_size = mortar_sizes.at(mortar_id);
+      const auto& mortar_size = mortar_infos.at(mortar_id).mortar_size();
 
       // Have to use packaged_data_buffer
       if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
@@ -290,7 +289,7 @@ void internal_mortar_data_impl(
     for (const auto& neighbor : neighbors_in_direction) {
       const DirectionalId<Dim> mortar_id{direction, neighbor};
       const auto& mortar_mesh = mortar_meshes.at(mortar_id);
-      const auto& mortar_size = mortar_sizes.at(mortar_id);
+      const auto& mortar_size = mortar_infos.at(mortar_id).mortar_size();
 
       if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
         auto& local_mortar = mortar_data_ptr->at(mortar_id).local();
@@ -347,7 +346,7 @@ void internal_mortar_data(
        &mesh = db::get<domain::Tags::Mesh<Dim>>(*box),
        &mesh_velocity = db::get<domain::Tags::MeshVelocity<Dim>>(*box),
        &mortar_meshes = db::get<Tags::MortarMesh<Dim>>(*box),
-       &mortar_sizes = db::get<Tags::MortarSize<Dim>>(*box),
+       &mortar_infos = db::get<Tags::MortarInfo<Dim>>(*box),
        &moving_mesh_map = db::get<domain::CoordinateMaps::Tags::CoordinateMap<
            Dim, Frame::Grid, Frame::Inertial>>(*box),
        &primitive_vars, &temporaries, &volume_fluxes](
@@ -357,7 +356,7 @@ void internal_mortar_data(
             normal_covector_and_magnitude_ptr, mortar_data_ptr,
             face_temporaries, packaged_data_buffer, boundary_correction,
             evolved_variables, volume_fluxes, temporaries, primitive_vars,
-            element, mesh, mortar_meshes, mortar_sizes, moving_mesh_map,
+            element, mesh, mortar_meshes, mortar_infos, moving_mesh_map,
             mesh_velocity, logical_to_inertial_inverse_jacobian,
             package_data_volume_args...);
       },

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_headers(
   InterfaceDataPolicy.hpp
   MortarData.hpp
   MortarDataHolder.hpp
+  MortarInfo.hpp
   MortarTags.hpp
   NormalVectorTags.hpp
   TimeDerivativeDecisions.hpp
@@ -27,6 +28,7 @@ spectre_target_sources(
   InterfaceDataPolicy.cpp
   MortarData.cpp
   MortarDataHolder.cpp
+  MortarInfo.cpp
   )
 
 add_subdirectory(Actions)

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -13,7 +13,9 @@
 #include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Element.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -30,7 +32,7 @@ using MortarMap = DirectionalIdMap<Dim, MappedType>;
 template <size_t Dim>
 std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>,
            DirectionalIdMap<Dim, Mesh<Dim - 1>>,
-           DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>,
+           DirectionalIdMap<Dim, MortarInfo<Dim>>,
            DirectionalIdMap<Dim, TimeStepId>,
            DirectionMap<Dim, std::optional<Variables<tmpl::list<
                                  evolution::dg::Tags::MagnitudeOfNormal,
@@ -43,7 +45,7 @@ mortars_apply_impl(const Domain<Dim>& domain,
                    const Mesh<Dim>& volume_mesh) {
   MortarMap<evolution::dg::MortarDataHolder<Dim>, Dim> mortar_data{};
   MortarMap<Mesh<Dim - 1>, Dim> mortar_meshes{};
-  MortarMap<std::array<Spectral::SegmentSize, Dim - 1>, Dim> mortar_sizes{};
+  MortarMap<MortarInfo<Dim>, Dim> mortar_infos{};
   MortarMap<TimeStepId, Dim> mortar_next_temporal_ids{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
@@ -55,19 +57,24 @@ mortars_apply_impl(const Domain<Dim>& domain,
       const DirectionalId<Dim> mortar_id{direction, neighbor};
       mortar_data.emplace(mortar_id, MortarDataHolder<Dim>{});
       const auto& neighbor_block = domain.blocks()[neighbor.block_id()];
+      const auto& neighbor_orientation = neighbors.orientation(neighbor);
       mortar_meshes.emplace(
           mortar_id,
           ::dg::mortar_mesh(
               volume_mesh.slice_away(direction.dimension()),
-              neighbors
-                  .orientation(
-                      neighbor)(::domain::Initialization::create_initial_mesh(
+              neighbor_orientation(
+                  ::domain::Initialization::create_initial_mesh(
                       initial_extents, neighbor_block, neighbor, quadrature))
                   .slice_away(direction.dimension())));
-      mortar_sizes.emplace(
+      mortar_infos.emplace(
           mortar_id,
-          ::dg::mortar_size(element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation(neighbor)));
+          MortarInfo<Dim>{
+              {.mortar_size = ::dg::mortar_size(element.id(), neighbor,
+                                                direction.dimension(),
+                                                neighbor_orientation),
+               .policy = neighbor_orientation.is_aligned()
+                             ? InterfaceDataPolicy::CopyProject
+                             : InterfaceDataPolicy::OrientCopyProject}});
       // Since no communication needs to happen for boundary conditions
       // the temporal id is not advanced on the boundary, so we only need to
       // initialize it on internal boundaries
@@ -80,7 +87,7 @@ mortars_apply_impl(const Domain<Dim>& domain,
   }
 
   return {std::move(mortar_data), std::move(mortar_meshes),
-          std::move(mortar_sizes), std::move(mortar_next_temporal_ids),
+          std::move(mortar_infos), std::move(mortar_next_temporal_ids),
           std::move(normal_covector_quantities)};
 }
 
@@ -90,8 +97,7 @@ mortars_apply_impl(const Domain<Dim>& domain,
   template std::tuple<                                                         \
       DirectionalIdMap<DIM(data), evolution::dg::MortarDataHolder<DIM(data)>>, \
       DirectionalIdMap<DIM(data), Mesh<DIM(data) - 1>>,                        \
-      DirectionalIdMap<DIM(data),                                              \
-                       std::array<Spectral::SegmentSize, DIM(data) - 1>>,      \
+      DirectionalIdMap<DIM(data), MortarInfo<DIM(data)>>,                      \
       DirectionalIdMap<DIM(data), TimeStepId>,                                 \
       DirectionMap<DIM(data),                                                  \
                    std::optional<Variables<tmpl::list<                         \

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -30,6 +30,7 @@
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
@@ -49,7 +50,6 @@ class GlobalCache;
 }  // namespace Parallel
 namespace Spectral {
 enum class Quadrature : uint8_t;
-enum class SegmentSize : uint8_t;
 }  // namespace Spectral
 namespace Tags {
 struct TimeStepId;
@@ -65,7 +65,7 @@ namespace detail {
 template <size_t Dim>
 std::tuple<DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>,
            DirectionalIdMap<Dim, Mesh<Dim - 1>>,
-           DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>,
+           DirectionalIdMap<Dim, MortarInfo<Dim>>,
            DirectionalIdMap<Dim, TimeStepId>,
            DirectionMap<Dim, std::optional<Variables<tmpl::list<
                                  evolution::dg::Tags::MagnitudeOfNormal,
@@ -82,9 +82,8 @@ void p_project(
         ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>*>
     /* mortar_data */,
     const gsl::not_null<::dg::MortarMap<Dim, Mesh<Dim - 1>>*> mortar_mesh,
-    const gsl::not_null<
-        ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>*>
-    /* mortar_size */,
+    const gsl::not_null<::dg::MortarMap<Dim, MortarInfo<Dim>>*>
+    /* mortar_infos */,
     const gsl::not_null<::dg::MortarMap<Dim, TimeStepId>*>
     /* mortar_next_temporal_id */,
     const gsl::not_null<
@@ -187,7 +186,7 @@ void p_project(
  * - Adds:
  *   - `Tags::MortarData<Dim>`
  *   - `Tags::MortarMesh<Dim>`
- *   - `Tags::MortarSize<Dim>`
+ *   - `Tags::MortarInfo<Dim>`
  *   - `Tags::MortarNextTemporalId<Dim>`
  *   - `evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>`
  *   - `evolution::dg::Tags::BoundaryData<Dim>`
@@ -206,7 +205,7 @@ struct Mortars {
                  evolution::dg::Tags::Quadrature>;
 
   using simple_tags = tmpl::list<
-      Tags::MortarData<Dim>, Tags::MortarMesh<Dim>, Tags::MortarSize<Dim>,
+      Tags::MortarData<Dim>, Tags::MortarMesh<Dim>, Tags::MortarInfo<Dim>,
       Tags::MortarNextTemporalId<Dim>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
       Tags::MortarDataHistory<
@@ -224,7 +223,7 @@ struct Mortars {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    auto [mortar_data, mortar_meshes, mortar_sizes, mortar_next_temporal_ids,
+    auto [mortar_data, mortar_meshes, mortar_infos, mortar_next_temporal_ids,
           normal_covector_quantities] =
         detail::mortars_apply_impl(
             db::get<::domain::Tags::Domain<Dim>>(box),
@@ -245,7 +244,7 @@ struct Mortars {
     }
     ::Initialization::mutate_assign<simple_tags>(
         make_not_null(&box), std::move(mortar_data), std::move(mortar_meshes),
-        std::move(mortar_sizes), std::move(mortar_next_temporal_ids),
+        std::move(mortar_infos), std::move(mortar_next_temporal_ids),
         std::move(normal_covector_quantities), std::move(boundary_data_history),
         typename evolution::dg::Tags::BoundaryData<Dim>::type{});
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
@@ -257,7 +256,7 @@ struct Mortars {
 /// Mutates:
 ///   - Tags::MortarData<dim>
 ///   - Tags::MortarMesh<dim>
-///   - Tags::MortarSize<dim>
+///   - Tags::MortarInfo<dim>
 ///   - Tags::MortarNextTemporalId<dim>
 ///   - evolution::dg::Tags::NormalCovectorAndMagnitude<dim>
 ///   - Tags::MortarDataHistory<dim, typename dt_variables_tag::type>>
@@ -284,7 +283,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
 
   using return_tags =
       tmpl::list<Tags::MortarData<dim>, Tags::MortarMesh<dim>,
-                 Tags::MortarSize<dim>, Tags::MortarNextTemporalId<dim>,
+                 Tags::MortarInfo<dim>, Tags::MortarNextTemporalId<dim>,
                  evolution::dg::Tags::NormalCovectorAndMagnitude<dim>,
                  Tags::MortarDataHistory<dim, typename dt_variables_tag::type>>;
   using argument_tags =
@@ -296,9 +295,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
           ::dg::MortarMap<dim, evolution::dg::MortarDataHolder<dim>>*>
           mortar_data,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> mortar_mesh,
-      const gsl::not_null<
-          ::dg::MortarMap<dim, std::array<Spectral::SegmentSize, dim - 1>>*>
-          mortar_size,
+      const gsl::not_null<::dg::MortarMap<dim, MortarInfo<dim>>*> mortar_infos,
       const gsl::not_null<::dg::MortarMap<dim, TimeStepId>*>
           mortar_next_temporal_id,
       const gsl::not_null<
@@ -309,7 +306,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
       const std::unordered_map<ElementId<dim>, amr::Info<dim>>& neighbor_info,
       const ::dg::MortarMap<dim, Mesh<dim>>& neighbor_mesh,
       const std::pair<Mesh<dim>, Element<dim>>& old_mesh_and_element) {
-    detail::p_project(mortar_data, mortar_mesh, mortar_size,
+    detail::p_project(mortar_data, mortar_mesh, mortar_infos,
                       mortar_next_temporal_id, normal_covector_and_magnitude,
                       mortar_data_history, new_mesh, new_element, neighbor_info,
                       neighbor_mesh, old_mesh_and_element);
@@ -321,9 +318,8 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
           ::dg::MortarMap<dim, evolution::dg::MortarDataHolder<dim>>*>
       /*mortar_data*/,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> /*mortar_mesh*/,
-      const gsl::not_null<
-          ::dg::MortarMap<dim, std::array<Spectral::SegmentSize, dim - 1>>*>
-      /*mortar_size*/,
+      const gsl::not_null<::dg::MortarMap<dim, MortarInfo<dim>>*>
+      /*mortar_infos*/,
       const gsl::not_null<
           ::dg::MortarMap<dim, TimeStepId>*> /*mortar_next_temporal_id*/,
       const gsl::not_null<
@@ -345,9 +341,8 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
           ::dg::MortarMap<dim, evolution::dg::MortarDataHolder<dim>>*>
       /*mortar_data*/,
       const gsl::not_null<::dg::MortarMap<dim, Mesh<dim - 1>>*> /*mortar_mesh*/,
-      const gsl::not_null<
-          ::dg::MortarMap<dim, std::array<Spectral::SegmentSize, dim - 1>>*>
-      /*mortar_size*/,
+      const gsl::not_null<::dg::MortarMap<dim, MortarInfo<dim>>*>
+      /*mortar_infos*/,
       const gsl::not_null<
           ::dg::MortarMap<dim, TimeStepId>*> /*mortar_next_temporal_id*/,
       const gsl::not_null<

--- a/src/Evolution/DiscontinuousGalerkin/MortarInfo.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarInfo.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+#include <pup_stl.h>
+
+namespace evolution::dg {
+template <size_t VolumeDim>
+MortarInfo<VolumeDim>::MortarInfo(MortarInfoData data)
+    : data_(std::move(data)) {}
+
+template <size_t VolumeDim>
+void MortarInfo<VolumeDim>::MortarInfoData::pup(PUP::er& p) {
+  p | mortar_size;
+  p | policy;
+}
+
+template <size_t VolumeDim>
+void MortarInfo<VolumeDim>::pup(PUP::er& p) {
+  p | data_;
+}
+
+template <size_t VolumeDim>
+bool operator==(const MortarInfo<VolumeDim>& lhs,
+                const MortarInfo<VolumeDim>& rhs) {
+  return lhs.policy() == rhs.policy() and
+         lhs.mortar_size() == rhs.mortar_size();
+}
+
+template <size_t VolumeDim>
+bool operator!=(const MortarInfo<VolumeDim>& lhs,
+                const MortarInfo<VolumeDim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os,
+                         const MortarInfo<VolumeDim>& mortar_info) {
+  using ::operator<<;
+  os << mortar_info.mortar_size() << ", " << mortar_info.policy();
+  return os;
+}
+
+template class MortarInfo<1>;
+template class MortarInfo<2>;
+template class MortarInfo<3>;
+template bool operator==(const MortarInfo<1>&, const MortarInfo<1>&);
+template bool operator==(const MortarInfo<2>&, const MortarInfo<2>&);
+template bool operator==(const MortarInfo<3>&, const MortarInfo<3>&);
+template bool operator!=(const MortarInfo<1>&, const MortarInfo<1>&);
+template bool operator!=(const MortarInfo<2>&, const MortarInfo<2>&);
+template bool operator!=(const MortarInfo<3>&, const MortarInfo<3>&);
+template std::ostream& operator<<(std::ostream&, const MortarInfo<1>&);
+template std::ostream& operator<<(std::ostream&, const MortarInfo<2>&);
+template std::ostream& operator<<(std::ostream&, const MortarInfo<3>&);
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/MortarInfo.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarInfo.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace evolution::dg {
+/// \brief Information about the mortar between two Elements
+///
+/// \details The following information is stored:
+/// - the InterfaceDataPolicy
+/// - the mortar size; for conforming neighbors this is (in each dimension of
+///   the mortar) the SegmentSize of the mortar with respect to the face of the
+///   host Element
+template <size_t VolumeDim>
+class MortarInfo {
+  struct MortarInfoData {
+    std::array<Spectral::SegmentSize, VolumeDim - 1> mortar_size{};
+    InterfaceDataPolicy policy{InterfaceDataPolicy::Uninitialized};
+    // NOLINTNEXTLINE(google-runtime-references)
+    void pup(PUP::er& p);
+  };
+
+ public:
+  MortarInfo() = default;
+  MortarInfo(const MortarInfo&) = default;
+  MortarInfo(MortarInfo&&) = default;
+  MortarInfo& operator=(const MortarInfo&) = default;
+  MortarInfo& operator=(MortarInfo&&) = default;
+  ~MortarInfo() = default;
+
+  explicit MortarInfo(MortarInfoData data);
+
+  /// For conforming neighbors, the SegmentSize of the mortar with respect to
+  /// the face of the host Element
+  const std::array<Spectral::SegmentSize, VolumeDim - 1>& mortar_size() const {
+    return data_.mortar_size;
+  }
+
+  /// The InterfaceDataPolicy of the host Element for the mortar
+  const InterfaceDataPolicy& policy() const { return data_.policy; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+ private:
+  MortarInfoData data_;
+};
+
+template <size_t VolumeDim>
+bool operator==(const MortarInfo<VolumeDim>& lhs,
+                const MortarInfo<VolumeDim>& rhs);
+
+template <size_t VolumeDim>
+bool operator!=(const MortarInfo<VolumeDim>& lhs,
+                const MortarInfo<VolumeDim>& rhs);
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os,
+                         const MortarInfo<VolumeDim>& mortar_info);
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarTags.hpp
@@ -20,10 +20,9 @@ template <size_t Dim>
 class MortarData;
 template <size_t Dim>
 class MortarDataHolder;
+template <size_t Dim>
+class MortarInfo;
 }  // namespace evolution::dg
-namespace Spectral {
-enum class SegmentSize : uint8_t;
-}  // namespace Spectral
 class TimeStepId;
 namespace TimeSteppers {
 template <typename LocalData, typename RemoteData, typename CouplingResult>
@@ -66,14 +65,12 @@ struct MortarMesh : db::SimpleTag {
   using type = DirectionalIdMap<Dim, Mesh<Dim - 1>>;
 };
 
-/// Size of a mortar, relative to the element face.  That is, the part
-/// of the face that it covers.
+/// The ::evolution::dg::MortarInfo for each mortar
 ///
 /// The `Dim` is the volume dimension, not the face dimension.
 template <size_t Dim>
-struct MortarSize : db::SimpleTag {
-  using type =
-      DirectionalIdMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>;
+struct MortarInfo : db::SimpleTag {
+  using type = DirectionalIdMap<Dim, ::evolution::dg::MortarInfo<Dim>>;
 };
 
 /// The next temporal id at which to receive data on the specified mortar.

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -27,6 +27,7 @@
 #include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Framework/ActionTesting.hpp"
@@ -787,8 +788,8 @@ void test_impl(const Spectral::Quadrature quadrature,
   }
 
   // Now retrieve dt tag and check that values are correct
-  const auto& mortar_sizes =
-      get_tag<evolution::dg::Tags::MortarSize<Dim>>(runner, self_id);
+  const auto& mortar_infos =
+      get_tag<evolution::dg::Tags::MortarInfo<Dim>>(runner, self_id);
 
   Variables<dt_variables_tags> dt_boundary_correction_on_mortar{};
   Variables<dt_variables_tags> dt_boundary_correction_projected_onto_face{};
@@ -800,7 +801,7 @@ void test_impl(const Spectral::Quadrature quadrature,
       [&det_inv_jacobian, &dg_formulation, &dt_boundary_correction_on_mortar,
        &dt_boundary_correction_projected_onto_face,
        &expected_dt_variables_volume, &mesh, &mortar_id_ptr, &mortar_meshes,
-       &mortar_sizes, &quadrature, &runner,
+       &mortar_infos, &quadrature, &runner,
        &self_id](const evolution::dg::MortarData<Dim>& local_mortar_data,
                  const evolution::dg::MortarData<Dim>& neighbor_mortar_data)
       -> Variables<db::wrap_tags_in<::Tags::dt, variables_tags>> {
@@ -854,7 +855,7 @@ void test_impl(const Spectral::Quadrature quadrature,
 
     // Project the boundary terms from the mortar to the face
     const std::array<Spectral::SegmentSize, Dim - 1>& mortar_size =
-        mortar_sizes.at(mortar_id);
+        mortar_infos.at(mortar_id).mortar_size();
     const Mesh<Dim - 1> face_mesh = mesh.slice_away(dimension);
 
     auto& dt_boundary_correction =

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_InterfaceDataPolicy.cpp
   Test_MortarData.cpp
   Test_MortarDataHolder.cpp
+  Test_MortarInfo.cpp
   Test_MortarTags.cpp
   Test_NormalVectorTags.cpp
   Test_UsingSubcell.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -28,6 +28,7 @@
 #include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
@@ -112,8 +113,7 @@ void test_impl(
     const Element<Dim>& element, const TimeStepId& time_step_id,
     const TimeStepId& next_time_step_id, const Spectral::Quadrature quadrature,
     const ::dg::MortarMap<Dim, Mesh<Dim - 1>>& expected_mortar_meshes,
-    const ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
-        expected_mortar_sizes,
+    const ::dg::MortarMap<Dim, MortarInfo<Dim>>& expected_mortar_infos,
     const DirectionMap<Dim, std::optional<Variables<tmpl::list<
                                 evolution::dg::Tags::MagnitudeOfNormal,
                                 evolution::dg::Tags::NormalCovector<Dim>>>>>&
@@ -148,8 +148,8 @@ void test_impl(
 
   const auto& mortar_meshes = get_tag(Tags::MortarMesh<Dim>{});
   CHECK(mortar_meshes == expected_mortar_meshes);
-  const auto& mortar_sizes = get_tag(Tags::MortarSize<Dim>{});
-  CHECK(mortar_sizes == expected_mortar_sizes);
+  const auto& mortar_infos = get_tag(Tags::MortarInfo<Dim>{});
+  CHECK(mortar_infos == expected_mortar_infos);
   const auto& mortar_data = get_tag(Tags::MortarData<Dim>{});
   const auto& boundary_data_history = get_tag(
       Tags::MortarDataHistory<
@@ -213,8 +213,10 @@ struct Test<1, LocalTimeStepping> {
                                                east_id};
     const ::dg::MortarMap<1, Mesh<0>> expected_mortar_meshes{
         {interface_mortar_id, {}}};
-    const ::dg::MortarMap<1, std::array<Spectral::SegmentSize, 0>>
-        expected_mortar_sizes{{interface_mortar_id, {}}};
+    const ::dg::MortarMap<1, MortarInfo<1>> expected_mortar_infos{
+        {interface_mortar_id,
+         MortarInfo<1>{
+             {.policy = evolution::dg::InterfaceDataPolicy::CopyProject}}}};
 
     const DirectionMap<
         1, std::optional<
@@ -225,7 +227,7 @@ struct Test<1, LocalTimeStepping> {
 
     test_impl<LocalTimeStepping>(initial_extents, element, time_step_id,
                                  next_time_step_id, quadrature,
-                                 expected_mortar_meshes, expected_mortar_sizes,
+                                 expected_mortar_meshes, expected_mortar_infos,
                                  expected_normal_covector_quantities);
   }
 };
@@ -271,11 +273,13 @@ struct Test<2, LocalTimeStepping> {
          Mesh<1>(2, Spectral::Basis::Legendre, quadrature)},
         {interface_mortar_id_south,
          Mesh<1>(3, Spectral::Basis::Legendre, quadrature)}};
-    ::dg::MortarMap<2, std::array<Spectral::SegmentSize, 1>>
-        expected_mortar_sizes{};
+    ::dg::MortarMap<2, MortarInfo<2>> expected_mortar_infos{};
     for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
-      expected_mortar_sizes[mortar_id_and_mesh.first] = {
-          {Spectral::SegmentSize::Full}};
+      expected_mortar_infos.emplace(
+          mortar_id_and_mesh.first,
+          MortarInfo<2>{
+              {.mortar_size = {{Spectral::SegmentSize::Full}},
+               .policy = evolution::dg::InterfaceDataPolicy::CopyProject}});
     }
 
     const DirectionMap<
@@ -289,7 +293,7 @@ struct Test<2, LocalTimeStepping> {
 
     test_impl<LocalTimeStepping>(initial_extents, element, time_step_id,
                                  next_time_step_id, quadrature,
-                                 expected_mortar_meshes, expected_mortar_sizes,
+                                 expected_mortar_meshes, expected_mortar_infos,
                                  expected_normal_covector_quantities);
   }
 };
@@ -341,11 +345,14 @@ struct Test<3, LocalTimeStepping> {
          Mesh<2>({{2, 4}}, Spectral::Basis::Legendre, quadrature)},
         {interface_mortar_id_top,
          Mesh<2>({{2, 3}}, Spectral::Basis::Legendre, quadrature)}};
-    ::dg::MortarMap<3, std::array<Spectral::SegmentSize, 2>>
-        expected_mortar_sizes{};
+    ::dg::MortarMap<3, MortarInfo<3>> expected_mortar_infos{};
     for (const auto& mortar_id_and_mesh : expected_mortar_meshes) {
-      expected_mortar_sizes[mortar_id_and_mesh.first] = {
-          {Spectral::SegmentSize::Full, Spectral::SegmentSize::Full}};
+      expected_mortar_infos.emplace(
+          mortar_id_and_mesh.first,
+          MortarInfo<3>{
+              {.mortar_size = {{Spectral::SegmentSize::Full,
+                                Spectral::SegmentSize::Full}},
+               .policy = evolution::dg::InterfaceDataPolicy::CopyProject}});
     }
 
     const DirectionMap<
@@ -359,7 +366,7 @@ struct Test<3, LocalTimeStepping> {
 
     test_impl<LocalTimeStepping>(initial_extents, element, time_step_id,
                                  next_time_step_id, quadrature,
-                                 expected_mortar_meshes, expected_mortar_sizes,
+                                 expected_mortar_meshes, expected_mortar_infos,
                                  expected_normal_covector_quantities);
   }
 };
@@ -400,8 +407,7 @@ template <size_t Dim, bool UsingLts>
 void test_p_refine(
     ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>& mortar_data,
     ::dg::MortarMap<Dim, Mesh<Dim - 1>>& mortar_mesh,
-    ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
-        mortar_size,
+    ::dg::MortarMap<Dim, MortarInfo<Dim>>& mortar_infos,
     ::dg::MortarMap<Dim, TimeStepId>& mortar_next_temporal_id,
     DirectionMap<Dim, std::optional<Variables<tmpl::list<
                           evolution::dg::Tags::MagnitudeOfNormal,
@@ -414,8 +420,7 @@ void test_p_refine(
     const ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>&
         expected_mortar_data,
     const ::dg::MortarMap<Dim, Mesh<Dim - 1>>& expected_mortar_mesh,
-    const ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>&
-        expected_mortar_size,
+    const ::dg::MortarMap<Dim, MortarInfo<Dim>>& expected_mortar_infos,
     const ::dg::MortarMap<Dim, TimeStepId>& expected_mortar_next_temporal_id,
     const DirectionMap<Dim, std::optional<Variables<tmpl::list<
                                 evolution::dg::Tags::MagnitudeOfNormal,
@@ -425,13 +430,13 @@ void test_p_refine(
   auto box = db::create<db::AddSimpleTags<
       domain::Tags::Mesh<Dim>, domain::Tags::Element<Dim>,
       domain::Tags::NeighborMesh<Dim>, amr::Tags::NeighborInfo<Dim>,
-      Tags::MortarData<Dim>, Tags::MortarMesh<Dim>, Tags::MortarSize<Dim>,
+      Tags::MortarData<Dim>, Tags::MortarMesh<Dim>, Tags::MortarInfo<Dim>,
       Tags::MortarNextTemporalId<Dim>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
       Tags::MortarDataHistory<Dim, typename dt_variables_tag<Dim>::type>>>(
       std::move(new_mesh), std::move(new_element),
       ::dg::MortarMap<Dim, Mesh<Dim>>{}, std::move(neighbor_info),
-      std::move(mortar_data), std::move(mortar_mesh), std::move(mortar_size),
+      std::move(mortar_data), std::move(mortar_mesh), std::move(mortar_infos),
       std::move(mortar_next_temporal_id),
       std::move(normal_covector_and_magnitude), std::move(mortar_data_history));
 
@@ -441,7 +446,7 @@ void test_p_refine(
 
   CHECK(db::get<Tags::MortarData<Dim>>(box) == expected_mortar_data);
   CHECK(db::get<Tags::MortarMesh<Dim>>(box) == expected_mortar_mesh);
-  CHECK(db::get<Tags::MortarSize<Dim>>(box) == expected_mortar_size);
+  CHECK(db::get<Tags::MortarInfo<Dim>>(box) == expected_mortar_infos);
   CHECK(db::get<Tags::MortarNextTemporalId<Dim>>(box) ==
         expected_mortar_next_temporal_id);
   CHECK(db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(box) ==
@@ -533,8 +538,7 @@ void test_p_refine_gts() {
 
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
-      mortar_size{};
+  ::dg::MortarMap<Dim, MortarInfo<Dim>> mortar_infos{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
                                    evolution::dg::Tags::NormalCovector<Dim>>>>>
@@ -552,10 +556,16 @@ void test_p_refine_gts() {
           mortar_id,
           ::dg::mortar_mesh(old_mesh.slice_away(direction.dimension()),
                             neighbor_mesh.slice_away(direction.dimension())));
-      mortar_size.emplace(
+      const auto& neighbor_orientation = neighbors.orientation(neighbor);
+      mortar_infos.emplace(
           mortar_id,
-          ::dg::mortar_size(old_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation(neighbor)));
+          MortarInfo<Dim>{
+              {.mortar_size = ::dg::mortar_size(old_element.id(), neighbor,
+                                                direction.dimension(),
+                                                neighbor_orientation),
+               .policy = neighbor_orientation.is_aligned()
+                             ? InterfaceDataPolicy::CopyProject
+                             : InterfaceDataPolicy::OrientCopyProject}});
       mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
       neighbor_info.emplace(
           neighbor,
@@ -566,8 +576,7 @@ void test_p_refine_gts() {
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>
       expected_mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> expected_mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
-      expected_mortar_size{};
+  ::dg::MortarMap<Dim, MortarInfo<Dim>> expected_mortar_infos{};
   ::dg::MortarMap<Dim, TimeStepId> expected_mortar_next_temporal_ids{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
@@ -584,10 +593,17 @@ void test_p_refine_gts() {
           ::dg::mortar_mesh(new_mesh.slice_away(direction.dimension()),
                             neighbor_info.at(neighbor).new_mesh.slice_away(
                                 direction.dimension())));
-      expected_mortar_size.emplace(
+      const auto& neighbor_orientation = neighbors.orientation(neighbor);
+      expected_mortar_infos.emplace(
           mortar_id,
-          ::dg::mortar_size(new_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation(neighbor)));
+          MortarInfo<Dim>{
+              {.mortar_size = ::dg::mortar_size(new_element.id(), neighbor,
+                                                direction.dimension(),
+                                                neighbor_orientation),
+               .policy = neighbor_orientation.is_aligned()
+                             ? evolution::dg::InterfaceDataPolicy::CopyProject
+                             : evolution::dg::InterfaceDataPolicy::
+                                   OrientCopyProject}});
       expected_mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
     }
   }
@@ -597,10 +613,10 @@ void test_p_refine_gts() {
   }
 
   test_p_refine<Dim, false>(
-      mortar_data, mortar_mesh, mortar_size, mortar_next_temporal_ids,
+      mortar_data, mortar_mesh, mortar_infos, mortar_next_temporal_ids,
       normal_covector_and_magnitude, mortar_data_history, old_mesh, new_mesh,
       old_element, new_element, neighbor_info, expected_mortar_data,
-      expected_mortar_mesh, expected_mortar_size,
+      expected_mortar_mesh, expected_mortar_infos,
       expected_mortar_next_temporal_ids, expected_normal_covector_and_magnitude,
       expected_mortar_data_history);
 }
@@ -654,8 +670,7 @@ void test_p_refine_lts() {
 
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>> mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
-      mortar_size{};
+  ::dg::MortarMap<Dim, MortarInfo<Dim>> mortar_infos{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
                                    evolution::dg::Tags::NormalCovector<Dim>>>>>
@@ -672,10 +687,16 @@ void test_p_refine_lts() {
           mortar_id,
           ::dg::mortar_mesh(old_mesh.slice_away(direction.dimension()),
                             neighbor_mesh.slice_away(direction.dimension())));
-      mortar_size.emplace(
+      const auto& neighbor_orientation = neighbors.orientation(neighbor);
+      mortar_infos.emplace(
           mortar_id,
-          ::dg::mortar_size(old_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation(neighbor)));
+          MortarInfo<Dim>{
+              {.mortar_size = ::dg::mortar_size(old_element.id(), neighbor,
+                                                direction.dimension(),
+                                                neighbor_orientation),
+               .policy = neighbor_orientation.is_aligned()
+                             ? InterfaceDataPolicy::CopyProject
+                             : InterfaceDataPolicy::OrientCopyProject}});
       mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
       neighbor_info.emplace(
           neighbor,
@@ -702,8 +723,7 @@ void test_p_refine_lts() {
   ::dg::MortarMap<Dim, evolution::dg::MortarDataHolder<Dim>>
       expected_mortar_data{};
   ::dg::MortarMap<Dim, Mesh<Dim - 1>> expected_mortar_mesh{};
-  ::dg::MortarMap<Dim, std::array<Spectral::SegmentSize, Dim - 1>>
-      expected_mortar_size{};
+  ::dg::MortarMap<Dim, MortarInfo<Dim>> expected_mortar_infos{};
   ::dg::MortarMap<Dim, TimeStepId> expected_mortar_next_temporal_ids{};
   DirectionMap<Dim, std::optional<Variables<
                         tmpl::list<evolution::dg::Tags::MagnitudeOfNormal,
@@ -720,10 +740,16 @@ void test_p_refine_lts() {
           ::dg::mortar_mesh(new_mesh.slice_away(direction.dimension()),
                             neighbor_info.at(neighbor).new_mesh.slice_away(
                                 direction.dimension())));
-      expected_mortar_size.emplace(
+      const auto& neighbor_orientation = neighbors.orientation(neighbor);
+      expected_mortar_infos.emplace(
           mortar_id,
-          ::dg::mortar_size(new_element.id(), neighbor, direction.dimension(),
-                            neighbors.orientation(neighbor)));
+          MortarInfo<Dim>{
+              {.mortar_size = ::dg::mortar_size(new_element.id(), neighbor,
+                                                direction.dimension(),
+                                                neighbor_orientation),
+               .policy = neighbor_orientation.is_aligned()
+                             ? InterfaceDataPolicy::CopyProject
+                             : InterfaceDataPolicy::OrientCopyProject}});
       expected_mortar_next_temporal_ids.emplace(mortar_id, next_temporal_id);
       expected_mortar_data_history.emplace(mortar_id,
                                            boundary_history_type<Dim>{});
@@ -750,10 +776,10 @@ void test_p_refine_lts() {
   }
 
   test_p_refine<Dim, true>(
-      mortar_data, mortar_mesh, mortar_size, mortar_next_temporal_ids,
+      mortar_data, mortar_mesh, mortar_infos, mortar_next_temporal_ids,
       normal_covector_and_magnitude, mortar_data_history, old_mesh, new_mesh,
       old_element, new_element, neighbor_info, expected_mortar_data,
-      expected_mortar_mesh, expected_mortar_size,
+      expected_mortar_mesh, expected_mortar_infos,
       expected_mortar_next_temporal_ids, expected_normal_covector_and_magnitude,
       expected_mortar_data_history);
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarInfo.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarInfo.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace evolution::dg {
+namespace {
+template <size_t Dim>
+void test(const std::array<Spectral::SegmentSize, Dim - 1>& mortar_size) {
+  const MortarInfo<Dim> nonconforming_mortar_info{
+      {.policy = InterfaceDataPolicy::NonconformingSelfInterpolates}};
+  CHECK(nonconforming_mortar_info.policy() ==
+        InterfaceDataPolicy::NonconformingSelfInterpolates);
+  CHECK(nonconforming_mortar_info.mortar_size() ==
+        make_array<Dim - 1>(Spectral::SegmentSize::Uninitialized));
+  const auto deserialized_nonconforming_mortar_info =
+      serialize_and_deserialize(nonconforming_mortar_info);
+  CHECK(nonconforming_mortar_info == deserialized_nonconforming_mortar_info);
+  const MortarInfo<Dim> conforming_mortar_info{
+      {.mortar_size = mortar_size, .policy = InterfaceDataPolicy::CopyProject}};
+  CHECK(conforming_mortar_info.policy() == InterfaceDataPolicy::CopyProject);
+  CHECK(conforming_mortar_info.mortar_size() == mortar_size);
+  const auto deserialized_conforming_mortar_info =
+      serialize_and_deserialize(conforming_mortar_info);
+  CHECK(conforming_mortar_info == deserialized_conforming_mortar_info);
+  CHECK(conforming_mortar_info != nonconforming_mortar_info);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.MortarInfo", "[Unit][Evolution]") {
+  test<1>({{}});
+  test<2>({{Spectral::SegmentSize::Full}});
+  test<3>(
+      {{Spectral::SegmentSize::UpperHalf, Spectral::SegmentSize::LowerHalf}});
+}
+}  // namespace evolution::dg

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarTags.cpp
@@ -17,7 +17,7 @@ void test() {
   TestHelpers::db::test_simple_tag<Tags::MortarDataHistory<Dim, double>>(
       "MortarDataHistory");
   TestHelpers::db::test_simple_tag<Tags::MortarMesh<Dim>>("MortarMesh");
-  TestHelpers::db::test_simple_tag<Tags::MortarSize<Dim>>("MortarSize");
+  TestHelpers::db::test_simple_tag<Tags::MortarInfo<Dim>>("MortarInfo");
   TestHelpers::db::test_simple_tag<Tags::MortarNextTemporalId<Dim>>(
       "MortarNextTemporalId");
   TestHelpers::db::test_simple_tag<Tags::BoundaryMessageFromInbox<Dim>>(

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -44,6 +44,7 @@
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/PassVariables.hpp"
@@ -1707,14 +1708,14 @@ void test_impl(const Spectral::Quadrature quadrature,
   }
 
   const auto& mortar_meshes = get_tag(::evolution::dg::Tags::MortarMesh<Dim>{});
-  const auto& mortar_sizes = get_tag(::evolution::dg::Tags::MortarSize<Dim>{});
+  const auto& mortar_infos = get_tag(::evolution::dg::Tags::MortarInfo<Dim>{});
 
   Variables<tmpl::list<Var3Squared>> volume_temporaries{
       mesh.number_of_grid_points()};
   get(get<Var3Squared>(volume_temporaries)) = square(get(var3));
   const auto compute_expected_mortar_data =
       [&element, &expected_fluxes, &face_normals, &get_tag, &mesh,
-       &mesh_velocity, &mortar_meshes, &mortar_sizes, &volume_temporaries,
+       &mesh_velocity, &mortar_meshes, &mortar_infos, &volume_temporaries,
        &variables_before_compute_time_derivatives](
           const Direction<Dim>& local_direction,
           const ElementId<Dim>& local_neighbor_id, const bool local_data) {
@@ -1778,7 +1779,7 @@ void test_impl(const Spectral::Quadrature quadrature,
         const auto mortar_id =
             DirectionalId<Dim>{local_direction, local_neighbor_id};
         const auto& mortar_mesh = mortar_meshes.at(mortar_id);
-        const auto& mortar_size = mortar_sizes.at(mortar_id);
+        const auto& mortar_size = mortar_infos.at(mortar_id).mortar_size();
 
         DataVector expected_data{};
         if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {


### PR DESCRIPTION
## Proposed changes

MortarInfo will be used to store information needed to do boundary corrections for non-conforming Blocks.

Initially MortarInfo will store the mortar size and InterfaceDataPolicy, but it will be easy to add additional information if needed without changing the Tags stored in the DataBox and the interfaces of evolution actions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
A mortar size will need to be obtained from the MortarInfo returned by Tags::MortarInfo instead of directly from Tags::MortarSize.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
