### PR TITLE
Add geodesic equation for null rays

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -316,6 +316,22 @@ eprint = {https://doi.org/10.1137/0916035}
   year          = {2014}
 }
 
+@article{Bohn:2014xxa,
+  author        = {Bohn, Andy and Throwe, William and H\'ebert, Fran\c{c}ois and
+                   Henriksson, Katherine and Bunandar, Darius and Scheel,
+                   Mark A. and Taylor, Nicholas W.},
+  title         = {What does a binary black hole merger look like?},
+  eprint        = {1410.7775},
+  archiveprefix = {arXiv},
+  primaryclass  = {gr-qc},
+  doi           = {10.1088/0264-9381/32/6/065002},
+  journal       = {Class. Quant. Grav.},
+  volume        = {32},
+  number        = {6},
+  pages         = {065002},
+  year          = {2015}
+}
+
 @article{Bohn:2016afc,
   author        = {Bohn, Andy and Kidder, Lawrence E. and Teukolsky, Saul A.},
   title         = {Parallel adaptive event horizon finder for numerical

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   DerivativesOfSpacetimeMetric.cpp
   ExtrinsicCurvature.cpp
   GeodesicAcceleration.cpp
+  GeodesicEquation.cpp
   InterfaceNullNormal.cpp
   InverseSpacetimeMetric.cpp
   KerrSchildCoords.cpp
@@ -46,6 +47,7 @@ spectre_target_headers(
   DetAndInverseSpatialMetric.hpp
   ExtrinsicCurvature.hpp
   GeodesicAcceleration.hpp
+  GeodesicEquation.hpp
   InterfaceNullNormal.hpp
   InverseSpacetimeMetric.hpp
   KerrSchildCoords.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/GeodesicEquation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeodesicEquation.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/GeodesicEquation.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+
+template <typename DataType, size_t Dim, typename Frame>
+void geodesic_equation(
+    // Output time derivs
+    const gsl::not_null<tnsr::I<DataType, Dim, Frame>*> dt_x,
+    const gsl::not_null<tnsr::i<DataType, Dim, Frame>*> dt_pi,
+    const gsl::not_null<Scalar<DataType>*> dt_lnp0,
+    // Current state
+    const tnsr::I<DataType, Dim, Frame>& /*x*/,
+    const tnsr::i<DataType, Dim, Frame>& pi, const Scalar<DataType>& /*lnp0*/,
+    // Background spacetime
+    const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, Dim, Frame>& deriv_lapse,
+    const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::iJ<DataType, Dim, Frame>& deriv_shift,
+    const tnsr::II<DataType, Dim, Frame>& inv_spatial_metric,
+    const tnsr::iJJ<DataType, Dim, Frame>& deriv_inv_spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& extrinsic_curvature) {
+  {
+    // Scope where we reuse allocation of dt_x as upper_pi
+    auto& upper_pi = *dt_x;
+    raise_or_lower_index(make_not_null(&upper_pi), pi, inv_spatial_metric);
+    tenex::evaluate(dt_lnp0, -deriv_lapse(ti::i) * upper_pi(ti::I) +
+                                 lapse() * extrinsic_curvature(ti::i, ti::j) *
+                                     upper_pi(ti::I) * upper_pi(ti::J));
+  }
+  // Complete computation of dt_x
+  tenex::update<ti::I>(dt_x, lapse() * (*dt_x)(ti::I)-shift(ti::I));
+  // Compute dt_pi
+  tenex::evaluate<ti::i>(
+      dt_pi, -deriv_lapse(ti::i) - (*dt_lnp0)() * pi(ti::i) +
+                 deriv_shift(ti::i, ti::K) * pi(ti::k) -
+                 0.5 * lapse() * deriv_inv_spatial_metric(ti::i, ti::J, ti::K) *
+                     pi(ti::j) * pi(ti::k));
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void geodesic_equation(                                             \
+      gsl::not_null<tnsr::I<DTYPE(data), DIM(data), FRAME(data)>*> dt_x,       \
+      gsl::not_null<tnsr::i<DTYPE(data), DIM(data), FRAME(data)>*> dt_pi,      \
+      gsl::not_null<Scalar<DTYPE(data)>*> dt_lnp0,                             \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x,                   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& pi,                  \
+      const Scalar<DTYPE(data)>& lnp0, const Scalar<DTYPE(data)>& lapse,       \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,         \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,               \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>& deriv_shift,        \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>& inv_spatial_metric, \
+      const tnsr::iJJ<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          deriv_inv_spatial_metric,                                            \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          extrinsic_curvature);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double), (3), (Frame::Inertial))
+
+#undef DTYPE
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/GeodesicEquation.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GeodesicEquation.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+
+/*!
+ * \brief First-order formulation of the geodesic equation for null geodesics
+ * that is suitable for ray tracing.
+ *
+ * This is the formulation of the geodesic equation that is originally used for
+ * ray tracing in \cite Bohn:2014xxa (Eq. (4)) and \cite Bohn:2016afc (Eq. (6)).
+ *
+ * For null rays with position $x^\mu$, proper time (or affine geodesic
+ * parameter) $\tau$, and four-momentum $p^\mu = dx^\mu / d\tau$, we first
+ * define the momentum variable
+ * \begin{equation}
+ *   \Pi_i = \frac{p_i}{\alpha p^0} = \frac{p_i}{\sqrt{\gamma^{jk} p_j p_k}}
+ *   \text{.}
+ * \end{equation}
+ * Here we work in a 3+1 decomposition of spacetime with time coordinate $t$,
+ * lapse $\alpha$, shift $\beta^i$, spatial metric $\gamma_{ij}$, and
+ * extrinsic curvature $K_{ij}$.
+ * Then, the geodesic equation is given by
+ * \begin{align}
+ *   \frac{d \Pi_i}{d t} &= -\partial_i \alpha + (\Pi^j \partial_j \alpha
+ *     -\alpha K_{jk}\Pi^j\Pi^k) \Pi_i) + \Pi_k \partial_i \beta^k
+ *     - \frac{1}{2} \alpha \Pi_j\Pi_k \partial_i \gamma^{jk} \\
+ *   \frac{d x^i}{d t} &= \alpha \Pi^i - \beta^i
+ *   \text{.}
+ * \end{align}
+ *
+ * This function also computes the evolution of the additional redshift variable
+ * $\ln(\alpha p^0)$ (Eq. (5) in \cite Bohn:2014xxa) as
+ * \begin{equation}
+ *   \frac{d \ln(\alpha p^0)}{d t} = -\Pi^i \partial_i \alpha
+ *     + \alpha K_{ij} \Pi^i \Pi^j
+ *   \text{.}
+ * \end{equation}
+ */
+template <typename DataType, size_t Dim, typename Frame>
+void geodesic_equation(
+    // Output time derivs
+    gsl::not_null<tnsr::I<DataType, Dim, Frame>*> dt_x,
+    gsl::not_null<tnsr::i<DataType, Dim, Frame>*> dt_pi,
+    gsl::not_null<Scalar<DataType>*> dt_lnp0,
+    // Current state
+    const tnsr::I<DataType, Dim, Frame>& x,
+    const tnsr::i<DataType, Dim, Frame>& pi, const Scalar<DataType>& lnp0,
+    // Background spacetime
+    const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, Dim, Frame>& deriv_lapse,
+    const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::iJ<DataType, Dim, Frame>& deriv_shift,
+    const tnsr::II<DataType, Dim, Frame>& inv_spatial_metric,
+    const tnsr::iJJ<DataType, Dim, Frame>& deriv_inv_spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& extrinsic_curvature);
+
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ComputeGhQuantities.cpp
   Test_ComputeSpacetimeQuantities.cpp
   Test_GeodesicAcceleration.cpp
+  Test_GeodesicEquation.cpp
   Test_InterfaceNullNormal.cpp
   Test_KerrSchildCoords.cpp
   Test_ProjectionOperators.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GeodesicEquation.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GeodesicEquation.py
@@ -1,0 +1,42 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def geodesic_equation(
+    x,
+    pi,
+    lnp0,
+    lapse,
+    deriv_lapse,
+    shift,
+    deriv_shift,
+    inv_spatial_metric,
+    deriv_inv_spatial_metric,
+    extrinsic_curvature,
+):
+    pi_upper = np.einsum("ij,j", inv_spatial_metric, pi)
+    dt_lnp0 = -np.einsum("i,i", deriv_lapse, pi_upper) + lapse * np.einsum(
+        "ij,i,j", extrinsic_curvature, pi_upper, pi_upper
+    )
+    dt_x = lapse * pi_upper - shift
+    dt_pi = (
+        -deriv_lapse
+        - dt_lnp0 * pi
+        + np.einsum("ik,k", deriv_shift, pi)
+        - 0.5 * lapse * np.einsum("ijk,j,k", deriv_inv_spatial_metric, pi, pi)
+    )
+    return [dt_x, dt_pi, dt_lnp0]
+
+
+def dt_x(*args):
+    return geodesic_equation(*args)[0]
+
+
+def dt_pi(*args):
+    return geodesic_equation(*args)[1]
+
+
+def dt_lnp0(*args):
+    return geodesic_equation(*args)[2]

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_GeodesicEquation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_GeodesicEquation.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeodesicEquation.hpp"
+
+namespace gr {
+
+SPECTRE_TEST_CASE("Unit.GeneralRelativity.GeodesicEquation",
+                  "[Unit][PointwiseFunctions]") {
+  MAKE_GENERATOR(generator);
+  const pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity");
+  pypp::check_with_random_values<1>(
+      &geodesic_equation<double, 3, Frame::Inertial>, "GeodesicEquation",
+      {"dt_x", "dt_pi", "dt_lnp0"}, {{{-1., 1.}}}, DataVector(5));
+}
+
+}  // namespace gr


### PR DESCRIPTION
## Proposed changes

Adds the formulation of the geodesic equation used for ray tracing in https://arxiv.org/abs/1410.7775.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
