### PR TITLE
Prevent writing volume data when AhC fails

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -111,6 +111,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
@@ -272,12 +273,23 @@ struct EvolutionMetavars {
         intrp::TargetPoints::ApparentHorizon<Ah, Frame>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::FindApparentHorizon<Ah, Frame>>;
-    using horizon_find_failure_callbacks =
-        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>;
-    using post_horizon_find_callbacks = tmpl::list<
-        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, Ah,
-                                             Frame>,
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Ah>>;
+    using horizon_find_failure_callbacks = tmpl::append<
+        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>,
+        tmpl::conditional_t<
+            Horizon == ::domain::ObjectLabel::C,
+            tmpl::list<
+                intrp::callbacks::SendDependencyToObserverWriter<false, Ah>>,
+            tmpl::list<>>>;
+    using post_horizon_find_callbacks = tmpl::append<
+        tmpl::conditional_t<
+            Horizon == ::domain::ObjectLabel::C,
+            tmpl::list<
+                intrp::callbacks::SendDependencyToObserverWriter<true, Ah>>,
+            tmpl::list<>>,
+        tmpl::list<
+            intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, Ah,
+                                                 Frame>,
+            intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Ah>>>;
     static std::string name() {
       return "ObservationAh" + ::domain::name(Horizon);
     }

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -71,7 +71,8 @@ struct InitializeWriter {
                  Tags::ContributorsOfTensorData, Tags::TensorData,
                  Tags::InterpolatorTensorData,
                  Tags::NodesExpectedToContributeReductions,
-                 Tags::NodesThatContributedReductions, Tags::H5FileLock>,
+                 Tags::NodesThatContributedReductions, Tags::H5FileLock,
+                 Tags::Dependencies>,
       typename Metavariables::observed_reduction_data_tags,
       tmpl::transform<
           typename Metavariables::observed_reduction_data_tags,

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -108,6 +108,13 @@ struct InterpolatorTensorData : db::SimpleTag {
                                             std::vector<ElementVolumeData>>>;
 };
 
+/// Map of ObservationIds that have dependencies for volume data to be written
+/// and whether or not the dependency has the volume data being written or
+/// discarded.
+struct Dependencies : db::SimpleTag {
+  using type = std::unordered_map<ObservationId, std::pair<std::string, bool>>;
+};
+
 /// \cond
 template <class... ReductionDatums>
 struct ReductionDataNames;

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -28,6 +29,7 @@
 #include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Local.hpp"
+#include "Parallel/NodeLock.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -60,16 +62,17 @@ namespace Actions {
 struct ContributeVolumeData {
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex>
-  static void apply(db::DataBox<DbTagsList>& box,
-                    Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index,
-                    const observers::ObservationId& observation_id,
-                    const std::string& subfile_name,
-                    const Parallel::ArrayComponentId& sender_array_id,
-                    ElementVolumeData&& received_volume_data) {
+  static void apply(
+      db::DataBox<DbTagsList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index,
+      const observers::ObservationId& observation_id,
+      const std::string& subfile_name,
+      const Parallel::ArrayComponentId& sender_array_id,
+      ElementVolumeData&& received_volume_data,
+      const std::optional<std::string>& dependency = std::nullopt) {
     db::mutate<Tags::TensorData, Tags::ContributorsOfTensorData>(
         [&array_index, &cache, &received_volume_data, &observation_id,
-         &sender_array_id, &subfile_name](
+         &sender_array_id, &subfile_name, &dependency](
             const gsl::not_null<std::unordered_map<
                 observers::ObservationId,
                 std::unordered_map<Parallel::ArrayComponentId,
@@ -105,8 +108,8 @@ struct ContributeVolumeData {
           }
           contributed_array_ids.insert(sender_array_id);
 
-          if (volume_data->count(observation_id) == 0 or
-              volume_data->at(observation_id).count(sender_array_id) == 0) {
+          if ((not volume_data->contains(observation_id)) or
+              (not volume_data->at(observation_id).contains(sender_array_id))) {
             volume_data->operator[](observation_id)
                 .emplace(sender_array_id, std::move(received_volume_data));
           } else {
@@ -139,7 +142,8 @@ struct ContributeVolumeData {
                 local_writer, observation_id,
                 Parallel::make_array_component_id<ParallelComponent>(
                     array_index),
-                subfile_name, std::move((*volume_data)[observation_id]));
+                subfile_name, std::move((*volume_data)[observation_id]),
+                dependency);
             volume_data->erase(observation_id);
             contributed_volume_data_ids->erase(observation_id);
           }
@@ -242,24 +246,27 @@ void write_combined_volume_data(
  * \ingroup ObserversGroup
  * \brief Move data to the observer writer for writing to disk.
  *
- * Once data from all cores is collected this action writes the data to disk.
+ * Once data from all cores is collected this action writes the data to disk if
+ * there isn't a dependency. Or if there is a dependency and it has been
+ * received already. If there is a dependency but it hasn't been received yet,
+ * data will be written by a call to `ContributeDependency`.
  */
 struct ContributeVolumeDataToWriter {
   template <typename ParallelComponent, typename DbTagsList,
             typename Metavariables, typename ArrayIndex>
-  static void apply(db::DataBox<DbTagsList>& box,
-                    Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& /*array_index*/,
-                    const gsl::not_null<Parallel::NodeLock*> node_lock,
-                    const observers::ObservationId& observation_id,
-                    Parallel::ArrayComponentId observer_group_id,
-                    const std::string& subfile_name,
-                    std::unordered_map<Parallel::ArrayComponentId,
-                                       std::vector<ElementVolumeData>>&&
-                        received_volume_data) {
+  static void apply(
+      db::DataBox<DbTagsList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/,
+      const gsl::not_null<Parallel::NodeLock*> node_lock,
+      const observers::ObservationId& observation_id,
+      Parallel::ArrayComponentId observer_group_id,
+      const std::string& subfile_name,
+      std::unordered_map<Parallel::ArrayComponentId,
+                         std::vector<ElementVolumeData>>&& received_volume_data,
+      const std::optional<std::string>& dependency = std::nullopt) {
     apply_impl<Tags::InterpolatorTensorData, ParallelComponent>(
         box, cache, node_lock, observation_id, observer_group_id, subfile_name,
-        std::move(received_volume_data));
+        std::move(received_volume_data), dependency);
   }
 
   template <typename ParallelComponent, typename DbTagsList,
@@ -272,23 +279,24 @@ struct ContributeVolumeDataToWriter {
       Parallel::ArrayComponentId observer_group_id,
       const std::string& subfile_name,
       std::unordered_map<Parallel::ArrayComponentId, ElementVolumeData>&&
-          received_volume_data) {
+          received_volume_data,
+      const std::optional<std::string>& dependency = std::nullopt) {
     apply_impl<Tags::TensorData, ParallelComponent>(
         box, cache, node_lock, observation_id, observer_group_id, subfile_name,
-        std::move(received_volume_data));
+        std::move(received_volume_data), dependency);
   }
 
  private:
   template <typename TensorDataTag, typename ParallelComponent,
             typename DbTagsList, typename Metavariables,
             typename VolumeDataAtObsId>
-  static void apply_impl(db::DataBox<DbTagsList>& box,
-                         Parallel::GlobalCache<Metavariables>& cache,
-                         const gsl::not_null<Parallel::NodeLock*> node_lock,
-                         const observers::ObservationId& observation_id,
-                         Parallel::ArrayComponentId observer_group_id,
-                         const std::string& subfile_name,
-                         VolumeDataAtObsId received_volume_data) {
+  static void apply_impl(
+      db::DataBox<DbTagsList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const gsl::not_null<Parallel::NodeLock*> node_lock,
+      const observers::ObservationId& observation_id,
+      Parallel::ArrayComponentId observer_group_id,
+      const std::string& subfile_name, VolumeDataAtObsId received_volume_data,
+      const std::optional<std::string>& dependency = std::nullopt) {
     // The below gymnastics with pointers is done in order to minimize the
     // time spent locking the entire node, which is necessary because the
     // DataBox does not allow any function calls, either get and mutate, during
@@ -340,6 +348,8 @@ struct ContributeVolumeDataToWriter {
               make_not_null(&box));
       auto& all_volume_data =
           db::get_mutable_reference<TensorDataTag>(make_not_null(&box));
+      auto& box_dependencies =
+          db::get_mutable_reference<Tags::Dependencies>(make_not_null(&box));
 
       auto& contributed_group_ids =
           volume_observers_contributed[observation_id];
@@ -366,10 +376,40 @@ struct ContributeVolumeDataToWriter {
       // group. If so we write to disk.
       if (volume_observers_contributed.at(observation_id).size() ==
           observations_registered_with_id) {
-        perform_write = true;
-        volume_data = std::move(all_volume_data[observation_id]);
-        all_volume_data.erase(observation_id);
-        volume_observers_contributed.erase(observation_id);
+        // Check if
+        //  1. there is an external dependencies
+        if (dependency.has_value()) {
+          //  2. if there is, that we have received something at this time
+          //  3. that the dependencies are the same
+          if (box_dependencies.contains(observation_id)) {
+            if (UNLIKELY(box_dependencies.at(observation_id).first !=
+                         dependency.value())) {
+              ERROR(
+                  "The dependency that was sent to the ObserverWriter from the "
+                  "elements ("
+                  << dependency.value()
+                  << ") does not match the dependency received from "
+                     "ContributeDependency ("
+                  << box_dependencies.at(observation_id).first << ").");
+            }
+            //  4. that we are writing the volume data to disk
+            if (box_dependencies.at(observation_id).second) {
+              perform_write = true;
+              volume_data = std::move(all_volume_data[observation_id]);
+            }
+
+            // Whether or not we are writing data to disk, we clean up because
+            // we have received both the volume data and the dependency
+            all_volume_data.erase(observation_id);
+            volume_observers_contributed.erase(observation_id);
+            box_dependencies.erase(observation_id);
+          }
+        } else {
+          perform_write = true;
+          volume_data = std::move(all_volume_data[observation_id]);
+          all_volume_data.erase(observation_id);
+          volume_observers_contributed.erase(observation_id);
+        }
       }
     }
 
@@ -377,6 +417,108 @@ struct ContributeVolumeDataToWriter {
       VolumeActions_detail::write_combined_volume_data<ParallelComponent>(
           cache, observation_id, volume_data, make_not_null(volume_file_lock),
           subfile_name);
+    }
+  }
+};
+
+/*!
+ * \brief Threaded action that will add a dependency to the ObserverWriter for a
+ * given ObservationId ( \p time + \p volume_subfile_name).
+ *
+ * \details If not all the volume data for this ObservationId has been received
+ * yet, then this will just add the dependency to the box and exit without
+ * writing anything. If all volume data arrives before this action is called,
+ * then it will write out the volume data (or remove it if we aren't writing).
+ */
+struct ContributeDependency {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<Parallel::NodeLock*> node_lock,
+                    const double time, const std::string& dependency,
+                    std::string volume_subfile_name,
+                    const bool write_volume_data) {
+    if (not volume_subfile_name.starts_with("/")) {
+      volume_subfile_name = "/" + volume_subfile_name;
+    }
+    if (not volume_subfile_name.ends_with(".vol")) {
+      volume_subfile_name += ".vol";
+    }
+
+    const ObservationId observation_id{time, volume_subfile_name};
+
+    // The below gymnastics with pointers is done in order to minimize the
+    // time spent locking the entire node, which is necessary because the
+    // DataBox does not allow any function calls, either get and mutate, during
+    // a mutate. We separate out writing from the operations that edit the
+    // DataBox since writing to disk can be very slow, but moving data around is
+    // comparatively quick.
+    Parallel::NodeLock* volume_file_lock = nullptr;
+    bool perform_write = false;
+    std::unordered_map<Parallel::ArrayComponentId, ElementVolumeData>
+        volume_data{};
+
+    // For now just hold the entire node. We can optimize with different locks
+    // later on
+    {
+      const std::lock_guard hold_lock(*node_lock);
+
+      db::mutate<Tags::H5FileLock, Tags::Dependencies>(
+          [&](const gsl::not_null<Parallel::NodeLock*> volume_file_lock_ptr,
+              const gsl::not_null<std::unordered_map<
+                  ObservationId, std::pair<std::string, bool>>*>
+                  dependencies) {
+            volume_file_lock = &*volume_file_lock_ptr;
+            (*dependencies)[observation_id] =
+                std::pair{dependency, write_volume_data};
+          },
+          make_not_null(&box));
+
+      auto& volume_observers_contributed =
+          db::get_mutable_reference<Tags::ContributorsOfTensorData>(
+              make_not_null(&box));
+      auto& all_volume_data =
+          db::get_mutable_reference<Tags::TensorData>(make_not_null(&box));
+      auto& box_dependencies =
+          db::get_mutable_reference<Tags::Dependencies>(make_not_null(&box));
+      const auto& expected_contributors =
+          db::get<Tags::ExpectedContributorsForObservations>(box);
+
+      if (not expected_contributors.contains(
+              observation_id.observation_key())) {
+        ERROR("Key " << observation_id.observation_key()
+                     << " was not registered.");
+      }
+
+      // We have not received any volume data at this time so we can't do
+      // anything
+      if (not(volume_observers_contributed.contains(observation_id) and
+              all_volume_data.contains(observation_id))) {
+        return;
+      }
+
+      // Check if we have received all "volume" data from the Observer
+      // group. If so we write to disk. Then always delete it since the volume
+      // data was waiting for this dependency to arrive to be written
+      if (volume_observers_contributed.at(observation_id).size() ==
+          expected_contributors.at(observation_id.observation_key()).size()) {
+        if (write_volume_data) {
+          perform_write = true;
+          volume_data = std::move(all_volume_data.at(observation_id));
+        }
+
+        all_volume_data.erase(observation_id);
+        volume_observers_contributed.erase(observation_id);
+        box_dependencies.erase(observation_id);
+      }
+    }
+
+    if (perform_write) {
+      VolumeActions_detail::write_combined_volume_data<ParallelComponent>(
+          cache, observation_id, volume_data, make_not_null(volume_file_lock),
+          volume_subfile_name);
     }
   }
 };

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -9,4 +9,5 @@ spectre_target_headers(
   ErrorOnFailedApparentHorizon.hpp
   FindApparentHorizon.hpp
   IgnoreFailedApparentHorizon.hpp
+  SendDependencyToObserverWriter.hpp
   )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -64,18 +64,14 @@ namespace intrp::callbacks {
 /// type alias called `post_horizon_find_callbacks`, which is a list of
 /// structs, each of which has a function
 ///
-/// \snippet
-/// ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
-/// post_horizon_find_callback_example
+/// \snippet ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp post_horizon_find_callback_example
 ///
 /// that is called if the FastFlow iteration has converged.
 /// InterpolationTargetTag also is assumed to contain an additional
 /// type alias called `horizon_find_failure_callbacks`, which is a list of
 /// structs, each of which has a function
 ///
-/// \snippet
-/// ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
-/// horizon_find_failure_callbacks_example
+/// \snippet ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp horizon_find_failure_callbacks_example
 ///
 /// that is called if the FastFlow iteration or the interpolation has
 /// failed.

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "ParallelAlgorithms/Interpolation/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
+
+/// \cond
+namespace logging::Tags {
+template <typename OptionsGroup>
+struct Verbosity;
+}  // namespace logging::Tags
+/// \endcond
+
+namespace intrp::callbacks {
+/*!
+ * \brief Post horizon find callback that will send a message to the
+ * ObserverWriter if we have a dependency telling it to write the volume data to
+ * disk or not depending on the \p WriteVolumeData template bool.
+ *
+ * \details Can be used whether the horizon finder fails or not. The
+ * `failure_reason` is not used when the horizon find fails.
+ */
+template <bool WriteVolumeData, typename InterpolationTargetTag>
+struct SendDependencyToObserverWriter {
+  // Callback for when horizon find succeeds
+  template <typename DbTags, typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const TemporalId& temporal_id) {
+    static_assert(WriteVolumeData);
+    apply_impl<InterpolationTargetTag>(box, cache, temporal_id);
+  }
+
+  // Callback for when horizon find fails
+  template <typename LocalInterpolationTargetTag, typename DbTags,
+            typename Metavariables, typename TemporalId>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const TemporalId& temporal_id,
+                    const FastFlow::Status /*failure_reason*/) {
+    static_assert(not WriteVolumeData);
+    apply_impl<LocalInterpolationTargetTag>(box, cache, temporal_id);
+  }
+
+ private:
+  template <typename LocalInterpolationTargetTag, typename DbTags,
+            typename Metavariables, typename TemporalId>
+  static void apply_impl(const db::DataBox<DbTags>& box,
+                         Parallel::GlobalCache<Metavariables>& cache,
+                         const TemporalId& temporal_id) {
+    static_assert(
+        std::is_same_v<InterpolationTargetTag, LocalInterpolationTargetTag>);
+
+    const auto& dependencies =
+        db::get<intrp::Tags::Dependencies<TemporalId>>(box);
+
+    ASSERT(dependencies.contains(temporal_id),
+           "TemporalId " << temporal_id
+                         << " not found in dependencies: " << dependencies);
+
+    const auto& dependency = dependencies.at(temporal_id);
+
+    if (dependency.has_value()) {
+      const auto& verbosity =
+          db::get<logging::Tags::Verbosity<InterpolationTargetTag>>(box);
+
+      auto& observer_writer_proxy = Parallel::get_parallel_component<
+          observers::ObserverWriter<Metavariables>>(cache);
+
+      Parallel::threaded_action<
+          observers::ThreadedActions::ContributeDependency>(
+          observer_writer_proxy,
+          InterpolationTarget_detail::get_temporal_id_value(temporal_id),
+          pretty_type::name<InterpolationTargetTag>(), dependency.value(),
+          WriteVolumeData);
+
+      if (verbosity >= ::Verbosity::Verbose) {
+        Parallel::printf(
+            "Remark: We are%s writing volume data for horizon finder %s",
+            WriteVolumeData ? "" : " not",
+            pretty_type::name<InterpolationTargetTag>());
+      }
+    }
+  }
+};
+}  // namespace intrp::callbacks

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp
@@ -98,7 +98,7 @@ class FindCommonHorizon<
       : observe_fields_event_(subfile_name, coordinates_floating_point_type,
                               floating_point_types, variables_to_observe,
                               active_block_or_block_groups, interpolation_mesh,
-                              context) {}
+                              std::nullopt, context) {}
 
   using compute_tags_for_observation_box = tmpl::remove_duplicates<tmpl::append<
       typename ObserveFieldsEvent::compute_tags_for_observation_box,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindCommonHorizon.hpp
@@ -98,7 +98,8 @@ class FindCommonHorizon<
       : observe_fields_event_(subfile_name, coordinates_floating_point_type,
                               floating_point_types, variables_to_observe,
                               active_block_or_block_groups, interpolation_mesh,
-                              std::nullopt, context) {}
+                              {name()}, context),
+        interpolate_event_(subfile_name) {}
 
   using compute_tags_for_observation_box = tmpl::remove_duplicates<tmpl::append<
       typename ObserveFieldsEvent::compute_tags_for_observation_box,

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -181,6 +182,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
 
   ObserveFields() = default;
 
+  // The dependency isn't available through Options
   ObserveFields(
       const std::string& subfile_name,
       FloatingPointType coordinates_floating_point_type,
@@ -188,7 +190,21 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       const std::vector<std::string>& variables_to_observe,
       std::optional<std::vector<std::string>> active_block_or_block_groups = {},
       std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
+      std::optional<std::string> dependency = {},
       const Options::Context& context = {});
+
+  ObserveFields(
+      const std::string& subfile_name,
+      FloatingPointType coordinates_floating_point_type,
+      const std::vector<FloatingPointType>& floating_point_types,
+      const std::vector<std::string>& variables_to_observe,
+      std::optional<std::vector<std::string>> active_block_or_block_groups = {},
+      std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
+      const Options::Context& context = {})
+      : ObserveFields(subfile_name, coordinates_floating_point_type,
+                      floating_point_types, variables_to_observe,
+                      std::move(active_block_or_block_groups),
+                      std::move(interpolation_mesh), std::nullopt, context) {}
 
   using compute_tags_for_observation_box =
       tmpl::list<Tensors..., NonTensorComputeTags...>;
@@ -217,7 +233,8 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
     }
     call_operator_impl(subfile_path_ + *section_observation_key,
                        variables_to_observe_, interpolation_mesh_, mesh, box,
-                       cache, array_index, component, observation_value);
+                       cache, array_index, component, observation_value,
+                       dependency_);
   }
 
   // We factor out the work into a static member function so it can  be shared
@@ -235,7 +252,8 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       Parallel::GlobalCache<Metavariables>& cache,
       const ElementId<VolumeDim>& element_id,
       const ParallelComponent* const /*meta*/,
-      const ObservationValue& observation_value) {
+      const ObservationValue& observation_value,
+      const std::optional<std::string>& dependency) {
     // if no interpolation_mesh is provided, the interpolation is essentially
     // ignored by the RegularGridInterpolant except for a single copy.
     const intrp::RegularGrid interpolant(mesh,
@@ -334,12 +352,12 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       Parallel::threaded_action<
           observers::ThreadedActions::ContributeVolumeDataToWriter>(
           local_observer, std::move(observation_id), array_component_id,
-          subfile_path, std::move(data_to_send));
+          subfile_path, std::move(data_to_send), dependency);
     } else {
       // Send data to volume observer
       Parallel::simple_action<observers::Actions::ContributeVolumeData>(
           local_observer, std::move(observation_id), subfile_path,
-          array_component_id, std::move(element_volume_data));
+          array_component_id, std::move(element_volume_data), dependency);
     }
   }
 
