### PR TITLE
Add combined event for AhC

### DIFF
--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -80,8 +80,8 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
       using post_interpolation_callbacks =
           tmpl::list<intrp::callbacks::FindApparentHorizon<InterpolationTarget,
                                                            ::Frame::Distorted>>;
-      using horizon_find_failure_callback =
-          intrp::callbacks::ErrorOnFailedApparentHorizon;
+      using horizon_find_failure_callbacks =
+          tmpl::list<intrp::callbacks::ErrorOnFailedApparentHorizon>;
       using post_horizon_find_callbacks =
           tmpl::list<control_system::RunCallbacks<FindHorizon, ControlSystems>,
                      ::ah::callbacks::ObserveCenters<InterpolationTarget,

--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -153,8 +153,8 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
       using post_interpolation_callbacks =
           tmpl::list<intrp::callbacks::FindApparentHorizon<InterpolationTarget,
                                                            ::Frame::Distorted>>;
-      using horizon_find_failure_callback =
-          intrp::callbacks::ErrorOnFailedApparentHorizon;
+      using horizon_find_failure_callbacks =
+          tmpl::list<intrp::callbacks::ErrorOnFailedApparentHorizon>;
       using post_horizon_find_callbacks =
           tmpl::list<control_system::RunCallbacks<Horizon, ControlSystems>>;
     };

--- a/src/ControlSystem/Measurements/SingleHorizon.hpp
+++ b/src/ControlSystem/Measurements/SingleHorizon.hpp
@@ -81,8 +81,8 @@ struct SingleHorizon : tt::ConformsTo<protocols::Measurement> {
       using post_interpolation_callbacks =
           tmpl::list<intrp::callbacks::FindApparentHorizon<InterpolationTarget,
                                                            ::Frame::Distorted>>;
-      using horizon_find_failure_callback =
-          intrp::callbacks::ErrorOnFailedApparentHorizon;
+      using horizon_find_failure_callbacks =
+          tmpl::list<intrp::callbacks::ErrorOnFailedApparentHorizon>;
       using post_horizon_find_callbacks = tmpl::list<
           control_system::RunCallbacks<Submeasurement, ControlSystems>>;
     };

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -271,8 +271,8 @@ struct EvolutionMetavars {
         intrp::TargetPoints::ApparentHorizon<Ah, Frame>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::FindApparentHorizon<Ah, Frame>>;
-    using horizon_find_failure_callback =
-        intrp::callbacks::IgnoreFailedApparentHorizon;
+    using horizon_find_failure_callbacks =
+        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, Ah,
                                              Frame>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -115,6 +115,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ObserveCenters.hpp"
@@ -462,7 +463,9 @@ struct EvolutionMetavars {
             tmpl::flatten<tmpl::list<
                 intrp::Events::Interpolate<3, AhA, interpolator_source_vars>,
                 intrp::Events::Interpolate<3, AhB, interpolator_source_vars>,
-                intrp::Events::Interpolate<3, AhC, interpolator_source_vars>,
+                ah::Events::FindCommonHorizon<
+                    volume_dim, AhC, interpolator_source_vars, observe_fields,
+                    non_tensor_compute_tags>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     3, BondiSachs, source_vars_no_deriv>,
                 intrp::Events::InterpolateWithoutInterpComponent<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -104,8 +104,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::FindApparentHorizon<ApparentHorizon,
                                                          ::Frame::Inertial>>;
-    using horizon_find_failure_callback =
-        intrp::callbacks::IgnoreFailedApparentHorizon;
+    using horizon_find_failure_callbacks =
+        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
                                                      ApparentHorizon>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -90,8 +90,8 @@ struct EvolutionMetavars
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callbacks = tmpl::list<
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>>;
-    using horizon_find_failure_callback =
-        intrp::callbacks::ErrorOnFailedApparentHorizon;
+    using horizon_find_failure_callbacks =
+        tmpl::list<intrp::callbacks::ErrorOnFailedApparentHorizon>;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>>;
   };

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -82,8 +82,8 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
         intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
     using post_interpolation_callbacks = tmpl::list<
         intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>>;
-    using horizon_find_failure_callback =
-        intrp::callbacks::IgnoreFailedApparentHorizon;
+    using horizon_find_failure_callbacks =
+        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>;
     using post_horizon_find_callbacks = tmpl::list<
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>,
         intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA,

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -259,10 +259,10 @@ struct ContributeVolumeDataToWriter {
                       << observation_id);
               }
             } else {
-              ERROR("key "
-                      << key
-                      << " not in the registered group ids. Known keys are "
-                      << keys_of(observations_registered));
+              ERROR(
+                  "key " << key
+                         << " not in the registered group ids. Known keys are "
+                         << keys_of(observations_registered));
             }
 
             all_volume_data = &*volume_data_ptr;
