### PR TITLE
AMR: add keep_coarse_grids option

### DIFF
--- a/docs/DevGuide/Amr.md
+++ b/docs/DevGuide/Amr.md
@@ -278,6 +278,7 @@ struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
         domain::Tags::InitialExtents<Dim>,
         domain::Tags::InitialRefinementLevels<Dim>,
         evolution::dg::Tags::Quadrature>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 ```
 

--- a/src/Domain/Amr/Helpers.cpp
+++ b/src/Domain/Amr/Helpers.cpp
@@ -98,14 +98,15 @@ ElementId<VolumeDim> id_of_parent(const ElementId<VolumeDim>& element_id,
 template <size_t VolumeDim>
 std::vector<ElementId<VolumeDim>> ids_of_children(
     const ElementId<VolumeDim>& element_id,
-    const std::array<amr::Flag, VolumeDim>& flags) {
+    const std::array<amr::Flag, VolumeDim>& flags,
+    const std::optional<size_t>& child_grid_index) {
   using ::operator<<;
   ASSERT(alg::count(flags, Flag::Split) > 0,
          "Element " << element_id << " has no children given flags " << flags);
   ASSERT(alg::count(flags, Flag::Join) == 0,
          "Splitting and joining an Element is not supported");
   const size_t block_id = element_id.block_id();
-  const size_t grid_index = element_id.grid_index();
+  const size_t grid_index = child_grid_index.value_or(element_id.grid_index());
   if constexpr (VolumeDim == 1) {
     return {{block_id,
              {{element_id.segment_id(0).id_of_child(Side::Lower)}},
@@ -220,7 +221,8 @@ bool prevent_element_from_joining_while_splitting(
       const std::array<amr::Flag, DIM(data)>& flags);                          \
   template std::vector<ElementId<DIM(data)>> ids_of_children(                  \
       const ElementId<DIM(data)>& element_id,                                  \
-      const std::array<amr::Flag, DIM(data)>& flags);                          \
+      const std::array<amr::Flag, DIM(data)>& flags,                           \
+      const std::optional<size_t>& child_grid_index);                          \
   template std::deque<ElementId<DIM(data)>> ids_of_joining_neighbors(          \
       const Element<DIM(data)>& element,                                       \
       const std::array<Flag, DIM(data)>& flags);                               \

--- a/src/Domain/Amr/Helpers.hpp
+++ b/src/Domain/Amr/Helpers.hpp
@@ -10,6 +10,7 @@
 #include <boost/rational.hpp>
 #include <cstddef>
 #include <deque>
+#include <optional>
 #include <vector>
 
 #include "Domain/Amr/Flag.hpp"
@@ -94,7 +95,8 @@ ElementId<VolumeDim> id_of_parent(const ElementId<VolumeDim>& element_id,
 template <size_t VolumeDim>
 std::vector<ElementId<VolumeDim>> ids_of_children(
     const ElementId<VolumeDim>& element_id,
-    const std::array<Flag, VolumeDim>& flags);
+    const std::array<Flag, VolumeDim>& flags,
+    const std::optional<size_t>& child_grid_index = std::nullopt);
 
 /// \ingroup AmrGroup
 /// \brief The ElementIds of the neighbors of `element` that will join with it

--- a/src/Domain/Amr/NeighborsOfChild.hpp
+++ b/src/Domain/Amr/NeighborsOfChild.hpp
@@ -29,10 +29,22 @@ class Neighbors;
 /// \endcond
 
 namespace amr {
-/// \ingroup AmrGroup
-/// \brief returns the neighbors and their Mesh%es of the Element with ElementId
-/// `child_id`, whose parent Element is `parent` which has Info `parent_info`
-/// and neighbor Info `parent_neighbor_info`
+/*!
+ * \ingroup AmrGroup
+ * \brief Determine the new neighbors of an element during AMR, and the
+ * neighbors' meshes.
+ *
+ * Can be used for both h-refinement and p-refinement.
+ *
+ * \param parent The parent element that is being refined. For h-refinement,
+ * this is the element that is being split into children. For p-refinement,
+ * this is the element that is being increased in resolution.
+ * \param parent_info The AMR info of the parent element.
+ * \param parent_neighbor_info The AMR info of the parent element's neighbors.
+ * \param child_id The ID of the child element that is being created. For
+ * h-refinement, this is the ID of the new child element. For p-refinement,
+ * this is the same as the ID of the parent element.
+ */
 template <size_t VolumeDim>
 std::pair<DirectionMap<VolumeDim, Neighbors<VolumeDim, ElementId<VolumeDim>>>,
           DirectionalIdMap<VolumeDim, Mesh<VolumeDim>>>

--- a/src/Domain/Amr/NewNeighborIds.cpp
+++ b/src/Domain/Amr/NewNeighborIds.cpp
@@ -47,6 +47,7 @@ std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>> new_neighbor_ids(
         previous_neighbors_amr_info) {
   std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>>
       new_neighbors_in_direction;
+  const size_t grid_index = my_id.grid_index();
 
   // Only one neighbor in 1D in a given direction
   if constexpr (VolumeDim == 1) {
@@ -69,7 +70,7 @@ std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>> new_neighbor_ids(
                     : previous_segment_id));
     new_neighbors_in_direction.try_emplace(
         {previous_neighbor_id.block_id(),
-         std::array<SegmentId, 1>({{new_segment_id}})},
+         std::array<SegmentId, 1>({{new_segment_id}}), grid_index},
         previous_neighbors_amr_info.at(previous_neighbor_id).new_mesh);
     return new_neighbors_in_direction;
   } else {
@@ -167,8 +168,7 @@ std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>> new_neighbor_ids(
             // neighbor; it is assumed they have the same new_mesh
             new_neighbors_in_direction.try_emplace(
                 {previous_neighbor_id.block_id(),
-                 std::array{segment_id_xi, segment_id_eta},
-                 previous_neighbor_id.grid_index()},
+                 std::array{segment_id_xi, segment_id_eta}, grid_index},
                 new_neighbor_mesh);
           } else if constexpr (VolumeDim == 3) {
             for (const auto segment_id_zeta : valid_neighbor_segment_ids[2]) {
@@ -177,7 +177,7 @@ std::unordered_map<ElementId<VolumeDim>, Mesh<VolumeDim>> new_neighbor_ids(
               new_neighbors_in_direction.try_emplace(
                   {previous_neighbor_id.block_id(),
                    std::array{segment_id_xi, segment_id_eta, segment_id_zeta},
-                   previous_neighbor_id.grid_index()},
+                   grid_index},
                   new_neighbor_mesh);
             }
           }

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -183,6 +183,7 @@ struct Metavariables {
     using projectors = tmpl::push_back<
         typename solver::amr_projectors,
         Elasticity::Actions::InitializeConstitutiveRelation<Dim>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -168,6 +168,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
     using projectors = typename solver::amr_projectors;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
@@ -146,6 +146,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
     using projectors = typename solver::amr_projectors;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -245,7 +245,7 @@ struct Solver {
       typename multigrid::initialize_element,
       typename schwarz_smoother::initialize_element,
       Initialization::Actions::InitializeItems<
-          ::amr::Initialization::Initialize<volume_dim>,
+          ::amr::Initialization::Initialize<volume_dim, Metavariables>,
           elliptic::amr::Actions::Initialize>,
       elliptic::Actions::InitializeFields<system, initial_guess_tag>,
       ::Actions::RandomizeVariables<fields_tag, RandomizeInitialGuess>,

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -195,6 +195,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
     using projectors = typename solver::amr_projectors;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -579,7 +579,7 @@ struct EvolutionMetavars {
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
           evolution::dg::Initialization::Domain<volume_dim,
                                                 use_control_systems>,
-          ::amr::Initialization::Initialize<volume_dim>,
+          ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,
       Initialization::Actions::AddComputeTags<tmpl::list<::Tags::DerivCompute<
@@ -702,6 +702,7 @@ struct EvolutionMetavars {
             intrp::Tags::InterpPointInfo<EvolutionMetavars>,
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -85,7 +85,6 @@ struct EvolutionMetavars
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = gh_dg_element_array;
-
     using projectors = tmpl::list<
         Initialization::ProjectTimeStepping<volume_dim>,
         evolution::dg::Initialization::ProjectDomain<volume_dim>,
@@ -107,6 +106,7 @@ struct EvolutionMetavars
         ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -271,7 +271,6 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = gh_dg_element_array;
-
     using projectors = tmpl::list<
         Initialization::ProjectTimeStepping<volume_dim>,
         evolution::dg::Initialization::ProjectDomain<volume_dim>,
@@ -296,6 +295,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
             intrp::Tags::InterpPointInfo<EvolutionMetavars>,
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -401,7 +401,7 @@ struct GeneralizedHarmonicTemplateBase {
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<DerivedMetavars, TimeStepperBase>,
           evolution::dg::Initialization::Domain<volume_dim, UseControlSystems>,
-          ::amr::Initialization::Initialize<volume_dim>,
+          ::amr::Initialization::Initialize<volume_dim, DerivedMetavars>,
           Initialization::TimeStepperHistory<DerivedMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,
       Initialization::Actions::AddComputeTags<::Tags::DerivCompute<

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -264,7 +264,7 @@ struct EvolutionMetavars {
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
           evolution::dg::Initialization::Domain<volume_dim>,
-          ::amr::Initialization::Initialize<volume_dim>,
+          ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,
       evolution::Initialization::Actions::SetVariables<
@@ -308,7 +308,6 @@ struct EvolutionMetavars {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
-
     using projectors = tmpl::list<
         Initialization::ProjectTimeStepping<volume_dim>,
         evolution::dg::Initialization::ProjectDomain<volume_dim>,
@@ -332,6 +331,7 @@ struct EvolutionMetavars {
         ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Executables/Examples/RandomAmr/CMakeLists.txt
+++ b/src/Executables/Examples/RandomAmr/CMakeLists.txt
@@ -13,8 +13,12 @@ set(LIBS_TO_LINK
   Utilities
   )
 
-function(add_random_amr_executable DIM)
-  set(EXECUTABLE "RandomAmr${DIM}D")
+function(add_random_amr_executable DIM KEEP_COARSE_GRIDS)
+  set(KEEP_COARSE_GRIDS_SUFFIX "")
+  if (KEEP_COARSE_GRIDS)
+    set(KEEP_COARSE_GRIDS_SUFFIX "KeepCoarseGrids")
+  endif()
+  set(EXECUTABLE "RandomAmr${KEEP_COARSE_GRIDS_SUFFIX}${DIM}D")
   add_spectre_executable(
     ${EXECUTABLE}
     EXCLUDE_FROM_ALL
@@ -24,10 +28,14 @@ function(add_random_amr_executable DIM)
     ${EXECUTABLE}
     PRIVATE
     DIM=${DIM}
+    KEEP_COARSE_GRIDS=${KEEP_COARSE_GRIDS}
     )
   target_link_libraries(${EXECUTABLE} PRIVATE ${LIBS_TO_LINK})
 endfunction()
 
-add_random_amr_executable(1)
-add_random_amr_executable(2)
-add_random_amr_executable(3)
+add_random_amr_executable(1 false)
+add_random_amr_executable(2 false)
+add_random_amr_executable(3 false)
+add_random_amr_executable(1 true)
+add_random_amr_executable(2 true)
+add_random_amr_executable(3 true)

--- a/src/Executables/Examples/RandomAmr/RandomAmr.cpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.cpp
@@ -11,7 +11,7 @@
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // Parameters chosen in CMakeLists.txt
-using metavariables = RandomAmrMetavars<DIM>;
+using metavariables = RandomAmrMetavars<DIM, KEEP_COARSE_GRIDS>;
 
 extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -88,7 +88,8 @@ struct RandomAmrMetavars {
               Parallel::Phase::Initialization,
               tmpl::list<Initialization::Actions::InitializeItems<
                              amr::Initialization::Domain<volume_dim>,
-                             amr::Initialization::Initialize<volume_dim>>,
+                             amr::Initialization::Initialize<
+                                 volume_dim, RandomAmrMetavars>>,
                          Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<Parallel::Phase::CheckDomain,
                                  tmpl::list<::amr::Actions::SendAmrDiagnostics,
@@ -106,10 +107,10 @@ struct RandomAmrMetavars {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
-
     using projectors = tmpl::list<::amr::projectors::DefaultInitialize<
         domain::Tags::InitialExtents<Dim>,
         domain::Tags::InitialRefinementLevels<Dim>,
         evolution::dg::Tags::Quadrature>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 };

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -24,9 +24,11 @@
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "Parallel/PhaseControl/VisitAndReturn.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Component.hpp"
+#include "ParallelAlgorithms/Amr/Actions/ElementsRegistration.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
 #include "ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
@@ -51,7 +53,7 @@ struct DummySystem {};
 /// executable.
 
 /// \brief The metavariables for the RandomAmr executable
-template <size_t Dim>
+template <size_t Dim, bool KeepCoarseGrids>
 struct RandomAmrMetavars {
   static constexpr size_t volume_dim = Dim;
   using system = DummySystem;
@@ -72,14 +74,16 @@ struct RandomAmrMetavars {
                 PhaseControl::VisitAndReturn<
                     Parallel::Phase::EvaluateAmrCriteria>,
                 PhaseControl::VisitAndReturn<Parallel::Phase::AdjustDomain>,
+                PhaseControl::VisitAndReturn<Parallel::Phase::UpdateSections>,
                 PhaseControl::VisitAndReturn<Parallel::Phase::CheckDomain>,
                 PhaseControl::CheckpointAndExitAfterWallclock>>,
         tmpl::pair<Trigger, tmpl::list<Triggers::Always>>>;
   };
 
   static constexpr auto default_phase_order =
-      std::array{Parallel::Phase::Initialization, Parallel::Phase::CheckDomain,
-                 Parallel::Phase::Evolve, Parallel::Phase::Exit};
+      std::array{Parallel::Phase::Initialization, Parallel::Phase::Register,
+                 Parallel::Phase::UpdateSections, Parallel::Phase::CheckDomain,
+                 Parallel::Phase::Evolve,         Parallel::Phase::Exit};
 
   using dg_element_array = DgElementArray<
       RandomAmrMetavars,
@@ -91,13 +95,22 @@ struct RandomAmrMetavars {
                              amr::Initialization::Initialize<
                                  volume_dim, RandomAmrMetavars>>,
                          Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<Parallel::Phase::Register,
+                                 tmpl::list<amr::Actions::RegisterElement,
+                                            Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<Parallel::Phase::CheckDomain,
                                  tmpl::list<::amr::Actions::SendAmrDiagnostics,
                                             Parallel::Actions::TerminatePhase>>,
-
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<PhaseControl::Actions::ExecutePhaseChange>>>>;
+
+  struct registration
+      : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {
+    using element_registrars =
+        tmpl::map<tmpl::pair<dg_element_array,
+                             tmpl::list<amr::Actions::RegisterElement>>>;
+  };
 
   using component_list =
       tmpl::list<amr::Component<RandomAmrMetavars>, dg_element_array>;
@@ -111,6 +124,6 @@ struct RandomAmrMetavars {
         domain::Tags::InitialExtents<Dim>,
         domain::Tags::InitialRefinementLevels<Dim>,
         evolution::dg::Tags::Quadrature>>;
-    static constexpr bool keep_coarse_grids = false;
+    static constexpr bool keep_coarse_grids = KeepCoarseGrids;
   };
 };

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -334,7 +334,8 @@ struct Metavariables {
                              Initialization::TimeStepping<Metavariables,
                                                           TimeStepperBase>,
                              evolution::dg::Initialization::Domain<Dim>,
-                             ::amr::Initialization::Initialize<volume_dim>,
+                             ::amr::Initialization::Initialize<volume_dim,
+                                                               Metavariables>,
                              Initialization::SetMeshType<Dim>>,
                          Initialization::Actions::AddComputeTags<tmpl::list<
                              ::domain::Tags::MinimumGridSpacingCompute<
@@ -371,6 +372,7 @@ struct Metavariables {
             ::domain::Tags::InitialExtents<Dim>,
             ::domain::Tags::InitialRefinementLevels<Dim>,
             evolution::dg::Tags::Quadrature>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   struct registration

--- a/src/Parallel/Phase.cpp
+++ b/src/Parallel/Phase.cpp
@@ -36,6 +36,7 @@ std::vector<Phase> known_phases() {
           Phase::Solve,
           Phase::Testing,
           Phase::UpdateOptionsAtRestartFromCheckpoint,
+          Phase::UpdateSections,
           Phase::WriteCheckpoint};
 }
 
@@ -83,6 +84,8 @@ std::ostream& operator<<(std::ostream& os, const Phase& phase) {
       return os << "Testing";
     case Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint:
       return os << "UpdateOptionsAtRestartFromCheckpoint";
+    case Parallel::Phase::UpdateSections:
+      return os << "UpdateSections";
     case Parallel::Phase::WriteCheckpoint:
       return os << "WriteCheckpoint";
     default:  // LCOV_EXCL_LINE

--- a/src/Parallel/Phase.hpp
+++ b/src/Parallel/Phase.hpp
@@ -87,6 +87,8 @@ enum class Phase {
   Testing,
   ///  phase in which options are changed after restart
   UpdateOptionsAtRestartFromCheckpoint,
+  ///  phase in which array sections are updated
+  UpdateSections,
   ///  phase in which checkpoint files are written to disk
   WriteCheckpoint
 };

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -30,6 +30,7 @@
 #include "Parallel/Phase.hpp"
 #include "Parallel/Printf/Printf.hpp"
 #include "Parallel/Tags/DistributedObjectTags.hpp"
+#include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CreateChild.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CreateParent.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
@@ -106,7 +107,10 @@ struct AdjustDomain {
       using tags_mutated_by_this_action = tmpl::list<
           ::domain::Tags::Element<volume_dim>, ::domain::Tags::Mesh<volume_dim>,
           ::domain::Tags::NeighborMesh<volume_dim>, amr::Tags::Info<volume_dim>,
-          amr::Tags::NeighborInfo<volume_dim>>;
+          amr::Tags::NeighborInfo<volume_dim>, amr::Tags::ParentId<volume_dim>,
+          amr::Tags::ChildIds<volume_dim>, amr::Tags::ParentMesh<volume_dim>,
+          Parallel::Tags::Section<ParallelComponent, amr::Tags::GridIndex>,
+          Parallel::Tags::Section<ParallelComponent, amr::Tags::IsFinestGrid>>;
       using mutated_tags =
           tmpl::append<distributed_object_tags, tags_mutated_by_this_action,
                        typename detail::GetMutatedTags<amr_projectors>::type>;
@@ -124,6 +128,9 @@ struct AdjustDomain {
       const auto& my_amr_flags = my_amr_info.flags;
       auto& element_array =
           Parallel::get_parallel_component<ParallelComponent>(cache);
+      auto& amr_component =
+          Parallel::get_parallel_component<amr::Component<Metavariables>>(
+              cache);
       const auto& phase_bookmarks =
           Parallel::local(element_array[element_id])->phase_bookmarks();
       const auto& verbosity =
@@ -149,10 +156,11 @@ struct AdjustDomain {
                "Element " << element_id
                           << " cannot both split and join, but had AMR flags "
                           << my_amr_flags << "\n");
-        auto children_ids = amr::ids_of_children(element_id, my_amr_flags);
-        auto& amr_component =
-            Parallel::get_parallel_component<amr::Component<Metavariables>>(
-                cache);
+        const size_t child_grid_index = Metavariables::amr::keep_coarse_grids
+                                            ? element_id.grid_index() + 1
+                                            : element_id.grid_index();
+        auto children_ids =
+            amr::ids_of_children(element_id, my_amr_flags, child_grid_index);
         if (verbosity >= Verbosity::Debug) {
           Parallel::printf("Splitting element %s into %zu: %s\n", element_id,
                            children_ids.size(), children_ids);
@@ -160,11 +168,21 @@ struct AdjustDomain {
         Parallel::simple_action<CreateChild>(amr_component, element_array,
                                              element_id, children_ids, 0_st,
                                              phase_bookmarks);
-
+        return;
       } else if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
                    return flag == amr::Flag::Join;
                  })) {
         // h-coarsening
+        if (Metavariables::amr::keep_coarse_grids) {
+          ERROR(
+              "When AMR keeps coarse grids then no h-coarsening during AMR is "
+              "allowed, but element "
+              << element_id
+              << " requested h-coarsening. Set the 'AllowCoarsening' policy to "
+                 "false to disable coarsening.");
+          // Note: this restriction could be relaxed if ever needed.
+          return;
+        }
         // Only one element should create the new parent
         if (amr::is_child_that_creates_parent(element_id, my_amr_flags)) {
           auto parent_id = amr::id_of_parent(element_id, my_amr_flags);
@@ -172,9 +190,6 @@ struct AdjustDomain {
               db::get<::domain::Tags::Element<volume_dim>>(box);
           auto ids_to_join =
               amr::ids_of_joining_neighbors(element, my_amr_flags);
-          auto& amr_component =
-              Parallel::get_parallel_component<amr::Component<Metavariables>>(
-                  cache);
           if (verbosity >= Verbosity::Debug) {
             Parallel::printf("Joining %zu elements: %s -> %s\n",
                              ids_to_join.size(), ids_to_join, parent_id);
@@ -183,94 +198,91 @@ struct AdjustDomain {
               amr_component, element_array, std::move(parent_id), element_id,
               std::move(ids_to_join), phase_bookmarks);
         }
+        return;
+      }
 
-      } else {
-        // Neither h-refinement nor h-coarsening. This element will remain.
-        const auto old_mesh_and_element =
-            std::make_pair(db::get<::domain::Tags::Mesh<volume_dim>>(box),
-                           db::get<::domain::Tags::Element<volume_dim>>(box));
-        const auto& old_mesh = old_mesh_and_element.first;
+      // Neither h-refinement nor h-coarsening. This element will remain.
 
-        // Determine new neighbors and update the Element
-        {  // avoid shadowing when mutating flags below
-          using NeighborMeshType =
-              DirectionalIdMap<volume_dim, ::Mesh<volume_dim>>;
-          const auto& amr_info_of_neighbors =
-              db::get<amr::Tags::NeighborInfo<volume_dim>>(box);
-          db::mutate<::domain::Tags::Element<volume_dim>,
-                     ::domain::Tags::NeighborMesh<volume_dim>>(
-              [&element_id, &amr_info_of_neighbors](
-                  const gsl::not_null<Element<volume_dim>*> element,
-                  const gsl::not_null<NeighborMeshType*> neighbor_meshes) {
-                auto new_neighbors = element->neighbors();
-                neighbor_meshes->clear();
-                for (auto& [direction, neighbors] : new_neighbors) {
-                  const auto new_neighbor_ids_and_meshes =
-                      amr::new_neighbor_ids(element_id, direction, neighbors,
-                                            amr_info_of_neighbors);
-                  std::unordered_set<ElementId<volume_dim>> new_neighbor_ids;
-                  for (const auto& [id, mesh] : new_neighbor_ids_and_meshes) {
-                    neighbor_meshes->insert({{direction, id}, mesh});
-                    new_neighbor_ids.insert(id);
-                  }
-                  neighbors.set_ids_to(new_neighbor_ids);
-                }
-                *element =
-                    Element<volume_dim>(element_id, std::move(new_neighbors));
-              },
-              make_not_null(&box));
-        }
+      if constexpr (Metavariables::amr::keep_coarse_grids) {
+        // Create new element that covers this one with an incremented grid
+        // index. p-refinement will be handled by the newly created element.
+        ElementId<volume_dim> new_element_id{element_id.block_id(),
+                                             element_id.segment_ids(),
+                                             element_id.grid_index() + 1};
+        Parallel::simple_action<CreateChild>(
+            amr_component, element_array, element_id,
+            std::vector<ElementId<volume_dim>>{new_element_id}, 0_st,
+            phase_bookmarks);
+        return;
+      }
 
-        // Check for p-refinement
-        if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
-              return (flag == amr::Flag::IncreaseResolution or
-                      flag == amr::Flag::DecreaseResolution);
-            })) {
-          db::mutate<::domain::Tags::Mesh<volume_dim>>(
-              [&old_mesh,
-               &my_amr_flags](const gsl::not_null<Mesh<volume_dim>*> mesh) {
-                *mesh = amr::projectors::mesh(old_mesh, my_amr_flags);
-              },
-              make_not_null(&box));
+      const auto old_mesh_and_element =
+          std::make_pair(db::get<::domain::Tags::Mesh<volume_dim>>(box),
+                         db::get<::domain::Tags::Element<volume_dim>>(box));
+      const auto& old_mesh = old_mesh_and_element.first;
 
-          if (verbosity >= Verbosity::Debug) {
-            Parallel::printf(
-                "Increasing order of element %s: %s -> %s\n", element_id,
-                old_mesh.extents(),
-                db::get<::domain::Tags::Mesh<volume_dim>>(box).extents());
-          }
-        }
+      // Determine new neighbors and update the Element
+      const auto& amr_info_of_neighbors =
+          db::get<amr::Tags::NeighborInfo<volume_dim>>(box);
+      auto [new_neighbors, new_neighbor_meshes] =
+          neighbors_of_child(old_mesh_and_element.second, my_amr_info,
+                             amr_info_of_neighbors, element_id);
+      ::Initialization::mutate_assign<
+          tmpl::list<::domain::Tags::Element<volume_dim>,
+                     ::domain::Tags::NeighborMesh<volume_dim>>>(
+          make_not_null(&box),
+          Element<volume_dim>(element_id, std::move(new_neighbors)),
+          std::move(new_neighbor_meshes));
 
-        // Run the projectors on all elements, even if they did no h-refinement.
-        // This allows projectors to update mutable items that depend upon the
-        // neighbors of the element.
-        tmpl::for_each<amr_projectors>(
-            [&box, &old_mesh_and_element](auto projector_v) {
-              using projector = typename decltype(projector_v)::type;
-              try {
-                db::mutate_apply<projector>(make_not_null(&box),
-                                            old_mesh_and_element);
-              } catch (std::exception& e) {
-                ERROR("Error in AMR projector '"
-                      << pretty_type::get_name<projector>() << "':\n"
-                      << e.what());
-              }
-            });
-
-        // Reset the AMR flags
-        db::mutate<amr::Tags::Info<volume_dim>,
-                   amr::Tags::NeighborInfo<volume_dim>>(
-            [](const gsl::not_null<amr::Info<volume_dim>*> amr_info,
-               const gsl::not_null<std::unordered_map<ElementId<volume_dim>,
-                                                      amr::Info<volume_dim>>*>
-                   amr_info_of_neighbors) {
-              amr_info_of_neighbors->clear();
-              for (size_t d = 0; d < volume_dim; ++d) {
-                amr_info->flags[d] = amr::Flag::Undefined;
-              }
+      // Check for p-refinement
+      if (alg::any_of(my_amr_flags, [](amr::Flag flag) {
+            return (flag == amr::Flag::IncreaseResolution or
+                    flag == amr::Flag::DecreaseResolution);
+          })) {
+        db::mutate<::domain::Tags::Mesh<volume_dim>>(
+            [&old_mesh,
+             &my_amr_flags](const gsl::not_null<Mesh<volume_dim>*> mesh) {
+              *mesh = amr::projectors::mesh(old_mesh, my_amr_flags);
             },
             make_not_null(&box));
+
+        if (verbosity >= Verbosity::Debug) {
+          Parallel::printf(
+              "Increasing order of element %s: %s -> %s\n", element_id,
+              old_mesh.extents(),
+              db::get<::domain::Tags::Mesh<volume_dim>>(box).extents());
+        }
       }
+
+      // Run the projectors on all elements, even if they did no p-refinement.
+      // This allows projectors to update mutable items that depend upon the
+      // neighbors of the element.
+      tmpl::for_each<amr_projectors>(
+          [&box, &old_mesh_and_element](auto projector_v) {
+            using projector = typename decltype(projector_v)::type;
+            try {
+              db::mutate_apply<projector>(make_not_null(&box),
+                                          old_mesh_and_element);
+            } catch (std::exception& e) {
+              ERROR("Error in AMR projector '"
+                    << pretty_type::get_name<projector>() << "':\n"
+                    << e.what());
+            }
+          });
+
+      // Reset the AMR flags
+      db::mutate<amr::Tags::Info<volume_dim>,
+                 amr::Tags::NeighborInfo<volume_dim>>(
+          [](const gsl::not_null<amr::Info<volume_dim>*> amr_info,
+             const gsl::not_null<std::unordered_map<ElementId<volume_dim>,
+                                                    amr::Info<volume_dim>>*>
+                 local_amr_info_of_neighbors) {
+            local_amr_info_of_neighbors->clear();
+            for (size_t d = 0; d < volume_dim; ++d) {
+              amr_info->flags[d] = amr::Flag::Undefined;
+            }
+          },
+          make_not_null(&box));
     }
   }
 };

--- a/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Actions/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_headers(
   Component.hpp
   CreateChild.hpp
   CreateParent.hpp
+  ElementsRegistration.hpp
   EvaluateRefinementCriteria.hpp
   Initialization.hpp
   Initialize.hpp

--- a/src/ParallelAlgorithms/Amr/Actions/Component.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Component.hpp
@@ -11,6 +11,7 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp"
+#include "ParallelAlgorithms/Amr/Actions/ElementsRegistration.hpp"
 #include "ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
@@ -44,7 +45,15 @@ struct Component {
                  logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>;
 
   using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<amr::Actions::InitializeElementsRegistration<volume_dim>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::UpdateSections,
+          tmpl::conditional_t<
+              metavariables::amr::keep_coarse_grids,
+              tmpl::list<::amr::Actions::UpdateSections<ElementArray>>,
+              tmpl::list<>>>>;
 
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<
       Parallel::get_initialization_actions_list<phase_dependent_action_list>>;

--- a/src/ParallelAlgorithms/Amr/Actions/Component.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Component.hpp
@@ -14,6 +14,8 @@
 #include "ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \ingroup AmrGroup
@@ -29,6 +31,10 @@ namespace amr {
 template <class Metavariables>
 struct Component {
   using metavariables = Metavariables;
+  static constexpr size_t volume_dim = Metavariables::volume_dim;
+  static_assert(tt::assert_conforms_to_v<typename metavariables::amr,
+                                         amr::protocols::AmrMetavariables>);
+  using ElementArray = typename metavariables::amr::element_array;
 
   using chare_type = Parallel::Algorithms::Singleton;
   static constexpr bool checkpoint_data = true;
@@ -49,30 +55,23 @@ struct Component {
     auto& local_cache = *Parallel::local_branch(global_cache_proxy);
     Parallel::get_parallel_component<Component>(local_cache)
         .start_phase(next_phase);
+    auto& element_array =
+        Parallel::get_parallel_component<ElementArray>(local_cache);
     if (Parallel::Phase::EvaluateAmrCriteria == next_phase) {
-      if constexpr (Parallel::is_dg_element_collection_v<
-                        typename metavariables::amr::element_array>) {
+      if constexpr (Parallel::is_dg_element_collection_v<ElementArray>) {
         Parallel::threaded_action<Parallel::Actions::SimpleActionOnElement<
-            ::amr::Actions::EvaluateRefinementCriteria, true>>(
-            Parallel::get_parallel_component<
-                typename metavariables::amr::element_array>(local_cache));
+            ::amr::Actions::EvaluateRefinementCriteria, true>>(element_array);
       } else {
         Parallel::simple_action<::amr::Actions::EvaluateRefinementCriteria>(
-            Parallel::get_parallel_component<
-                typename metavariables::amr::element_array>(local_cache));
+            element_array);
       }
     }
     if (Parallel::Phase::AdjustDomain == next_phase) {
-      if constexpr (Parallel::is_dg_element_collection_v<
-                        typename metavariables::amr::element_array>) {
+      if constexpr (Parallel::is_dg_element_collection_v<ElementArray>) {
         Parallel::threaded_action<Parallel::Actions::SimpleActionOnElement<
-            ::amr::Actions::AdjustDomain, true>>(
-            Parallel::get_parallel_component<
-                typename metavariables::amr::element_array>(local_cache));
+            ::amr::Actions::AdjustDomain, true>>(element_array);
       } else {
-        Parallel::simple_action<::amr::Actions::AdjustDomain>(
-            Parallel::get_parallel_component<
-                typename metavariables::amr::element_array>(local_cache));
+        Parallel::simple_action<::amr::Actions::AdjustDomain>(element_array);
       }
     }
   }

--- a/src/ParallelAlgorithms/Amr/Actions/ElementsRegistration.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/ElementsRegistration.hpp
@@ -1,0 +1,240 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// The actions in this file keep track of all element IDs during AMR and update
+/// the array sections that represent the grid hierarchy.
+
+#pragma once
+
+#include <algorithm>
+#include <charm++.h>
+#include <cstddef>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/ElementRegistration.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "Parallel/Protocols/ElementRegistrar.hpp"
+#include "Parallel/Section.hpp"
+#include "Parallel/Tags/Section.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace amr {
+template <typename Metavariables>
+struct Component;
+}  // namespace amr
+
+namespace amr::Actions {
+
+template <size_t Dim>
+struct InitializeElementsRegistration {
+  using simple_tags = tmpl::list<Tags::AllElementIds<Dim>>;
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+  }
+};
+
+struct RegisterOrDeregisterElement {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex, size_t Dim>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ElementId<Dim>& element_id,
+                    const bool register_or_deregister) {
+    db::mutate<Tags::AllElementIds<Dim>>(
+        [&element_id, register_or_deregister](const auto all_element_ids) {
+          auto& element_ids = (*all_element_ids)[element_id.grid_index()];
+          if (register_or_deregister) {
+            element_ids.insert(element_id);
+          } else {
+            element_ids.erase(element_id);
+          }
+        },
+        make_not_null(&box));
+  }
+};
+
+struct RegisterElement : tt::ConformsTo<Parallel::protocols::ElementRegistrar> {
+ public:  // ElementRegistrar protocol
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, size_t Dim>
+  static void perform_registration(const db::DataBox<DbTagList>& /*box*/,
+                                   Parallel::GlobalCache<Metavariables>& cache,
+                                   const ElementId<Dim>& element_id) {
+    Parallel::simple_action<RegisterOrDeregisterElement>(
+        Parallel::get_parallel_component<::amr::Component<Metavariables>>(
+            cache),
+        element_id, true);
+  }
+
+  template <typename ParallelComponent, typename DbTagList,
+            typename Metavariables, size_t Dim>
+  static void perform_deregistration(
+      const db::DataBox<DbTagList>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id) {
+    Parallel::simple_action<RegisterOrDeregisterElement>(
+        Parallel::get_parallel_component<::amr::Component<Metavariables>>(
+            cache),
+        element_id, false);
+  }
+
+ public:  // Iterable action
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent, size_t Dim>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    perform_registration<ParallelComponent>(box, cache, element_id);
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+struct UpdateSectionsOnElement {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, size_t Dim>
+  static void apply(
+      db::DataBox<DbTagsList>& box,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& element_id, const size_t grid_index,
+      Parallel::Section<ParallelComponent, Tags::GridIndex> grid_index_section,
+      std::optional<Parallel::Section<ParallelComponent, Tags::IsFinestGrid>>
+          finest_grid_section) {
+    if (grid_index != element_id.grid_index()) {
+      // Discard broadcast to elements that are not part of the section. This
+      // happens because we broadcast to all elements, not just to the section.
+      // Broadcasting to the section fails with a segfault for some reason.
+      return;
+    }
+    db::mutate<Parallel::Tags::Section<ParallelComponent, Tags::GridIndex>,
+               Parallel::Tags::Section<ParallelComponent, Tags::IsFinestGrid>>(
+        [&grid_index_section, &finest_grid_section](
+            const auto stored_grid_index_section,
+            const auto stored_finest_grid_section) {
+          // Only update the grid index section if we don't have one already
+          // because the elements in the old grid didn't change. This avoids a
+          // bug(?) with Charm++ where section reductions don't work with the
+          // new section. It's possible that this issue is with (not) updating
+          // the section cookie, but it's not clear how to do that because a
+          // multicast message is needed for that and we can't even do a
+          // broadcast to the section without a segfault.
+          if (not stored_grid_index_section->has_value()) {
+            *stored_grid_index_section = std::move(grid_index_section);
+          }
+          *stored_finest_grid_section = std::move(finest_grid_section);
+        },
+        make_not_null(&box));
+  }
+};
+
+struct DestroyGrid {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, size_t Dim>
+  static void apply(db::DataBox<DbTagsList>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ElementId<Dim>& element_id, const size_t grid_index) {
+    if (grid_index == element_id.grid_index()) {
+      // Destroy the element
+      Parallel::deregister_element<ParallelComponent>(box, cache, element_id);
+      auto& array_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(cache);
+      array_proxy[element_id].ckDestroy();
+      return;
+    }
+    // Unregister the parent ID if it was destroyed
+    const auto& parent_id = db::get<amr::Tags::ParentId<Dim>>(box);
+    if (parent_id.has_value() and parent_id->grid_index() == grid_index) {
+      db::mutate<amr::Tags::ParentId<Dim>, amr::Tags::ParentMesh<Dim>>(
+          [](const gsl::not_null<std::optional<ElementId<Dim>>*>
+                 stored_parent_id,
+             const gsl::not_null<std::optional<Mesh<Dim>>*>
+                 stored_parent_mesh) {
+            *stored_parent_id = std::nullopt;
+            *stored_parent_mesh = std::nullopt;
+          },
+          make_not_null(&box));
+    }
+  }
+};
+
+template <typename ElementArray>
+struct UpdateSections {
+  using const_global_cache_tags = tmpl::list<amr::Tags::MaxCoarseLevels>;
+
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    static constexpr size_t Dim = Metavariables::volume_dim;
+    const auto& all_element_ids = db::get<Tags::AllElementIds<Dim>>(box);
+    auto& element_array = Parallel::get_parallel_component<ElementArray>(cache);
+    const size_t finest_grid_index = std::prev(all_element_ids.end())->first;
+    const std::optional<size_t> max_coarse_levels =
+        db::get<amr::Tags::MaxCoarseLevels>(box);
+    for (const auto& [grid_index, element_ids] : all_element_ids) {
+      if (max_coarse_levels.has_value() and
+          finest_grid_index - grid_index > max_coarse_levels.value()) {
+        // Delete grids that are coarser than the maximum allowed level
+        Parallel::simple_action<DestroyGrid>(element_array, grid_index);
+        continue;
+      }
+      std::vector<CkArrayIndex> array_indices(element_ids.size());
+      std::transform(
+          element_ids.begin(), element_ids.end(), array_indices.begin(),
+          [](const ElementId<Dim>& local_element_id) {
+            return Parallel::ArrayIndex<ElementId<Dim>>(local_element_id);
+          });
+      using GridIndexSection = Parallel::Section<ElementArray, Tags::GridIndex>;
+      GridIndexSection grid_index_section{
+          grid_index, GridIndexSection::cproxy_section::ckNew(
+                          element_array.ckGetArrayID(), array_indices.data(),
+                          array_indices.size())};
+      using FinestGridSection =
+          Parallel::Section<ElementArray, Tags::IsFinestGrid>;
+      const std::optional<FinestGridSection> finest_grid_section =
+          grid_index == finest_grid_index
+              ? std::make_optional(FinestGridSection{
+                    true, FinestGridSection::cproxy_section::ckNew(
+                              element_array.ckGetArrayID(),
+                              array_indices.data(), array_indices.size())})
+              : std::nullopt;
+      // Send new sections to all elements. Broadcasting to the section fails
+      // with a segfault for some reason.
+      Parallel::simple_action<UpdateSectionsOnElement>(
+          element_array, grid_index, grid_index_section, finest_grid_section);
+    }
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+  }
+};
+
+}  // namespace amr::Actions

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -23,6 +23,7 @@
 #include "Parallel/ArrayCollection/SimpleActionOnElement.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/Actions/GetItemFromDistributedObject.hpp"
 #include "ParallelAlgorithms/Amr/Actions/UpdateAmrDecision.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
@@ -31,6 +32,7 @@
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -84,10 +86,20 @@ namespace amr::Actions {
 /// - Sends the (possibly updated) decision to all of the neighboring Elements
 struct EvaluateRefinementCriteria {
   template <typename ParallelComponent, typename DbTagList,
-            typename Metavariables>
+            typename Metavariables, size_t Dim>
   static void apply(db::DataBox<DbTagList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
-                    const ElementId<Metavariables::volume_dim>& element_id) {
+                    const ElementId<Dim>& element_id) {
+    if constexpr (Metavariables::amr::keep_coarse_grids) {
+      // Only evaluate the criteria on the finest grid. The other elements keep
+      // their flags as Undefined and will therefore be skipped by AdjustDomain.
+      const bool is_finest_grid =
+          db::get<amr::Tags::ChildIds<Dim>>(box).empty();
+      if (not is_finest_grid) {
+        return;
+      }
+    }
+
     constexpr size_t volume_dim = Metavariables::volume_dim;
     auto overall_decision = make_array<volume_dim>(amr::Flag::Undefined);
 

--- a/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
@@ -10,8 +10,10 @@
 #include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/Tags/Flags.hpp"
 #include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace amr::Initialization {
@@ -19,8 +21,12 @@ namespace amr::Initialization {
 /// \brief Initialize items related to adaptive mesh refinement
 ///
 /// \see InitializeItems
-template <size_t Dim>
+template <size_t Dim, typename Metavariables>
 struct Initialize {
+  static_assert(tt::assert_conforms_to_v<typename Metavariables::amr,
+                                         amr::protocols::AmrMetavariables>);
+  using ElementArray = typename Metavariables::amr::element_array;
+
   using const_global_cache_tags = tmpl::list<>;
   using mutable_global_cache_tags = tmpl::list<>;
   using simple_tags_from_options = tmpl::list<>;

--- a/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Initialize.hpp
@@ -10,7 +10,10 @@
 #include "Domain/Amr/Info.hpp"
 #include "Domain/Amr/Tags/Flags.hpp"
 #include "Domain/Amr/Tags/NeighborFlags.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -33,10 +36,22 @@ struct Initialize {
 
   using argument_tags = tmpl::list<>;
   using return_tags = tmpl::list<amr::Tags::Info<Dim>>;
-  using simple_tags =
-      tmpl::push_back<return_tags, amr::Tags::NeighborInfo<Dim>>;
+  using simple_tags = tmpl::append<
+      return_tags, tmpl::list<amr::Tags::NeighborInfo<Dim>>,
+      tmpl::conditional_t<
+          Metavariables::amr::keep_coarse_grids,
+          tmpl::list<
+              amr::Tags::ParentId<Dim>, amr::Tags::ChildIds<Dim>,
+              amr::Tags::ParentMesh<Dim>,
+              Parallel::Tags::Section<ElementArray, amr::Tags::GridIndex>,
+              Parallel::Tags::Section<ElementArray, amr::Tags::IsFinestGrid>>,
+          tmpl::list<>>>;
 
-  using compute_tags = tmpl::list<>;
+  using compute_tags = tmpl::conditional_t<
+      Metavariables::amr::keep_coarse_grids,
+      tmpl::list<amr::Tags::GridIndexObservationKeyCompute<Dim>,
+                 amr::Tags::IsFinestGridObservationKeyCompute<Dim>>,
+      tmpl::list<>>;
 
   /// Given the items fetched from a DataBox by the argument_tags, mutate
   /// the items in the DataBox corresponding to return_tags

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <unordered_map>
 #include <utility>
 
@@ -23,6 +24,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/ElementRegistration.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -76,6 +78,16 @@ struct InitializeChild {
         ::domain::Tags::NeighborMesh<volume_dim>>>(
         make_not_null(&box), std::move(child), std::move(child_mesh),
         std::move(neighbors.second));
+
+    if constexpr (Metavariables::amr::keep_coarse_grids) {
+      if (db::get<amr::Tags::MaxCoarseLevels>(box).value_or(
+              std::numeric_limits<size_t>::max()) > 0) {
+        ::Initialization::mutate_assign<
+            tmpl::list<amr::Tags::ParentId<volume_dim>,
+                       amr::Tags::ParentMesh<volume_dim>>>(
+            make_not_null(&box), parent.id(), parent_mesh);
+      }
+    }
 
     tmpl::for_each<typename Metavariables::amr::projectors>(
         [&box, &parent_items](auto projector_v) {

--- a/src/ParallelAlgorithms/Amr/Actions/RunAmrDiagnostics.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/RunAmrDiagnostics.hpp
@@ -51,7 +51,7 @@ struct RunAmrDiagnostics {
             typename Metavariables, typename ArrayIndex>
   static void apply(db::DataBox<DbTagList>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
+                    const ArrayIndex& /*array_index*/, const size_t grid_index,
                     const boost::rational<size_t>& volume,
                     const size_t number_of_elements,
                     const size_t number_of_grid_points,
@@ -67,16 +67,21 @@ struct RunAmrDiagnostics {
     }
     if (db::get<logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>(box) >=
         Verbosity::Quiet) {
+      const std::string title = Metavariables::amr::keep_coarse_grids
+                                    ? MakeString{} << "AMR level " << grid_index
+                                                   << ":\n"
+                                    : std::string{""};
       const std::string string_gcc_needs_to_use_in_order_for_printf_to_compile =
           MakeString{} << "Average refinement levels: "
                        << avg_refinement_levels_by_dim
                        << "\nAverage grid points: " << avg_extents_by_dim
                        << "\n";
       Parallel::printf(
+          "%s"
           "Number of elements: %zu\n"
           "Number of grid points: %zu\n"
           "%s\n",
-          number_of_elements, number_of_grid_points,
+          title, number_of_elements, number_of_grid_points,
           string_gcc_needs_to_use_in_order_for_printf_to_compile);
     }
   }

--- a/src/ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp
@@ -14,6 +14,7 @@
 #include "IO/Logging/Verbosity.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
+#include "Parallel/GetSection.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Printf/Printf.hpp"
 #include "Parallel/Reduction.hpp"
@@ -44,6 +45,8 @@ struct SendAmrDiagnostics {
       tmpl::list<logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>;
 
   using ReductionData = Parallel::ReductionData<
+      // Grid index
+      Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
       // fraction of Block volume
       Parallel::ReductionDatum<boost::rational<size_t>, funcl::Plus<>>,
       // number of elements
@@ -53,11 +56,11 @@ struct SendAmrDiagnostics {
       // average refinement level by dimension
       Parallel::ReductionDatum<
           std::vector<double>, funcl::ElementWise<funcl::Plus<>>,
-          funcl::ElementWise<funcl::Divides<>>, std::index_sequence<1>>,
+          funcl::ElementWise<funcl::Divides<>>, std::index_sequence<2>>,
       // average number of grid points by dimension
       Parallel::ReductionDatum<
           std::vector<double>, funcl::ElementWise<funcl::Plus<>>,
-          funcl::ElementWise<funcl::Divides<>>, std::index_sequence<1>>>;
+          funcl::ElementWise<funcl::Divides<>>, std::index_sequence<2>>>;
 
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
@@ -89,12 +92,24 @@ struct SendAmrDiagnostics {
         Parallel::printf("%s h-refinement %s, p-refinement %s\n",
                          get_output(element_id), get_output(refinement_levels),
                          get_output(mesh.extents()));
+        if constexpr (Metavariables::amr::keep_coarse_grids) {
+          const auto& parent_id = db::get<amr::Tags::ParentId<Dim>>(box);
+          const auto& child_ids = db::get<amr::Tags::ChildIds<Dim>>(box);
+          Parallel::printf("%s parent %s, children %s\n",
+                           get_output(element_id), get_output(parent_id),
+                           get_output(child_ids));
+        }
       }
+      auto& grid_index_section = Parallel::get_section<
+          ParallelComponent,
+          tmpl::conditional_t<Metavariables::amr::keep_coarse_grids,
+                              amr::Tags::GridIndex, void>>(make_not_null(&box));
       Parallel::contribute_to_reduction<amr::Actions::RunAmrDiagnostics>(
-          ReductionData{amr::fraction_of_block_volume(element_id), 1,
+          ReductionData{element_id.grid_index(),
+                        amr::fraction_of_block_volume(element_id), 1,
                         mesh.number_of_grid_points(), refinement_levels_by_dim,
                         extents_by_dim},
-          my_proxy, target_proxy);
+          my_proxy, target_proxy, make_not_null(&grid_index_section));
     }
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/src/ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <limits>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -11,6 +12,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "ParallelAlgorithms/Amr/Actions/InitializeChild.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
 
 namespace amr::Actions {
 /// \brief Sends data from the parent element to its children elements during
@@ -23,12 +25,11 @@ namespace amr::Actions {
 /// itself.
 struct SendDataToChildren {
   template <typename ParallelComponent, typename DbTagList,
-            typename Metavariables>
+            typename Metavariables, size_t Dim>
   static void apply(db::DataBox<DbTagList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
-                    const ElementId<Metavariables::volume_dim>& element_id,
-                    const std::vector<ElementId<Metavariables::volume_dim>>&
-                        ids_of_children) {
+                    const ElementId<Dim>& element_id,
+                    const std::vector<ElementId<Dim>>& ids_of_children) {
     auto& array_proxy =
         Parallel::get_parallel_component<ParallelComponent>(cache);
     for (const auto& child_id : ids_of_children) {
@@ -39,8 +40,37 @@ struct SendDataToChildren {
               box));
     }
 
-    Parallel::deregister_element<ParallelComponent>(box, cache, element_id);
+    if constexpr (Metavariables::amr::keep_coarse_grids) {
+      if (db::get<amr::Tags::MaxCoarseLevels>(box).value_or(
+              std::numeric_limits<size_t>::max()) > 0) {
+        // Register the children elements in the parent element
+        Parallel::deregister_element<ParallelComponent>(box, cache, element_id);
+        ::Initialization::mutate_assign<tmpl::list<amr::Tags::ChildIds<Dim>>>(
+            make_not_null(&box),
+            std::unordered_set<ElementId<Dim>>{ids_of_children.begin(),
+                                               ids_of_children.end()});
+        Parallel::register_element<ParallelComponent>(box, cache, element_id);
+        // Note: we don't run AMR projectors on the parent element because the
+        // parent element didn't change, with the exception of
+        // `amr::Tags::ChildIds<Dim>`.
+        // Reset the AMR flags
+        db::mutate<amr::Tags::Info<Dim>, amr::Tags::NeighborInfo<Dim>>(
+            [](const gsl::not_null<amr::Info<Dim>*> amr_info,
+               const gsl::not_null<
+                   std::unordered_map<ElementId<Dim>, amr::Info<Dim>>*>
+                   amr_info_of_neighbors) {
+              amr_info_of_neighbors->clear();
+              for (size_t d = 0; d < Dim; ++d) {
+                amr_info->flags[d] = amr::Flag::Undefined;
+              }
+            },
+            make_not_null(&box));
+        return;
+      }
+    }
 
+    // Destroy the parent element
+    Parallel::deregister_element<ParallelComponent>(box, cache, element_id);
     array_proxy[element_id].ckDestroy();
   }
 };

--- a/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
+++ b/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
@@ -21,6 +21,9 @@ namespace amr::protocols {
 ///       order to initialize data on newly created elements.
 ///     - amr::Actions::AdjustDomain in order to update data on existing
 ///       elements in case their Mesh or neighbors have changed.
+/// - `keep_coarse_grids`: A boolean indicating that AMR should create a
+///   completely new grid at each AMR step with an incremented grid index, and
+///   keep the old grid around. This is useful for multigrid solvers.
 ///
 /// Here is an example for a class conforming to this protocol:
 ///
@@ -33,6 +36,7 @@ struct AmrMetavariables {
     static_assert(
         tmpl::all<projectors,
                   tt::assert_conforms_to<tmpl::_1, Projector>>::value);
+    static constexpr bool keep_coarse_grids = ConformingType::keep_coarse_grids;
   };
 };
 }  // namespace amr::protocols

--- a/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
+++ b/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
@@ -21,9 +21,24 @@ namespace amr::protocols {
 ///       order to initialize data on newly created elements.
 ///     - amr::Actions::AdjustDomain in order to update data on existing
 ///       elements in case their Mesh or neighbors have changed.
+///   In these projectors you must handle _all_ mutable tags in the DataBox,
+///   except for a few tags that are handled by the AMR actions themselves
+///   (e.g. `domain::Tags::Element`, `domain::Tags::Mesh`, and
+///   `domain::Tags::NeighborMesh` are handled by AMR). See
+///   `amr::protocols::Projector` for details.
 /// - `keep_coarse_grids`: A boolean indicating that AMR should create a
 ///   completely new grid at each AMR step with an incremented grid index, and
 ///   keep the old grid around. This is useful for multigrid solvers.
+///   If this is true, then the `element_array` must include
+///   `::amr::Actions::RegisterElement` in the registration phase action list
+///   and in `Metavariables::registration::element_registrars`. You must also
+///   ensure to visit `Phase::UpdateSections` in the default phase order after
+///   registration, and in each AMR step after
+///   `Phase::EvaluateRefinementCriteria` and `Phase::AdjustDomain`.
+///   When this is enabled, you can use `amr::Tags::ParentId` and
+///   `amr::Tags::ChildIds` to traverse the grid hierarchy. However, you cannot
+///   rely on these tags to be up-to-date in the AMR projectors, as they are
+///   sometime updated after the projectors are run.
 ///
 /// Here is an example for a class conforming to this protocol:
 ///

--- a/src/ParallelAlgorithms/Amr/Tags.hpp
+++ b/src/ParallelAlgorithms/Amr/Tags.hpp
@@ -3,9 +3,22 @@
 
 #pragma once
 
+#include <cstddef>
+#include <map>
+#include <optional>
 #include <string>
+#include <unordered_set>
 
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Auto.hpp"
 #include "Options/String.hpp"
+#include "Parallel/Tags/Section.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// Options for AMR
 namespace amr::OptionTags {
@@ -16,4 +29,116 @@ struct AmrGroup {
       "Options for adaptive mesh refinement (AMR)";
 };
 
+struct MaxCoarseLevels {
+  using type = Options::Auto<size_t>;
+  static constexpr Options::String help =
+      "Maximum number of coarser AMR levels to keep. A value of '0' means that "
+      "only the finest grid is kept, and 'Auto' means the number of levels "
+      "is not restricted.";
+  using group = AmrGroup;
+};
+
 }  // namespace amr::OptionTags
+
+/// AMR tags
+namespace amr::Tags {
+
+/// Maximum number of AMR levels that will be kept. A value of '0' means that
+/// only the finest grid is kept, and `std::nullopt` means the number of levels
+/// is not restricted.
+struct MaxCoarseLevels : db::SimpleTag {
+  using type = std::optional<size_t>;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::MaxCoarseLevels>;
+  static type create_from_options(const type value) { return value; };
+};
+
+/// All element IDs grouped by grid index are stored in this tag. The element
+/// IDs are registered and deregistered during AMR.
+template <size_t Dim>
+struct AllElementIds : db::SimpleTag {
+  using type = std::map<size_t, std::unordered_set<ElementId<Dim>>>;
+};
+
+/// The ID of the element that covers the same region or more on the coarser
+/// (parent) grid. Only important if AMR is configured to keep coarse grids
+/// around.
+template <size_t Dim>
+struct ParentId : db::SimpleTag {
+  using type = std::optional<ElementId<Dim>>;
+};
+
+/// The IDs of the elements that cover the same region on the finer (child)
+/// grid. Only important if AMR is configured to keep coarse grids around.
+template <size_t Dim>
+struct ChildIds : db::SimpleTag {
+  using type = std::unordered_set<ElementId<Dim>>;
+};
+
+/// The mesh of the parent element. Needed for projections between grids.
+/// Only important if AMR is configured to keep coarse grids around.
+template <size_t Dim>
+struct ParentMesh : db::SimpleTag {
+  using type = std::optional<Mesh<Dim>>;
+};
+
+/// The AMR level of the element. This is used to tag a
+/// `Parallel::Tags::Section` that contains all elements on the same grid.
+/// Only important if AMR is configured to keep coarse grids around.
+struct GridIndex {
+  using type = size_t;
+};
+
+/// True on the finest AMR grid (the one with the highest grid index), false on
+/// all other grids. This is used to tag a `Parallel::Tags::Section` that
+/// contains all elements on the finest grid.
+/// Only important if AMR is configured to keep coarse grids around.
+struct IsFinestGrid {
+  using type = bool;
+};
+
+/// An `observers::Tags::ObservationKey` that identifies the grid index.
+/// Can be used to tag observations with the grid index.
+template <size_t Dim>
+struct GridIndexObservationKeyCompute
+    : db::ComputeTag,
+      observers::Tags::ObservationKey<GridIndex> {
+  using base = observers::Tags::ObservationKey<GridIndex>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<domain::Tags::Element<Dim>, amr::Tags::ChildIds<Dim>>;
+  static void function(
+      const gsl::not_null<std::optional<std::string>*> observation_key,
+      const Element<Dim>& element,
+      const std::unordered_set<ElementId<Dim>>& child_ids) {
+    const auto& element_id = element.id();
+    const bool is_finest_grid = child_ids.empty();
+    *observation_key =
+        is_finest_grid
+            ? std::string{""}
+            : (std::string{"Level"} + std::to_string(element_id.grid_index()));
+  }
+};
+
+/// An `observers::Tags::ObservationKey` that identifies the finest grid.
+/// Can be used to observe things only on the finest grid.
+template <size_t Dim>
+struct IsFinestGridObservationKeyCompute
+    : db::ComputeTag,
+      observers::Tags::ObservationKey<IsFinestGrid> {
+  using base = observers::Tags::ObservationKey<IsFinestGrid>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<amr::Tags::ChildIds<Dim>>;
+  static void function(
+      const gsl::not_null<std::optional<std::string>*> observation_key,
+      const std::unordered_set<ElementId<Dim>>& child_ids) {
+    const bool is_finest_grid = child_ids.empty();
+    if (is_finest_grid) {
+      *observation_key = std::string{""};
+    } else {
+      *observation_key = std::nullopt;
+    }
+  }
+};
+
+}  // namespace amr::Tags

--- a/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
@@ -1,0 +1,63 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: RandomAmrKeepCoarseGrids1D
+Testing:
+  Check: parse;execute
+  Timeout: 10
+  ExpectedExitCode: 2
+  Priority: High
+ExpectedOutput:
+  - Checkpoints/Checkpoint_0000
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+Amr:
+  Criteria:
+    - Random:
+        ProbabilityWeights:
+          Split: 2
+          Join: 1
+          DoNothing: 1
+  Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
+    Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: [0, 8]
+      NumGridPoints: Auto
+      ErrorBeyondLimits: False
+    AllowCoarsening: False
+  MaxCoarseLevels: Auto
+  Verbosity: Verbose
+
+DomainCreator:
+  Interval:
+    LowerBound: [-0.5]
+    UpperBound: [6.5]
+    Distribution: [Linear]
+    InitialRefinement: [2]
+    InitialGridPoints: [2]
+    TimeDependence: None
+    IsPeriodicIn: [False]
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Always
+    PhaseChanges:
+      - VisitAndReturn(EvaluateAmrCriteria)
+      - VisitAndReturn(AdjustDomain)
+      - VisitAndReturn(UpdateSections)
+      - VisitAndReturn(CheckDomain)
+      - CheckpointAndExitAfterWallclock:
+          WallclockHours: 0.0
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Quadrature: GaussLobatto

--- a/tests/Unit/Domain/Amr/Test_Helpers.cpp
+++ b/tests/Unit/Domain/Amr/Test_Helpers.cpp
@@ -218,10 +218,11 @@ void test_ids_of_children() {
                                                        amr::Flag::Split}) ==
         std::vector{ElementId<2>{0, {{SegmentId(3, 0), SegmentId(2, 2)}}},
                     ElementId<2>{0, {{SegmentId(3, 0), SegmentId(2, 3)}}}});
-  CHECK(amr::ids_of_children(element_id_2d, std::array{amr::Flag::Split,
-                                                       amr::Flag::DoNothing}) ==
-        std::vector{ElementId<2>{0, {{SegmentId(4, 0), SegmentId(1, 1)}}},
-                    ElementId<2>{0, {{SegmentId(4, 1), SegmentId(1, 1)}}}});
+  CHECK(amr::ids_of_children(element_id_2d,
+                             std::array{amr::Flag::Split, amr::Flag::DoNothing},
+                             1) ==
+        std::vector{ElementId<2>{0, {{SegmentId(4, 0), SegmentId(1, 1)}}, 1},
+                    ElementId<2>{0, {{SegmentId(4, 1), SegmentId(1, 1)}}, 1}});
   const ElementId<3> element_id_3d{
       7, {{SegmentId(5, 31), SegmentId(2, 0), SegmentId(4, 15)}}};
   CHECK(amr::ids_of_children(

--- a/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
+++ b/tests/Unit/Domain/Amr/Test_NewNeighborIds.cpp
@@ -71,6 +71,9 @@ void test(const gsl::not_null<std::mt19937*> generator) {
 
   for (const auto& element_id : element_ids_to_test<Dim>()) {
     CAPTURE(element_id);
+    const ElementId<Dim> new_element_id{element_id.block_id(),
+                                        element_id.segment_ids(),
+                                        element_id.grid_index() + 1};
     for (const auto& direction :
          random_sample(2, Direction<Dim>::all_directions(), generator)) {
       CAPTURE(direction);
@@ -97,7 +100,7 @@ void test(const gsl::not_null<std::mt19937*> generator) {
                      generator)) {
               CAPTURE(neighbor_info);
               const auto neighbor_ids_and_meshes = new_neighbor_ids(
-                  element_id, direction, neighbors, neighbor_info);
+                  new_element_id, direction, neighbors, neighbor_info);
               std::unordered_set<ElementId<Dim>> new_neighbor_ids;
               for (const auto& [id, mesh] : neighbor_ids_and_meshes) {
                 new_neighbor_ids.insert(id);
@@ -107,8 +110,8 @@ void test(const gsl::not_null<std::mt19937*> generator) {
                   std::move(new_neighbor_ids), neighbors.orientations(),
                   neighbors.are_conforming()};
               CAPTURE(new_neighbors);
-              TestHelpers::domain::check_neighbors(new_neighbors, element_id,
-                                                   direction);
+              TestHelpers::domain::check_neighbors(new_neighbors,
+                                                   new_element_id, direction);
             }
           }
         }
@@ -128,7 +131,7 @@ void test(const gsl::not_null<std::mt19937*> generator) {
                    generator)) {
             CAPTURE(neighbor_info);
             const auto neighbor_ids_and_meshes = new_neighbor_ids(
-                element_id, direction, neighbors, neighbor_info);
+                new_element_id, direction, neighbors, neighbor_info);
             std::unordered_set<ElementId<Dim>> new_neighbor_ids;
             for (const auto& [id, mesh] : neighbor_ids_and_meshes) {
               new_neighbor_ids.insert(id);
@@ -138,7 +141,7 @@ void test(const gsl::not_null<std::mt19937*> generator) {
                 Neighbors<Dim>{new_neighbor_ids, neighbors.orientations(),
                                neighbors.are_conforming()};
             CAPTURE(new_neighbors);
-            TestHelpers::domain::check_neighbors(new_neighbors, element_id,
+            TestHelpers::domain::check_neighbors(new_neighbors, new_element_id,
                                                  direction);
           }
         }

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -425,7 +425,7 @@ struct ElementArray {
                      ::elliptic::dg::Actions::initialize_operator<
                          System, background_tag>,
                      Initialization::Actions::InitializeItems<
-                         ::amr::Initialization::Initialize<Dim>>,
+                         ::amr::Initialization::Initialize<Dim, metavariables>>,
                      ExtraInitActions, Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
@@ -487,6 +487,8 @@ struct Metavariables {
   using overlaps_tag =
       LinearSolver::Schwarz::Tags::Overlaps<Tag, volume_dim, DummyOptionsGroup>;
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = ElementArray<Metavariables, System, SubdomainOperator,
+                                       ExtraInitActions>;
     using projectors = tmpl::flatten<tmpl::list<
         ::amr::projectors::DefaultInitialize<tmpl::append<
             tmpl::list<domain::Tags::InitialExtents<volume_dim>,
@@ -513,6 +515,7 @@ struct Metavariables {
         elliptic::dg::Actions::amr_projectors<
             System, typename element_array::background_tag>,
         typename element_array::dg_operator::amr_projectors, ExtraInitActions>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -148,7 +148,7 @@ struct ElementArray {
                          System, analytic_solution_tag>,
                      ::elliptic::dg::Actions::initialize_operator<System>,
                      Initialization::Actions::InitializeItems<
-                         ::amr::Initialization::Initialize<Dim>>,
+                         ::amr::Initialization::Initialize<Dim, metavariables>>,
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
@@ -230,6 +230,7 @@ struct Metavariables {
         tmpl::pair<::amr::Criterion, tmpl::list<::amr::Criteria::Random>>>;
   };
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = ElementArray<System, Linearized, Metavariables>;
     using projectors = tmpl::flatten<tmpl::list<
         ProjectTemporalId<Metavariables>,
         ::amr::projectors::DefaultInitialize<
@@ -247,6 +248,7 @@ struct Metavariables {
         elliptic::dg::Actions::amr_projectors<
             System, typename element_array::analytic_solution_tag>,
         typename element_array::dg_operator::amr_projectors>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Structure/NeighborHelpers.cpp
@@ -527,6 +527,7 @@ void check_neighbors(const Neighbors<Dim>& neighbors,
   const Side element_side = opposite(neighbor_side);
   double surface_area_covered = 0.0;
   for (const auto& neighbor : neighbors) {
+    CHECK(neighbor.grid_index() == element_id.grid_index());
     const OrientationMap<Dim>& orientation_map =
         neighbors.orientation(neighbor);
     double neighbor_overlap_area = 1.0;

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -131,6 +131,7 @@ struct Metavariables {
     using projectors = tmpl::list<::amr::projectors::DefaultInitialize<
         Parallel::Tags::GlobalCacheImpl<Metavariables>,
         domain::Tags::NeighborMesh<1>>>;
+    static constexpr bool keep_coarse_grids = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -69,16 +69,39 @@ struct MockCreateChild {
       const size_t index_of_child_id,
       const std::unordered_map<Parallel::Phase, size_t>&
           parent_phase_bookmarks) {
-    CHECK(parent_id == ElementId<1>{0, std::array{SegmentId{1, 1}}});
-    if (index_of_child_id == 0) {
-      CHECK(children_ids ==
-            std::vector{ElementId<1>{0, std::array{SegmentId{2, 2}}},
-                        ElementId<1>{0, std::array{SegmentId{2, 3}}}});
+    if constexpr (Metavariables::amr::keep_coarse_grids) {
+      if (parent_id == ElementId<1>{0, std::array{SegmentId{3, 0}}}) {
+        // Element 1 does nothing
+        CHECK(children_ids ==
+              std::vector{ElementId<1>{0, std::array{SegmentId{3, 0}}, 1}});
+      } else if (parent_id == ElementId<1>{0, std::array{SegmentId{3, 1}}}) {
+        // Element 2 does nothing
+        CHECK(children_ids ==
+              std::vector{ElementId<1>{0, std::array{SegmentId{3, 1}}, 1}});
+      } else if (parent_id == ElementId<1>{0, std::array{SegmentId{2, 1}}}) {
+        // Element 3 increases resolution
+        CHECK(children_ids ==
+              std::vector{ElementId<1>{0, std::array{SegmentId{2, 1}}, 1}});
+      } else if (parent_id == ElementId<1>{0, std::array{SegmentId{1, 1}}}) {
+        // Element 4 splits
+        CHECK(children_ids ==
+              std::vector{ElementId<1>{0, std::array{SegmentId{2, 2}}, 1},
+                          ElementId<1>{0, std::array{SegmentId{2, 3}}, 1}});
+      } else {
+        ERROR("Unexpected parent id");
+      }
     } else {
-      CHECK(index_of_child_id == 1);
-      CHECK(children_ids ==
-            std::vector{ElementId<1>{0, std::array{SegmentId{2, 2}}},
-                        ElementId<1>{0, std::array{SegmentId{2, 3}}}});
+      CHECK(parent_id == ElementId<1>{0, std::array{SegmentId{1, 1}}});
+      if (index_of_child_id == 0) {
+        CHECK(children_ids ==
+              std::vector{ElementId<1>{0, std::array{SegmentId{2, 2}}},
+                          ElementId<1>{0, std::array{SegmentId{2, 3}}}});
+      } else {
+        CHECK(index_of_child_id == 1);
+        CHECK(children_ids ==
+              std::vector{ElementId<1>{0, std::array{SegmentId{2, 2}}},
+                          ElementId<1>{0, std::array{SegmentId{2, 3}}}});
+      }
     }
     CHECK(parent_phase_bookmarks.empty());
   }
@@ -120,6 +143,7 @@ struct SingletonComponent {
       tmpl::list<MockCreateChild, MockCreateParent>;
 };
 
+template <bool KeepCoarseGrids>
 struct Metavariables {
   static constexpr size_t volume_dim = 1;
   using component_list = tmpl::list<ArrayComponent<Metavariables>,
@@ -131,10 +155,11 @@ struct Metavariables {
     using projectors = tmpl::list<::amr::projectors::DefaultInitialize<
         Parallel::Tags::GlobalCacheImpl<Metavariables>,
         domain::Tags::NeighborMesh<1>>>;
-    static constexpr bool keep_coarse_grids = false;
+    static constexpr bool keep_coarse_grids = KeepCoarseGrids;
   };
 };
 
+template <typename Metavariables>
 void check_box(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
                const ElementId<1>& element_id,
                const Element<1>& expected_element, const Mesh<1>& expected_mesh,
@@ -142,6 +167,7 @@ void check_box(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
                const amr::Info<1>& expected_info,
                const std::unordered_map<ElementId<1>, amr::Info<1>>&
                    expected_neighbor_info) {
+  CAPTURE(element_id);
   using array_component = ArrayComponent<Metavariables>;
   CHECK(
       ActionTesting::get_databox_tag<array_component, domain::Tags::Element<1>>(
@@ -162,9 +188,11 @@ void check_box(const ActionTesting::MockRuntimeSystem<Metavariables>& runner,
   }
 }
 
+template <bool KeepCoarseGrids>
 void test() {
-  using array_component = ArrayComponent<Metavariables>;
-  using singleton_component = SingletonComponent<Metavariables>;
+  using metavariables = Metavariables<KeepCoarseGrids>;
+  using array_component = ArrayComponent<metavariables>;
+  using singleton_component = SingletonComponent<metavariables>;
 
   const OrientationMap<1> aligned = OrientationMap<1>::create_aligned();
 
@@ -216,6 +244,20 @@ void test() {
                               element_3_mesh_post_refinement};
   amr::Info<1> element_4_info{{amr::Flag::Split}, element_4_mesh};
 
+  if constexpr (KeepCoarseGrids) {
+    // Disable coarsening
+    const amr::Policies policies{amr::Isotropy::Anisotropic, amr::Limits{},
+                                 true, false};
+    amr::enforce_policies(make_not_null(&element_1_info.flags), policies,
+                          element_1_id, element_1_mesh);
+    amr::enforce_policies(make_not_null(&element_2_info.flags), policies,
+                          element_2_id, element_2_mesh);
+    amr::enforce_policies(make_not_null(&element_3_info.flags), policies,
+                          element_3_id, element_3_mesh);
+    amr::enforce_policies(make_not_null(&element_4_info.flags), policies,
+                          element_4_id, element_4_mesh);
+  }
+
   std::unordered_map<ElementId<1>, amr::Info<1>> element_1_neighbor_info{
       {element_2_id, element_2_info}};
   std::unordered_map<ElementId<1>, amr::Info<1>> element_2_neighbor_info{
@@ -227,7 +269,7 @@ void test() {
 
   using NeighborMeshes = DirectionalIdMap<1, Mesh<1>>;
 
-  ActionTesting::MockRuntimeSystem<Metavariables> runner{{::Verbosity::Debug}};
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{::Verbosity::Debug}};
   ActionTesting::emplace_component_and_initialize<array_component>(
       &runner, element_1_id,
       {element_1, element_1_mesh, NeighborMeshes{}, element_1_info,
@@ -259,6 +301,7 @@ void test() {
             runner, 0) == 0);
 
   // This should queue CreateParent on the singleton
+  // If KeepCoarseGrids is true: this should queue CreateChild
   ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
       make_not_null(&runner), element_1_id);
   check_for_empty_queues_on_elements();
@@ -266,38 +309,37 @@ void test() {
             runner, 0) == 1);
 
   // This should do nothing
+  // If KeepCoarseGrids is true: this should queue CreateChild
   ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
       make_not_null(&runner), element_2_id);
   check_for_empty_queues_on_elements();
   CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
-            runner, 0) == 1);
+            runner, 0) == (KeepCoarseGrids ? 2 : 1));
 
   // This should p-refine element_3
+  // If KeepCoarseGrids is true: this should queue CreateChild
   ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
       make_not_null(&runner), element_3_id);
   check_for_empty_queues_on_elements();
   CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
-            runner, 0) == 1);
+            runner, 0) == (KeepCoarseGrids ? 3 : 1));
 
   // This should queue CreateChild on the singleton
   ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
       make_not_null(&runner), element_4_id);
   check_for_empty_queues_on_elements();
   CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
-            runner, 0) == 2);
+            runner, 0) == (KeepCoarseGrids ? 4 : 2));
 
   // This will invoke the queued actions on the singleton calling the mock
   // actions
-  ActionTesting::invoke_queued_simple_action<singleton_component>(
-      make_not_null(&runner), 0);
-  check_for_empty_queues_on_elements();
-  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
-            runner, 0) == 1);
-  ActionTesting::invoke_queued_simple_action<singleton_component>(
-      make_not_null(&runner), 0);
-  check_for_empty_queues_on_elements();
-  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
-            runner, 0) == 0);
+  for (size_t i = 0; i < (KeepCoarseGrids ? 4 : 2); ++i) {
+    ActionTesting::invoke_queued_simple_action<singleton_component>(
+        make_not_null(&runner), 0);
+    check_for_empty_queues_on_elements();
+    CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+              runner, 0) == (KeepCoarseGrids ? 4 : 2) - i - 1);
+  }
 
   check_box(runner, element_1_id, element_1, element_1_mesh, NeighborMeshes{},
             element_1_info, element_1_neighbor_info);
@@ -305,31 +347,38 @@ void test() {
             element_2_info, element_2_neighbor_info);
   check_box(runner, element_4_id, element_4, element_4_mesh, NeighborMeshes{},
             element_4_info, element_4_neighbor_info);
-  const ElementId<1> new_parent_id{
-      ElementId<1>{0, std::array{SegmentId{2, 0}}}};
-  const ElementId<1> new_lower_child_id{
-      ElementId<1>{0, std::array{SegmentId{2, 2}}}};
-  const Element<1> element_3_post_refinement{
-      element_3_id,
-      DirectionMap<1, Neighbors<1>>{
-          {Direction<1>::lower_xi(),
-           Neighbors<1>{std::unordered_set{new_parent_id}, aligned}},
-          {Direction<1>::upper_xi(),
-           Neighbors<1>{std::unordered_set{new_lower_child_id}, aligned}}}};
-  DirectionalIdMap<1, Mesh<1>> expected_element_3_neighbor_meshes;
-  expected_element_3_neighbor_meshes.emplace(std::pair{
-      DirectionalId{Direction<1>::lower_xi(), new_parent_id}, element_2_mesh});
-  expected_element_3_neighbor_meshes.emplace(
-      std::pair{DirectionalId{Direction<1>::upper_xi(), new_lower_child_id},
-                element_4_mesh});
-  check_box(runner, element_3_id, element_3_post_refinement,
-            element_3_mesh_post_refinement, expected_element_3_neighbor_meshes,
-            {std::array{amr::Flag::Undefined}, element_3_mesh_post_refinement},
-            {});
+  if constexpr (KeepCoarseGrids) {
+    check_box(runner, element_3_id, element_3, element_3_mesh, NeighborMeshes{},
+              element_3_info, element_3_neighbor_info);
+  } else {
+    const ElementId<1> new_parent_id{
+        ElementId<1>{0, std::array{SegmentId{2, 0}}}};
+    const ElementId<1> new_lower_child_id{
+        ElementId<1>{0, std::array{SegmentId{2, 2}}}};
+    const Element<1> element_3_post_refinement{
+        element_3_id,
+        DirectionMap<1, Neighbors<1>>{
+            {Direction<1>::lower_xi(),
+             Neighbors<1>{std::unordered_set{new_parent_id}, aligned}},
+            {Direction<1>::upper_xi(),
+             Neighbors<1>{std::unordered_set{new_lower_child_id}, aligned}}}};
+    DirectionalIdMap<1, Mesh<1>> expected_element_3_neighbor_meshes;
+    expected_element_3_neighbor_meshes.emplace(
+        std::pair{DirectionalId{Direction<1>::lower_xi(), new_parent_id},
+                  element_2_mesh});
+    expected_element_3_neighbor_meshes.emplace(
+        std::pair{DirectionalId{Direction<1>::upper_xi(), new_lower_child_id},
+                  element_4_mesh});
+    check_box(
+        runner, element_3_id, element_3_post_refinement,
+        element_3_mesh_post_refinement, expected_element_3_neighbor_meshes,
+        {std::array{amr::Flag::Undefined}, element_3_mesh_post_refinement}, {});
+  }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Amr.Actions.AdjustDomain",
                   "[Unit][ParallelAlgorithms]") {
-  test();
+  test<false>();
+  test<true>();
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -31,6 +31,7 @@
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -81,6 +82,12 @@ struct Metavariables {
     using factory_classes = tmpl::map<tmpl::pair<
         amr::Criterion, tmpl::list<amr::Criteria::Random,
                                    amr::Criteria::DriveToTarget<volume_dim>>>>;
+  };
+
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = Component<Metavariables>;
+    using projectors = tmpl::list<>;
+    static constexpr bool keep_coarse_grids = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
@@ -13,16 +13,27 @@
 #include "Domain/Amr/Tags/NeighborFlags.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 namespace {
+struct Metavariables {
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = void;
+    using projectors = tmpl::list<>;
+    static constexpr bool keep_coarse_grids = false;
+  };
+};
+
 template <size_t Dim>
 void test() {
   auto box = db::create<
       db::AddSimpleTags<amr::Tags::Info<Dim>, amr::Tags::NeighborInfo<Dim>>>(
       amr::Info<Dim>{}, std::unordered_map<ElementId<Dim>, amr::Info<Dim>>{});
-  db::mutate_apply<amr::Initialization::Initialize<Dim>>(make_not_null(&box));
+  db::mutate_apply<amr::Initialization::Initialize<Dim, Metavariables>>(
+      make_not_null(&box));
   CHECK(db::get<amr::Tags::Info<Dim>>(box).flags ==
         make_array<Dim>(amr::Flag::Undefined));
   CHECK(db::get<amr::Tags::Info<Dim>>(box).new_mesh == Mesh<Dim>{});

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
@@ -69,6 +69,7 @@ struct Metavariables {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using projectors = tmpl::list<>;
+    static constexpr bool keep_coarse_grids = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -69,6 +69,7 @@ struct Metavariables {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using projectors = tmpl::list<>;
+    [[maybe_unused]] static constexpr bool keep_coarse_grids = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
@@ -29,6 +29,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "Parallel/Protocols/RegistrationMetavariables.hpp"
 #include "ParallelAlgorithms/Amr/Actions/SendDataToChildren.hpp"
+#include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
 namespace {
@@ -118,6 +119,12 @@ struct Metavariables {
     using element_registrars =
         tmpl::map<tmpl::pair<Component<Metavariables>,
                              tmpl::list<TestHelpers::amr::RegisterElement>>>;
+  };
+
+  struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
+    using element_array = Component<Metavariables>;
+    using projectors = tmpl::list<>;
+    static constexpr bool keep_coarse_grids = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -34,6 +34,7 @@ set(LIBRARY_SOURCES
   Projectors/Test_Tensors.cpp
   Projectors/Test_Variables.cpp
   Test_Protocols.cpp
+  Test_Tags.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/ParallelAlgorithms/Amr/Test_Protocols.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Test_Protocols.cpp
@@ -17,6 +17,7 @@ struct Metavariables {
     using projectors =
         tmpl::list<Initialization::ProjectTimeStepping<1>,
                    evolution::dg::Initialization::ProjectDomain<1>>;
+    [[maybe_unused]] static constexpr bool keep_coarse_grids = false;
   };
   // [amr_projectors]
 };

--- a/tests/Unit/ParallelAlgorithms/Amr/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Test_Tags.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "ParallelAlgorithms/Amr/Tags.hpp"
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Tags",
+                  "[ParallelAlgorithms][Unit]") {
+  TestHelpers::db::test_simple_tag<amr::Tags::AllElementIds<1>>(
+      "AllElementIds");
+  TestHelpers::db::test_simple_tag<amr::Tags::ParentId<1>>("ParentId");
+  TestHelpers::db::test_simple_tag<amr::Tags::ChildIds<1>>("ChildIds");
+  TestHelpers::db::test_simple_tag<amr::Tags::ParentMesh<1>>("ParentMesh");
+  TestHelpers::db::test_compute_tag<
+      amr::Tags::GridIndexObservationKeyCompute<1>>(
+      "ObservationKey(GridIndex)");
+  TestHelpers::db::test_compute_tag<
+      amr::Tags::IsFinestGridObservationKeyCompute<1>>(
+      "ObservationKey(IsFinestGrid)");
+}

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -115,6 +115,7 @@ struct Metavariables {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
+    [[maybe_unused]] static constexpr bool keep_coarse_grids = false;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
@@ -149,6 +149,7 @@ struct Metavariables {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
+    [[maybe_unused]] static constexpr bool keep_coarse_grids = false;
   };
 
   using component_list = tmpl::flatten<tmpl::list<


### PR DESCRIPTION
## Proposed changes

Makes multigrid work with AMR. To do this, adds the compile-time option `keep_coarse_grids` to AMR, which makes AMR create a new grid at each AMR step with an incremented grid index and keep the old grid around. Then, multigrid can use this grid hierarchy.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In new executables, add the following line to `Metavariables::amr` to keep the standard AMR behavior:
```cpp
    static constexpr bool keep_coarse_grids = false;
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
