### PR TITLE
Add callback to dump scalar variables together with metric variables on worldtube

### DIFF
--- a/src/Evolution/Executables/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarTensor/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(
   PRIVATE
   Actions
   ApparentHorizonFinder
+  Cce
   Charmxx::main
   ControlSystem
   CoordinateMaps

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -15,6 +15,7 @@
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Evolution/Actions/RunEventsAndTriggers.hpp"
 #include "Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp"
+#include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
 #include "Evolution/Systems/ScalarTensor/Actions/SetInitialData.hpp"
 #include "Options/FactoryHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
@@ -137,14 +138,34 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
   static constexpr bool use_control_systems =
       tmpl::size<control_systems>::value > 0;
 
+  struct BondiSachs;
+
   using interpolation_target_tags = tmpl::push_back<
       control_system::metafunctions::interpolation_target_tags<control_systems>,
-      AhA, ExcisionBoundaryA, SphericalSurface>;
+      AhA, ExcisionBoundaryA, SphericalSurface, BondiSachs>;
   using interpolator_source_vars = ::ah::source_vars<volume_dim>;
 
   using scalar_charge_interpolator_source_vars =
       detail::ObserverTags::scalar_charge_vars_to_interpolate_to_target;
+  using source_vars_no_deriv = tmpl::list<
+      gr::Tags::SpacetimeMetric<DataVector, volume_dim>,
+      gh::Tags::Pi<DataVector, volume_dim>,
+      gh::Tags::Phi<DataVector, volume_dim>, CurvedScalarWave::Tags::Psi,
+      CurvedScalarWave::Tags::Pi, CurvedScalarWave::Tags::Phi<volume_dim>,
+      gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, volume_dim>>;
 
+  struct BondiSachs : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+    static std::string name() { return "BondiSachsInterpolation"; }
+    using temporal_id = ::Tags::Time;
+    using vars_to_interpolate_to_target = source_vars_no_deriv;
+    using compute_target_points =
+        intrp::TargetPoints::Sphere<BondiSachs, ::Frame::Inertial>;
+    using post_interpolation_callbacks = tmpl::list<
+        intrp::callbacks::DumpBondiSachsOnWorldtube<BondiSachs, true>>;
+    using compute_items_on_target = tmpl::list<>;
+    template <typename Metavariables>
+    using interpolating_component = typename Metavariables::st_dg_element_array;
+  };
   // The interpolator_source_vars need to be the same in both the
   // Interpolate event and the InterpolateWithoutInterpComponent event.  The
   // Interpolate event interpolates to the horizon, and the
@@ -161,16 +182,18 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
                         LtsTimeStepper>,
             tmpl::pair<LtsTimeStepper,
                        TimeSteppers::monotonic_lts_time_steppers>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       intrp::Events::Interpolate<volume_dim, AhA,
-                                                  interpolator_source_vars>,
-                       intrp::Events::InterpolateWithoutInterpComponent<
-                         volume_dim, ExcisionBoundaryA,
-                           interpolator_source_vars>,
-                       intrp::Events::InterpolateWithoutInterpComponent<
-                           volume_dim, SphericalSurface,
-                           scalar_charge_interpolator_source_vars>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                intrp::Events::Interpolate<volume_dim, AhA,
+                                           interpolator_source_vars>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    3, BondiSachs, source_vars_no_deriv>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    volume_dim, ExcisionBoundaryA, interpolator_source_vars>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    volume_dim, SphericalSurface,
+                    scalar_charge_interpolator_source_vars>>>>,
         tmpl::pair<DenseTrigger,
                    control_system::control_system_triggers<control_systems>>>;
   };

--- a/src/Evolution/Systems/Cce/BoundaryData.cpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.cpp
@@ -1059,4 +1059,25 @@ void du_j_worldtube_data(
     }
   }
 }
+
+void klein_gordon_psi_worldtube_data(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> kg_psi,
+    const Scalar<DataVector>& csw_psi) {
+  get(*kg_psi).data() = std::complex<double>(1.0, 0.0) * get(csw_psi);
+}
+
+void klein_gordon_pi_worldtube_data(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> kg_pi,
+    const Scalar<DataVector>& csw_pi, const tnsr::i<DataVector, 3>& csw_phi,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift) {
+  // Pure time derivative
+  // dt Psi = - lapse * Pi + shift^{i} Phi_{i}
+  get(*kg_pi).data() =
+      std::complex<double>(-1.0, 0.0) * get(lapse) * get(csw_pi);
+  for (size_t i = 0; i < 3; i++) {
+    get(*kg_pi).data() +=
+        std::complex<double>(1.0, 0.0) * shift.get(i) * csw_phi.get(i);
+  }
+}
+
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/BoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.hpp
@@ -566,34 +566,65 @@ void du_j_worldtube_data(
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
     const tnsr::I<ComplexDataVector, 2, Frame::RadialNull>& dyad);
 
