### PR TITLE
Remove a default parameter in Tensor metafunctions

### DIFF
--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -83,8 +83,7 @@ constexpr bool check_index_symmetry_v =
  * \tparam VolumeDim the volume dimension of the tensor index to prepend
  * \tparam Fr the ::Frame of the tensor index to prepend
  */
-template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
-          typename Fr = Frame::Grid>
+template <typename TheTensor, std::size_t VolumeDim, UpLo Ul, typename Fr>
 using prepend_spatial_index =
     ::Tensor<typename TheTensor::type,
              tmpl::push_front<typename TheTensor::symmetry,
@@ -101,8 +100,7 @@ using prepend_spatial_index =
  * \tparam VolumeDim the volume dimension of the tensor indices to prepend
  * \tparam Fr the ::Frame of the tensor indices to prepend
  */
-template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
-          typename Fr = Frame::Grid>
+template <typename TheTensor, std::size_t VolumeDim, UpLo Ul, typename Fr>
 using prepend_two_symmetric_spatial_indices = ::Tensor<
     typename TheTensor::type,
     tmpl::push_front<tmpl::push_front<typename TheTensor::symmetry,
@@ -120,8 +118,7 @@ using prepend_two_symmetric_spatial_indices = ::Tensor<
  * \tparam VolumeDim the volume dimension of the tensor index to prepend
  * \tparam Fr the ::Frame of the tensor index to prepend
  */
-template <typename TheTensor, std::size_t VolumeDim, UpLo Ul,
-          typename Fr = Frame::Grid>
+template <typename TheTensor, std::size_t VolumeDim, UpLo Ul, typename Fr>
 using prepend_spacetime_index =
     ::Tensor<typename TheTensor::type,
              tmpl::push_front<typename TheTensor::symmetry,


### PR DESCRIPTION
## Proposed changes

I got a compiler error because I didn't know about this default parameter. Seems better to remove the default.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
