### PR TITLE
Update ScalarTensor executable

### DIFF
--- a/src/Evolution/Executables/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarTensor/CMakeLists.txt
@@ -1,20 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(EXECUTABLE EvolveScalarTensorSingleBlackHole)
-
-add_spectre_executable(
-  ${EXECUTABLE}
-  EXCLUDE_FROM_ALL
-  EvolveScalarTensorSingleBlackHole.cpp
-  )
-
-target_link_libraries(
-  ${EXECUTABLE}
-  PRIVATE
+set(LIBS_TO_LINK
   Actions
   ApparentHorizonFinder
-  Cce
   Charmxx::main
   ControlSystem
   CoordinateMaps
@@ -46,4 +35,17 @@ target_link_libraries(
   Serialization
   Time
   Utilities
+  )
+
+set(SINGLE_BH_EXECUTABLE EvolveScalarTensorSingleBlackHole)
+add_spectre_executable(
+  ${SINGLE_BH_EXECUTABLE}
+  EXCLUDE_FROM_ALL
+  EvolveScalarTensorSingleBlackHole.cpp
+  )
+target_link_libraries(
+  ${SINGLE_BH_EXECUTABLE}
+  PRIVATE
+  ${LIBS_TO_LINK}
+  Cce
   )

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -8,9 +8,13 @@
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
 #include "ControlSystem/Component.hpp"
+#include "ControlSystem/ControlErrors/Size/Factory.hpp"
+#include "ControlSystem/ControlErrors/Size/State.hpp"
 #include "ControlSystem/Measurements/SingleHorizon.hpp"
 #include "ControlSystem/Metafunctions.hpp"
 #include "ControlSystem/Systems/Shape.hpp"
+#include "ControlSystem/Systems/Size.hpp"
+#include "ControlSystem/Systems/Translation.hpp"
 #include "ControlSystem/Trigger.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Evolution/Actions/RunEventsAndTriggers.hpp"
@@ -32,6 +36,8 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ObserveCenters.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/InitializeInterpolationTarget.hpp"
@@ -53,9 +59,13 @@
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeSlabSize/Tags.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/Tags/StepperErrors.hpp"
 #include "Time/Tags/Time.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
 struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
@@ -70,26 +80,30 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
       "field \n"
       "on a domain with a single horizon and corresponding excised region"};
 
-  struct AhA : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
+  template <typename Frame>
+  struct Ah : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
     using temporal_id = ::Tags::Time;
-    using tags_to_observe = ::ah::tags_for_observing<Frame::Inertial>;
+    using tags_to_observe = ::ah::tags_for_observing<Frame>;
     using surface_tags_to_observe = ::ah::surface_tags_for_observing;
     using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
     using vars_to_interpolate_to_target =
-        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>;
+        ::ah::vars_to_interpolate_to_target<volume_dim, Frame>;
     using compute_items_on_target =
-        ::ah::compute_items_on_target<volume_dim, Frame::Inertial>;
+        ::ah::compute_items_on_target<volume_dim, Frame>;
     using compute_target_points =
-        intrp::TargetPoints::ApparentHorizon<AhA, ::Frame::Inertial>;
-    using post_interpolation_callbacks = tmpl::list<
-        intrp::callbacks::FindApparentHorizon<AhA, ::Frame::Inertial>>;
+        intrp::TargetPoints::ApparentHorizon<Ah, Frame>;
+    using post_interpolation_callbacks =
+        tmpl::list<intrp::callbacks::FindApparentHorizon<Ah, Frame>>;
     using horizon_find_failure_callbacks =
         tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>;
     using post_horizon_find_callbacks = tmpl::list<
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, AhA>,
-        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, AhA,
-                                             ::Frame::Inertial>>;
+        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Ah>,
+        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, Ah,
+                                             Frame>,
+        ::ah::callbacks::ObserveCenters<Ah, Frame>>;
   };