+/*!
+ * \brief Convert real scalar to complex spinweighted scalar
+ */
+void klein_gordon_psi_worldtube_data(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> kg_psi,
+    const Scalar<DataVector>& csw_psi);
+
+/*!
+ * \brief Compute the time derivative of the scalar for cce and store as a
+ * complex spinweighted scalar
+ */
+void klein_gordon_pi_worldtube_data(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> kg_pi,
+    const Scalar<DataVector>& csw_pi, const tnsr::i<DataVector, 3>& csw_phi,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift);
+
 namespace Tags {
 /*!
- * \brief The collection of tags mutated by `create_bondi_boundary_data`
+ * \brief The collection of tags mutated by `create_bondi_boundary_data` (and
+ * `create_klein_gordon_boundary_data` if Klein-Gordon variables are included)
  *
  * \details This list is used in the evolution of `CharacteristicExtract`
  */
-template <template <typename> class BoundaryPrefix>
+template <template <typename> class BoundaryPrefix,
+          bool IncludeKleinGordon = false>
 using characteristic_worldtube_boundary_tags = db::wrap_tags_in<
     BoundaryPrefix,
-    tmpl::list<Tags::BondiBeta, Tags::BondiU, Tags::Dr<Tags::BondiU>,
-               Tags::BondiQ, Tags::BondiW, Tags::BondiJ, Tags::Dr<Tags::BondiJ>,
-               Tags::BondiH, Tags::Du<Tags::BondiJ>, Tags::BondiR,
-               Tags::Du<Tags::BondiR>, Tags::DuRDividedByR>>;
+    tmpl::append<
+        tmpl::list<Tags::BondiBeta, Tags::BondiU, Tags::Dr<Tags::BondiU>,
+                   Tags::BondiQ, Tags::BondiW, Tags::BondiJ,
+                   Tags::Dr<Tags::BondiJ>, Tags::BondiH, Tags::Du<Tags::BondiJ>,
+                   Tags::BondiR, Tags::Du<Tags::BondiR>, Tags::DuRDividedByR>,
+        tmpl::conditional_t<
+            IncludeKleinGordon,
+            tmpl::list<Cce::Tags::KleinGordonPsi, Cce::Tags::KleinGordonPi>,
+            tmpl::list<>>>>;
 
 /*!
  * \brief The collection of tags for worldtube quantities that need to be
  * written to disk during the Cauchy evolution that the `CharacateristicExtract`
  * need.
  *
- * \details This list is used when writing Bondi quantities to disk.
+ * \details This list is used when writing Bondi quantities to disk. For the
+ * combined ScalarTensor system, this list also includes the Klein-Gordon scalar
+ * variables.
  */
-template <template <typename> class BoundaryPrefix = Cce::Tags::BoundaryValue>
+template <template <typename> class BoundaryPrefix = Cce::Tags::BoundaryValue,
+          bool IncludeKleinGordon = false>
 using worldtube_boundary_tags_for_writing = db::wrap_tags_in<
     BoundaryPrefix,
-    tmpl::list<Cce::Tags::BondiBeta, Cce::Tags::Dr<Cce::Tags::BondiJ>,
-               Cce::Tags::Du<Cce::Tags::BondiR>, Cce::Tags::BondiJ,
-               Cce::Tags::Du<Cce::Tags::BondiJ>, Cce::Tags::BondiQ,
-               Cce::Tags::BondiR, Cce::Tags::BondiU, Cce::Tags::BondiW>>;
+    tmpl::append<
+        tmpl::list<Cce::Tags::BondiBeta, Cce::Tags::Dr<Cce::Tags::BondiJ>,
+                   Cce::Tags::Du<Cce::Tags::BondiR>, Cce::Tags::BondiJ,
+                   Cce::Tags::Du<Cce::Tags::BondiJ>, Cce::Tags::BondiQ,
+                   Cce::Tags::BondiR, Cce::Tags::BondiU, Cce::Tags::BondiW>,
+        tmpl::conditional_t<
+            IncludeKleinGordon,
+            tmpl::list<Cce::Tags::KleinGordonPsi, Cce::Tags::KleinGordonPi>,
+            tmpl::list<>>>>;
 
 using klein_gordon_worldtube_boundary_tags =
     tmpl::list<Tags::BoundaryValue<Tags::KleinGordonPsi>,
@@ -1426,4 +1457,26 @@ void create_bondi_boundary_data(
       spacetime_metric, null_l, du_null_l, cartesian_to_spherical_jacobian,
       l_max, extraction_radius);
 }
+
+/*!
+ * \brief Process the worldtube data from CurvedScalarWave quantities
+ *  to desired cce scalar quantities
+ */
+template <typename BoundaryTagList>
+void create_klein_gordon_boundary_data(
+    const gsl::not_null<Variables<BoundaryTagList>*> bondi_boundary_data,
+    const tnsr::i<DataVector, 3>& csw_phi, const Scalar<DataVector>& csw_pi,
+    const Scalar<DataVector>& csw_psi, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3>& shift) {
+  klein_gordon_psi_worldtube_data(
+      make_not_null(&get<Tags::BoundaryValue<Tags::KleinGordonPsi>>(
+          *bondi_boundary_data)),
+      csw_psi);
+
+  klein_gordon_pi_worldtube_data(
+      make_not_null(
+          &get<Tags::BoundaryValue<Tags::KleinGordonPi>>(*bondi_boundary_data)),
+      csw_pi, csw_phi, lapse, shift);
+}
+
 }  // namespace Cce

