### PR TITLE
Add second FD spacetime derivatives for SoCcz4

### DIFF
--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
@@ -15,6 +15,8 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp"
 #include "Evolution/Systems/Ccz4/System.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
 #include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
@@ -85,6 +87,74 @@ void spacetime_derivatives(
                          volume_evolved_variables.number_of_grid_points());
 
   ::fd::partial_derivatives<gradients_tags>(
+      result, volume_Ccz4_vars, ghost_cell_vars, volume_mesh,
+      number_of_Ccz4_components, deriv_order,
+      cell_centered_logical_to_inertial_inv_jacobian);
+}
+
+void second_spacetime_derivatives(
+    const gsl::not_null<Variables<
+        db::wrap_tags_in<::Tags::second_deriv, System::gradients_tags,
+                         tmpl::size_t<3>, Frame::Inertial>>*>
+        result,
+    const Variables<typename System::variables_tag::tags_list>&
+        volume_evolved_variables,
+    const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&
+        all_ghost_data,
+    const size_t& deriv_order, const Mesh<3>& volume_mesh,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>&
+        cell_centered_logical_to_inertial_inv_jacobian) {
+  ASSERT(deriv_order == 4,
+         "Only fourth order second partial derivatives have been implemented.");
+
+  using gradients_tags = typename System::gradients_tags;
+  if (UNLIKELY(result->number_of_grid_points() !=
+               volume_evolved_variables.number_of_grid_points())) {
+    result->initialize(volume_evolved_variables.number_of_grid_points());
+  }
+
+  using first_Ccz4_tag = tmpl::front<Tags::spacetime_reconstruction_tags>;
+  constexpr size_t number_of_Ccz4_components =
+      Variables<Tags::spacetime_reconstruction_tags>::
+          number_of_independent_components;
+
+  DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
+  for (const auto& [directional_element_id, ghost_data] : all_ghost_data) {
+    using NeighborVariables =
+        Variables<Tags::spacetime_reconstruction_tags>;
+    const DataVector& neighbor_data =
+        ghost_data.neighbor_ghost_data_for_reconstruction();
+    const size_t neighbor_number_of_points =
+        neighbor_data.size() /
+        NeighborVariables::number_of_independent_components;
+    ASSERT(
+        neighbor_data.size() %
+                NeighborVariables::number_of_independent_components ==
+            0,
+        "Amount of reconstruction data sent ("
+            << neighbor_data.size() << ") from " << directional_element_id
+            << " is not a multiple of the number of reconstruction variables "
+            << NeighborVariables::number_of_independent_components);
+    // Use a Variables view to get offset into spacetime variables
+    // without having to do pointer math.
+    const NeighborVariables
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        view{const_cast<double*>(neighbor_data.data()),
+             neighbor_number_of_points *
+                 NeighborVariables::number_of_independent_components};
+    ghost_cell_vars.insert(std::pair{
+        directional_element_id.direction(),
+        gsl::make_span(get<first_Ccz4_tag>(view)[0].data(),
+                       number_of_Ccz4_components * neighbor_number_of_points)});
+  }
+
+  const auto volume_Ccz4_vars =
+      gsl::make_span(get<first_Ccz4_tag>(volume_evolved_variables)[0].data(),
+                     number_of_Ccz4_components *
+                         volume_evolved_variables.number_of_grid_points());
+
+  second_partial_derivatives<gradients_tags>(
       result, volume_Ccz4_vars, ghost_cell_vars, volume_mesh,
       number_of_Ccz4_components, deriv_order,
       cell_centered_logical_to_inertial_inv_jacobian);

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
@@ -51,4 +51,26 @@ void spacetime_derivatives(
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&
         cell_centered_logical_to_inertial_inv_jacobian);
+
+/*!
+ * \brief Compute second partial derivatives of all the evolved variables in the
+ * second order Ccz4 system
+ * \details
+ * The derivatives are computed using FD of order deriv_order.
+ *
+ * \note Only 3D 4-th order second derivatives are implemented.
+ */
+void second_spacetime_derivatives(
+    gsl::not_null<Variables<
+        db::wrap_tags_in<::Tags::second_deriv, System::gradients_tags,
+                         tmpl::size_t<3>, Frame::Inertial>>*>
+        result,
+    const Variables<typename System::variables_tag::tags_list>&
+        volume_evolved_variables,
+    const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&
+        all_ghost_data,
+    const size_t& deriv_order, const Mesh<3>& volume_mesh,
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                          Frame::Inertial>&
+        cell_centered_logical_to_inertial_inv_jacobian);
 }  // namespace Ccz4::fd

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Derivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Derivatives.cpp
@@ -48,7 +48,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
   const Element<3> element = TestHelpers::Ccz4::fd::detail::set_element();
 
   // Testing spacetime_derivatives()
