### PR TITLE
Add constructor for replay FoT in FromVolumeFile

### DIFF
--- a/src/Domain/Creators/TimeDependentOptions/ExpansionMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ExpansionMap.cpp
@@ -79,7 +79,7 @@ FunctionsOfTimeMap get_expansion(
 
   if (std::holds_alternative<FromVolumeFile>(expansion_map_options)) {
     const auto& from_vol_file = std::get<FromVolumeFile>(expansion_map_options);
-    const auto volume_fot = from_vol_file.retrieve_function_of_time(
+    auto volume_fot = from_vol_file.retrieve_function_of_time(
         {name, name_outer_boundary}, initial_time);
 
     // Expansion must be either a PiecewisePolynomial or a SettleToConstant
@@ -97,8 +97,12 @@ FunctionsOfTimeMap get_expansion(
           "initialize the expansion map.");
     }
 
-    result[name] =
-        volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    if (from_vol_file.replay()) {
+      result[name] = std::move(volume_fot.at(name));
+    } else {
+      result[name] =
+          volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    }
 
     // Outer boundary must be either a FixedSpeedCubic or a SettleToConstant
     const auto* outer_boundary_cubic_volume_fot =
@@ -121,8 +125,12 @@ FunctionsOfTimeMap get_expansion(
            "SettleToConstant, but SettleToConstant functions of time aren't "
            "allowed.");
 
-    result[name_outer_boundary] =
-        volume_fot.at(name_outer_boundary)->get_clone();
+    if (from_vol_file.replay()) {
+      result[name] = std::move(volume_fot.at(name_outer_boundary));
+    } else {
+      result[name_outer_boundary] =
+          volume_fot.at(name_outer_boundary)->get_clone();
+    }
   } else if (std::holds_alternative<ExpansionMapOptions<AllowSettleFoTs>>(
                  expansion_map_options)) {
     const auto& hard_coded_options =

--- a/src/Domain/Creators/TimeDependentOptions/ExpansionMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ExpansionMap.hpp
@@ -105,9 +105,8 @@ struct ExpansionMapOptions {
  * \brief Helper functions that take the variant of the expansion map options,
  * and return the fully constructed expansion functions of time.
  *
- * \details Even if the functions of time are read from a file, they will have a
- * new \p initial_time and \p expiration_time (no expiration time for the outer
- * boundary function of time though).
+ * \details The function of time will have a new \p initial_time and \p
+ * expiration_time, unless it is read from a file and is replaying.
  */
 template <bool AllowSettleFoTs>
 FunctionsOfTimeMap get_expansion(

--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
@@ -82,9 +82,10 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_function_of_time(
 }  // namespace
 
 FromVolumeFile::FromVolumeFile(std::string h5_filename,
-                               std::string subfile_name)
+                               std::string subfile_name, const bool replay)
     : h5_filename_(std::move(h5_filename)),
-      subfile_name_(std::move(subfile_name)) {}
+      subfile_name_(std::move(subfile_name)),
+      replay_(replay) {}
 
 FunctionsOfTimeMap FromVolumeFile::retrieve_function_of_time(
     const std::unordered_set<std::string>& function_of_time_names,

--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
@@ -44,7 +44,9 @@ struct FromVolumeFile {
       "Read function of time coefficients from a volume subfile of an H5 file.";
 
   FromVolumeFile() = default;
-  FromVolumeFile(std::string h5_filename, std::string subfile_name);
+  // The replay option cannot be set from options
+  FromVolumeFile(std::string h5_filename, std::string subfile_name,
+                 bool replay = false);
 
   /*!
    * \brief Searches the last observation in the volume subfile and returns
@@ -58,9 +60,16 @@ struct FromVolumeFile {
       const std::unordered_set<std::string>& function_of_time_names,
       const std::optional<double>& time) const;
 
+  /*!
+   * \brief Whether the function of time from the volume file should just be
+   * replayed (read in and unmodified), or not.
+   */
+  bool replay() const { return replay_; }
+
  private:
   std::string h5_filename_;
   std::string subfile_name_;
+  bool replay_{false};
 };
 /// @}
 }  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/RotationMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/RotationMap.cpp
@@ -66,7 +66,7 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_rotation(
 
   if (std::holds_alternative<FromVolumeFile>(rotation_map_options)) {
     const auto& from_vol_file = std::get<FromVolumeFile>(rotation_map_options);
-    const auto volume_fot =
+    auto volume_fot =
         from_vol_file.retrieve_function_of_time({name}, initial_time);
 
     // It must be either a QuaternionFoT or a SettleToConstant
@@ -84,7 +84,12 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_rotation(
           "use it to initialize the rotation map.");
     }
 
-    result = volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    if (from_vol_file.replay()) {
+      result = std::move(volume_fot.at(name));
+    } else {
+      result =
+          volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    }
   } else if (std::holds_alternative<RotationMapOptions<AllowSettleFoTs>>(
                  rotation_map_options)) {
     const auto& hard_coded_options =

--- a/src/Domain/Creators/TimeDependentOptions/RotationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/RotationMap.hpp
@@ -86,8 +86,8 @@ struct RotationMapOptions {
  * \brief Helper function that takes the variant of the rotation map options,
  * and returns the fully constructed rotation function of time.
  *
- * \details Even if the function of time is read from a file, it will have a
- * new \p initial_time and \p expiration_time.
+ * \details The function of time will have a new \p initial_time and \p
+ * expiration_time, unless it is read from a file and is replaying.
  */
 template <bool AllowSettleFoTs>
 std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_rotation(

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
@@ -25,6 +25,8 @@
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -64,13 +66,18 @@ template <ObjectLabel Object>
 FromVolumeFileShapeSize<Object>::FromVolumeFileShapeSize(
     const std::optional<size_t>& l_max_in,
     const bool transition_ends_at_cube_in, std::string h5_filename,
-    std::string subfile_name)
+    std::string subfile_name, const Options::Context& context)
     : FromVolumeFile(std::move(h5_filename), std::move(subfile_name)),
       transition_ends_at_cube(transition_ends_at_cube_in) {
+  if (this->replay() and l_max_in.has_value()) {
+    PARSE_ERROR(context,
+                "Cannot supply LMax for shape map while also replaying.");
+  }
+
   if (l_max_in.has_value()) {
     l_max = l_max_in.value();
   } else {
-    const auto shape_fot_map = retrieve_function_of_time(
+    const auto shape_fot_map = this->retrieve_function_of_time(
         {std::string{"Shape" + name(Object)}}, std::nullopt);
     const auto& shape_fot = shape_fot_map.at("Shape" + name(Object));
 
@@ -80,7 +87,7 @@ FromVolumeFileShapeSize<Object>::FromVolumeFileShapeSize(
     // num_components = 2 * (l_max + 1)**2 if l_max == m_max which it is for the
     // shape map. This is why we can divide by 2 and take the sqrt without
     // worrying about odd numbers or non-perfect squares
-    l_max = -1 + sqrt(function[0].size() / 2);
+    l_max = -1 + sqrt(function[0].size() / 2);  // NOLINT
   }
 }
 
@@ -119,7 +126,7 @@ FunctionsOfTimeMap get_shape_and_size(
           shape_map_options)) {
     const auto& from_vol_file =
         std::get<FromVolumeFileShapeSize<Object>>(shape_map_options);
-    const auto volume_fots = from_vol_file.retrieve_function_of_time(
+    auto volume_fots = from_vol_file.retrieve_function_of_time(
         {shape_name, size_name}, initial_time);
 
     const auto check_fot = [&]<size_t MaxDeriv>(const std::string& name) {
@@ -137,34 +144,44 @@ FunctionsOfTimeMap get_shape_and_size(
     check_fot.template operator()<2>(shape_name);
     check_fot.template operator()<3>(size_name);
 
-    // Not const in case we move it below
-    auto temporary_shape_fot =
-        volume_fots.at(shape_name)
-            ->create_at_time(initial_time, shape_expiration_time);
-    const auto shape_funcs =
-        temporary_shape_fot->func_and_2_derivs(initial_time);
-
-    const size_t file_l_max = -1 + sqrt(shape_funcs[0].size() / 2);
-
-    // Prolong or restrict if necessary, otherwise just use the exact function
-    // of time from the volume file
-    if (file_l_max != l_max) {
-      std::array<DataVector, 3> new_shape_funcs{};
-      const ylm::Spherepack file_spherepack{file_l_max, file_l_max};
-      const ylm::Spherepack new_spherepack{l_max, l_max};
-      for (size_t i = 0; i < shape_funcs.size(); i++) {
-        gsl::at(new_shape_funcs, i) = file_spherepack.prolong_or_restrict(
-            gsl::at(shape_funcs, i), new_spherepack);
-      }
-
-      result[shape_name] =
-          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
-              initial_time, std::move(new_shape_funcs), shape_expiration_time);
+    if (from_vol_file.replay()) {
+      result[shape_name] = std::move(volume_fots.at(shape_name));
     } else {
-      result[shape_name] = std::move(temporary_shape_fot);
+      // Not const in case we move it below
+      auto temporary_shape_fot =
+          volume_fots.at(shape_name)
+              ->create_at_time(initial_time, shape_expiration_time);
+      const auto shape_funcs =
+          temporary_shape_fot->func_and_2_derivs(initial_time);
+
+      const size_t file_l_max = -1 + sqrt(shape_funcs[0].size() / 2);  // NOLINT
+
+      // Prolong or restrict if necessary, otherwise just use the exact function
+      // of time from the volume file
+      if (file_l_max != l_max) {
+        std::array<DataVector, 3> new_shape_funcs{};
+        const ylm::Spherepack file_spherepack{file_l_max, file_l_max};
+        const ylm::Spherepack new_spherepack{l_max, l_max};
+        for (size_t i = 0; i < shape_funcs.size(); i++) {
+          gsl::at(new_shape_funcs, i) = file_spherepack.prolong_or_restrict(
+              gsl::at(shape_funcs, i), new_spherepack);
+        }
+
+        result[shape_name] =
+            std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+                initial_time, std::move(new_shape_funcs),
+                shape_expiration_time);
+      } else {
+        result[shape_name] = std::move(temporary_shape_fot);
+      }
     }
-    result[size_name] = volume_fots.at(size_name)->create_at_time(
-        initial_time, size_expiration_time);
+
+    if (from_vol_file.replay()) {
+      result[size_name] = std::move(volume_fots.at(size_name));
+    } else {
+      result[size_name] = volume_fots.at(size_name)->create_at_time(
+          initial_time, size_expiration_time);
+    }
 
     return result;
   }

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
@@ -211,7 +211,8 @@ struct FromVolumeFileShapeSize : public FromVolumeFile {
   FromVolumeFileShapeSize() = default;
   FromVolumeFileShapeSize(const std::optional<size_t>& l_max_in,
                           bool transition_ends_at_cube_in,
-                          std::string h5_filename, std::string subfile_name);
+                          std::string h5_filename, std::string subfile_name,
+                          const Options::Context& context = {});
 
   size_t l_max{};
   bool transition_ends_at_cube{};

--- a/src/Domain/Creators/TimeDependentOptions/SkewMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/SkewMap.cpp
@@ -28,7 +28,7 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_skew(
 
   if (std::holds_alternative<FromVolumeFile>(skew_map_options)) {
     const auto& from_vol_file = std::get<FromVolumeFile>(skew_map_options);
-    const auto volume_fot =
+    auto volume_fot =
         from_vol_file.retrieve_function_of_time({name}, initial_time);
 
     // It must be a PiecewisePolynomial
@@ -39,7 +39,12 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_skew(
           "PiecewisePolynomial<2>. Cannot use it to initialize the skew map.");
     }
 
-    result = volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    if (from_vol_file.replay()) {
+      result = std::move(volume_fot.at(name));
+    } else {
+      result =
+          volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    }
   } else if (std::holds_alternative<SkewMapOptions>(skew_map_options)) {
     const auto& hard_coded_options = std::get<SkewMapOptions>(skew_map_options);
 

--- a/src/Domain/Creators/TimeDependentOptions/SkewMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/SkewMap.hpp
@@ -61,8 +61,8 @@ struct SkewMapOptions {
  * \brief Helper function that takes the variant of the skew map options,
  * and returns the fully constructed skew function of time.
  *
- * \details Even if the function of time is read from a file, it will have a
- * new \p initial_time and \p expiration_time.
+ * \details The function of time will have a new \p initial_time and \p
+ * expiration_time, unless it is read from a file and is replaying.
  */
 std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_skew(
     const std::variant<SkewMapOptions, FromVolumeFile>& skew_map_options,

--- a/src/Domain/Creators/TimeDependentOptions/TranslationMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/TranslationMap.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_translation(
   if (std::holds_alternative<FromVolumeFile>(translation_map_options)) {
     const auto& from_vol_file =
         std::get<FromVolumeFile>(translation_map_options);
-    const auto volume_fot =
+    auto volume_fot =
         from_vol_file.retrieve_function_of_time({name}, initial_time);
 
     // It must be a PiecewisePolynomial
@@ -55,7 +55,12 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_translation(
           "map.");
     }
 
-    result = volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    if (from_vol_file.replay()) {
+      result = std::move(volume_fot.at(name));
+    } else {
+      result =
+          volume_fot.at(name)->create_at_time(initial_time, expiration_time);
+    }
   } else if (std::holds_alternative<TranslationMapOptions<Dim>>(
                  translation_map_options)) {
     const auto& hard_coded_options =

--- a/src/Domain/Creators/TimeDependentOptions/TranslationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/TranslationMap.hpp
@@ -57,8 +57,8 @@ struct TranslationMapOptions {
  * \brief Helper function that takes the variant of the translation map options,
  * and returns the fully constructed translation function of time.
  *
- * \details Even if the function of time is read from a file, it will have a
- * new \p initial_time and \p expiration_time.
+ * \details The function of time will have a new \p initial_time and \p
+ * expiration_time, unless it is read from a file and is replaying.
  */
 template <size_t Dim>
 std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_translation(

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
@@ -68,6 +68,18 @@ void test(const std::string& function_of_time_name) {
         dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>&>(
             *functions_of_time.at(function_of_time_name)));
 
+  const auto from_volume_file_replay =
+      domain::creators::time_dependent_options::FromVolumeFile(
+          filename, subfile_name, true);
+
+  const domain::FunctionsOfTimeMap fot_from_file_replay =
+      from_volume_file.retrieve_function_of_time({function_of_time_name}, time);
+
+  CHECK(dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>&>(
+            *fot_from_file_replay.at(function_of_time_name)) ==
+        dynamic_cast<domain::FunctionsOfTime::PiecewisePolynomial<2>&>(
+            *functions_of_time.at(function_of_time_name)));
+
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }


### PR DESCRIPTION
## Proposed changes

Adds a constructor to replay a function of time from volume data allowing access to all the history and updates of the function of time. This is needed for the transition to ringdown translation function of time.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