--- a/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
+++ b/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
@@ -44,6 +44,15 @@
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+namespace CurvedScalarWave::Tags {
+struct Psi;
+struct Pi;
+template <size_t SpatialDim>
+struct Phi;
+}  // namespace CurvedScalarWave::Tags
+/// \endcond
+
 namespace intrp::callbacks {
 /*!
  * \brief Post interpolation callback that dumps metric data in Bondi-Sachs form
@@ -57,6 +66,13 @@ namespace intrp::callbacks {
  * - `gr::Tags::SpacetimeMetric`
  * - `gh::Tags::Pi`
  * - `gh::Tags::Phi`
+ *
+ * If IncludeKleinGordon is true, also expect:
+ * - `CurvedScalarWave::Tags::Psi`
+ * - `CurvedScalarWave::Tags::Pi`
+ * - `CurvedScalarWave::Tags::Phi`
+ * - `gr::Tags::Lapse`
+ * - `gr::Tags::Shift`
  *
  * This callback will write a new `H5` file for each extraction radius in the
  * Sphere target. The name of this file will be a file prefix specified by the
@@ -74,33 +90,46 @@ namespace intrp::callbacks {
  * - `Cce::Tags::BondiU`
  * - `Cce::Tags::BondiW`
  *
- * \note For all real quantities (Beta, DuR, R, W) we omit writing the
- * negative m modes, and the imaginary part of the m = 0 mode.
+ * If IncludeKleinGordon is true, also writes:
+ * - `Cce::Tags::KleinGordonPsi`
+ * - `Cce::Tags::KleinGordonPi`
+ *
+ * \note For all real quantities (Beta, DuR, R, W) (as well as the Klein-Gordon
+ * Psi an Pi if included) we omit writing the negative m modes, and the
+ * imaginary part of the m = 0 mode.
  */
-template <typename InterpolationTargetTag>
+template <typename InterpolationTargetTag, bool IncludeKleinGordon = false>
 struct DumpBondiSachsOnWorldtube
     : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
+  static constexpr bool include_klein_gordon = IncludeKleinGordon;
   static constexpr double fill_invalid_points_with =
       std::numeric_limits<double>::quiet_NaN();
 
   using const_global_cache_tags = tmpl::list<Cce::Tags::FilePrefix>;
 
   using cce_boundary_tags = Cce::Tags::characteristic_worldtube_boundary_tags<
-      Cce::Tags::BoundaryValue, false>;
+      Cce::Tags::BoundaryValue, include_klein_gordon>;
 
-  using gh_source_vars_for_cce =
+  using extra_klein_gordon_cce_tags =
+      tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                 CurvedScalarWave::Tags::Phi<3>, gr::Tags::Lapse<DataVector>,
+                 gr::Tags::Shift<DataVector, 3>>;
+
+  using gh_source_vars_for_cce = tmpl::append<
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
-                 gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>;
+                 gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>,
+      tmpl::conditional_t<include_klein_gordon, extra_klein_gordon_cce_tags,
+                          tmpl::list<>>>;
 
   using gh_source_vars_from_interpolation =
       typename InterpolationTargetTag::vars_to_interpolate_to_target;
 
   static_assert(
-      std::is_same_v<
-          tmpl::list_difference<Cce::Tags::worldtube_boundary_tags_for_writing<
-                                    Cce::Tags::BoundaryValue, false>,
-                                cce_boundary_tags>,
-          tmpl::list<>>,
+      std::is_same_v<tmpl::list_difference<
+                         Cce::Tags::worldtube_boundary_tags_for_writing<
+                             Cce::Tags::BoundaryValue, include_klein_gordon>,
+                         cce_boundary_tags>,
+                     tmpl::list<>>,
       "Cce tags to dump are not in the boundary tags.");
 
   static_assert(
@@ -112,13 +141,15 @@ struct DumpBondiSachsOnWorldtube
                                              gh_source_vars_from_interpolation>,
                        tmpl::list<>>>::type::value,
       "To use DumpBondiSachsOnWorldtube, the GH source variables must be the "
-      "spacetime metric, pi, and phi.");
+      "spacetime metric, pi, and phi. If Klein Gordon variables are included, "
+      "the source variables must also include the CurvedScalarWave Psi and Pi, "
+      "as well as Lapse and shift.");
 
   static_assert(
       std::is_same_v<typename InterpolationTargetTag::compute_target_points,
                      intrp::TargetPoints::Sphere<InterpolationTargetTag,
                                                  ::Frame::Inertial>>,
-      "To use the DumpBondiSachsOnWorltube post interpolation callback, you "
+      "To use the DumpBondiSachsOnWorldtube post interpolation callback, you "
       "must use the intrp::TargetPoints::Sphere target in the inertial "
       "frame");
 
@@ -156,6 +187,18 @@ struct DumpBondiSachsOnWorldtube
     const tnsr::aa<DataVector, 3, ::Frame::Inertial> pi;
     const tnsr::iaa<DataVector, 3, ::Frame::Inertial> phi;
 