@@ -451,17 +451,15 @@ struct WriteVolumeData {
       db::DataBox<DbTagsList>& box,
       const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
       Parallel::GlobalCache<Metavariables>& cache,
-      const std::string& h5_file_name,
-      const std::string& subfile_path,
+      const std::string& h5_file_name, const std::string& subfile_path,
       const observers::ObservationId& observation_id,
       std::vector<ElementVolumeData>&& volume_data) {
     auto& volume_file_lock =
-        db::get_mutable_reference<Tags::H5FileLock>(
-            make_not_null(&box));
+        db::get_mutable_reference<Tags::H5FileLock>(make_not_null(&box));
     const std::lock_guard hold_lock(volume_file_lock);
     VolumeActions_detail::write_data(
-        h5_file_name, observers::input_source_from_cache(cache),
-        subfile_path, observation_id, std::move(volume_data));
+        h5_file_name, observers::input_source_from_cache(cache), subfile_path,
+        observation_id, std::move(volume_data));
   }
 };
 }  // namespace ThreadedActions

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -22,6 +22,7 @@ spectre_target_headers(
   ComputeHorizonVolumeQuantities.hpp
   ComputeHorizonVolumeQuantities.tpp
   FastFlow.hpp
+  FindCommonHorizon.hpp
   HorizonAliases.hpp
   InterpolationTarget.hpp
   ObserveCenters.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -70,11 +70,12 @@ namespace intrp::callbacks {
 ///
 /// that is called if the FastFlow iteration has converged.
 /// InterpolationTargetTag also is assumed to contain an additional
-/// struct called `horizon_find_failure_callback`, which has a function
+/// type alias called `horizon_find_failure_callbacks`, which is a list of
+/// structs, each of which has a function
 ///
 /// \snippet
 /// ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
-/// horizon_find_failure_callback_example
+/// horizon_find_failure_callbacks_example
 ///
 /// that is called if the FastFlow iteration or the interpolation has
 /// failed.
@@ -297,9 +298,14 @@ struct FindApparentHorizon
         // up the volume data, since we still need it.
         return false;
       } else {
-        InterpolationTargetTag::horizon_find_failure_callback::template apply<
-            InterpolationTargetTag>(*box, *cache, temporal_id,
-                                    FastFlow::Status::InterpolationFailure);
+        tmpl::for_each<
+            typename InterpolationTargetTag::horizon_find_failure_callbacks>(
+            [&box, &cache, &temporal_id](auto callback_v) {
+              using callback = tmpl::type_from<decltype(callback_v)>;
+              callback::template apply<InterpolationTargetTag>(
+                  *box, *cache, temporal_id,
+                  FastFlow::Status::InterpolationFailure);
+            });
         horizon_finder_failed = true;
       }
     }
