### PR TITLE
Add function to compute the convergence rate of a power monitor

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
   BLAS::BLAS
   DataStructures
   ErrorHandling
+  Interpolation
   Options
   Serialization
   Spectral

--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
@@ -3,14 +3,17 @@
 
 #include "NumericalAlgorithms/LinearOperators/PowerMonitors.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
+#include <limits>
 
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/SliceIterator.hpp"
+#include "NumericalAlgorithms/Interpolation/LinearRegression.hpp"
 #include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -51,7 +54,7 @@ void power_monitors(const gsl::not_null<std::array<DataVector, Dim>*> result,
           slice_sum += square(mode);
         }
       }
-      slice_sum /= n_slice;
+      slice_sum /= static_cast<double>(n_slice);
       slice_sum = sqrt(slice_sum);
 
       gsl::at(*result, sliced_dim)[index] = slice_sum;
@@ -145,6 +148,68 @@ std::array<double, Dim> absolute_truncation_error(
     gsl::at(result, d) = umax * relative_truncation_error_in_d;
   }
   return result;
+}
+
+double convergence_rate(const DataVector& power_monitor,
+                        const size_t number_of_filtered_modes) {
+  // Need enough unfiltered modes to compute the convergence rate. Here,
+  // require at least 4 unfiltered modes.
+  ASSERT(
+      power_monitor.size() > number_of_filtered_modes + 3,
+      "Power monitor needs at least 4 unfiltered modes to compute convergence "
+      "rate, but power monitor has size "
+          << power_monitor.size() << " with " << number_of_filtered_modes
+          << " filtered modes");
+
+  const size_t n_tilde = power_monitor.size() - number_of_filtered_modes;
+  std::vector<double> mode_numbers_for_fit{};
+  std::vector<double> mode_powers_for_fit{};
+  mode_numbers_for_fit.reserve(n_tilde);
+  mode_powers_for_fit.reserve(n_tilde);
+
+  const size_t n_tilde_minus_one = n_tilde - 1;
+  std::vector<double> slopes{};
+  std::vector<double> delta_slopes{};
+
+  // It turns out (as can be verified empirically) that the number of terms
+  // in this loop is 3 * (n_tilde - 5) for n_tilde > 6, 4 for n_tilde == 5,
+  // and 3 for n_tilde == 4 or n_tilde == 3. Here reserve the correct number of
+  // elements in terms of n_tilde, except don't use an extra if to
+  // distinguish between the 3 and 4 special cases (no harm in reserving space
+  // for a single extra double).
+  const size_t max_slope_size = n_tilde > 6 ? 3 * (n_tilde - 5) : 4;
+  slopes.reserve(max_slope_size);
+  delta_slopes.reserve(max_slope_size);
+  for (size_t k1 = 0; k1 < 3; ++k1) {
+    for (size_t k2 = std::min(k1 + 4, n_tilde_minus_one);
+         k2 <= n_tilde_minus_one; ++k2) {
+      mode_numbers_for_fit.resize(k2 - k1 + 1);
+      mode_powers_for_fit.resize(k2 - k1 + 1);
+      for (size_t k = k1; k <= k2; ++k) {
+        mode_numbers_for_fit[k - k1] = static_cast<double>(k);
+        mode_powers_for_fit[k - k1] = log10(power_monitor[k]);
+      }
+      const intrp::LinearRegressionResult regression_result =
+          intrp::linear_regression(mode_numbers_for_fit, mode_powers_for_fit);
+      slopes.push_back(regression_result.slope);
+      delta_slopes.push_back(regression_result.delta_slope);
+    }
+  }
+  const auto max_delta =
+      std::max_element(delta_slopes.begin(), delta_slopes.end());
+  // Scale the small factor to be a few orders of magnitude smaller than
+  // the max slope delta, as SpEC does. But in case the fit happens to have
+  // identically zero errors, make sure eps is still nonzero.
+  const double eps = std::max(*max_delta * 1.e-3, 1.e-15);
+  double num = 0.0;
+  double denom = 0.0;
+  for (size_t i = 0; i < slopes.size(); ++i) {
+    const double one_over_denom_this_term =
+        1.0 / (eps + gsl::at(delta_slopes, i));
+    denom += one_over_denom_this_term;
+    num += gsl::at(slopes, i) * one_over_denom_this_term;
+  }
+  return -num / denom;
 }
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
@@ -83,7 +83,7 @@ std::array<DataVector, Dim> power_monitors(const VectorType& u,
  *
  */
 double relative_truncation_error(const DataVector& power_monitor,
-                                 const size_t num_modes_to_use);
+                                 size_t num_modes_to_use);
 /// @}
 
 /*!
@@ -119,4 +119,39 @@ template <typename VectorType, size_t Dim>
 std::array<double, Dim> absolute_truncation_error(
     const VectorType& tensor_component, const Mesh<Dim>& mesh);
 /// @}
+
+/*!
+ * \ingroup SpectralGroup
+ * \brief Returns the convergence rate of a power monitor.
+ *
+ * \details Returns the convergence rate of a power monitor as a weighted
+ * average of slopes measured using different subsets of spectral modes
+ * in the power monitor. Equation (53) of \cite Szilagyi2014fna gives
+ * the convergence rate $\mathcal{C}$ in terms of a power monitor $P_k$ as
+ * \begin{equation}
+ * \mathcal{C}(P_k) = -\frac{\sum_{k_1=0}^2\sum_{k_2=\tilde{k}_1}^{\tilde{N}-1}
+ *   \frac{\mathcal{S}(k_1,k_2)}{\epsilon + \mathcal{E}(k_1,k_2)}}{
+ *   \sum_{k_1=0}^2\sum_{k_2=\tilde{k}_1}^{\tilde{N}-1}
+ *   \frac{1}{\epsilon + \mathcal{E}(k_1,k_2)}}.
+ * \end{equation}
+ * Here, $\mathcal{S}(k_1,k_2)$ is the slope of a linear regression fit of
+ * $\log_{10}(P_k)$ with $k$ satisfying $k_1\leq k \leq k_2$,
+ * $\mathcal{E}(k_1,k_2)$ is the error of the slope in that fit,
+ * $\epsilon=\max\left(10^{-3}\max\left(\mathcal{E}(k_1,k_2)\right),
+ * 10^{-15}\right)$ is a small number to avoid dividing by zero in the event the
+ * fit errors vanish,
+ * $\max\left(\mathcal{E}(k_1,k_2)\right)$ is the maximum fit error of each
+ * fit whose slope is included in the summation,
+ * $\tilde{k}_1 = \min\left(k_1+4,\tilde{N}-1\right)$,
+ * $\tilde{N} = N-N_f$, $N$ is the number of modes in the
+ * power monitor, and the highest $N_f$ modes are filtered. Note that the
+ * way $\epsilon$ is defined is so that it matches SpEC's definition, while
+ * also ensuring that it is nonzero even if the error in the slope fit is
+ * exactly zero.
+ * \param power_monitor The power monitor.
+ * \param number_of_filtered_modes How many of the highest modes of the
+ * power monitor are filtered (default 0).
+ */
+double convergence_rate(const DataVector& power_monitor,
+                        size_t number_of_filtered_modes = 0);
 }  // namespace PowerMonitors

