### PR TITLE
Disable regular Spack CI test

### DIFF
--- a/.github/workflows/Spack.yaml
+++ b/.github/workflows/Spack.yaml
@@ -1,12 +1,14 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Regularly scheduled installation test with the Spack package manager
+# Installation test with the Spack package manager
 name: Spack
 
 on:
-  schedule:
-    - cron: '0 0 * * 1' # every Monday morning
+  # Could run this on a schedule once Spack is stable enough to not break every
+  # week.
+  # schedule:
+  #   - cron: '0 0 * * 1' # every Monday morning
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/Spack.yaml
+++ b/.github/workflows/Spack.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         host: [ubuntu-latest, macos-latest]
-        compiler: [gcc, clang, apple-clang]
+        compiler: [gcc, llvm, apple-clang]
         exclude:
           - host: ubuntu-latest
             compiler: apple-clang
@@ -44,13 +44,13 @@ jobs:
           executables=SolvePoisson1D
           +python
           ~debug_symbols
-          %${{ matrix.compiler }}
+          ^${{ matrix.compiler }}
           ^charmpp backend=multicore
           ^hdf5~mpi
       SPACK_COLOR: always
     steps:
       - name: Install compiler
-        if: matrix.host == 'macos-latest' && matrix.compiler == 'clang'
+        if: matrix.host == 'macos-latest' && matrix.compiler == 'llvm'
         run: |
           brew install llvm
           echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
@@ -65,15 +65,6 @@ jobs:
           spack compiler find
           spack compiler info ${{ matrix.compiler }}
           spack external find
-      - name: Configure mixed toolchain
-        if: matrix.host == 'ubuntu-latest' && matrix.compiler == 'clang'
-        # Clang doesn't bundle a fortran compiler, so we specify one
-        run: |
-          export FC=$(which gfortran)
-          export COMPILERS_CONFIG="$HOME/.spack/*/compilers.yaml"
-          sed -i "s|f77: null$|f77: $FC|" $COMPILERS_CONFIG
-          sed -i "s|fc: null$|fc: $FC|" $COMPILERS_CONFIG
-          cat $COMPILERS_CONFIG
       - name: Print packages to install
         run: |
           spack spec -I ${SPECTRE_SPEC}


### PR DESCRIPTION
## Proposed changes

Breaks a lot because Spack isn't stable enough yet.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
