### PR TITLE
Compute horizon quantities at excisions for the zero-expansion BC.

### DIFF
--- a/support/Pipelines/Bbh/ControlId.py
+++ b/support/Pipelines/Bbh/ControlId.py
@@ -57,6 +57,7 @@ def control_id(
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
     refinement_level: int = 1,
     polynomial_order: int = 6,
+    negative_expansion_bc: bool = True,
 ):
     """Control BBH physical parameters.
 
@@ -186,6 +187,7 @@ def control_id(
                 scheduler=None,
                 refinement_level=refinement_level,
                 polynomial_order=polynomial_order,
+                negative_expansion_bc=negative_expansion_bc,
             )
 
         # Initialize dictionary to hold the measured physical parameters

--- a/support/Pipelines/Bbh/FindHorizon.py
+++ b/support/Pipelines/Bbh/FindHorizon.py
@@ -12,6 +12,11 @@ import spectre.IO.H5 as spectre_h5
 from spectre.ApparentHorizonFinder import FastFlow, FlowType, Status
 from spectre.DataStructures import DataVector
 from spectre.DataStructures.Tensor import tnsr
+from spectre.Domain import (
+    deserialize_domain,
+    deserialize_functions_of_time,
+    strahlkorper_in_inertial_frame_aligned,
+)
 from spectre.IO.Exporter import ObservationId, interpolate_tensors_to_points
 from spectre.PointwiseFunctions.GeneralRelativity.Surfaces import (
     horizon_quantities,
@@ -23,7 +28,10 @@ from spectre.SphericalHarmonics import (
     cartesian_coords,
     ylm_legend_and_data,
 )
-from spectre.Visualization.OpenVolfiles import open_volfiles_command
+from spectre.Visualization.OpenVolfiles import (
+    open_volfiles,
+    open_volfiles_command,
+)
 from spectre.Visualization.ReadH5 import list_observations
 
 logger = logging.getLogger(__name__)
@@ -274,6 +282,129 @@ def find_horizon(
             )
             datfile.append(reduction_data)
     return strahlkorper, quantities
+
+
+def use_excision_as_horizon(
+    h5_files: Union[str, Sequence[str]],
+    subfile_name: str,
+    obs_id: int,
+    obs_time: float,
+    l_max: int,
+    radius: float,
+    center: Sequence[float],
+    output_reductions_file: Optional[Union[str, Path]] = None,
+    output_quantities_subfile: Optional[str] = None,
+    tensor_names: Optional[Sequence[str]] = None,
+):
+    """Use excision to compute horizon quantities.
+
+    The volume data must contain the spatial metric, inverse spatial metric,
+    extrinsic curvature, spatial Christoffel symbols, and spatial Ricci tensor.
+
+    Arguments:
+      h5_files: List of H5 files containing volume data or glob pattern.
+      subfile_name: Name of the volume data subfile in the 'h5_files'.
+      obs_id: Observation ID in the volume data.
+      obs_time: Time of the observation.
+      l_max: Maximum l-mode for the horizon Ylm representation.
+      radius: Radius of the excision.
+      center: Center of the excision.
+      output_reductions_file: Optional. H5 output file where the reduction
+        quantities on the horizon will be written, e.g. masses and spins.
+        Can be a new or existing file. Requires 'output_quantities_subfile'
+        is also specified.
+      output_quantities_subfile: Optional. Name of the subfile in the
+        'output_reductions_file' where the horizon quantities will be written,
+        e.g. masses and spins.
+      tensor_names: Optional. List of tensor names in the volume data that
+        represent the spatial metric, inverse spatial metric, extrinsic
+        curvature, spatial Christoffel symbols, and spatial Ricci tensor, in
+        this order. Defaults to ["SpatialMetric", "InverseSpatialMetric",
+        "ExtrinsicCurvature", "SpatialChristoffelSecondKind", "SpatialRicci"].
+
+    Returns: The Strahlkorper representing the horizon, and a dictionary of
+      horizon quantities (e.g. area, mass, spin, etc.).
+    """
+    if not tensor_names:
+        tensor_names = [
+            "SpatialMetric",
+            "InverseSpatialMetric",
+            "ExtrinsicCurvature",
+            "SpatialChristoffelSecondKind",
+            "SpatialRicci",
+        ]
+
+    # Define excision in the grid frame
+    excision_grid = Strahlkorper[Frame.Grid](l_max, radius, center)
+
+    # Interpolate the tensors to the excision points
+    (
+        spatial_metric,
+        inv_spatial_metric,
+        extrinsic_curvature,
+        spatial_christoffel_second_kind,
+        spatial_ricci,
+    ) = interpolate_tensors_to_points(
+        h5_files,
+        subfile_name,
+        observation=ObservationId(obs_id),
+        target_points=cartesian_coords(excision_grid),
+        tensor_names=tensor_names,
+        tensor_types=[
+            tnsr.ii[DataVector, 3],
+            tnsr.II[DataVector, 3],
+            tnsr.ii[DataVector, 3],
+            tnsr.Ijj[DataVector, 3],
+            tnsr.ii[DataVector, 3],
+        ],
+    )
+
+    # Deserialize domain and get the excision in the inertial frame
+    if isinstance(h5_files, str):
+        h5_files = [h5_files]
+    for volfile in open_volfiles(h5_files, subfile_name, obs_id):
+        dim = volfile.get_dimension()
+        domain = deserialize_domain[dim](volfile.get_domain(obs_id))
+        if domain.is_time_dependent():
+            functions_of_time = deserialize_functions_of_time(
+                volfile.get_functions_of_time(obs_id)
+            )
+            excision_inertial = strahlkorper_in_inertial_frame_aligned(
+                excision_grid, domain, functions_of_time, obs_time
+            )
+        else:
+            # When the domain is time-independent, the excision is the same in
+            # the grid and inertial frames.
+            excision_inertial = Strahlkorper[Frame.Inertial](
+                l_max, radius, center
+            )
+        break
+
+    # Compute horizon quantities
+    quantities = horizon_quantities(
+        excision_inertial,
+        spatial_metric=spatial_metric,
+        inv_spatial_metric=inv_spatial_metric,
+        extrinsic_curvature=extrinsic_curvature,
+        spatial_christoffel_second_kind=spatial_christoffel_second_kind,
+        spatial_ricci=spatial_ricci,
+    )
+
+    if output_reductions_file:
+        assert output_quantities_subfile, (
+            "Specify 'output_quantities_subfile' if 'output_reductions_file'"
+            " is specified."
+        )
+        if Path(output_reductions_file).suffix not in [".h5", ".hdf5"]:
+            output_reductions_file += ".h5"
+        legend, reduction_data = _horizon_reduction_data(quantities)
+        with spectre_h5.H5File(str(output_reductions_file), "a") as output_file:
+            datfile = output_file.try_insert_dat(
+                output_quantities_subfile, legend, 0
+            )
+            datfile.append(reduction_data)
+
+    return excision_inertial, quantities
 
 
 @click.command(name="find-horizon")

--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -54,6 +54,7 @@ def id_parameters(
     radial_expansion_velocity: float,
     refinement_level: int,
     polynomial_order: int,
+    negative_expansion_bc: bool,
 ):
     """Determine initial data parameters from options.
 