--- a/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
@@ -36,6 +36,9 @@ void bind_power_monitors(py::module& m) {
   bind_power_monitors_impl<1>(m);
   bind_power_monitors_impl<2>(m);
   bind_power_monitors_impl<3>(m);
+  m.def("convergence_rate",
+        py::overload_cast<const DataVector&, const size_t>(&convergence_rate),
+        py::arg("power_monitor"), py::arg("number_of_filtered_modes") = 0);
 }
 
 }  // namespace PowerMonitors::py_bindings

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Python/Test_PowerMonitors.py
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Python/Test_PowerMonitors.py
@@ -8,6 +8,7 @@ import numpy as np
 from spectre.DataStructures import DataVector
 from spectre.NumericalAlgorithms.LinearOperators import (
     absolute_truncation_error,
+    convergence_rate,
     power_monitors,
     relative_truncation_error,
 )
@@ -79,6 +80,15 @@ class TestPowerMonitors(unittest.TestCase):
         np.testing.assert_allclose(
             abs_error, expected_absolute_truncation_error, 1e-12, 1e-12
         )
+
+    # Check that the convergence rate for a straight line is consistent with
+    # the analytic expectation
+    def test_convergence_rate(self):
+        slope, offset = -0.4, 1.4
+        modes = np.arange(0, 14, 1)
+        test_power_monitor = 10.0 ** (slope * modes + offset)
+        rate = convergence_rate(test_power_monitor, 3)
+        np.testing.assert_allclose(rate, -slope)
 
 
 if __name__ == "__main__":

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
@@ -10,11 +10,13 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/PowerMonitors.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
@@ -234,6 +236,59 @@ void test_relative_truncation_error_linear_function() {
   }
 }
 
