### PR TITLE
Interpolated boundary data

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -127,12 +127,13 @@ void retrieve_boundary_data_spsc(
           auto& [volume_mesh, volume_mesh_ghost_cell_data,
                  boundary_correction_mesh, ghost_cell_data,
                  boundary_correction_data, validity_range, tci_status,
-                 integration_order] = data;
+                 integration_order, interpolated_boundary_data] = data;
           (void)ghost_cell_data;
           auto& [current_volume_mesh, current_volume_mesh_ghost_cell_data,
                  current_boundary_correction_mesh, current_ghost_cell_data,
                  current_boundary_correction_data, current_validity_range,
-                 current_tci_status, current_integration_order] = it->second;
+                 current_tci_status, current_integration_order,
+                 current_interpolated_boundary_data] = it->second;
           // Need to use when optimizing subcell
           (void)current_volume_mesh_ghost_cell_data;
           // We have already received some data at this time. Receiving
@@ -181,6 +182,7 @@ void retrieve_boundary_data_spsc(
           current_validity_range = validity_range;
           current_tci_status = tci_status;
           current_integration_order = integration_order;
+          current_interpolated_boundary_data = interpolated_boundary_data;
         } else {
           // We have not received ghost cells or fluxes at this time.
           if (not current_inbox

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -740,7 +740,8 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
                         {std::move(neighbor_boundary_data_on_mortar)},
                         next_time_step_id,
                         tci_decision,
-                        integration_order};
+                        integration_order,
+                        std::nullopt};
       } else {
         data = SendData{volume_mesh,
                         ghost_data_mesh,
@@ -749,7 +750,8 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
                         {std::move(neighbor_boundary_data_on_mortar)},
                         next_time_step_id,
                         tci_decision,
-                        integration_order};
+                        integration_order,
+                        std::nullopt};
       }
 
       // Send mortar data (the `std::tuple` named `data`) to neighbor

--- a/src/Evolution/DiscontinuousGalerkin/BoundaryData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryData.cpp
@@ -6,6 +6,7 @@
 #include <pup.h>
 #include <pup_stl.h>
 
+#include "Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Serialization/PupStlCpp17.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -21,6 +22,7 @@ void BoundaryData<Dim>::pup(PUP::er& p) {
   p | validity_range;
   p | tci_status;
   p | integration_order;
+  p | interpolated_boundary_data;
 }
 
 template <size_t Dim>
@@ -32,7 +34,8 @@ bool operator==(const BoundaryData<Dim>& lhs, const BoundaryData<Dim>& rhs) {
          lhs.boundary_correction_data == rhs.boundary_correction_data and
          lhs.validity_range == rhs.validity_range and
          lhs.tci_status == rhs.tci_status and
-         lhs.integration_order == rhs.integration_order;
+         lhs.integration_order == rhs.integration_order and
+         lhs.interpolated_boundary_data == rhs.interpolated_boundary_data;
 }
 
 template <size_t Dim>
