### PR TITLE
Add first FD spacetime_derivatives() for SoCcz4

### DIFF
--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -1,9 +1,14 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY SoCcz4)
+
+add_spectre_library(${LIBRARY})
+
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Derivatives.cpp
   SecondPartialDerivatives.cpp
   )
 
@@ -11,6 +16,25 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Derivatives.hpp
   SecondPartialDerivatives.hpp
   SecondPartialDerivatives.tpp
+  System.hpp
+  Tags.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  Ccz4
+  DataStructures
+  DomainStructure
+  ErrorHandling
+  DgSubcell
+  FiniteDifference
+  GeneralRelativity
+  Options
+  Spectral
+  Utilities
+  INTERFACE
   )

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Ccz4/System.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+void spacetime_derivatives(
+    const gsl::not_null<Variables<
+        db::wrap_tags_in<::Tags::deriv, typename System::gradients_tags,
+                         tmpl::size_t<3>, Frame::Inertial>>*>
+        result,
+    const Variables<typename System::variables_tag::tags_list>&
+        volume_evolved_variables,
+    const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&
+        all_ghost_data,
+    const size_t& deriv_order, const Mesh<3>& volume_mesh,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>&
+        cell_centered_logical_to_inertial_inv_jacobian) {
+  using gradients_tags = typename System::gradients_tags;
+  if (UNLIKELY(result->number_of_grid_points() !=
+               volume_evolved_variables.number_of_grid_points())) {
+    result->initialize(volume_evolved_variables.number_of_grid_points());
+  }
+
+  using first_Ccz4_tag = tmpl::front<Tags::spacetime_reconstruction_tags>;
+  constexpr size_t number_of_Ccz4_components =
+      Variables<Tags::spacetime_reconstruction_tags>::
+          number_of_independent_components;
+
+  DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
+  for (const auto& [directional_element_id, ghost_data] : all_ghost_data) {
+    using NeighborVariables =
+        Variables<Tags::spacetime_reconstruction_tags>;
+    const DataVector& neighbor_data =
+        ghost_data.neighbor_ghost_data_for_reconstruction();
+    const size_t neighbor_number_of_points =
+        neighbor_data.size() /
+        NeighborVariables::number_of_independent_components;
+    ASSERT(
+        neighbor_data.size() %
+                NeighborVariables::number_of_independent_components ==
+            0,
+        "Amount of reconstruction data sent ("
+            << neighbor_data.size() << ") from " << directional_element_id
+            << " is not a multiple of the number of reconstruction variables "
+            << NeighborVariables::number_of_independent_components);
+    // Use a Variables view to get offset into spacetime variables
+    // without having to do pointer math.
+    const NeighborVariables
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        view{const_cast<double*>(neighbor_data.data()),
+             neighbor_number_of_points *
+                 NeighborVariables::number_of_independent_components};
+    ghost_cell_vars.insert(std::pair{
+        directional_element_id.direction(),
+        gsl::make_span(get<first_Ccz4_tag>(view)[0].data(),
+                       number_of_Ccz4_components * neighbor_number_of_points)});
+  }
+
+  const auto volume_Ccz4_vars =
+      gsl::make_span(get<first_Ccz4_tag>(volume_evolved_variables)[0].data(),
+                     number_of_Ccz4_components *
+                         volume_evolved_variables.number_of_grid_points());
+
+  ::fd::partial_derivatives<gradients_tags>(
+      result, volume_Ccz4_vars, ghost_cell_vars, volume_mesh,
+      number_of_Ccz4_components, deriv_order,
+      cell_centered_logical_to_inertial_inv_jacobian);
+}
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/System.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+template <typename TagsList>
+class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
+/// \endcond
+
+namespace Ccz4::fd {
+/*!
+ * \brief Compute first partial derivatives of all the evolved variables in the
+ * second order Ccz4 system.
+ *
+ * The derivatives are computed using FD of order deriv_order using stencil
+ * the same as `fd::partial_derivatives()`.
+ *
+ */
+void spacetime_derivatives(
+    gsl::not_null<Variables<
+        db::wrap_tags_in<::Tags::deriv, typename System::gradients_tags,
+                         tmpl::size_t<3>, Frame::Inertial>>*>
+        result,
+    const Variables<typename System::variables_tag::tags_list>&
+        volume_evolved_variables,
+    const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&
+        all_ghost_data,
+    const size_t& deriv_order, const Mesh<3>& volume_mesh,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>&
+        cell_centered_logical_to_inertial_inv_jacobian);
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp
@@ -89,7 +89,7 @@ void second_logical_partial_derivatives(
 template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
 void second_partial_derivatives(
     gsl::not_null<
-        Variables<db::wrap_tags_in<Tags::second_deriv, DerivativeTags,
+        Variables<db::wrap_tags_in<::Tags::second_deriv, DerivativeTags,
                                    tmpl::size_t<Dim>, DerivativeFrame>>*>
         second_partial_derivatives,
     const gsl::span<const double>& volume_vars,

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp
@@ -164,7 +164,7 @@ void second_partial_derivatives_impl(
 template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
 void second_partial_derivatives(
     const gsl::not_null<
-        Variables<db::wrap_tags_in<Tags::second_deriv, DerivativeTags,
+        Variables<db::wrap_tags_in<::Tags::second_deriv, DerivativeTags,
                                    tmpl::size_t<Dim>, DerivativeFrame>>*>
         second_partial_derivatives,
     const gsl::span<const double>& volume_vars,

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+struct System {
+  using variables_tag = ::Tags::Variables<tmpl::list<
+      Tags::ConformalMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<DataVector, 3>, Tags::ConformalFactor<DataVector>,
+      Tags::ATilde<DataVector, 3>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>, Tags::Theta<DataVector>,
+      Tags::GammaHat<DataVector, 3>, Tags::AuxiliaryShiftB<DataVector, 3>>>;
+
+  using gradients_tags =
+      tmpl::list<Tags::ConformalMetric<DataVector, 3>,
+                 gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+                 Tags::ConformalFactor<DataVector>, Tags::ATilde<DataVector, 3>,
+                 gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                 Tags::Theta<DataVector>, Tags::GammaHat<DataVector, 3>,
+                 Tags::AuxiliaryShiftB<DataVector, 3>>;
+};
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Evolution/Systems/Ccz4/TagsDeclarations.hpp"
+#include "Evolution/Tags.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+
+namespace Ccz4::fd::Tags {
+/// \brief Tags sent for second-order Ccz4 evolution.
+using spacetime_reconstruction_tags = tmpl::list<
+    ::Ccz4::Tags::ConformalMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
+    gr::Tags::Shift<DataVector, 3>, ::Ccz4::Tags::ConformalFactor<DataVector>,
+    ::Ccz4::Tags::ATilde<DataVector, 3>,
+    gr::Tags::TraceExtrinsicCurvature<DataVector>,
+    ::Ccz4::Tags::Theta<DataVector>, ::Ccz4::Tags::GammaHat<DataVector, 3>,
+    ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>;
+}  // namespace Ccz4::fd::Tags

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
+  FiniteDifference/Test_Derivatives.cpp
   FiniteDifference/Test_SecondPartialDerivatives.cpp
   Test_ATilde.cpp
   Test_Christoffel.cpp
@@ -28,10 +29,12 @@ target_link_libraries(
   DataStructures
   Domain
   ErrorHandling
+  Framework
   GeneralRelativity
   GeneralRelativityHelpers
   GeneralRelativitySolutions
   LinearOperators
+  SoCcz4
   Spectral
   Utilities
 )

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Derivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Derivatives.cpp
@@ -1,0 +1,253 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/System.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Framework/TestingFramework.hpp"
+#include "Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+// [[TimeOut, 10]]
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
+                  "[Unit][Evolution]") {
+  const size_t points_per_dimension = 5;
+  const size_t ghost_zone_size = 3;
+  const size_t fd_deriv_order = 4;
+  const Mesh<3> subcell_mesh{points_per_dimension,
+                             Spectral::Basis::FiniteDifference,
+                             Spectral::Quadrature::CellCentered};
+  const auto logical_coords =
+      TestHelpers::Ccz4::fd::detail::set_logical_coordinates(subcell_mesh);
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_jacobian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    cell_centered_logical_to_inertial_inv_jacobian.get(i, i) = 1.0;
+  }
+
+  const Element<3> element = TestHelpers::Ccz4::fd::detail::set_element();
+
+  // Testing spacetime_derivatives()
+  const DirectionalIdMap<3, evolution::dg::subcell::GhostData> all_ghost_data =
+      TestHelpers::Ccz4::fd::detail::compute_ghost_data(
+          subcell_mesh, logical_coords, element.neighbors(), ghost_zone_size,
+          TestHelpers::Ccz4::fd::detail::compute_prim_solution);
+
+  auto volume_prims_for_recons =
+      TestHelpers::Ccz4::fd::detail::compute_prim_solution(logical_coords);
+  Variables<typename Ccz4::fd::System::variables_tag::tags_list>
+      volume_evolved_vars{subcell_mesh.number_of_grid_points()};
+
+  get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(
+          volume_prims_for_recons);
+  get<::Ccz4::Tags::ATilde<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::ATilde<DataVector, 3>>(volume_prims_for_recons);
+  get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_prims_for_recons);
+  get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(volume_evolved_vars) =
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(
+          volume_prims_for_recons);
+  get<::Ccz4::Tags::Theta<DataVector>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::Theta<DataVector>>(volume_prims_for_recons);
+  get<::Ccz4::Tags::GammaHat<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::GammaHat<DataVector, 3>>(volume_prims_for_recons);
+  get<gr::Tags::Shift<DataVector, 3>>(volume_evolved_vars) =
+      get<gr::Tags::Shift<DataVector, 3>>(volume_prims_for_recons);
+  get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(
+        volume_prims_for_recons);
+  get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars) =
+      get<gr::Tags::Lapse<DataVector>>(volume_prims_for_recons);
+
+  Variables<
+      db::wrap_tags_in<Tags::deriv, typename Ccz4::fd::System::gradients_tags,
+                       tmpl::size_t<3>, Frame::Inertial>>
+      deriv_of_Ccz4_vars{subcell_mesh.number_of_grid_points()};
+
+  ::Ccz4::fd::spacetime_derivatives(
+      make_not_null(&deriv_of_Ccz4_vars), volume_evolved_vars, all_ghost_data,
+      fd_deriv_order, subcell_mesh,
+      cell_centered_logical_to_inertial_inv_jacobian);
+
+  Variables<
+      db::wrap_tags_in<Tags::deriv, typename Ccz4::fd::System::gradients_tags,
+                       tmpl::size_t<3>, Frame::Inertial>>
+      expected_deriv_of_Ccz4_vars{subcell_mesh.number_of_grid_points()};
+
+  auto& expected_d_metric =
+      get<::Tags::deriv<::Ccz4::Tags::ConformalMetric<DataVector, 3>,
+                        tmpl::size_t<3>, Frame::Inertial>>(
+          expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        expected_d_metric.get(i, j, k) =
+            (i == j) ? static_cast<double>(10 * j + 50 * k + 1) : 0.0;
+      }
+    }
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<::Ccz4::Tags::ConformalMetric<DataVector, 3>,
+                         tmpl::size_t<3>, Frame::Inertial>>(
+          deriv_of_Ccz4_vars)),
+      expected_d_metric);
+
+  auto& expected_d_atilde =
+      get<::Tags::deriv<::Ccz4::Tags::ATilde<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        expected_d_atilde.get(i, j, k) =
+            i == j ? static_cast<double>(1000 * j + 5000 * k + 1) : 0.0;
+      }
+    }
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<::Ccz4::Tags::ATilde<DataVector, 3>, tmpl::size_t<3>,
+                         Frame::Inertial>>(deriv_of_Ccz4_vars)),
+      expected_d_atilde);
+
+  auto& expected_d_conformal_factor =
+      get<::Tags::deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(
+          expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    expected_d_conformal_factor.get(i) = 1;
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                         tmpl::size_t<3>, Frame::Inertial>>(
+          deriv_of_Ccz4_vars)),
+      expected_d_conformal_factor);
+
+  auto& expected_d_trace_extrinsic_curvature =
+      get<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                        tmpl::size_t<3>, Frame::Inertial>>(
+          expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    expected_d_trace_extrinsic_curvature.get(i) = 1;
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                         tmpl::size_t<3>, Frame::Inertial>>(
+          deriv_of_Ccz4_vars)),
+      expected_d_trace_extrinsic_curvature);
+
+  auto& expected_d_theta =
+      get<::Tags::deriv<::Ccz4::Tags::Theta<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>>(expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    expected_d_theta.get(i) = 1;
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<::Ccz4::Tags::Theta<DataVector>, tmpl::size_t<3>,
+                         Frame::Inertial>>(deriv_of_Ccz4_vars)),
+      expected_d_theta);
+
+  auto& expected_d_gamma_hat =
+      get<::Tags::deriv<::Ccz4::Tags::GammaHat<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      expected_d_gamma_hat.get(i, j) = 1;
+    }
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<::Ccz4::Tags::GammaHat<DataVector, 3>, tmpl::size_t<3>,
+                         Frame::Inertial>>(deriv_of_Ccz4_vars)),
+      expected_d_gamma_hat);
+
+  auto& expected_d_lapse =
+      get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                        Frame::Inertial>>(expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    expected_d_lapse.get(i) = 1;
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                         Frame::Inertial>>(deriv_of_Ccz4_vars)),
+      expected_d_lapse);
+
+  auto& expected_d_shift =
+      get<::Tags::deriv<gr::Tags::Shift<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      expected_d_shift.get(i, j) = 1;
+    }
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<gr::Tags::Shift<DataVector, 3>, tmpl::size_t<3>,
+                         Frame::Inertial>>(deriv_of_Ccz4_vars)),
+      expected_d_shift);
+
+  auto& expected_d_field_b =
+      get<::Tags::deriv<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>,
+        tmpl::size_t<3>, Frame::Inertial>>(expected_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      expected_d_field_b.get(i, j) = 1;
+    }
+  }
+
+  CHECK_ITERABLE_APPROX(
+      (get<::Tags::deriv<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>,
+        tmpl::size_t<3>, Frame::Inertial>>(deriv_of_Ccz4_vars)),
+          expected_d_field_b);
+
+// Test ASSERT triggers for incorrect neighbor size.
+#ifdef SPECTRE_DEBUG
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const DirectionalId<3> directional_element_id{
+        direction, *element.neighbors().at(direction).begin()};
+    DirectionalIdMap<3, evolution::dg::subcell::GhostData> bad_ghost_data =
+        all_ghost_data;
+    DataVector& neighbor_data = bad_ghost_data.at(directional_element_id)
+                                    .neighbor_ghost_data_for_reconstruction();
+    neighbor_data = DataVector{2};
+    const std::string match_string{
+        MakeString{}
+        << "Amount of reconstruction data sent (" << neighbor_data.size()
+        << ") from " << directional_element_id
+        << " is not a multiple of the number of reconstruction variables "
+        << Variables<Ccz4::fd::Tags::spacetime_reconstruction_tags>::
+               number_of_independent_components};
+    CHECK_THROWS_WITH(
+        Ccz4::fd::spacetime_derivatives(
+            make_not_null(&deriv_of_Ccz4_vars), volume_evolved_vars,
+            bad_ghost_data, fd_deriv_order, subcell_mesh,
+            cell_centered_logical_to_inertial_inv_jacobian),
+        Catch::Matchers::ContainsSubstring(match_string));
+  }
+#endif  // SPECTRE_DEBUG
+}