+void test_convergence_rate() {
+  // First, check that a power monitor with an exact, constant slope has the
+  // expected convergence rate
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> slope_dis(-4.0, -1.0);
+  const double expected_slope = slope_dis(gen);
+  std::uniform_real_distribution<> offset_dis(-0.4, -0.1);
+  const double offset = offset_dis(gen);
+  const size_t size_of_power_monitor{10};
+  DataVector power_monitor_with_known_slope{size_of_power_monitor};
+  for (size_t i = 0; i < size_of_power_monitor; ++i) {
+    power_monitor_with_known_slope[i] =
+        pow(10.0, static_cast<double>(i) * expected_slope + offset);
+  }
+  constexpr size_t filtered_modes = 2;
+
+  double convergence_rate = PowerMonitors::convergence_rate(
+      power_monitor_with_known_slope, filtered_modes);
+  CHECK(approx(convergence_rate) == -expected_slope);
+
+  // Change the filtered modes' power to a NaN, and ensure that this mode
+  // is ignored when computing the convergence rate.
+  power_monitor_with_known_slope[8] =
+      std::numeric_limits<double>::signaling_NaN();
+  power_monitor_with_known_slope[9] =
+      std::numeric_limits<double>::signaling_NaN();
+  convergence_rate = PowerMonitors::convergence_rate(
+      power_monitor_with_known_slope, filtered_modes);
+  CHECK(approx(convergence_rate) == -expected_slope);
+
+  // Test that adding noise of amplitude 1e-2 affects the slope recovered
+  // by no more than that amount
+  constexpr double noise_amp = 0.01;
+  std::uniform_real_distribution<> noise_dis(-noise_amp, noise_amp);
+  for (size_t i = 0; i < size_of_power_monitor - filtered_modes; ++i) {
+    power_monitor_with_known_slope[i] *= pow(10.0, noise_dis(gen));
+  }
+  convergence_rate = PowerMonitors::convergence_rate(
+      power_monitor_with_known_slope, filtered_modes);
+  // define custom approx for higher derivative checks
+  const Approx custom_approx = Approx::custom().epsilon(noise_amp).scale(1.0);
+  CHECK(custom_approx(convergence_rate) == -expected_slope);
+
+// Check assert that sufficient modes were provided
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      PowerMonitors::convergence_rate(power_monitor_with_known_slope,
+                                      size_of_power_monitor - 3),
+      Catch::Matchers::ContainsSubstring(
+          "Power monitor needs at least 4 unfiltered modes to compute "
+          "convergence"));
+#endif
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PowerMonitors",
@@ -243,4 +298,5 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PowerMonitors",
   test_relative_truncation_error_impl();
   test_relative_truncation_error_with_symmetry();
   test_relative_truncation_error_linear_function();
+  test_convergence_rate();
 }


### PR DESCRIPTION
## Proposed changes

Add a function to compute the convergence rate of a power monitor, the same way SpEC computes this convergence rate (Eq. (53) of Szilagyi (2014)). This is necessary to implement a function to compute how many pile up modes are in a power monitor, which I plan to add in a follow-up PR rot this one.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