+
+  using ApparentHorizon = Ah<::Frame::Distorted>;
 
   struct ExcisionBoundaryA
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -130,10 +144,17 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
     using interpolating_component = typename metavariables::st_dg_element_array;
   };
 
-  using control_systems = tmpl::list<control_system::Systems::Shape<
-      ::domain::ObjectLabel::None, 2,
-      control_system::measurements::SingleHorizon<
-          ::domain::ObjectLabel::None>>>;
+  using control_systems =
+      tmpl::list<control_system::Systems::Shape<
+                     ::domain::ObjectLabel::None, 2,
+                     control_system::measurements::SingleHorizon<
+                         ::domain::ObjectLabel::None>>,
+                 control_system::Systems::Translation<
+                     2,
+                     control_system::measurements::SingleHorizon<
+                         ::domain::ObjectLabel::None>,
+                     1>,
+                 control_system::Systems::Size<::domain::ObjectLabel::None, 2>>;
 
   static constexpr bool use_control_systems =
       tmpl::size<control_systems>::value > 0;
@@ -142,7 +163,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
 
   using interpolation_target_tags = tmpl::push_back<
       control_system::metafunctions::interpolation_target_tags<control_systems>,
-      AhA, ExcisionBoundaryA, SphericalSurface, BondiSachs>;
+      ApparentHorizon, ExcisionBoundaryA, SphericalSurface, BondiSachs>;
   using interpolator_source_vars = ::ah::source_vars<volume_dim>;
 
   using scalar_charge_interpolator_source_vars =
@@ -185,17 +206,21 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
         tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<
-                intrp::Events::Interpolate<volume_dim, AhA,
+                intrp::Events::Interpolate<volume_dim, ApparentHorizon,
                                            interpolator_source_vars>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     3, BondiSachs, source_vars_no_deriv>,
+                control_system::metafunctions::control_system_events<
+                    control_systems>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     volume_dim, ExcisionBoundaryA, interpolator_source_vars>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     volume_dim, SphericalSurface,
                     scalar_charge_interpolator_source_vars>>>>,
         tmpl::pair<DenseTrigger,
-                   control_system::control_system_triggers<control_systems>>>;
+                   control_system::control_system_triggers<control_systems>>,
+        tmpl::pair<control_system::size::State,
+                   control_system::size::States::factory_creatable_states>>;
   };
 
   using typename st_base::const_global_cache_tags;
@@ -203,7 +228,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::push_back<
           tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename AhA::post_horizon_find_callbacks>>;
+          typename ApparentHorizon::post_horizon_find_callbacks>>;
 
   using dg_registration_list =
       tmpl::push_back<typename st_base::dg_registration_list,
@@ -252,7 +277,14 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
                   evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::PostFailureCleanup,