+    const Scalar<DataVector> csw_psi;
+    const Scalar<DataVector> csw_pi;
+    const tnsr::i<DataVector, 3, ::Frame::Inertial> csw_phi;
+    const Scalar<DataVector> lapse;
+    const tnsr::I<DataVector, 3, ::Frame::Inertial> shift;
+
+    (void)csw_psi;
+    (void)csw_pi;
+    (void)csw_phi;
+    (void)lapse;
+    (void)shift;
+
     // Bondi data
     Variables<cce_boundary_tags> bondi_boundary_data{num_points_single_sphere};
 
@@ -187,10 +230,37 @@ struct DumpBondiSachsOnWorldtube
         }
       }
 
-      offset += num_points_single_sphere;
-
       Cce::create_bondi_boundary_data(make_not_null(&bondi_boundary_data), phi,
                                       pi, spacetime_metric, radius, l_max);
+
+      if constexpr (include_klein_gordon) {
+        const auto& all_csw_psi = get<CurvedScalarWave::Tags::Psi>(all_gh_vars);
+        const auto& all_csw_pi = get<CurvedScalarWave::Tags::Pi>(all_gh_vars);
+        const auto& all_csw_phi =
+            get<CurvedScalarWave::Tags::Phi<3>>(all_gh_vars);
+        const auto& all_lapse = get<gr::Tags::Lapse<DataVector>>(all_gh_vars);
+        const auto& all_shift =
+            get<gr::Tags::Shift<DataVector, 3>>(all_gh_vars);
+
+        make_const_view(make_not_null(&csw_psi.get()), all_csw_psi.get(),
+                        offset, num_points_single_sphere);
+        make_const_view(make_not_null(&csw_pi.get()), all_csw_pi.get(), offset,
+                        num_points_single_sphere);
+        make_const_view(make_not_null(&lapse.get()), all_lapse.get(), offset,
+                        num_points_single_sphere);
+        for (size_t i = 0; i < 3; i++) {
+          make_const_view(make_not_null(&csw_phi.get(i)), all_csw_phi.get(i),
+                          offset, num_points_single_sphere);
+          make_const_view(make_not_null(&shift.get(i)), all_shift.get(i),
+                          offset, num_points_single_sphere);
+        }
+
+        Cce::create_klein_gordon_boundary_data(
+            make_not_null(&bondi_boundary_data), csw_phi, csw_pi, csw_psi,
+            lapse, shift);
+      }
+
+      offset += num_points_single_sphere;
 
       const std::string filename =
           MakeString{} << filename_prefix << "CceR" << std::setfill('0')
@@ -202,17 +272,18 @@ struct DumpBondiSachsOnWorldtube
       Cce::WorldtubeModeRecorder recorder{l_max, filename};
 
       tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<
-          Cce::Tags::BoundaryValue, false>>([&](auto tag_v) {
-        using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
-        constexpr int spin = tag::tag::type::type::spin;
+          Cce::Tags::BoundaryValue, include_klein_gordon>>(
+          [&](auto tag_v) {
+            using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+            constexpr int spin = tag::tag::type::type::spin;
 
-        const ComplexDataVector& bondi_nodal_data =
-            get(get<tag>(bondi_boundary_data)).data();
+            const ComplexDataVector& bondi_nodal_data =
+                get(get<tag>(bondi_boundary_data)).data();
 
-        recorder.append_modal_data<spin>(
-            Cce::dataset_label_for_tag<typename tag::tag>(), time,
-            bondi_nodal_data, l_max);
-      });
+            recorder.append_modal_data<spin>(
+                Cce::dataset_label_for_tag<typename tag::tag>(), time,
+                bondi_nodal_data, l_max);
+          });
     }
   }
 };

--- a/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
+++ b/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
@@ -86,7 +86,7 @@ struct DumpBondiSachsOnWorldtube
   using const_global_cache_tags = tmpl::list<Cce::Tags::FilePrefix>;
 
   using cce_boundary_tags = Cce::Tags::characteristic_worldtube_boundary_tags<
-      Cce::Tags::BoundaryValue>;
+      Cce::Tags::BoundaryValue, false>;
 
   using gh_source_vars_for_cce =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
@@ -96,10 +96,11 @@ struct DumpBondiSachsOnWorldtube
       typename InterpolationTargetTag::vars_to_interpolate_to_target;
 
   static_assert(
-      std::is_same_v<tmpl::list_difference<
-                         Cce::Tags::worldtube_boundary_tags_for_writing<>,
-                         cce_boundary_tags>,
-                     tmpl::list<>>,
+      std::is_same_v<
+          tmpl::list_difference<Cce::Tags::worldtube_boundary_tags_for_writing<
+                                    Cce::Tags::BoundaryValue, false>,
+                                cce_boundary_tags>,
+          tmpl::list<>>,
       "Cce tags to dump are not in the boundary tags.");
 
   static_assert(
@@ -200,18 +201,18 @@ struct DumpBondiSachsOnWorldtube
       const std::lock_guard lock(*hdf5_lock);
       Cce::WorldtubeModeRecorder recorder{l_max, filename};
 
-      tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<>>(
-          [&](auto tag_v) {
-            using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
-            constexpr int spin = tag::tag::type::type::spin;
+      tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<
+          Cce::Tags::BoundaryValue, false>>([&](auto tag_v) {
+        using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+        constexpr int spin = tag::tag::type::type::spin;
 
-            const ComplexDataVector& bondi_nodal_data =
-                get(get<tag>(bondi_boundary_data)).data();
+        const ComplexDataVector& bondi_nodal_data =
+            get(get<tag>(bondi_boundary_data)).data();
 
-            recorder.append_modal_data<spin>(
-                Cce::dataset_label_for_tag<typename tag::tag>(), time,
-                bondi_nodal_data, l_max);
-          });
+        recorder.append_modal_data<spin>(
+            Cce::dataset_label_for_tag<typename tag::tag>(), time,
+            bondi_nodal_data, l_max);
+      });
     }
   }
 };

