### PR TITLE
Update Pipeline for Unequal Mass Runs

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -193,6 +193,16 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
       PARSE_ERROR(context,
                   "ObjectA's inner radius must be less than its outer radius.");
     }
+    // The length of the cube surrounding each object is length_inner_cube_
+    // / 2.0, this checks to make sure that the shell is not touching the cube.
+    if (object_a.outer_radius >=
+        (length_inner_cube_ / 2.0) + offset_x_coord_a_) {
+      PARSE_ERROR(
+          context,
+          "ObjectA's outer radius is too large for the given separation, "
+          " try using "
+              << length_inner_cube_ / (2.5 * cube_scale));
+    }
     if (object_a.use_logarithmic_map and not object_a.is_excised()) {
       PARSE_ERROR(
           context,
@@ -220,6 +230,16 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
     if (object_b.outer_radius < object_b.inner_radius) {
       PARSE_ERROR(context,
                   "ObjectB's inner radius must be less than its outer radius.");
+    }
+    // The length of the cube surrounding each object is length_inner_cube_
+    // / 2.0, this checks to make sure that the shell is not touching the cube.
+    if (object_b.outer_radius >=
+        (length_inner_cube_ / 2.0) - offset_x_coord_b_) {
+      PARSE_ERROR(
+          context,
+          "ObjectB's outer radius is too large for the given separation, "
+          " try using "
+              << length_inner_cube_ / (2.5 * cube_scale));
     }
     if (object_b.use_logarithmic_map and not object_b.is_excised()) {
       PARSE_ERROR(

--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -92,6 +92,15 @@ def id_parameters(
     L1_dist_B = separation - L1_dist_A
     falloff_width_A = 3.0 / 5.0 * L1_dist_A
     falloff_width_B = 3.0 / 5.0 * L1_dist_B
+    # This extra refinement was found through trial and error and allowed mass
+    # ratio 6 to evolve through inspiral stably.
+    mass_ratio = conformal_mass_a / conformal_mass_b
+    extra_radial_refinement_l = (
+        round(mass_ratio / 3.0) - 1 if (mass_ratio > 3.0) else 0
+    )
+    extra_radial_refinement_p = (
+        round(mass_ratio / 5.0) if (mass_ratio > 5.0) else 0
+    )
     return {
         "ConformalMassRight": conformal_mass_a,
         "ConformalMassLeft": conformal_mass_b,
@@ -104,6 +113,7 @@ def id_parameters(
         "LinearVelocity_z": linear_velocity[2],
         "ExcisionRadiusRight": 0.93 * r_plus_A,
         "ExcisionRadiusLeft": 0.93 * r_plus_B,
+        "ObjectOuterRadius": separation / 3.75,
         "OrbitalAngularVelocity": orbital_angular_velocity,
         "RadialExpansionVelocity": radial_expansion_velocity,
         "ConformalSpinRight_x": chi_A[0],
@@ -120,9 +130,12 @@ def id_parameters(
         "HorizonRotationLeft_z": Omega_B[2],
         "FalloffWidthRight": falloff_width_A,
         "FalloffWidthLeft": falloff_width_B,
+        "EnvelopeRadius": 4.0 * separation,
         # Resolution
         "L": refinement_level,
         "P": polynomial_order,
+        "ExtraRadRef": extra_radial_refinement_l,
+        "ExtraRadPoints": extra_radial_refinement_p,
     }
 
 

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -74,7 +74,7 @@ DomainCreator:
   BinaryCompactObject:
     ObjectA:
       InnerRadius: {{ ExcisionRadiusRight }}
-      OuterRadius: 4.
+      OuterRadius: {{ ObjectOuterRadius }}
       XCoord: *x_right
       Interior:
         ExciseWithBoundaryCondition:
@@ -89,7 +89,7 @@ DomainCreator:
       UseLogarithmicMap: True
     ObjectB:
       InnerRadius: {{ ExcisionRadiusLeft }}
-      OuterRadius: 4.
+      OuterRadius: {{ ObjectOuterRadius }}
       XCoord: *x_left
       Interior:
         ExciseWithBoundaryCondition:
@@ -104,7 +104,7 @@ DomainCreator:
       UseLogarithmicMap: True
     CenterOfMassOffset: [*y_offset, *z_offset]
     Envelope:
-      Radius: &outer_shell_inner_radius 60.
+      Radius: &outer_shell_inner_radius {{ EnvelopeRadius }}
       RadialDistribution: Projective
     OuterShell:
       Radius: &outer_radius 1e5
@@ -116,7 +116,7 @@ DomainCreator:
     CubeScale: 1.0
     InitialRefinement:
       ObjectAShell:     [{{ L }}, {{ L }}, {{ L }}]
-      ObjectBShell:     [{{ L }}, {{ L }}, {{ L }}]
+      ObjectBShell:     [{{ L }}, {{ L }}, {{ L + ExtraRadRef }}]
       ObjectACube:      [{{ L }}, {{ L }}, {{ L }}]
       ObjectBCube:      [{{ L }}, {{ L }}, {{ L }}]
       Envelope:         [{{ L }}, {{ L }}, {{ L + 1 }}]
@@ -125,7 +125,7 @@ DomainCreator:
     # will need AMR to optimize the domain further.
     InitialGridPoints:
       ObjectAShell:   [{{ P + 1}}, {{ P + 1}}, {{ P + 5}}]
-      ObjectBShell:   [{{ P + 1}}, {{ P + 1}}, {{ P + 5}}]
+      ObjectBShell:   [{{ P + 1}}, {{ P + 1}}, {{ P + 5 + ExtraRadPoints}}]
       ObjectACube:    [{{ P + 1}}, {{ P + 1}}, {{ P + 2}}]
       ObjectBCube:    [{{ P + 1}}, {{ P + 1}}, {{ P + 2}}]
       Envelope:       [{{ P + 1}}, {{ P + 1}}, {{ P + 1}}]

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -46,6 +46,15 @@ def _control_system_params(
     increase_threshold_fraction = 0.25
     min_kinematic_timescale = 1e-2
 
+    size_b_timescale = damping_time_base * 0.2 * mass_left
+    # Found that changing the size_a timescale to be the same timescale as
+    # size_b fixed early incoming char speeds for higher mass ratio runs.
+    size_a_timescale = (
+        size_b_timescale
+        if (mass_ratio > 2.0)
+        else damping_time_base * 0.2 * mass_right
+    )
+
     return {
         "MinKinematicTimescale": min_kinematic_timescale,
         "MaxDampingTimescale": max_damping_timescale,
@@ -54,8 +63,8 @@ def _control_system_params(
         "SkewTimescale": 0.5 * (
             5.0 * min_kinematic_timescale + max_damping_timescale
         ),
-        "SizeATimescale": damping_time_base * 0.2 * mass_right,
-        "SizeBTimescale": damping_time_base * 0.2 * mass_left,
+        "SizeATimescale": size_a_timescale,
+        "SizeBTimescale": size_b_timescale,
         "ShapeATimescale": 5.0 * kinematic_timescale,
         "ShapeBTimescale": 5.0 * kinematic_timescale,
         "SizeIncreaseThreshold": 1e-3,
@@ -112,15 +121,42 @@ def inspiral_parameters(
       refinement_level: h-refinement level.
       polynomial_order: p-refinement level.
     """
+    # For constraints and control system params we just use the target masses
+    # and spins, not the values measured on the horizons, because these numbers
+    # don't have to be exact and the horizon quantities will change a bit during
+    # the evolution anyway.
+    target_params = id_metadata["TargetParams"]
+    mass_ratio = target_params["MassRatio"]
+    mass_a = mass_ratio / (1.0 + mass_ratio)
+    mass_b = 1.0 / (1.0 + mass_ratio)
+    spin_magnitude_a = np.linalg.norm(target_params["DimensionlessSpinA"])
+    spin_magnitude_b = np.linalg.norm(target_params["DimensionlessSpinB"])
     # Initial data can be either from an ID solve or from a previous evolution
     id_from_evolution = "Evolution" in id_input_file
-    target_params = id_metadata["TargetParams"]
     id_domain_creator = id_input_file["DomainCreator"]["BinaryCompactObject"]
     # This factor is to account for the ID excision not being the same shape as
     # the final horizon found after the last iteration. Found through trial and
     # error that increasing the excision size by this factor allowed the runs to
     # evolve without early incoming char speeds.
-    excision_radius_factor = 1.0 if id_from_evolution else 1.0385
+    # For unequal masses, this was found through trial and error that
+    # decreasing the excision size of object b allowed the runs to evolve
+    # without early incoming char speeds.
+    excision_radius_factor_a = 1.0 if id_from_evolution else 1.0385
+    excision_radius_factor_b = (
+        1.0 if (id_from_evolution or mass_ratio > 2.0) else 1.0385
+    )
+    initial_separation = (
+        id_domain_creator["ObjectA"]["XCoord"]
+        - id_domain_creator["ObjectB"]["XCoord"]
+    )
+    # This extra refinement was found through trial and error and allowed mass
+    # ratio 6 to evolve through inspiral stably.
+    extra_radial_refinement_l = (
+        round(mass_ratio / 2.0) - 1 if (mass_ratio > 2.0) else 0
+    )
+    extra_radial_refinement_p = (
+        round(mass_ratio / 5.0) if (mass_ratio > 5.0) else 0
+    )
     params = {
         # Initial data files
         "IdFileGlob": str(
@@ -130,18 +166,29 @@ def inspiral_parameters(
         "IdFromEvolution": id_from_evolution,
         # Domain geometry
         "ExcisionRadiusA": (
-            id_domain_creator["ObjectA"]["InnerRadius"] * excision_radius_factor
+            id_domain_creator["ObjectA"]["InnerRadius"]
+            * excision_radius_factor_a
         ),
         "ExcisionRadiusB": (
-            id_domain_creator["ObjectB"]["InnerRadius"] * excision_radius_factor
+            id_domain_creator["ObjectB"]["InnerRadius"]
+            * excision_radius_factor_b
         ),
+        "ObjectOuterRadius": initial_separation / 2.5,
         "XCoordA": id_domain_creator["ObjectA"]["XCoord"],
         "XCoordB": id_domain_creator["ObjectB"]["XCoord"],
         "CenterOfMassOffset_y": id_domain_creator["CenterOfMassOffset"][0],
         "CenterOfMassOffset_z": id_domain_creator["CenterOfMassOffset"][1],
+        "EnvelopeRadius": 100.0 / 15.0 * initial_separation,
+        # SpEC chooses the outer radius based on a Newtonian estimate of the
+        # wave zone (See function AutoRmax in SpEC/Support/Perl/SpEC.pm). This
+        # may need to be ported over eventually. The CCE extraction radii may
+        # also need to be adjusted to account for different outer shell radii.
+        "OuterShellRadius": 600.0 / 15.0 * initial_separation,
         # Resolution
         "L": refinement_level,
         "P": polynomial_order,
+        "ExtraRadRef": extra_radial_refinement_l,
+        "ExtraRadPoints": extra_radial_refinement_p,
     }
 
     # Initial functions of time (set from ID or load from evolution data)
@@ -183,21 +230,6 @@ def inspiral_parameters(
                 "ExcisionBShapeSpin_z": id_shape_B["InitialValues"]["Spin"][2],
             }
         )
-
-    # For constraints and control system params we just use the target masses
-    # and spins, not the values measured on the horizons, because these numbers
-    # don't have to be exact and the horizon quantities will change a bit during
-    # the evolution anyway.
-    target_params = id_metadata["TargetParams"]
-    mass_ratio = target_params["MassRatio"]
-    mass_a = mass_ratio / (1.0 + mass_ratio)
-    mass_b = 1.0 / (1.0 + mass_ratio)
-    spin_magnitude_a = np.linalg.norm(target_params["DimensionlessSpinA"])
-    spin_magnitude_b = np.linalg.norm(target_params["DimensionlessSpinB"])
-    initial_separation = (
-        id_domain_creator["ObjectA"]["XCoord"]
-        - id_domain_creator["ObjectB"]["XCoord"]
-    )
 
     # Constraint damping parameters
     params.update(
@@ -270,6 +302,12 @@ def inspiral_parameters_spec(
     spin_magnitude_left = id_params["ID_chiBMagnitude"]
     spin_magnitude_right = id_params["ID_chiAMagnitude"]
     initial_separation = id_params["ID_d"]
+    extra_radial_refinement_l = (
+        round(mass_ratio / 2.0) - 1 if (mass_ratio > 2.0) else 0
+    )
+    extra_radial_refinement_p = (
+        round(mass_ratio / 5.0) if (mass_ratio > 5.0) else 0
+    )
 
     params = {
         # Initial data files
@@ -280,6 +318,7 @@ def inspiral_parameters_spec(
         # or about 0.9434 * horizon radius.
         "ExcisionRadiusA": id_params["ID_rExcA"] * 1.06,
         "ExcisionRadiusB": id_params["ID_rExcB"] * 1.06,
+        "ObjectOuterRadius": initial_separation / 2.5,
         "XCoordA": id_params["ID_cA"][0],
         "XCoordB": id_params["ID_cB"][0],
         # COM offset in y and z is the same for both objects
@@ -288,9 +327,16 @@ def inspiral_parameters_spec(
         # Initial functions of time
         "InitialAngularVelocity": id_params["ID_Omega0"],
         "RadialExpansionVelocity": id_params["ID_adot0"],
+        "EnvelopeRadius": 100.0 / 15.0 * initial_separation,
+        # SpEC chooses the outer radius based on a Newtonian estimate of the
+        # wave zone (See function AutoRmax in SpEC/Support/Perl/SpEC.pm). This
+        # may need to be ported over eventually. The CCE extraction radii may
+        # also need to be adjusted to account for different outer shell radii.
+        "OuterShellRadius": 600.0 / 15.0 * initial_separation,
         # Resolution
         "L": refinement_level,
-        "P": polynomial_order,
+        "ExtraRadRef": extra_radial_refinement_l,
+        "ExtraRadPoints": extra_radial_refinement_p,
     }
 
     # Constraint damping parameters

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -72,7 +72,7 @@ DomainCreator:
       InnerRadius: &ExcisionRadiusA {{ ExcisionRadiusA }}
       # Found that the max allowable value for the OuterRadius is 6.0. Higher
       # values cause the constraints to blow up the cubes around each object.
-      OuterRadius: 6.0
+      OuterRadius: {{ ObjectOuterRadius }}
       XCoord: &XCoordA {{ XCoordA }}
       Interior:
         ExciseWithBoundaryCondition:
@@ -82,7 +82,7 @@ DomainCreator:
       InnerRadius: &ExcisionRadiusB {{ ExcisionRadiusB }}
       # Found that the max allowable value for the OuterRadius is 6.0. Higher
       # values cause the constraints to blow up the cubes around each object.
-      OuterRadius: 6.0
+      OuterRadius: {{ ObjectOuterRadius }}
       XCoord: &XCoordB {{ XCoordB }}
       Interior:
         ExciseWithBoundaryCondition:
@@ -92,13 +92,13 @@ DomainCreator:
       - &YOffset {{ CenterOfMassOffset_y }}
       - &ZOffset {{ CenterOfMassOffset_z }}
     Envelope:
-      Radius: 100.0
+      Radius: {{ EnvelopeRadius }}
       # Radial distribution is logarithmic to transition from grid point
       # spacing around the excisions to the grid point spacing in the
       # outer shell
       RadialDistribution: Logarithmic
     OuterShell:
-      Radius: 600.0
+      Radius: {{ OuterShellRadius }}
       # Radial distribution is linear to resolve gravitational waves
       RadialPartitioning: []
       RadialDistribution: Linear
@@ -115,17 +115,17 @@ DomainCreator:
     InitialRefinement:
       ObjectAShell:   [{{ L + 1 }}, {{ L + 1 }}, {{ L + 1 }}]
       ObjectACube:    [{{ L + 2 }}, {{ L + 2 }}, {{ L + 1 }}]
-      ObjectBShell:   [{{ L + 1 }}, {{ L + 1 }}, {{ L + 1 }}]
+      ObjectBShell:   [{{ L + 1 }}, {{ L + 1 }}, {{ L + 1 + ExtraRadRef }}]
       ObjectBCube:    [{{ L + 2 }}, {{ L + 2 }}, {{ L + 1 }}]
       Envelope:       [{{ L + 1 }}, {{ L + 1 }}, {{ L + 1 }}]
-      OuterShell0:     [{{ L     }}, {{ L     }}, {{ L + 2 }}]
+      OuterShell0:    [{{ L     }}, {{ L     }}, {{ L + 2 }}]
     InitialGridPoints:
       ObjectAShell:   [{{ P + 3 }}, {{ P + 3 }}, {{ P + 1 }}]
       ObjectACube:    [{{ P     }}, {{ P     }}, {{ P - 1 }}]
-      ObjectBShell:   [{{ P + 3 }}, {{ P + 3 }}, {{ P + 1 }}]
+      ObjectBShell:   [{{ P + 3 }}, {{ P + 3 }}, {{ P + 1 + ExtraRadPoints }}]
       ObjectBCube:    [{{ P     }}, {{ P     }}, {{ P - 1 }}]
       Envelope:       [{{ P + 3 }}, {{ P + 3 }}, {{ P + 5 }}]
-      OuterShell0:     [{{ P + 3 }}, {{ P + 3 }}, {{ P + 4 }}]
+      OuterShell0:    [{{ P + 3 }}, {{ P + 3 }}, {{ P + 4 }}]
 {% if IdFromEvolution %}
     TimeDependentMaps:
       InitialTime: &InitialTime {{ InitialTime }}
@@ -540,7 +540,7 @@ ControlSystems:
       DecreaseFactor: &DecreaseFactor 0.98
     ControlError:
   Rotation: *KinematicControlSystem
-  Translation: None
+  Translation: *KinematicControlSystem
   Skew:
     Averager: *KinematicAverager
     Controller: *KinematicController

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -807,8 +807,8 @@ void test_binary_factory() {
 void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{20.0},
           Distribution::Linear, 120.0, std::nullopt,
@@ -817,8 +817,8 @@ void test_parse_errors() {
           "First radial partition must be larger than the envelope radius"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{40.0},
           Distribution::Linear, 120.0, std::nullopt,
@@ -827,8 +827,8 @@ void test_parse_errors() {
           "Last radial partition must be smaller than the outer radius"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{28.0, 28.0},
           Distribution::Linear, 120.0, std::nullopt,
@@ -837,8 +837,8 @@ void test_parse_errors() {
           "Radial partitioning contains duplicate element"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{28.0, 29.0},
           std::vector{Distribution::Linear}, 120.0, std::nullopt,
@@ -847,8 +847,8 @@ void test_parse_errors() {
           "Specify a 'RadialDistribution' for every spherical shell."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.3, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{}, Distribution::Linear,
           120.0, std::nullopt, create_outer_boundary_condition(),
@@ -857,8 +857,8 @@ void test_parse_errors() {
           "The x-coordinate of ObjectA's center is expected to be positive."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.5, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{}, Distribution::Linear,
           120.0, std::nullopt, create_outer_boundary_condition(),
@@ -889,8 +889,8 @@ void test_parse_errors() {
           "separation between the two objects."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{1.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{1.5, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{}, Distribution::Linear,
           120.0, std::nullopt, create_outer_boundary_condition(),
@@ -899,8 +899,8 @@ void test_parse_errors() {
           "ObjectB's inner radius must be less than its outer radius."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{3.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{3.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{}, Distribution::Linear,
           120.0, std::nullopt, create_outer_boundary_condition(),
@@ -910,7 +910,29 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.5, 1.0, -1.0, std::nullopt, true},
+          Object{0.5, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "ObjectA's outer radius is too large for the given separation,  try "
+          "using 0.8"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "ObjectB's outer radius is too large for the given separation,  try "
+          "using 0.8"));
+  CHECK_THROWS_WITH(
+      domain::creators::BinaryCompactObject(
+          Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, -1.0, std::nullopt, true},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, true, 6_st,
           Distribution::Projective, std::vector<double>{}, Distribution::Linear,
           120.0, std::nullopt, create_outer_boundary_condition(),
@@ -921,8 +943,8 @@ void test_parse_errors() {
           "of Object B"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.3, 1.0, 1.0, std::nullopt, true},
-          Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, 1.0, std::nullopt, true},
+          Object{0.5, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
           Distribution::Projective, std::vector<double>{}, Distribution::Linear,
           120.0, std::nullopt, create_outer_boundary_condition(),
@@ -933,15 +955,15 @@ void test_parse_errors() {
           "of Object A"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.3, 1.0, 1.0, false, false},
-          Object{0.5, 1.0, -1.0, false, false},
+          Object{0.3, 0.8, 1.0, false, false},
+          Object{0.5, 0.8, -1.0, false, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.2, 2_st, 6_st),
       Catch::Matchers::ContainsSubstring(
           "A filled object cannot be offset within its cube."));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0,
           std::vector<std::array<size_t, 3>>{}, 6_st, true,
           Distribution::Projective, std::vector<double>{}, Distribution::Linear,
@@ -950,8 +972,8 @@ void test_parse_errors() {
       Catch::Matchers::ContainsSubstring("Invalid 'InitialRefinement'"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
-          Object{0.3, 1.0, 1.0, {{create_inner_boundary_condition()}}, false},
-          Object{0.5, 1.0, -1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.5, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
           std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st,
           std::vector<std::array<size_t, 3>>{}, true, Distribution::Projective,
           std::vector<double>{}, Distribution::Linear, 120.0, std::nullopt,

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "    UseLogarithmicMap: false\n"
       "  ObjectB:\n"
       "    InnerRadius: 1.9\n"
-      "    OuterRadius: 3.0\n"
+      "    OuterRadius: 2.4\n"
       "    XCoord: -1e-99\n"
       "    Interior:\n"
       "      ExciseWithBoundaryCondition:\n"


### PR DESCRIPTION
## Proposed changes

This updates the pipeline to support higher mass ratio runs, and adjusts the domain based on initial separation of the objects (needed for smaller/larger separations runs). This was tested up to q = 6. Also adds some checks for object outer radii.

### Upgrade instructions

<!--
-->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