+              tmpl::list<Actions::RunEventsOnFailure<::Tags::Time>,
+                         Parallel::Actions::TerminatePhase>>>>>;
+
+  // ControlSystem/Measurements/CharSpeed.hpp assumes gh_dg_element_array
+  using gh_dg_element_array = st_dg_element_array;
 
   template <typename ParallelComponent>
   struct registration_list {

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -459,9 +459,6 @@ struct ScalarTensorTemplateBase {
       dg::Actions::Filter<Filters::Exponential<1>,
                           system::scalar_system::variables_tag::tags_list>>;
 
-  //   // For labeling the yaml option for RandomizeVariables
-  //   struct RandomizeInitialGuess {};
-
   template <bool UseControlSystems>
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
@@ -469,11 +466,6 @@ struct ScalarTensorTemplateBase {
           evolution::dg::Initialization::Domain<volume_dim, UseControlSystems>,
           Initialization::TimeStepperHistory<derived_metavars>>,
       Initialization::Actions::NonconservativeSystem<system>,
-      evolution::Initialization::Actions::SetVariables<
-          domain::Tags::Coordinates<volume_dim, Frame::ElementLogical>>,
-      // Random noise system::variables_tag
-      //   Actions::RandomizeVariables<typename system::variables_tag,
-      //                               RandomizeInitialGuess>,
       Initialization::Actions::AddComputeTags<::Tags::DerivCompute<
           typename system::variables_tag, domain::Tags::Mesh<volume_dim>,
           domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -178,6 +178,7 @@ constexpr auto make_default_phase_order() {
 
 struct ObserverTags {
   static constexpr size_t volume_dim = 3_st;
+  static constexpr bool backreaction_is_enabled = false;
 
   using system = ScalarTensor::System;
 
@@ -267,8 +268,12 @@ struct ObserverTags {
           ::domain::Tags::Coordinates<volume_dim, Frame::Inertial>>,
       // The 4-index constraint is only implemented in 3d
       tmpl::list<
+          tmpl::conditional_t<
+              backreaction_is_enabled,
+              ScalarTensor::Tags::FConstraintCompute<
+                  volume_dim, Frame::Inertial>,
+              gh::Tags::FConstraintCompute<volume_dim, Frame::Inertial>>,
           gh::Tags::FourIndexConstraintCompute<volume_dim, Frame::Inertial>,
-          ScalarTensor::Tags::FConstraintCompute<volume_dim, Frame::Inertial>,
           ::Tags::PointwiseL2NormCompute<
               gh::Tags::FConstraint<DataVector, volume_dim>>,
           ::Tags::PointwiseL2NormCompute<

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -208,8 +208,7 @@ struct ObserverTags {
                                          Frame::Inertial>,
           gr::Tags::Shift<DataVector, volume_dim, Frame::Inertial>,
           gr::Tags::Lapse<DataVector>,
-          gr::Tags::SqrtDetSpatialMetricCompute<DataVector, volume_dim,
-                                                Frame::Inertial>,
+          gr::Tags::SqrtDetSpatialMetric<DataVector>,
           gr::Tags::SpacetimeNormalOneFormCompute<DataVector, volume_dim,
                                                   Frame::Inertial>,
           gr::Tags::SpacetimeNormalVector<DataVector, volume_dim,
@@ -228,19 +227,16 @@ struct ObserverTags {
                                                       Frame::Inertial>,
           gr::Tags::ExtrinsicCurvature<DataVector, volume_dim, Frame::Inertial>,
           gr::Tags::TraceExtrinsicCurvature<DataVector>,
+          // More 3 plus 1 variables
+          ::Tags::deriv<gr::Tags::SpatialChristoffelSecondKind<
+                            DataVector, volume_dim, Frame::Inertial>,
+                        tmpl::size_t<volume_dim>, Frame::Inertial>,
+          gr::Tags::SpatialRicci<DataVector, volume_dim, Frame::Inertial>,
+          gr::Tags::SpatialRicciScalar<DataVector>,
           // Compute the constraints of GH
           gh::Tags::GaugeConstraintCompute<volume_dim, Frame::Inertial>,
           gh::Tags::TwoIndexConstraintCompute<volume_dim, Frame::Inertial>,
           gh::Tags::ThreeIndexConstraintCompute<volume_dim, Frame::Inertial>,
-          ::Tags::DerivTensorCompute<
-              gr::Tags::SpatialChristoffelSecondKind<DataVector, volume_dim>,
-              ::domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
-                                              Frame::Inertial>,
-              ::domain::Tags::Mesh<volume_dim>>,
-          gr::Tags::SpatialRicciCompute<DataVector, volume_dim,
-                                        ::Frame::Inertial>,
-          gr::Tags::SpatialRicciScalarCompute<DataVector, volume_dim,
-                                              ::Frame::Inertial>,
           // Compute the constraints of CSW
           ScalarTensor::Tags::CswOneIndexConstraintCompute<volume_dim>,
           ScalarTensor::Tags::CswTwoIndexConstraintCompute<volume_dim>,
@@ -259,6 +255,10 @@ struct ObserverTags {
           // Damping parameters
           gh::Tags::ConstraintGamma0, gh::Tags::ConstraintGamma1,
           gh::Tags::ConstraintGamma2,
+          ScalarTensor::Tags::CswCompute<
+              CurvedScalarWave::Tags::ConstraintGamma1>,
+          ScalarTensor::Tags::CswCompute<
+              CurvedScalarWave::Tags::ConstraintGamma2>,
           // Sources
           ScalarTensor::Tags::TraceReversedStressEnergyCompute,
           ScalarTensor::Tags::ScalarSource,
@@ -274,13 +274,14 @@ struct ObserverTags {
           ::Tags::PointwiseL2NormCompute<
               gh::Tags::FourIndexConstraint<DataVector, volume_dim>>,
           gh::Tags::ConstraintEnergyCompute<volume_dim, Frame::Inertial>,
-          ::Tags::DerivTensorCompute<
-              gr::Tags::ExtrinsicCurvature<DataVector, volume_dim>,
-              ::domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
-                                              Frame::Inertial>,
-              ::domain::Tags::Mesh<volume_dim>>,
-          gr::Tags::WeylElectricCompute<DataVector, volume_dim,
-                                        Frame::Inertial>,
+          ::Tags::deriv<gr::Tags::ExtrinsicCurvature<DataVector, volume_dim,
+                                                     Frame::Inertial>,
+                        tmpl::size_t<volume_dim>, Frame::Inertial>,
+          gr::Tags::CovariantDerivativeOfExtrinsicCurvature<
+              DataVector, volume_dim, Frame::Inertial>,
+          gr::Tags::WeylElectric<DataVector, volume_dim, Frame::Inertial>,
+          gr::Tags::WeylElectricScalar<DataVector>,
+          gr::Tags::WeylMagneticScalar<DataVector>,
           gr::Tags::Psi4RealCompute<Frame::Inertial>>>;
   using non_tensor_compute_tags = tmpl::list<
       ::Events::Tags::ObserverMeshCompute<volume_dim>,
@@ -400,9 +401,7 @@ struct ScalarTensorTemplateBase {
           tmpl::at<typename factory_creation::factory_classes, Event>>>;
 
   using initialize_initial_data_dependent_quantities_actions = tmpl::list<
-      Initialization::Actions::AddComputeTags<
-          ScalarTensor::Initialization::scalar_tensor_3plus1_compute_tags<
-              volume_dim>>,
+      ScalarTensor::Actions::InitializeGhAnd3Plus1Variables,
       Actions::MutateApply<gh::gauges::SetPiAndPhiFromConstraints<
           gh::ScalarTensor::AnalyticData::all_analytic_data, volume_dim>>,
       Parallel::Actions::TerminatePhase>;

--- a/src/Evolution/Systems/ScalarTensor/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Initialize.hpp
@@ -36,8 +36,8 @@
 #include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/ScalarTensor/ConstraintDampingTags.hpp"
 #include "PointwiseFunctions/ScalarTensor/ConstraintGammas.hpp"
+#include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/ScalarSource.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Tags.hpp"
-#include "PointwiseFunctions/ScalarTensor/ScalarSource.hpp"
 #include "PointwiseFunctions/ScalarTensor/SourceTags.hpp"
 #include "Utilities/TMPL.hpp"
 

--- a/src/Evolution/Systems/ScalarTensor/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Initialize.hpp
@@ -11,9 +11,12 @@
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/ScalarTensor/Tags.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintDampingTags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
@@ -22,29 +25,35 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/ScalarTensor/ConstraintDampingTags.hpp"
 #include "PointwiseFunctions/ScalarTensor/ConstraintGammas.hpp"
+#include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Tags.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarSource.hpp"
+#include "PointwiseFunctions/ScalarTensor/SourceTags.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace ScalarTensor::Initialization {
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+/// \endcond
 
-/// \brief List of compute tags to be initialized in the ScalarTensor system
-///
-/// \details The compute tags required include those specified in
-/// ::gh::Actions::InitializeGhAnd3Plus1Variables as well as the tags required
-/// to compute spacetime quantities appearing in the scalar evolution equations.
-/// Namely, we include the compute tags associated to the trace of the extrinsic
-/// curvature and the trace of the spatial Christoffel symbol, as well as the
-/// compute tag required to calculate the source term of the scalar equation.
+namespace ScalarTensor {
+namespace Initialization {
+/// \brief List of basic compute tags to initialize the the ScalarTensor without
+/// scalar sources
 template <size_t Dim, typename Fr = Frame::Inertial>
-using scalar_tensor_3plus1_compute_tags = tmpl::list<
+using scalar_tensor_basic_compute_tags = tmpl::list<
     // Needed to compute the characteristic speeds for the AH finder
     gr::Tags::SpatialMetricCompute<DataVector, Dim, Fr>,
     gr::Tags::DetAndInverseSpatialMetricCompute<DataVector, Dim, Fr>,
@@ -76,4 +85,70 @@ using scalar_tensor_3plus1_compute_tags = tmpl::list<
 
     ScalarTensor::Tags::ScalarSourceCompute>;
 
-}  // namespace ScalarTensor::Initialization
+/// \brief List of compute tags to the coupling to curvature
+template <size_t Dim, typename Fr = Frame::Inertial>
+using sgb_extra_compute_tags = tmpl::list<
+    ::Tags::DerivTensorCompute<
+        gr::Tags::ExtrinsicCurvature<DataVector, Dim, Fr>,
+        ::domain::Tags::InverseJacobian<Dim, ::Frame::ElementLogical,
+                                        ::Frame::Inertial>,
+        ::domain::Tags::Mesh<Dim>>,
+    gr::Tags::CovariantDerivativeOfExtrinsicCurvatureCompute<Dim, Fr>,
+    ::Tags::DerivTensorCompute<
+        gr::Tags::SpatialChristoffelSecondKind<DataVector, Dim, Fr>,
+        ::domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                        Frame::Inertial>,
+        ::domain::Tags::Mesh<Dim>>,
+    gr::Tags::SpatialRicciCompute<DataVector, Dim, Fr>,
+    gr::Tags::SpatialRicciScalarCompute<DataVector, Dim, Fr>,
+    gr::Tags::WeylElectricCompute<DataVector, Dim, Fr>,
+    gr::Tags::WeylElectricScalarCompute<DataVector, Dim, Fr>,
+    gr::Tags::SqrtDetSpatialMetricCompute<DataVector, Dim, Fr>,
+    gr::Tags::WeylMagneticCompute<DataVector, Dim, Fr>,
+    gr::Tags::WeylMagneticScalarCompute<DataVector, Dim, Fr>>;
+
+/// \brief List of compute tags to be initialized in the ScalarTensor system
+///
+/// \details The compute tags required include those specified in
+/// ::gh::Actions::InitializeGhAnd3Plus1Variables as well as the tags required
+/// to compute spacetime quantities appearing in the scalar evolution equations.
+/// Namely, we include the compute tags associated to the trace of the extrinsic
+/// curvature and the trace of the spatial Christoffel symbol, as well as the
+/// compute tag required to calculate the source term of the scalar equation.
+template <size_t Dim, typename Fr = Frame::Inertial>
+using scalar_tensor_3plus1_compute_tags =
+    tmpl::append<scalar_tensor_basic_compute_tags<Dim, Fr>,
+                 sgb_extra_compute_tags<Dim, Fr>>;
+}  // namespace Initialization
+
+namespace Actions {
+struct InitializeGhAnd3Plus1Variables {
+  static constexpr size_t volume_dim = 3;
+  using frame = Frame::Inertial;
+  using compute_tags = db::AddComputeTags<
+      Initialization::scalar_tensor_3plus1_compute_tags<volume_dim, frame>>;
+
+  using const_global_cache_tags = tmpl::list<
+      gh::Tags::DampingFunctionGamma0<volume_dim, Frame::Grid>,
+      gh::Tags::DampingFunctionGamma1<volume_dim, Frame::Grid>,
+      gh::Tags::DampingFunctionGamma2<volume_dim, Frame::Grid>,
+      ScalarTensor::Tags::DampingFunctionGamma1<volume_dim, Frame::Grid>,
+      ScalarTensor::Tags::DampingFunctionGamma2<volume_dim, Frame::Grid>,
+      ScalarTensor::Tags::RampUpParameters,
+      ScalarTensor::Tags::CouplingParameters, ScalarTensor::Tags::ScalarMass>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace Actions
+
+}  // namespace ScalarTensor

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
@@ -170,7 +170,9 @@ evolution::dg::TimeDerivativeDecisions<3> TimeDerivative::apply(
   trace_reversed_stress_energy(stress_energy, pi_scalar, phi_scalar,
                                lapse_scalar, shift_scalar);
 
-  add_stress_energy_term_to_dt_pi(dt_pi, *stress_energy, lapse_scalar);
+  if constexpr (backreaction_is_enabled) {
+    add_stress_energy_term_to_dt_pi(dt_pi, *stress_energy, lapse_scalar);
+  }
 
   add_scalar_source_to_dt_pi_scalar(dt_pi_scalar, scalar_source, lapse_scalar);
   return {true};

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
@@ -38,9 +38,14 @@ namespace ScalarTensor {
  * to the \f$\partial_t \Pi_{a b}\f$ variable in the Generalized Harmonic
  * system, as well as adding any scalar sources to the variable \f$\partial_t
  * \Pi\f$.
+ *
+ * \warning Backreaction of the scalar field onto the metric is currently
+ * disabled and the system is evolved in the test-field (or decoupling)
+ * approximation.
  */
 struct TimeDerivative {
   static constexpr size_t dim = 3;
+  static constexpr bool backreaction_is_enabled = false;
   using gh_dt_tags =
       db::wrap_tags_in<::Tags::dt,
                        typename gh::System<dim>::variables_tag::tags_list>;

--- a/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/ScalarSource.hpp
+++ b/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/ScalarSource.hpp
@@ -9,6 +9,7 @@
 #include "Evolution/Systems/ScalarTensor/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/CouplingParameters.hpp"
+#include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Tags.hpp"
 #include "PointwiseFunctions/ScalarTensor/SourceTags.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/Gsl.hpp"
@@ -91,5 +92,29 @@ void multiply_by_negative_second_deriv_of_coupling_func(
     const Scalar<DataVector>& psi,
     const CouplingParameterOptions& coupling_parameters,
     std::pair<double, double> start_and_ramp_times, double time);
+
+namespace Tags {
+/*!
+ * \copydoc ScalarTensor::gauss_bonnet_scalar_source
+ */
+struct ScalarSourceCompute : ScalarSource, db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::WeylElectricScalar<DataVector>,
+      gr::Tags::WeylMagneticScalar<DataVector>, CurvedScalarWave::Tags::Psi,
+      ScalarTensor::Tags::CouplingParameters, ScalarTensor::Tags::ScalarMass,
+      ScalarTensor::Tags::RampUpParameters, ::Tags::Time>;
+  using return_type = Scalar<DataVector>;
+  static constexpr void (*function)(
+      const gsl::not_null<Scalar<DataVector>*> /* scalar_source */,
+      const Scalar<DataVector>& /* weyl_electric_scalar */,
+      const Scalar<DataVector>& /* weyl_magnetic_scalar */,
+      const Scalar<DataVector>& /* psi */,
+      const CouplingParameterOptions& /* coupling_parameters */,
+      const double /* mass_psi */,
+      const std::pair<double, double> /* start_and_ramp_times */,
+      const double /* time */) = &gauss_bonnet_scalar_source;
+  using base = ScalarSource;
+};
+}  // namespace Tags
 
 }  // namespace ScalarTensor

--- a/src/PointwiseFunctions/ScalarTensor/ScalarSource.hpp
+++ b/src/PointwiseFunctions/ScalarTensor/ScalarSource.hpp
@@ -3,13 +3,7 @@
 
 #pragma once
 
-#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
-#include "Evolution/Systems/ScalarTensor/Tags.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "PointwiseFunctions/ScalarTensor/SourceTags.hpp"
-#include "Time/Tags/Time.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace ScalarTensor {
@@ -76,23 +70,4 @@ void add_scalar_source_to_dt_pi_scalar(
 void mass_source(gsl::not_null<Scalar<DataVector>*> scalar_source,
                  const Scalar<DataVector>& psi, double mass_psi);
 
-namespace Tags {
-
-/*!
- * \brief Compute tag for the scalar source.
- *
- * \details Compute the scalar source from data box items using
- * `mass_source`.
- */
-struct ScalarSourceCompute : ScalarSource, db::ComputeTag {
-  using argument_tags =
-      tmpl::list<CurvedScalarWave::Tags::Psi, ScalarTensor::Tags::ScalarMass>;
-  using return_type = Scalar<DataVector>;
-  static constexpr void (*function)(const gsl::not_null<return_type*> result,
-                                    const Scalar<DataVector>&,
-                                    const double) = &mass_source;
-  using base = ScalarSource;
-};
-
-}  // namespace Tags
 }  // namespace ScalarTensor

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -11,7 +11,7 @@ ExpectedOutput:
   - KerrSchildSphericalHarmonicSurfaces.h5
 OutputFileChecks:
   - Label: "check_horizon_find"
-    Subfile: "/AhA.dat"
+    Subfile: "/Ah.dat"
     FileGlob: "KerrSchildSphericalHarmonicReductions.h5"
     AbsoluteTolerance: 1e2
 
@@ -19,10 +19,6 @@ OutputFileChecks:
 
 Parallelization:
   ElementDistribution: NumGridPoints
-
-ResourceInfo:
-  AvoidGlobalProc0: false
-  Singletons: Auto
 
 Evolution:
   InitialTime: 0.0
@@ -195,7 +191,7 @@ EventsAndTriggersAtSlabs:
           Interval: 2
           Offset: 2
     Events:
-      - AhA
+      - Ah
   - Trigger:
       Slabs:
         EvenlySpaced:
@@ -215,6 +211,14 @@ EventsAndTriggersAtSteps:
 
 EventsAndDenseTriggers:
 
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
+    - ObserveTimeStepVolume:
+        SubfileName: FailureTimeStep
+        FloatingPointType: Double
+        CoordinatesFloatingPointType: Float
+
 Observers:
   VolumeFileName: "KerrSchildSphericalHarmonicVolume"
   ReductionFileName: "KerrSchildSphericalHarmonicReductions"
@@ -225,27 +229,28 @@ Interpolator:
   Verbosity: Silent
 
 ApparentHorizons:
-  AhA: &AhA
+  Ah: &Ah
     InitialGuess:
       LMax: &LMax 4
       Radius: 2.2
-      Center: [0.0, 0.0, 0.0]
+      Center: [0., 0., 0.]
     FastFlow:
       Flow: Fast
       Alpha: 1.0
       Beta: 0.5
       AbsTol: 1e-12
-      TruncationTol: 1e-2
-      DivergenceTol: 1.2
+      TruncationTol: 1e-5
+      DivergenceTol: 5
       DivergenceIter: 5
       MaxIts: 100
-    Verbosity: Verbose
+    Verbosity: Quiet
     MaxInterpolationRetries: 3
-    BlocksForInterpolation: All
-  ControlSystemSingleAh: *AhA
+    BlocksForInterpolation: ["Shell0"]
+  ControlSystemSingleAh: *Ah
+  ControlSystemCharSpeedAh: *Ah
 
 InterpolationTargets:
-  ExcisionBoundaryA:
+  ExcisionBoundaryA: &ExBdry
     LMax: *LMax
     Center: [0.0, 0.0, 0.0]
     Radius: *InnerRadius
@@ -260,6 +265,7 @@ InterpolationTargets:
     Center: [0., 0., 0.]
     Radius: 12.0
     AngularOrdering: Strahlkorper
+  ControlSystemCharSpeedExcision: *ExBdry
 
 Cce:
   BondiSachsOutputFilePrefix: "BondiSachs"
@@ -269,5 +275,9 @@ ControlSystems:
   MeasurementsPerUpdate: 4
   Verbosity: Silent
   Shape: None
+  Translation: None
+  Size: None
 
-
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
@@ -32,6 +32,8 @@
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
                   "[Unit][Evolution]") {
+  // Backreaction of the scalar on the metric is currently disabled
+  static constexpr bool backreaction_is_enabled = false;
 
   using gh_dt_variables_tags = ScalarTensor::TimeDerivative::gh_dt_tags;
   using scalar_dt_variables_tags = ScalarTensor::TimeDerivative::scalar_dt_tags;
@@ -268,14 +270,15 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
 
   // When we have backreaction we also need to compute and apply the correction
   // to dt pi for the expected variables
-
-  ScalarTensor::add_stress_energy_term_to_dt_pi(
-      make_not_null(
-          &get<::Tags::dt<gh::Tags::Pi<DataVector, 3>>>(expected_dt_variables)),
-      get<ScalarTensor::Tags::TraceReversedStressEnergy<DataVector, 3,
-                                                        ::Frame::Inertial>>(
-          expected_temp_variables),
-      tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables));
+  if constexpr (backreaction_is_enabled) {
+    ScalarTensor::add_stress_energy_term_to_dt_pi(
+        make_not_null(&get<::Tags::dt<gh::Tags::Pi<DataVector, 3>>>(
+            expected_dt_variables)),
+        get<ScalarTensor::Tags::TraceReversedStressEnergy<DataVector, 3,
+                                                          ::Frame::Inertial>>(
+            expected_temp_variables),
+        tuples::get<gr::Tags::Lapse<DataVector>>(arg_variables));
+  }
 
   ScalarTensor::add_scalar_source_to_dt_pi_scalar(
       make_not_null(

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Test_ScalarSource.cpp
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Test_ScalarSource.cpp
@@ -67,6 +67,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarTensor.Sgb.ScalarSource",
   const pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/ScalarTensor"};
 
+  TestHelpers::db::test_compute_tag<ScalarTensor::Tags::ScalarSourceCompute>(
+      "ScalarSource");
+
   pypp::check_with_random_values<
       1,
       Scalar<DataVector> (*)(

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/Test_SourceTags.cpp
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/Test_SourceTags.cpp
@@ -20,6 +20,4 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarTensor.SourceTags",
       "0.0");
   TestHelpers::test_option_tag<ScalarTensor::OptionTags::RampUpDuration>(
       "100.0");
-  TestHelpers::db::test_compute_tag<ScalarTensor::Tags::ScalarSourceCompute>(
-      "ScalarSource");
 }


### PR DESCRIPTION
## Proposed changes

- Add extra 3+1 quantities to compute curvature scalars.
- Disable backreaction for consistency with the test-field approximation.
- Change `ScalarSource` compute tag to include the coupling to curvature.
- Update evolution executable for single black hole (among these changes, including control systems).

Depends on: #6155 #6647 #6638 #6650  

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