@@ -382,6 +400,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
     p | variables_to_observe_;
     p | active_block_or_block_groups_;
     p | interpolation_mesh_;
+    p | dependency_;
   }
 
  private:
@@ -414,6 +433,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
   std::unordered_map<std::string, FloatingPointType> variables_to_observe_{};
   std::optional<std::vector<std::string>> active_block_or_block_groups_{};
   std::optional<Mesh<VolumeDim>> interpolation_mesh_{};
+  std::optional<std::string> dependency_;
 };
 
 template <size_t VolumeDim, typename... Tensors,
@@ -427,7 +447,7 @@ ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         const std::vector<std::string>& variables_to_observe,
         std::optional<std::vector<std::string>> active_block_or_block_groups,
         std::optional<Mesh<VolumeDim>> interpolation_mesh,
-        const Options::Context& context)
+        std::optional<std::string> dependency, const Options::Context& context)
     : subfile_path_("/" + subfile_name),
       variables_to_observe_([&context, &floating_point_types,
                              &variables_to_observe]() {
@@ -455,7 +475,8 @@ ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         return result;
       }()),
       active_block_or_block_groups_(std::move(active_block_or_block_groups)),
-      interpolation_mesh_(interpolation_mesh) {
+      interpolation_mesh_(interpolation_mesh),
+      dependency_(std::move(dependency)) {
   ASSERT(
       (... or (db::tag_name<Tensors>() == "InertialCoordinates")),
       "There is no tag with name 'InertialCoordinates' specified "

--- a/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/Helpers/IO/Observers/ObserverHelpers.hpp
@@ -39,8 +39,7 @@ struct RegisterObservers {
   static std::pair<observers::TypeOfObservation, observers::ObservationKey>
   register_info(const db::DataBox<DbTagsList>& /*box*/,
                 const ArrayIndex& /*array_index*/) {
-    return {TypeOfObservation,
-            observers::ObservationKey{"ElementObservationType"}};
+    return {TypeOfObservation, observers::ObservationKey{"/element_data.vol"}};
   }
 };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -57,22 +57,26 @@ struct MockContributeVolumeData {
     std::string subfile_name{};
     Parallel::ArrayComponentId array_component_id{};
     ElementVolumeData received_volume_data{};
+    std::optional<std::string> dependency{};
   };
   static Results results;
 
   template <typename ParallelComponent, typename... DbTags,
             typename Metavariables, typename ArrayIndex>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
-                    Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const observers::ObservationId& observation_id,
-                    const std::string& subfile_name,
-                    const Parallel::ArrayComponentId& array_component_id,
-                    ElementVolumeData&& received_volume_data) {
+  static void apply(
+      db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const observers::ObservationId& observation_id,
+      const std::string& subfile_name,
+      const Parallel::ArrayComponentId& array_component_id,
+      ElementVolumeData&& received_volume_data,
+      const std::optional<std::string>& dependency = std::nullopt) {
     results.observation_id = observation_id;
     results.subfile_name = subfile_name;
     results.array_component_id = array_component_id;
     results.received_volume_data = std::move(received_volume_data);
+    results.dependency = dependency;
   }
 };
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -234,14 +234,16 @@ struct ScalarSystem {
   static ObserveEvent make_test_object(
       const std::optional<Mesh<volume_dim>>& interpolating_mesh,
       std::optional<std::vector<std::string>> active_block_or_block_groups =
-          std::nullopt) {
+          std::nullopt,
+      std::optional<std::string> dependency = std::nullopt) {
     return ObserveEvent{
         "element_data",
         FloatingPointType::Double,
         {FloatingPointType::Double},
         {"Scalar", "ScalarVarTimesTwo", "ScalarVarTimesThree", "Error(Scalar)"},
         std::move(active_block_or_block_groups),
-        interpolating_mesh};
+        interpolating_mesh,
+        std::move(dependency)};
   }
 };
 
@@ -361,7 +363,8 @@ struct ComplicatedSystem {
   static ObserveEvent make_test_object(
       const std::optional<Mesh<volume_dim>>& interpolating_mesh,
       std::optional<std::vector<std::string>> active_block_or_block_groups =
-          std::nullopt) {
+          std::nullopt,
+      std::optional<std::string> dependency = std::nullopt) {
     return ObserveEvent(
         "element_data", FloatingPointType::Double,
         {FloatingPointType::Double, FloatingPointType::Double,
@@ -370,7 +373,8 @@ struct ComplicatedSystem {
          FloatingPointType::Double, FloatingPointType::Float},
         {"Scalar", "ScalarVarTimesTwo", "ScalarVarTimesThree", "Vector",
          "Tensor", "Tensor2", "Error(Vector)", "Error(Tensor2)"},
-        std::move(active_block_or_block_groups), interpolating_mesh);
+        std::move(active_block_or_block_groups), interpolating_mesh,
+        std::move(dependency));
   }
 };
 }  // namespace TestHelpers::dg::Events::ObserveFields

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -245,7 +245,7 @@ void test_reduction_observer(const bool observe_per_core) {
       runner.simple_action<obs_component,
                            observers::Actions::ContributeReductionData>(
           get_global_core_id(id),
-          observers::ObservationId{time, "ElementObservationType"},
+          observers::ObservationId{time, "/element_data.vol"},
           Parallel::make_array_component_id<element_comp>(id), "/element_data",
           legend, std::move(reduction_data_fakes), std::move(formatter),
           observe_per_core);

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -129,7 +129,7 @@ void check_observer_registration() {
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
   // Test registration occurred as expected
-  const observers::ObservationKey obs_id_key{"ElementObservationType"};
+  const observers::ObservationKey obs_id_key{"/element_data.vol"};
   std::unordered_map<observers::ObservationKey,
                      std::unordered_set<Parallel::ArrayComponentId>>
       expected_obs_ids{};

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -47,6 +47,7 @@
 #include "Parallel/ArrayComponentId.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/CartesianProduct.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -117,8 +118,8 @@ void check_write_volume_data(
   const std::vector<Spectral::Quadrature> h5_write_volume_expected_quadratures{
       {expected_mesh.quadrature(0), expected_mesh.quadrature(1)}};
 
-  const observers::ObservationId write_vol_observation_id{
-      1., "ElementObservationType"};
+  const observers::ObservationId write_vol_observation_id{1.,
+                                                          "/element_data.vol"};
 
   if (file_system::check_if_file_exists(h5_write_volume_file_name + ".h5"s)) {
     file_system::rm(h5_write_volume_file_name + ".h5"s, true);
@@ -161,6 +162,7 @@ void check_write_volume_data(
 }
 }  // namespace
 
+// [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
   using registration_list = tmpl::list<
       observers::Actions::RegisterWithObservers<
@@ -230,117 +232,198 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
     file_system::rm(h5_file_name, true);
   }
 
-  // Test passing volume data...
-  const observers::ObservationId observation_id{3., "ElementObservationType"};
-  for (const auto& id : element_ids) {
-    const Parallel::ArrayComponentId array_id =
-        Parallel::make_array_component_id<element_comp>(id);
-
-    auto [mesh, fake_volume_data] = make_fake_volume_data(array_id);
-    runner
-        .simple_action<obs_component, observers::Actions::ContributeVolumeData>(
-            0, observation_id, std::string{"/element_data"}, array_id,
-            ElementVolumeData{id, std::move(fake_volume_data), mesh});
-  }
-  // Invoke the simple action 'ContributeVolumeDataToWriter'
-  // to move the volume data to the Writer parallel component.
-  runner.invoke_queued_threaded_action<obs_writer>(0);
-  CHECK(ActionTesting::is_threaded_action_queue_empty<obs_writer>(runner, 0));
-
-  REQUIRE(file_system::check_if_file_exists(h5_file_name));
-  // Check that the H5 file was written correctly.
-  h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
-  const auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
-
-  const auto temporal_id = observation_id.hash();
-  CHECK(volume_file.list_observation_ids() == std::vector<size_t>{temporal_id});
-
-  const auto tensor_names = volume_file.list_tensor_components(temporal_id);
   const std::vector<std::string> expected_tensor_names{"T_x",  "T_y",  "S_xx",
                                                        "S_yy", "S_xy", "S_yx"};
-  CAPTURE(tensor_names);
   CAPTURE(expected_tensor_names);
-  REQUIRE(alg::all_of(tensor_names,
-                      [&expected_tensor_names](const std::string& name) {
-                        return alg::found(expected_tensor_names, name);
-                      }));
-  REQUIRE(alg::all_of(expected_tensor_names,
-                      [&tensor_names](const std::string& name) {
-                        return alg::found(tensor_names, name);
-                      }));
-  const std::vector<std::string> grid_names =
-      volume_file.get_grid_names(temporal_id);
-  // A pair holds an element_id, and it's "place" in the string of grid names
-  std::vector<std::tuple<ElementId<2>, size_t>> pairs;
-  auto start = grid_names.begin();
-  auto end = grid_names.end();
-  for (const auto& element_id : element_ids) {
-    const auto place =
-        std::find(start, end, get_output<ElementId<2>>(element_id));
-    // Check that the grid was actually found
-    REQUIRE(place != end);
-    // Store a tuple of the element_id and its place
-    pairs.emplace_back(element_id, std::distance(start, place));
-  }
-  // Sort element_ids by place, this is necessary because the elements are
-  // written to file in an unpredictable order, so to extract this order,
-  // we look at the string of grid names, as it is written in the same order as
-  // the elements.
-  std::sort(pairs.begin(), pairs.end(),
-            [](const std::tuple<ElementId<2>, size_t>& pair_1,
-               const std::tuple<ElementId<2>, size_t>& pair_2) {
-              return std::get<1>(pair_1) < std::get<1>(pair_2);
-            });
-  std::vector<ElementId<2>> sorted_element_ids;
-  sorted_element_ids.reserve(pairs.size());
-  for (const auto& pair : pairs) {
-    sorted_element_ids.push_back(std::get<0>(pair));
-  }
-  // Read the Tensor Data that was written to the file
-  std::unordered_map<std::string, DataVector> read_tensor_data;
-  for (const auto& tensor_name :
-       volume_file.list_tensor_components(temporal_id)) {
-    read_tensor_data[tensor_name] = std::get<DataVector>(
-        volume_file.get_tensor_component(temporal_id, tensor_name).data);
-  }
-  // Read the extents that were written to file
-  const std::vector<std::vector<size_t>> read_extents =
-      volume_file.get_extents(temporal_id);
-  const auto read_bases = volume_file.get_bases(temporal_id);
-  const auto read_quadratures = volume_file.get_quadratures(temporal_id);
-  // The data is stored contiguously, and each element has a subset of the
-  // data.  We need to keep track of how many points have already been checked
-  // so that we know where to look in the tensor component data for the current
-  // grid's data.
-  size_t points_processed = 0;
-  for (size_t i = 0; i < sorted_element_ids.size(); i++) {
-    const auto& element_id = sorted_element_ids[i];
-    const std::string grid_name = MakeString{} << element_id;
-    const Parallel::ArrayComponentId array_id =
-        Parallel::make_array_component_id<element_comp>(element_id);
-    const auto volume_data_fakes = make_fake_volume_data(array_id);
-    // Each element contains as many data points as the product of its
-    // extents, compute this number
-    const size_t stride =
-        alg::accumulate(std::get<0>(volume_data_fakes).extents().indices(),
-                        static_cast<size_t>(1), std::multiplies<>{});
 
-    // Check that the extents and tensor data were correctly written
-    CHECK(std::vector<size_t>{std::get<0>(volume_data_fakes).extents(0),
-                              std::get<0>(volume_data_fakes).extents(1)} ==
-          read_extents[i]);
-    for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
-      CHECK(std::get<DataVector>(tensor_component.data) ==
-            DataVector(
-                &(read_tensor_data[tensor_component.name][points_processed]),
-                stride));
+  // Test passing volume data. Last three arguments are only used if dependency
+  // has a value
+  const auto test_volume_actions = [&](const std::optional<std::string>&
+                                           dependency = std::nullopt,
+                                       const bool write_volume_data = true,
+                                       const bool
+                                           send_dependency_before_elements =
+                                               true,
+                                       const bool test_error = false) {
+    const observers::ObservationId observation_id{3., "/element_data.vol"};
+
+    CAPTURE(observation_id);
+    CAPTURE(dependency);
+    CAPTURE(write_volume_data);
+    CAPTURE(send_dependency_before_elements);
+
+    if (file_system::check_if_file_exists(h5_file_name)) {
+      file_system::rm(h5_file_name, true);
     }
-    points_processed += stride;
-  }
 
-  if (file_system::check_if_file_exists(h5_file_name)) {
-    file_system::rm(h5_file_name, true);
+    const auto send_dependency = [&]() {
+      ActionTesting::threaded_action<
+          obs_writer, observers::ThreadedActions::ContributeDependency>(
+          make_not_null(&runner), 0, observation_id.value(),
+          test_error ? "BadDependency" : dependency.value(), "element_data",
+          write_volume_data);
+    };
+    if (dependency.has_value() and send_dependency_before_elements) {
+      send_dependency();
+    }
+
+    for (const auto& id : element_ids) {
+      const Parallel::ArrayComponentId array_id =
+          Parallel::make_array_component_id<element_comp>(id);
+
+      auto [mesh, fake_volume_data] = make_fake_volume_data(array_id);
+      ActionTesting::simple_action<obs_component,
+                                   observers::Actions::ContributeVolumeData>(
+          make_not_null(&runner), 0, observation_id,
+          std::string{"/element_data"}, array_id,
+          ElementVolumeData{id, std::move(fake_volume_data), mesh}, dependency);
+    }
+    // Invoke the simple action 'ContributeVolumeDataToWriter'
+    // to move the volume data to the Writer parallel component.
+    if (test_error) {
+      CHECK_THROWS_WITH(
+          ActionTesting::invoke_queued_threaded_action<obs_writer>(
+              make_not_null(&runner), 0),
+          Catch::Matchers::ContainsSubstring(
+              "The dependency that was sent to the ObserverWriter from the "
+              "elements (TestDependency) does not match the dependency "
+              "received from ContributeDependency (BadDependency)"));
+      return;
+    } else {
+      ActionTesting::invoke_queued_threaded_action<obs_writer>(
+          make_not_null(&runner), 0);
+    }
+    CHECK(ActionTesting::is_threaded_action_queue_empty<obs_writer>(runner, 0));
+
+    // If we have a dependency, volume data should still be in the writer if
+    // we are sending the dependency after all the elements
+    if (dependency.has_value()) {
+      const auto& all_volume_data =
+          ActionTesting::get_databox_tag<obs_writer,
+                                         observers::Tags::TensorData>(runner,
+                                                                      0);
+      REQUIRE(all_volume_data.contains(observation_id) !=
+              send_dependency_before_elements);
+
+      // Now we send the dependency if we didn't before
+      if (not send_dependency_before_elements) {
+        send_dependency();
+      }
+
+      // Now we should be guaranteed to have written the volume data (or
+      // deleted it because we aren't writing)
+      REQUIRE_FALSE(all_volume_data.contains(observation_id));
+
+      // Check that we indeed didn't write anything if we weren't supposed
+      // to
+      if (not write_volume_data) {
+        REQUIRE_FALSE(file_system::check_if_file_exists(h5_file_name));
+        return;
+      }
+    }
+
+    REQUIRE(file_system::check_if_file_exists(h5_file_name));
+    // Check that the H5 file was written correctly.
+    const h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+    const auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
+
+    const auto temporal_id = observation_id.hash();
+    CHECK(volume_file.list_observation_ids() ==
+          std::vector<size_t>{temporal_id});
+
+    const auto tensor_names = volume_file.list_tensor_components(temporal_id);
+    CAPTURE(tensor_names);
+    REQUIRE(alg::all_of(tensor_names,
+                        [&expected_tensor_names](const std::string& name) {
+                          return alg::found(expected_tensor_names, name);
+                        }));
+    REQUIRE(alg::all_of(expected_tensor_names,
+                        [&tensor_names](const std::string& name) {
+                          return alg::found(tensor_names, name);
+                        }));
+    const std::vector<std::string> grid_names =
+        volume_file.get_grid_names(temporal_id);
+    // A pair holds an element_id, and it's "place" in the string of grid
+    // names
+    std::vector<std::tuple<ElementId<2>, size_t>> pairs;
+    auto start = grid_names.begin();
+    auto end = grid_names.end();
+    for (const auto& element_id : element_ids) {
+      const auto place =
+          std::find(start, end, get_output<ElementId<2>>(element_id));
+      // Check that the grid was actually found
+      REQUIRE(place != end);
+      // Store a tuple of the element_id and its place
+      pairs.emplace_back(element_id, std::distance(start, place));
+    }
+    // Sort element_ids by place, this is necessary because the elements are
+    // written to file in an unpredictable order, so to extract this order,
+    // we look at the string of grid names, as it is written in the same
+    // order as the elements.
+    std::sort(pairs.begin(), pairs.end(),
+              [](const std::tuple<ElementId<2>, size_t>& pair_1,
+                 const std::tuple<ElementId<2>, size_t>& pair_2) {
+                return std::get<1>(pair_1) < std::get<1>(pair_2);
+              });
+    std::vector<ElementId<2>> sorted_element_ids;
+    sorted_element_ids.reserve(pairs.size());
+    for (const auto& pair : pairs) {
+      sorted_element_ids.push_back(std::get<0>(pair));
+    }
+    // Read the Tensor Data that was written to the file
+    std::unordered_map<std::string, DataVector> read_tensor_data;
+    for (const auto& tensor_name :
+         volume_file.list_tensor_components(temporal_id)) {
+      read_tensor_data[tensor_name] = std::get<DataVector>(
+          volume_file.get_tensor_component(temporal_id, tensor_name).data);
+    }
+    // Read the extents that were written to file
+    const std::vector<std::vector<size_t>> read_extents =
+        volume_file.get_extents(temporal_id);
+    const auto read_bases = volume_file.get_bases(temporal_id);
+    const auto read_quadratures = volume_file.get_quadratures(temporal_id);
+    // The data is stored contiguously, and each element has a subset of the
+    // data.  We need to keep track of how many points have already been
+    // checked so that we know where to look in the tensor component data
+    // for the current grid's data.
+    size_t points_processed = 0;
+    for (size_t i = 0; i < sorted_element_ids.size(); i++) {
+      const auto& element_id = sorted_element_ids[i];
+      const std::string grid_name = MakeString{} << element_id;
+      const Parallel::ArrayComponentId array_id =
+          Parallel::make_array_component_id<element_comp>(element_id);
+      const auto volume_data_fakes = make_fake_volume_data(array_id);
+      // Each element contains as many data points as the product of its
+      // extents, compute this number
+      const size_t stride =
+          alg::accumulate(std::get<0>(volume_data_fakes).extents().indices(),
+                          static_cast<size_t>(1), std::multiplies<>{});
+
+      // Check that the extents and tensor data were correctly written
+      CHECK(std::vector<size_t>{std::get<0>(volume_data_fakes).extents(0),
+                                std::get<0>(volume_data_fakes).extents(1)} ==
+            read_extents[i]);
+      for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
+        CHECK(std::get<DataVector>(tensor_component.data) ==
+              DataVector(
+                  &(read_tensor_data[tensor_component.name][points_processed]),
+                  stride));
+      }
+      points_processed += stride;
+    }
+
+    if (file_system::check_if_file_exists(h5_file_name)) {
+      file_system::rm(h5_file_name, true);
+    }
+  };
+
+  test_volume_actions();
+  for (const auto& [write_volume_data, send_dependency_before_elements] :
+       cartesian_product(std::array{true, false}, std::array{true, false})) {
+    test_volume_actions({"TestDependency"}, write_volume_data,
+                        send_dependency_before_elements);
   }
+  test_volume_actions({"TestDependency"}, true, true, true);
 
   check_write_volume_data<metavariables, obs_writer, element_comp>(
       make_not_null(&runner), element_ids[0], expected_tensor_names);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -37,6 +37,7 @@
 #include "Framework/TestHelpers.hpp"
 #include "IO/Logging/Tags.hpp"
 #include "IO/Logging/Verbosity.hpp"
+#include "IO/Observer/VolumeActions.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
@@ -50,6 +51,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
@@ -132,6 +134,25 @@ struct ExtraHorizonFindFailureCallback {
                     const TemporalId& /*temporal_id*/,
                     const FastFlow::Status failure_reason) {
     callback_failure_status = failure_reason;
+  }
+};
+
+// This should be set before each test happens
+bool expected_write_volume_data = false;  // NOLINT
+struct MockContributeDependency {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
+                    const double /*time*/, const std::string& dependency,
+                    std::string volume_subfile_name,
+                    const bool write_volume_data) {
+    // The time is different throughout the test so we don't check it here
+    CHECK(volume_subfile_name == "FakeVolumeSubfile");
+    CHECK(dependency == "AhA");
+    CHECK(write_volume_data == expected_write_volume_data);
   }
 };
 