--- a/src/Evolution/Systems/Cce/WorldtubeModeRecorder.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeModeRecorder.cpp
@@ -64,6 +64,16 @@ std::string dataset_label_for_tag<Cce::Tags::Du<Cce::Tags::BondiR>>() {
   return "DuR";
 }
 
+template <>
+std::string dataset_label_for_tag<Cce::Tags::KleinGordonPsi>() {
+  return "KGPsi";
+}
+
+template <>
+std::string dataset_label_for_tag<Cce::Tags::KleinGordonPi>() {
+  return "dtKGPsi";
+}
+
 WorldtubeModeRecorder::WorldtubeModeRecorder() = default;
 WorldtubeModeRecorder::WorldtubeModeRecorder(const size_t output_l_max,
                                              const std::string& h5_filename)

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -244,11 +244,19 @@ InterpolationTargets:
     Center: [0.0, 0.0, 0.0]
     Radius: *InnerRadius
     AngularOrdering: "Strahlkorper"
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [100, 150, 200]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
   SphericalSurface:
     LMax: 10
     Center: [0., 0., 0.]
     Radius: 12.0
     AngularOrdering: Strahlkorper
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
 
 ControlSystems:
   WriteDataToDisk: false

--- a/tests/Unit/Evolution/Systems/Cce/BoundaryData.py
+++ b/tests/Unit/Evolution/Systems/Cce/BoundaryData.py
@@ -554,3 +554,11 @@ def du_j_worldtube_data(
         )
         / local_bondi_r**2
     )
+
+
+def klein_gordon_psi_worldtube_data(csw_psi):
+    return csw_psi + 0j
+
+
+def klein_gordon_pi_worldtube_data(csw_pi, csw_phi, lapse, shift):
+    return -lapse * csw_pi + np.dot(shift, csw_phi) + 0j

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -93,6 +93,12 @@ void pypp_test_worldtube_computation_steps() {
   pypp::check_with_random_values<1>(&du_j_worldtube_data, "BoundaryData",
                                     {"du_j_worldtube_data"}, {{{1.0, 5.0}}},
                                     DataVector{num_pts});
+  pypp::check_with_random_values<1>(
+      &klein_gordon_psi_worldtube_data, "BoundaryData",
+      {"klein_gordon_psi_worldtube_data"}, {{{1.0, 5.0}}}, DataVector{num_pts});
+  pypp::check_with_random_values<1>(
+      &klein_gordon_pi_worldtube_data, "BoundaryData",
+      {"klein_gordon_pi_worldtube_data"}, {{{1.0, 5.0}}}, DataVector{num_pts});
 }
 
 template <typename Generator>