@@ -375,8 +381,13 @@ struct FindApparentHorizon
         // (i.e. the simple_action that we just called).
         return false;
       } else if (not has_converged) {
-        InterpolationTargetTag::horizon_find_failure_callback::template apply<
-            InterpolationTargetTag>(*box, *cache, temporal_id, status);
+        tmpl::for_each<
+            typename InterpolationTargetTag::horizon_find_failure_callbacks>(
+            [&box, &cache, &temporal_id, &status](auto callback_v) {
+              using callback = tmpl::type_from<decltype(callback_v)>;
+              callback::template apply<InterpolationTargetTag>(
+                  *box, *cache, temporal_id, status);
+            });
         horizon_finder_failed = true;
       }
     }

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp
@@ -1,0 +1,171 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "Options/String.hpp"
+#include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
+#include "Parallel/ArrayCollection/PerformAlgorithmOnElement.hpp"
+#include "Parallel/ArrayCollection/Tags/ElementLocations.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Actions/GetItemFromDistributedObject.hpp"
+#include "ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "ParallelAlgorithms/Interpolation/Events/GetComputeItemsOnSource.hpp"
+#include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+template <size_t VolumeDim>
+class ElementId;
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace Tags {
+struct Time;
+}  // namespace Tags
+namespace Events::Tags {
+template <size_t Dim>
+struct ObserverMesh;
+}  // namespace Events::Tags
+/// \endcond
+
+namespace ah::Events {
+/*!
+ * \brief Event that combines the `intrp::Events::interpolate` event with
+ * `dg::Events::ObserveFields` specifically for common horizon finding.
+ *
+ * \details This is just a thin wrapper around each event and doesn't do
+ * anything extra.
+ */
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename InterpolatorSourceVarTags, typename Tensors,
+          typename NonTensorComputeTagsList = tmpl::list<>>
+class FindCommonHorizon;
+
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename... InterpolatorSourceVarTags, typename... Tensors,
+          typename... NonTensorComputeTags>
+class FindCommonHorizon<
+    VolumeDim, InterpolationTargetTag, tmpl::list<InterpolatorSourceVarTags...>,
+    tmpl::list<Tensors...>, tmpl::list<NonTensorComputeTags...>>
+    : public Event {
+  using ObserveFieldsEvent =
+      dg::Events::ObserveFields<VolumeDim, tmpl::list<Tensors...>,
+                                tmpl::list<NonTensorComputeTags...>>;
+  using InterpolateEvent =
+      intrp::Events::Interpolate<VolumeDim, InterpolationTargetTag,
+                                 tmpl::list<InterpolatorSourceVarTags...>>;
+
+ public:
+  /// \cond
+  explicit FindCommonHorizon(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(FindCommonHorizon);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::append<typename ObserveFieldsEvent::options,
+                               typename InterpolateEvent::options>;
+  static constexpr Options::String help =
+      "Starts a common horizon find and sends the evolved variables to be "
+      "written to disk.";
+
+  static std::string name() {
+    return pretty_type::name<InterpolationTargetTag>();
+  }
+
+  FindCommonHorizon() = default;
+
+  FindCommonHorizon(
+      const std::string& subfile_name,
+      FloatingPointType coordinates_floating_point_type,
+      const std::vector<FloatingPointType>& floating_point_types,
+      const std::vector<std::string>& variables_to_observe,
+      std::optional<std::vector<std::string>> active_block_or_block_groups = {},
+      std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
+      const Options::Context& context = {})
+      : observe_fields_event_(subfile_name, coordinates_floating_point_type,
+                              floating_point_types, variables_to_observe,
+                              active_block_or_block_groups, interpolation_mesh,
+                              context) {}
+
+  using compute_tags_for_observation_box = tmpl::remove_duplicates<tmpl::append<
+      typename ObserveFieldsEvent::compute_tags_for_observation_box,
+      typename InterpolateEvent::compute_tags_for_observation_box>>;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<::Tags::ObservationBox,
+                                   ::Events::Tags::ObserverMesh<VolumeDim>>;
+
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename Metavariables, typename ParallelComponent>
+  void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
+                  const Mesh<VolumeDim>& mesh,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<VolumeDim>& array_index,
+                  const ParallelComponent* const component,
+                  const ObservationValue& observation_value) const {
+    observe_fields_event_(box, mesh, cache, array_index, component,
+                          observation_value);
+
+    interpolate_event_(get<typename InterpolationTargetTag::temporal_id>(box),
+                       mesh, get<InterpolatorSourceVarTags>(box)..., cache,
+                       array_index, component, observation_value);
+  }
+
+  using observation_registration_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList>
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration(
+      const db::DataBox<DbTagsList>& box) const {
+    return observe_fields_event_.get_observation_type_and_key_for_registration(
+        box);
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override {
+    Event::pup(p);
+    p | observe_fields_event_;
+    p | interpolate_event_;
+  }
+
+ private:
+  ObserveFieldsEvent observe_fields_event_;
+  InterpolateEvent interpolate_event_;
+};
+
+/// \cond
+// NOLINTBEGIN
+template <size_t VolumeDim, typename InterpolationTargetTag,
+          typename... InterpolatorSourceVarTags, typename... Tensors,
+          typename... NonTensorComputeTags>
+PUP::able::PUP_ID FindCommonHorizon<
+    VolumeDim, InterpolationTargetTag, tmpl::list<InterpolatorSourceVarTags...>,
+    tmpl::list<Tensors...>, tmpl::list<NonTensorComputeTags...>>::my_PUP_ID = 0;
+// NOLINTEND
+/// \endcond
+}  // namespace ah::Events

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -397,8 +397,7 @@ EventsAndTriggersAtSlabs:
           DelayChange: 0
           StepChoosers:
             - Constant: 0.01
-      - ObservationAhC
-      - ObserveFields:
+      - ObservationAhC:
           SubfileName: ForContinuation
           VariablesToObserve:
             - SpacetimeMetric

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -239,7 +239,17 @@ EventsAndTriggersAtSlabs:
       SeparationLessThan:
         Value: 2.0
     Events:
-      - ObservationAhC
+      - ObservationAhC:
+          SubfileName: ForContinuation
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+          InterpolateToMesh: None
+          # This volume data is for ringdown, so double precision is needed.
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          BlocksToObserve: All
   - Trigger:
       TimeCompares:
         Comparison: GreaterThan

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ComputeExcisionBoundaryVolumeQuantities.cpp
   Test_ComputeHorizonVolumeQuantities.cpp
   Test_FastFlow.cpp
+  Test_FindCommonHorizon.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_ObserveCenters.cpp
   Test_Tags.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -110,16 +110,28 @@ namespace {
 // This struct is here to generate a snippet for the dox.
 // Otherwise, we would just call ErrorOnFailedApparentHorizon directly.
 struct TestHorizonFindFailureCallback {
-  // [horizon_find_failure_callback_example]
+  // [horizon_find_failure_callbacks_example]
   template <typename InterpolationTargetTag, typename DbTags,
             typename Metavariables, typename TemporalId>
   static void apply(const db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& cache,
                     const TemporalId& temporal_id,
                     const FastFlow::Status failure_reason) {
-    // [horizon_find_failure_callback_example]
+    // [horizon_find_failure_callbacks_example]
     intrp::callbacks::ErrorOnFailedApparentHorizon::template apply<
         InterpolationTargetTag>(box, cache, temporal_id, failure_reason);
+  }
+};
+
+FastFlow::Status callback_failure_status = FastFlow::Status::MaxIts;  // NOLINT
+struct ExtraHorizonFindFailureCallback {
+  template <typename InterpolationTargetTag, typename DbTags,
+            typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& /*box*/,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const TemporalId& /*temporal_id*/,
+                    const FastFlow::Status failure_reason) {
+    callback_failure_status = failure_reason;
   }
 };
 
@@ -276,7 +288,11 @@ struct MockMetavariables {
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::FindApparentHorizon<AhA, TargetFrame>>;
     using post_horizon_find_callbacks = PostHorizonFindCallbacks;
-    using horizon_find_failure_callback = TestHorizonFindFailureCallback;
+    // The order of these failure callbacks is important so that we can test the
+    // first is called and the second gives an error
+    using horizon_find_failure_callbacks =
+        tmpl::list<ExtraHorizonFindFailureCallback,
+                   TestHorizonFindFailureCallback>;
   };
   using interpolator_source_vars =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
@@ -831,27 +847,33 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
       });
 
   test_schwarzschild_horizon_called = 0;