@@ -271,8 +292,24 @@ struct mock_interpolator {
   using component_being_mocked = intrp::Interpolator<Metavariables>;
 };
 
+template <typename Metavariables>
+struct mock_observer_writer {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = int;
+
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using replace_these_threaded_actions =
+      tmpl::list<observers::ThreadedActions::ContributeDependency>;
+  using with_these_threaded_actions = tmpl::list<MockContributeDependency>;
+};
+
 template <typename PostHorizonFindCallbacks, typename IsTimeDependent,
-          typename TargetFrame>
+          typename TargetFrame, bool SendDependency>
 struct MockMetavariables {
   static constexpr bool use_time_dependent_maps = IsTimeDependent::value;
   struct AhA : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -287,12 +324,23 @@ struct MockMetavariables {
         intrp::TargetPoints::ApparentHorizon<AhA, TargetFrame>;
     using post_interpolation_callbacks =
         tmpl::list<intrp::callbacks::FindApparentHorizon<AhA, TargetFrame>>;
-    using post_horizon_find_callbacks = PostHorizonFindCallbacks;
+    using post_horizon_find_callbacks = tmpl::append<
+        PostHorizonFindCallbacks,
+        tmpl::conditional_t<
+            SendDependency,
+            tmpl::list<
+                intrp::callbacks::SendDependencyToObserverWriter<true, AhA>>,
+            tmpl::list<>>>;
     // The order of these failure callbacks is important so that we can test the
-    // first is called and the second gives an error
-    using horizon_find_failure_callbacks =
+    // first are called and the last gives an error
+    using horizon_find_failure_callbacks = tmpl::append<
+        tmpl::conditional_t<
+            SendDependency,
+            tmpl::list<
+                intrp::callbacks::SendDependencyToObserverWriter<false, AhA>>,
+            tmpl::list<>>,
         tmpl::list<ExtraHorizonFindFailureCallback,
-                   TestHorizonFindFailureCallback>;
+                   TestHorizonFindFailureCallback>>;
   };
   using interpolator_source_vars =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
@@ -301,24 +349,27 @@ struct MockMetavariables {
   static constexpr size_t volume_dim = 3;
   using component_list =
       tmpl::list<mock_interpolation_target<MockMetavariables, AhA>,
-                 mock_interpolator<MockMetavariables>>;
+                 mock_interpolator<MockMetavariables>,
+                 mock_observer_writer<MockMetavariables>>;
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
 };
 
 template <typename PostHorizonFindCallbacks, typename IsTimeDependent,
           typename Frame = ::Frame::Inertial, bool UseShapeMap = false,
+          bool SendDependency = false,
           bool MakeHorizonFinderFailOnPurpose = false>
-void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
-                           const size_t l_max,
-                           const size_t grid_points_each_dimension,
-                           const double mass,
-                           const std::array<double, 3>& dimensionless_spin,
-                           const size_t max_its = 100_st) {
-  using metavars =
-      MockMetavariables<PostHorizonFindCallbacks, IsTimeDependent, Frame>;
+void test_apparent_horizon(
+    const gsl::not_null<size_t*> test_horizon_called, const size_t l_max,
+    const size_t grid_points_each_dimension, const double mass,
+    const std::array<double, 3>& dimensionless_spin,
+    const std::optional<std::string>& dependency = std::nullopt,
+    const size_t max_its = 100_st) {
+  using metavars = MockMetavariables<PostHorizonFindCallbacks, IsTimeDependent,
+                                     Frame, SendDependency>;
   using interp_component = mock_interpolator<metavars>;
   using target_component =
       mock_interpolation_target<metavars, typename metavars::AhA>;
+  using obs_writer_component = mock_observer_writer<metavars>;
 
   // Assert that the FindApparentHorizon callback conforms to the protocol
   static_assert(
@@ -409,6 +460,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
+  ActionTesting::emplace_nodegroup_component<obs_writer_component>(&runner);
   ActionTesting::emplace_group_component<interp_component>(&runner);
   for (size_t i = 0; i < 2; ++i) {
     for (int indx = 0; indx < 5; ++indx) {
@@ -470,7 +522,7 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
     ActionTesting::simple_action<
         target_component, intrp::Actions::AddTemporalIdsToInterpolationTarget<
                               typename metavars::AhA>>(
-        make_not_null(&runner), 0, temporal_id, std::nullopt);
+        make_not_null(&runner), 0, temporal_id, dependency);
   }
 
   // Center of the analytic solution.
@@ -774,6 +826,24 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
   // Make sure function was called three times per
   // post_horizon_find_callback.
   CHECK(*test_horizon_called == 3 * tmpl::size<PostHorizonFindCallbacks>{});
+
+  if constexpr (SendDependency) {
+    // Three actions if the horizon find succeeds, only one if it fails
+    const size_t expected_number_of_actions =
+        MakeHorizonFinderFailOnPurpose ? 1 : 3;
+    // Two nodes
+    for (int node = 0; node < 2; node++) {
+      CHECK(ActionTesting::number_of_queued_threaded_actions<
+                obs_writer_component>(runner, node) ==
+            expected_number_of_actions);
+      for (size_t i = 0; i < expected_number_of_actions; i++) {
+        // Set before we check it
+        expected_write_volume_data = not MakeHorizonFinderFailOnPurpose;
+        ActionTesting::invoke_queued_threaded_action<obs_writer_component>(
+            make_not_null(&runner), node);
+      }
+    }
+  }
 }
 
 // This tests the entire AH finder including numerical interpolation.
@@ -831,19 +901,22 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
 
   // Time-dependent tests in distorted frame using both translation and shape
   // maps.
+  const std::optional<std::string> dependency{"FakeVolumeSubfile"};
   tmpl::for_each<tmpl::list<std::true_type, std::false_type>>(
-      [](auto use_shape_map) {
+      [&](auto use_shape_map) {
         constexpr bool UseShapeMap =
             tmpl::type_from<std::decay_t<decltype(use_shape_map)>>::value;
         test_schwarzschild_horizon_called = 0;
         test_kerr_horizon_called = 0;
         test_apparent_horizon<
             tmpl::list<TestSchwarzschildHorizon<Frame::Distorted>>,
-            std::true_type, Frame::Distorted, UseShapeMap>(
-            &test_schwarzschild_horizon_called, 3, 6, 1.0, {{0.0, 0.0, 0.0}});
+            std::true_type, Frame::Distorted, UseShapeMap, true>(
+            &test_schwarzschild_horizon_called, 3, 6, 1.0, {{0.0, 0.0, 0.0}},
+            dependency);
         test_apparent_horizon<tmpl::list<TestKerrHorizon<Frame::Distorted>>,
-                              std::true_type, Frame::Distorted, UseShapeMap>(
-            &test_kerr_horizon_called, 3, 7, 1.1, {{0.12, 0.23, 0.45}});
+                              std::true_type, Frame::Distorted, UseShapeMap,
+                              true>(&test_kerr_horizon_called, 3, 7, 1.1,
+                                    {{0.12, 0.23, 0.45}}, dependency);
       });
 
   test_schwarzschild_horizon_called = 0;
@@ -851,8 +924,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
   CHECK_THROWS_WITH(
       (test_apparent_horizon<
           tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
-          Frame::Inertial, false, true>(&test_schwarzschild_horizon_called, 3,
-                                        4, 1.0, {{0.0, 0.0, 0.0}})),
+          Frame::Inertial, false, false, true>(
+          &test_schwarzschild_horizon_called, 3, 4, 1.0, {{0.0, 0.0, 0.0}})),
       Catch::Matchers::ContainsSubstring("Cannot interpolate onto surface"));
   CHECK(callback_failure_status == FastFlow::Status::InterpolationFailure);
 
@@ -860,20 +933,21 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
   callback_failure_status = FastFlow::Status::MaxIts;
   CHECK_THROWS_WITH(
       (test_apparent_horizon<
-          tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
-          Frame::Inertial, false, true>(&test_schwarzschild_horizon_called, 3,
-                                        4, 10.0, {{0.0, 0.0, 0.0}})),
+           tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>,
+           std::true_type, Frame::Inertial, false, true, true>(
+           &test_schwarzschild_horizon_called, 3, 4, 10.0, {{0.0, 0.0, 0.0}}),
+       dependency),
       Catch::Matchers::ContainsSubstring("Cannot interpolate onto surface"));
   CHECK(callback_failure_status == FastFlow::Status::InterpolationFailure);
 
   test_schwarzschild_horizon_called = 0;
   callback_failure_status = FastFlow::Status::MaxIts;
-  CHECK_THROWS_WITH(
-      (test_apparent_horizon<
-          tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>, std::true_type,
-          Frame::Inertial, false, false>(&test_schwarzschild_horizon_called, 3,
-                                         4, 1.0, {{0.0, 0.0, 0.0}}, 1)),
-      Catch::Matchers::ContainsSubstring("Too many iterations"));
+  CHECK_THROWS_WITH((test_apparent_horizon<
+                        tmpl::list<TestSchwarzschildHorizon<Frame::Inertial>>,
+                        std::true_type, Frame::Inertial, false, false>(
+                        &test_schwarzschild_horizon_called, 3, 4, 1.0,
+                        {{0.0, 0.0, 0.0}}, std::nullopt, 1)),
+                    Catch::Matchers::ContainsSubstring("Too many iterations"));
   CHECK(callback_failure_status == FastFlow::Status::MaxIts);
 }
 }  // namespace

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/FloatingPointType.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Creators/Rectilinear.hpp"
@@ -27,6 +28,7 @@
 #include "IO/Logging/Verbosity.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -55,7 +57,7 @@
 namespace {
 // Mock actions only exist so we don't need all other action down the line. In
 // this test we'll only check that actions are queued since each individual
-// event is tested elsewhere
+// event is tested elsewhere, but we do check the dependencies
 struct MockContributeVolumeData {
   template <typename ParallelComponent, typename... DbTags,
             typename Metavariables, typename ArrayIndex>
@@ -67,7 +69,9 @@ struct MockContributeVolumeData {
       const std::string& /*subfile_name*/,
       const Parallel::ArrayComponentId& /*array_component_id*/,
       ElementVolumeData&& /*received_volume_data*/,
-      const std::optional<std::string>& /*dependency*/ = std::nullopt) {}
+      const std::optional<std::string>& dependency = std::nullopt) {
+    CHECK(dependency == std::optional{"InterpolationTargetA"});
+  }
 };
 
 struct MockInterpolatorReceiveVolumeData {
@@ -92,7 +96,9 @@ struct MockAddTemporalIdsToInterpolationTarget {
                     const ArrayIndex& /*array_index*/,
                     const LinkedMessageId<double>&
                     /*temporal_id*/,
-                    std::optional<std::string> /*dependency*/) {}  // NOLINT
+                    std::optional<std::string> dependency) {  // NOLINT
+    CHECK(dependency == std::optional{"SubfileName"});
+  }
 };
 
 template <typename Metavariables>
