### PR TITLE
Simplify volume actions, add dependency to interp framework

### DIFF
--- a/docs/DevGuide/Observers.md
+++ b/docs/DevGuide/Observers.md
@@ -118,9 +118,7 @@ parallel performance and threading, the amount of work done while the entire
 node is locked should be minimized. To this end, we have additional locks. One
 for the HDF5 files because we do not require a threadsafe HDF5
 (`observers::Tags::H5FileLock`). We also have locks for the objects mutated when
-contributing reduction data (`observers::Tags::ReductionDataLock`) and the
-objects mutated when contributing volume data
-(`observers::Tags::VolumeDataLock`).
+contributing reduction data (`observers::Tags::ReductionDataLock`).
 
 ### Future changes
 - It would be preferable to make the `Observer` and `ObserverWriter` parallel

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -68,8 +68,8 @@ struct InitializeWriter {
   using simple_tags = tmpl::append<
       tmpl::list<Tags::ExpectedContributorsForObservations,
                  Tags::ContributorsOfReductionData, Tags::ReductionDataLock,
-                 Tags::ContributorsOfTensorData, Tags::VolumeDataLock,
-                 Tags::TensorData, Tags::InterpolatorTensorData,
+                 Tags::ContributorsOfTensorData, Tags::TensorData,
+                 Tags::InterpolatorTensorData,
                  Tags::NodesExpectedToContributeReductions,
                  Tags::NodesThatContributedReductions, Tags::H5FileLock>,
       typename Metavariables::observed_reduction_data_tags,

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -93,14 +93,6 @@ struct ContributorsOfTensorData : db::SimpleTag {
                          std::unordered_set<Parallel::ArrayComponentId>>;
 };
 
-/// \brief Lock used when contributing volume data.
-///
-/// A separate lock from the node lock of the nodegroup is used in order to
-/// allow other cores to contribute reduction data, write to disk, etc.
-struct VolumeDataLock : db::SimpleTag {
-  using type = Parallel::NodeLock;
-};
-
 /// Volume tensor data to be written to disk.
 struct TensorData : db::SimpleTag {
   using type = std::unordered_map<

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -157,6 +157,86 @@ void write_data(const std::string& h5_file_name,
                 const std::string& subfile_path,
                 const observers::ObservationId& observation_id,
                 std::vector<ElementVolumeData>&& volume_data);
+
+template <typename ParallelComponent, typename Metavariables,
+          typename VolumeDataAtObsId>
+void write_combined_volume_data(
+    Parallel::GlobalCache<Metavariables>& cache,
+    const observers::ObservationId& observation_id,
+    const VolumeDataAtObsId& volume_data,
+    const gsl::not_null<Parallel::NodeLock*> volume_file_lock,
+    const std::string& subfile_name) {
+  ASSERT(not volume_data.empty(),
+         "Failed to populate volume_data before trying to write it.");
+
+  std::vector<ElementVolumeData> volume_data_to_write;
+
+  if constexpr (std::is_same_v<tmpl::at_c<VolumeDataAtObsId, 1>,
+                               ElementVolumeData>) {
+    volume_data_to_write.reserve(volume_data.size());
+    for (const auto& [id, element] : volume_data) {
+      (void)id;  // avoid compiler warnings
+      volume_data_to_write.push_back(element);
+    }
+  } else {
+    size_t total_size = 0;
+    for (const auto& [id, vec_elements] : volume_data) {
+      (void)id;  // avoid compiler warnings
+      total_size += vec_elements.size();
+    }
+    volume_data_to_write.reserve(total_size);
+
+    for (const auto& [id, vec_elements] : volume_data) {
+      (void)id;  // avoid compiler warnings
+      volume_data_to_write.insert(volume_data_to_write.end(),
+                                  vec_elements.begin(), vec_elements.end());
+    }
+  }
+
+  // Write to file. We use a separate node lock because writing can be
+  // very time consuming (it's network dependent, depends on how full the
+  // disks are, what other users are doing, etc.) and we want to be able
+  // to continue to work on the nodegroup while we are writing data to
+  // disk.
+  const std::lock_guard hold_lock(*volume_file_lock);
+  {
+    // Scoping is for closing HDF5 file before we release the lock.
+    const auto& file_prefix = Parallel::get<Tags::VolumeFileName>(cache);
+    auto& my_proxy = Parallel::get_parallel_component<ParallelComponent>(cache);
+    h5::H5File<h5::AccessType::ReadWrite> h5file(
+        file_prefix +
+            std::to_string(
+                Parallel::my_node<int>(*Parallel::local_branch(my_proxy))) +
+            ".h5",
+        true, observers::input_source_from_cache(cache));
+    constexpr size_t version_number = 0;
+    auto& volume_file =
+        h5file.try_insert<h5::VolumeData>(subfile_name, version_number);
+
+    // Serialize domain. See `Domain` docs for details on the serialization.
+    // The domain is retrieved from the global cache using the standard
+    // domain tag. If more flexibility is required here later, then the
+    // domain can be passed along with the `ContributeVolumeData` action.
+    const auto serialized_domain = serialize(
+        Parallel::get<domain::Tags::Domain<Metavariables::volume_dim>>(cache));
+    const auto serialized_functions_of_time =
+        [&cache]() -> std::optional<std::vector<char>> {
+      // Functions-of-time are in the _mutable_ global cache, so they aren't
+      // accessible through the DataBox by default
+      if constexpr (Parallel::is_in_global_cache<
+                        Metavariables, domain::Tags::FunctionsOfTime>) {
+        return serialize(get<domain::Tags::FunctionsOfTime>(cache));
+      } else {
+        (void)cache;
+        return std::nullopt;
+      }
+    }();
+    // Write the data to the file
+    volume_file.write_volume_data(observation_id.hash(), observation_id.value(),
+                                  volume_data_to_write, serialized_domain,
+                                  serialized_functions_of_time);
+  }
+}
 }  // namespace VolumeActions_detail
 /*!
  * \ingroup ObserversGroup
@@ -325,78 +405,9 @@ struct ContributeVolumeDataToWriter {
     }
 
     if (perform_write) {
-      ASSERT(not volume_data.empty(),
-             "Failed to populate volume_data before trying to write it.");
-
-      std::vector<ElementVolumeData> volume_data_to_write;
-
-      if constexpr (std::is_same_v<tmpl::at_c<VolumeDataAtObsId, 1>,
-                                   ElementVolumeData>) {
-        volume_data_to_write.reserve(volume_data.size());
-        for (const auto& [id, element] : volume_data) {
-          (void)id;  // avoid compiler warnings
-          volume_data_to_write.push_back(element);
-        }
-      } else {
-        size_t total_size = 0;
-        for (const auto& [id, vec_elements] : volume_data) {
-          (void)id;  // avoid compiler warnings
-          total_size += vec_elements.size();
-        }
-        volume_data_to_write.reserve(total_size);
-
-        for (const auto& [id, vec_elements] : volume_data) {
-          (void)id;  // avoid compiler warnings
-          volume_data_to_write.insert(volume_data_to_write.end(),
-                                      vec_elements.begin(), vec_elements.end());
-        }
-      }
-
-      // Write to file. We use a separate node lock because writing can be
-      // very time consuming (it's network dependent, depends on how full the
-      // disks are, what other users are doing, etc.) and we want to be able
-      // to continue to work on the nodegroup while we are writing data to
-      // disk.
-      const std::lock_guard hold_lock(*volume_file_lock);
-      {
-        // Scoping is for closing HDF5 file before we release the lock.
-        const auto& file_prefix = Parallel::get<Tags::VolumeFileName>(cache);
-        auto& my_proxy =
-            Parallel::get_parallel_component<ParallelComponent>(cache);
-        h5::H5File<h5::AccessType::ReadWrite> h5file(
-            file_prefix +
-                std::to_string(
-                    Parallel::my_node<int>(*Parallel::local_branch(my_proxy))) +
-                ".h5",
-            true, observers::input_source_from_cache(cache));
-        constexpr size_t version_number = 0;
-        auto& volume_file =
-            h5file.try_insert<h5::VolumeData>(subfile_name, version_number);
-
-        // Serialize domain. See `Domain` docs for details on the serialization.
-        // The domain is retrieved from the global cache using the standard
-        // domain tag. If more flexibility is required here later, then the
-        // domain can be passed along with the `ContributeVolumeData` action.
-        const auto serialized_domain = serialize(
-            Parallel::get<domain::Tags::Domain<Metavariables::volume_dim>>(
-                cache));
-        const auto serialized_functions_of_time =
-            [&cache]() -> std::optional<std::vector<char>> {
-          // Functions-of-time are in the _mutable_ global cache, so they aren't
-          // accessible through the DataBox by default
-          if constexpr (Parallel::is_in_global_cache<
-                            Metavariables, domain::Tags::FunctionsOfTime>) {
-            return serialize(get<domain::Tags::FunctionsOfTime>(cache));
-          } else {
-            (void)cache;
-            return std::nullopt;
-          }
-        }();
-        // Write the data to the file
-        volume_file.write_volume_data(
-            observation_id.hash(), observation_id.value(), volume_data_to_write,
-            serialized_domain, serialized_functions_of_time);
-      }
+      VolumeActions_detail::write_combined_volume_data<ParallelComponent>(
+          cache, observation_id, volume_data, make_not_null(volume_file_lock),
+          subfile_name);
     }
   }
 };

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -291,116 +291,85 @@ struct ContributeVolumeDataToWriter {
                          VolumeDataAtObsId received_volume_data) {
     // The below gymnastics with pointers is done in order to minimize the
     // time spent locking the entire node, which is necessary because the
-    // DataBox does not allow any functions calls, both get and mutate, during
-    // a mutate. This design choice in DataBox is necessary to guarantee a
-    // consistent state throughout mutation. Here, however, we need to be
-    // reasonable efficient in parallel and so we manually guarantee that
-    // consistent state. To this end, we create pointers and assign to them
-    // the data in the DataBox which is guaranteed to be pointer stable. The
-    // data itself is guaranteed to be stable inside the VolumeDataLock.
-    typename TensorDataTag::type* all_volume_data = nullptr;
-    VolumeDataAtObsId volume_data;
+    // DataBox does not allow any function calls, either get and mutate, during
+    // a mutate. We separate out writing from the operations that edit the
+    // DataBox since writing to disk can be very slow, but moving data around is
+    // comparatively quick.
     Parallel::NodeLock* volume_file_lock = nullptr;
-    std::unordered_map<ObservationId,
-                       std::unordered_set<Parallel::ArrayComponentId>>*
-        volume_observers_contributed = nullptr;
-    Parallel::NodeLock* volume_data_lock = nullptr;
-    size_t observations_registered_with_id = std::numeric_limits<size_t>::max();
+    bool perform_write = false;
+    VolumeDataAtObsId volume_data{};
 
     {
       const std::lock_guard hold_lock(*node_lock);
-      db::mutate<TensorDataTag, Tags::ContributorsOfTensorData,
-                 Tags::VolumeDataLock, Tags::H5FileLock>(
-          [&observation_id, &observations_registered_with_id,
-           &observer_group_id, &all_volume_data, &volume_observers_contributed,
-           &volume_data_lock, &volume_file_lock](
-              const gsl::not_null<typename TensorDataTag::type*>
-                  volume_data_ptr,
-              const gsl::not_null<std::unordered_map<
-                  ObservationId,
-                  std::unordered_set<Parallel::ArrayComponentId>>*>
-                  volume_observers_contributed_ptr,
-              const gsl::not_null<Parallel::NodeLock*> volume_data_lock_ptr,
-              const gsl::not_null<Parallel::NodeLock*> volume_file_lock_ptr,
-              const std::unordered_map<
-                  ObservationKey,
-                  std::unordered_set<Parallel::ArrayComponentId>>&
-                  observations_registered) {
-            const ObservationKey& key{observation_id.observation_key()};
-            if (const auto& registered_group_ids =
-                    observations_registered.find(key);
-                LIKELY(registered_group_ids != observations_registered.end())) {
-              if (UNLIKELY(
-                      registered_group_ids->second.find(observer_group_id) ==
-                      registered_group_ids->second.end())) {
-                ERROR("The observer group id "
-                      << observer_group_id
-                      << " was not registered for the observation id "
-                      << observation_id);
-              }
-            } else {
-              ERROR(
-                  "key " << key
-                         << " not in the registered group ids. Known keys are "
-                         << keys_of(observations_registered));
-            }
 
-            all_volume_data = &*volume_data_ptr;
-            volume_observers_contributed = &*volume_observers_contributed_ptr;
-            volume_data_lock = &*volume_data_lock_ptr;
-            observations_registered_with_id =
-                observations_registered.at(key).size();
+      // Set file lock for later
+      db::mutate<Tags::H5FileLock>(
+          [&volume_file_lock](
+              const gsl::not_null<Parallel::NodeLock*> volume_file_lock_ptr) {
             volume_file_lock = &*volume_file_lock_ptr;
           },
-          make_not_null(&box),
-          db::get<Tags::ExpectedContributorsForObservations>(box));
-    }
+          make_not_null(&box));
 
-    ASSERT(all_volume_data != nullptr,
-           "Failed to set all_volume_data in the mutate");
-    ASSERT(volume_file_lock != nullptr,
-           "Failed to set volume_file_lock in the mutate");
-    ASSERT(volume_observers_contributed != nullptr,
-           "Failed to set volume_observers_contributed in the mutate");
-    ASSERT(volume_data_lock != nullptr,
-           "Failed to set volume_data_lock in the mutate");
-    ASSERT(
-        observations_registered_with_id != std::numeric_limits<size_t>::max(),
-        "Failed to set observations_registered_with_id when mutating the "
-        "DataBox. This is a bug in the code.");
+      ASSERT(volume_file_lock != nullptr,
+             "Failed to set volume_file_lock in the mutate");
 
-    bool perform_write = false;
-    {
-      const std::lock_guard hold_lock(*volume_data_lock);
+      const auto& observations_registered =
+          db::get<Tags::ExpectedContributorsForObservations>(box);
+
+      const ObservationKey& key = observation_id.observation_key();
+      if (LIKELY(observations_registered.contains(key))) {
+        if (UNLIKELY(not observations_registered.at(key).contains(
+                observer_group_id))) {
+          ERROR("The observer group id "
+                << observer_group_id
+                << " was not registered for the observation id "
+                << observation_id);
+        }
+      } else {
+        ERROR("key " << key
+                     << " not in the registered group ids. Known keys are "
+                     << keys_of(observations_registered));
+      }
+
+      const size_t observations_registered_with_id =
+          observations_registered.at(key).size();
+
+      // Ok because we have the node lock
+      auto& volume_observers_contributed =
+          db::get_mutable_reference<Tags::ContributorsOfTensorData>(
+              make_not_null(&box));
+      auto& all_volume_data =
+          db::get_mutable_reference<TensorDataTag>(make_not_null(&box));
+
       auto& contributed_group_ids =
-          (*volume_observers_contributed)[observation_id];
+          volume_observers_contributed[observation_id];
 
-      if (UNLIKELY(contributed_group_ids.find(observer_group_id) !=
-                   contributed_group_ids.end())) {
+      if (UNLIKELY(contributed_group_ids.contains(observer_group_id))) {
         ERROR("Already received reduction data to observation id "
               << observation_id << " from array component id "
               << observer_group_id);
       }
       contributed_group_ids.insert(observer_group_id);
 
-      if (all_volume_data->find(observation_id) == all_volume_data->end()) {
-        // We haven't been called before on this processing element.
-        all_volume_data->operator[](observation_id) =
-            std::move(received_volume_data);
-      } else {
-        auto& current_data = all_volume_data->at(observation_id);
+      // Add received volume data to the box
+      if (all_volume_data.contains(observation_id)) {
+        auto& current_data = all_volume_data.at(observation_id);
         current_data.insert(
             std::make_move_iterator(received_volume_data.begin()),
             std::make_move_iterator(received_volume_data.end()));
+      } else {
+        // We haven't been called before on this processing element.
+        all_volume_data[observation_id] = std::move(received_volume_data);
       }
+
       // Check if we have received all "volume" data from the Observer
       // group. If so we write to disk.
-      if (volume_observers_contributed->at(observation_id).size() ==
+      if (volume_observers_contributed.at(observation_id).size() ==
           observations_registered_with_id) {
         perform_write = true;
-        volume_data = std::move(all_volume_data->operator[](observation_id));
-        all_volume_data->erase(observation_id);
-        volume_observers_contributed->erase(observation_id);
+        volume_data = std::move(all_volume_data[observation_id]);
+        all_volume_data.erase(observation_id);
+        volume_observers_contributed.erase(observation_id);
       }
     }
 

--- a/src/ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/AddTemporalIdsToInterpolationTarget.hpp
@@ -57,7 +57,8 @@ struct AddTemporalIdsToInterpolationTarget {
   static void apply(db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index,
-                    const TemporalId& temporal_id) {
+                    const TemporalId& temporal_id,
+                    std::optional<std::string> dependency) {
     static_assert(
         InterpolationTargetTag::compute_target_points::is_sequential::value,
         "Actions::AddTemporalIdsToInterpolationTarget can be used only with "
@@ -66,7 +67,8 @@ struct AddTemporalIdsToInterpolationTarget {
     const bool pending_temporal_ids_was_empty_on_entry =
         db::get<Tags::PendingTemporalIds<TemporalId>>(box).empty();
     InterpolationTarget_detail::flag_temporal_id_as_pending<
-        InterpolationTargetTag>(make_not_null(&box), temporal_id);
+        InterpolationTargetTag>(make_not_null(&box), temporal_id,
+                                std::move(dependency));
 
     // - If Tags::CurrentTemporalIds has a value, then there is an
     //   interpolation in progress, so do nothing here.  (If there's

--- a/src/ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp
@@ -71,7 +71,7 @@ struct InitializeInterpolationTarget {
   using return_tag_list_initial = tmpl::list<
       Tags::IndicesOfFilledInterpPoints<TemporalId>,
       Tags::IndicesOfInvalidInterpPoints<TemporalId>,
-      Tags::PendingTemporalIds<TemporalId>,
+      Tags::PendingTemporalIds<TemporalId>, Tags::Dependencies<TemporalId>,
       tmpl::conditional_t<is_sequential::value,
                           Tags::CurrentTemporalId<TemporalId>,
                           Tags::TemporalIds<TemporalId>>,

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -69,6 +69,10 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
 
   Interpolate() = default;
 
+  /// This constructor is not available through options
+  explicit Interpolate(std::optional<std::string> dependency)
+      : dependency_(std::move(dependency)) {}
+
   using compute_tags_for_observation_box =
       detail::get_compute_items_on_source_or_default_t<InterpolationTargetTag,
                                                        tmpl::list<>>;
@@ -116,10 +120,11 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
               ->at(array_index)
               .get_core());
       interpolate<InterpolationTargetTag>(temporal_id, mesh, cache, array_index,
-                                          core_id, interpolator_source_vars...);
+                                          core_id, dependency_,
+                                          interpolator_source_vars...);
     } else {
       interpolate<InterpolationTargetTag>(temporal_id, mesh, cache, array_index,
-                                          std::nullopt,
+                                          std::nullopt, dependency_,
                                           interpolator_source_vars...);
     }
   }
@@ -134,6 +139,14 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
   }
 
   bool needs_evolved_variables() const override { return true; }
+
+  void pup(PUP::er& p) override {
+    Event::pup(p);
+    p | dependency_;
+  }
+
+ private:
+  std::optional<std::string> dependency_;
 };
 
 /// \cond

--- a/src/ParallelAlgorithms/Interpolation/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolate.hpp
@@ -42,6 +42,7 @@ void interpolate(
     const Mesh<VolumeDim>& mesh, Parallel::GlobalCache<Metavariables>& cache,
     const ElementId<VolumeDim>& array_index,
     const std::optional<int> interpolator_id,
+    const std::optional<std::string>& dependency,
     const InterpolatorSourceVars&... interpolator_source_vars_input) {
   Variables<typename Metavariables::interpolator_source_vars>
       interpolator_source_vars(mesh.number_of_grid_points());
@@ -78,6 +79,6 @@ void interpolate(
       InterpolationTarget<Metavariables, InterpolationTargetTag>>(cache);
   Parallel::simple_action<
       Actions::AddTemporalIdsToInterpolationTarget<InterpolationTargetTag>>(
-      target, temporal_id);
+      target, temporal_id, dependency);
 }
 }  // namespace intrp

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <sstream>
 #include <type_traits>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -31,8 +32,10 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/TagsMetafunctions.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/PrettyType.hpp"
@@ -368,11 +371,15 @@ void clean_up_interpolation_target(
         box);
   }
   db::mutate<Tags::CompletedTemporalIds<TemporalId>,
+             Tags::Dependencies<TemporalId>,
              Tags::IndicesOfFilledInterpPoints<TemporalId>,
              Tags::IndicesOfInvalidInterpPoints<TemporalId>,
              Tags::InterpolatedVars<InterpolationTargetTag, TemporalId>>(
       [&temporal_id](
           const gsl::not_null<std::deque<TemporalId>*> completed_ids,
+          const gsl::not_null<
+              std::unordered_map<TemporalId, std::optional<std::string>>*>
+              dependencies,
           const gsl::not_null<
               std::unordered_map<TemporalId, std::unordered_set<size_t>>*>
               indices_of_filled,
@@ -394,6 +401,7 @@ void clean_up_interpolation_target(
         if (completed_ids->size() > 1000) {
           completed_ids->pop_front();
         }
+        dependencies->erase(temporal_id);
         indices_of_filled->erase(temporal_id);
         indices_of_invalid->erase(temporal_id);
         interpolated_vars->erase(temporal_id);
@@ -494,7 +502,8 @@ bool flag_temporal_id_for_interpolation(
 
 /// Tells an InterpolationTarget that it should interpolate at
 /// the supplied temporal_ids.  Changes the InterpolationTarget's DataBox
-/// accordingly.
+/// accordingly. Also adds a dependency to the box at this time if there isn't
+/// one already. If there's already one, ASSERTs that they are the same.
 ///
 /// flag_temporal_ids_as_pending is called by an Action
 /// of InterpolationTarget
@@ -503,7 +512,8 @@ bool flag_temporal_id_for_interpolation(
 /// - AddTemporalIdsToInterpolationTarget (called by Events::Interpolate)
 template <typename InterpolationTargetTag, typename DbTags, typename TemporalId>
 void flag_temporal_id_as_pending(const gsl::not_null<db::DataBox<DbTags>*> box,
-                                 const TemporalId& temporal_id) {
+                                 const TemporalId& temporal_id,
+                                 std::optional<std::string> dependency) {
   // We allow this function to be called multiple times with the same
   // temporal_ids (e.g. from each element, or from each node of a
   // NodeGroup ParallelComponent such as Interpolator). If multiple
@@ -517,12 +527,17 @@ void flag_temporal_id_as_pending(const gsl::not_null<db::DataBox<DbTags>*> box,
   // temporal_ids that we have already completed interpolation on.  So
   // here we do not add any temporal_ids that are already present in
   // `id` or `completed_ids`.
-  db::mutate_apply<tmpl::list<Tags::PendingTemporalIds<TemporalId>>,
+  db::mutate_apply<tmpl::list<Tags::PendingTemporalIds<TemporalId>,
+                              Tags::Dependencies<TemporalId>>,
                    tmpl::list<Tags::CurrentTemporalId<TemporalId>,
                               Tags::CompletedTemporalIds<TemporalId>>>(
-      [&temporal_id](const gsl::not_null<std::deque<TemporalId>*> pending_ids,
-                     const std::optional<TemporalId>& current_id,
-                     const std::deque<TemporalId>& completed_ids) {
+      [&temporal_id, &dependency](
+          const gsl::not_null<std::deque<TemporalId>*> pending_ids,
+          const gsl::not_null<
+              std::unordered_map<TemporalId, std::optional<std::string>>*>
+              dependencies,
+          const std::optional<TemporalId>& current_id,
+          const std::deque<TemporalId>& completed_ids) {
         if (not(alg::found(completed_ids, temporal_id) or
                 (current_id.has_value() and
                  current_id.value() == temporal_id) or
@@ -530,6 +545,17 @@ void flag_temporal_id_as_pending(const gsl::not_null<db::DataBox<DbTags>*> box,
           pending_ids->push_back(temporal_id);
 
           alg::sort(*pending_ids);
+        }
+
+        if (dependencies->contains(temporal_id)) {
+          ASSERT(dependencies->at(temporal_id) == dependency,
+                 "Already have dependency at time "
+                     << get_temporal_id_value(temporal_id) << ": "
+                     << dependencies->at(temporal_id)
+                     << ", which is not the same as the incoming one "
+                     << dependency);
+        } else {
+          (*dependencies)[temporal_id] = std::move(dependency);
         }
       },
       box);

--- a/src/ParallelAlgorithms/Interpolation/Tags.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Tags.hpp
@@ -100,6 +100,12 @@ struct IndicesOfInvalidInterpPoints : db::SimpleTag {
   using type = std::unordered_map<TemporalId, std::unordered_set<size_t>>;
 };
 
+/// Holds potential dependency for apparent horizon callbacks.
+template <typename TemporalId>
+struct Dependencies : db::SimpleTag {
+  using type = std::unordered_map<TemporalId, std::optional<std::string>>;
+};
+
 /// `temporal_id`s that have been flagged to interpolate on, but that
 /// have not yet been added to Tags::CurrentTemporalId.  A `temporal_id` is
 /// pending if the `FunctionOfTime`s are not up to date for the time

--- a/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
+++ b/tests/Unit/IO/Observers/Test_GetLockPointer.cpp
@@ -20,7 +20,6 @@
 
 namespace {
 Parallel::NodeLock* h5_lock_to_check;
-Parallel::NodeLock* volume_lock_to_check;
 
 template <typename LockTag>
 struct mock_lock_retrieval_action {
@@ -34,11 +33,7 @@ struct mock_lock_retrieval_action {
                         observers::ObserverWriter<Metavariables>>(cache))
                     ->template local_synchronous_action<
                         observers::Actions::GetLockPointer<LockTag>>();
-    if constexpr (std::is_same_v<LockTag, observers::Tags::H5FileLock>) {
-      h5_lock_to_check = lock;
-    } else {
-      volume_lock_to_check = lock;
-    }
+    h5_lock_to_check = lock;
   }
 };
 
@@ -49,8 +44,7 @@ struct mock_observer_writer {
   using replace_these_simple_actions = tmpl::list<>;
   using with_these_simple_actions = tmpl::list<>;
 
-  using simple_tags =
-      tmpl::list<observers::Tags::H5FileLock, observers::Tags::VolumeDataLock>;
+  using simple_tags = tmpl::list<observers::Tags::H5FileLock>;
 
   using const_global_cache_tags = tmpl::list<>;
 
@@ -93,23 +87,17 @@ SPECTRE_TEST_CASE("Unit.IO.Observer.GetNodeLockPointer", "[Unit][Cce]") {
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_array_component_and_initialize<writer_component>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0,
-      {Parallel::NodeLock{}, Parallel::NodeLock{}});
+      {Parallel::NodeLock{}});
   ActionTesting::emplace_array_component<array_component>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
 
   ActionTesting::simple_action<
       array_component, mock_lock_retrieval_action<observers::Tags::H5FileLock>>(
       make_not_null(&runner), 0);
-  ActionTesting::simple_action<
-      array_component,
-      mock_lock_retrieval_action<observers::Tags::VolumeDataLock>>(
-      make_not_null(&runner), 0);
 
-  db::mutate<observers::Tags::H5FileLock, observers::Tags::VolumeDataLock>(
-      [](const gsl::not_null<Parallel::NodeLock*> h5_lock,
-         const gsl::not_null<Parallel::NodeLock*> volume_lock) {
+  db::mutate<observers::Tags::H5FileLock>(
+      [](const gsl::not_null<Parallel::NodeLock*> h5_lock) {
         CHECK(h5_lock.get() == h5_lock_to_check);
-        CHECK(volume_lock.get() == volume_lock_to_check);
       },
       make_not_null(&ActionTesting::get_databox<writer_component>(
           make_not_null(&runner), 0)));

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -27,7 +27,6 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   TestHelpers::db::test_simple_tag<ReductionDataLock>("ReductionDataLock");
   TestHelpers::db::test_simple_tag<ContributorsOfTensorData>(
       "ContributorsOfTensorData");
-  TestHelpers::db::test_simple_tag<VolumeDataLock>("VolumeDataLock");
   TestHelpers::db::test_simple_tag<TensorData>("TensorData");
   TestHelpers::db::test_simple_tag<ReductionData<double>>("ReductionData");
   TestHelpers::db::test_simple_tag<ReductionDataNames<double>>(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -469,8 +469,8 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   for (const auto& temporal_id : temporal_ids) {
     ActionTesting::simple_action<
         target_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                              typename metavars::AhA>>(make_not_null(&runner),
-                                                       0, temporal_id);
+                              typename metavars::AhA>>(
+        make_not_null(&runner), 0, temporal_id, std::nullopt);
   }
 
   // Center of the analytic solution.

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
@@ -89,7 +89,8 @@ struct MockAddTemporalIdsToInterpolationTarget {
                     Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const LinkedMessageId<double>&
-                    /*temporal_id*/) {}
+                    /*temporal_id*/,
+                    std::optional<std::string> /*dependency*/) {}  // NOLINT
 };
 
 template <typename Metavariables>

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -1,12 +1,16 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Framework/MockRuntimeSystemFreeFunctions.hpp"
 #include "Framework/TestingFramework.hpp"
 