@@ -87,6 +88,7 @@ def id_parameters(
     r_plus_B = conformal_mass_b * (1.0 + np.sqrt(1 - np.dot(chi_B, chi_B)))
     Omega_B = -0.5 * chi_B / r_plus_B
     Omega_B[2] += orbital_angular_velocity
+    excision_factor = 0.93 if negative_expansion_bc else 1.0
     # Falloff widths of superposition
     L1_dist_A = L1_distance(conformal_mass_a, conformal_mass_b, separation)
     L1_dist_B = separation - L1_dist_A
@@ -111,8 +113,8 @@ def id_parameters(
         "LinearVelocity_x": linear_velocity[0],
         "LinearVelocity_y": linear_velocity[1],
         "LinearVelocity_z": linear_velocity[2],
-        "ExcisionRadiusRight": 0.93 * r_plus_A,
-        "ExcisionRadiusLeft": 0.93 * r_plus_B,
+        "ExcisionRadiusRight": excision_factor * r_plus_A,
+        "ExcisionRadiusLeft": excision_factor * r_plus_B,
         "ObjectOuterRadius": separation / 3.75,
         "OrbitalAngularVelocity": orbital_angular_velocity,
         "RadialExpansionVelocity": radial_expansion_velocity,
@@ -160,6 +162,7 @@ def generate_id(
     control: bool = False,
     evolve: bool = False,
     eccentricity_control: bool = False,
+    negative_expansion_bc: bool = True,
     pipeline_dir: Optional[Union[str, Path]] = None,
     run_dir: Optional[Union[str, Path]] = None,
     segments_dir: Optional[Union[str, Path]] = None,
@@ -206,6 +209,10 @@ def generate_id(
       evolve: Set to True to evolve the initial data after generation.
       eccentricity_control: If set to True, an eccentricity reduction script is
         run on the initial data to correct the initial orbital parameters.
+      negative_expansion_bc: If set to True, the excision boundaries are set to
+        be inside of the apparent horizons. This helps to find horizons and
+        start an evolution from the initial data without extrapolation.
+        (default: True)
       pipeline_dir: Directory where steps in the pipeline are created. Required
         when 'evolve' is set to True. The initial data will be created in a
         subdirectory '001_InitialData'.
@@ -289,6 +296,7 @@ def generate_id(
         linear_velocity=linear_velocity,
         refinement_level=refinement_level,
         polynomial_order=polynomial_order,
+        negative_expansion_bc=negative_expansion_bc,
     )
     logger.debug(f"Initial data parameters: {pretty_repr(id_params)}")
 
@@ -305,6 +313,7 @@ def generate_id(
         control=control,
         evolve=evolve,
         eccentricity_control=eccentricity_control,
+        negative_expansion_bc=negative_expansion_bc,
         pipeline_dir=pipeline_dir,
         run_dir=run_dir,
         segments_dir=segments_dir,
@@ -447,6 +456,17 @@ def generate_id(
     help=(
         "Perform eccentricity reduction script that finds current eccentricity"
         "and better guesses for the input orbital parameters."
+    ),
+)
+@click.option(
+    "--negative-expansion-bc/--no-negative-expansion-bc",
+    default=True,
+    show_default=True,
+    help=(
+        "Use negative expansion boundary condition so that the excision"
+        "boundaries are inside of the apparent horizons. This helps to find"
+        "horizons and start an evolution from the initial data without"
+        "extrapolation."
     ),
 )
 @click.option(

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -24,6 +24,7 @@ Next:
       - AdmLinearMomentum
     evolve: {{ evolve }}
     eccentricity_control: {{ eccentricity_control }}
+    negative_expansion_bc: {{ negative_expansion_bc }}
     scheduler: {{ scheduler | default("None") }}
     copy_executable: {{ copy_executable | default("None") }}
     submit_script_template: {{ submit_script_template | default("None") }}
@@ -85,7 +86,11 @@ DomainCreator:
               - {{ HorizonRotationRight_y }}
               - {{ HorizonRotationRight_z }}
             Lapse: *kerr_right
+            {% if negative_expansion_bc %}
             NegativeExpansion: *kerr_right
+            {% else %}
+            NegativeExpansion: None
+            {% endif %}
       UseLogarithmicMap: True
     ObjectB:
       InnerRadius: {{ ExcisionRadiusLeft }}
@@ -100,7 +105,11 @@ DomainCreator:
               - {{ HorizonRotationLeft_y }}
               - {{ HorizonRotationLeft_z }}
             Lapse: *kerr_left
+            {% if negative_expansion_bc %}
             NegativeExpansion: *kerr_left
+            {% else %}
+            NegativeExpansion: None
+            {% endif %}
       UseLogarithmicMap: True
     CenterOfMassOffset: [*y_offset, *z_offset]
     Envelope:

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -15,7 +15,11 @@ from spectre.Pipelines.Bbh.ControlId import (
     TargetParams,
     control_id,
 )
-from spectre.Pipelines.Bbh.FindHorizon import find_horizon, vec_to_string
+from spectre.Pipelines.Bbh.FindHorizon import (
+    find_horizon,
+    use_excision_as_horizon,
+    vec_to_string,
+)
 from spectre.SphericalHarmonics import Frame, Strahlkorper
 from spectre.support.Schedule import schedule, scheduler_options
 from spectre.Visualization.OpenVolfiles import open_volfiles
@@ -38,6 +42,7 @@ def postprocess_id(
     control_params: List[TargetParams] = [],
     evolve: bool = False,
     eccentricity_control: bool = False,
+    negative_expansion_bc: bool = True,
     pipeline_dir: Optional[Union[str, Path]] = None,
     **scheduler_kwargs,
 ):
@@ -111,22 +116,35 @@ def postprocess_id(
     for object_label, xcoord, excision_radius in zip(
         ["AhA", "AhB"], [x_A, x_B], [excision_radius_A, excision_radius_B]
     ):
-        _, horizon_quantities = find_horizon(
-            id_volfiles,
-            subfile_name=id_subfile_name,
-            obs_id=obs_id,
-            obs_time=0.0,
-            initial_guess=Strahlkorper[Frame.Inertial](
+        if negative_expansion_bc:
+            _, horizon_quantities = find_horizon(
+                id_volfiles,
+                subfile_name=id_subfile_name,
+                obs_id=obs_id,
+                obs_time=0.0,
+                initial_guess=Strahlkorper[Frame.Inertial](
+                    l_max=horizon_l_max,
+                    radius=excision_radius * 1.5,
+                    center=[xcoord, y_offset, z_offset],
+                ),
+                output_surfaces_file=horizons_file,
+                output_coeffs_subfile=f"{object_label}/Coefficients",
+                output_coords_subfile=f"{object_label}/Coordinates",
+                output_reductions_file=horizons_file,
+                output_quantities_subfile=object_label,
+            )
+        else:
+            _, horizon_quantities = use_excision_as_horizon(
+                id_volfiles,
+                subfile_name=id_subfile_name,
+                obs_id=obs_id,
+                obs_time=0.0,
                 l_max=horizon_l_max,
-                radius=excision_radius * 1.5,
+                radius=excision_radius,
                 center=[xcoord, y_offset, z_offset],
-            ),
-            output_surfaces_file=horizons_file,
-            output_coeffs_subfile=f"{object_label}/Coefficients",
-            output_coords_subfile=f"{object_label}/Coordinates",
-            output_reductions_file=horizons_file,
-            output_quantities_subfile=object_label,
-        )
+                output_reductions_file=horizons_file,
+                output_quantities_subfile=object_label,
+            )
         logger.info(
             f"{object_label} has mass"
             f" {horizon_quantities['ChristodoulouMass']:g} and spin"
@@ -143,6 +161,7 @@ def postprocess_id(
             max_iterations=control_max_iterations,
             refinement_level=control_refinement_level,
             polynomial_order=control_polynomial_order,
+            negative_expansion_bc=negative_expansion_bc,
         )
         id_run_dir = last_control_run_dir
         id_input_file_path = f"{last_control_run_dir}/InitialData.yaml"

--- a/tests/support/Pipelines/Bbh/Test_FindHorizon.py
+++ b/tests/support/Pipelines/Bbh/Test_FindHorizon.py
@@ -16,7 +16,11 @@ from spectre.Domain.Creators import Sphere
 from spectre.Informer import unit_test_build_path
 from spectre.IO.H5.IterElements import Element
 from spectre.NumericalAlgorithms.LinearOperators import partial_derivative
-from spectre.Pipelines.Bbh.FindHorizon import find_horizon, find_horizon_command
+from spectre.Pipelines.Bbh.FindHorizon import (
+    find_horizon,
+    find_horizon_command,
+    use_excision_as_horizon,
+)
 from spectre.PointwiseFunctions.AnalyticSolutions.GeneralRelativity import (
     KerrSchild,
 )
@@ -134,6 +138,27 @@ class TestFindHorizon(unittest.TestCase):
         )
         # Mass and spin should be 1.0 and 0.0
         npt.assert_allclose(quantities["ChristodoulouMass"], 1.0, atol=1e-3)
+        npt.assert_allclose(
+            quantities["DimensionlessSpinMagnitude"], 0.0, atol=1e-3
+        )
+
+    def test_use_excision_as_horizon(self):
+        horizon, quantities = use_excision_as_horizon(
+            self.h5_filename,
+            subfile_name="element_data",
+            obs_id=0,
+            obs_time=0.0,
+            l_max=12,
+            radius=1.0,
+            center=[0.0, 0.0, 0.0],
+        )
+        # Horizon should be a sphere of coordinate radius 1.0
+        npt.assert_allclose(
+            np.linalg.norm(cartesian_coords(horizon), axis=0), 1.0, atol=1e-3
+        )
+        # Mass should be 0.5 because r=2M and we're at r=1.0
+        npt.assert_allclose(quantities["ChristodoulouMass"], 0.5, atol=1e-3)
+        # Spin should be 0.0
         npt.assert_allclose(
             quantities["DimensionlessSpinMagnitude"], 0.0, atol=1e-3
         )

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -40,6 +40,7 @@ class TestInitialData(unittest.TestCase):
             radial_expansion_velocity=-1.0e-5,
             refinement_level=1,
             polynomial_order=5,
+            negative_expansion_bc=True,
         )
         self.assertEqual(params["ConformalMassRight"], 0.6)
         self.assertEqual(params["ConformalMassLeft"], 0.4)
@@ -183,6 +184,7 @@ class TestInitialData(unittest.TestCase):
                     ],
                     "evolve": True,
                     "eccentricity_control": True,
+                    "negative_expansion_bc": True,
                     "scheduler": "None",
                     "copy_executable": "None",
                     "submit_script_template": "None",


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds support for computing horizon quantities at the excisions. This is needed when creating initial data with the zero-expansion boundary condition, which is now possible to do by passing `--no-negative-expansion-bc` to `spectre bbh generate-id`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
