### PR TITLE
Add missing option for skew map on input file

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -137,6 +137,9 @@ DomainCreator:
         SubfileName: "VolumeData"
       TranslationMap:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      SkewMap:
+        H5Filename: "{{ FotFilename }}"
+        SubfileName: "VolumeData"
       ShapeMapA:
         H5Filename: "{{ FotFilename }}"
         SubfileName: "VolumeData"


### PR DESCRIPTION
## Proposed changes

Minor input file correction. A skew map option was missing for the case when one restarts from volume data of a previous evolution.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
