### PR TITLE
Add spatial covariant derivative of extrinsic curvature

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.cpp
@@ -46,6 +46,37 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
                       spatial_metric, dt_spatial_metric, deriv_spatial_metric);
   return ex_curvature;
 }
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+void covariant_derivative_of_extrinsic_curvature(
+    const gsl::not_null<tnsr::ijj<DataType, SpatialDim, Frame>*> grad_ex_curv,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_ex_curv,
+    const tnsr::ii<DataType, SpatialDim, Frame>& ex_curv,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind) {
+  set_number_of_grid_points(grad_ex_curv, ex_curv);
+  tenex::evaluate<ti::i, ti::j, ti::k>(
+      grad_ex_curv, d_ex_curv(ti::i, ti::j, ti::k) -
+                        spatial_christoffel_second_kind(ti::L, ti::i, ti::j) *
+                            ex_curv(ti::l, ti::k) -
+                        spatial_christoffel_second_kind(ti::L, ti::i, ti::k) *
+                            ex_curv(ti::j, ti::l));
+}
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::ijj<DataType, SpatialDim, Frame>
+covariant_derivative_of_extrinsic_curvature(
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_ex_curv,
+    const tnsr::ii<DataType, SpatialDim, Frame>& ex_curv,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind) {
+  tnsr::ijj<DataType, SpatialDim, Frame> grad_ex_curv{};
+  covariant_derivative_of_extrinsic_curvature(make_not_null(&grad_ex_curv),
+                                              d_ex_curv, ex_curv,
+                                              spatial_christoffel_second_kind);
+  return grad_ex_curv;
+}
+
 }  // namespace gr
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -71,7 +102,20 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
-          deriv_spatial_metric);
+          deriv_spatial_metric);                                              \
+  template void gr::covariant_derivative_of_extrinsic_curvature(              \
+      const gsl::not_null<tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          grad_ex_curv,                                                       \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& d_ex_curv,        \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& ex_curv,           \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          spatial_christoffel_second_kind);                                   \
+  template tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>                     \
+  gr::covariant_derivative_of_extrinsic_curvature(                            \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>& d_ex_curv,        \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& ex_curv,           \
+      const tnsr::Ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          spatial_christoffel_second_kind);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Distorted, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \ingroup GeneralRelativityGroup
@@ -47,4 +48,60 @@ void extrinsic_curvature(
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>& deriv_spatial_metric);
 /// @}
+
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief  Computes the spatial covariant derivative of the extrinsic curvature.
+ *  \details The spatial covariant derivative is computed as
+ * \f[ D_k K_{ij} = \partial_k K_{ij} - {^{(3)}\Gamma^{l}_{ki}} K_{lj}
+ * - {^{(3)}\Gamma^{l}_{kj}}K_{il} \f]
+ * where \f$ {^{(3)}\Gamma^{k}_{ij}} \f$ is the spatial Christoffel symbol of
+ * the second kind.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::ijj<DataType, SpatialDim, Frame>
+covariant_derivative_of_extrinsic_curvature(
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_ex_curv,
+    const tnsr::ii<DataType, SpatialDim, Frame>& ex_curv,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind);
+template <typename DataType, size_t SpatialDim, typename Frame>
+void covariant_derivative_of_extrinsic_curvature(
+    gsl::not_null<tnsr::ijj<DataType, SpatialDim, Frame>*> grad_ex_curv,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_ex_curv,
+    const tnsr::ii<DataType, SpatialDim, Frame>& ex_curv,
+    const tnsr::Ijj<DataType, SpatialDim, Frame>&
+        spatial_christoffel_second_kind);
+/// @}
+
+namespace Tags {
+/// \copydoc covariant_derivative_of_extrinsic_curvature
+template <size_t SpatialDim, typename Frame>
+struct CovariantDerivativeOfExtrinsicCurvatureCompute
+    : gr::Tags::CovariantDerivativeOfExtrinsicCurvature<DataVector, SpatialDim,
+                                                        Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      ::Tags::deriv<gr::Tags::ExtrinsicCurvature<DataVector, SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      gr::Tags::ExtrinsicCurvature<DataVector, SpatialDim, Frame>,
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, SpatialDim, Frame>>;
+
+  using return_type = tnsr::ijj<DataVector, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      const gsl::not_null<tnsr::ijj<DataVector, SpatialDim, Frame>*>,
+      const tnsr::ijj<DataVector, SpatialDim, Frame>&,
+      const tnsr::ii<DataVector, SpatialDim, Frame>&,
+      const tnsr::Ijj<DataVector, SpatialDim, Frame>&
+          spatial_christoffel_second_kind)>(
+      &covariant_derivative_of_extrinsic_curvature<DataVector, SpatialDim,
+                                                   Frame>);
+
+  using base =
+      gr::Tags::CovariantDerivativeOfExtrinsicCurvature<DataVector, SpatialDim,
+                                                        Frame>;
+};
+}  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -143,6 +143,10 @@ template <typename DataType>
 struct TraceExtrinsicCurvature : db::SimpleTag {
   using type = Scalar<DataType>;
 };