-  const DirectionalIdMap<3, evolution::dg::subcell::GhostData> all_ghost_data =
+  DirectionalIdMap<3, evolution::dg::subcell::GhostData> all_ghost_data =
       TestHelpers::Ccz4::fd::detail::compute_ghost_data(
           subcell_mesh, logical_coords, element.neighbors(), ghost_zone_size,
           TestHelpers::Ccz4::fd::detail::compute_prim_solution);
@@ -76,7 +76,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
       get<gr::Tags::Shift<DataVector, 3>>(volume_prims_for_recons);
   get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(volume_evolved_vars) =
       get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(
-        volume_prims_for_recons);
+          volume_prims_for_recons);
   get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars) =
       get<gr::Tags::Lapse<DataVector>>(volume_prims_for_recons);
 
@@ -213,7 +213,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
 
   auto& expected_d_field_b =
       get<::Tags::deriv<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>,
-        tmpl::size_t<3>, Frame::Inertial>>(expected_deriv_of_Ccz4_vars);
+                        tmpl::size_t<3>, Frame::Inertial>>(
+          expected_deriv_of_Ccz4_vars);
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
       expected_d_field_b.get(i, j) = 1;
@@ -222,8 +223,222 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
 
   CHECK_ITERABLE_APPROX(
       (get<::Tags::deriv<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>,
-        tmpl::size_t<3>, Frame::Inertial>>(deriv_of_Ccz4_vars)),
-          expected_d_field_b);
+                         tmpl::size_t<3>, Frame::Inertial>>(
+          deriv_of_Ccz4_vars)),
+      expected_d_field_b);
+
+  // Testing second_spacetime_derivatives()
+  all_ghost_data = TestHelpers::Ccz4::fd::detail::compute_ghost_data(
+      subcell_mesh, logical_coords, element.neighbors(), ghost_zone_size,
+      TestHelpers::Ccz4::fd::detail::compute_prim_solution_for_second_deriv);
+
+  volume_prims_for_recons =
+      TestHelpers::Ccz4::fd::detail::compute_prim_solution_for_second_deriv(
+          logical_coords);
+
+  get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(
+          volume_prims_for_recons);
+  get<::Ccz4::Tags::ATilde<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::ATilde<DataVector, 3>>(volume_prims_for_recons);
+  get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_prims_for_recons);
+  get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(volume_evolved_vars) =
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(
+          volume_prims_for_recons);
+  get<::Ccz4::Tags::Theta<DataVector>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::Theta<DataVector>>(volume_prims_for_recons);
+  get<::Ccz4::Tags::GammaHat<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::GammaHat<DataVector, 3>>(volume_prims_for_recons);
+  get<gr::Tags::Shift<DataVector, 3>>(volume_evolved_vars) =
+      get<gr::Tags::Shift<DataVector, 3>>(volume_prims_for_recons);
+  get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(volume_evolved_vars) =
+      get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(
+          volume_prims_for_recons);
+  get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars) =
+      get<gr::Tags::Lapse<DataVector>>(volume_prims_for_recons);
+
+  Variables<db::wrap_tags_in<::Tags::second_deriv,
+                             typename Ccz4::fd::System::gradients_tags,
+                             tmpl::size_t<3>, Frame::Inertial>>
+      second_deriv_of_Ccz4_vars{subcell_mesh.number_of_grid_points()};
+
+  ::Ccz4::fd::second_spacetime_derivatives(
+      make_not_null(&second_deriv_of_Ccz4_vars), volume_evolved_vars,
+      all_ghost_data, fd_deriv_order, subcell_mesh,
+      cell_centered_logical_to_inertial_inv_jacobian);
+
+  Variables<db::wrap_tags_in<::Tags::second_deriv,
+                             typename Ccz4::fd::System::gradients_tags,
+                             tmpl::size_t<3>, Frame::Inertial>>
+      expected_second_deriv_of_Ccz4_vars{subcell_mesh.number_of_grid_points()};
+
+  auto& expected_second_d_metric =
+      get<::Tags::second_deriv<::Ccz4::Tags::ConformalMetric<DataVector, 3>,
+                               tmpl::size_t<3>, Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        for (size_t l = 0; l < 3; ++l) {
+          expected_second_d_metric.get(i, j, k, l) =
+              (i == j and i == k)
+                  ? static_cast<double>(2 * (10 * k + 50 * l + 1))
+                  : 0.0;
+        }
+      }
+    }
+  }
+
+  const Approx custom_approx =
+      Approx::custom().epsilon(1.0e-12).scale(*std::max_element(
+          volume_evolved_vars.data(),
+          volume_evolved_vars.data() + volume_evolved_vars.size() - 1));
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<::Ccz4::Tags::ConformalMetric<DataVector, 3>,
+                                tmpl::size_t<3>, Frame::Inertial>>(
+          second_deriv_of_Ccz4_vars)),
+      expected_second_d_metric, custom_approx);
+
+  auto& expected_second_d_atilde =
+      get<::Tags::second_deriv<::Ccz4::Tags::ATilde<DataVector, 3>,
+                               tmpl::size_t<3>, Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        for (size_t l = 0; l < 3; ++l) {
+          expected_second_d_atilde.get(i, j, k, l) =
+              (i == j and i == k)
+                  ? static_cast<double>(2 * (1000 * k + 5000 * l + 1))
+                  : 0.0;
+        }
+      }
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<::Ccz4::Tags::ATilde<DataVector, 3>,
+                                tmpl::size_t<3>, Frame::Inertial>>(
+          second_deriv_of_Ccz4_vars)),
+      expected_second_d_atilde, custom_approx);
+
+  auto& expected_second_d_conformal_factor =
+      get<::Tags::second_deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                               tmpl::size_t<3>, Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      expected_second_d_conformal_factor.get(i, j) = i == j ? 2 : 0.0;
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                                tmpl::size_t<3>, Frame::Inertial>>(
+          second_deriv_of_Ccz4_vars)),
+      expected_second_d_conformal_factor, custom_approx);
+
+  auto& expected_second_d_trace_extrinsic_curvature =
+      get<::Tags::second_deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                               tmpl::size_t<3>, Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      expected_second_d_trace_extrinsic_curvature.get(i, j) = i == j ? 2 : 0.0;
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                                tmpl::size_t<3>, Frame::Inertial>>(
+          second_deriv_of_Ccz4_vars)),
+      expected_second_d_trace_extrinsic_curvature, custom_approx);
+
+  auto& expected_second_d_theta =
+      get<::Tags::second_deriv<::Ccz4::Tags::Theta<DataVector>, tmpl::size_t<3>,
+                               Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      expected_second_d_theta.get(i, j) = i == j ? 2 : 0.0;
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<::Ccz4::Tags::Theta<DataVector>,
+                                tmpl::size_t<3>, Frame::Inertial>>(
+          second_deriv_of_Ccz4_vars)),
+      expected_second_d_theta, custom_approx);
+
+  auto& expected_second_d_gamma_hat =
+      get<::Tags::second_deriv<::Ccz4::Tags::GammaHat<DataVector, 3>,
+                               tmpl::size_t<3>, Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        expected_second_d_gamma_hat.get(i, j, k) = i == j ? 2 : 0.0;
+      }
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<::Ccz4::Tags::GammaHat<DataVector, 3>,
+                                tmpl::size_t<3>, Frame::Inertial>>(
+          second_deriv_of_Ccz4_vars)),
+      expected_second_d_gamma_hat, custom_approx);
+
+  auto& expected_second_d_lapse =
+      get<::Tags::second_deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                               Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      expected_second_d_lapse.get(i, j) = i == j ? 2 : 0.0;
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                                Frame::Inertial>>(second_deriv_of_Ccz4_vars)),
+      expected_second_d_lapse, custom_approx);
+
+  auto& expected_second_d_shift =
+      get<::Tags::second_deriv<gr::Tags::Shift<DataVector, 3>, tmpl::size_t<3>,
+                               Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        expected_second_d_shift.get(i, j, k) = i == j ? 2 : 0.0;
+      }
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<gr::Tags::Shift<DataVector, 3>, tmpl::size_t<3>,
+                                Frame::Inertial>>(second_deriv_of_Ccz4_vars)),
+      expected_second_d_shift, custom_approx);
+
+  auto& expected_second_d_field_b =
+      get<::Tags::second_deriv<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>,
+                               tmpl::size_t<3>, Frame::Inertial>>(
+          expected_second_deriv_of_Ccz4_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        expected_second_d_field_b.get(i, j, k) = i == j ? 2 : 0.0;
+      }
+    }
+  }
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Tags::second_deriv<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>,
+                                tmpl::size_t<3>, Frame::Inertial>>(
+          second_deriv_of_Ccz4_vars)),
+      expected_second_d_field_b, custom_approx);
 
 // Test ASSERT triggers for incorrect neighbor size.
 #ifdef SPECTRE_DEBUG
