### PR TITLE
Fix bug in AH finder initial guess

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp
@@ -30,7 +30,7 @@ namespace intrp::callbacks {
 struct ErrorOnFailedApparentHorizon {
   template <typename InterpolationTargetTag, typename DbTags,
             typename Metavariables, typename TemporalId>
-  static void apply(const db::DataBox<DbTags>& box,
+  static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const TemporalId& temporal_id,
                     const FastFlow::Status failure_reason) {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -186,19 +186,24 @@ struct FindApparentHorizon
       const auto& options = Parallel::get<
           intrp::Tags::ApparentHorizon<InterpolationTargetTag, Frame>>(*cache);
 
-      // Can't recover from the first iteration or if we've exceeded our number
-      // of attempts
-      if (current_iteration > 0 and failed_interpolation_iterations <=
-                                        options.max_interpolation_retries) {
-        // Move the new trial surface halfway between the current surface and
-        // the previous surface
+      // Can't recover if we've exceeded our number of attempts
+      if (failed_interpolation_iterations <=
+          options.max_interpolation_retries) {
         db::mutate<ylm::Tags::Strahlkorper<Frame>>(
-            [](const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
-               const ylm::Strahlkorper<Frame>&
-                   previous_strahlkorper_iteration) {
-              strahlkorper->coefficients() +=
-                  0.5 * (previous_strahlkorper_iteration.coefficients() -
-                         strahlkorper->coefficients());
+            [&](const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
+                const ylm::Strahlkorper<Frame>&
+                    previous_strahlkorper_iteration) {
+              if (current_iteration == 0) {
+                // If this is the zeroth iteration and we couldn't interpolate,
+                // then just try increasing the size of the horizon by 50%
+                strahlkorper->coefficients()[0] *= 1.5;
+              } else {
+                // Otherwise move the new trial surface halfway between the
+                // current surface and the previous surface
+                strahlkorper->coefficients() +=
+                    0.5 * (previous_strahlkorper_iteration.coefficients() -
+                           strahlkorper->coefficients());
+              }
             },
             box, db::get<ah::Tags::PreviousIterationStrahlkorper<Frame>>(*box));
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp
@@ -157,98 +157,20 @@ struct FindApparentHorizon
     if (current_iteration == 0) {
       // If we get here, we are in a new apparent horizon search, as
       // opposed to a subsequent iteration of the same horizon search.
-      //
-      // So put new initial guess into ylm::Tags::Strahlkorper<Frame>.
-      // We need to do this now, and not at the end of the previous horizon
-      // search, because only now do we know the temporal_id of this horizon
-      // search.
-      db::mutate<ylm::Tags::Strahlkorper<Frame>,
-                 ylm::Tags::PreviousStrahlkorpers<Frame>,
-                 ah::Tags::PreviousIterationStrahlkorper<Frame>,
+      db::mutate<ah::Tags::PreviousIterationStrahlkorper<Frame>,
                  ah::Tags::FailedInterpolationIterations>(
-          [&temporal_id](
-              const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
-              const gsl::not_null<
-                  std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>*>
-                  previous_strahlkorpers,
-              const gsl::not_null<ylm::Strahlkorper<Frame>*>
-                  previous_fast_flow_strahlkorper,
-              const gsl::not_null<size_t*> failed_interpolation_iterations) {
+          [](const gsl::not_null<ylm::Strahlkorper<Frame>*>
+                 previous_fast_flow_strahlkorper,
+             const gsl::not_null<size_t*> failed_interpolation_iterations,
+             const ylm::Strahlkorper<Frame>& strahlkorper) {
             // Reset to zero. Will only be used starting from the second
             // iteration
             *failed_interpolation_iterations = 0;
 
-            // If we have zero previous_strahlkorpers, then the
-            // initial guess is already in strahlkorper, so do
-            // nothing.
-            //
-            // If we have one previous_strahlkorper, then we have had
-            // a successful horizon find, and the initial guess for the
-            // next horizon find is already in strahlkorper, so
-            // again we do nothing.
-            //
-            // If we have 2 previous_strahlkorpers and the time of the second
-            // one is a NaN, this means that the corresponding
-            // previous_strahlkorper is the original initial guess, so
-            // again we do nothing.
-            //
-            // If we have 2 valid previous_strahlkorpers, then
-            // we set the initial guess by linear extrapolation in time
-            // using the last 2 previous_strahlkorpers.
-            //
-            // If we have 3 valid previous_strahlkorpers, then
-            // we set the initial guess by quadratic extrapolation in time
-            // using the last 3 previous_strahlkorpers.
-            //
-            // For extrapolation, we assume that
-            // * Expansion center of all the Strahlkorpers are equal.
-            // * Maximum L of all the Strahlkorpers are equal.
-            // It is easy to relax the max L assumption once we start
-            // adaptively changing the L of the strahlkorpers.
-            if (previous_strahlkorpers->size() > 1 and
-                not std::isnan((*previous_strahlkorpers)[1].first)) {
-              if (previous_strahlkorpers->size() > 2 and
-                  not std::isnan((*previous_strahlkorpers)[2].first)) {
-                // Quadratic extrapolation
-                const double new_time =
-                    InterpolationTarget_detail::get_temporal_id_value(
-                        temporal_id);
-                const double dt_0 =
-                    (*previous_strahlkorpers)[0].first - new_time;
-                const double dt_1 =
-                    (*previous_strahlkorpers)[1].first - new_time;
-                const double dt_2 =
-                    (*previous_strahlkorpers)[2].first - new_time;
-                const double fac_0 =
-                    dt_1 * dt_2 / ((dt_1 - dt_0) * (dt_2 - dt_0));
-                const double fac_1 =
-                    dt_0 * dt_2 / ((dt_2 - dt_1) * (dt_0 - dt_1));
-                const double fac_2 = 1.0 - fac_0 - fac_1;
-                strahlkorper->coefficients() =
-                    fac_0 * (*previous_strahlkorpers)[0].second.coefficients() +
-                    fac_1 * (*previous_strahlkorpers)[1].second.coefficients() +
-                    fac_2 * (*previous_strahlkorpers)[2].second.coefficients();
-              } else {
-                // Linear extrapolation
-                const double new_time =
-                    InterpolationTarget_detail::get_temporal_id_value(
-                        temporal_id);
-                const double dt_0 =
-                    (*previous_strahlkorpers)[0].first - new_time;
-                const double dt_1 =
-                    (*previous_strahlkorpers)[1].first - new_time;
-                const double fac_0 = dt_1 / (dt_1 - dt_0);
-                const double fac_1 = 1.0 - fac_0;
-                strahlkorper->coefficients() =
-                    fac_0 * (*previous_strahlkorpers)[0].second.coefficients() +
-                    fac_1 * (*previous_strahlkorpers)[1].second.coefficients();
-              }
-            }
-
             // First iteration the previous is just the initial guess
-            (*previous_fast_flow_strahlkorper) = *strahlkorper;
+            (*previous_fast_flow_strahlkorper) = strahlkorper;
           },
-          box);
+          box, db::get<ylm::Tags::Strahlkorper<Frame>>(*box));
     }
 
     // Deal with the possibility that some of the points might be

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp
@@ -30,7 +30,7 @@ namespace intrp::callbacks {
 struct IgnoreFailedApparentHorizon {
   template <typename InterpolationTargetTag, typename DbTags,
             typename Metavariables, typename TemporalId>
-  static void apply(const db::DataBox<DbTags>& box,
+  static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const TemporalId& temporal_id,
                     const FastFlow::Status failure_reason) {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
@@ -308,8 +308,7 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
 
   template <typename Metavariables, typename DbTags, typename TemporalId>
   static tnsr::I<DataVector, 3, Frame> points(
-      const db::DataBox<DbTags>& box,
-      const tmpl::type_<Metavariables>& /*meta*/,
+      db::DataBox<DbTags>& box, const tmpl::type_<Metavariables>& /*meta*/,
       const TemporalId& /*temporal_id*/) {
     const auto& fast_flow = db::get<::ah::Tags::FastFlow>(box);
     const auto& strahlkorper = db::get<ylm::Tags::Strahlkorper<Frame>>(box);

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
@@ -22,6 +22,7 @@
 #include "IO/Logging/Tags.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
@@ -314,29 +315,11 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
     const auto& strahlkorper = db::get<ylm::Tags::Strahlkorper<Frame>>(box);
 
     const size_t L_mesh = fast_flow.current_l_mesh(strahlkorper);
+
     const auto prolonged_strahlkorper =
         ylm::Strahlkorper<Frame>(L_mesh, L_mesh, strahlkorper);
 
-    Variables<tmpl::list<::Tags::Tempi<0, 2, ::Frame::Spherical<Frame>>,
-                         ::Tags::Tempi<1, 3, Frame>, ::Tags::TempScalar<2>>>
-        temp_buffer(prolonged_strahlkorper.ylm_spherepack().physical_size());
-
-    auto& theta_phi =
-        get<::Tags::Tempi<0, 2, ::Frame::Spherical<Frame>>>(temp_buffer);
-    auto& r_hat = get<::Tags::Tempi<1, 3, Frame>>(temp_buffer);
-    auto& radius = get<::Tags::TempScalar<2>>(temp_buffer);
-    ylm::Tags::ThetaPhiCompute<Frame>::function(make_not_null(&theta_phi),
-                                                prolonged_strahlkorper);
-    ylm::Tags::RhatCompute<Frame>::function(make_not_null(&r_hat), theta_phi);
-    ylm::Tags::RadiusCompute<Frame>::function(make_not_null(&radius),
-                                              prolonged_strahlkorper);
-
-    tnsr::I<DataVector, 3, Frame> prolonged_coords{};
-    ylm::Tags::CartesianCoordsCompute<Frame>::function(
-        make_not_null(&prolonged_coords), prolonged_strahlkorper, radius,
-        r_hat);
-
-    return prolonged_coords;
+    return ylm::cartesian_coords(prolonged_strahlkorper);
   }
 };
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp
@@ -309,8 +309,85 @@ struct ApparentHorizon : tt::ConformsTo<intrp::protocols::ComputeTargetPoints> {
   template <typename Metavariables, typename DbTags, typename TemporalId>
   static tnsr::I<DataVector, 3, Frame> points(
       db::DataBox<DbTags>& box, const tmpl::type_<Metavariables>& /*meta*/,
-      const TemporalId& /*temporal_id*/) {
+      const TemporalId& temporal_id) {
     const auto& fast_flow = db::get<::ah::Tags::FastFlow>(box);
+
+    if (fast_flow.current_iteration() == 0) {
+      // Put new initial guess into ylm::Tags::Strahlkorper<Frame>.
+      // We need to do this now, and not at the end of the previous horizon
+      // search, because only now do we know the temporal_id of this horizon
+      // search.
+      db::mutate<ylm::Tags::Strahlkorper<Frame>>(
+          [&temporal_id](
+              const gsl::not_null<ylm::Strahlkorper<Frame>*> strahlkorper,
+              const std::deque<std::pair<double, ylm::Strahlkorper<Frame>>>&
+                  previous_strahlkorpers) {
+            // If we have zero previous_strahlkorpers, then the
+            // initial guess is already in strahlkorper, so do
+            // nothing.
+            //
+            // If we have one previous_strahlkorper, then we have had
+            // a successful horizon find, and the initial guess for the
+            // next horizon find is already in strahlkorper, so
+            // again we do nothing.
+            //
+            // If we have 2 previous_strahlkorpers and the time of the second
+            // one is a NaN, this means that the corresponding
+            // previous_strahlkorper is the original initial guess, so
+            // again we do nothing.
+            //
+            // If we have 2 valid previous_strahlkorpers, then
+            // we set the initial guess by linear extrapolation in time
+            // using the last 2 previous_strahlkorpers.
+            //
+            // If we have 3 valid previous_strahlkorpers, then
+            // we set the initial guess by quadratic extrapolation in time
+            // using the last 3 previous_strahlkorpers.
+            //
+            // For extrapolation, we assume that
+            // * Expansion center of all the Strahlkorpers are equal.
+            // * Maximum L of all the Strahlkorpers are equal.
+            // It is easy to relax the max L assumption once we start
+            // adaptively changing the L of the strahlkorpers.
+            if (previous_strahlkorpers.size() > 1 and
+                not std::isnan(previous_strahlkorpers[1].first)) {
+              if (previous_strahlkorpers.size() > 2 and
+                  not std::isnan(previous_strahlkorpers[2].first)) {
+                // Quadratic extrapolation
+                const double new_time =
+                    InterpolationTarget_detail::get_temporal_id_value(
+                        temporal_id);
+                const double dt_0 = previous_strahlkorpers[0].first - new_time;
+                const double dt_1 = previous_strahlkorpers[1].first - new_time;
+                const double dt_2 = previous_strahlkorpers[2].first - new_time;
+                const double fac_0 =
+                    dt_1 * dt_2 / ((dt_1 - dt_0) * (dt_2 - dt_0));
+                const double fac_1 =
+                    dt_0 * dt_2 / ((dt_2 - dt_1) * (dt_0 - dt_1));
+                const double fac_2 = 1.0 - fac_0 - fac_1;
+                strahlkorper->coefficients() =
+                    fac_0 * previous_strahlkorpers[0].second.coefficients() +
+                    fac_1 * previous_strahlkorpers[1].second.coefficients() +
+                    fac_2 * previous_strahlkorpers[2].second.coefficients();
+              } else {
+                // Linear extrapolation
+                const double new_time =
+                    InterpolationTarget_detail::get_temporal_id_value(
+                        temporal_id);
+                const double dt_0 = previous_strahlkorpers[0].first - new_time;
+                const double dt_1 = previous_strahlkorpers[1].first - new_time;
+                const double fac_0 = dt_1 / (dt_1 - dt_0);
+                const double fac_1 = 1.0 - fac_0;
+                strahlkorper->coefficients() =
+                    fac_0 * previous_strahlkorpers[0].second.coefficients() +
+                    fac_1 * previous_strahlkorpers[1].second.coefficients();
+              }
+            }
+          },
+          make_not_null(&box),
+          db::get<ylm::Tags::PreviousStrahlkorpers<Frame>>(box));
+    }
+
     const auto& strahlkorper = db::get<ylm::Tags::Strahlkorper<Frame>>(box);
 
     const size_t L_mesh = fast_flow.current_l_mesh(strahlkorper);

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -701,7 +701,7 @@ auto block_logical_coords(
 ///                             and by FindApparentHorizon)
 template <typename InterpolationTargetTag, typename DbTags,
           typename Metavariables, typename TemporalId>
-auto block_logical_coords(const db::DataBox<DbTags>& box,
+auto block_logical_coords(db::DataBox<DbTags>& box,
                           const Parallel::GlobalCache<Metavariables>& cache,
                           const TemporalId& temporal_id) {
   return block_logical_coords<InterpolationTargetTag>(

--- a/src/ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Protocols/ComputeTargetPoints.hpp
@@ -30,7 +30,8 @@ namespace intrp::protocols {
  *   in
  *
  * - a function `points` with signature matching the one in the example that
- *   will compute the points in the given `frame`.
+ *   will compute the points in the given `frame` (with or without the `const &`
+ *   on the box argument).
  *
  * A struct that conforms to this protocol can optionally have any of these
  * members as well:
@@ -65,17 +66,6 @@ struct ComputeTargetPoints {
                   std::is_same_v<is_sequential, std::false_type>);
 
     using frame = typename ConformingType::frame;
-
-    template <size_t Dim>
-    static constexpr bool conforms = std::is_same_v<
-        tnsr::I<DataVector, Dim, frame>,
-        decltype(ConformingType::points(
-            std::declval<const db::DataBox<DummyTag>&>(),
-            std::declval<const tmpl::type_<DummyMetavariables>&>(),
-            std::declval<const double&>()))>;
-
-    static_assert(conforms<1> or conforms<2> or conforms<3>);
-
     // We don't check the initialize() function because it is optional
   };
 };

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -115,7 +115,7 @@ struct TestHorizonFindFailureCallback {
   // [horizon_find_failure_callbacks_example]
   template <typename InterpolationTargetTag, typename DbTags,
             typename Metavariables, typename TemporalId>
-  static void apply(const db::DataBox<DbTags>& box,
+  static void apply(db::DataBox<DbTags>& box,
                     const Parallel::GlobalCache<Metavariables>& cache,
                     const TemporalId& temporal_id,
                     const FastFlow::Status failure_reason) {
@@ -129,7 +129,7 @@ FastFlow::Status callback_failure_status = FastFlow::Status::MaxIts;  // NOLINT
 struct ExtraHorizonFindFailureCallback {
   template <typename InterpolationTargetTag, typename DbTags,
             typename Metavariables, typename TemporalId>
-  static void apply(const db::DataBox<DbTags>& /*box*/,
+  static void apply(db::DataBox<DbTags>& /*box*/,
                     const Parallel::GlobalCache<Metavariables>& /*cache*/,
                     const TemporalId& /*temporal_id*/,
                     const FastFlow::Status failure_reason) {


### PR DESCRIPTION
## Proposed changes

Previously there was a bug that made us not do any extrapolation for the initial guess of the horizon finder. This PR fixes that. There's a significant reduction in the number of iterations taken:

![ah_iterations](https://github.com/user-attachments/assets/bfdc8dcb-2c64-4918-ad91-2373272cc4d6)

It also attempts to recover from failed interpolation on the first iteration which previously would immediately fail. I've tested that this allows the ObservationAh{A/B} horizon finder to succeed robustly now instead of failing if the time between horizon finds was too big.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
