### PR TITLE
Multigrid: add direct bottom solver

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -32,6 +32,7 @@
 #include "Elliptic/Systems/GetModifyBoundaryData.hpp"
 #include "Elliptic/Systems/GetSourcesComputer.hpp"
 #include "Elliptic/Utilities/ApplyAt.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/HasReceivedFromAllMortars.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
@@ -40,6 +41,7 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InboxInserters.hpp"
 #include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -55,6 +57,11 @@ namespace elliptic::dg::Actions {
 // they don't work on their own. Instead, the public interface (defined below)
 // exposes them in action lists.
 namespace detail {
+
+// This is a global ID that identifies the DG operator application. It
+// increments with each application of the operator.
+struct DgOperatorLabel {};
+using TemporalIdTag = Convergence::Tags::IterationId<DgOperatorLabel>;
 
 // This tag is used to communicate mortar data across neighbors
 template <size_t Dim, typename TemporalIdTag, typename PrimalFields,
@@ -156,7 +163,7 @@ struct PrepareAndSendMortarData<
 
  public:
   // Request these tags be added to the DataBox. We
-  // don't actually need to initialize them, because the `TemporalIdTag` and the
+  // don't actually need to initialize them, because the
   // `PrimalFieldsTag` will be set by other actions before applying the operator
   // and the remaining tags hold output of the operator.
   using simple_tags =
@@ -335,7 +342,7 @@ struct ReceiveMortarDataAndApplyOperator<
     const auto& temporal_id = get<TemporalIdTag>(box);
     const auto& element = get<domain::Tags::Element<Dim>>(box);
 
-    if (not::dg::has_received_from_all_mortars<mortar_data_inbox_tag>(
+    if (not ::dg::has_received_from_all_mortars<mortar_data_inbox_tag>(
             temporal_id, element, inboxes)) {
       return {Parallel::AlgorithmExecution::Retry, std::nullopt};
     }
@@ -412,6 +419,13 @@ struct ReceiveMortarDataAndApplyOperator<
         db::get<elliptic::dg::Tags::Formulation>(box), temporal_id,
         fluxes_args_on_faces,
         std::forward_as_tuple(db::get<SourcesArgsTags>(box)...));
+
+    // Increment temporal ID
+    db::mutate<TemporalIdTag>(
+        [](const gsl::not_null<size_t*> stored_temporal_id) {
+          ++(*stored_temporal_id);
+        },
+        make_not_null(&box));
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
@@ -495,14 +509,13 @@ using amr_projectors = tmpl::append<
  * \par AMR
  * Also add the `amr_projectors` to the list of AMR projectors to support AMR.
  */
-template <typename System, bool Linearized, typename TemporalIdTag,
-          typename PrimalFieldsTag, typename PrimalFluxesTag,
-          typename OperatorAppliedToFieldsTag,
+template <typename System, bool Linearized, typename PrimalFieldsTag,
+          typename PrimalFluxesTag, typename OperatorAppliedToFieldsTag,
           typename PrimalMortarFieldsTag = PrimalFieldsTag,
           typename PrimalMortarFluxesTag = PrimalFluxesTag>
 struct DgOperator {
   using system = System;
-  using temporal_id_tag = TemporalIdTag;
+  using temporal_id_tag = detail::TemporalIdTag;
 
  private:
   static constexpr size_t Dim = System::volume_dim;
@@ -510,20 +523,22 @@ struct DgOperator {
  public:
   using apply_actions =
       tmpl::list<detail::PrepareAndSendMortarData<
-                     System, Linearized, TemporalIdTag, PrimalFieldsTag,
+                     System, Linearized, temporal_id_tag, PrimalFieldsTag,
                      PrimalFluxesTag, OperatorAppliedToFieldsTag,
                      PrimalMortarFieldsTag, PrimalMortarFluxesTag>,
                  detail::ReceiveMortarDataAndApplyOperator<
-                     System, Linearized, TemporalIdTag, PrimalFieldsTag,
+                     System, Linearized, temporal_id_tag, PrimalFieldsTag,
                      PrimalFluxesTag, OperatorAppliedToFieldsTag,
                      PrimalMortarFieldsTag, PrimalMortarFluxesTag>>;
-  using amr_projectors = tmpl::list<::amr::projectors::DefaultInitialize<
-      PrimalFluxesTag, OperatorAppliedToFieldsTag,
-      ::Tags::Mortars<elliptic::dg::Tags::MortarData<
-                          typename TemporalIdTag::type,
-                          typename PrimalMortarFieldsTag::tags_list,
-                          typename PrimalMortarFluxesTag::tags_list>,
-                      Dim>>>;
+  using amr_projectors = tmpl::list<
+      ::amr::projectors::DefaultInitialize<
+          PrimalFluxesTag, OperatorAppliedToFieldsTag,
+          ::Tags::Mortars<elliptic::dg::Tags::MortarData<
+                              typename temporal_id_tag::type,
+                              typename PrimalMortarFieldsTag::tags_list,
+                              typename PrimalMortarFluxesTag::tags_list>,
+                          Dim>>,
+      ::amr::projectors::CopyFromCreatorOrLeaveAsIs<temporal_id_tag>>;
 };
 
 /*!

--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -128,8 +128,6 @@ struct Metavariables {
         tmpl::pair<
             PhaseChange,
             tmpl::list<
-                // Phase for building a matrix representation of the operator
-                PhaseControl::VisitAndReturn<Parallel::Phase::BuildMatrix>,
                 // Phases for AMR
                 PhaseControl::VisitAndReturn<
                     Parallel::Phase::EvaluateAmrCriteria>,
@@ -156,25 +154,21 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<
-          Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                 initialization_actions>,
-          Parallel::PhaseActions<
-              Parallel::Phase::Register,
-              tmpl::push_back<register_actions,
-                              Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::Restart,
-              tmpl::push_back<register_actions,
-                              Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
-          Parallel::PhaseActions<Parallel::Phase::CheckDomain,
-                                 tmpl::list<::amr::Actions::SendAmrDiagnostics,
-                                            Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::BuildMatrix,
-              tmpl::push_back<typename solver::build_matrix_actions,
-                              Parallel::Actions::TerminatePhase>>>,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialization_actions>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Register,
+                     tmpl::push_back<register_actions,
+                                     Parallel::Actions::TerminatePhase>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Restart,
+                     tmpl::push_back<register_actions,
+                                     Parallel::Actions::TerminatePhase>>,
+                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::CheckDomain,
+                     tmpl::list<::amr::Actions::SendAmrDiagnostics,
+                                Parallel::Actions::TerminatePhase>>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename solver::multigrid::options_group>>;
 

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -116,8 +116,6 @@ struct Metavariables {
         tmpl::pair<
             PhaseChange,
             tmpl::list<
-                // Phase for building a matrix representation of the operator
-                PhaseControl::VisitAndReturn<Parallel::Phase::BuildMatrix>,
                 // Phases for AMR
                 PhaseControl::VisitAndReturn<
                     Parallel::Phase::EvaluateAmrCriteria>,
@@ -143,25 +141,21 @@ struct Metavariables {
 
   using dg_element_array = elliptic::DgElementArray<
       Metavariables,
-      tmpl::list<
-          Parallel::PhaseActions<Parallel::Phase::Initialization,
-                                 initialization_actions>,
-          Parallel::PhaseActions<
-              Parallel::Phase::Register,
-              tmpl::push_back<register_actions,
-                              Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::Restart,
-              tmpl::push_back<register_actions,
-                              Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
-          Parallel::PhaseActions<Parallel::Phase::CheckDomain,
-                                 tmpl::list<::amr::Actions::SendAmrDiagnostics,
-                                            Parallel::Actions::TerminatePhase>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::BuildMatrix,
-              tmpl::push_back<typename solver::build_matrix_actions,
-                              Parallel::Actions::TerminatePhase>>>,
+      tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
+                                        initialization_actions>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Register,
+                     tmpl::push_back<register_actions,
+                                     Parallel::Actions::TerminatePhase>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Restart,
+                     tmpl::push_back<register_actions,
+                                     Parallel::Actions::TerminatePhase>>,
+                 Parallel::PhaseActions<Parallel::Phase::Solve, solve_actions>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::CheckDomain,
+                     tmpl::list<::amr::Actions::SendAmrDiagnostics,
+                                Parallel::Actions::TerminatePhase>>>,
       LinearSolver::multigrid::ElementsAllocator<
           volume_dim, typename solver::multigrid::options_group>>;
 

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -210,10 +210,7 @@ struct Solver {
 
   template <bool Linearized>
   using dg_operator = elliptic::dg::Actions::DgOperator<
-      system, Linearized,
-      tmpl::conditional_t<Linearized, linear_solver_iteration_id,
-                          nonlinear_solver_iteration_id>,
-      tmpl::conditional_t<Linearized, vars_tag, fields_tag>,
+      system, Linearized, tmpl::conditional_t<Linearized, vars_tag, fields_tag>,
       tmpl::conditional_t<Linearized, fluxes_vars_tag, fluxes_tag>,
       tmpl::conditional_t<Linearized, operator_applied_to_vars_tag,
                           operator_applied_to_fields_tag>>;
@@ -362,19 +359,18 @@ struct Solver {
           typename schwarz_smoother::options_group, false, amr_iteration_id>,
       init_subdomain_action,
       // Linear or nonlinear solve
-      tmpl::conditional_t<
-          is_linear,
-          // Linear solve
-          tmpl::list<
-              // Apply the DG operator to the initial guess
-              typename elliptic::dg::Actions::DgOperator<
-                  system, true, linear_solver_iteration_id, fields_tag,
-                  fluxes_vars_tag, operator_applied_to_fields_tag, vars_tag,
-                  fluxes_vars_tag>::apply_actions,
-              // Krylov solve
-              linear_solve_actions<tmpl::list<>>>,
-          // Nonlinear solve
-          nonlinear_solve_actions<tmpl::list<>>>>>;
+      tmpl::conditional_t<is_linear,
+                          // Linear solve
+                          tmpl::list<
+                              // Apply the DG operator to the initial guess
+                              typename elliptic::dg::Actions::DgOperator<
+                                  system, true, fields_tag, fluxes_vars_tag,
+                                  operator_applied_to_fields_tag, vars_tag,
+                                  fluxes_vars_tag>::apply_actions,
+                              // Krylov solve
+                              linear_solve_actions<tmpl::list<>>>,
+                          // Nonlinear solve
+                          nonlinear_solve_actions<tmpl::list<>>>>>;
 
   template <typename Tag>
   using overlaps_tag =

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -216,9 +216,11 @@ struct Solver {
                           operator_applied_to_fields_tag>>;
 
   using build_matrix = LinearSolver::Actions::BuildMatrix<
-      fields_tag, fixed_sources_tag, vars_tag, operator_applied_to_vars_tag,
+      typename multigrid::smooth_fields_tag,
+      typename multigrid::smooth_source_tag, vars_tag,
+      operator_applied_to_vars_tag,
       domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
-      LinearSolver::multigrid::Tags::IsFinestGrid>;
+      LinearSolver::multigrid::Tags::MultigridLevel>;
 
   using build_matrix_actions = typename build_matrix::template actions<
       typename dg_operator<true>::apply_actions>;
@@ -264,10 +266,11 @@ struct Solver {
                                                     fluxes_tag>>>>>;
 
   using register_actions = tmpl::flatten<tmpl::list<
-      tmpl::conditional_t<is_linear, typename build_matrix::register_actions,
+      tmpl::conditional_t<is_linear, tmpl::list<>,
                           typename nonlinear_solver::register_element>,
       typename multigrid::register_element,
-      typename schwarz_smoother::register_element>>;
+      typename schwarz_smoother::register_element,
+      typename build_matrix::register_actions>>;
 
   template <typename Label>
   using smooth_actions = typename schwarz_smoother::template solve<
@@ -304,7 +307,8 @@ struct Solver {
               typename dg_operator<true>::apply_actions,
               // Schwarz smoothing on each multigrid level
               smooth_actions<LinearSolver::multigrid::VcycleDownLabel>,
-              smooth_actions<LinearSolver::multigrid::VcycleUpLabel>>,
+              smooth_actions<LinearSolver::multigrid::VcycleUpLabel>,
+              build_matrix_actions>,
           // Support disabling the preconditioner
           ::LinearSolver::Actions::make_identity_if_skipped<
               multigrid, typename dg_operator<true>::apply_actions>>,
@@ -334,6 +338,8 @@ struct Solver {
           LinearSolver::Schwarz::Actions::ResetSubdomainSolver<
               typename schwarz_smoother::subdomain_solver,
               typename schwarz_smoother::options_group>,
+          // Reset explicitly built matrix
+          typename build_matrix::reset_actions,
           // Linear solve for correction
           linear_solve_actions<tmpl::list<>>>,
       StepActions>;
@@ -383,6 +389,7 @@ struct Solver {
       typename linear_solver::amr_projectors,
       typename multigrid::amr_projectors,
       typename schwarz_smoother::amr_projectors,
+      typename build_matrix::amr_projectors,
       ::amr::projectors::DefaultInitialize<tmpl::append<
           tmpl::list<domain::Tags::InitialExtents<volume_dim>,
                      domain::Tags::InitialRefinementLevels<volume_dim>>,
@@ -400,7 +407,7 @@ struct Solver {
       init_analytic_solution_action,
       elliptic::dg::Actions::amr_projectors<system, background_tag>,
       typename dg_operator<true>::amr_projectors,
-      tmpl::conditional_t<is_linear, typename build_matrix::amr_projectors,
+      tmpl::conditional_t<is_linear, tmpl::list<>,
                           typename dg_operator<false>::amr_projectors>,
       // Actions below may use faces and normals
       elliptic::Actions::InitializeFixedSources<system, background_tag>,
@@ -412,15 +419,14 @@ struct Solver {
           tmpl::list<>>,
       elliptic::amr::Actions::Initialize>>;
 
-  using component_list = tmpl::flatten<tmpl::list<
-      tmpl::conditional_t<
-          is_linear,
-          typename build_matrix::template component_list<Metavariables>,
-          typename nonlinear_solver::component_list>,
-      typename linear_solver::component_list,
-      typename multigrid::component_list,
-      typename schwarz_smoother::component_list,
-      ::amr::Component<Metavariables>>>;
+  using component_list = tmpl::flatten<
+      tmpl::list<tmpl::conditional_t<is_linear, tmpl::list<>,
+                                     typename nonlinear_solver::component_list>,
+                 typename linear_solver::component_list,
+                 typename multigrid::component_list,
+                 typename schwarz_smoother::component_list,
+                 typename build_matrix::template component_list<Metavariables>,
+                 ::amr::Component<Metavariables>>>;
 };
 
 }  // namespace elliptic

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -216,8 +216,7 @@ struct Solver {
                           operator_applied_to_fields_tag>>;
 
   using build_matrix = LinearSolver::Actions::BuildMatrix<
-      typename dg_operator<true>::temporal_id_tag, fields_tag,
-      fixed_sources_tag, vars_tag, operator_applied_to_vars_tag,
+      fields_tag, fixed_sources_tag, vars_tag, operator_applied_to_vars_tag,
       domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
       LinearSolver::multigrid::Tags::IsFinestGrid>;
 

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.cpp
@@ -16,8 +16,7 @@ namespace LinearSolver::Actions::detail {
 template <size_t Dim>
 std::pair<size_t, size_t> total_num_points_and_local_first_index(
     const ElementId<Dim>& element_id,
-    const std::map<ElementId<Dim>, size_t>& num_points_per_element,
-    const size_t num_vars) {
+    const std::map<ElementId<Dim>, size_t>& num_points_per_element) {
   size_t total_num_points = 0;
   size_t local_first_index = 0;
   for (const auto& [element_id_i, num_points] : num_points_per_element) {
@@ -26,8 +25,6 @@ std::pair<size_t, size_t> total_num_points_and_local_first_index(
     }
     total_num_points += num_points;
   }
-  total_num_points *= num_vars;
-  local_first_index *= num_vars;
   return {total_num_points, local_first_index};
 }
 
@@ -47,8 +44,7 @@ std::optional<size_t> local_unit_vector_index(const size_t iteration_id,
 #define INSTANTIATION(r, data)                                               \
   template std::pair<size_t, size_t> total_num_points_and_local_first_index( \
       const ElementId<DIM(data)>& element_id,                                \
-      const std::map<ElementId<DIM(data)>, size_t>& num_points_per_element,  \
-      const size_t num_vars);
+      const std::map<ElementId<DIM(data)>, size_t>& num_points_per_element);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -27,6 +27,7 @@
 #include "IO/Observer/GetSectionObservationKey.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GetSection.hpp"
 #include "Parallel/Phase.hpp"
@@ -118,11 +119,12 @@ namespace Actions {
 
 namespace detail {
 
-template <typename IterationIdTag, typename FieldsTag, typename FixedSourcesTag,
-          typename OperandTag, typename OperatorAppliedToOperandTag,
-          typename CoordsTag, typename ArraySectionIdTag>
+template <typename FieldsTag, typename FixedSourcesTag, typename OperandTag,
+          typename OperatorAppliedToOperandTag, typename CoordsTag,
+          typename ArraySectionIdTag>
 struct BuildMatrixMetavars {
-  using iteration_id_tag = IterationIdTag;
+  using iteration_id_tag = Convergence::Tags::IterationId<
+      LinearSolver::OptionTags::BuildMatrixOptionsGroup>;
   using fields_tag = FieldsTag;
   using fixed_sources_tag = FixedSourcesTag;
   using operand_tag = OperandTag;
@@ -660,9 +662,6 @@ struct ProjectBuildMatrix : tt::ConformsTo<::amr::protocols::Projector> {
  * linear operator to the `OperandTag`. Also add the `amr_projectors` to the
  * list of AMR projectors and the `register_actions`
  *
- * \tparam IterationIdTag Used to keep track of the iteration over all matrix
- * columns. Should be the same that's used to identify iterations in the
- * `ApplyOperatorActions`.
  * \tparam FieldsTag The solution will be stored here (if direct solve is
  * enabled).
  * \tparam FixedSourcesTag The source `b` in the problem `Ax = b`. Only used
@@ -676,15 +675,15 @@ struct ProjectBuildMatrix : tt::ConformsTo<::amr::protocols::Projector> {
  * \tparam ArraySectionIdTag Can identify a subset of elements that this
  * algorithm should run over, e.g. in a multigrid setting.
  */
-template <typename IterationIdTag, typename FieldsTag, typename FixedSourcesTag,
-          typename OperandTag, typename OperatorAppliedToOperandTag,
-          typename CoordsTag, typename ArraySectionIdTag = void>
+template <typename FieldsTag, typename FixedSourcesTag, typename OperandTag,
+          typename OperatorAppliedToOperandTag, typename CoordsTag,
+          typename ArraySectionIdTag = void>
 struct BuildMatrix {
  private:
   using BuildMatrixMetavars =
-      detail::BuildMatrixMetavars<IterationIdTag, FieldsTag, FixedSourcesTag,
-                                  OperandTag, OperatorAppliedToOperandTag,
-                                  CoordsTag, ArraySectionIdTag>;
+      detail::BuildMatrixMetavars<FieldsTag, FixedSourcesTag, OperandTag,
+                                  OperatorAppliedToOperandTag, CoordsTag,
+                                  ArraySectionIdTag>;
 
  public:
   template <typename Metavariables>

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -55,7 +55,7 @@ struct BuildMatrixOptionsGroup {
 };
 
 struct MatrixSubfileName {
-  using type = std::string;
+  using type = Options::Auto<std::string, Options::AutoLabel::None>;
   using group = BuildMatrixOptionsGroup;
   static constexpr Options::String help = {
       "Subfile name in the volume data H5 files where the matrix will be "
@@ -80,7 +80,7 @@ namespace Tags {
 
 /// Subfile name in the volume data H5 files where the matrix will be stored.
 struct MatrixSubfileName : db::SimpleTag {
-  using type = std::string;
+  using type = std::optional<std::string>;
   using option_tags = tmpl::list<OptionTags::MatrixSubfileName>;
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& value) { return value; }
@@ -237,9 +237,10 @@ struct RegisterWithVolumeObserver {
            "The identifier 'Unused' is reserved to indicate that no "
            "observations with this key will be contributed. Use a different "
            "key, or change the identifier 'Unused' to something else.");
+    const auto& subfile_name = get<Tags::MatrixSubfileName>(box);
     return {
         observers::TypeOfObservation::Volume,
-        observers::ObservationKey(get<Tags::MatrixSubfileName>(box) +
+        observers::ObservationKey(subfile_name.value_or("Unused") +
                                   section_observation_key.value_or("Unused"))};
   }
 };
@@ -447,11 +448,14 @@ struct StoreMatrixColumn {
         },
         make_not_null(&box));
     // Write it out to disk
-    detail::observe_matrix_column<ParallelComponent>(
-        iteration_id, operator_applied_to_operand, element_id,
-        get<domain::Tags::Mesh<Dim>>(box), get<CoordsTag>(box),
-        get<Tags::MatrixSubfileName>(box),
-        *observers::get_section_observation_key<ArraySectionIdTag>(box), cache);
+    if (const auto& subfile_name = get<Tags::MatrixSubfileName>(box);
+        subfile_name.has_value()) {
+      detail::observe_matrix_column<ParallelComponent>(
+          iteration_id, operator_applied_to_operand, element_id,
+          get<domain::Tags::Mesh<Dim>>(box), get<CoordsTag>(box), *subfile_name,
+          *observers::get_section_observation_key<ArraySectionIdTag>(box),
+          cache);
+    }
     // Reset operand to zero
     const std::optional<size_t> local_unit_vector_index =
         detail::local_unit_vector_index(iteration_id, local_first_index,

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -160,12 +160,13 @@ struct BuildMatrixMetavars {
 
 /// \brief The total number of grid points (size of the matrix) and the index of
 /// the first grid point in this element (the offset into the matrix
-/// corresponding to this element).
+/// corresponding to this element). The `num_points_per_element` should hold
+/// the total number of degrees of freedom for each element, so the number of
+/// variables times the number of grid points.
 template <size_t Dim>
 std::pair<size_t, size_t> total_num_points_and_local_first_index(
     const ElementId<Dim>& element_id,
-    const std::map<ElementId<Dim>, size_t>& num_points_per_element,
-    size_t num_vars);
+    const std::map<ElementId<Dim>, size_t>& num_points_per_element);
 
 /// \brief The index of the '1' of the unit vector in this element, or
 /// std::nullopt if the '1' is in another element.
@@ -371,9 +372,8 @@ struct PrepareBuildMatrix {
       return;
     }
     const auto [total_num_points, local_first_index] =
-        detail::total_num_points_and_local_first_index(
-            element_id, num_points_per_element,
-            OperandTag::type::number_of_independent_components);
+        detail::total_num_points_and_local_first_index(element_id,
+                                                       num_points_per_element);
     if (get<logging::Tags::Verbosity<OptionTags::BuildMatrixOptionsGroup>>(
             box) >= Verbosity::Quiet and
         local_first_index == 0) {

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -36,6 +36,7 @@
 #include "Parallel/Section.hpp"
 #include "Parallel/Tags/Section.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
+#include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -617,6 +618,7 @@ struct StoreSolution {
  private:
   using value_type = typename BuildMatrixMetavars::value_type;
   using FieldsTag = typename BuildMatrixMetavars::fields_tag;
+  using FixedSourcesTag = typename BuildMatrixMetavars::fixed_sources_tag;
 
  public:
   template <typename ParallelComponent, typename DbTagsList,
@@ -629,13 +631,19 @@ struct StoreSolution {
       return;
     }
     const size_t local_first_index = db::get<Tags::LocalFirstIndex>(box);
-    db::mutate<FieldsTag>(
-        [&solution, &local_first_index](const auto fields) {
+    db::mutate<
+        FieldsTag,
+        db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, FieldsTag>>(
+        [&solution, &local_first_index](const auto fields,
+                                        const auto operator_applied_to_fields,
+                                        const auto& fixed_sources) {
           std::copy_n(
               solution.begin() + static_cast<ptrdiff_t>(local_first_index),
               fields->size(), fields->data());
+          // The linear problem is solved now, so Ax = b
+          *operator_applied_to_fields = fixed_sources;
         },
-        make_not_null(&box));
+        make_not_null(&box), db::get<FixedSourcesTag>(box));
     // Proceed with algorithm
     Parallel::get_parallel_component<ParallelComponent>(cache)[element_id]
         .perform_algorithm(true);

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -279,7 +279,7 @@ struct CollectTotalNumPoints {
       db::DataBox<DbTags>& box,
       const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
       Parallel::GlobalCache<Metavariables>& cache,
-      const ElementId<Dim>& array_index, const ActionList /*meta*/,
+      const ElementId<Dim>& element_id, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     // Skip everything on elements that are not part of the section
     if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
@@ -306,11 +306,14 @@ struct CollectTotalNumPoints {
     auto& section = Parallel::get_section<ParallelComponent, ArraySectionIdTag>(
         make_not_null(&box));
     Parallel::contribute_to_reduction<PrepareBuildMatrix<BuildMatrixMetavars>>(
-        Parallel::ReductionData<Parallel::ReductionDatum<
-            std::map<ElementId<Dim>, size_t>, funcl::Merge<>>>{
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+            Parallel::ReductionDatum<std::map<ElementId<Dim>, size_t>,
+                                     funcl::Merge<>>>{
+            element_id.grid_index(),
             std::map<ElementId<Dim>, size_t>{
-                std::make_pair(array_index, get<OperandTag>(box).size())}},
-        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
+                std::make_pair(element_id, get<OperandTag>(box).size())}},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[element_id],
         Parallel::get_parallel_component<ParallelComponent>(cache),
         make_not_null(&section));
     // Pause the algorithm for now. The reduction will be broadcast to the next
@@ -332,8 +335,11 @@ struct PrepareBuildMatrix {
             typename Metavariables, size_t Dim>
   static void apply(
       db::DataBox<DbTagsList>& box, Parallel::GlobalCache<Metavariables>& cache,
-      const ElementId<Dim>& element_id,
+      const ElementId<Dim>& element_id, const size_t grid_index,
       const std::map<ElementId<Dim>, size_t>& num_points_per_element) {
+    if (grid_index != element_id.grid_index()) {
+      return;
+    }
     const auto [total_num_points, local_first_index] =
         detail::total_num_points_and_local_first_index(
             element_id, num_points_per_element,
@@ -532,8 +538,11 @@ struct AssembleFullMatrix {
         make_not_null(&box));
     Parallel::contribute_to_reduction<
         InvertMatrix<ParallelComponent, BuildMatrixMetavars>>(
-        Parallel::ReductionData<Parallel::ReductionDatum<
-            std::map<ElementId<Dim>, ReductionType>, funcl::Merge<>>>{
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+            Parallel::ReductionDatum<std::map<ElementId<Dim>, ReductionType>,
+                                     funcl::Merge<>>>{
+            element_id.grid_index(),
             std::map<ElementId<Dim>, ReductionType>{std::make_pair(
                 element_id, ReductionType{get<Tags::Matrix<value_type>>(box),
                                           get<FixedSourcesTag>(box)})}},
@@ -563,7 +572,7 @@ struct InvertMatrix {
             typename Metavariables, typename ArrayIndex, size_t Dim>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
-                    const ArrayIndex& /*array_index*/,
+                    const ArrayIndex& /*array_index*/, const size_t grid_index,
                     const std::map<ElementId<Dim>, ReductionType>&
                         matrix_and_sources_slices) {
     const size_t total_num_points =
@@ -599,7 +608,7 @@ struct InvertMatrix {
     // Broadcast the solution to the elements
     Parallel::simple_action<StoreSolution<BuildMatrixMetavars>>(
         Parallel::get_parallel_component<ElementArrayComponent>(cache),
-        solution);
+        grid_index, solution);
   }
 };
 
@@ -614,8 +623,11 @@ struct StoreSolution {
             typename Metavariables, size_t Dim>
   static void apply(db::DataBox<DbTagsList>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
-                    const ElementId<Dim>& element_id,
+                    const ElementId<Dim>& element_id, const size_t grid_index,
                     const blaze::DynamicVector<value_type>& solution) {
+    if (grid_index != element_id.grid_index()) {
+      return;
+    }
     const size_t local_first_index = db::get<Tags::LocalFirstIndex>(box);
     db::mutate<FieldsTag>(
         [&solution, &local_first_index](const auto fields) {

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -35,6 +35,7 @@
 #include "Parallel/Reduction.hpp"
 #include "Parallel/Section.hpp"
 #include "Parallel/Tags/Section.hpp"
+#include "ParallelAlgorithms/Actions/Goto.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "ParallelAlgorithms/LinearSolver/Tags.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -76,6 +77,18 @@ struct EnableDirectSolve {
       "This can be unfeasible if the linear problem is too big."};
 };
 
+struct SkipResets {
+  using type = bool;
+  using group = BuildMatrixOptionsGroup;
+  static constexpr Options::String help = {
+      "Skip resets of the built matrix. This only has an effect in cases "
+      "where the operator changes, e.g. between nonlinear-solver iterations. "
+      "Skipping resets avoids expensive re-building of the matrix, but comes "
+      "at the cost of less accurate preconditioning and thus potentially more "
+      "preconditioned iterations. Whether or not this helps convergence "
+      "overall is highly problem-dependent."};
+};
+
 }  // namespace OptionTags
 
 namespace Tags {
@@ -114,6 +127,13 @@ struct EnableDirectSolve : db::SimpleTag {
   static type create_from_options(const type& value) { return value; }
 };
 
+struct SkipResets : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::SkipResets>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& value) { return value; }
+};
+
 }  // namespace Tags
 
 namespace Actions {
@@ -134,6 +154,8 @@ struct BuildMatrixMetavars {
   using array_section_id_tag = ArraySectionIdTag;
 
   using value_type = typename OperatorAppliedToOperandTag::type::value_type;
+
+  struct end_label {};
 };
 
 /// \brief The total number of grid points (size of the matrix) and the index of
@@ -287,11 +309,18 @@ struct CollectTotalNumPoints {
       if (not db::get<Parallel::Tags::Section<ParallelComponent,
                                               ArraySectionIdTag>>(box)
                   .has_value()) {
-        constexpr size_t last_action_index =
-            tmpl::index_of<ActionList,
-                           AssembleFullMatrix<BuildMatrixMetavars>>::value;
+        constexpr size_t last_action_index = tmpl::index_of<
+            ActionList,
+            ::Actions::Label<typename BuildMatrixMetavars::end_label>>::value;
         return {Parallel::AlgorithmExecution::Continue, last_action_index + 1};
       }
+    }
+    if (db::get<Tags::TotalNumPoints>(box) != 0) {
+      // We have built the matrix already, so we can skip ahead
+      constexpr size_t assemble_matrix_index =
+          tmpl::index_of<ActionList,
+                         AssembleFullMatrix<BuildMatrixMetavars>>::value;
+      return {Parallel::AlgorithmExecution::Continue, assemble_matrix_index};
     }
     db::mutate<Tags::TotalNumPoints, OperandTag>(
         [](const auto total_num_points, const auto operand,
@@ -659,14 +688,62 @@ struct ProjectBuildMatrix : tt::ConformsTo<::amr::protocols::Projector> {
 
  public:
   using return_tags =
-      tmpl::list<Tags::TotalNumPoints, Tags::LocalFirstIndex, IterationIdTag,
-                 OperandTag, Tags::Matrix<value_type>>;
+      tmpl::list<Tags::TotalNumPoints, Tags::Matrix<value_type>,
+                 Tags::LocalFirstIndex, IterationIdTag, OperandTag>;
   using argument_tags = tmpl::list<>;
 
   template <typename... AmrData>
-  static void apply(const gsl::not_null<size_t*> /*unused*/,
-                    const AmrData&... /*amr_data*/) {
-    // Nothing to do. Everything gets initialized at the start of the algorithm.
+  static void apply(
+      const gsl::not_null<size_t*> total_num_points,
+      const gsl::not_null<blaze::CompressedMatrix<value_type>*> matrix,
+      const AmrData&... /*amr_data*/) {
+    // Reset the built matrix when AMR changes the grid.
+    // In case AMR is configured to keep coarse grids then the coarse-grid
+    // elements don't run projectors during AMR, so they are not reset and just
+    // keep the built matrix. This is good because the coarse grids are
+    // unchanged and so the matrix is still valid (and can be used as bottom
+    // solver in multigrid).
+    *total_num_points = 0;
+    matrix->clear();
+  }
+};
+
+/// Dispatch global reduction to get the size of the matrix
+template <typename BuildMatrixMetavars>
+struct ResetBuiltMatrix {
+ private:
+  using value_type = typename BuildMatrixMetavars::value_type;
+  using ArraySectionIdTag = typename BuildMatrixMetavars::array_section_id_tag;
+
+ public:
+  using const_global_cache_tags = tmpl::list<Tags::SkipResets>;
+
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    // Skip on elements that are not part of the section
+    if constexpr (not std::is_same_v<ArraySectionIdTag, void>) {
+      if (not db::get<Parallel::Tags::Section<ParallelComponent,
+                                              ArraySectionIdTag>>(box)
+                  .has_value()) {
+        return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+      }
+    }
+    if (db::get<Tags::SkipResets>(box)) {
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
+    db::mutate<Tags::TotalNumPoints, Tags::Matrix<value_type>>(
+        [](const auto total_num_points, const auto matrix) {
+          *total_num_points = 0;
+          matrix->clear();
+        },
+        make_not_null(&box));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
 
@@ -704,6 +781,12 @@ struct BuildMatrix {
       detail::BuildMatrixMetavars<FieldsTag, FixedSourcesTag, OperandTag,
                                   OperatorAppliedToOperandTag, CoordsTag,
                                   ArraySectionIdTag>;
+  static_assert(
+      std::is_same_v<FieldsTag, OperandTag>,
+      "The operand and the fields tags must be the same. This is just so that "
+      "at the end of the algorithm the operator is applied to the solution "
+      "fields. This restriction can be lifted if needed by copying the fields "
+      "into the operand and back.");
 
  public:
   template <typename Metavariables>
@@ -718,13 +801,28 @@ struct BuildMatrix {
                  StoreMatrixColumn<BuildMatrixMetavars>,
                  // Algorithm iterates until matrix is complete, then proceeds
                  // below
-                 AssembleFullMatrix<BuildMatrixMetavars>>;
+                 AssembleFullMatrix<BuildMatrixMetavars>,
+                 // Apply operator to the solution. Note that FieldsTag and
+                 // OperandTag must be the same for this (see assert above).
+                 // Note also that this operator application is not needed in
+                 // most cases, as the linear problem is solved exactly and
+                 // therefore Ax = b is set in 'StoreSolution'. However, this
+                 // operator application is needed if the operator changes
+                 // between nonlinear solver iterations but we skip the reset,
+                 // so the matrix represents the old operator. It's just one
+                 // more operator application, so we keep it always enabled for
+                 // now.
+                 ApplyOperatorActions,
+                 ::Actions::Label<typename BuildMatrixMetavars::end_label>>;
 
   using amr_projectors = tmpl::list<ProjectBuildMatrix<BuildMatrixMetavars>>;
 
   /// Add to the register phase to enable observations
   using register_actions = tmpl::list<observers::Actions::RegisterWithObservers<
       detail::RegisterWithVolumeObserver<ArraySectionIdTag>>>;
+
+  /// Add to the action list to reset the matrix
+  using reset_actions = tmpl::list<ResetBuiltMatrix<BuildMatrixMetavars>>;
 };
 
 }  // namespace Actions

--- a/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Actions/BuildMatrix.hpp
@@ -48,6 +48,8 @@
 namespace LinearSolver {
 namespace OptionTags {
 
+/// Options for building the explicit matrix representation of the linear
+/// operator.
 struct BuildMatrixOptionsGroup {
   static std::string name() { return "BuildMatrix"; }
   static constexpr Options::String help = {
@@ -57,6 +59,7 @@ struct BuildMatrixOptionsGroup {
       "solve the elliptic problem (that should happen iteratively)."};
 };
 
+/// Subfile name in the volume data H5 files where the matrix will be stored.
 struct MatrixSubfileName {
   using type = Options::Auto<std::string, Options::AutoLabel::None>;
   using group = BuildMatrixOptionsGroup;
@@ -69,6 +72,7 @@ struct MatrixSubfileName {
       "component."};
 };
 
+/// Option for enabling direct solve of the linear problem.
 struct EnableDirectSolve {
   using type = bool;
   using group = BuildMatrixOptionsGroup;
@@ -77,6 +81,7 @@ struct EnableDirectSolve {
       "This can be unfeasible if the linear problem is too big."};
 };
 
+/// Option for skipping resets of the built matrix.
 struct SkipResets {
   using type = bool;
   using group = BuildMatrixOptionsGroup;
@@ -120,6 +125,7 @@ struct Matrix : db::SimpleTag {
   using type = blaze::CompressedMatrix<ValueType>;
 };
 
+/// Option for enabling direct solve of the linear problem.
 struct EnableDirectSolve : db::SimpleTag {
   using type = bool;
   using option_tags = tmpl::list<OptionTags::EnableDirectSolve>;
@@ -127,6 +133,7 @@ struct EnableDirectSolve : db::SimpleTag {
   static type create_from_options(const type& value) { return value; }
 };
 
+/// Option for skipping resets of the built matrix.
 struct SkipResets : db::SimpleTag {
   using type = bool;
   using option_tags = tmpl::list<OptionTags::SkipResets>;

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
@@ -46,6 +46,8 @@ namespace LinearSolver::multigrid::detail {
 template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
 struct SendCorrectionToFinerGrid;
 template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+struct SkipBottomSolver;
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
 struct SkipPostSmoothingAtBottom;
 /// \endcond
 
@@ -188,7 +190,8 @@ using ReceiveResidualFromFinerGrid = Actions::ReceiveFieldsFromFinerGrid<
 // `SourceTag`, this action prepares the pre-smoothing that will determine
 // an approximate solution on this grid. The pre-smoother is a separate
 // linear solver that runs independently after this action.
-template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag,
+          bool EnableBottomSolver>
 struct PreparePreSmoothing {
  private:
   using fields_tag = FieldsTag;
@@ -197,8 +200,13 @@ struct PreparePreSmoothing {
   using source_tag = SourceTag;
 
  public:
-  using const_global_cache_tags = tmpl::list<
-      LinearSolver::multigrid::Tags::EnablePreSmoothing<OptionsGroup>>;
+  using const_global_cache_tags = tmpl::append<
+      tmpl::list<
+          LinearSolver::multigrid::Tags::EnablePreSmoothing<OptionsGroup>>,
+      tmpl::conditional_t<EnableBottomSolver,
+                          tmpl::list<LinearSolver::multigrid::Tags::
+                                         UseBottomSolver<OptionsGroup>>,
+                          tmpl::list<>>>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
@@ -210,10 +218,15 @@ struct PreparePreSmoothing {
       const ParallelComponent* const /*meta*/) {
     const size_t iteration_id =
         db::get<Convergence::Tags::IterationId<OptionsGroup>>(box);
+    const bool is_coarsest_grid =
+        not db::get<Tags::ParentId<Dim>>(box).has_value();
     if (UNLIKELY(db::get<logging::Tags::Verbosity<OptionsGroup>>(box) >=
                  ::Verbosity::Debug)) {
-      Parallel::printf("%s %s(%zu): Prepare pre-smoothing\n", element_id,
-                       pretty_type::name<OptionsGroup>(), iteration_id);
+      Parallel::printf("%s %s(%zu): Prepare %s\n", element_id,
+                       pretty_type::name<OptionsGroup>(), iteration_id,
+                       (EnableBottomSolver and is_coarsest_grid)
+                           ? "bottom-solver"
+                           : "pre-smoothing");
     }
 
     // On coarser grids the smoother solves for a correction to the finer-grid
@@ -251,7 +264,18 @@ struct PreparePreSmoothing {
           db::get<source_tag>(box));
     }
 
-    // Skip pre-smoothing, if requested
+    // Skip pre-smoothing, if requested, or use bottom solver
+    if constexpr (EnableBottomSolver) {
+      if (db::get<LinearSolver::multigrid::Tags::UseBottomSolver<OptionsGroup>>(
+              box) and
+          is_coarsest_grid) {
+        const size_t bottom_solver_index =
+            tmpl::index_of<ActionList, SkipBottomSolver<FieldsTag, OptionsGroup,
+                                                        SourceTag>>::value +
+            1;
+        return {Parallel::AlgorithmExecution::Continue, bottom_solver_index};
+      }
+    }
     const size_t first_action_after_pre_smoothing_index = tmpl::index_of<
         ActionList,
         SkipPostSmoothingAtBottom<FieldsTag, OptionsGroup, SourceTag>>::value;
@@ -264,6 +288,26 @@ struct PreparePreSmoothing {
             box)
             ? (this_action_index + 1)
             : first_action_after_pre_smoothing_index};
+  }
+};
+
+// Once pre-smoothing is done, skip the bottom solver that comes next in the
+// action list. On the coarsest grid we directly jump to the bottom solver.
+template <typename FieldsTag, typename OptionsGroup, typename SourceTag>
+struct SkipBottomSolver {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Dim>& /*element_id*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    const size_t first_action_after_bottom_solver_index = tmpl::index_of<
+        ActionList,
+        SkipPostSmoothingAtBottom<FieldsTag, OptionsGroup, SourceTag>>::value;
+    return {Parallel::AlgorithmExecution::Continue,
+            first_action_after_bottom_solver_index};
   }
 };
 

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Multigrid.hpp
@@ -69,7 +69,7 @@ struct VcycleUpLabel {};
  * See section 3 in \cite Fortunato2019jl for details on the inter-mesh
  * operators.
  *
- * \par Smoother
+ * \par Smoother and bottom solver
  * On every level of the grid hierarchy the multigrid solver relies on a
  * "smoother" that performs an approximate linear solve on that level. The
  * smoother can be any linear solver that solves the `smooth_fields_tag` for the
@@ -87,7 +87,14 @@ struct VcycleUpLabel {};
  *
  * \snippet Test_MultigridAlgorithm.cpp setup_smoother
  *
- * The smoother can be used to construct an action list like this:
+ * On the coarsest level of the grid hierarchy, the multigrid algorithm can also
+ * use a separate "bottom solver". If enabled, the bottom solver replaces the
+ * pre-smoother on the coarsest grid. The bottom solver can also be any linear
+ * solver, but it is typically a direct solver that solves the linear problem
+ * exactly (see `LinearSolver::Actions::BuildMatrix` for a good bottom solver).
+ *
+ * The smoother and bottom solver can be used to construct an action list like
+ * this:
  *
  * \snippet Test_MultigridAlgorithm.cpp action_list
  *
@@ -103,10 +110,11 @@ struct VcycleUpLabel {};
  * as the source for the smoother on the coarser grid. When going up again, the
  * algorithm projects the solution of the smoother to the next-finer grid,
  * adding it to the solution on the finer grid as a correction. The bottom-most
- * coarsest grid (the "tip" of the V-cycle) may skip the post-smoothing, so the
- * result of the pre-smoother is immediately projected up to the finer grid
- * (controlled by the
- * `LinearSolver::multigrid::Tags::EnablePostSmoothingAtBottom` option). On the
+ * coarsest grid (the "tip" of the V-cycle) may run the bottom solver instead of
+ * the pre-smoother. It may also skip the post-smoother, so the result of the
+ * bottom solver is immediately projected up to the finer grid (controlled by
+ * the options `LinearSolver::multigrid::Tags::UseBottomSolver` and
+ * `LinearSolver::multigrid::Tags::EnablePostSmoothingAtBottom`). On the
  * top-most finest grid (the "original" grid that represents the overall
  * solution) the algorithm applies the smoothing and the corrections from the
  * coarser grids directly to the solution fields.
@@ -153,13 +161,17 @@ struct Multigrid {
                      detail::RegisterWithVolumeObserver<OptionsGroup>>>;
 
   template <typename ApplyOperatorActions, typename PreSmootherActions,
-            typename PostSmootherActions, typename Label = OptionsGroup>
+            typename PostSmootherActions,
+            typename BottomSolverActions = tmpl::list<>,
+            typename Label = OptionsGroup>
   using solve = tmpl::list<
       async_solvers::PrepareSolve<FieldsTag, OptionsGroup, SourceTag, Label,
                                   Tags::IsFinestGrid, false>,
       detail::ReceiveResidualFromFinerGrid<Dim, FieldsTag, OptionsGroup,
                                            SourceTag>,
-      detail::PreparePreSmoothing<FieldsTag, OptionsGroup, SourceTag>,
+      detail::PreparePreSmoothing<
+          FieldsTag, OptionsGroup, SourceTag,
+          not std::is_same_v<BottomSolverActions, tmpl::list<>>>,
       // No need to apply the linear operator here:
       // - On the finest grid, the operator applied to the fields should have
       //   already been computed at this point, either applied to the initial
@@ -168,6 +180,8 @@ struct Multigrid {
       // - On coarser grids, the initial fields are zero, so the operator
       //   applied to them is also zero.
       PreSmootherActions,
+      detail::SkipBottomSolver<FieldsTag, OptionsGroup, SourceTag>,
+      BottomSolverActions,
       detail::SkipPostSmoothingAtBottom<FieldsTag, OptionsGroup, SourceTag>,
       detail::SendResidualToCoarserGrid<FieldsTag, OptionsGroup,
                                         ResidualIsMassiveTag, SourceTag>,

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp
@@ -59,6 +59,20 @@ struct EnablePreSmoothing {
 };
 
 template <typename OptionsGroup>
+struct UseBottomSolver {
+  using type = bool;
+  static constexpr Options::String help =
+      "Set to 'True' to use a separate bottom solver on the coarsest level "
+      "instead of pre-smoothing. The bottom solver typically builds the matrix "
+      "explicitly and inverts it directly. Use the bottom solver if "
+      "pre-smoothing is not sufficiently effective on the bottom grid. "
+      "The bottom solver can significantly cut down the number of iterations "
+      "needed to converge to the solution at the cost of building the matrix "
+      "explicitly and inverting it directly on the coarsest level.";
+  using group = OptionsGroup;
+};
+
+template <typename OptionsGroup>
 struct EnablePostSmoothingAtBottom {
   static std::string name() { return "PostSmoothingAtBottom"; }
   using type = bool;
@@ -140,6 +154,18 @@ struct EnablePreSmoothing : db::SimpleTag {
   static type create_from_options(const type value) { return value; };
   static std::string name() {
     return "EnablePreSmoothing(" + pretty_type::name<OptionsGroup>() + ")";
+  }
+};
+
+/// Enable the bottom solver
+template <typename OptionsGroup>
+struct UseBottomSolver : db::SimpleTag {
+  using type = bool;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::UseBottomSolver<OptionsGroup>>;
+  static type create_from_options(const type value) { return value; };
+  static std::string name() {
+    return "UseBottomSolver(" + pretty_type::name<OptionsGroup>() + ")";
   }
 };
 

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -211,6 +211,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: True
     Verbosity: Silent
     OutputVolumeData: False
@@ -268,3 +269,9 @@ RandomizeInitialGuess: None
 ResourceInfo:
   AvoidGlobalProc0: false
   Singletons: Auto
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  SkipResets: True

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -79,6 +79,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: False
     Verbosity: Quiet
     OutputVolumeData: False
@@ -127,6 +128,6 @@ Amr:
 PhaseChangeAndTriggers: []
 
 BuildMatrix:
-  MatrixSubfileName: Matrix
+  MatrixSubfileName: None
   Verbosity: Verbose
   EnableDirectSolve: True

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -93,6 +93,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: True
     Verbosity: Silent
     OutputVolumeData: False
@@ -160,6 +161,6 @@ Amr:
 PhaseChangeAndTriggers: []
 
 BuildMatrix:
-  MatrixSubfileName: Matrix
+  MatrixSubfileName: None
   Verbosity: Verbose
   EnableDirectSolve: True

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -108,6 +108,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: True
     Verbosity: Silent
     OutputVolumeData: False
@@ -184,6 +185,6 @@ ResourceInfo:
   Singletons: Auto
 
 BuildMatrix:
-  MatrixSubfileName: Matrix
+  MatrixSubfileName: None
   Verbosity: Verbose
   EnableDirectSolve: True

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -97,6 +97,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: False
     Verbosity: Silent
     OutputVolumeData: False
@@ -137,7 +138,7 @@ EventsAndTriggersAtIterations:
           BlocksToObserve: All
 
 BuildMatrix:
-  MatrixSubfileName: Matrix
+  MatrixSubfileName: None
   Verbosity: Verbose
   EnableDirectSolve: True
 

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -8,7 +8,6 @@ Testing:
 ExpectedOutput:
   - PoissonProductOfSinusoids1DReductions.h5
   - PoissonProductOfSinusoids1DVolume0.h5
-  - SubdomainMatrix*.txt
 OutputFileChecks:
   - Label: Discretization error
     Subfile: ErrorNorms.dat
@@ -18,28 +17,22 @@ OutputFileChecks:
       - [1, 8, 4.71238898038469e+00, 4.14037391064113e-03]
       - [2, 16, 4.71238898038469e+00, 1.96421037243931e-04]
       - [3, 20, 4.71238898038469e+00, 1.47125554015345e-05]
-    AbsoluteTolerance: 1e-8
+    AbsoluteTolerance: 1e-6
   - Label: Linear solver convergence
     Subfile: GmresResiduals.dat
     FileGlob: PoissonProductOfSinusoids1DReductions.h5
     SkipColumns: [1] # Skip walltime
     ExpectedData:
-      # AMR iteration 0 (solved by building matrix and direct solve)
-      - [0, 1.e-16]
+      # Each AMR iteration is solved directly by the multigrid bottom solver
+      # AMR iteration 0
+      - [0, 1.218121e+01]
+      - [1, 0.0]
       # AMR iteration 1
-      - [0, 2.09447729412913e-01]
-      - [1, 2.46546953964650e-03]
-      - [2, 8.48550910654618e-04]
-      - [3, 2.44047574357982e-04]
-      - [4, 2.63835241157592e-05]
-      - [5, 2.07844911429961e-07]
+      - [0, 2.094477e-01]
+      - [1, 0.0]
       # AMR iteration 2
-      - [0, 3.15882858760581e-02]
-      - [1, 7.82175835835042e-04]
-      - [2, 1.13099440899420e-04]
-      - [3, 5.55444538380480e-05]
-      - [4, 1.11628047012794e-05]
-      - [5, 1.65458379564807e-08]
+      - [0, 3.158830e-02]
+      - [1, 0.0]
     AbsoluteTolerance: 1e-6
 
 ---
@@ -100,13 +93,6 @@ Amr:
   Iterations: 3
 
 PhaseChangeAndTriggers:
-  # Build explicit matrix representation for initial domain
-  - Trigger:
-      EveryNIterations:
-        N: 100
-        Offset: 0
-    PhaseChanges:
-      - VisitAndReturn(BuildMatrix)
   # Run AMR in every iteration, but not on the initial guess
   - Trigger:
       EveryNIterations:
@@ -140,6 +126,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: 1
     PreSmoothing: True
+    UseBottomSolver: True
     PostSmoothingAtBottom: False
     Verbosity: Silent
     OutputVolumeData: True
@@ -150,7 +137,7 @@ LinearSolver:
     Verbosity: Silent
     SubdomainSolver:
       ExplicitInverse:
-        WriteMatrixToFile: "SubdomainMatrix"
+        WriteMatrixToFile: None
     ObservePerCoreReductions: False
 
 RadiallyCompressedCoordinates: None
@@ -173,6 +160,6 @@ EventsAndTriggersAtIterations:
           BlocksToObserve: All
 
 BuildMatrix:
-  MatrixSubfileName: Matrix
+  MatrixSubfileName: None
   Verbosity: Verbose
   EnableDirectSolve: True

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -8,6 +8,7 @@ Testing:
 ExpectedOutput:
   - PoissonProductOfSinusoids2DReductions.h5
   - PoissonProductOfSinusoids2DVolume0.h5
+  - SubdomainMatrix*.txt
 OutputFileChecks:
   - Label: Discretization error
     Subfile: ErrorNorms.dat
@@ -81,6 +82,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: False
     Verbosity: Verbose
     OutputVolumeData: False
@@ -91,7 +93,7 @@ LinearSolver:
     Verbosity: Quiet
     SubdomainSolver:
       ExplicitInverse:
-        WriteMatrixToFile: None
+        WriteMatrixToFile: "SubdomainMatrix"
     ObservePerCoreReductions: False
 
 RadiallyCompressedCoordinates: None
@@ -129,6 +131,6 @@ Amr:
 PhaseChangeAndTriggers: []
 
 BuildMatrix:
-  MatrixSubfileName: Matrix
+  MatrixSubfileName: "FullMatrix"
   Verbosity: Verbose
   EnableDirectSolve: True

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -85,6 +85,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: True
     PostSmoothingAtBottom: False
     Verbosity: Verbose
     OutputVolumeData: False
@@ -133,6 +134,6 @@ Amr:
 PhaseChangeAndTriggers: []
 
 BuildMatrix:
-  MatrixSubfileName: Matrix
+  MatrixSubfileName: None
   Verbosity: Verbose
   EnableDirectSolve: True

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -132,6 +132,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: 1
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: False
     Verbosity: Silent
     OutputVolumeData: False
@@ -178,3 +179,9 @@ EventsAndTriggersAtIterations:
             - Name: AdmMassIntegrand
               NormType: VolumeIntegral
               Components: Individual
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  SkipResets: True

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -206,6 +206,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: True
     Verbosity: Silent
     OutputVolumeData: False
@@ -273,3 +274,9 @@ EventsAndTriggersAtIterations:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  SkipResets: True

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -144,6 +144,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: True
     Verbosity: Silent
     OutputVolumeData: False
@@ -239,3 +240,9 @@ Amr:
   Iterations: 1
 
 PhaseChangeAndTriggers: []
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  SkipResets: True

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -175,6 +175,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: 1
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: False
     Verbosity: Silent
     OutputVolumeData: False
@@ -245,3 +246,10 @@ EventsAndTriggersAtIterations:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  # Can't skip resets if bottom solver is enabled because we start at flatness
+  SkipResets: False

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -93,6 +93,7 @@ LinearSolver:
     Iterations: 1
     MaxLevels: Auto
     PreSmoothing: True
+    UseBottomSolver: False
     PostSmoothingAtBottom: False
     Verbosity: Verbose
     OutputVolumeData: False
@@ -173,3 +174,9 @@ Amr:
   Iterations: 1
 
 PhaseChangeAndTriggers: []
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  SkipResets: True

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -113,10 +113,6 @@ struct SubdomainOperatorTag : db::SimpleTag {
   using type = SubdomainOperatorType;
 };
 
-struct TemporalIdTag : db::SimpleTag {
-  using type = size_t;
-};
-
 template <typename Tag>
 struct DgOperatorAppliedTo : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
@@ -418,8 +414,7 @@ struct ElementArray {
       SubdomainOperatorAppliedToDataTag<Dim, typename fields_tag::tags_list>;
 
   using dg_operator =
-      ::elliptic::dg::Actions::DgOperator<System, true, TemporalIdTag,
-                                          fields_tag, fluxes_tag,
+      ::elliptic::dg::Actions::DgOperator<System, true, fields_tag, fluxes_tag,
                                           operator_applied_to_fields_tag>;
 
   using background_tag =
@@ -464,10 +459,11 @@ struct ElementArray {
           tmpl::list<
               // Init subdomain
               LinearSolver::Schwarz::Actions::SendOverlapFields<
-                  subdomain_init_tags, DummyOptionsGroup, false, TemporalIdTag>,
+                  subdomain_init_tags, DummyOptionsGroup, false,
+                  typename dg_operator::temporal_id_tag>,
               LinearSolver::Schwarz::Actions::ReceiveOverlapFields<
                   Dim, subdomain_init_tags, DummyOptionsGroup, false,
-                  TemporalIdTag>,
+                  typename dg_operator::temporal_id_tag>,
               init_subdomain_action, init_random_subdomain_data_action,
               Parallel::Actions::TerminatePhase,
               // Full DG operator
@@ -540,7 +536,7 @@ struct Metavariables {
             typename element_array::init_random_subdomain_data_action::
                 simple_tags>>,
         ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
-            OverrideBoundaryConditionsTag, TemporalIdTag,
+            OverrideBoundaryConditionsTag,
             // Work around a segfault because this tag isn't handled
             // correctly by the testing framework
             Parallel::Tags::GlobalCache<Metavariables>>,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -82,26 +82,6 @@ struct Var : db::SimpleTag, db::PrefixTag {
   using tag = Tag;
 };
 
-struct TemporalIdTag : db::SimpleTag {
-  using type = size_t;
-};
-
-struct IncrementTemporalId {
-  template <typename DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent>
-  static Parallel::iterable_action_return_t apply(
-      db::DataBox<DbTags>& box,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::GlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/) {
-    db::mutate<TemporalIdTag>([](const auto temporal_id) { (*temporal_id)++; },
-                              make_not_null(&box));
-    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
-  }
-};
-
 // Label to indicate the start of the apply-operator actions
 struct ApplyOperatorStart {};
 
@@ -122,8 +102,8 @@ struct ElementArray {
   using operator_applied_to_vars_tag =
       ::Tags::Variables<db::wrap_tags_in<DgOperatorAppliedTo, primal_vars>>;
   using dg_operator =
-      ::elliptic::dg::Actions::DgOperator<System, Linearized, TemporalIdTag,
-                                          vars_tag, primal_fluxes_vars_tag,
+      ::elliptic::dg::Actions::DgOperator<System, Linearized, vars_tag,
+                                          primal_fluxes_vars_tag,
                                           operator_applied_to_vars_tag>;
   // Don't wrap the fixed sources in the `Var` prefix because typically we want
   // to impose inhomogeneous boundary conditions on the un-prefixed vars, i.e.
@@ -158,7 +138,7 @@ struct ElementArray {
                              ImposeInhomogeneousBoundaryConditionsOnSource<
                                  System, fixed_sources_tag>>,
                      ::Actions::Label<ApplyOperatorStart>,
-                     typename dg_operator::apply_actions, IncrementTemporalId,
+                     typename dg_operator::apply_actions,
                      Parallel::Actions::TerminatePhase>>>;
 };
 
@@ -178,36 +158,16 @@ struct AmrComponent {
 };
 
 template <typename Metavariables>
-struct ProjectTemporalId : tt::ConformsTo<::amr::protocols::Projector> {
-  using return_tags =
-      tmpl::list<TemporalIdTag,
-                 // Work around a segfault because this tag isn't handled
-                 // correctly by the testing framework
-                 Parallel::Tags::GlobalCache<Metavariables>>;
+struct ProjectMetavars : tt::ConformsTo<::amr::protocols::Projector> {
+  using return_tags = tmpl::list<
+      // Work around a segfault because this tag isn't handled
+      // correctly by the testing framework
+      Parallel::Tags::GlobalCache<Metavariables>>;
   using argument_tags = tmpl::list<>;
-  // p-refinement
-  template <size_t Dim>
+  template <typename... AmrData>
   static void apply(
-      const gsl::not_null<size_t*> /*temporal_id*/,
       const gsl::not_null<Parallel::GlobalCache<Metavariables>**> /*cache*/,
-      const std::pair<Mesh<Dim>, Element<Dim>>& /*old_mesh_and_element*/) {}
-  // h-refinement
-  template <typename... ParentTags>
-  static void apply(
-      const gsl::not_null<size_t*> temporal_id,
-      const gsl::not_null<Parallel::GlobalCache<Metavariables>**> /*cache*/,
-      const tuples::TaggedTuple<ParentTags...>& parent_items) {
-    *temporal_id = get<TemporalIdTag>(parent_items);
-  }
-  // h-coarsening
-  template <size_t Dim, typename... ChildTags>
-  static void apply(
-      const gsl::not_null<size_t*> temporal_id,
-      const gsl::not_null<Parallel::GlobalCache<Metavariables>**> /*cache*/,
-      const std::unordered_map<
-          ElementId<Dim>, tuples::TaggedTuple<ChildTags...>>& children_items) {
-    *temporal_id = get<TemporalIdTag>(children_items.begin()->second);
-  }
+      const AmrData&... /*amr_data*/) {}
 };
 
 template <typename System, bool Linearized, typename AnalyticSolution>
@@ -234,7 +194,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = ElementArray<System, Linearized, Metavariables>;
     using projectors = tmpl::flatten<tmpl::list<
-        ProjectTemporalId<Metavariables>,
+        ProjectMetavars<Metavariables>,
         ::amr::projectors::DefaultInitialize<
             tmpl::list<domain::Tags::InitialExtents<volume_dim>,
                        domain::Tags::InitialRefinementLevels<volume_dim>,
@@ -447,7 +407,6 @@ void test_dg_operator(
       ActionTesting::next_action<element_array>(make_not_null(&runner),
                                                 element_id);
     }
-    set_tag(TemporalIdTag{}, 0_st, element_id);
   }
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/CMakeLists.txt
@@ -5,6 +5,12 @@ set(LIBRARY "LinearSolverHelpers")
 
 add_spectre_library(${LIBRARY} INTERFACE)
 
+spectre_target_sources(
+  ${LIBRARY}
+  INTERFACE
+  DistributedLinearSolverAlgorithmTestHelpers.cpp
+  )
+
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/Unit

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.cpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
+
+namespace DistributedLinearSolverAlgorithmTestHelpers {
+
+blaze::DynamicMatrix<double> combine_matrix_slices(
+    const std::vector<blaze::DynamicMatrix<double>>& matrix_slices) {
+  const size_t num_slices = matrix_slices.size();
+  const size_t num_cols_per_slice = matrix_slices.begin()->columns();
+  const size_t total_num_points = num_slices * num_cols_per_slice;
+  blaze::DynamicMatrix<double> full_matrix(total_num_points, total_num_points);
+  for (size_t i = 0; i < num_slices; ++i) {
+    blaze::submatrix(full_matrix, 0, i * num_cols_per_slice, total_num_points,
+                     num_cols_per_slice) = gsl::at(matrix_slices, i);
+  }
+  return full_matrix;
+}
+
+}  // namespace DistributedLinearSolverAlgorithmTestHelpers

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -129,6 +129,10 @@ inline size_t get_index(const ElementId<1>& element_id) {
   return element_id.segment_id(0).index();
 }
 
+// Assemble the full matrix from its per-element slices
+blaze::DynamicMatrix<double> combine_matrix_slices(
+    const std::vector<blaze::DynamicMatrix<double>>& matrix_slices);
+
 // In the following `ComputeOperatorAction` and `CollectOperatorAction` actions
 // we compute A(p)=sum_elements(A_element(p_element)) in a global reduction and
 // then broadcast the global A(p) back to the elements so that they can extract

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
@@ -224,6 +224,94 @@ struct CollectOperatorAction {
   }
 };
 
+// The next two actions solve the linear problem Ax = b directly by collecting
+// the source b from all elements and applying the inverse of the operator A to
+// it.
+
+template <typename FieldsTag, typename SourceTag>
+struct SolveDirectly;
+
+template <typename FieldsTag, typename SourceTag>
+struct PrepareDirectSolve {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<1>& element_id, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    auto& section = *db::get_mutable_reference<Parallel::Tags::Section<
+        ParallelComponent, ::LinearSolver::multigrid::Tags::MultigridLevel>>(
+        make_not_null(&box));
+    Parallel::contribute_to_reduction<SolveDirectly<FieldsTag, SourceTag>>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<
+                std::map<ElementId<1>, typename SourceTag::type>,
+                funcl::Merge<>>,
+            Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>>{
+            std::map<ElementId<1>, typename SourceTag::type>{
+                std::make_pair(element_id, get<SourceTag>(box))},
+            element_id.grid_index()},
+        section.proxy()[element_id], section.proxy(), make_not_null(&section));
+    // Pause algorithm for now. The reduction will be broadcast to the next
+    // action which is responsible for restarting the algorithm.
+    return {Parallel::AlgorithmExecution::Pause, std::nullopt};
+  }
+};
+
+template <typename FieldsTag, typename SourceTag>
+struct SolveDirectly {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables>
+  static void apply(
+      db::DataBox<DbTagsList>& box, Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<1>& element_id,
+      const std::map<ElementId<1>, typename SourceTag::type>& source_slices,
+      const size_t broadcasting_multigrid_level) {
+    // We're receiving broadcasts also from reductions over other sections.
+    // See issue: https://github.com/sxs-collaboration/spectre/issues/3220
+    const size_t multigrid_level = element_id.grid_index();
+    if (multigrid_level != broadcasting_multigrid_level) {
+      return;
+    }
+    // Assemble full source vector and matrix
+    const auto& operator_matrices = get<LinearOperator>(box)[multigrid_level];
+    const auto full_matrix =
+        helpers_distributed::combine_matrix_slices(operator_matrices);
+    const size_t num_points = operator_matrices[0].columns();
+    const size_t total_num_points = full_matrix.rows();
+    blaze::DynamicVector<double> source(total_num_points);
+    for (const auto& [local_element_id, source_slice] : source_slices) {
+      const size_t element_index =
+          helpers_distributed::get_index(local_element_id);
+      std::copy_n(source_slice.data(), source_slice.size(),
+                  source.data() + element_index * num_points);
+    }
+    // Solve the linear system
+    const blaze::DynamicVector<double> solution =
+        blaze::solve(full_matrix, source);
+    // Store solution in the DataBox
+    db::mutate<
+        FieldsTag,
+        db::add_tag_prefix<::LinearSolver::Tags::OperatorAppliedTo, FieldsTag>>(
+        [&solution, &element_id, &num_points](
+            auto solution_slice, auto operator_applied_to_operand_slice,
+            const auto& source_slice) {
+          const size_t element_index =
+              helpers_distributed::get_index(element_id);
+          std::copy_n(solution.data() + element_index * num_points, num_points,
+                      solution_slice->data());
+          // The linear problem is solved, so Ax = b
+          *operator_applied_to_operand_slice = source_slice;
+        },
+        make_not_null(&box), db::get<SourceTag>(box));
+    // Proceed with algorithm
+    Parallel::get_parallel_component<ParallelComponent>(cache)[element_id]
+        .perform_algorithm(true);
+  }
+};
+
 template <typename OptionsGroup>
 struct TestResult {
   using const_global_cache_tags =

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Actions/Test_BuildMatrix.cpp
@@ -35,8 +35,6 @@ namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
 namespace {
 
-struct IterationIdLabel {};
-
 struct TestResult {
   using const_global_cache_tags =
       tmpl::list<helpers_distributed::ExpectedResult>;
@@ -116,7 +114,6 @@ struct Metavariables {
   };
 
   using build_matrix = LinearSolver::Actions::BuildMatrix<
-      Convergence::Tags::IterationId<IterationIdLabel>,
       helpers_distributed::fields_tag,
       db::add_tag_prefix<::Tags::FixedSource, helpers_distributed::fields_tag>,
       helpers_distributed::fields_tag,

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -65,6 +65,10 @@ struct Metavariables {
       LinearSolver::multigrid::Tags::MultigridLevel>;
   // [setup_smoother]
 
+  using bottom_solver_actions = tmpl::list<
+      helpers_mg::PrepareDirectSolve<typename multigrid::smooth_fields_tag,
+                                     typename multigrid::smooth_source_tag>>;
+
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
@@ -96,7 +100,8 @@ struct Metavariables {
                  typename multigrid::template solve<
                      compute_operator_action<typename smoother::fields_tag>,
                      smooth_actions<LinearSolver::multigrid::VcycleDownLabel>,
-                     smooth_actions<LinearSolver::multigrid::VcycleUpLabel>>,
+                     smooth_actions<LinearSolver::multigrid::VcycleUpLabel>,
+                     bottom_solver_actions>,
                  Parallel::Actions::TerminatePhase>;
   // [action_list]
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -70,10 +70,11 @@ Observers:
   ReductionFileName: "Test_MultigridAlgorithm_Reductions"
 
 MultigridSolver:
-  Iterations: 5
+  Iterations: 7
   Verbosity: Verbose
   MaxLevels: Auto
   PreSmoothing: True
+  UseBottomSolver: True
   PostSmoothingAtBottom: False
   OutputVolumeData: True
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -65,6 +65,7 @@ MultigridSolver:
   Verbosity: Verbose
   MaxLevels: Auto
   PreSmoothing: True
+  UseBottomSolver: False
   PostSmoothingAtBottom: False
   OutputVolumeData: True
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_SchwarzAlgorithm.cpp
@@ -46,19 +46,6 @@ struct SchwarzSmoother {
       "Options for the iterative Schwarz smoother";
 };
 
-blaze::DynamicMatrix<double> combine_matrix_slices(
-    const std::vector<blaze::DynamicMatrix<double>>& matrix_slices) {
-  const size_t num_slices = matrix_slices.size();
-  const size_t num_cols_per_slice = matrix_slices.begin()->columns();
-  const size_t total_num_points = num_slices * num_cols_per_slice;
-  blaze::DynamicMatrix<double> full_matrix(total_num_points, total_num_points);
-  for (size_t i = 0; i < num_slices; ++i) {
-    blaze::submatrix(full_matrix, 0, i * num_cols_per_slice, total_num_points,
-                     num_cols_per_slice) = gsl::at(matrix_slices, i);
-  }
-  return full_matrix;
-}
-
 template <typename Tag>
 blaze::DynamicVector<double> extend_subdomain_data(
     const LinearSolver::Schwarz::ElementCenteredSubdomainData<
@@ -156,7 +143,8 @@ struct SubdomainOperator : LinearSolver::Schwarz::SubdomainOperator<1> {
     result->destructive_resize(operand);
 
     // Assemble full operator matrix
-    const auto operator_matrix = combine_matrix_slices(matrix_slices);
+    const auto operator_matrix =
+        helpers_distributed::combine_matrix_slices(matrix_slices);
 
     // Extend subdomain data with zeros outside the subdomain
     const auto extended_operand =


### PR DESCRIPTION
## Proposed changes

Allows to use a separate "bottom solver" at the coarsest multigrid level. The bottom solver builds the linear operator matrix explicitly and inverts it directly. This can significantly cut down the number of iterations the solver needs at the cost of building and inverting the coarsest-grid matrix. It is useful for problems where the Schwarz smoother is ineffective at the coarsest grid, e.g. complex problems with oscillating modes like the self-force problem. I may enable this for BBH ID as well at some point if it proves effective.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In elliptic input files, add the option `LinearSolver.Multigrid.UseBottomSolver: False`. You can also set it to `True` to try the direct bottom solver. Also add the `BuildMatrix` section:
```yaml
BuildMatrix:
  MatrixSubfileName: None
  Verbosity: Quiet
  EnableDirectSolve: True
  SkipResets: False
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