+#include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <deque>
 #include <memory>
 #include <type_traits>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -245,7 +249,7 @@ void test_add_temporal_ids() {
     ActionTesting::simple_action<
         target_component, ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               typename metavars::InterpolationTargetA>>(
-        make_not_null(&runner), 0, id);
+        make_not_null(&runner), 0, id, std::nullopt);
   };
 
   add_id_to_target(temporal_id_1);
@@ -404,15 +408,20 @@ void test_add_linked_message_id() {
   // This allows us to do a lot of quick testing
   const auto reset_box = [&]() {
     db::mutate<::intrp::Tags::CurrentTemporalId<LinkedMessageId<double>>,
+               ::intrp::Tags::Dependencies<LinkedMessageId<double>>,
                ::intrp::Tags::PendingTemporalIds<LinkedMessageId<double>>,
                ::intrp::Tags::CompletedTemporalIds<LinkedMessageId<double>>>(
         [&](const gsl::not_null<std::optional<LinkedMessageId<double>>*>
                 current_id,
+            const gsl::not_null<std::unordered_map<LinkedMessageId<double>,
+                                                   std::optional<std::string>>*>
+                dependencies,
             const gsl::not_null<std::deque<LinkedMessageId<double>>*>
                 pending_ids,
             const gsl::not_null<std::deque<LinkedMessageId<double>>*>
                 completed_ids) {
           completed_ids->clear();
+          dependencies->clear();
           pending_ids->clear();
           current_id->reset();
         },
@@ -434,12 +443,14 @@ void test_add_linked_message_id() {
             make_not_null(&target_box));
       };
 
-  const auto add_id_to_target = [&](const LinkedMessageId<double>& id) {
-    ActionTesting::simple_action<
-        target_component,
-        ::intrp::Actions::AddTemporalIdsToInterpolationTarget<target_tag>>(
-        make_not_null(&runner), 0, id);
-  };
+  const auto add_id_to_target =
+      [&](const LinkedMessageId<double>& id,
+          const std::optional<std::string>& dependency = std::nullopt) {
+        ActionTesting::simple_action<
+            target_component,
+            ::intrp::Actions::AddTemporalIdsToInterpolationTarget<target_tag>>(
+            make_not_null(&runner), 0, id, dependency);
+      };
 
   const auto check_empty = [&]<template <typename> typename Tag>() {
     if constexpr (tt::is_a_v<std::optional,
@@ -469,6 +480,19 @@ void test_add_linked_message_id() {
                 .value() == ids.front());
     }
   };
+  const auto check_dependency =
+      [&](const LinkedMessageId<double>& id, const bool value_should_exist,
+          const std::optional<std::string>& dependency = std::nullopt) {
+        const auto& dependencies = ActionTesting::get_databox_tag<
+            target_component,
+            ::intrp::Tags::Dependencies<LinkedMessageId<double>>>(runner, 0);
+
+        CHECK(dependencies.contains(id) == value_should_exist);
+        if (value_should_exist) {
+          REQUIRE(dependencies.contains(id));
+          CHECK(dependencies.at(id) == dependency);
+        }
+      };
 
   // PendingTemporalIds and TemporalIds should be
   // initially empty.
@@ -486,7 +510,7 @@ void test_add_linked_message_id() {
         temporal_ids[0]);
 
     // Add an out of order id
-    add_id_to_target(temporal_ids[2]);
+    add_id_to_target(temporal_ids[2], {"Dependency2"});
 
     // This should have gone into Pending and the first one was moved to
     // TemporalIds
@@ -494,13 +518,14 @@ void test_add_linked_message_id() {
         {temporal_ids[2]});
     check_values.template operator()<::intrp::Tags::CurrentTemporalId>(
         {temporal_ids[0]});
+    check_dependency(temporal_ids[2], true, {"Dependency2"});
 
     reset_box();
     insert_id_into.template operator()<::intrp::Tags::PendingTemporalIds>(
         temporal_ids[0]);
 
     // Add an in order id
-    add_id_to_target(temporal_ids[1]);
+    add_id_to_target(temporal_ids[1], {"Dependency1"});
 
     // This should also be in Pending, again because Pending wasn't empty on
     // entry
@@ -508,6 +533,7 @@ void test_add_linked_message_id() {
         {temporal_ids[1]});
     check_values.template operator()<::intrp::Tags::CurrentTemporalId>(
         {temporal_ids[0]});
+    check_dependency(temporal_ids[1], true, {"Dependency1"});
   }
 
   // For the rest of this test we will start with Pending being empty
@@ -526,6 +552,8 @@ void test_add_linked_message_id() {
         {temporal_ids[2]});
     check_values.template operator()<::intrp::Tags::CurrentTemporalId>(
         {temporal_ids[0]});
+    check_dependency(temporal_ids[1], false);
+    check_dependency(temporal_ids[2], true, std::nullopt);
 
     reset_box();
     insert_id_into.template operator()<::intrp::Tags::CurrentTemporalId>(
@@ -541,6 +569,7 @@ void test_add_linked_message_id() {
         {temporal_ids[1]});
     check_values.template operator()<::intrp::Tags::CurrentTemporalId>(
         {temporal_ids[0]});
+    check_dependency(temporal_ids[1], true, std::nullopt);
   }
 
   // For the rest of this test we will start with TemporalIds being empty
@@ -559,6 +588,8 @@ void test_add_linked_message_id() {
     check_values.template operator()<::intrp::Tags::PendingTemporalIds>(
         {temporal_ids[2]});
     check_empty.template operator()<::intrp::Tags::CurrentTemporalId>();
+    check_dependency(temporal_ids[1], false);
+    check_dependency(temporal_ids[2], true, std::nullopt);
 
     reset_box();
     insert_id_into.template operator()<::intrp::Tags::CompletedTemporalIds>(
@@ -572,6 +603,7 @@ void test_add_linked_message_id() {
     check_empty.template operator()<::intrp::Tags::PendingTemporalIds>();
     check_values.template operator()<::intrp::Tags::CurrentTemporalId>(
         {temporal_ids[1]});
+    check_dependency(temporal_ids[1], true, std::nullopt);
   }
 
   // Finally we will start with everything being empty
@@ -586,6 +618,8 @@ void test_add_linked_message_id() {
     check_values.template operator()<::intrp::Tags::PendingTemporalIds>(
         {temporal_ids[1]});
     check_empty.template operator()<::intrp::Tags::CurrentTemporalId>();
+    check_dependency(temporal_ids[0], false);
+    check_dependency(temporal_ids[1], true, std::nullopt);
 
     // Send the first id
     add_id_to_target(temporal_ids[0]);
@@ -596,6 +630,7 @@ void test_add_linked_message_id() {
         {temporal_ids[1]});
     check_values.template operator()<::intrp::Tags::CurrentTemporalId>(
         {temporal_ids[0]});
+    check_dependency(temporal_ids[0], true, std::nullopt);
   }
 }
 
@@ -649,7 +684,7 @@ void test_add_temporal_ids_time_dependent() {
     ActionTesting::simple_action<
         target_component,
         ::intrp::Actions::AddTemporalIdsToInterpolationTarget<target_tag>>(
-        make_not_null(&runner), 0, id);
+        make_not_null(&runner), 0, id, std::nullopt);
   };
 
   // Two of the temporal_ids are before the expiration_time, the

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Framework/TestHelpers.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <algorithm>
@@ -113,10 +114,13 @@ struct MockAddTemporalIdsToInterpolationTarget {
       Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/,
       const typename Metavariables::InterpolatorTargetA::temporal_id::type&
-      /*temporal_id*/) {
+      /*temporal_id*/,
+      std::optional<std::string> dependency) {
     // We are not testing this Action here.
-    // Do nothing except make sure it is called once.
+    // Do nothing except make sure it is called once and the dependency is
+    // correct
     ++called_mock_add_temporal_ids_to_interpolation_target;
+    CHECK(dependency == std::optional<std::string>{"FakeDependency"});
   }
 };
 
