### PR TITLE
AMR: add AllowCoarsening policy

### DIFF
--- a/docs/DevGuide/Amr.md
+++ b/docs/DevGuide/Amr.md
@@ -344,6 +344,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 ```
 

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
@@ -25,6 +25,14 @@ void enforce_policies(const gsl::not_null<std::array<Flag, Dim>*> amr_decision,
     *amr_decision = make_array<Dim>(*alg::max_element(*amr_decision));
   }
 
+  if (not amr_policies.allow_coarsening()) {
+    for (size_t d = 0; d < Dim; ++d) {
+      if (gsl::at(*amr_decision, d) < Flag::DoNothing) {
+        gsl::at(*amr_decision, d) = Flag::DoNothing;
+      }
+    }
+  }
+
   const auto& limits = amr_policies.limits();
 
   const auto error_if_beyond_limits = [&](const size_t direction,

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
@@ -7,22 +7,26 @@
 
 namespace amr {
 Policies::Policies(const amr::Isotropy isotropy, const amr::Limits& limits,
-                   const bool enforce_two_to_one_balance_in_normal_direction)
+                   const bool enforce_two_to_one_balance_in_normal_direction,
+                   const bool allow_coarsening)
     : isotropy_(isotropy),
       limits_(limits),
       enforce_two_to_one_balance_in_normal_direction_(
-          enforce_two_to_one_balance_in_normal_direction) {}
+          enforce_two_to_one_balance_in_normal_direction),
+      allow_coarsening_(allow_coarsening) {}
 
 void Policies::pup(PUP::er& p) {
   p | isotropy_;
   p | limits_;
   p | enforce_two_to_one_balance_in_normal_direction_;
+  p | allow_coarsening_;
 }
 
 bool operator==(const Policies& lhs, const Policies& rhs) {
   return lhs.isotropy() == rhs.isotropy() and lhs.limits() == rhs.limits() and
          lhs.enforce_two_to_one_balance_in_normal_direction() ==
-             rhs.enforce_two_to_one_balance_in_normal_direction();
+             rhs.enforce_two_to_one_balance_in_normal_direction() and
+         lhs.allow_coarsening() == rhs.allow_coarsening();
 }
 
 bool operator!=(const Policies& lhs, const Policies& rhs) {

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
@@ -43,8 +43,16 @@ class Policies {
         "element faces."};
   };
 
+  /// Whether or not to allow coarsening or only refining
+  struct AllowCoarsening {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Whether or not to allow coarsening or only refining."};
+  };
+
   using options =
-      tmpl::list<Isotropy, Limits, EnforceTwoToOneBalanceInNormalDirection>;
+      tmpl::list<Isotropy, Limits, EnforceTwoToOneBalanceInNormalDirection,
+                 AllowCoarsening>;
 
   static constexpr Options::String help = {
       "Policies controlling adaptive mesh refinement."};
@@ -52,7 +60,8 @@ class Policies {
   Policies() = default;
 
   Policies(amr::Isotropy isotropy, const amr::Limits& limits,
-           bool enforce_two_to_one_balance_in_normal_direction);
+           bool enforce_two_to_one_balance_in_normal_direction,
+           bool allow_coarsening);
 
   amr::Isotropy isotropy() const { return isotropy_; }
 
@@ -62,12 +71,15 @@ class Policies {
     return enforce_two_to_one_balance_in_normal_direction_;
   }
 
+  bool allow_coarsening() const { return allow_coarsening_; }
+
   void pup(PUP::er& p);
 
  private:
   amr::Isotropy isotropy_{amr::Isotropy::Anisotropic};
   amr::Limits limits_{};
   bool enforce_two_to_one_balance_in_normal_direction_{true};
+  bool allow_coarsening_{true};
 };
 
 bool operator==(const Policies& lhs, const Policies& rhs);

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -162,6 +162,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -295,6 +295,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -181,6 +181,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -121,6 +121,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -154,6 +154,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -171,6 +171,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -29,6 +29,7 @@ Amr:
       RefinementLevel: [0, 8]
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 
 DomainCreator:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -28,6 +28,7 @@ Amr:
       RefinementLevel: [0, 4]
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -23,6 +23,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -23,6 +23,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -24,6 +24,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 ResourceInfo:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -151,6 +151,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -35,6 +35,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -36,6 +36,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -58,6 +58,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -60,6 +60,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 2
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -94,6 +94,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 3
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -123,6 +123,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -127,6 +127,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -84,6 +84,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 2
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -38,6 +38,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -40,6 +40,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -41,6 +41,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -39,6 +39,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -33,6 +33,7 @@ Amr:
       RefinementLevel: Auto
       NumGridPoints: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Verbosity: Verbose
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -167,6 +167,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -235,6 +235,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -124,6 +124,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 2
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -169,6 +169,7 @@ Amr:
       NumGridPoints: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
+    AllowCoarsening: True
   Iterations: 1
 
 PhaseChangeAndTriggers: []

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -594,7 +594,8 @@ void test_subdomain_operator(
         std::make_unique<RandomBackground<Dim>>(), overlap,
         ::Verbosity::Verbose, penalty_parameter, use_massive_dg_operator,
         quadrature, ::dg::Formulation::StrongInertial, std::move(amr_criteria),
-        ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true},
+        ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true,
+                        true},
         ::Verbosity::Debug}};
 
     // Initialize all elements, generating random subdomain data

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -414,7 +414,8 @@ void test_dg_operator(
       std::move(boundary_conditions), penalty_parameter,
       use_massive_dg_operator, quadrature, dg_formulation, analytic_solution,
       std::move(amr_criteria),
-      ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true},
+      ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true,
+                      true},
       ::Verbosity::Debug}};
 
   // DataBox shortcuts

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -120,7 +120,7 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
 
   ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
       {std::move(criteria),
-       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true}}};
+       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
 
   const Element<1> self(self_id,
                         {{{Direction<1>::lower_xi(),
@@ -267,7 +267,7 @@ void check_split_while_join_is_avoided() {
   // action should change the flags to (DoNothing, Split)
   ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
       {std::move(criteria),
-       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true}}};
+       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
 
   const Element<2> self(self_id, {});
   ActionTesting::emplace_component_and_initialize<my_component>(

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_UpdateAmrDecision.cpp
@@ -94,7 +94,7 @@ void test() {
   std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info{};
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true}}};
+      {amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
 
   const Element<1> self(
       self_id, {{{Direction<1>::lower_xi(),

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
@@ -124,7 +124,7 @@ void test() {
                         amr::Criteria::Tags::Criteria, amr::Tags::Policies>>(
       Metavariables{}, time, std::move(functions_of_time), std::move(domain),
       mesh, std::move(criteria),
-      amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true});
+      amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true});
 
   const double observation_value = 1.23;
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
@@ -80,7 +80,7 @@ void test(const Event& event) {
   const Mesh<1> mesh{std::array{3_st}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
   const amr::Policies policies{amr::Isotropy::Anisotropic,
-                               amr::Limits{0, 0, 3, 5}, true};
+                               amr::Limits{0, 0, 3, 5}, true, true};
 
   {
     INFO("Basic function");
@@ -141,7 +141,7 @@ void test(const Event& event) {
 
     const amr::Policies error_policies{amr::Isotropy::Anisotropic,
                                        amr::Limits{{{0, 0}}, {{3, 5}}, true},
-                                       true};
+                                       true, true};
     db::mutate<amr::Tags::Policies>(
         [&](const gsl::not_null<amr::Policies*> box_policies) {
           *box_policies = error_policies;

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
@@ -47,8 +47,10 @@ void test_1d() {
   const auto join = std::array{amr::Flag::Join};
   const auto all_flags = std::vector{split, increase, stay, decrease, join};
 
-  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true};
-  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}, true};
+  const amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true,
+                                true};
+  const amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{},
+                                  true, true};
   const auto policies = std::array{anisotropic, isotropic};
   const ElementId<1> element_id{0, {{{1, 0}}}};
   const Mesh<1> mesh{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
@@ -58,21 +60,34 @@ void test_1d() {
     }
   }
 
-  amr::Policies policy{amr::Isotropy::Anisotropic, amr::Limits{0, 5, 1, 12},
-                       true};
-  test_decision(join, policy, ElementId<1>{0}, mesh, stay);
-  test_decision(split, policy, ElementId<1>{0, {{{5, 2}}}}, mesh, stay);
-  test_decision(
-      decrease, policy, element_id,
-      Mesh<1>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}, stay);
-  test_decision(
-      decrease, policy, element_id,
-      Mesh<1>{2, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
-      stay);
-  test_decision(
-      increase, policy, element_id,
-      Mesh<1>{12, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss},
-      stay);
+  {
+    INFO("Limits");
+    const amr::Policies policy{amr::Isotropy::Anisotropic,
+                               amr::Limits{0, 5, 1, 12}, true, true};
+    test_decision(join, policy, ElementId<1>{0}, mesh, stay);
+    test_decision(split, policy, ElementId<1>{0, {{{5, 2}}}}, mesh, stay);
+    test_decision(
+        decrease, policy, element_id,
+        Mesh<1>{1, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss},
+        stay);
+    test_decision(decrease, policy, element_id,
+                  Mesh<1>{2, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto},
+                  stay);
+    test_decision(
+        increase, policy, element_id,
+        Mesh<1>{12, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss},
+        stay);
+  }
+  {
+    INFO("No coarsening");
+    const amr::Policies policy{amr::Isotropy::Anisotropic, amr::Limits{}, true,
+                               false};
+    test_decision(join, policy, element_id, mesh, stay);
+    test_decision(split, policy, element_id, mesh, split);
+    test_decision(decrease, policy, element_id, mesh, stay);
+    test_decision(increase, policy, element_id, mesh, increase);
+  }
 }
 
 void test_2d() {
@@ -127,8 +142,10 @@ void test_2d() {
       split_join,        increase_join,  stay_join,         decrease_join,
       join_join};
 
-  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true};
-  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}, true};
+  const amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true,
+                                true};
+  const amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{},
+                                  true, true};
 
   const ElementId<2> element_id{0, {{{1, 0}, {1, 0}}}};
   const Mesh<2> mesh{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
@@ -156,6 +173,30 @@ void test_2d() {
     test_decision(flags, isotropic, element_id, mesh, decrease_decrease);
   }
   test_decision(join_join, isotropic, element_id, mesh, join_join);
+
+  {
+    INFO("No coarsening");
+    const amr::Policies policy{amr::Isotropy::Anisotropic, amr::Limits{}, true,
+                               false};
+    for (const auto flags :
+         {stay_stay, decrease_stay, join_stay, stay_decrease, decrease_decrease,
+          join_decrease, stay_join, decrease_join, join_join}) {
+      test_decision(flags, policy, element_id, mesh, stay_stay);
+    }
+    for (const auto flags : {split_split, increase_split, stay_split,
+                             split_increase, increase_increase, stay_increase,
+                             split_stay, increase_stay, stay_stay}) {
+      test_decision(flags, policy, element_id, mesh, flags);
+    }
+    test_decision(decrease_split, policy, element_id, mesh, stay_split);
+    test_decision(join_split, policy, element_id, mesh, stay_split);
+    test_decision(decrease_increase, policy, element_id, mesh, stay_increase);
+    test_decision(join_increase, policy, element_id, mesh, stay_increase);
+    test_decision(split_decrease, policy, element_id, mesh, split_stay);
+    test_decision(increase_decrease, policy, element_id, mesh, increase_stay);
+    test_decision(split_join, policy, element_id, mesh, split_stay);
+    test_decision(increase_join, policy, element_id, mesh, increase_stay);
+  }
 }
 
 void test_3d() {
@@ -163,8 +204,11 @@ void test_3d() {
       std::array{amr::Flag::DoNothing, amr::Flag::Split, amr::Flag::Split};
   const auto split_split_split =
       std::array{amr::Flag::Split, amr::Flag::Split, amr::Flag::Split};
-  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true};
-  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}, true};
+  const auto join_split_split =
+      std::array{amr::Flag::Join, amr::Flag::Split, amr::Flag::Split};
+  amr::Policies isotropic{amr::Isotropy::Isotropic, amr::Limits{}, true, true};
+  amr::Policies anisotropic{amr::Isotropy::Anisotropic, amr::Limits{}, true,
+                            true};
   ElementId<3> element_id{0, {{{1, 0}, {1, 0}, {1, 0}}}};
   const Mesh<3> mesh{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
   test_decision(stay_split_split, anisotropic, element_id, mesh,
@@ -174,14 +218,25 @@ void test_3d() {
 
   // Test error beyond limits
   isotropic = amr::Policies{amr::Isotropy::Isotropic,
-                            amr::Limits{{{0, 0}}, {{2, 8}}, true}, true};
-  anisotropic = amr::Policies{amr::Isotropy::Anisotropic,
-                              amr::Limits{{{0, 0}}, {{2, 8}}, true}, true};
+                            amr::Limits{{{0, 0}}, {{2, 8}}, true}, true, true};
+  anisotropic =
+      amr::Policies{amr::Isotropy::Anisotropic,
+                    amr::Limits{{{0, 0}}, {{2, 8}}, true}, true, true};
   element_id = ElementId<3>{0};
   test_decision(stay_split_split, anisotropic, element_id, mesh,
                 stay_split_split, true);
   test_decision(stay_split_split, isotropic, element_id, mesh,
                 split_split_split, true);
+
+  {
+    INFO("No coarsening");
+    const amr::Policies policy{amr::Isotropy::Anisotropic, amr::Limits{}, true,
+                               false};
+    for (const auto flags : {stay_split_split, split_split_split}) {
+      test_decision(flags, policy, element_id, mesh, flags);
+    }
+    test_decision(join_split_split, policy, element_id, mesh, stay_split_split);
+  }
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
@@ -11,22 +11,25 @@
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
+#include "Utilities/CartesianProduct.hpp"
 
 namespace {
 void test_equality() {
   INFO("Equality");
-  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true} ==
-        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true});
-  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true} !=
-        amr::Policies{amr::Isotropy::Isotropic, amr::Limits{}, true});
-  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true} !=
-        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, false});
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true} ==
+        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true});
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true} !=
+        amr::Policies{amr::Isotropy::Isotropic, amr::Limits{}, true, true});
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true} !=
+        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, false, true});
+  CHECK(amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true} !=
+        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, false});
 }
 
 void test_pup() {
   INFO("Serialization");
   test_serialization(
-      amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true});
+      amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true});
 }
 
 void test_option_parsing() {
@@ -35,40 +38,45 @@ void test_option_parsing() {
       std::array{amr::Isotropy::Anisotropic, amr::Isotropy::Isotropic};
   const amr::Limits default_limits{};
   const amr::Limits specified_limits{1, 5, 3, 7};
-  for (const auto isotropy : isotropies) {
+  for (const auto& [isotropy, enforce_two_to_one, allow_coarsening] :
+       cartesian_product(isotropies, std::array{true, false},
+                         std::array{true, false})) {
     CAPTURE(isotropy);
-    for (const auto enforce_two_to_one : std::array{true, false}) {
-      CAPTURE(enforce_two_to_one);
-      {
-        INFO("specified limits");
-        std::ostringstream creation_string;
-        creation_string << "Isotropy: " << isotropy << "\n";
-        creation_string << "Limits:\n"
-                        << "  RefinementLevel: [1, 5]\n"
-                        << "  NumGridPoints: [3, 7]\n"
-                        << "  ErrorBeyondLimits: False\n";
-        creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
-                        << std::boolalpha << enforce_two_to_one << "\n";
-        const auto policies =
-            TestHelpers::test_creation<amr::Policies>(creation_string.str());
-        CHECK(policies ==
-              amr::Policies{isotropy, specified_limits, enforce_two_to_one});
-      }
-      {
-        INFO("default limits");
-        std::ostringstream creation_string;
-        creation_string << "Isotropy: " << isotropy << "\n";
-        creation_string << "Limits:\n"
-                        << "  RefinementLevel: Auto\n"
-                        << "  NumGridPoints: Auto\n"
-                        << "  ErrorBeyondLimits: False\n";
-        creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
-                        << std::boolalpha << enforce_two_to_one << "\n";
-        const auto policies =
-            TestHelpers::test_creation<amr::Policies>(creation_string.str());
-        CHECK(policies ==
-              amr::Policies{isotropy, default_limits, enforce_two_to_one});
-      }
+    CAPTURE(enforce_two_to_one);
+    CAPTURE(allow_coarsening);
+    {
+      INFO("specified limits");
+      std::ostringstream creation_string;
+      creation_string << "Isotropy: " << isotropy << "\n";
+      creation_string << "Limits:\n"
+                      << "  RefinementLevel: [1, 5]\n"
+                      << "  NumGridPoints: [3, 7]\n"
+                      << "  ErrorBeyondLimits: False\n";
+      creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
+                      << std::boolalpha << enforce_two_to_one << "\n";
+      creation_string << "AllowCoarsening: " << std::boolalpha
+                      << allow_coarsening << "\n";
+      const auto policies =
+          TestHelpers::test_creation<amr::Policies>(creation_string.str());
+      CHECK(policies == amr::Policies{isotropy, specified_limits,
+                                      enforce_two_to_one, allow_coarsening});
+    }
+    {
+      INFO("default limits");
+      std::ostringstream creation_string;
+      creation_string << "Isotropy: " << isotropy << "\n";
+      creation_string << "Limits:\n"
+                      << "  RefinementLevel: Auto\n"
+                      << "  NumGridPoints: Auto\n"
+                      << "  ErrorBeyondLimits: False\n";
+      creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
+                      << std::boolalpha << enforce_two_to_one << "\n";
+      creation_string << "AllowCoarsening: " << std::boolalpha
+                      << allow_coarsening << "\n";
+      const auto policies =
+          TestHelpers::test_creation<amr::Policies>(creation_string.str());
+      CHECK(policies == amr::Policies{isotropy, default_limits,
+                                      enforce_two_to_one, allow_coarsening});
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

Allows to disable coarsening, meaning AMR will only ever refine or do nothing. One use case is to make sure multigrid levels created by AMR are guaranteed to be sequentially finer. Also useful to try AMR in BBH runs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In input files, add the following line to `Amr.Policies` to keep the current behavior unchanged:
```yaml
AllowCoarsening: True
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