@@ -255,20 +261,30 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindCommonHorizon",
   const ::Event::ObservationValue observation_value{"FindCommonHorizon",
                                                     observation_time};
 
+  // Actual coords don't matter
+  const auto logical_coords = logical_coordinates(mesh);
   auto box = db::create<db::AddSimpleTags<
       Parallel::Tags::MetavariablesImpl<metavars>,
       Parallel::Tags::GlobalCacheImpl<metavars>,
       metavars::InterpolationTargetA::temporal_id, ::Tags::Time,
       ::Events::Tags::ObserverMesh<metavars::volume_dim>,
+      ::domain::Tags::Coordinates<3, ::Frame::Inertial>,
       ::Tags::Variables<typename decltype(vars)::tags_list>>>(
-      metavars{}, &cache, temporal_id, observation_time, mesh, vars);
+      metavars{}, &cache, temporal_id, observation_time, mesh,
+      tnsr::I<DataVector, 3, ::Frame::Inertial>{
+          std::array{logical_coords[0], logical_coords[1], logical_coords[2]}},
+      vars);
 
   using FindCommonHorizon = ah::Events::FindCommonHorizon<
       metavars::volume_dim, typename metavars::InterpolationTargetA,
       typename metavars::interpolator_source_vars,
-      typename metavars::interpolator_source_vars>;
+      tmpl::push_back<typename metavars::interpolator_source_vars,
+                      ::domain::Tags::Coordinates<3, ::Frame::Inertial>>>;
 
