### PR TITLE
Mark approx const

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -624,6 +624,8 @@ void test_wedge3d_large_radius() {
         const auto inv_jacobian = map.inv_jacobian(logical_point);
         CAPTURE(jacobian);
         CAPTURE(inv_jacobian);
+        auto jacobian_approx = approx;
+        jacobian_approx.scale(square(expected_radius));
 
         {
           const std::array<double, 3> radial_vector =
@@ -637,7 +639,6 @@ void test_wedge3d_large_radius() {
           }
 
           CAPTURE(r_dot_jacobian);
-          auto jacobian_approx = approx.scale(square(expected_radius));
           CHECK(gsl::at(r_dot_jacobian, 0) == jacobian_approx(0.0));
           CHECK(gsl::at(r_dot_jacobian, 1) == jacobian_approx(0.0));
           CHECK(gsl::at(r_dot_jacobian, 2) ==
@@ -650,10 +651,12 @@ void test_wedge3d_large_radius() {
             inv_jacobian(ti::I, ti::k) * jacobian(ti::K, ti::j));
         CAPTURE(jacobian_times_inverse);
         CAPTURE(inverse_times_jacobian);
-        CHECK_ITERABLE_APPROX(jacobian_times_inverse,
-                              (identity<3, double>(0.0)));
-        CHECK_ITERABLE_APPROX(inverse_times_jacobian,
-                              (identity<3, double>(0.0)));
+        CHECK_ITERABLE_CUSTOM_APPROX(jacobian_times_inverse,
+                                     (identity<3, double>(0.0)),
+                                     jacobian_approx);
+        CHECK_ITERABLE_CUSTOM_APPROX(inverse_times_jacobian,
+                                     (identity<3, double>(0.0)),
+                                     jacobian_approx);
       };
 
       // Check that points on the corners of the reference cube map to

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -348,10 +348,8 @@ void test_dg_operator(
     const bool use_massive_dg_operator, const Spectral::Quadrature quadrature,
     const ::dg::Formulation dg_formulation,
     const AnalyticSolution& analytic_solution,
-    // NOLINTNEXTLINE(google-runtime-references)
-    Approx& analytic_solution_aux_approx,
-    // NOLINTNEXTLINE(google-runtime-references)
-    Approx& analytic_solution_operator_approx,
+    const Approx& analytic_solution_aux_approx,
+    const Approx& analytic_solution_operator_approx,
     const std::vector<std::tuple<
         std::unordered_map<ElementId<Dim>,
                            typename ElementArray::vars_tag::type>,
@@ -466,8 +464,8 @@ void test_dg_operator(
               all_expected_primal_fluxes_vars,
           const std::unordered_map<ElementId<Dim>, OperatorAppliedToVars>&
               all_expected_operator_applied_to_vars,
-          Approx& custom_aux_approx = approx,
-          Approx& custom_operator_approx = approx) {
+          const Approx& custom_aux_approx = approx,
+          const Approx& custom_operator_approx = approx) {
         // Set variables data on central element and on its neighbors
         for (const auto& element_id : all_element_ids) {
           const auto vars = all_vars.find(element_id);

--- a/tests/Unit/Framework/TestHelpers.hpp
+++ b/tests/Unit/Framework/TestHelpers.hpp
@@ -517,9 +517,8 @@ struct check_variables_approx;
 
 template <typename TagList>
 struct check_variables_approx<Variables<TagList>> {
-  // clang-tidy: non-const reference
   static void apply(const Variables<TagList>& a, const Variables<TagList>& b,
-                    Approx& appx = approx) {  // NOLINT
+                    const Approx& appx = approx) {
     tmpl::for_each<TagList>([&a, &b, &appx](auto x) {
       using Tag = typename decltype(x)::type;
       INFO(db::tag_name<Tag>());
@@ -536,8 +535,7 @@ struct check_variables_approx<Variables<TagList>> {
 // checking on the wrapped `data()` for the SpinWeighted
 template <typename T>
 struct check_iterable_approx<T, Requires<is_any_spin_weighted_v<T>>> {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+  static void apply(const T& a, const T& b, const Approx& appx = approx) {
     check_iterable_approx<typename T::value_type>::apply(a.data(), b.data(),
                                                          appx);
   }

--- a/tests/Unit/Framework/TestingFramework.hpp
+++ b/tests/Unit/Framework/TestingFramework.hpp
@@ -76,7 +76,7 @@ using Approx = Catch::Approx;
  * \snippet Test_TestingFramework.cpp approx_test
  */
 // clang-tidy: static object creation may throw exception
-static Approx approx =                                          // NOLINT
+static const Approx approx =                                    // NOLINT
     Approx::custom()                                            // NOLINT
         .epsilon(std::numeric_limits<double>::epsilon() * 100)  // NOLINT
         .scale(1.0);                                            // NOLINT
@@ -111,17 +111,15 @@ static Approx approx =                                          // NOLINT
 /// \cond HIDDEN_SYMBOLS
 template <typename T, typename = std::nullptr_t>
 struct check_iterable_approx {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+  static void apply(const T& a, const T& b, const Approx& appx = approx) {
     CHECK(a == appx(b));
   }
 };
 
 template <typename T>
 struct check_iterable_approx<std::complex<T>, std::nullptr_t> {
-  // clang-tidy: non-const reference
   static void apply(const std::complex<T>& a, const std::complex<T>& b,
-                    Approx& appx = approx) {  // NOLINT
+                    const Approx& appx = approx) {
     check_iterable_approx<T>::apply(real(a), real(b), appx);
     check_iterable_approx<T>::apply(imag(a), imag(b), appx);
   }
@@ -131,8 +129,7 @@ template <typename T>
 struct check_iterable_approx<
     T, Requires<not tt::is_maplike_v<T> and tt::is_iterable_v<T> and
                 not tt::is_a_v<std::unordered_set, T>>> {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+  static void apply(const T& a, const T& b, const Approx& appx = approx) {
     CAPTURE(a);
     CAPTURE(b);
     auto a_it = a.begin();
@@ -158,9 +155,7 @@ struct check_iterable_approx<
 
 template <typename T>
 struct check_iterable_approx<T, Requires<tt::is_a_v<std::unordered_set, T>>> {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b,
-                    Approx& /*appx*/ = approx) {  // NOLINT
+  static void apply(const T& a, const T& b, const Approx& /*appx*/ = approx) {
     // Approximate comparison of unordered sets is difficult
     CHECK(a == b);
   }
@@ -169,8 +164,7 @@ struct check_iterable_approx<T, Requires<tt::is_a_v<std::unordered_set, T>>> {
 template <typename T>
 struct check_iterable_approx<
     T, Requires<tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+  static void apply(const T& a, const T& b, const Approx& appx = approx) {
     CAPTURE(a);
     CAPTURE(b);
     for (const auto& kv : a) {
@@ -207,9 +201,7 @@ struct check_iterable_approx<
 template <typename M>
 struct check_iterable_approx<M, Requires<blaze::IsColumnMajorMatrix_v<M> and
                                          blaze::IsDenseMatrix_v<M>>> {
-  // clang-tidy: non-const reference
-  static void apply(const M& a, const M& b,
-                    Approx& appx = approx) {  // NOLINT
+  static void apply(const M& a, const M& b, const Approx& appx = approx) {
     CHECK(a.columns() == b.columns());
     for (size_t j = 0; j < a.columns(); j++) {
       CAPTURE(a);

--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -492,7 +492,7 @@ void test_einsum(const T& used_for_size) {
       "PyppPyTests", "test_einsum", scalar, vector, tnsr_ia, tnsr_AA, tnsr_iaa);
   // [einsum_example]
   CHECK_ITERABLE_CUSTOM_APPROX(expected, tensor_from_python,
-                               approx.epsilon(2.0e-13));
+                               Approx::custom().epsilon(2.0e-13));
 }
 
 void test_function_of_time() {

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp
@@ -53,12 +53,13 @@ void check_burgers_solution(const Solution& solution,
       CHECK(get(solution.du_dt(xp, time)) == approx(dtup));
       // Check that the time derivative is the derivative of the
       // value.
+      const auto deriv_approx = Approx::custom().epsilon(1.e-10);
       CHECK(numerical_derivative(
                 [&solution, &xp](const std::array<double, 1>& t) {
                   return std::array<double, 1>{{get(solution.u(xp, t[0]))}};
                 },
                 std::array<double, 1>{{time}}, 0,
-                1e-4)[0] == approx.epsilon(1e-10)(dtup));
+                1e-4)[0] == deriv_approx(dtup));
       // Check that the Burgers equation is satisfied.
       CHECK(numerical_derivative(
                 [&solution, &time](const std::array<double, 1>& x) {
@@ -69,7 +70,7 @@ void check_burgers_solution(const Solution& solution,
                   return std::array<double, 1>{{get<0>(flux)[0]}};
                 },
                 std::array<double, 1>{{get<0>(xp)}}, 0,
-                1e-4)[0] == approx(-dtup));
+                1e-4)[0] == deriv_approx(-dtup));
     }
   }
 }

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -378,7 +378,8 @@ void verify_consistency(const Solution& solution, const double time,
                  Tags::dt<SpatialMetric>, detail::deriv<SpatialMetric, Frame>,
                  Tags::dt<Lapse>, Tags::dt<Shift>, detail::deriv<Lapse, Frame>>;
 
-  auto derivative_approx = approx.epsilon(derivative_tolerance);
+  auto derivative_approx = approx;
+  derivative_approx.epsilon(derivative_tolerance);
 
   const auto vars = solution.variables(position, time, tags{});
 
@@ -448,7 +449,8 @@ void verify_spatial_consistency(const Solution& solution, const double time,
                  Tags::dt<SpatialMetric>, detail::deriv<SpatialMetric, Frame>,
                  Tags::dt<Lapse>, Tags::dt<Shift>, detail::deriv<Lapse, Frame>>;
 
-  auto derivative_approx = approx.epsilon(derivative_tolerance);
+  auto derivative_approx = approx;
+  derivative_approx.epsilon(derivative_tolerance);
 
   const auto vars = solution.variables(position, time, tags{});
 

--- a/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Helpers/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -412,7 +412,7 @@ void check_dense_output(
 
   // Check that the dense output is continuous
   {
-    auto local_approx = approx.epsilon(1e-12);
+    const auto local_approx = Approx::custom().scale(1.0).epsilon(1e-12);
     for (const auto time_step :
          {Slab(0., 1.).duration(), -Slab(-1., 0.).duration()}) {
       CAPTURE(time_step);

--- a/tests/Unit/Utilities/Test_FractionUtilities.cpp
+++ b/tests/Unit/Utilities/Test_FractionUtilities.cpp
@@ -62,8 +62,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
     const double value = dist(gen);
     // Set the scale because the fractional part of a negative number
     // (defined as `x - floor(x)`) can be larger than the number.
-    auto approx_value =
-        approx.scale(std::max(value, std::abs(std::floor(value))))(value);
+    auto local_approx = approx;
+    local_approx.scale(std::max(value, std::abs(std::floor(value))));
     ContinuedFractionSummer<Rational> summer;
     bool should_be_smaller = true;
     std::vector<int64_t> terms{};  // Only for output
@@ -77,7 +77,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
 
       // Convergents to a continued fraction always alternate between
       // over- and underestimates.
-      if (convergents.back() != approx_value) {
+      if (convergents.back() != local_approx(value)) {
         if (should_be_smaller) {
           CHECK(convergents.back() <= value);
         } else {
@@ -88,7 +88,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.FractionUtilities.ContinuedFraction",
     }
     CAPTURE(terms);
     CAPTURE(convergents);
-    CHECK(convergents.back() == approx_value);
+    CHECK(convergents.back() == local_approx(value));
   }
 }
 


### PR DESCRIPTION
And fix places that accidentally modified it.

Const-correctness of Approx was fixed in Catch version 3.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
