### PR TITLE
Add interpolator for nonconforming boundary data

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   LiftFromBoundary.cpp
   MetricIdentityJacobian.cpp
   MortarHelpers.cpp
+  MortarInterpolator.cpp
   )
 
 spectre_target_headers(
@@ -28,6 +29,7 @@ spectre_target_headers(
   LiftFromBoundary.hpp
   MetricIdentityJacobian.hpp
   MortarHelpers.hpp
+  MortarInterpolator.hpp
   NormalDotFlux.hpp
   ProjectToBoundary.hpp
   SimpleBoundaryData.hpp
@@ -40,11 +42,14 @@ target_link_libraries(
   PUBLIC
   Boost::boost
   DataStructures
+  Domain
   DomainStructure
   ErrorHandling
+  Interpolation
   Options
   Serialization
   Spectral
+  SphericalHarmonicsHelpers
   Utilities
   INTERFACE
   Domain

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarInterpolator.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarInterpolator.cpp
@@ -1,0 +1,242 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarInterpolator.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InterfaceLogicalCoordinates.hpp"
+#include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+tnsr::I<DataVector, Dim - 1, Frame::ElementLogical>
+compute_neighbor_target_points(
+    const tnsr::I<DataVector, Dim, Frame::Grid>& host_grid_coordinates,
+    const ElementMap<Dim, Frame::Grid>& element_map,
+    const size_t boundary_dimension) {
+  tnsr::I<DataVector, Dim - 1, Frame::ElementLogical> result{
+      get<0>(host_grid_coordinates).size()};
+  tnsr::I<double, Dim, Frame::Grid> x{};
+  for (size_t s = 0; s < get<0>(host_grid_coordinates).size(); ++s) {
+    for (size_t d = 0; d < Dim; ++d) {
+      x.get(d) = host_grid_coordinates.get(d)[s];
+    }
+    const auto xi = element_map.inverse(x);
+    for (size_t d = 0; d < boundary_dimension; ++d) {
+      result.get(d)[s] = xi.get(d);
+    }
+    for (size_t d = boundary_dimension; d < Dim - 1; ++d) {
+      result.get(d)[s] = xi.get(d + 1);
+    }
+  }
+  return result;
+}
+}  // namespace
+
+namespace evolution::dg {
+template <size_t Dim>
+MortarInterpolator<Dim>::MortarInterpolator(
+    const ElementId<Dim>& host_id, const DirectionalId<Dim>& neighbor_id,
+    const Domain<Dim>& domain, const Mesh<Dim - 1>& host_mortar_mesh,
+    const Mesh<Dim - 1>& neighbor_mortar_mesh)
+    : host_id_(host_id), neighbor_id_(neighbor_id) {
+  reset_if_necessary(domain, host_mortar_mesh, neighbor_mortar_mesh);
+}
+
+template <size_t Dim>
+void MortarInterpolator<Dim>::interpolate_to_host(
+    const gsl::not_null<DataVector*> result,
+    const DataVector& neighbor_data) const {
+  const size_t number_of_components =
+      neighbor_data.size() / neighbor_mortar_mesh_.number_of_grid_points();
+  ASSERT(result->size() ==
+             host_mortar_mesh_.number_of_grid_points() * number_of_components,
+         "Expected result to have size "
+             << host_mortar_mesh_.number_of_grid_points() * number_of_components
+             << ", not " << result->size());
+  gsl::span<double> result_span{result->data(), result->size()};
+  neighbor_to_host_interpolant_.interpolate(
+      make_not_null(&result_span),
+      gsl::make_span(neighbor_data.data(), neighbor_data.size()));
+}
+
+template <size_t Dim>
+DataVector MortarInterpolator<Dim>::interpolate_to_host(
+    const DataVector& neighbor_data) const {
+  const size_t number_of_components =
+      neighbor_data.size() / neighbor_mortar_mesh_.number_of_grid_points();
+  DataVector result{host_mortar_mesh_.number_of_grid_points() *
+                    number_of_components};
+  interpolate_to_host(make_not_null(&result), neighbor_data);
+  return result;
+}
+
+template <size_t Dim>
+void MortarInterpolator<Dim>::interpolate_to_neighbor(
+    const gsl::not_null<DataVector*> result,
+    const DataVector& host_data) const {
+  const size_t number_of_components =
+      host_data.size() / host_mortar_mesh_.number_of_grid_points();
+  ASSERT(
+      result->size() ==
+          interpolated_neighbor_data_offsets_.size() * number_of_components,
+      "Expected result to have size "
+          << interpolated_neighbor_data_offsets_.size() * number_of_components
+          << ", not " << result->size());
+  gsl::span<double> result_span{result->data(), result->size()};
+  host_to_neighbor_interpolant_.interpolate(
+      make_not_null(&result_span),
+      gsl::make_span(host_data.data(), host_data.size()));
+}
+
+template <size_t Dim>
+DataVector MortarInterpolator<Dim>::interpolate_to_neighbor(
+    const DataVector& host_data) const {
+  const size_t number_of_components =
+      host_data.size() / host_mortar_mesh_.number_of_grid_points();
+  DataVector result{interpolated_neighbor_data_offsets_.size() *
+                    number_of_components};
+  interpolate_to_neighbor(make_not_null(&result), host_data);
+  return result;
+}
+
+template <size_t Dim>
+void MortarInterpolator<Dim>::reset_if_necessary(
+    const Domain<Dim>& domain, const Mesh<Dim - 1>& host_mortar_mesh,
+    const Mesh<Dim - 1>& neighbor_mortar_mesh) {
+  if (host_mortar_mesh == host_mortar_mesh_ and
+      neighbor_mortar_mesh == neighbor_mortar_mesh_) {
+    return;
+  }
+  host_mortar_mesh_ = host_mortar_mesh;
+  neighbor_mortar_mesh_ = neighbor_mortar_mesh;
+  const Block<Dim>& host_block = domain.blocks()[host_id_.block_id()];
+  const Block<Dim>& neighbor_block =
+      domain.blocks()[neighbor_id_.id().block_id()];
+  const ElementMap<Dim, Frame::Grid> host_element_logical_to_grid_map{
+      host_id_, host_block};
+  const ElementMap<Dim, Frame::Grid> neighbor_element_logical_to_grid_map{
+      neighbor_id_.id(), neighbor_block};
+  const auto& orientation = host_block.neighbors()
+                                .at(neighbor_id_.direction())
+                                .orientations()
+                                .at(neighbor_block.id());
+
+  // Setup interpolator from neighbor (e.g. S2 shell) to host (e.g. cube face)
+  // The target points are the points of the host mortar mesh
+  // Do not need to worry about which block as there is a single neighbor
+  // and it must contain the target points
+  {
+    const auto host_element_logical_coords = interface_logical_coordinates(
+        host_mortar_mesh_, neighbor_id_.direction());
+    const auto host_grid_coords =
+        host_element_logical_to_grid_map(host_element_logical_coords);
+    const auto target_points_in_neighbor = compute_neighbor_target_points(
+        host_grid_coords, neighbor_element_logical_to_grid_map,
+        orientation(neighbor_id_.direction().dimension()));
+    neighbor_to_host_interpolant_ = intrp::Irregular<Dim - 1>{
+        neighbor_mortar_mesh_, target_points_in_neighbor};
+  }
+
+  // Setup interpolator from host (e.g. cube face) to neighbor (e.g. S2 shell)
+  // The target points are those of the neighbor mortar mesh that the host
+  // contains.
+  const auto neighbor_element_logical_coords = interface_logical_coordinates(
+      neighbor_mortar_mesh_, orientation(neighbor_id_.direction().opposite()));
+  const auto neighbor_grid_coords =
+      neighbor_element_logical_to_grid_map(neighbor_element_logical_coords);
+  const size_t npts_neighbor = neighbor_mortar_mesh_.number_of_grid_points();
+  interpolated_neighbor_data_offsets_.clear();
+  interpolated_neighbor_data_offsets_.reserve(npts_neighbor);
+  std::vector<tnsr::I<double, Dim, Frame::ElementLogical>>
+      host_element_logical_coords{};
+  host_element_logical_coords.reserve(npts_neighbor);
+  tnsr::I<double, Dim, Frame::Grid> x{};
+  for (size_t s = 0; s < npts_neighbor; ++s) {
+    for (size_t d = 0; d < Dim; ++d) {
+      x.get(d) = neighbor_grid_coords.get(d)[s];
+    }
+    const auto block_xi = block_logical_coordinates_single_point(x, host_block);
+    if (block_xi.has_value()) {
+      const auto xi = element_logical_coordinates(block_xi.value(), host_id_);
+      if (xi.has_value()) {
+        interpolated_neighbor_data_offsets_.emplace_back(s);
+        host_element_logical_coords.emplace_back(xi.value());
+      }
+    }
+  }
+  const size_t npts_neighbor_in_host =
+      interpolated_neighbor_data_offsets_.size();
+  tnsr::I<DataVector, Dim - 1, Frame::ElementLogical> target_points_in_host{
+      npts_neighbor_in_host};
+  const size_t boundary_dimension = neighbor_id_.direction().dimension();
+  for (size_t s = 0; s < npts_neighbor_in_host; ++s) {
+    for (size_t d = 0; d < boundary_dimension; ++d) {
+      target_points_in_host.get(d)[s] = host_element_logical_coords[s].get(d);
+    }
+    for (size_t d = boundary_dimension; d < Dim - 1; ++d) {
+      target_points_in_host.get(d)[s] =
+          host_element_logical_coords[s].get(d + 1);
+    }
+  }
+  host_to_neighbor_interpolant_ =
+      intrp::Irregular<Dim - 1>{host_mortar_mesh_, target_points_in_host};
+}
+
+template <size_t Dim>
+void MortarInterpolator<Dim>::pup(PUP::er& p) {
+  p | host_id_;
+  p | neighbor_id_;
+  p | host_mortar_mesh_;
+  p | neighbor_mortar_mesh_;
+  p | neighbor_to_host_interpolant_;
+  p | host_to_neighbor_interpolant_;
+  p | interpolated_neighbor_data_offsets_;
+}
+
+template <size_t Dim>
+bool operator==(const MortarInterpolator<Dim>& lhs,
+                const MortarInterpolator<Dim>& rhs) {
+  return lhs.host_id_ == rhs.host_id_ and
+         lhs.neighbor_id_ == rhs.neighbor_id_ and
+         lhs.host_mortar_mesh_ == rhs.host_mortar_mesh_ and
+         lhs.neighbor_mortar_mesh_ == rhs.neighbor_mortar_mesh_ and
+         lhs.neighbor_to_host_interpolant_ ==
+             rhs.neighbor_to_host_interpolant_ and
+         lhs.host_to_neighbor_interpolant_ ==
+             rhs.host_to_neighbor_interpolant_ and
+         lhs.interpolated_neighbor_data_offsets_ ==
+             rhs.interpolated_neighbor_data_offsets_;
+}
+
+template <size_t Dim>
+bool operator!=(const MortarInterpolator<Dim>& lhs,
+                const MortarInterpolator<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template class MortarInterpolator<2>;
+template class MortarInterpolator<3>;
+template bool operator==(const MortarInterpolator<2>&,
+                         const MortarInterpolator<2>&);
+template bool operator==(const MortarInterpolator<3>&,
+                         const MortarInterpolator<3>&);
+template bool operator!=(const MortarInterpolator<2>&,
+                         const MortarInterpolator<2>&);
+template bool operator!=(const MortarInterpolator<3>&,
+                         const MortarInterpolator<3>&);
+}  // namespace evolution::dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarInterpolator.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarInterpolator.hpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+/// \cond
+template <size_t Dim>
+class Domain;
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace evolution::dg {
+/// \brief Interpolator to be used for interpolating boundary data from (to) a
+/// Neighbor onto a mortar between nonconforming Blocks.
+///
+/// \details This interpolator is designed to be used when multiple
+/// nonconforming elements are neighbors with a single element (e.g deformed
+/// cubes of a cubed sphere next to a single S2 spherical shell). Each of the
+/// multiple elements (the hosts) should create this class to both interpolate
+/// neighbor boundary data to the mortar of the host as well as interpolate the
+/// host boundary data onto the subset of points of the mortar of the neighbor.
+///
+/// \note For nonconforming neighbors, the block logical coordinates of
+/// neighboring elements are not related by a discrete rotation (i.e. an
+/// OrientationMap). Therefore boundary data cannot be copied or projected to a
+/// neighbor, but must be interpolated.  As nonconforming neighbors cannot exist
+/// in one dimension, this class is not instantiated for Dim = 1.
+template <size_t Dim>
+class MortarInterpolator {
+ public:
+  /// The Element with host_id is one of the multiple nonconforming Elements
+  /// abutting the single Element with neighbor_id.  The host_mortar_mesh and
+  /// neighbor_mortar_mesh are simply the appropriate face Mesh of the host and
+  /// neighbor.
+  MortarInterpolator(const ElementId<Dim>& host_id,
+                     const DirectionalId<Dim>& neighbor_id,
+                     const Domain<Dim>& domain,
+                     const Mesh<Dim - 1>& host_mortar_mesh,
+                     const Mesh<Dim - 1>& neighbor_mortar_mesh);
+
+  MortarInterpolator() = default;
+
+  /// @{
+  /// \brief Interpolates the boundary data of the neighbor to the host mortar
+  ///
+  /// \details neighbor_data is a type-erased Variables so will have a size
+  /// equal to the product of the number of components and the number of grid
+  /// points of the neighbor_mortar_mesh.  The returned DataVector will have a
+  /// size equal to the number of components and the number of grid points of
+  /// the host_mortar_mesh.
+  void interpolate_to_host(gsl::not_null<DataVector*> result,
+                           const DataVector& neighbor_data) const;
+  DataVector interpolate_to_host(const DataVector& neighbor_data) const;
+  /// @}
+
+  /// @{
+  /// \brief Interpolates the boundary data of the host to a subset of the
+  /// points of the neighbor mortar
+  ///
+  /// \details host_data is a type-erased Variables so will have a size
+  /// equal to the product of the number of components and the number of grid
+  /// points of the host_mortar_mesh.  The returned DataVector will have a
+  /// size equal to the number of components and the number of grid points of
+  /// the neighbor_mortar_mesh that the host is able to interpolate to.
+  void interpolate_to_neighbor(gsl::not_null<DataVector*> result,
+                               const DataVector& host_data) const;
+  DataVector interpolate_to_neighbor(const DataVector& host_data) const;
+  /// @}
+
+  /// \brief The offsets of the data returned by interpolate_to_neighbor into
+  /// the full data on the neighbor_mortar_mesh.
+  ///
+  /// \details  The DataVectors of type-erased Variables store data such that
+  /// the grid point index varies fastest (as opposed to the component index).
+  /// The size of the returned vector is equal to the number of grid points of
+  /// the neighbor_mortar_mesh that the host is able to interpolate to, and the
+  /// values of the returned vector map the grid point index of the partial
+  /// DataVector returned by interpolate_to_neighbor to the grid point index of
+  /// the full DataVector on the neighbor_mortar_mesh
+  const std::vector<size_t>& interpolated_neighbor_data_offsets() const {
+    return interpolated_neighbor_data_offsets_;
+  }
+
+  /// \brief Updates the interpolator if either of the mortar Mesh change
+  void reset_if_necessary(const Domain<Dim>& domain,
+                          const Mesh<Dim - 1>& host_mortar_mesh,
+                          const Mesh<Dim - 1>& neighbor_mortar_mesh);
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+ private:
+  template <size_t LocalDim>
+  friend bool operator==(const MortarInterpolator<LocalDim>& lhs,
+                         const MortarInterpolator<LocalDim>& rhs);
+
+  ElementId<Dim> host_id_{};
+  DirectionalId<Dim> neighbor_id_{};
+  Mesh<Dim - 1> host_mortar_mesh_{};
+  Mesh<Dim - 1> neighbor_mortar_mesh_{};
+  intrp::Irregular<Dim - 1> neighbor_to_host_interpolant_{};
+  intrp::Irregular<Dim - 1> host_to_neighbor_interpolant_{};
+  std::vector<size_t> interpolated_neighbor_data_offsets_{};
+};
+
+template <size_t Dim>
+bool operator==(const MortarInterpolator<Dim>& lhs,
+                const MortarInterpolator<Dim>& rhs);
+}  // namespace evolution::dg

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_LiftFromBoundary.cpp
   Test_MetricIdentityJacobian.cpp
   Test_MortarHelpers.cpp
+  Test_MortarInterpolator.cpp
   Test_NormalDotFlux.cpp
   Test_ProjectToBoundary.cpp
   Test_SimpleBoundaryData.cpp

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
@@ -1,0 +1,230 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/SphericalToCartesianPfaffian.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InterfaceLogicalCoordinates.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/Topology.hpp"
+#include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarInterpolator.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+Domain<3> create_non_conforming_spherical_shells(const double inner_radius,
+                                                 const double interface_radius,
+                                                 const double outer_radius) {
+  std::vector<Block<3>> blocks;
+  blocks.reserve(7);
+  const std::vector<std::array<size_t, 8>> corners_of_wedges =
+      corners_for_radially_layered_domains(1, false);
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> neighbors_of_wedges{};
+  set_internal_boundaries<3>(make_not_null(&neighbors_of_wedges),
+                             corners_of_wedges);
+  const OrientationMap<3> shell_to_wedge{
+      {{Direction<3>::upper_zeta(), Direction<3>::self(),
+        Direction<3>::self()}}};
+  DirectionMap<3, BlockNeighbors<3>> neighbors_of_shell{};
+  neighbors_of_shell.emplace(std::pair{Direction<3>::lower_xi(),
+                                       BlockNeighbors<3>{{0, 1, 2, 3, 4, 5},
+                                                         {{0, shell_to_wedge},
+                                                          {1, shell_to_wedge},
+                                                          {2, shell_to_wedge},
+                                                          {3, shell_to_wedge},
+                                                          {4, shell_to_wedge},
+                                                          {5, shell_to_wedge}},
+                                                         false}});
+  for (size_t i = 0; i < 6; ++i) {
+    neighbors_of_wedges[i].emplace(std::pair{
+        Direction<3>::upper_zeta(),
+        BlockNeighbors<3>{{6}, {{6, shell_to_wedge.inverse_map()}}, false}});
+  }
+
+  auto wedge_coord_maps = domain::make_vector_coordinate_map_base<
+      Frame::BlockLogical, Frame::Inertial, 3>(sph_wedge_coordinate_maps(
+      inner_radius, interface_radius, 1.0, 1.0, true));
+  auto sphere_map = domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                     Frame::Inertial>(
+      domain::CoordinateMaps::ProductOf2Maps<
+          domain::CoordinateMaps::Affine, domain::CoordinateMaps::Identity<2>>{
+          domain::CoordinateMaps::Affine{-1.0, 1.0, interface_radius,
+                                         outer_radius},
+          domain::CoordinateMaps::Identity<2>{}},
+      domain::CoordinateMaps::SphericalToCartesianPfaffian{});
+  for (size_t i = 0; i < 6; ++i) {
+    blocks.emplace_back(
+        std::move(wedge_coord_maps[i]), i, std::move(neighbors_of_wedges[i]),
+        "Wedge" + std::to_string(i), domain::topologies::hypercube<3>);
+  }
+  blocks.emplace_back(std::move(sphere_map), 6_st,
+                      std::move(neighbors_of_shell), "Shell",
+                      domain::topologies::spherical_shell);
+  return Domain(std::move(blocks));
+}
+
+DataVector vars_shell(const Mesh<2>& shell_mortar_mesh) {
+  const YlmTestFunctions::ProductOfPolynomials f1(1, 2, 3);
+  const YlmTestFunctions::ProductOfPolynomials f2(3, 1, 2);
+  const auto shell_theta_phi = logical_coordinates(shell_mortar_mesh);
+  const DataVector f1_shell = f1(shell_theta_phi);
+  const DataVector f2_shell = f2(shell_theta_phi);
+  const size_t npts = shell_mortar_mesh.number_of_grid_points();
+  DataVector result{2 * npts};
+  std::copy(f1_shell.begin(), f1_shell.end(), result.begin());
+  std::copy(f2_shell.begin(), f2_shell.end(),
+            result.begin() + static_cast<ptrdiff_t>(npts));
+  return result;
+}
+
+DataVector vars_cubed_sphere(
+    const Domain<3>& domain, const ElementId<3>& neighbor_id,
+    const std::vector<std::array<size_t, 3>>& refinement_levels,
+    const Mesh<2>& cubed_sphere_mortar_mesh) {
+  const Element<3> cubed_sphere =
+      domain::Initialization::create_initial_element(
+          neighbor_id, domain.blocks(), refinement_levels);
+  const auto xi = interface_logical_coordinates(cubed_sphere_mortar_mesh,
+                                                Direction<3>::upper_zeta());
+  const ElementMap<3, Frame::Inertial> cubed_sphere_map{
+      neighbor_id, domain.blocks()[neighbor_id.block_id()]};
+  const auto x_inertial = cubed_sphere_map(xi);
+  const auto& x = get<0>(x_inertial);
+  const auto& y = get<1>(x_inertial);
+  const auto& z = get<2>(x_inertial);
+  const auto theta = atan2(hypot(x, y), z);
+  const auto phi = atan2(y, x);
+  const YlmTestFunctions::ProductOfPolynomials f1(1, 2, 3);
+  const YlmTestFunctions::ProductOfPolynomials f2(3, 1, 2);
+  const DataVector f1_cubed_sphere = f1(theta, phi);
+  const DataVector f2_cubed_sphere = f2(theta, phi);
+  const size_t npts = cubed_sphere_mortar_mesh.number_of_grid_points();
+  DataVector result{2 * npts};
+  std::copy(f1_cubed_sphere.begin(), f1_cubed_sphere.end(), result.begin());
+  std::copy(f2_cubed_sphere.begin(), f2_cubed_sphere.end(),
+            result.begin() + static_cast<ptrdiff_t>(npts));
+  return result;
+}
+
+template <size_t Dim>
+void insert_mortar_data(
+    DataVector& mortar_data, const Mesh<2>& target_mortar_mesh,
+    const DataVector& source_data,
+    const evolution::dg::MortarInterpolator<Dim>& interpolator) {
+  const auto& offsets = interpolator.interpolated_neighbor_data_offsets();
+  const DataVector subset_of_mortar_data =
+      interpolator.interpolate_to_neighbor(source_data);
+  for (size_t i = 0; i < offsets.size(); ++i) {
+    mortar_data[offsets[i]] = subset_of_mortar_data[i];
+    mortar_data[offsets[i] + target_mortar_mesh.number_of_grid_points()] =
+        subset_of_mortar_data[i + offsets.size()];
+  }
+}
+
+void test_non_conforming_spheres() {
+  const auto domain = create_non_conforming_spherical_shells(2.0, 3.0, 4.0);
+  std::vector<std::array<size_t, 3>> refinement_levels{
+      7, std::array{2_st, 2_st, 2_st}};
+  refinement_levels[6] = std::array{0_st, 0_st, 0_st};
+  const ElementId<3> shell_id{6};
+  const Element<3> shell = domain::Initialization::create_initial_element(
+      shell_id, domain.blocks(), refinement_levels);
+  const auto& shell_neighbor_ids =
+      shell.neighbors().at(Direction<3>::lower_xi());
+  const Mesh<2> shell_mortar_mesh{
+      std::array{8_st, 15_st},
+      std::array{Spectral::Basis::SphericalHarmonic,
+                 Spectral::Basis::SphericalHarmonic},
+      std::array{Spectral::Quadrature::Gauss,
+                 Spectral::Quadrature::Equiangular}};
+  const Mesh<2> shell_mortar_mesh_2{
+      std::array{9_st, 17_st},
+      std::array{Spectral::Basis::SphericalHarmonic,
+                 Spectral::Basis::SphericalHarmonic},
+      std::array{Spectral::Quadrature::Gauss,
+                 Spectral::Quadrature::Equiangular}};
+  const Mesh<2> cubed_sphere_mortar_mesh{11_st, Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto};
+  const Mesh<2> cubed_sphere_mortar_mesh_2{12_st, Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::GaussLobatto};
+  const DataVector v_shell = vars_shell(shell_mortar_mesh);
+  const DataVector v_shell_2 = vars_shell(shell_mortar_mesh_2);
+  DataVector interpolated_v_shell{2 * shell_mortar_mesh.number_of_grid_points(),
+                                  std::numeric_limits<double>::quiet_NaN()};
+  DataVector interpolated_v_shell_2{
+      2 * shell_mortar_mesh_2.number_of_grid_points(),
+      std::numeric_limits<double>::quiet_NaN()};
+  DataVector interpolated_v_shell_3{
+      2 * shell_mortar_mesh_2.number_of_grid_points(),
+      std::numeric_limits<double>::quiet_NaN()};
+  for (const auto& neighbor_id : shell_neighbor_ids) {
+    const DataVector v_cubed_sphere = vars_cubed_sphere(
+        domain, neighbor_id, refinement_levels, cubed_sphere_mortar_mesh);
+    evolution::dg::MortarInterpolator<3> interpolator{
+        neighbor_id, DirectionalId<3>{Direction<3>::upper_zeta(), shell_id},
+        domain, cubed_sphere_mortar_mesh, shell_mortar_mesh};
+    const DataVector interpolated_v_cubed_sphere =
+        interpolator.interpolate_to_host(v_shell);
+    CHECK_ITERABLE_APPROX(interpolated_v_cubed_sphere, v_cubed_sphere);
+    insert_mortar_data(interpolated_v_shell, shell_mortar_mesh, v_cubed_sphere,
+                       interpolator);
+    interpolator.reset_if_necessary(domain, cubed_sphere_mortar_mesh,
+                                    shell_mortar_mesh_2);
+    const DataVector interpolated_v_cubed_sphere_2 =
+        interpolator.interpolate_to_host(v_shell_2);
+    CHECK_ITERABLE_APPROX(interpolated_v_cubed_sphere_2, v_cubed_sphere);
+    insert_mortar_data(interpolated_v_shell_2, shell_mortar_mesh_2,
+                       v_cubed_sphere, interpolator);
+    interpolator.reset_if_necessary(domain, cubed_sphere_mortar_mesh_2,
+                                    shell_mortar_mesh_2);
+    const DataVector interpolated_v_cubed_sphere_3 =
+        interpolator.interpolate_to_host(v_shell_2);
+    const DataVector v_cubed_sphere_2 = vars_cubed_sphere(
+        domain, neighbor_id, refinement_levels, cubed_sphere_mortar_mesh_2);
+    CHECK_ITERABLE_APPROX(interpolated_v_cubed_sphere_3, v_cubed_sphere_2);
+    insert_mortar_data(interpolated_v_shell_3, shell_mortar_mesh_2,
+                       v_cubed_sphere_2, interpolator);
+  }
+  Approx custom_approx = Approx::custom().epsilon(1.0e-11).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(interpolated_v_shell, v_shell, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(interpolated_v_shell_2, v_shell_2,
+                               custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(interpolated_v_shell_3, v_shell_2,
+                               custom_approx);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.MortarInterpolator", "[Unit][Evolution]") {
+  test_non_conforming_spheres();
+}


### PR DESCRIPTION
The MortarInterpolator will be used to interpolate boundary data from nonconforming neighbors such as a S2 spherical shell abutting multiple cubed sphere elements.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
