### PR TITLE
Allow colons inside bibtex keys

### DIFF
--- a/docs/DevGuide/WritingDox.md
+++ b/docs/DevGuide/WritingDox.md
@@ -163,14 +163,12 @@ When you refer to publications or books in the documentation, add a
 corresponding entry to `docs/References.bib`. Follow these guidelines when
 editing `docs/References.bib`:
 
-- Ideally, find the publication on [INSPIRE HEP](https://inspirehep.net), copy
-its BibTeX entry, remove the colon `:` from its key and add the `url` field (see
-below). We remove the colon because it can create problems in HTML related to
-its function as a CSS selector.
+- Ideally, find the publication on [INSPIRE HEP](https://inspirehep.net) and
+copy its BibTeX entry.
 - For publications that are not listed on [INSPIRE HEP](https://inspirehep.net),
 make sure to format the new entry's key in the same style, i.e.
-`(<Author>[a-zA-Z]+)(<Year>[0-9]{4})(<ID>[a-z]*)`. Good keys are, for
-instance, `Einstein1915` or `LVC2016a`. For books you may omit the year.
+`(<Author>[a-zA-Z]+):(<Year>[0-9]{4})(<ID>[a-z]*)`. Good keys are, for
+instance, `Einstein:1915` or `LVC:2016a`. For books you may omit the year.
 - Sort the list of BibTeX entries in the file alphabetically by their keys.
 - Provide open access or preprint information whenever possible. For
 publications available on [arXiv](https://arxiv.org), for instance, add the

--- a/docs/config/js/spectre.js
+++ b/docs/config/js/spectre.js
@@ -69,7 +69,9 @@ window.onload = function(){
         var tooltip_base = this;
         // Get the reference id, e.g. `CITEREF_Kopriva`. This is the one used as
         // anchor on the bibliography page.
-        var ref_id = $(this).attr('href').match(/CITEREF_([a-zA-Z0-9]+)/)[0];
+        var ref_id = $(this).attr('href').match(/CITEREF_(.*)/)[0];
+        // Backslashify colons, which indicate CSS pseudo-selectors
+        ref_id = ref_id.replaceAll(":", "\\:");
         // Load the bibliography page to retrieve the reference data as nicely
         // formatted HTML.
         // This does not work locally because it is forbidden to access files,


### PR DESCRIPTION
The colon just needs to be backslashified before going into a jQuery .find(), as
otherwise it's syntax for a CSS pseudo-selector. Literal colons are allowed in
HTML id attributes (though discouraged because of this issue).

-------

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->