+template <typename DataType, size_t Dim, typename Frame>
+struct CovariantDerivativeOfExtrinsicCurvature : db::SimpleTag {
+  using type = tnsr::ijj<DataType, Dim, Frame>;
+};
 
 /*!
  * \brief Holds a quantity that's similar to the shift, but isn't the shift.

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -61,6 +61,8 @@ template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
 struct ExtrinsicCurvature;
 template <typename DataType>
 struct TraceExtrinsicCurvature;
+template <typename DataType, size_t Dim, typename Frame>
+struct CovariantDerivativeOfExtrinsicCurvature;
 template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
 struct SpatialRicci;
 template <typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp
@@ -84,8 +84,7 @@ template <typename DataType, size_t Dim, typename Frame>
 struct WeylMagneticCompute : WeylMagnetic<DataType, Dim, Frame>,
                              db::ComputeTag {
   using argument_tags = tmpl::list<
-      ::Tags::deriv<gr::Tags::ExtrinsicCurvature<DataType, Dim, Frame>,
-                    tmpl::size_t<Dim>, Frame>,
+      gr::Tags::CovariantDerivativeOfExtrinsicCurvature<DataType, Dim, Frame>,
       gr::Tags::SpatialMetric<DataType, Dim, Frame>,
       gr::Tags::SqrtDetSpatialMetric<DataType>>;
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
@@ -153,6 +153,22 @@ def extrinsic_curvature(
     return ext_curve
 
 
+def covariant_deriv_extrinsic_curvture_adm(
+    d_ex_curv,
+    ex_curv,
+    spatial_christoffel_second_kind,
+):
+    grad_ex_curv = d_ex_curv
+    grad_ex_curv += -np.einsum(
+        "lki,lj->kij", spatial_christoffel_second_kind, ex_curv
+    )
+    grad_ex_curv += -np.einsum(
+        "lkj,il->kij", spatial_christoffel_second_kind, ex_curv
+    )
+
+    return grad_ex_curv
+
+
 def deriv_inverse_spatial_metric(inverse_spatial_metric, d_spatial_metric):
     return -np.einsum(
         "in,mj,knm->kij",

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -153,7 +153,18 @@ void test_compute_extrinsic_curvature(const DataType& used_for_size) {
       "ComputeSpacetimeQuantities", "extrinsic_curvature", {{{-10., 10.}}},
       used_for_size);
 }
-
+template <size_t SpatialDim, typename DataType>
+void test_cov_deriv_extrinsic_curvature_adm(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::ijj<DataType, SpatialDim, Frame::Inertial> (*)(
+          const tnsr::ijj<DataType, SpatialDim, Frame::Inertial>&,
+          const tnsr::ii<DataType, SpatialDim, Frame::Inertial>&,
+          const tnsr::Ijj<DataType, SpatialDim, Frame::Inertial>&)>(
+          &::gr::covariant_derivative_of_extrinsic_curvature<
+              DataType, SpatialDim, Frame::Inertial>),
+      "ComputeSpacetimeQuantities", "covariant_deriv_extrinsic_curvture_adm",
+      {{{-1., 1.}}}, used_for_size);
+}
 template <size_t Dim, typename T>
 void test_compute_spatial_metric_lapse_shift(const T& used_for_size) {
   // Set up random values for lapse, shift, and spatial_metric.
@@ -232,6 +243,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_deriv_inverse_spatial_metric,
                                     (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_cov_deriv_extrinsic_curvature_adm,
+                                    (1, 2, 3));
 
   // Check that compute items work correctly in the DataBox
   // First, check that the names are correct
@@ -263,6 +276,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   TestHelpers::db::test_compute_tag<
       gr::Tags::DerivativesOfSpacetimeMetricCompute<3, Frame::Inertial>>(
       "DerivativesOfSpacetimeMetric");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::CovariantDerivativeOfExtrinsicCurvatureCompute<
+          3, Frame::Inertial>>("CovariantDerivativeOfExtrinsicCurvature");
 
   // Second, put the compute items into a data box and check that they
   // put the correct results

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -81,6 +81,9 @@ void test_simple_tags() {
       gr::Tags::ExtrinsicCurvature<Type, Dim, Frame>>("ExtrinsicCurvature");
   TestHelpers::db::test_simple_tag<gr::Tags::TraceExtrinsicCurvature<Type>>(
       "TraceExtrinsicCurvature");
+  TestHelpers::db::test_simple_tag<
+      gr::Tags::CovariantDerivativeOfExtrinsicCurvature<Type, Dim, Frame>>(
+      "CovariantDerivativeOfExtrinsicCurvature");
   TestHelpers::db::test_simple_tag<gr::Tags::SpatialRicci<Type, Dim, Frame>>(
       "SpatialRicci");
   TestHelpers::db::test_simple_tag<gr::Tags::EnergyDensity<Type>>(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylMagnetic.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_WeylMagnetic.cpp
@@ -74,8 +74,8 @@ void test_compute_item_in_databox(const DataType& used_for_size) {
                       make_not_null(&inverse_spatial_metric), used_for_size);
 
   const auto box = db::create<
-      db::AddSimpleTags<::Tags::deriv<gr::Tags::ExtrinsicCurvature<DataType, 3>,
-                                      tmpl::size_t<3>, Frame::Inertial>,
+      db::AddSimpleTags<gr::Tags::CovariantDerivativeOfExtrinsicCurvature<
+                            DataType, 3, Frame::Inertial>,
                         gr::Tags::SpatialMetric<DataType, 3>,
                         gr::Tags::SqrtDetSpatialMetric<DataType>,
                         gr::Tags::InverseSpatialMetric<DataType, 3>>,


### PR DESCRIPTION
## Proposed changes

Add compute tag for the spatial covariant derivative of the extrinsic curvature. 

To compute WeylMagnetic (magnetic part of the Weyl tensor) we need the Spatial Covariant derivative of the Extrinsic curvature. The compute tag for WeylMagnetic was previously requiring the (partial) derivative of the extrinsic curvature. Despite the LeviCivita symbol in the definition of the WeylMagnetic, there are still terms proportional to the 3-Christoffel symbols that do not cancel. I replace the incorrect argument tag in WeylMagneticCompute. This compute tag was not used anywhere in the code.

Note: I just noticed there was already a function to compute it from gh variables, but I think I cannot make a useful compute Tag with it (bc of the partial derivatives of the gh quantities).


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