@@ -42,6 +45,7 @@ bool operator!=(const BoundaryData<Dim>& lhs, const BoundaryData<Dim>& rhs) {
 
 template <size_t Dim>
 std::ostream& operator<<(std::ostream& os, const BoundaryData<Dim>& value) {
+  using ::operator<<;
   return os << "Volume mesh: " << value.volume_mesh << '\n'
             << "Ghost mesh: " << value.volume_mesh_ghost_cell_data << '\n'
             << "Boundary correction mesh: " << value.boundary_correction_mesh
@@ -51,7 +55,9 @@ std::ostream& operator<<(std::ostream& os, const BoundaryData<Dim>& value) {
             << '\n'
             << "Validy range: " << value.validity_range << '\n'
             << "TCI status: " << value.tci_status << '\n'
-            << "Integration order: " << value.integration_order;
+            << "Integration order: " << value.integration_order << '\n'
+            << "Interpolated boundary data: "
+            << value.interpolated_boundary_data;
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Evolution/DiscontinuousGalerkin/BoundaryData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryData.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "DataStructures/DataVector.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Time/TimeStepId.hpp"
 
@@ -30,6 +31,9 @@ namespace evolution::dg {
  * 7. the troubled cell indicator status used for determining halos around
  *    troubled cells.
  * 8. the integration order of the time-stepper
+ * 9. the InterpolatedBoundaryData sent by a non-conforming Element that
+ *    interpolates its data to a subset of the points of the Element receiving
+ *    this BoundaryData
  */
 template <size_t Dim>
 struct BoundaryData {
@@ -44,6 +48,7 @@ struct BoundaryData {
   ::TimeStepId validity_range{};
   int tci_status{};
   size_t integration_order{std::numeric_limits<size_t>::max()};
+  std::optional<InterpolatedBoundaryData<Dim>> interpolated_boundary_data{};
 };
 
 template <size_t Dim>

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   DgElementArray.hpp
   InboxTags.hpp
   InterfaceDataPolicy.hpp
+  InterpolatedBoundaryData.hpp
   MortarData.hpp
   MortarDataHolder.hpp
   MortarInfo.hpp
@@ -26,6 +27,7 @@ spectre_target_sources(
   AtomicInboxBoundaryData.cpp
   BoundaryData.cpp
   InterfaceDataPolicy.cpp
+  InterpolatedBoundaryData.cpp
   MortarData.cpp
   MortarDataHolder.cpp
   MortarInfo.cpp

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -54,6 +54,9 @@ namespace evolution::dg::Tags {
  * 7. the troublade cell indicator status using for determining halos around
  *    troubled cells.
  * 8. the integration order of the time-stepper.
+ * 9. the InterpolatedBoundaryData sent by a non-conforming Element that
+ *    interpolates its data to a subset of the points of the Element receiving
+ *    this BoundaryData
  *
  * The TimeStepId is the neighboring element's next time step. When using local
  * time stepping, the neighbor's boundary data is valid up until this time,
@@ -177,12 +180,14 @@ struct BoundaryCorrectionAndGhostCellsInbox {
     if (auto it = current_inbox.find(data.first); it != current_inbox.end()) {
       auto& [volume_mesh, volume_mesh_ghost_cell_data, boundary_correction_mesh,
              ghost_cell_data, boundary_correction_data, validity_range,
-             tci_status, integration_order] = data.second;
+             tci_status, integration_order, interpolated_boundary_data] =
+          data.second;
       (void)ghost_cell_data;
       auto& [current_volume_mesh, current_volume_mesh_ghost_cell_data,
              current_boundary_correction_mesh, current_ghost_cell_data,
              current_boundary_correction_data, current_validity_range,
-             current_tci_status, current_integration_order] = it->second;
+             current_tci_status, current_integration_order,
+             current_interpolated_boundary_data] = it->second;
       (void)current_volume_mesh_ghost_cell_data;  // Need to use when
                                                   // optimizing subcell
       // We have already received some data at this time. Receiving data twice
@@ -228,6 +233,7 @@ struct BoundaryCorrectionAndGhostCellsInbox {
       current_validity_range = validity_range;
       current_tci_status = tci_status;
       current_integration_order = integration_order;
+      current_interpolated_boundary_data = interpolated_boundary_data;
     } else {
       // We have not received ghost cells or fluxes at this time.
       if (not current_inbox.insert(std::forward<ReceiveDataType>(data))

--- a/src/Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.cpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp"
+
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+#include <vector>
+
+#include "Utilities/StdHelpers.hpp"
+
+namespace evolution::dg {
+template <size_t VolumeDim>
+InterpolatedBoundaryData<VolumeDim>::InterpolatedBoundaryData(
+    InterpolatedBoundaryData::Info info)
+    : info_(std::move(info)) {}
+
+template <size_t VolumeDim>
+void InterpolatedBoundaryData<VolumeDim>::Info::pup(PUP::er& p) {
+  p | data;
+  p | target_mesh;
+  p | offsets;
+}
+
+template <size_t VolumeDim>
+void InterpolatedBoundaryData<VolumeDim>::pup(PUP::er& p) {
+  p | info_;
+}
+
+template <size_t VolumeDim>
+bool operator==(const InterpolatedBoundaryData<VolumeDim>& lhs,
+                const InterpolatedBoundaryData<VolumeDim>& rhs) {
+  return lhs.boundary_data() == rhs.boundary_data() and
+         lhs.target_mesh() == rhs.target_mesh() and
+         lhs.offsets() == rhs.offsets();
+}
+
+template <size_t VolumeDim>
+bool operator!=(const InterpolatedBoundaryData<VolumeDim>& lhs,
+                const InterpolatedBoundaryData<VolumeDim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os,
+                         const InterpolatedBoundaryData<VolumeDim>& value) {
+  using ::operator<<;
+  os << "boundary data = " << value.boundary_data()
+     << "\ntarget mesh = " << value.target_mesh()
+     << "\noffsets = " << value.offsets();
+  return os;
+}
+
+template class InterpolatedBoundaryData<1>;
+template class InterpolatedBoundaryData<2>;
+template class InterpolatedBoundaryData<3>;
+template bool operator==(const InterpolatedBoundaryData<1>&,
+                         const InterpolatedBoundaryData<1>&);
+template bool operator==(const InterpolatedBoundaryData<2>&,
+                         const InterpolatedBoundaryData<2>&);
+template bool operator==(const InterpolatedBoundaryData<3>&,
+                         const InterpolatedBoundaryData<3>&);
+template bool operator!=(const InterpolatedBoundaryData<1>&,
+                         const InterpolatedBoundaryData<1>&);
+template bool operator!=(const InterpolatedBoundaryData<2>&,
+                         const InterpolatedBoundaryData<2>&);
+template bool operator!=(const InterpolatedBoundaryData<3>&,
+                         const InterpolatedBoundaryData<3>&);
+template std::ostream& operator<<(std::ostream&,
+                                  const InterpolatedBoundaryData<1>&);
+template std::ostream& operator<<(std::ostream&,
+                                  const InterpolatedBoundaryData<2>&);
+template std::ostream& operator<<(std::ostream&,
+                                  const InterpolatedBoundaryData<3>&);
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iosfwd>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace evolution::dg {
+/// \brief Information sent by a non-conforming Element that interpolates its
+/// boundary data to a subset of the points of the Element receiving this
+///
+/// \details The following information is sent:
+/// - the interpolated data (as a DataVector representing a type-erased
+///   Variables)
+/// - the Mesh that was used to compute the target points of the boundary face
+///   of the receiving Element.  This is sent so that the receiving Element can
+///   check if the data was interpolated to the correct points.
+/// - the offsets of the interpolated data with respect to the target Mesh
+template <size_t VolumeDim>
+class InterpolatedBoundaryData {
+  struct Info {
+    DataVector data{};
+    Mesh<VolumeDim - 1> target_mesh{};
+    std::vector<size_t> offsets{};
+    // NOLINTNEXTLINE(google-runtime-references)
+    void pup(PUP::er& p);
+  };
+
+ public:
+  InterpolatedBoundaryData() = default;
+  InterpolatedBoundaryData(const InterpolatedBoundaryData&) = default;
+  InterpolatedBoundaryData(InterpolatedBoundaryData&&) = default;
+  InterpolatedBoundaryData& operator=(const InterpolatedBoundaryData&) =
+      default;
+  InterpolatedBoundaryData& operator=(InterpolatedBoundaryData&&) = default;
+  ~InterpolatedBoundaryData() = default;
+
+  explicit InterpolatedBoundaryData(InterpolatedBoundaryData::Info info);
+
+  const DataVector& boundary_data() const { return info_.data; }
+  const Mesh<VolumeDim - 1>& target_mesh() const { return info_.target_mesh; }
+  const std::vector<size_t>& offsets() const { return info_.offsets; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+ private:
+  Info info_;
+};
+
+template <size_t VolumeDim>
+bool operator==(const InterpolatedBoundaryData<VolumeDim>& lhs,
+                const InterpolatedBoundaryData<VolumeDim>& rhs);
+
+template <size_t VolumeDim>
+bool operator!=(const InterpolatedBoundaryData<VolumeDim>& lhs,
+                const InterpolatedBoundaryData<VolumeDim>& rhs);
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os,
+                         const InterpolatedBoundaryData<VolumeDim>& value);
+}  // namespace evolution::dg

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_BoundaryCorrectionsHelper.cpp
   Test_BoundaryData.cpp
   Test_InterfaceDataPolicy.cpp
+  Test_InterpolatedBoundaryData.cpp
   Test_MortarData.cpp
   Test_MortarDataHolder.cpp
   Test_MortarInfo.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryData.cpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -34,43 +35,60 @@ void test() {
                                 DataVector{1, 4.4},
                                 TimeStepId{true, 1, time},
                                 7,
-                                3};
+                                3,
+                                std::nullopt};
   CHECK(data0 == BoundaryData<Dim>{volume_mesh, ghost_data_mesh, mortar_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
-                                   TimeStepId{true, 1, time}, 7, 3});
-  CHECK(data0 != BoundaryData<Dim>{Mesh<Dim>{6, Spectral::Basis::Legendre,
-                                             Spectral::Quadrature::Gauss},
-                                   ghost_data_mesh, mortar_mesh,
-                                   DataVector{2, 2.3}, DataVector{1, 4.4},
-                                   TimeStepId{true, 1, time}, 7, 3});
+                                   TimeStepId{true, 1, time}, 7, 3,
+                                   std::nullopt});
+  CHECK(
+      data0 !=
+      BoundaryData<Dim>{
+          Mesh<Dim>{6, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss},
+          ghost_data_mesh, mortar_mesh, DataVector{2, 2.3}, DataVector{1, 4.4},
+          TimeStepId{true, 1, time}, 7, 3, std::nullopt});
   CHECK(data0 !=
         BoundaryData<Dim>{volume_mesh,
                           Mesh<Dim>{11, Spectral::Basis::FiniteDifference,
                                     Spectral::Quadrature::CellCentered},
                           mortar_mesh, DataVector{2, 2.3}, DataVector{1, 4.4},
-                          TimeStepId{true, 1, time}, 7, 3});
+                          TimeStepId{true, 1, time}, 7, 3, std::nullopt});
   if constexpr (Dim > 1) {
     CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh,
                                      Mesh<Dim - 1>{2, Spectral::Basis::Legendre,
                                                    Spectral::Quadrature::Gauss},
                                      DataVector{2, 2.3}, DataVector{1, 4.4},
-                                     TimeStepId{true, 1, time}, 7, 3});
+                                     TimeStepId{true, 1, time}, 7, 3,
+                                     std::nullopt});
   }
   CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, mortar_mesh,
                                    DataVector{9, 2.3}, DataVector{1, 4.4},
-                                   TimeStepId{true, 1, time}, 7, 3});
+                                   TimeStepId{true, 1, time}, 7, 3,
+                                   std::nullopt});
   CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, mortar_mesh,
                                    DataVector{2, 2.3}, DataVector{6, 4.4},