+  callback_failure_status = FastFlow::Status::MaxIts;
   CHECK_THROWS_WITH(
       (test_apparent_horizon<
           tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
           Frame::Inertial, false, true>(&test_schwarzschild_horizon_called, 3,
                                         4, 1.0, {{0.0, 0.0, 0.0}})),
       Catch::Matchers::ContainsSubstring("Cannot interpolate onto surface"));
+  CHECK(callback_failure_status == FastFlow::Status::InterpolationFailure);
 
   test_schwarzschild_horizon_called = 0;
+  callback_failure_status = FastFlow::Status::MaxIts;
   CHECK_THROWS_WITH(
       (test_apparent_horizon<
           tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
           Frame::Inertial, false, true>(&test_schwarzschild_horizon_called, 3,
                                         4, 10.0, {{0.0, 0.0, 0.0}})),
       Catch::Matchers::ContainsSubstring("Cannot interpolate onto surface"));
+  CHECK(callback_failure_status == FastFlow::Status::InterpolationFailure);
 
   test_schwarzschild_horizon_called = 0;
+  callback_failure_status = FastFlow::Status::MaxIts;
   CHECK_THROWS_WITH(
       (test_apparent_horizon<
           tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
           Frame::Inertial, false, false>(&test_schwarzschild_horizon_called, 3,
                                          4, 1.0, {{0.0, 0.0, 0.0}}, 1)),
       Catch::Matchers::ContainsSubstring("Too many iterations"));
