### PR TITLE
Add Strahlkorper power monitor

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/StrahlkorperFunctions.cpp
@@ -19,6 +19,9 @@ void bind_strahlkorper_functions_impl(pybind11::module& m) {  // NOLINT
   m.def("cartesian_coords",
         py::overload_cast<const Strahlkorper&>(&ylm::cartesian_coords<Frame>),
         py::arg("strahlkorper"));
+  m.def("power_monitor",
+        py::overload_cast<const Strahlkorper&>(&ylm::power_monitor<Frame>),
+        py::arg("strahlkorper"));
 }
 }  // namespace
 

--- a/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
@@ -3,6 +3,7 @@
 
 #include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
 
+#include <algorithm>
 #include <deque>
 #include <utility>
 
@@ -11,6 +12,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "NumericalAlgorithms/FiniteDifference/NonUniform1D.hpp"
 #include "NumericalAlgorithms/Interpolation/LinearLeastSquares.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -500,6 +502,29 @@ void time_deriv_of_strahlkorper(
   time_deriv->coefficients() = std::move(new_coefficients);
 }
 
+template <typename Frame>
+void power_monitor(gsl::not_null<DataVector*> result,
+                   const Strahlkorper<Frame>& strahlkorper) {
+  result->destructive_resize(strahlkorper.l_max() + 1);
+  *result = 0.0;
+  for (SpherepackIterator it(strahlkorper.l_max(), strahlkorper.m_max()); it;
+       ++it) {
+    (*result)[it.l()] += square(strahlkorper.coefficients()[it()]);
+  }
+  for (size_t l = 0; l <= strahlkorper.l_max(); ++l) {
+    const double normalization =
+        2.0 * static_cast<double>(std::min(l, strahlkorper.m_max())) + 1.0;
+    (*result)[l] = sqrt((*result)[l] / normalization);
+  }
+}
+
+template <typename Frame>
+DataVector power_monitor(const Strahlkorper<Frame>& strahlkorper) {
+  DataVector result{strahlkorper.l_max() + 1, 0.0};
+  power_monitor(make_not_null(&result), strahlkorper);
+  return result;
+}
+
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                  \
@@ -615,7 +640,12 @@ void time_deriv_of_strahlkorper(
       const std::vector<Strahlkorper<FRAME(data)>>& strahlkorpers);           \
   template void ylm::time_deriv_of_strahlkorper(                              \
       const gsl::not_null<Strahlkorper<FRAME(data)>*>,                        \
-      const std::deque<std::pair<double, Strahlkorper<FRAME(data)>>>&);
+      const std::deque<std::pair<double, Strahlkorper<FRAME(data)>>>&);       \
+  template void ylm::power_monitor(                                           \
+      gsl::not_null<DataVector*> result,                                      \
+      const Strahlkorper<FRAME(data)>& strahlkorper);                         \
+  template DataVector ylm::power_monitor(                                     \
+      const Strahlkorper<FRAME(data)>& strahlkorper);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Distorted, Frame::Grid, Frame::Inertial))

--- a/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp
@@ -397,4 +397,47 @@ void time_deriv_of_strahlkorper(
     gsl::not_null<Strahlkorper<Frame>*> time_deriv,
     const std::deque<std::pair<double, Strahlkorper<Frame>>>&
         previous_strahlkorpers);
+
+/// @{
+/*!
+ * \brief Compute the power monitor of a Strahlkorper
+ *
+ * \details Computes a Strahlkorper represented as a spectral expansion
+ * in scalar spherical harmonics $Y_{lm}(\theta,\phi)$ up to
+ * $l=l_{\rm max}$ and $m=m_{\rm max}$. Then this function
+ * computes the power in each $l$. If
+ * a Strahlkorper's radius $r(\theta,\phi)$ is expanded as
+ * \begin{equation}
+ * r(\theta,\phi) = \sum_{l=0}^{l_{\rm max}}
+ *   \sum_{m=-\mathcal{M}}^{\mathcal{M}} C_{lm} Y_{lm}(\theta,\phi),
+ * \end{equation}
+ * where $\mathcal{M}$ is $l$ or $m_{\rm max}$, whichever is smaller,
+ * then the power monitor $P_l$ is the square root of a normalized sum of
+ * the magnitudes squared of the coefficients $C_{lm}$:
+ * \begin{equation}
+ * P_l = \sqrt{\frac{1}{2 \mathcal{M}+1}\sum_{m=-\mathcal{M}}^\mathcal{M}
+ *       \left|C_{lm}\right|^2}.
+ * \end{equation}
+ * See Eq. (51) and the surrounding discussion in \cite Szilagyi2014fna
+ * for the motivation of this power monitor, which is useful in adaptively
+ * selecting the angular resolution $l_{\rm max}$ when finding
+ * apparent horizons. But note that because internally the Strahlkorper is
+ * represented as a Spherepack expansion, the implementation of this function
+ * uses that expansion rather than a literal implementation of the
+ * above equations. As a result, it's the Spherepack spectral coefficients
+ * that get squared and (for each $l$) summed over.
+ * \param strahlkorper The Strahlkorper surface.
+ */
+template <typename Frame>
+DataVector power_monitor(const Strahlkorper<Frame>& strahlkorper);
+
+/*!
+ * \copydoc power_monitor
+ * \param result A DataVector containing the power monitor $P_l$ for each
+ * $l$ up to the Strahlkorper's `l_max`.
+ */
+template <typename Frame>
+void power_monitor(gsl::not_null<DataVector*> result,
+                   const Strahlkorper<Frame>& strahlkorper);
+/// @}
 }  // namespace ylm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Python/Test_Strahlkorper.py
