### PR TITLE
Remove pointless O(N^2) string processing

### DIFF
--- a/src/Parallel/CharmRegistration.cpp
+++ b/src/Parallel/CharmRegistration.cpp
@@ -13,28 +13,16 @@ std::string get_template_parameters_as_string_impl(
   std::string template_params =
       function_name.substr(function_name.find(std::string("Args = ")) + 8);
   template_params.erase(template_params.end() - 2, template_params.end());
-  size_t pos = 0;
-  while ((pos = template_params.find(" >")) != std::string::npos) {
-    template_params.replace(pos, 1, ">");
-    template_params.erase(pos + 1, 1);
-  }
-  pos = 0;
-  while ((pos = template_params.find(", ", pos)) != std::string::npos) {
-    template_params.erase(pos + 1, 1);
-  }
-  pos = 0;
-  while ((pos = template_params.find('>', pos + 2)) != std::string::npos) {
-    template_params.replace(pos, 1, " >");
-  }
-  std::replace(template_params.begin(), template_params.end(), '%', '>');
   // GCC's __PRETTY_FUNCTION__ adds the return type at the end, so we remove it.
-  if (template_params.find('}') != std::string::npos) {
-    template_params.erase(template_params.find('}'), template_params.size());
+  if (const auto brace = template_params.find('}');
+      brace != std::string::npos) {
+    template_params.erase(brace, template_params.size());
   }
   // Remove all spaces
   const auto new_end =
       std::remove(template_params.begin(), template_params.end(), ' ');
   template_params.erase(new_end, template_params.end());
+  std::replace(template_params.begin(), template_params.end(), '%', '>');
   return template_params;
 }
 }  // namespace Parallel::charmxx


### PR DESCRIPTION
Drop O(N^2) manipulation of spaces, since we follow up with an O(N) pass that removes all the spaces.  Also minor other reorganization including putting operations that delete text first so later operations have less to operate on.

I believe this is the reason elliptic executable startup was so slow.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