+  CHECK(callback_failure_status == FastFlow::Status::MaxIts);
 }
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
@@ -1,0 +1,287 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Rectilinear.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Helpers/ParallelAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolator.hpp"
+#include "ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp"
+#include "ParallelAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp"
+#include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+// Mock actions only exist so we don't need all other action down the line. In
+// this test we'll only check that actions are queued since each individual
+// event is tested elsewhere
+struct MockContributeVolumeData {
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const observers::ObservationId& /*observation_id*/,
+                    const std::string& /*subfile_name*/,
+                    const Parallel::ArrayComponentId& /*array_component_id*/,
+                    ElementVolumeData&& /*received_volume_data*/) {}
+};
+
+struct MockInterpolatorReceiveVolumeData {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex, size_t VolumeDim>
+  static void apply(
+      db::DataBox<DbTags>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const LinkedMessageId<double>& /*temporal_id*/,
+      const ElementId<VolumeDim>& /*element_id*/,
+      const ::Mesh<VolumeDim>& /*mesh*/,
+      Variables<typename Metavariables::interpolator_source_vars>&& /*vars*/) {}
+};
+
+template <typename InterpolationTargetTag>
+struct MockAddTemporalIdsToInterpolationTarget {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const LinkedMessageId<double>&
+                    /*temporal_id*/) {}
+};
+
+template <typename Metavariables>
+struct MockObserver {
+  using component_being_mocked = observers::Observer<Metavariables>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeVolumeData>;
+  using with_these_simple_actions = tmpl::list<MockContributeVolumeData>;
+};
+
+template <typename Metavariables>
+struct MockInterpolator {
+  using component_being_mocked = intrp::Interpolator<Metavariables>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<::intrp::Actions::InitializeInterpolator<
+          metavariables::volume_dim,
+          intrp::Tags::VolumeVarsInfo<Metavariables,
+                                      ::Tags::TimeAndPrevious<0>>,
+          intrp::Tags::InterpolatedVarsHolders<Metavariables>>>>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<intrp::Actions::InterpolatorReceiveVolumeData<
+          ::Tags::TimeAndPrevious<0>>>;
+  using with_these_simple_actions =
+      tmpl::list<MockInterpolatorReceiveVolumeData>;
+};
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct MockInterpolationTarget {
+  static_assert(
+      tt::assert_conforms_to_v<InterpolationTargetTag,
+                               intrp::protocols::InterpolationTargetTag>);
+  using component_being_mocked =
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<intrp::Actions::AddTemporalIdsToInterpolationTarget<
+          typename Metavariables::InterpolationTargetA>>;
+  using with_these_simple_actions =
+      tmpl::list<MockAddTemporalIdsToInterpolationTarget<
+          typename Metavariables::InterpolationTargetA>>;
+};
+
+template <typename Metavariables>
+struct MockElement {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Metavariables::volume_dim>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using initial_databox = db::compute_databox_type<
+      db::AddSimpleTags<::ah::source_vars<Metavariables::volume_dim>>>;
+  using const_global_cache_tags =
+      tmpl::list<::domain::Tags::Domain<metavariables::volume_dim>,
+                 InterpTargetTestHelpers::Tags::BlocksForInterpolation>;
+};
+
+struct MockMetavariables {
+  static constexpr size_t volume_dim = 3;
+  struct InterpolationTargetA
+      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+    using temporal_id = ::Tags::TimeAndPrevious<0>;
+    // Not the normal vars we'd interpolate but this is just a test
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,
+                   gh::Tags::Pi<DataVector, volume_dim>,
+                   gh::Tags::Phi<DataVector, volume_dim>>;
+    using compute_items_on_target = tmpl::list<>;
+    using compute_target_points =
+        ::intrp::TargetPoints::ApparentHorizon<InterpolationTargetA,
+                                               ::Frame::Inertial>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::ObserveTimeSeriesOnSurface<
+            tmpl::list<>, InterpolationTargetA>>;
+  };
+  using interpolator_source_vars = ::ah::source_vars<volume_dim>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list = tmpl::list<
+      MockObserver<MockMetavariables>, MockInterpolator<MockMetavariables>,
+      MockInterpolationTarget<MockMetavariables, InterpolationTargetA>,
+      MockElement<MockMetavariables>>;
+};
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindCommonHorizon",
+                  "[ApparentHorizonFinder][Unit]") {
+  ::domain::creators::register_derived_with_charm();
+  using metavars = MockMetavariables;
+  const ElementId<metavars::volume_dim> element_id(0);
+  const ElementId<metavars::volume_dim> array_index(element_id);
+
+  using obs_component = MockObserver<metavars>;
+  using interp_component = MockInterpolator<metavars>;
+  using interp_target_component =
+      MockInterpolationTarget<metavars, metavars::InterpolationTargetA>;
+  using elem_component = MockElement<metavars>;
+
+  const ::domain::creators::Brick brick{
+      {0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}, {0, 0, 0}, {5, 5, 5}};
+  const auto block_names = brick.block_names();
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {brick.create_domain(),
+       std::unordered_map<std::string, std::unordered_set<std::string>>{
+           {"InterpolationTargetA", {block_names.begin(), block_names.end()}}},
+       ::Verbosity::Silent}};
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+  ActionTesting::emplace_group_component<obs_component>(make_not_null(&runner));
+  ActionTesting::emplace_group_component<interp_component>(
+      make_not_null(&runner));
+  ActionTesting::next_action<interp_component>(make_not_null(&runner), 0);
+  ActionTesting::emplace_component<interp_target_component>(
+      make_not_null(&runner), 0);
+  ActionTesting::emplace_component<elem_component>(make_not_null(&runner),
+                                                   array_index);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  const auto check_results = [&runner,
+                              &element_id](const size_t num_queued_actions) {
+    CHECK(ActionTesting::is_simple_action_queue_empty<elem_component>(
+        runner, element_id));
+    CHECK(ActionTesting::number_of_queued_simple_actions<obs_component>(
+              runner, 0) == num_queued_actions);
+    CHECK(ActionTesting::number_of_queued_simple_actions<interp_component>(
+              runner, 0) == num_queued_actions);
+    CHECK(
+        ActionTesting::number_of_queued_simple_actions<interp_target_component>(
+            runner, 0) == num_queued_actions);
+  };
+
+  // No events queued yet
+  check_results(0);
+
+  const Mesh<metavars::volume_dim> mesh(5, Spectral::Basis::Legendre,
+                                        Spectral::Quadrature::GaussLobatto);
+  const double observation_time = 2.0;
+  const Variables<metavars::interpolator_source_vars> vars(
+      mesh.number_of_grid_points(), 1.0);
+  auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
+
+  const LinkedMessageId<double> temporal_id{observation_time, std::nullopt};
+  const ::Event::ObservationValue observation_value{"FindCommonHorizon",
+                                                    observation_time};
+
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<metavars>,
+      Parallel::Tags::GlobalCacheImpl<metavars>,
+      metavars::InterpolationTargetA::temporal_id, ::Tags::Time,
+      ::Events::Tags::ObserverMesh<metavars::volume_dim>,
+      ::Tags::Variables<typename decltype(vars)::tags_list>>>(
+      metavars{}, &cache, temporal_id, observation_time, mesh, vars);
+
+  using FindCommonHorizon = ah::Events::FindCommonHorizon<
+      metavars::volume_dim, typename metavars::InterpolationTargetA,
+      typename metavars::interpolator_source_vars,
+      typename metavars::interpolator_source_vars>;
+
+  const FindCommonHorizon find_common_horizon{};
+
+  CHECK(find_common_horizon.needs_evolved_variables());
+  CHECK(find_common_horizon.is_ready(cache, 0,
+                                     std::add_pointer_t<elem_component>{}));
+
+  // Only compute tags for cache items necessary for observation box since this
+  // test just puts the tags in the regular box
+  auto obs_box =
+      make_observation_box<tmpl::list<Parallel::Tags::FromGlobalCache<
+          ::domain::Tags::Domain<metavars::volume_dim>>>>(make_not_null(&box));
+  find_common_horizon(obs_box, mesh, cache, array_index,
+                      std::add_pointer_t<elem_component>{}, observation_value);
+
+  // Since this event is a combination of two events, and those two events are
+  // individually tested, here we only check we have the correct number of
+  // queued actions on each component.
+  check_results(1);
+}
+}  // namespace

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -241,31 +241,31 @@ void test_observe(
   // gcc 6.4.0 gets confused if we try to capture tensor_data by
   // reference and fails to compile because it wants it to be
   // non-const, so we capture a pointer instead.
-  const auto check_component_impl = [&num_components_observed,
-                                     tensor_data = &results.received_volume_data
-                                                        .tensor_components,
-                                     &interpolant](const std::string& component,
-                                                   const DataVector& expected) {
-    CAPTURE(*tensor_data);
-    CAPTURE(component);
-    const DataVector interpolated_expected = interpolant.interpolate(expected);
-    const auto it =
-        alg::find_if(*tensor_data, [&component](const TensorComponent& tc) {
-          return tc.name == component;
-        });
-    REQUIRE(it != tensor_data->end());
-    CAPTURE(component);
-    if (component.substr(0, 6) == "Tensor" or
-        component.substr(0, 7) == "Tensor2" or
-        component.substr(0, 14) == "Error(Tensor2)") {
-      CHECK(std::get<std::vector<float>>(it->data) ==
-            std::vector<float>{interpolated_expected.begin(),
-                               interpolated_expected.end()});
-    } else {
-      CHECK(std::get<DataVector>(it->data) == interpolated_expected);
-    }
-    ++num_components_observed;
-  };
+  const auto check_component_impl =
+      [&num_components_observed,
+       tensor_data = &results.received_volume_data.tensor_components,
+       &interpolant](const std::string& component, const DataVector& expected) {
+        CAPTURE(*tensor_data);
+        CAPTURE(component);
+        const DataVector interpolated_expected =
+            interpolant.interpolate(expected);
+        const auto it =
+            alg::find_if(*tensor_data, [&component](const TensorComponent& tc) {
+              return tc.name == component;
+            });
+        REQUIRE(it != tensor_data->end());
+        CAPTURE(component);
+        if (component.substr(0, 6) == "Tensor" or
+            component.substr(0, 7) == "Tensor2" or
+            component.substr(0, 14) == "Error(Tensor2)") {
+          CHECK(std::get<std::vector<float>>(it->data) ==
+                std::vector<float>{interpolated_expected.begin(),
+                                   interpolated_expected.end()});
+        } else {
+          CHECK(std::get<DataVector>(it->data) == interpolated_expected);
+        }
+        ++num_components_observed;
+      };
   const auto check_component = [&check_component_impl](
                                    const std::string& component,
                                    const auto& expected) {


### PR DESCRIPTION
## Proposed changes

Adds a new event `FindCommonHorizon` that is a wrapper around the Interpolate event which starts a horizon find, and the ObserveFields event which writes volume data to disk for the ringdown restart.

This is the first of 3 PRs that avoid writing volume data for a common horizon find that fails.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In BBH input files, the part of the events and triggers at slabs block which had the ringdown events goes from this
```yaml
      - ObservationAhC
      - ObserveFields:
          SubfileName: ForContinuation
          VariablesToObserve:
            - SpacetimeMetric
            - Pi
            - Phi
          InterpolateToMesh: None
          # This volume data is for ringdown, so double precision is needed.
          CoordinatesFloatingPointType: Double
          FloatingPointTypes: [Double]
          BlocksToObserve: All
```
to this
```yaml
      - ObservationAhC:
          SubfileName: ForContinuation
          VariablesToObserve:
            - SpacetimeMetric
            - Pi
            - Phi
          InterpolateToMesh: None
          # This volume data is for ringdown, so double precision is needed.
          CoordinatesFloatingPointType: Double
          FloatingPointTypes: [Double]
          BlocksToObserve: All
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