@@ -15,6 +15,7 @@ from spectre.SphericalHarmonics import (
     Frame,
     Strahlkorper,
     cartesian_coords,
+    power_monitor,
     read_surface_ylm,
     read_surface_ylm_single_time,
     write_sphere_of_points_to_text_file,
@@ -53,6 +54,13 @@ class TestStrahlkorper(unittest.TestCase):
         x = np.array(cartesian_coords(strahlkorper))
         r = np.linalg.norm(x, axis=0)
         npt.assert_allclose(r, 1.0)
+
+        power = np.array(power_monitor(strahlkorper))
+        for i, power_in_mode in enumerate(power):
+            if i > 0:
+                self.assertAlmostEqual(power_in_mode, 0.0)
+            else:
+                self.assertAlmostEqual(power_in_mode, 2.0 * np.sqrt(2.0))
 
         legend, ylm_data = ylm_legend_and_data(strahlkorper, 1.0, 12)
         self.assertEqual(len(legend), 174)

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
@@ -3,14 +3,18 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <deque>
+#include <random>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
@@ -511,6 +515,47 @@ void test_time_deriv_strahlkorper() {
     }
   }
 }
+
+void test_power_monitor() {
+  constexpr size_t l_max = 5;
+  constexpr size_t m_max = 4;
+
+  // Check that all power monitors for a spherical Strahlkorper vanish, except
+  // for the l=0 power monitor, which has a value of 2 sqrt(2) * radius.
+  // This is because f = (1/2)(1/sqrt(2)) P_0^0 a00, and the associated
+  // Legendre polynomial P_0^0 == 1.
+  constexpr double radius = 4.567;
+  const std::array<double, 3> center{0.1, -1.2, 2.3};
+  Strahlkorper<Frame::Inertial> spherical_strahlkorper{l_max, m_max, radius,
+                                                       center};
+  const DataVector power_spherical = power_monitor(spherical_strahlkorper);
+  DataVector expected_power_spherical{l_max + 1, 0.0};
+  expected_power_spherical[0] = 2.0 * sqrt(2.0) * radius;
+  CHECK_ITERABLE_APPROX(power_spherical, expected_power_spherical);
+
+  // Check that power monitor behaves as expected for Strahlkorper that is
+  // not spherical, performing the calculation in a slightly different way
+  // from the code being tested
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-0.01, 0.01);
+  const auto nonspherical_coefs = make_with_random_values<ModalVector>(
+      make_not_null(&generator), make_not_null(&distribution),
+      spherical_strahlkorper.coefficients());
+  const Strahlkorper<Frame::Inertial> nonspherical_strahlkorper{
+      l_max, m_max, nonspherical_coefs, center};
+  const DataVector power_nonspherical =
+      power_monitor(nonspherical_strahlkorper);
+  const auto nonspherical_coefs_sq = square(nonspherical_coefs);
+  DataVector power_nonspherical_expected = DataVector{l_max + 1, 0.0};
+  for (SpherepackIterator it(l_max, m_max); it; ++it) {
+    power_nonspherical_expected[it.l()] +=
+        nonspherical_coefs_sq[it()] /
+        (2.0 * static_cast<double>(std::min(it.l(), m_max)) + 1.0);
+  }
+  power_nonspherical_expected = sqrt(power_nonspherical_expected);
+
+  CHECK_ITERABLE_APPROX(power_nonspherical, power_nonspherical_expected);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.StrahlkorperFunctions",
@@ -523,5 +568,6 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.StrahlkorperFunctions",
   test_fit_ylm_coeffs_same();
   test_fit_ylm_coeffs_diff();
   test_time_deriv_strahlkorper();
+  test_power_monitor();
 }
 }  // namespace ylm


### PR DESCRIPTION
## Proposed changes

Add a function in `StrahlkorperFunctions.cpp` that takes a Strahlkorper and computes a power monitor, using the same method as SpEC does in SpEC's `SurfacePowerDiagnostics.cpp`. This function is an ingredient for the "Shape" criteria for adaptive horizon finding. The existing `power_monitor` functionality in `NumericalAlgorithms/LinearOperators/PowerMonitors.?pp`  works on meshes, but not on Strahlkorpers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