@@ -245,6 +460,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
     CHECK_THROWS_WITH(
         Ccz4::fd::spacetime_derivatives(
             make_not_null(&deriv_of_Ccz4_vars), volume_evolved_vars,
+            bad_ghost_data, fd_deriv_order, subcell_mesh,
+            cell_centered_logical_to_inertial_inv_jacobian),
+        Catch::Matchers::ContainsSubstring(match_string));
+    CHECK_THROWS_WITH(
+        Ccz4::fd::second_spacetime_derivatives(
+            make_not_null(&second_deriv_of_Ccz4_vars), volume_evolved_vars,
             bad_ghost_data, fd_deriv_order, subcell_mesh,
             cell_centered_logical_to_inertial_inv_jacobian),
         Catch::Matchers::ContainsSubstring(match_string));

--- a/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
@@ -82,8 +82,7 @@ DirectionalIdMap<3, GhostData> compute_ghost_data(
                             coords_range, std::forward<Args>(args)...);
 }
 
-inline Variables<
-    ::Ccz4::fd::Tags::spacetime_reconstruction_tags>
+inline Variables<::Ccz4::fd::Tags::spacetime_reconstruction_tags>
 compute_prim_solution(
     const tnsr::I<DataVector, 3, Frame::ElementLogical>& coords) {
   using ConformalMetric = ::Ccz4::Tags::ConformalMetric<DataVector, 3>;
@@ -96,8 +95,8 @@ compute_prim_solution(
   using Shift = gr::Tags::Shift<DataVector, 3>;
   using AuxiliaryShiftB = ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>;
 
-  Variables<::Ccz4::fd::Tags::spacetime_reconstruction_tags>
-      vars{get<0>(coords).size(), 0.0};
+  Variables<::Ccz4::fd::Tags::spacetime_reconstruction_tags> vars{
+      get<0>(coords).size(), 0.0};
   for (size_t i = 0; i < 3; ++i) {
     get(get<ConformalFactor>(vars)) += coords.get(i);
     get(get<TraceExtrinsicCurvature>(vars)) += coords.get(i);
@@ -117,7 +116,7 @@ compute_prim_solution(
     get<GammaHat>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 10);
     get<Shift>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 60);
     get<AuxiliaryShiftB>(vars).get(j) +=
-      1.0e-2 * static_cast<double>((j + 2) + 110);
+        1.0e-2 * static_cast<double>((j + 2) + 110);
   }
 
   auto& conformal_metric = get<ConformalMetric>(vars);
@@ -130,6 +129,63 @@ compute_prim_solution(
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
       atilde.get(i, j) = (1000 * i + 5000 * j + 1) * coords.get(i);
+    }
+  }
+  return vars;
+}
+
+inline Variables<::Ccz4::fd::Tags::spacetime_reconstruction_tags>
+compute_prim_solution_for_second_deriv(
+    const tnsr::I<DataVector, 3, Frame::ElementLogical>& coords) {
+  using ConformalMetric = ::Ccz4::Tags::ConformalMetric<DataVector, 3>;
+  using ATilde = ::Ccz4::Tags::ATilde<DataVector, 3>;
+  using ConformalFactor = ::Ccz4::Tags::ConformalFactor<DataVector>;
+  using TraceExtrinsicCurvature = gr::Tags::TraceExtrinsicCurvature<DataVector>;
+  using Theta = ::Ccz4::Tags::Theta<DataVector>;
+  using GammaHat = ::Ccz4::Tags::GammaHat<DataVector, 3>;
+  using Lapse = gr::Tags::Lapse<DataVector>;
+  using Shift = gr::Tags::Shift<DataVector, 3>;
+  using AuxiliaryShiftB = ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>;
+
+  Variables<::Ccz4::fd::Tags::spacetime_reconstruction_tags> vars{
+      get<0>(coords).size(), 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    get(get<ConformalFactor>(vars)) += square(coords.get(i)) + coords.get(i);
+    get(get<TraceExtrinsicCurvature>(vars)) +=
+        square(coords.get(i)) + coords.get(i);
+    get(get<Theta>(vars)) += square(coords.get(i)) + coords.get(i);
+    get(get<Lapse>(vars)) += square(coords.get(i)) + coords.get(i);
+    for (size_t j = 0; j < 3; ++j) {
+      get<GammaHat>(vars).get(j) += square(coords.get(i)) + coords.get(i);
+      get<Shift>(vars).get(j) += square(coords.get(i)) + coords.get(i);
+      get<AuxiliaryShiftB>(vars).get(j) +=
+          square(coords.get(i)) + coords.get(i);
+    }
+  }
+  get(get<ConformalFactor>(vars)) += 2.0;
+  get(get<TraceExtrinsicCurvature>(vars)) += 15.0;
+  get(get<Theta>(vars)) += 30.0;
+  get(get<Lapse>(vars)) += 50.0;
+  for (size_t j = 0; j < 3; ++j) {
+    get<GammaHat>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 10);
+    get<Shift>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 60);
+    get<AuxiliaryShiftB>(vars).get(j) +=
+        1.0e-2 * static_cast<double>((j + 2) + 110);
+  }
+
+  auto& conformal_metric = get<ConformalMetric>(vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      conformal_metric.get(i, j) =
+          (10 * i + 50 * j + 1) * square(coords.get(i)) +
+          (10 * i + 50 * j + 1) * coords.get(i);
+    }
+  }
+  auto& atilde = get<ATilde>(vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      atilde.get(i, j) = (1000 * i + 5000 * j + 1) * square(coords.get(i)) +
+                         (1000 * i + 5000 * j + 1) * coords.get(i);
     }
   }
   return vars;


### PR DESCRIPTION
Add the second spatial derivatives of spacetime variables by finite differencing for calculating the RHS of the evolution equations of the second-order Ccz4 system (see eq. 4(a)-4(i) of this [paper](https://journals.aps.org/prd/pdf/10.1103/PhysRevD.97.084053)).

We use the 4th order second partial derivatives stencils implemented in SecondPartialDerivatives.hpp/.tpp to calculate the second spatial derivatives of all the evolved variable defined by variables_tag in FiniteDifference/System.hpp. We have only implemented the 4th order finite differencing here.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