--- a/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_set>
+#include <utility>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Ccz4/System.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace TestHelpers::Ccz4::fd::detail {
+using GhostData = evolution::dg::subcell::GhostData;
+template <typename Fr = Frame::ElementLogical, typename F, typename... Args>
+DirectionalIdMap<3, GhostData> compute_ghost_data(
+    const Mesh<3>& subcell_mesh,
+    const tnsr::I<DataVector, 3, Fr>& volume_coords,
+    const DirectionMap<3, Neighbors<3>>& neighbors,
+    const size_t ghost_zone_size, const F& compute_variables_of_neighbor_data,
+    const std::array<double, 3>& coords_range, const Args&... args) {
+  DirectionalIdMap<3, GhostData> ghost_data{};
+  for (const auto& [direction, neighbors_in_direction] : neighbors) {
+    REQUIRE(neighbors_in_direction.size() == 1);
+    const ElementId<3>& neighbor_id = *neighbors_in_direction.begin();
+    auto neighbor_coords = volume_coords;
+    neighbor_coords.get(direction.dimension()) +=
+        direction.sign() * gsl::at(coords_range, direction.dimension());
+    const auto neighbor_vars_for_reconstruction =
+        compute_variables_of_neighbor_data(neighbor_coords, args...);
+
+    const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+        gsl::make_span(neighbor_vars_for_reconstruction.data(),
+                       neighbor_vars_for_reconstruction.size()),
+        subcell_mesh.extents(), ghost_zone_size,
+        std::unordered_set{direction.opposite()}, 0, {});
+    REQUIRE(sliced_data.size() == 1);
+    REQUIRE(sliced_data.contains(direction.opposite()));
+    ghost_data[DirectionalId<3>{direction, neighbor_id}] = GhostData{1};
+    ghost_data.at(DirectionalId<3>{direction, neighbor_id})
+        .neighbor_ghost_data_for_reconstruction() =
+        sliced_data.at(direction.opposite());
+  }
+  return ghost_data;
+}
+
+template <typename Fr = Frame::ElementLogical, typename F, typename... Args>
+DirectionalIdMap<3, GhostData> compute_ghost_data(
+    const Mesh<3>& subcell_mesh,
+    const tnsr::I<DataVector, 3, Fr>& volume_coords,
+    const DirectionMap<3, Neighbors<3>>& neighbors,
+    const size_t ghost_zone_size, const F& compute_variables_of_neighbor_data,
+    Args&&... args) {
+  const std::array<double, 3> coords_range{2., 2., 2.};
+  return compute_ghost_data(subcell_mesh, volume_coords, neighbors,
+                            ghost_zone_size, compute_variables_of_neighbor_data,
+                            coords_range, std::forward<Args>(args)...);
+}
+
+inline Variables<
+    ::Ccz4::fd::Tags::spacetime_reconstruction_tags>
+compute_prim_solution(
+    const tnsr::I<DataVector, 3, Frame::ElementLogical>& coords) {
+  using ConformalMetric = ::Ccz4::Tags::ConformalMetric<DataVector, 3>;
+  using ATilde = ::Ccz4::Tags::ATilde<DataVector, 3>;
+  using ConformalFactor = ::Ccz4::Tags::ConformalFactor<DataVector>;
+  using TraceExtrinsicCurvature = gr::Tags::TraceExtrinsicCurvature<DataVector>;
+  using Theta = ::Ccz4::Tags::Theta<DataVector>;
+  using GammaHat = ::Ccz4::Tags::GammaHat<DataVector, 3>;
+  using Lapse = gr::Tags::Lapse<DataVector>;
+  using Shift = gr::Tags::Shift<DataVector, 3>;
+  using AuxiliaryShiftB = ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>;
+
+  Variables<::Ccz4::fd::Tags::spacetime_reconstruction_tags>
+      vars{get<0>(coords).size(), 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    get(get<ConformalFactor>(vars)) += coords.get(i);
+    get(get<TraceExtrinsicCurvature>(vars)) += coords.get(i);
+    get(get<Theta>(vars)) += coords.get(i);
+    get(get<Lapse>(vars)) += coords.get(i);
+    for (size_t j = 0; j < 3; ++j) {
+      get<GammaHat>(vars).get(j) += coords.get(i);
+      get<Shift>(vars).get(j) += coords.get(i);
+      get<AuxiliaryShiftB>(vars).get(j) += coords.get(i);
+    }
+  }
+  get(get<ConformalFactor>(vars)) += 2.0;
+  get(get<TraceExtrinsicCurvature>(vars)) += 15.0;
+  get(get<Theta>(vars)) += 30.0;
+  get(get<Lapse>(vars)) += 50.0;
+  for (size_t j = 0; j < 3; ++j) {
+    get<GammaHat>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 10);
+    get<Shift>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 60);
+    get<AuxiliaryShiftB>(vars).get(j) +=
+      1.0e-2 * static_cast<double>((j + 2) + 110);
+  }
+
+  auto& conformal_metric = get<ConformalMetric>(vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      conformal_metric.get(i, j) = (10 * i + 50 * j + 1) * coords.get(i);
+    }
+  }
+  auto& atilde = get<ATilde>(vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      atilde.get(i, j) = (1000 * i + 5000 * j + 1) * coords.get(i);
+    }
+  }
+  return vars;
+}
+
+inline Element<3> set_element(const bool skip_last = false) {
+  /* I don't know what this is doing; it seems to set up */
+  /* some element adjacency relations */
+  DirectionMap<3, Neighbors<3>> neighbors{};
+  for (size_t i = 0; i < 6; ++i) {
+    if (skip_last and i == 5) {
+      break;
+    }
+    neighbors[gsl::at(Direction<3>::all_directions(), i)] = Neighbors<3>{
+        {ElementId<3>{i + 1, {}}}, OrientationMap<3>::create_aligned()};
+  }
+  return Element<3>{ElementId<3>{0, {}}, neighbors};
+}
+
+inline tnsr::I<DataVector, 3, Frame::ElementLogical> set_logical_coordinates(
+    const Mesh<3>& subcell_mesh) {
+  /* this computes the positions of the grid points in [-1,1]^3 */
+  auto logical_coords = logical_coordinates(subcell_mesh);
+  // Make the logical coordinates different in each direction
+  for (size_t i = 1; i < 3; ++i) {
+    /* this seems to shift all grid points in [-1,1]^3 by some number */
+    logical_coords.get(i) += static_cast<double>(4 * i);
+  }
+  return logical_coords;
+}
+}  // namespace TestHelpers::Ccz4::fd::detail


### PR DESCRIPTION
Add the first spatial derivatives by finite differencing for calculating the RHS of the evolution equations of the second-order Ccz4 system (see eq. 4(a)-4(i) of this [paper](https://journals.aps.org/prd/pdf/10.1103/PhysRevD.97.084053)). 

We create a new library SoCcz4 in the `Ccz4/FiniteDifference` directory to better separate the finite difference related code from the Ccz4 library which uses DG code. We use the 4th order first partial derivatives stencils implemented in `NumericalAlgorithm` in `Derivatives.cpp` to calculate the spatial derivatives of all the evolved variable defined by `variables_tag` in `FiniteDifference/System.hpp`. We use 4th order finite differencing here to keep the same order as the second partial derivatives which only have a 4th order finite difference stencil.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