--- a/tests/Unit/Evolution/Systems/Cce/Test_DumpBondiSachsOnWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_DumpBondiSachsOnWorldtube.cpp
@@ -178,60 +178,58 @@ void test(const std::string& filename_prefix,
     const auto file = h5::H5File<h5::AccessType::ReadOnly>(
         get_filename(filename_prefix, radius));
 
-    tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<>>(
-        [&file, &bondi_boundary_data, &times, &l_max, &expected_all_legend,
-         &expected_real_legend](auto tag_v) {
-          using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
-          const auto& bondi_data = get(get<tag>(bondi_boundary_data));
-          constexpr int spin = tag::tag::type::type::spin;
-          constexpr bool is_real = spin == 0;
-          const auto& expected_legend =
-              is_real ? expected_real_legend : expected_all_legend;
+    tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<
+        Cce::Tags::BoundaryValue, false>>([&file, &bondi_boundary_data, &times,
+                                           &l_max, &expected_all_legend,
+                                           &expected_real_legend](auto tag_v) {
+      using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+      const auto& bondi_data = get(get<tag>(bondi_boundary_data));
+      constexpr int spin = tag::tag::type::type::spin;
+      constexpr bool is_real = spin == 0;
+      const auto& expected_legend =
+          is_real ? expected_real_legend : expected_all_legend;
 
-          SpinWeighted<ComplexModalVector, spin> expected_data{
-              square(l_max + 1)};
-          Spectral::Swsh::libsharp_to_goldberg_modes(
-              make_not_null(&expected_data),
-              Spectral::Swsh::swsh_transform(l_max, 1, bondi_data), l_max);
+      SpinWeighted<ComplexModalVector, spin> expected_data{square(l_max + 1)};
+      Spectral::Swsh::libsharp_to_goldberg_modes(
+          make_not_null(&expected_data),
+          Spectral::Swsh::swsh_transform(l_max, 1, bondi_data), l_max);
 
-          const std::string tag_path =
-              Cce::dataset_label_for_tag<typename tag::tag>();
-          CAPTURE(tag_path);
-          const auto& dat_file = file.get<h5::Dat>(tag_path);
-          const Matrix written_data = dat_file.get_data();
+      const std::string tag_path =
+          Cce::dataset_label_for_tag<typename tag::tag>();
+      CAPTURE(tag_path);
+      const auto& dat_file = file.get<h5::Dat>(tag_path);
+      const Matrix written_data = dat_file.get_data();
 
-          CHECK(expected_legend == dat_file.get_legend());
-          CHECK(times.size() == written_data.rows());
-          const size_t expected_data_size =
-              square(l_max + 1) * (is_real ? 1 : 2);
-          CHECK(expected_data_size == written_data.columns() - 1);
+      CHECK(expected_legend == dat_file.get_legend());
+      CHECK(times.size() == written_data.rows());
+      const size_t expected_data_size = square(l_max + 1) * (is_real ? 1 : 2);
+      CHECK(expected_data_size == written_data.columns() - 1);
 
-          // Since the metric isn't changing it should be the same data on each
-          // row just with a different time
-          for (size_t j = 0; j < times.size(); j++) {
-            const double time = times[j];
-            CAPTURE(time);
-            CHECK(time == written_data(j, 0));
-            size_t counter = 1;
-            for (size_t ell = 0; ell <= l_max; ell++) {
-              for (size_t m = is_real ? 0 : -ell; m <= ell; m++) {
-                const size_t goldberg_index =
-                    Spectral::Swsh::goldberg_mode_index(l_max, ell,
-                                                        static_cast<int>(m));
-                CHECK(written_data(j, counter) ==
-                      real(expected_data.data()[goldberg_index]));
-                counter++;
-                if (not is_real or m != 0) {
-                  CHECK(written_data(j, counter) ==
-                        imag(expected_data.data()[goldberg_index]));
-                  counter++;
-                }
-              }
+      // Since the metric isn't changing it should be the same data on each
+      // row just with a different time
+      for (size_t j = 0; j < times.size(); j++) {
+        const double time = times[j];
+        CAPTURE(time);
+        CHECK(time == written_data(j, 0));
+        size_t counter = 1;
+        for (size_t ell = 0; ell <= l_max; ell++) {
+          for (size_t m = is_real ? 0 : -ell; m <= ell; m++) {
+            const size_t goldberg_index = Spectral::Swsh::goldberg_mode_index(
+                l_max, ell, static_cast<int>(m));
+            CHECK(written_data(j, counter) ==
+                  real(expected_data.data()[goldberg_index]));
+            counter++;
+            if (not is_real or m != 0) {
+              CHECK(written_data(j, counter) ==
+                    imag(expected_data.data()[goldberg_index]));
+              counter++;
             }
           }
+        }
+      }
 
-          file.close_current_object();
-        });
+      file.close_current_object();
+    });
   }
 }
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_DumpBondiSachsOnWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_DumpBondiSachsOnWorldtube.cpp
@@ -19,6 +19,7 @@
 #include "Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/WorldtubeModeRecorder.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -51,16 +52,25 @@ struct MockObserverWriter {
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
 };
 
+template <bool IncludeKleinGordon>
 struct test_metavariables {
   struct Target : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
-    using vars_to_interpolate_to_target =
+    using vars_to_interpolate_to_target = tmpl::append<
         tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
-                   gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>;
+                   gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>,
+        tmpl::conditional_t<
+            IncludeKleinGordon,
+            tmpl::list<CurvedScalarWave::Tags::Psi, CurvedScalarWave::Tags::Pi,
+                       CurvedScalarWave::Tags::Phi<3>,
+                       gr::Tags::Lapse<DataVector>,
+                       gr::Tags::Shift<DataVector, 3>>,
+            tmpl::list<>>>;
     using compute_target_points =
         intrp::TargetPoints::Sphere<Target, ::Frame::Inertial>;
     using post_interpolation_callbacks =
-        tmpl::list<intrp::callbacks::DumpBondiSachsOnWorldtube<Target>>;
+        tmpl::list<intrp::callbacks::DumpBondiSachsOnWorldtube<
+            Target, IncludeKleinGordon>>;
     using compute_items_on_target = tmpl::list<>;
   };
 
