### PR TITLE
Add ExtraFileCheckExecs to CheckOutputFiles.py

### DIFF
--- a/cmake/RunInputFileTest.sh
+++ b/cmake/RunInputFileTest.sh
@@ -57,6 +57,8 @@ done
 if [ "$check_output_values" = "true" ]; then
     @Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/tools/CheckOutputFiles.py \
         --input-file $input_file --run-directory $test_dir \
+        --cmake-source-directory @CMAKE_SOURCE_DIR@ \
+        --cmake-bin-directory @CMAKE_BINARY_DIR@ \
         || exit 1
 fi
 if [ "$check_output_present" = "true" ]; then

--- a/tools/CheckOutputFiles.py
+++ b/tools/CheckOutputFiles.py
@@ -363,6 +363,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--input-filename")
     parser.add_argument("--run-directory")
+    parser.add_argument("--cmake-source-directory")
+    parser.add_argument("--cmake-bin-directory")
     logging.basicConfig(level=logging.INFO)
     duplicate_test_case, remaining_args = parser.parse_known_args(
         namespace=H5CheckTestCase

--- a/tools/CheckOutputFiles.py
+++ b/tools/CheckOutputFiles.py
@@ -6,6 +6,7 @@ import glob
 import logging
 import os
 import re
+import subprocess
 import unittest
 
 import h5py
@@ -311,15 +312,15 @@ class H5Check:
             )
 
 
-class H5CheckTestCase(unittest.TestCase):
-    """The unit test object for performing all H5 checks for a given input file
+class OutputCheckTestCase(unittest.TestCase):
+    """The unit test object for performing output checks for a given input file
 
     The parameters for the H5 output checks are determined by the
-    command-line arguments. The first argument (sys.argv[1]) is the yaml
-    input file. The second argument is the directory in which to find the
-    run's.h5 files.
+    command-line arguments. The `--input-filename` flag specifies the yaml
+    input file. The `--run-directory` specifies the directory in which to find
+    the run's .h5 files.
 
-    The H5 checks and arguments are parsed from the "OutputFileChecks" in the
+    The H5 checks and arguments are parsed from the `OutputFileChecks` in the
     input file metadata:
 
     ```yaml
@@ -336,6 +337,26 @@ class H5CheckTestCase(unittest.TestCase):
         RelativeTolerance: 1e-6
         SkipColumns: [0, 1]
     ```
+
+    Extra checking executables can be invoked from the `ExtraFileCheckExecs`
+    section in the input file metadata:
+
+    ```yaml
+    ExtraFileCheckExecs:
+      - Label: "label1"
+        Executable: "check1.py"
+        Arguments: ["--additional", "--arguments"]
+      - Label: "label2"
+        Executable: "check2.py"
+        Arguments:
+          - "--other"
+          - "--arguments"
+    ```
+    Each `Executable` will be invoked with `subprocess.run`, so it must be
+    executable (with a shebang if a it's e.g. a python script). It will receive
+    command line arguments corresponding to --input-filename, --run-directory,
+    --cmake-source-directory, --cmake-bin-directory, and the contents of
+    `Arguments`.
     """
 
     def test_h5_output(self):
@@ -358,6 +379,33 @@ class H5CheckTestCase(unittest.TestCase):
             with self.subTest(test=h5_check.test_h5_label):
                 h5_check.perform_check(self.run_directory)
 
+    def test_extra_execs(self):
+        extra_check_list = []
+        with open(self.input_filename, "r") as open_input_file:
+            parsed_yaml = next(yaml.safe_load_all(open_input_file))
+        if "ExtraFileCheckExecs" in parsed_yaml:
+            for check_block in parsed_yaml["ExtraFileCheckExecs"]:
+                logging.info("Parsed extra check : " + check_block["Label"])
+                extra_check_list.append(check_block)
+        for extra_check in extra_check_list:
+            with self.subTest(test=extra_check["Label"]):
+                dirname = os.path.dirname(self.input_filename)
+                cmdline = [
+                    os.path.join(dirname, extra_check["Executable"]),
+                    "--input-filename",
+                    self.input_filename,
+                    "--run-directory",
+                    self.run_directory,
+                    "--cmake-source-directory",
+                    self.cmake_source_directory,
+                    "--cmake-bin-directory",
+                    self.cmake_bin_directory,
+                ]
+                if "Arguments" in extra_check:
+                    cmdline = cmdline + extra_check["Arguments"]
+                run_result = subprocess.run(cmdline)
+                self.assertEqual(run_result.returncode, 0)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -367,7 +415,7 @@ if __name__ == "__main__":
     parser.add_argument("--cmake-bin-directory")
     logging.basicConfig(level=logging.INFO)
     duplicate_test_case, remaining_args = parser.parse_known_args(
-        namespace=H5CheckTestCase
+        namespace=OutputCheckTestCase
     )
     del duplicate_test_case
     # Use of full command-line arguments breaks the unit-test framework


### PR DESCRIPTION
## Proposed changes

This lets an input file test perform custom checks by having CheckOutputFiles.py
invoke any number of additional executables. This is needed for #6648

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->