### PR TITLE
Promote HomogeneousSphere solution to be usable in GhGrMhd

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIBS_TO_LINK
   Limiters
   LinearOperators
   MathFunctions
+  MonteCarloSolutions
   Observer
   Options
   Parallel

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -197,6 +197,8 @@
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/Factory.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/HomogeneousSphere.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.hpp"

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/AllSolutions.hpp
@@ -8,6 +8,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GhGrMhd/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GhRelativisticEuler/Factory.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/Factory.hpp"
 #include "Utilities/TMPL.hpp"
 
 // Check if SpEC is linked and therefore we can load SpEC initial data
@@ -33,6 +34,7 @@ namespace ghmhd::GhValenciaDivClean::InitialData {
 using analytic_solutions_and_data_list =
     tmpl::append<gh::RelativisticEuler::Solutions::all_solutions,
                  gh::grmhd::Solutions::all_solutions,
+                 RadiationTransport::MonteCarlo::Solutions::all_solutions,
                  gh::grmhd::AnalyticData::all_analytic_data>;
 using initial_data_list = tmpl::flatten<tmpl::list<
     analytic_solutions_and_data_list,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(
   GhRelativisticEulerSolutions
   Hydro
   LinearOperators
+  MonteCarloSolutions
   Serialization
   Utilities
   ValenciaDivClean

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/HomogeneousSphere.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/HomogeneousSphere.cpp
@@ -146,6 +146,23 @@ HomogeneousSphere::variables(
 }
 
 template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
+HomogeneousSphere::variables(
+    const tnsr::I<DataType, 3>& x, double t,
+    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const {
+  auto primitives = this->variables<DataType>(
+      x, t,
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::Pressure<DataType>,
+                 hydro::Tags::SpecificInternalEnergy<DataType>>{});
+  return tuples::get<hydro::Tags::Pressure<DataType>>(primitives) /
+             tuples::get<hydro::Tags::RestMassDensity<DataType>>(primitives) +
+         tuples::get<hydro::Tags::SpecificInternalEnergy<DataType>>(
+             primitives) +
+         1.0;
+}
+
+template <typename DataType>
 tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
 HomogeneousSphere::variables(
     const tnsr::I<DataType, 3>& x, double /*t*/,

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/HomogeneousSphere.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/HomogeneousSphere.hpp
@@ -12,6 +12,7 @@
 #include "Options/String.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -45,6 +46,8 @@ class HomogeneousSphere : public evolution::initial_data::InitialData,
   equation_of_state() const {
     return *equation_of_state_;
   }
+
+  static const size_t volume_dim = 3;
 
   /// The radius of the sphere
   struct Radius {
@@ -131,6 +134,11 @@ class HomogeneousSphere : public evolution::initial_data::InitialData,
 
   template <typename DataType>
   auto variables(const tnsr::I<DataType, 3>& x, double /*t*/,
+                 tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/)
+      const -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x, double /*t*/,
                  tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
       const -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
 
@@ -158,9 +166,13 @@ class HomogeneousSphere : public evolution::initial_data::InitialData,
   }
 
   /// Retrieve the metric variables
-  template <typename DataType, typename Tag>
-  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x, double t,
-                                     tmpl::list<Tag> /*meta*/) const {
+  template <typename DataType, typename Tag,
+            Requires<not tmpl::list_contains_v<
+                tmpl::push_back<hydro::grmhd_tags<DataType>,
+                                hydro::Tags::SpecificEnthalpy<DataType>>,
+                Tag>> = nullptr>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x,
+                                     double t, tmpl::list<Tag> /*meta*/) const {
     return background_spacetime_.variables(x, t, tmpl::list<Tag>{});
   }
 
@@ -183,7 +195,8 @@ class HomogeneousSphere : public evolution::initial_data::InitialData,
        std::numeric_limits<double>::signaling_NaN()}};
 
   std::unique_ptr<equation_of_state_type> equation_of_state_;
-  gr::Solutions::Minkowski<3> background_spacetime_{};
+  gh::Solutions::WrappedGr<gr::Solutions::Minkowski<3>>
+      background_spacetime_{};
 };
 
 bool operator!=(const HomogeneousSphere& lhs, const HomogeneousSphere& rhs);


### PR DESCRIPTION
## Proposed changes

Modify the existing Monte-Carlo solution HomogeneousSphere (Which can also serve as a fixed background with tabulated EoS) to be usable as initial condition for GhValenciaDivClean.

### Upgrade instructions

NA

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

NA