-  const FindCommonHorizon find_common_horizon{};
+  const FindCommonHorizon find_common_horizon{"SubfileName",
+                                              FloatingPointType::Double,
+                                              {FloatingPointType::Double},
+                                              {"Pi"}};
 
   CHECK(find_common_horizon.needs_evolved_variables());
   CHECK(find_common_horizon.is_ready(cache, 0,

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindCommonHorizon.cpp
@@ -59,13 +59,15 @@ namespace {
 struct MockContributeVolumeData {
   template <typename ParallelComponent, typename... DbTags,
             typename Metavariables, typename ArrayIndex>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
-                    Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const observers::ObservationId& /*observation_id*/,
-                    const std::string& /*subfile_name*/,
-                    const Parallel::ArrayComponentId& /*array_component_id*/,
-                    ElementVolumeData&& /*received_volume_data*/) {}
+  static void apply(
+      db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const observers::ObservationId& /*observation_id*/,
+      const std::string& /*subfile_name*/,
+      const Parallel::ArrayComponentId& /*array_component_id*/,
+      ElementVolumeData&& /*received_volume_data*/,
+      const std::optional<std::string>& /*dependency*/ = std::nullopt) {}
 };
 
 struct MockInterpolatorReceiveVolumeData {

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -99,7 +99,8 @@ void test_observe(
     const std::unique_ptr<ObserveEvent> observe,
     const std::optional<Mesh<System::volume_dim>>& interpolating_mesh,
     const bool has_analytic_solutions, const bool test_specific_blocks,
-    const std::optional<std::string>& section = std::nullopt) {
+    const std::optional<std::string>& section = std::nullopt,
+    const std::optional<std::string>& dependency = std::nullopt) {
   INFO(test_specific_blocks);
   using metavariables = Metavariables<System, false>;
   constexpr size_t volume_dim = System::volume_dim;
@@ -224,6 +225,7 @@ void test_observe(
   CHECK(results.observation_id.observation_key() ==
         expected_observation_key_for_reg);
   CHECK(results.subfile_name == expected_subfile_name);
+  CHECK(results.dependency == dependency);
   CHECK(results.array_component_id ==
         Parallel::make_array_component_id<element_component>(array_index));
   CHECK(results.received_volume_data.extents.size() == volume_dim);
@@ -326,20 +328,23 @@ void test_system(
     const std::string& mesh_creation_string,
     const std::optional<Mesh<System::volume_dim>>& interpolating_mesh = {},
     const bool has_analytic_solutions = true,
-    const std::optional<std::string>& section = std::nullopt) {
+    const std::optional<std::string>& section = std::nullopt,
+    const std::optional<std::string>& dependency = std::nullopt) {
   INFO(pretty_type::get_name<System>());
   CAPTURE(has_analytic_solutions);
   CAPTURE(mesh_creation_string);
   using ArraySectionIdTag = typename System::array_section_id;
   INFO(pretty_type::get_name<ArraySectionIdTag>());
   CAPTURE(section);
+  CAPTURE(dependency);
   using metavariables = Metavariables<System, false>;
   for (const bool test_specific_blocks : {false, true}) {
     test_observe<System, ArraySectionIdTag>(
         std::make_unique<typename System::ObserveEvent>(
-            System::make_test_object(interpolating_mesh)),
+            System::make_test_object(interpolating_mesh, std::nullopt,
+                                     dependency)),
         interpolating_mesh, has_analytic_solutions, test_specific_blocks,
-        section);
+        section, dependency);
     INFO("create/serialize");
     register_factory_classes_with_charm<metavariables>();
     {
@@ -349,9 +354,10 @@ void test_system(
           TestHelpers::test_creation<std::unique_ptr<Event>, metavariables>(
               creation_string);
       auto serialized_event = serialize_and_deserialize(factory_event);
+      // No dependency from factory creation
       test_observe<System, ArraySectionIdTag>(
           std::move(serialized_event), interpolating_mesh,
-          has_analytic_solutions, test_specific_blocks, section);
+          has_analytic_solutions, test_specific_blocks, section, std::nullopt);
     }
   }
 }
@@ -360,7 +366,7 @@ void test_system(
 SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
   {
     INFO("No Interpolation");
-    const std::string interpolating_mesh_str = "  InterpolateToMesh: None";
+    const std::string interpolating_mesh_str = "  InterpolateToMesh: None\n";
     using system_no_section = ScalarSystem<dg::Events::ObserveFields, void>;
     using system_with_section =
         ScalarSystem<dg::Events::ObserveFields, TestSectionIdTag>;
@@ -375,7 +381,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
         (system_no_section, system_with_section,
          ComplicatedSystem<dg::Events::ObserveFields>));
     INVOKE_TEST_FUNCTION(test_system,
-                         (interpolating_mesh_str, std::nullopt, false),
+                         (interpolating_mesh_str, std::nullopt, false,
+                          std::nullopt, "TestDependency"),
                          (ScalarSystem<dg::Events::ObserveFields>,
                           ComplicatedSystem<dg::Events::ObserveFields>));
   }


### PR DESCRIPTION
## Proposed changes

This is the third of 3 PRs that avoid writing volume data for a common horizon find that fails.

Adds optional dependencies to the ObserverWriter so that it is aware it needs to wait for an external message, then edits ObserveFields to send this optional dependency (not available through options so no current input files are affected). Then, finally adds a callback to the common horizon finder that will couple AhC to the ObserverWriter. The very last commit is the one that actually causes the logic to behave differently than before.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

~Depends on and includes #6622 and #6623~

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