@@ -70,7 +80,8 @@ struct test_metavariables {
 
   using const_global_cache_tags =
       tmpl::list<intrp::Tags::Sphere<Target>, Cce::Tags::FilePrefix>;
-  using component_list = tmpl::list<MockObserverWriter<test_metavariables>>;
+  using component_list =
+      tmpl::list<MockObserverWriter<test_metavariables<IncludeKleinGordon>>>;
 };
 
 std::string get_filename(const std::string& filename_prefix,
@@ -79,8 +90,9 @@ std::string get_filename(const std::string& filename_prefix,
                       << std::setw(4) << std::lround(radius) << ".h5";
 }
 
-template <typename Tags>
+template <typename Tags, bool IncludeKleinGordon>
 auto make_spacetime_variables(const size_t size) {
+  static constexpr bool include_klein_gordon = IncludeKleinGordon;
   Variables<Tags> spacetime_variables{size, 0.0};
   auto& spacetime_metric =
       get<gr::Tags::SpacetimeMetric<DataVector, 3>>(spacetime_variables);
@@ -88,12 +100,22 @@ auto make_spacetime_variables(const size_t size) {
   for (size_t i = 1; i < 4; i++) {
     spacetime_metric.get(i, i) = 1.0;
   }
+  if constexpr (include_klein_gordon) {
+    auto& csw_psi = get<CurvedScalarWave::Tags::Psi>(spacetime_variables);
+    auto& lapse = get<gr::Tags::Lapse<DataVector>>(spacetime_variables);
+    get(csw_psi) = 1.0;
+    get(lapse) = 1.0;
+  }
   return spacetime_variables;
 }
 
-void test(const std::string& filename_prefix,
-          const std::vector<double>& radii) {
-  using metavars = test_metavariables;
+// True when Klein Gordon scalar variables are also dumped on the worldtube
+template <bool IncludeKleinGordon>
+void test_impl(const std::string& filename_prefix,
+               const std::vector<double>& radii) {
+  static constexpr bool include_klein_gordon = IncludeKleinGordon;
+  CAPTURE(include_klein_gordon);
+  using metavars = test_metavariables<include_klein_gordon>;
   using target = typename metavars::Target;
   using writer = MockObserverWriter<metavars>;
   using spacetime_tags = typename target::vars_to_interpolate_to_target;
@@ -118,10 +140,11 @@ void test(const std::string& filename_prefix,
   // It doesn't really matter what the GH data is so long as we are able to
   // calculate bondi data, because this is just testing that we can write the
   // data. So choose Minkowski spacetime. This means pi, phi, and deriv phi are
-  // trivially 0.
+  // trivially 0. If the Klein-Gordon variables are included, choose constant
+  // scalar (csw_pi and csw_phi are zero in this case).
   Variables<spacetime_tags> spacetime_variables =
-      make_spacetime_variables<spacetime_tags>(radii.size() *
-                                               num_points_single_sphere);
+      make_spacetime_variables<spacetime_tags, include_klein_gordon>(
+          radii.size() * num_points_single_sphere);
 
   // Options for Sphere
   const ylm::AngularOrdering angular_ordering = ylm::AngularOrdering::Cce;
@@ -164,72 +187,96 @@ void test(const std::string& filename_prefix,
     callback::apply(box, cache, time);
   }
 
-  Variables<spacetime_tags> single_spacetime_variables =
-      make_spacetime_variables<spacetime_tags>(num_points_single_sphere);
-  const auto& [spacetime_metric, pi, phi] = single_spacetime_variables;
+  const Variables<spacetime_tags> single_spacetime_variables =
+      make_spacetime_variables<spacetime_tags, include_klein_gordon>(
+          num_points_single_sphere);
   Variables<cce_tags> bondi_boundary_data{num_points_single_sphere};
 
-  for (size_t i = 0; i < radii.size(); i++) {
-    const double radius = radii[i];
+  const auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(single_spacetime_variables);
+  const auto& pi = get<gh::Tags::Pi<DataVector, 3>>(single_spacetime_variables);
+  const auto& phi =
+      get<gh::Tags::Phi<DataVector, 3>>(single_spacetime_variables);
+
+  for (const auto& radius : radii) {
     CAPTURE(radius);
     // Have to create the bondi data for every radius individually
     Cce::create_bondi_boundary_data(make_not_null(&bondi_boundary_data), phi,
                                     pi, spacetime_metric, radius, l_max);
+    if constexpr (include_klein_gordon) {
+      const auto& csw_psi =
+          get<CurvedScalarWave::Tags::Psi>(single_spacetime_variables);
+      const auto& csw_pi =
+          get<CurvedScalarWave::Tags::Pi>(single_spacetime_variables);
+      const auto& csw_phi =
+          get<CurvedScalarWave::Tags::Phi<3>>(single_spacetime_variables);
+      const auto& lapse =
+          get<gr::Tags::Lapse<DataVector>>(single_spacetime_variables);
+      const auto& shift =
+          get<gr::Tags::Shift<DataVector, 3>>(single_spacetime_variables);
+
+      Cce::create_klein_gordon_boundary_data(
+          make_not_null(&bondi_boundary_data), csw_phi, csw_pi, csw_psi, lapse,
+          shift);
+    }
     const auto file = h5::H5File<h5::AccessType::ReadOnly>(
         get_filename(filename_prefix, radius));
 
     tmpl::for_each<Cce::Tags::worldtube_boundary_tags_for_writing<
-        Cce::Tags::BoundaryValue, false>>([&file, &bondi_boundary_data, &times,
-                                           &l_max, &expected_all_legend,
-                                           &expected_real_legend](auto tag_v) {
-      using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
-      const auto& bondi_data = get(get<tag>(bondi_boundary_data));
-      constexpr int spin = tag::tag::type::type::spin;
-      constexpr bool is_real = spin == 0;
-      const auto& expected_legend =
-          is_real ? expected_real_legend : expected_all_legend;
+        Cce::Tags::BoundaryValue, include_klein_gordon>>(
+        [&file, &bondi_boundary_data, &times, &l_max, &expected_all_legend,
+         &expected_real_legend](auto tag_v) {
+          using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+          const auto& bondi_data = get(get<tag>(bondi_boundary_data));
+          constexpr int spin = tag::tag::type::type::spin;
+          constexpr bool is_real = spin == 0;
+          const auto& expected_legend =
+              is_real ? expected_real_legend : expected_all_legend;
 
-      SpinWeighted<ComplexModalVector, spin> expected_data{square(l_max + 1)};
-      Spectral::Swsh::libsharp_to_goldberg_modes(
-          make_not_null(&expected_data),
-          Spectral::Swsh::swsh_transform(l_max, 1, bondi_data), l_max);
+          SpinWeighted<ComplexModalVector, spin> expected_data{
+              square(l_max + 1)};
+          Spectral::Swsh::libsharp_to_goldberg_modes(
+              make_not_null(&expected_data),
+              Spectral::Swsh::swsh_transform(l_max, 1, bondi_data), l_max);
 
-      const std::string tag_path =
-          Cce::dataset_label_for_tag<typename tag::tag>();
-      CAPTURE(tag_path);
-      const auto& dat_file = file.get<h5::Dat>(tag_path);
-      const Matrix written_data = dat_file.get_data();
+          const std::string tag_path =
+              Cce::dataset_label_for_tag<typename tag::tag>();
+          CAPTURE(tag_path);
+          const auto& dat_file = file.get<h5::Dat>(tag_path);
+          const Matrix written_data = dat_file.get_data();
 
-      CHECK(expected_legend == dat_file.get_legend());
-      CHECK(times.size() == written_data.rows());
-      const size_t expected_data_size = square(l_max + 1) * (is_real ? 1 : 2);
-      CHECK(expected_data_size == written_data.columns() - 1);
+          CHECK(expected_legend == dat_file.get_legend());
+          CHECK(times.size() == written_data.rows());
+          const size_t expected_data_size =
+              square(l_max + 1) * (is_real ? 1 : 2);
+          CHECK(expected_data_size == written_data.columns() - 1);
 
-      // Since the metric isn't changing it should be the same data on each
-      // row just with a different time
-      for (size_t j = 0; j < times.size(); j++) {
-        const double time = times[j];
-        CAPTURE(time);
-        CHECK(time == written_data(j, 0));
-        size_t counter = 1;
-        for (size_t ell = 0; ell <= l_max; ell++) {
-          for (size_t m = is_real ? 0 : -ell; m <= ell; m++) {
-            const size_t goldberg_index = Spectral::Swsh::goldberg_mode_index(
-                l_max, ell, static_cast<int>(m));
-            CHECK(written_data(j, counter) ==
-                  real(expected_data.data()[goldberg_index]));
-            counter++;
-            if (not is_real or m != 0) {
-              CHECK(written_data(j, counter) ==
-                    imag(expected_data.data()[goldberg_index]));
-              counter++;
+          // Since the metric isn't changing it should be the same data on each
+          // row just with a different time
+          for (size_t j = 0; j < times.size(); j++) {
+            const double time = times[j];
+            CAPTURE(time);
+            CHECK(time == written_data(j, 0));
+            size_t counter = 1;
+            for (size_t ell = 0; ell <= l_max; ell++) {
+              for (size_t m = is_real ? 0 : -ell; m <= ell; m++) {
+                const size_t goldberg_index =
+                    Spectral::Swsh::goldberg_mode_index(l_max, ell,
+                                                        static_cast<int>(m));
+                CHECK(written_data(j, counter) ==
+                      real(expected_data.data()[goldberg_index]));
+                counter++;
+                if (not is_real or m != 0) {
+                  CHECK(written_data(j, counter) ==
+                        imag(expected_data.data()[goldberg_index]));
+                  counter++;
+                }
+              }
             }
           }
-        }
-      }
 
-      file.close_current_object();
-    });
+          file.close_current_object();
+        });
   }
 }
 
@@ -243,20 +290,27 @@ void delete_files(const std::string& filename_prefix,
   }
 }
 
-// [Timeout, 10]
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.DumpBondiSachsOnWorldtube",
-                  "[Unit][Cce]") {
-  const std::string filename_prefix{"Shrek-the-Third"};
+template <bool IncludeKleinGordon>
+void test() {
+  const std::string& filename_prefix = "Shrek-the-Third";
   std::vector<double> radii{100.0};
 
   delete_files(filename_prefix, radii);
-  test(filename_prefix, radii);
+  test_impl<IncludeKleinGordon>(filename_prefix, radii);
 
   radii.push_back(150.0);
   radii.push_back(200.0 - std::numeric_limits<double>::epsilon());
 
   delete_files(filename_prefix, radii);
-  test(filename_prefix, radii);
+  test_impl<IncludeKleinGordon>(filename_prefix, radii);
   delete_files(filename_prefix, radii);
+}
+
+// [Timeout, 10]
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.DumpBondiSachsOnWorldtube",
+                  "[Unit][Cce]") {
+  test<false>();
+  // Test with Klein-Gordon variables included
+  test<true>();
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Write CurvedScalarWave variables together with the BondiSachs quantities for Cce.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