@@ -290,7 +294,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
   const double invalid_time = 0.2;
 
   intrp::interpolate<MockMetavariables::InterpolatorTargetA>(
-      temporal_id, mesh, cache, array_index, std::nullopt,
+      temporal_id, mesh, cache, array_index, std::nullopt, {"FakeDependency"},
       get<Tags::Lapse>(vars));
 
   check_results();
@@ -306,7 +310,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
       ::Tags::Variables<typename decltype(vars)::tags_list>>>(
       metavars{}, temporal_id, invalid_time, mesh, vars);
 
-  metavars::event event{};
+  const metavars::event event{{"FakeDependency"}};
+  const metavars::event serialized_event = serialize_and_deserialize(event);
 
   // Update time in box and functions of time
   db::mutate<::Tags::Time>([](gsl::not_null<double*> time) { *time = 1.0; },
@@ -315,13 +320,13 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
                    control_system::UpdateSingleFunctionOfTime>(
       cache, name, initial_expr_time, DataVector{1, 0.0}, observation_time);
 
-  CHECK(event.needs_evolved_variables());
+  CHECK(serialized_event.needs_evolved_variables());
 
   auto obs_box = make_observation_box<
       typename metavars::event::compute_tags_for_observation_box>(
       make_not_null(&box));
-  event.run(make_not_null(&obs_box), cache, array_index,
-            std::add_pointer_t<elem_component>{}, {});
+  serialized_event.run(make_not_null(&obs_box), cache, array_index,
+                       std::add_pointer_t<elem_component>{}, {});
 
   check_results();
 }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -368,8 +368,9 @@ void test_interpolation_target_receive_vars() {
       {std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
        std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{
            invalid_indices},
-       pending_temporal_ids, current_temporal_id,
-       std::deque<temporal_id_type>{},
+       pending_temporal_ids,
+       std::unordered_map<temporal_id_type, std::optional<std::string>>{},
+       current_temporal_id, std::deque<temporal_id_type>{},
        std::unordered_map<
            temporal_id_type,
            Variables<typename target_tag::vars_to_interpolate_to_target>>{

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -265,8 +265,9 @@ void test() {
       &runner, 0,
       {std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
        std::unordered_map<temporal_id_type, std::unordered_set<size_t>>{},
-       std::deque<temporal_id_type>{}, std::unordered_set<temporal_id_type>{},
        std::deque<temporal_id_type>{},
+       std::unordered_map<temporal_id_type, std::optional<std::string>>{},
+       std::unordered_set<temporal_id_type>{}, std::deque<temporal_id_type>{},
        std::unordered_map<temporal_id_type,
                           Variables<typename metavars::InterpolationTargetA::
                                         vars_to_interpolate_to_target>>{},

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -359,11 +359,11 @@ void run_test(gsl::not_null<Generator*> generator,
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               typename metavars::LineA>>(
-      make_not_null(&runner), 0, temporal_id.substep_time());
+      make_not_null(&runner), 0, temporal_id.substep_time(), std::nullopt);
   ActionTesting::simple_action<
       target_b_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
-                              typename metavars::LineB>>(make_not_null(&runner),
-                                                         0, temporal_id);
+                              typename metavars::LineB>>(
+      make_not_null(&runner), 0, temporal_id, std::nullopt);
 
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 0));
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 1));

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -715,23 +715,23 @@ void run_test() {
   ActionTesting::simple_action<
       target_a_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceA>>(
-      make_not_null(&runner), 0, temporal_id.substep_time());
+      make_not_null(&runner), 0, temporal_id.substep_time(), std::nullopt);
   ActionTesting::simple_action<
       target_b_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceB>>(
-      make_not_null(&runner), 0, temporal_id);
+      make_not_null(&runner), 0, temporal_id, std::nullopt);
   ActionTesting::simple_action<
       target_c_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceC>>(
-      make_not_null(&runner), 0, temporal_id);
+      make_not_null(&runner), 0, temporal_id, std::nullopt);
   ActionTesting::simple_action<
       target_d_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceD>>(
-      make_not_null(&runner), 0, temporal_id.substep_time());
+      make_not_null(&runner), 0, temporal_id.substep_time(), std::nullopt);
   ActionTesting::simple_action<
       target_e_component,
       intrp::Actions::AddTemporalIdsToInterpolationTarget<metavars::SurfaceE>>(
-      make_not_null(&runner), 0, temporal_id.substep_time());
+      make_not_null(&runner), 0, temporal_id.substep_time(), std::nullopt);
 
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 0));
   CHECK(ActionTesting::is_simple_action_queue_empty<obs_writer>(runner, 1));

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -410,15 +410,15 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetA>>(
-      make_not_null(&runner), 0, temporal_id);
+      make_not_null(&runner), 0, temporal_id, std::nullopt);
   ActionTesting::simple_action<
       target_b_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetB>>(
-      make_not_null(&runner), 0, temporal_id);
+      make_not_null(&runner), 0, temporal_id, std::nullopt);
   ActionTesting::simple_action<
       target_c_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetC>>(
-      make_not_null(&runner), 0, temporal_id);
+      make_not_null(&runner), 0, temporal_id, std::nullopt);
 
   // Create volume data and send it to the interpolator.
   for (const auto& element_id : element_ids) {
@@ -475,7 +475,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   ActionTesting::simple_action<
       target_a_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               metavars::InterpolationTargetA>>(
-      make_not_null(&runner), 0, temporal_id);
+      make_not_null(&runner), 0, temporal_id, std::nullopt);
   // ...so make sure it was ignored by checking that there isn't anything
   // else in the simple_action queue of the target or the interpolator.
   CHECK(ActionTesting::is_simple_action_queue_empty<target_a_component>(runner,


### PR DESCRIPTION
## Proposed changes

This is the second of 3 PRs that avoid writing volume data for a common horizon find that fails.

This PR is some miscellaneous changes to `VolumeActions.hpp` that are needed and also adds what is called a "dependency" to the interpolation framework which the combined common horizon event in #6622 will make use of eventually. Currently, this dependency does nothing.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Technically depends on #6622, but only for a single test so I didn't include those commits here. Whichever is merged first, I'll just rebase.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
