### PR TITLE
Add function to get number of pile up modes

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
@@ -150,16 +150,17 @@ std::array<double, Dim> absolute_truncation_error(
   return result;
 }
 
-double convergence_rate(const DataVector& power_monitor,
-                        const size_t number_of_filtered_modes) {
+ConvergenceInfo convergence_rate_and_number_of_pile_up_modes(
+    const DataVector& power_monitor, const size_t number_of_filtered_modes) {
   // Need enough unfiltered modes to compute the convergence rate. Here,
   // require at least 4 unfiltered modes.
   ASSERT(
       power_monitor.size() > number_of_filtered_modes + 3,
       "Power monitor needs at least 4 unfiltered modes to compute convergence "
-      "rate, but power monitor has size "
+      "rate and number of pile up modes, but power monitor has size "
           << power_monitor.size() << " with " << number_of_filtered_modes
           << " filtered modes");
+  ConvergenceInfo result{};
 
   const size_t n_tilde = power_monitor.size() - number_of_filtered_modes;
   std::vector<double> mode_numbers_for_fit{};
@@ -172,14 +173,29 @@ double convergence_rate(const DataVector& power_monitor,
   std::vector<double> delta_slopes{};
 
   // It turns out (as can be verified empirically) that the number of terms
-  // in this loop is 3 * (n_tilde - 5) for n_tilde > 6, 4 for n_tilde == 5,
-  // and 3 for n_tilde == 4 or n_tilde == 3. Here reserve the correct number of
-  // elements in terms of n_tilde, except don't use an extra if to
-  // distinguish between the 3 and 4 special cases (no harm in reserving space
-  // for a single extra double).
+  // in the loop to compute the convergence rate is 3 * (n_tilde - 5) for
+  // n_tilde > 6, 4 for n_tilde == 5, and 3 for n_tilde == 4 or n_tilde == 3.
+  // Here reserve the correct number of elements in terms of n_tilde, except
+  // don't use an extra if to distinguish between the 3 and 4 special cases (no
+  // harm in reserving space for a single extra double).
   const size_t max_slope_size = n_tilde > 6 ? 3 * (n_tilde - 5) : 4;
   slopes.reserve(max_slope_size);
   delta_slopes.reserve(max_slope_size);
+
+  // Compute log of the power monitor only for unfiltered modes, and
+  // ensure that log10 never causes a floating point exception here.
+  constexpr double eps_for_log = 100.0 * std::numeric_limits<double>::min();
+  const double log_floor = log10(eps_for_log);
+  DataVector log_power = power_monitor;
+  for (size_t i = 0; i < power_monitor.size() - number_of_filtered_modes; ++i) {
+    if (abs(log_power[i]) < eps_for_log) {
+      log_power[i] = log_floor;
+    } else {
+      log_power[i] = log10(abs(log_power[i]));
+    }
+  }
+
+  // Compute convergence rate
   for (size_t k1 = 0; k1 < 3; ++k1) {
     for (size_t k2 = std::min(k1 + 4, n_tilde_minus_one);
          k2 <= n_tilde_minus_one; ++k2) {
@@ -187,12 +203,22 @@ double convergence_rate(const DataVector& power_monitor,
       mode_powers_for_fit.resize(k2 - k1 + 1);
       for (size_t k = k1; k <= k2; ++k) {
         mode_numbers_for_fit[k - k1] = static_cast<double>(k);
-        mode_powers_for_fit[k - k1] = log10(power_monitor[k]);
+        mode_powers_for_fit[k - k1] = log_power[k];
       }
-      const intrp::LinearRegressionResult regression_result =
-          intrp::linear_regression(mode_numbers_for_fit, mode_powers_for_fit);
-      slopes.push_back(regression_result.slope);
-      delta_slopes.push_back(regression_result.delta_slope);
+      if (mode_numbers_for_fit.size() > 2) {
+        const intrp::LinearRegressionResult regression_result =
+            intrp::linear_regression(mode_numbers_for_fit, mode_powers_for_fit);
+        slopes.push_back(regression_result.slope);
+        delta_slopes.push_back(regression_result.delta_slope);
+      } else if (mode_numbers_for_fit.size() == 2 and
+                 mode_numbers_for_fit[0] != mode_numbers_for_fit[1]) {
+        slopes.push_back((mode_powers_for_fit[1] - mode_powers_for_fit[0]) /
+                         (mode_numbers_for_fit[1] - mode_numbers_for_fit[0]));
+        delta_slopes.push_back(0.0);
+      } else {
+        // Cannot construct a slope; skip this term in sum
+        continue;
+      }
     }
   }
   const auto max_delta =
@@ -209,7 +235,55 @@ double convergence_rate(const DataVector& power_monitor,
     denom += one_over_denom_this_term;
     num += gsl::at(slopes, i) * one_over_denom_this_term;
   }
-  return -num / denom;
+  result.convergence_rate = -num / denom;
+
+  // Compute number of pile up modes
+  // First, if the convergence rate is nearly zero, return zero pile up modes.
+  // A convergence rate near zero typically means that the function is not at
+  // all resolved (e.g. a step function), so the power spectrum is approximately
+  // flat. If the convergence rate is approximately flat, it's not realistic to
+  // attempt to distinguish whatever small, residual convergence might be
+  // present vs. pile up modes. Returning zero for an approximately flat power
+  // monitor also avoids dividing by approximately zero (or, in the case of
+  // an exactly flat power monitor, by exactly zero).
+  if (std::abs(result.convergence_rate) < 1.e-10) {
+    result.number_of_pile_up_modes = 0.0;
+  } else {
+    double number_of_pile_up_modes = 0.0;
+    for (size_t j = 2; j < n_tilde - 1; ++j) {
+      const size_t j_max = std::min(n_tilde - 1, j + 4);
+      mode_numbers_for_fit.resize(j_max - j + 1);
+      mode_powers_for_fit.resize(j_max - j + 1);
+      for (size_t i = j; i <= j_max; ++i) {
+        mode_numbers_for_fit[i - j] = static_cast<double>(i);
+        mode_powers_for_fit[i - j] = log_power[i];
+      }
+      double local_convergence_rate =
+          std::numeric_limits<double>::signaling_NaN();
+      if (mode_numbers_for_fit.size() > 2) {
+        local_convergence_rate =
+            -intrp::linear_regression(mode_numbers_for_fit, mode_powers_for_fit)
+                 .slope;
+      } else if (mode_numbers_for_fit.size() == 2 and
+                 mode_numbers_for_fit[1] != mode_numbers_for_fit[0]) {
+        local_convergence_rate =
+            (mode_powers_for_fit[1] - mode_powers_for_fit[0]) /
+            (mode_numbers_for_fit[1] - mode_numbers_for_fit[0]);
+      } else {
+        // cannot measure slope, so skip this term in sum
+        continue;
+      }
+      const double conv_ratio =
+          square(local_convergence_rate / result.convergence_rate);
+      // Avoid underflow: if conv_ratio < 16, just add zero.
+      // exp(-32.0*16.0) ~ 1.0e-195, which is still large enough to
+      // avoid underflow.
+      number_of_pile_up_modes +=
+          conv_ratio < 16.0 ? exp(-32.0 * conv_ratio) : 0.0;
+    }
+    result.number_of_pile_up_modes = number_of_pile_up_modes;
+  }
+  return result;
 }
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.hpp
@@ -120,11 +120,18 @@ std::array<double, Dim> absolute_truncation_error(
     const VectorType& tensor_component, const Mesh<Dim>& mesh);
 /// @}
 
+/// Holds convergence rate and pile up modes of a power monitor
+struct ConvergenceInfo {
+  double convergence_rate{std::numeric_limits<double>::signaling_NaN()};
+  double number_of_pile_up_modes{std::numeric_limits<double>::signaling_NaN()};
+};
+
 /*!
  * \ingroup SpectralGroup
- * \brief Returns the convergence rate of a power monitor.
+ * \brief Returns the convergence rate and the number of pile up modes of a
+ * power monitor as a ConvergenceInfo.
  *
- * \details Returns the convergence rate of a power monitor as a weighted
+ * \details Computes the convergence rate of a power monitor as a weighted
  * average of slopes measured using different subsets of spectral modes
  * in the power monitor. Equation (53) of \cite Szilagyi2014fna gives
  * the convergence rate $\mathcal{C}$ in terms of a power monitor $P_k$ as
@@ -148,10 +155,42 @@ std::array<double, Dim> absolute_truncation_error(
  * way $\epsilon$ is defined is so that it matches SpEC's definition, while
  * also ensuring that it is nonzero even if the error in the slope fit is
  * exactly zero.
+ *
+ * Also computes the number of pile up modes in a power monitor. Pile up
+ * modes are modes where the power is no longer converging at the overall
+ * convergence rate. Following Eq. (56) of \cite Szilagyi2014fna, the number of
+ * pile up modes $\mathcal{P}$ is defined as
+ * \begin{equation}
+ * \mathcal{P}(P_k) = \sum_{j=2}^{\tilde{N}-2}
+ * \exp\left[-32\left(\frac{\tilde{\mathcal{C}}_j}
+ * {\mathcal{C}(P_k)}\right)^2\right],
+ * \end{equation}
+ * where $\mathcal{C}(P_k)$ is the convergence rate of the power monitor $P_k$,
+ * the local convergence rate $\tilde{\mathcal{C}}_j$ of mode $j$ is
+ * \begin{equation}
+ * \tilde{\mathcal{C}}_j = -\mathcal{S}(j,\min(\tilde{N}-1,j+4)),
+ * \end{equation}
+ * $\mathcal{S}(k_1,k_2)$ is the slope of a linear regression fit of
+ * $\log_{10}(P_k)$ with $k$ satisfying $k_1\leq k \leq k_2$,
+ * $\tilde{N} = N-N_f$, $N$ is the number of modes in the
+ * power monitor, and the highest $N_f$ modes are filtered.
+ * The motivation of this definition is the following: if the local
+ * convergence rate $\tilde{\mathcal{C}}_j$ is comparable to the overall
+ * convergence rate $\mathcal{C}(P_k)$, then the $j^{\rm th}$ term in the
+ * summation becomes $\approx \exp(-32) \approx 10^{-14}$, while if
+ * $\tilde{\mathcal{C}}_j \ll \mathcal{C}(P_k)$, then the $j^{\rm th}$ term in
+ * the summation is $\approx \exp(0) = 1$. Note that the coefficient value 32
+ * is chosen to agree with SpEC.
+ * \note The summation goes up to $\tilde{N}-2$ so that there is it least one
+ * larger unfiltered mode for use in computing the slope. The highest mode
+ * used when computing the slope is the highest unfiltered mode, $\tilde{N}-1$.
+ * Mode numbers in the power monitor are zero based. These choices are off by
+ * one vs. Eqs. (55) and (56) of \cite Szilagyi2014fna, because those formulas
+ * apparently assume one-based indexing.
  * \param power_monitor The power monitor.
  * \param number_of_filtered_modes How many of the highest modes of the
  * power monitor are filtered (default 0).
  */
-double convergence_rate(const DataVector& power_monitor,
-                        size_t number_of_filtered_modes = 0);
+ConvergenceInfo convergence_rate_and_number_of_pile_up_modes(
+    const DataVector& power_monitor, size_t number_of_filtered_modes = 0);
 }  // namespace PowerMonitors

--- a/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Python/PowerMonitors.cpp
@@ -36,9 +36,19 @@ void bind_power_monitors(py::module& m) {
   bind_power_monitors_impl<1>(m);
   bind_power_monitors_impl<2>(m);
   bind_power_monitors_impl<3>(m);
-  m.def("convergence_rate",
-        py::overload_cast<const DataVector&, const size_t>(&convergence_rate),
-        py::arg("power_monitor"), py::arg("number_of_filtered_modes") = 0);
+  m.def(
+      "convergence_rate_and_number_of_pile_up_modes",
+      [](const DataVector& power_monitor,
+         const size_t number_of_filtered_modes) {
+        py::dict result{};
+        const ConvergenceInfo info =
+            convergence_rate_and_number_of_pile_up_modes(
+                power_monitor, number_of_filtered_modes);
+        result["convergence_rate"] = info.convergence_rate;
+        result["number_of_pile_up_modes"] = info.number_of_pile_up_modes;
+        return result;
+      },
+      py::arg("power_monitor"), py::arg("number_of_filtered_modes") = 0);
 }
 
 }  // namespace PowerMonitors::py_bindings

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Python/Test_PowerMonitors.py
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Python/Test_PowerMonitors.py
@@ -8,7 +8,7 @@ import numpy as np
 from spectre.DataStructures import DataVector
 from spectre.NumericalAlgorithms.LinearOperators import (
     absolute_truncation_error,
-    convergence_rate,
+    convergence_rate_and_number_of_pile_up_modes,
     power_monitors,
     relative_truncation_error,
 )
@@ -19,6 +19,7 @@ from spectre.Spectral import (
     Quadrature,
     logical_coordinates,
 )
+from spectre.SphericalHarmonics import Frame, Strahlkorper, power_monitor
 
 
 class TestPowerMonitors(unittest.TestCase):
@@ -83,12 +84,30 @@ class TestPowerMonitors(unittest.TestCase):
 
     # Check that the convergence rate for a straight line is consistent with
     # the analytic expectation
-    def test_convergence_rate(self):
+    def test_convergence_rate_and_pile_up_modes(self):
         slope, offset = -0.4, 1.4
         modes = np.arange(0, 14, 1)
+        filtered_modes = 3
         test_power_monitor = 10.0 ** (slope * modes + offset)
-        rate = convergence_rate(test_power_monitor, 3)
+        rate = convergence_rate_and_number_of_pile_up_modes(
+            test_power_monitor, filtered_modes
+        )["convergence_rate"]
         np.testing.assert_allclose(rate, -slope)
+
+        # Check that a straight line with some pile up modes added by hand
+        # recovers the correct integer number of pile up modes
+        expected_pile_up_modes = 5
+        modes_to_fill = filtered_modes + expected_pile_up_modes
+        for i in range(0, modes_to_fill, 1):
+            test_power_monitor[len(test_power_monitor) - i - 1] = (
+                test_power_monitor[len(test_power_monitor) - modes_to_fill - 1]
+            )
+        pile_up_modes = convergence_rate_and_number_of_pile_up_modes(
+            test_power_monitor, filtered_modes
+        )["number_of_pile_up_modes"]
+        np.testing.assert_allclose(
+            np.floor(pile_up_modes), expected_pile_up_modes
+        )
 
 
 if __name__ == "__main__":

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
@@ -253,8 +253,10 @@ void test_convergence_rate() {
   }
   constexpr size_t filtered_modes = 2;
 
-  double convergence_rate = PowerMonitors::convergence_rate(
-      power_monitor_with_known_slope, filtered_modes);
+  double convergence_rate =
+      PowerMonitors::convergence_rate_and_number_of_pile_up_modes(
+          power_monitor_with_known_slope, filtered_modes)
+          .convergence_rate;
   CHECK(approx(convergence_rate) == -expected_slope);
 
   // Change the filtered modes' power to a NaN, and ensure that this mode
@@ -263,8 +265,10 @@ void test_convergence_rate() {
       std::numeric_limits<double>::signaling_NaN();
   power_monitor_with_known_slope[9] =
       std::numeric_limits<double>::signaling_NaN();
-  convergence_rate = PowerMonitors::convergence_rate(
-      power_monitor_with_known_slope, filtered_modes);
+  convergence_rate =
+      PowerMonitors::convergence_rate_and_number_of_pile_up_modes(
+          power_monitor_with_known_slope, filtered_modes)
+          .convergence_rate;
   CHECK(approx(convergence_rate) == -expected_slope);
 
   // Test that adding noise of amplitude 1e-2 affects the slope recovered
@@ -274,8 +278,10 @@ void test_convergence_rate() {
   for (size_t i = 0; i < size_of_power_monitor - filtered_modes; ++i) {
     power_monitor_with_known_slope[i] *= pow(10.0, noise_dis(gen));
   }
-  convergence_rate = PowerMonitors::convergence_rate(
-      power_monitor_with_known_slope, filtered_modes);
+  convergence_rate =
+      PowerMonitors::convergence_rate_and_number_of_pile_up_modes(
+          power_monitor_with_known_slope, filtered_modes)
+          .convergence_rate;
   // define custom approx for higher derivative checks
   const Approx custom_approx = Approx::custom().epsilon(noise_amp).scale(1.0);
   CHECK(custom_approx(convergence_rate) == -expected_slope);
@@ -283,12 +289,80 @@ void test_convergence_rate() {
 // Check assert that sufficient modes were provided
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
-      PowerMonitors::convergence_rate(power_monitor_with_known_slope,
-                                      size_of_power_monitor - 3),
+      PowerMonitors::convergence_rate_and_number_of_pile_up_modes(
+          power_monitor_with_known_slope, size_of_power_monitor - 3),
       Catch::Matchers::ContainsSubstring(
           "Power monitor needs at least 4 unfiltered modes to compute "
           "convergence"));
 #endif
+}
+
+void test_pile_up_modes() {
+  // Check assert that sufficient modes were provided
+  // First, check that a power monitor with an exact, constant slope has the
+  // vanishing pile up modes
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> slope_dis(-2.0, -1.0);
+  const double expected_slope = slope_dis(gen);
+  std::uniform_real_distribution<> offset_dis(-0.4, -0.1);
+  const double offset = offset_dis(gen);
+  const size_t size_of_power_monitor{20};
+  DataVector power_monitor_with_known_slope{size_of_power_monitor};
+  for (size_t i = 0; i < size_of_power_monitor; ++i) {
+    power_monitor_with_known_slope[i] =
+        pow(10.0, static_cast<double>(i) * expected_slope + offset);
+  }
+  constexpr size_t filtered_modes = 2;
+
+  const double pile_up_modes_known_slope =
+      PowerMonitors::convergence_rate_and_number_of_pile_up_modes(
+          power_monitor_with_known_slope, filtered_modes)
+          .number_of_pile_up_modes;
+  const Approx custom_approx = Approx::custom().epsilon(1.e-10).scale(1.0);
+  CHECK(custom_approx(pile_up_modes_known_slope) == 0.0);
+
+  // Revise the power monitor to artificially introduce pile up modes
+  // Set the top n modes to be equal to the n-1 power, so the slope is zero.
+  // Because the number of pile up modes is defined as a double, the computed
+  // pile up mode count will have a fractional part as well as the expected
+  // integer number of pile up modes. In the test, ignore the fractional part,
+  // but make sure that the expected integer number of pile up modes is
+  // recovered. Always leave at least 2 unfiltered modes not piled up.
+  for (size_t expected_pile_up_modes = 1;
+       expected_pile_up_modes < size_of_power_monitor - filtered_modes - 2;
+       ++expected_pile_up_modes) {
+    DataVector power_monitor_with_pile_up_modes =
+        power_monitor_with_known_slope;
+    for (size_t i =
+             size_of_power_monitor - filtered_modes - expected_pile_up_modes;
+         i < size_of_power_monitor - filtered_modes; ++i) {
+      power_monitor_with_pile_up_modes[i] =
+          power_monitor_with_pile_up_modes[size_of_power_monitor -
+                                           filtered_modes -
+                                           expected_pile_up_modes - 1];
+    }
+    // Ensure that filtered modes are not used by replacing them with NaN
+    for (size_t i = size_of_power_monitor - filtered_modes;
+         i < size_of_power_monitor; ++i) {
+      power_monitor_with_pile_up_modes[i] =
+          std::numeric_limits<double>::signaling_NaN();
+    }
+    const double pile_up_modes =
+        PowerMonitors::convergence_rate_and_number_of_pile_up_modes(
+            power_monitor_with_pile_up_modes, filtered_modes)
+            .number_of_pile_up_modes;
+    CHECK(static_cast<size_t>(std::floor(pile_up_modes)) ==
+          expected_pile_up_modes);
+  }
+
+  // Check that a power monitor with zero convergence rate returns zero piled up
+  // modes
+  power_monitor_with_known_slope = power_monitor_with_known_slope[0];
+  const double pile_up_modes_zero_convergence =
+      PowerMonitors::convergence_rate_and_number_of_pile_up_modes(
+          power_monitor_with_known_slope, filtered_modes)
+          .number_of_pile_up_modes;
+  CHECK(pile_up_modes_zero_convergence == 0.0);
 }
 }  // namespace
 
@@ -300,4 +374,5 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PowerMonitors",
   test_relative_truncation_error_with_symmetry();
   test_relative_truncation_error_linear_function();
   test_convergence_rate();
+  test_pile_up_modes();
 }


### PR DESCRIPTION
## Proposed changes

Add a function to compute the number of pile up modes in a power monitor, and ensures that the power monitor `convergence_rate()` does not fail with a floating point exception if a mode has zero power.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

I have used [Cursor](https://cursor.com) with generative-AI features, including tab completion, on this PR. I have examined each proposed change, and to the best of my knowledge, they do not contain code that is copyrighted or not licensed for our use.