-                                   TimeStepId{true, 1, time}, 7, 3});
+                                   TimeStepId{true, 1, time}, 7, 3,
+                                   std::nullopt});
   CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, mortar_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
-                                   TimeStepId{true, 2, time}, 7, 3});
+                                   TimeStepId{true, 2, time}, 7, 3,
+                                   std::nullopt});
   CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, mortar_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
-                                   TimeStepId{true, 1, time}, 9, 3});
+                                   TimeStepId{true, 1, time}, 9, 3,
+                                   std::nullopt});
   CHECK(data0 != BoundaryData<Dim>{volume_mesh, ghost_data_mesh, mortar_mesh,
                                    DataVector{2, 2.3}, DataVector{1, 4.4},
-                                   TimeStepId{true, 2, time}, 7, 5});
+                                   TimeStepId{true, 2, time}, 7, 5,
+                                   std::nullopt});
+  CHECK(data0 !=
+        BoundaryData<Dim>{volume_mesh, ghost_data_mesh, mortar_mesh,
+                          DataVector{2, 2.3}, DataVector{1, 4.4},
+                          TimeStepId{true, 1, time}, 7, 3,
+                          InterpolatedBoundaryData<Dim>{
+                              {.data = DataVector{3, 1.0},
+                               .target_mesh = mortar_mesh,
+                               .offsets = std::vector{0_st, 2_st, 3_st}}}});
   CHECK(get_output(data0) ==
         std::string(
             "Volume mesh: " + get_output(volume_mesh) +
@@ -79,7 +97,8 @@ void test() {
             "\nGhost cell data: " + get_output(DataVector{2, 2.3}) +
             "\nBoundary correction data: " + get_output(DataVector{1, 4.4}) +
             "\nValidy range: " + get_output(TimeStepId{true, 1, time}) +
-            "\nTCI status: 7\nIntegration order: 3"));
+            "\nTCI status: 7\nIntegration order: 3\nInterpolated boundary "
+            "data: --"));
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InterpolatedBoundaryData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InterpolatedBoundaryData.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace evolution::dg {
+namespace {
+template <size_t Dim>
+void test() {
+  const DataVector interpolated_data{3, 1.0};
+  const Mesh<Dim - 1> mesh{3_st, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::Gauss};
+  const std::vector<size_t> offsets{0_st, 2_st, 3_st};
+  const InterpolatedBoundaryData<Dim> interpolated_boundary_data{
+      {.data = interpolated_data, .target_mesh = mesh, .offsets = offsets}};
+  CHECK(interpolated_boundary_data.boundary_data() == interpolated_data);
+  CHECK(interpolated_boundary_data.target_mesh() == mesh);
+  CHECK(interpolated_boundary_data.offsets() == offsets);
+  CHECK(get_output(interpolated_boundary_data) ==
+        std::string("boundary data = " + get_output(interpolated_data) +
+                    "\ntarget mesh = " + get_output(mesh) +
+                    "\noffsets = " + get_output(offsets)));
+  const auto deserialized_interpolated_boundary_data =
+      serialize_and_deserialize(interpolated_boundary_data);
+  CHECK(interpolated_boundary_data == deserialized_interpolated_boundary_data);
+  const DataVector interpolated_data_2{3, 1.5};
+  const Mesh<Dim - 1> mesh_2{4_st, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::Gauss};
+  const std::vector<size_t> offsets_2{2_st, 5_st, 7_st};
+  const InterpolatedBoundaryData<Dim> interpolated_boundary_data_2{
+      {.data = interpolated_data_2, .target_mesh = mesh, .offsets = offsets}};
+  CHECK(interpolated_boundary_data != interpolated_boundary_data_2);
+  const InterpolatedBoundaryData<Dim> interpolated_boundary_data_3{
+      {.data = interpolated_data, .target_mesh = mesh_2, .offsets = offsets}};
+  if constexpr (Dim > 1) {
+    // All Mesh<0> are equivalent
+    CHECK(interpolated_boundary_data != interpolated_boundary_data_3);
+  }
+  const InterpolatedBoundaryData<Dim> interpolated_boundary_data_4{
+      {.data = interpolated_data, .target_mesh = mesh, .offsets = offsets_2}};
+  CHECK(interpolated_boundary_data != interpolated_boundary_data_4);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.InterpolatedBoundaryData",
+                  "[Unit][Evolution]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace evolution::dg


### PR DESCRIPTION
## Proposed changes

Add struct to hold information needed for communicating interpolated boundary data for non-conforming (e.g. S2 spherical shell next to multiple cubed sphere Elements) neighbors.

Add an optional of the new struct to BoundaryData

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
