### PR TITLE
Add time derivative for SoCcz4

### DIFF
--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_headers(
   Derivatives.hpp
   SecondPartialDerivatives.hpp
   SecondPartialDerivatives.tpp
+  SoTimeDerivative.hpp
   System.hpp
   Tags.hpp
   )

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
@@ -1,0 +1,862 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataBox/AsAccess.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedContainers.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
+#include "Evolution/Systems/Ccz4/DerivLapse.hpp"
+#include "Evolution/Systems/Ccz4/DerivZ4Constraint.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
+#include "Evolution/Systems/Ccz4/Ricci.hpp"
+#include "Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Evolution/Systems/Ccz4/TagsDeclarations.hpp"
+#include "Evolution/Systems/Ccz4/TempTags.hpp"
+#include "Evolution/Systems/Ccz4/TimeDerivative.hpp"
+#include "Evolution/Systems/Ccz4/Z4Constraint.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/*!
+ * \brief The namespace for evolving the second-order Ccz4 system.
+ * Spatial derivatives are computed using 4-th order finite
+ * differencing. Currently this system only works in 3D.
+ */
+namespace Ccz4::fd {
+const size_t Dim = 3;
+
+namespace detail {
+// Calculate the time derivative of the evolved variables for the second-order
+// Ccz4 system. There is quite some overlap between this apply() funcion
+// and the apply() function in the first-order Ccz4 system. However,
+// it is not straightforward to directly reuse the first-order
+// apply() function as the function signatures differ significantly.
+template <size_t Dim>
+static void apply(
+    // LHS time derivatives of evolved variables: eq 4(a) - 4(i)
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*> dt_conformal_spatial_metric,
+    const gsl::not_null<Scalar<DataVector>*> dt_lapse,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> dt_shift,
+    const gsl::not_null<Scalar<DataVector>*> dt_conformal_factor,
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*> dt_a_tilde,
+    const gsl::not_null<Scalar<DataVector>*> dt_trace_extrinsic_curvature,
+    const gsl::not_null<Scalar<DataVector>*> dt_theta,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> dt_gamma_hat,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> dt_b,
+
+    // quantities we need for computing eq 4, 13-27
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor_squared,
+    const gsl::not_null<Scalar<DataVector>*> det_conformal_spatial_metric,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*>
+        inv_conformal_spatial_metric,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> inv_spatial_metric,
+    const gsl::not_null<tnsr::II<DataVector, Dim>*> inv_a_tilde,
+    // temporary expressions
+    const gsl::not_null<tnsr::ij<DataVector, Dim>*> a_tilde_times_field_b,
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*>
+        a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde,
+    const gsl::not_null<Scalar<DataVector>*> contracted_field_b,
+    const gsl::not_null<tnsr::ijK<DataVector, Dim>*> symmetrized_d_field_b,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*>
+        contracted_symmetrized_d_field_b,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> field_d_up_times_a_tilde,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*>
+        contracted_field_d_up,  // temp for eq 18 -20
+    const gsl::not_null<Scalar<DataVector>*>
+        half_conformal_factor_squared,  // temp for eq 25
+    const gsl::not_null<tnsr::ij<DataVector, Dim>*>
+        conformal_metric_times_field_b,
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*>
+        conformal_metric_times_trace_a_tilde,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*>
+        inv_conformal_metric_times_d_a_tilde,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*>
+        gamma_hat_minus_contracted_conformal_christoffel,
+    const gsl::not_null<tnsr::iJ<DataVector, Dim>*>
+        d_gamma_hat_minus_contracted_conformal_christoffel,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*>
+        contracted_christoffel_second_kind,  // temp for eq 18 -20
+    const gsl::not_null<tnsr::ij<DataVector, Dim>*>
+        contracted_d_conformal_christoffel_difference,  // temp for eq 18 -20
+    const gsl::not_null<Scalar<DataVector>*> k_minus_2_theta_c,
+    const gsl::not_null<Scalar<DataVector>*> k_minus_k0_minus_2_theta_c,
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*> lapse_times_a_tilde,
+    const gsl::not_null<tnsr::ijj<DataVector, Dim>*> lapse_times_d_a_tilde,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> lapse_times_field_a,
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*>
+        lapse_times_conformal_spatial_metric,
+    const gsl::not_null<Scalar<DataVector>*> lapse_times_slicing_condition,
+    const gsl::not_null<Scalar<DataVector>*>
+        lapse_times_ricci_scalar_plus_divergence_z4_constraint,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> shift_times_deriv_gamma_hat,
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*>
+        inv_tau_times_conformal_metric,
+    // expressions and identities needed for evolution equations: eq 13 - 27
+    const gsl::not_null<Scalar<DataVector>*> trace_a_tilde,       // eq 13
+    const gsl::not_null<tnsr::iJJ<DataVector, Dim>*> field_d_up,  // eq 14
+    const gsl::not_null<tnsr::Ijj<DataVector, Dim>*>
+        conformal_christoffel_second_kind,  // eq 15
+    const gsl::not_null<tnsr::iJkk<DataVector, Dim>*>
+        d_conformal_christoffel_second_kind,  // eq 16
+    const gsl::not_null<tnsr::Ijj<DataVector, Dim>*>
+        christoffel_second_kind,  // eq 17
+    const gsl::not_null<tnsr::ii<DataVector, Dim>*>
+        spatial_ricci_tensor,  // eq 18 - 20
+    const gsl::not_null<tnsr::ij<DataVector, Dim>*> grad_grad_lapse,  // eq 21
+    const gsl::not_null<Scalar<DataVector>*> divergence_lapse,        // eq 22
+    const gsl::not_null<tnsr::I<DataVector, Dim>*>
+        contracted_conformal_christoffel_second_kind,  // eq 23
+    const gsl::not_null<tnsr::iJ<DataVector, Dim>*>
+        d_contracted_conformal_christoffel_second_kind,  // eq 24
+    const gsl::not_null<tnsr::i<DataVector, Dim>*>
+        spatial_z4_constraint,  // eq 25
+    const gsl::not_null<tnsr::I<DataVector, Dim>*>
+        upper_spatial_z4_constraint,  // eq 25
+    const gsl::not_null<tnsr::ij<DataVector, Dim>*>
+        grad_spatial_z4_constraint,  // eq 26
+    const gsl::not_null<Scalar<DataVector>*>
+        ricci_scalar_plus_divergence_z4_constraint,  // eq 27
+
+    // fixed params for SO-CCZ4
+    // c = 1.0, cleaning_speed = 1.0
+    // one_over_relaxation_time = 0.0
+    const double c, const double cleaning_speed,  // e in the paper
+    const double one_over_relaxation_time,        // \tau^{-1}
+
+    // free params for SO-CCZ4
+    const Scalar<DataVector>& eta, const double f, const double kappa_1,
+    const double kappa_2, const double kappa_3, const Scalar<DataVector>& k_0,
+
+    // evolved variables
+    const tnsr::ii<DataVector, Dim>& conformal_spatial_metric,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
+    const Scalar<DataVector>& conformal_factor,
+    const tnsr::ii<DataVector, Dim>& a_tilde,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const Scalar<DataVector>& theta, const tnsr::I<DataVector, Dim>& gamma_hat,
+    const tnsr::I<DataVector, Dim>& b,
+
+    // auxilliary fields and their derivatives
+    const tnsr::i<DataVector, Dim>& field_a,
+    const tnsr::iJ<DataVector, Dim>& field_b,
+    const tnsr::ijj<DataVector, Dim>& field_d,
+    const tnsr::i<DataVector, Dim>& field_p,
+    const tnsr::ii<DataVector, Dim>& d_field_a,
+    const tnsr::iiJ<DataVector, Dim>& d_field_b,
+    const tnsr::iijj<DataVector, Dim>& d_field_d,
+    const tnsr::ii<DataVector, Dim>& d_field_p,
+
+    // spatial derivatives of other evolved variables
+    const tnsr::ijj<DataVector, Dim>& d_a_tilde,
+    const tnsr::i<DataVector, Dim>& d_trace_extrinsic_curvature,
+    const tnsr::i<DataVector, Dim>& d_theta,
+    const tnsr::iJ<DataVector, Dim>& d_gamma_hat,
+    const tnsr::iJ<DataVector, Dim>& d_b) {
+  constexpr double one_third = 1.0 / 3.0;
+
+  // quantities we need for computing eq 4, 13 - 27
+
+  determinant_and_inverse(det_conformal_spatial_metric,
+                          inv_conformal_spatial_metric,
+                          conformal_spatial_metric);
+
+  get(*conformal_factor_squared) = square(get(conformal_factor));
+
+  ::tenex::evaluate<ti::I, ti::J>(
+      inv_spatial_metric, (*conformal_factor_squared)() *
+                              (*inv_conformal_spatial_metric)(ti::I, ti::J));
+
+  ::tenex::evaluate<ti::I, ti::J>(
+      inv_a_tilde, a_tilde(ti::k, ti::l) *
+                       (*inv_conformal_spatial_metric)(ti::I, ti::K) *
+                       (*inv_conformal_spatial_metric)(ti::J, ti::L));
+
+  ASSERT(min(get(lapse)) > 0.0,
+         "The lapse must be positive when using 1+log slicing.");
+
+  // slicing_condition and d_slicing_condition is not used in SO-CCZ4
+  // \alpha g(\alpha)  == 2
+  *lapse_times_slicing_condition =
+      make_with_value<Scalar<DataVector>>(lapse, 2.0);
+
+  // expressions and identities needed for evolution equations: eq 13 - 27
+
+  // eq 13
+  ::tenex::evaluate(
+      trace_a_tilde,
+      (*inv_conformal_spatial_metric)(ti::I, ti::J) * a_tilde(ti::i, ti::j));
+
+  // from eq 14: field_d_up is the D_k^{ij} tensor
+  ::tenex::evaluate<ti::k, ti::I, ti::J>(
+      field_d_up, (*inv_conformal_spatial_metric)(ti::I, ti::N) *
+                      (*inv_conformal_spatial_metric)(ti::M, ti::J) *
+                      field_d(ti::k, ti::n, ti::m));
+
+  // eq 15
+  ::Ccz4::conformal_christoffel_second_kind(conformal_christoffel_second_kind,
+                                            *inv_conformal_spatial_metric,
+                                            field_d);
+
+  // eq 16
+  ::Ccz4::deriv_conformal_christoffel_second_kind(
+      d_conformal_christoffel_second_kind, *inv_conformal_spatial_metric,
+      field_d, d_field_d, *field_d_up);
+
+  // eq 17
+  ::Ccz4::christoffel_second_kind(christoffel_second_kind,
+                                  conformal_spatial_metric,
+                                  *inv_conformal_spatial_metric, field_p,
+                                  *conformal_christoffel_second_kind);
+
+  // temporary expressions needed for eq 18 - 20
+  ::tenex::evaluate<ti::l>(contracted_christoffel_second_kind,
+                           (*christoffel_second_kind)(ti::M, ti::l, ti::m));
+
+  // comment for the future: we should probably ensure the traces are taken
+  // before computing the differences as the off-diagonal terms are not
+  // needed
+  ::tenex::evaluate<ti::i, ti::j>(
+      contracted_d_conformal_christoffel_difference,
+      (*d_conformal_christoffel_second_kind)(ti::m, ti::M, ti::i, ti::j) -
+          (*d_conformal_christoffel_second_kind)(ti::j, ti::M, ti::i, ti::m));
+
+  ::tenex::evaluate<ti::L>(contracted_field_d_up,
+                           (*field_d_up)(ti::m, ti::M, ti::L));
+
+  // eq 18 - 20
+  ::Ccz4::spatial_ricci_tensor(
+      spatial_ricci_tensor, *christoffel_second_kind,
+      *contracted_christoffel_second_kind,
+      *contracted_d_conformal_christoffel_difference, conformal_spatial_metric,
+      *inv_conformal_spatial_metric, field_d, *field_d_up,
+      *contracted_field_d_up, field_p, d_field_p);
+
+  // eq 21
+  ::Ccz4::grad_grad_lapse(grad_grad_lapse, lapse, *christoffel_second_kind,
+                          field_a, d_field_a);
+
+  // eq 22
+  ::Ccz4::divergence_lapse(divergence_lapse, *conformal_factor_squared,
+                           *inv_conformal_spatial_metric, *grad_grad_lapse);
+
+  // eq 23
+  ::Ccz4::contracted_conformal_christoffel_second_kind(
+      contracted_conformal_christoffel_second_kind,
+      *inv_conformal_spatial_metric, *conformal_christoffel_second_kind);
+
+  // eq 24
+  ::Ccz4::deriv_contracted_conformal_christoffel_second_kind(
+      d_contracted_conformal_christoffel_second_kind,
+      *inv_conformal_spatial_metric, *field_d_up,
+      *conformal_christoffel_second_kind, *d_conformal_christoffel_second_kind);
+
+  // temp for eq 25
+  ::tenex::evaluate<ti::I>(
+      gamma_hat_minus_contracted_conformal_christoffel,
+      gamma_hat(ti::I) -
+          (*contracted_conformal_christoffel_second_kind)(ti::I));
+
+  // eq 25
+  ::Ccz4::spatial_z4_constraint(
+      spatial_z4_constraint, conformal_spatial_metric,
+      *gamma_hat_minus_contracted_conformal_christoffel);
+
+  // temp for eq 25
+  ::tenex::evaluate(half_conformal_factor_squared,
+                    0.5 * (*conformal_factor_squared)());
+
+  // eq 25
+  ::Ccz4::upper_spatial_z4_constraint(
+      upper_spatial_z4_constraint, *half_conformal_factor_squared,
+      *gamma_hat_minus_contracted_conformal_christoffel);
+
+  // temp for eq 26
+  ::tenex::evaluate<ti::i, ti::L>(
+      d_gamma_hat_minus_contracted_conformal_christoffel,
+      d_gamma_hat(ti::i, ti::L) -
+          (*d_contracted_conformal_christoffel_second_kind)(ti::i, ti::L));
+
+  // eq 26
+  ::Ccz4::grad_spatial_z4_constraint(
+      grad_spatial_z4_constraint, *spatial_z4_constraint,
+      conformal_spatial_metric, *christoffel_second_kind, field_d,
+      *gamma_hat_minus_contracted_conformal_christoffel,
+      *d_gamma_hat_minus_contracted_conformal_christoffel);
+
+  // eq 27
+  ::Ccz4::ricci_scalar_plus_divergence_z4_constraint(
+      ricci_scalar_plus_divergence_z4_constraint, *conformal_factor_squared,
+      *inv_conformal_spatial_metric, *spatial_ricci_tensor,
+      *grad_spatial_z4_constraint);
+
+  // temporary expressions not already computed above
+
+  ::tenex::evaluate(contracted_field_b, field_b(ti::k, ti::K));
+
+  ::tenex::evaluate<ti::k, ti::j, ti::I>(
+      symmetrized_d_field_b,
+      0.5 * (d_field_b(ti::k, ti::j, ti::I) + d_field_b(ti::j, ti::k, ti::I)));
+
+  ::tenex::evaluate<ti::k>(contracted_symmetrized_d_field_b,
+                           (*symmetrized_d_field_b)(ti::k, ti::i, ti::I));
+
+  ::tenex::evaluate<ti::k>(
+      field_d_up_times_a_tilde,
+      (*field_d_up)(ti::k, ti::I, ti::J) * a_tilde(ti::i, ti::j));
+
+  ::tenex::evaluate<ti::i, ti::j>(
+      conformal_metric_times_field_b,
+      conformal_spatial_metric(ti::k, ti::i) * field_b(ti::j, ti::K));
+
+  ::tenex::evaluate<ti::i, ti::j>(
+      conformal_metric_times_trace_a_tilde,
+      conformal_spatial_metric(ti::i, ti::j) * (*trace_a_tilde)());
+
+  ::tenex::evaluate<ti::k>(inv_conformal_metric_times_d_a_tilde,
+                           (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                               d_a_tilde(ti::k, ti::i, ti::j));
+
+  ::tenex::evaluate<ti::i, ti::j>(
+      a_tilde_times_field_b, a_tilde(ti::k, ti::i) * field_b(ti::j, ti::K));
+
+  ::tenex::evaluate<ti::i, ti::j>(
+      a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde,
+      a_tilde(ti::i, ti::j) -
+          one_third * (*conformal_metric_times_trace_a_tilde)(ti::i, ti::j));
+
+  ::tenex::evaluate(k_minus_2_theta_c,
+                    trace_extrinsic_curvature() - 2.0 * c * theta());
+
+  ::tenex::evaluate(k_minus_k0_minus_2_theta_c, (*k_minus_2_theta_c)() - k_0());
+
+  ::tenex::evaluate<ti::i, ti::j>(lapse_times_a_tilde,
+                                  (lapse)() * a_tilde(ti::i, ti::j));
+
+  tenex::evaluate<ti::k, ti::i, ti::j>(
+      lapse_times_d_a_tilde, (lapse)() * d_a_tilde(ti::k, ti::i, ti::j));
+
+  ::tenex::evaluate<ti::k>(lapse_times_field_a, (lapse)() * field_a(ti::k));
+
+  ::tenex::evaluate<ti::i, ti::j>(
+      lapse_times_conformal_spatial_metric,
+      (lapse)() * conformal_spatial_metric(ti::i, ti::j));
+
+  ::tenex::evaluate(
+      lapse_times_ricci_scalar_plus_divergence_z4_constraint,
+      (lapse)() * (*ricci_scalar_plus_divergence_z4_constraint)());
+
+  ::tenex::evaluate<ti::I>(shift_times_deriv_gamma_hat,
+                           shift(ti::K) * d_gamma_hat(ti::k, ti::I));
+
+  ::tenex::evaluate<ti::i, ti::j>(
+      inv_tau_times_conformal_metric,
+      one_over_relaxation_time * conformal_spatial_metric(ti::i, ti::j));
+
+  // time derivative computation: eq 4(a) - 4(i)
+  // The way we evaluate the following may seem weird compared
+  // to 4(a) - 4(i). This is because we try to reuse the first-order
+  // Ccz4 codes as much as possible. Hence, the following is written
+  // based on 12a-12i, with s=1, and red terms canceled.
+
+  // eq 12a : time derivative of the conformal spatial metric
+  // this reduces to eq 4a for our choice of \tau^{-1}=0.
+  ::tenex::evaluate<ti::i, ti::j>(
+      dt_conformal_spatial_metric,
+      2.0 * shift(ti::K) * field_d(ti::k, ti::i, ti::j) +
+          (*conformal_metric_times_field_b)(ti::i, ti::j) +
+          (*conformal_metric_times_field_b)(ti::j, ti::i) -
+          2.0 * one_third * conformal_spatial_metric(ti::i, ti::j) *
+              (*contracted_field_b)() -
+          2.0 * (lapse)() *
+              (*a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde)(
+                  ti::i, ti::j) -
+          (*inv_tau_times_conformal_metric)(ti::i, ti::j) *
+              ((*det_conformal_spatial_metric)() - 1.0));
+
+  // time derivative of the lapse
+  ::tenex::evaluate<>(dt_lapse, (shift(ti::K) * field_a(ti::k) -
+                                 (*lapse_times_slicing_condition)() *
+                                     (*k_minus_k0_minus_2_theta_c)()) *
+                                    lapse());
+
+  // time derivative of the shift
+  ::tenex::evaluate<ti::I>(dt_shift,
+                           f * b(ti::I) + shift(ti::K) * field_b(ti::k, ti::I));
+
+  // time derivative of the the conformal factor
+  ::tenex::evaluate(dt_conformal_factor,
+                    (shift(ti::K) * field_p(ti::k) +
+                     one_third * ((lapse)() * trace_extrinsic_curvature() -
+                                  (*contracted_field_b)())) *
+                        conformal_factor());
+
+  // time derivative of the trace-free part of the extrinsic curvature
+  ::tenex::evaluate<ti::i, ti::j>(
+      dt_a_tilde,
+      shift(ti::K) * d_a_tilde(ti::k, ti::i, ti::j) +
+          (*conformal_factor_squared)() *
+              ((lapse)() * ((*spatial_ricci_tensor)(ti::i, ti::j) +
+                            (*grad_spatial_z4_constraint)(ti::i, ti::j) +
+                            (*grad_spatial_z4_constraint)(ti::j, ti::i)) -
+               (*grad_grad_lapse)(ti::i, ti::j)) -
+          one_third * conformal_spatial_metric(ti::i, ti::j) *
+              ((*lapse_times_ricci_scalar_plus_divergence_z4_constraint)() -
+               (*divergence_lapse)()) +
+          (*a_tilde_times_field_b)(ti::i, ti::j) +
+          (*a_tilde_times_field_b)(ti::j, ti::i) -
+          2.0 * one_third * a_tilde(ti::i, ti::j) * (*contracted_field_b)() +
+          (*lapse_times_a_tilde)(ti::i, ti::j) * (*k_minus_2_theta_c)() -
+          2.0 * (*lapse_times_a_tilde)(ti::i, ti::l) *
+              (*inv_conformal_spatial_metric)(ti::L, ti::M) *
+              a_tilde(ti::m, ti::j) -
+          (*inv_tau_times_conformal_metric)(ti::i, ti::j) * (*trace_a_tilde)());
+
+  // time derivative of the trace of the extrinsic curvature
+  ::tenex::evaluate(
+      dt_trace_extrinsic_curvature,
+      shift(ti::K) * d_trace_extrinsic_curvature(ti::k) -
+          (*divergence_lapse)() +
+          (*lapse_times_ricci_scalar_plus_divergence_z4_constraint)() +
+          (lapse)() * (trace_extrinsic_curvature() * (*k_minus_2_theta_c)() -
+                       3.0 * kappa_1 * (1.0 + kappa_2) * theta()));
+
+  // time derivative of the projection of the Z4 four-vector along
+  // the normal direction
+  ::tenex::evaluate(
+      dt_theta,
+      shift(ti::K) * d_theta(ti::k) +
+          (lapse)() *
+              (0.5 * square(cleaning_speed) *
+                   ((*ricci_scalar_plus_divergence_z4_constraint)() +
+                    2.0 * one_third * square(trace_extrinsic_curvature()) -
+                    a_tilde(ti::i, ti::j) * (*inv_a_tilde)(ti::I, ti::J)) -
+               c * theta() * trace_extrinsic_curvature() -
+               (*upper_spatial_z4_constraint)(ti::I)*field_a(ti::i) -
+               kappa_1 * (2.0 + kappa_2) * theta()));
+
+  // time derivative \hat{\Gamma}^i
+  // first, compute terms without s
+  ::tenex::evaluate<ti::I>(
+      dt_gamma_hat,
+      // terms without lapse nor s
+      (*shift_times_deriv_gamma_hat)(ti::I) +
+          2.0 * one_third *
+              (*contracted_conformal_christoffel_second_kind)(ti::I) *
+              (*contracted_field_b)() -
+          (*contracted_conformal_christoffel_second_kind)(ti::K)*field_b(
+              ti::k, ti::I) +
+          2.0 * kappa_3 * (*spatial_z4_constraint)(ti::j) *
+              (2.0 * one_third * (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                   (*contracted_field_b)() -
+               (*inv_conformal_spatial_metric)(ti::J, ti::K) *
+                   field_b(ti::k, ti::I)) +
+          // terms with lapse but not s
+          2.0 * (lapse)() *
+              (-2.0 * one_third *
+                   (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                   d_trace_extrinsic_curvature(ti::j) +
+               (*inv_conformal_spatial_metric)(ti::K, ti::I) * d_theta(ti::k) +
+               (*conformal_christoffel_second_kind)(ti::I, ti::j, ti::k) *
+                   (*inv_a_tilde)(ti::J, ti::K) -
+               3.0 * (*inv_a_tilde)(ti::I, ti::J) * field_p(ti::j) -
+               (*inv_conformal_spatial_metric)(ti::K, ti::I) *
+                   (theta() * field_a(ti::k) +
+                    2.0 * one_third * trace_extrinsic_curvature() *
+                        (*spatial_z4_constraint)(ti::k)) -
+               (*inv_a_tilde)(ti::I, ti::J) * field_a(ti::j) -
+               kappa_1 * (*inv_conformal_spatial_metric)(ti::I, ti::J) *
+                   (*spatial_z4_constraint)(ti::j)));
+  // We add the following since s=1 (Gamma-driver gauge) is assumed in SoCcz4
+  ::tenex::update<ti::I>(dt_gamma_hat,
+                         (*dt_gamma_hat)(ti::I) +
+                             // red terms should cancel
+                             // terms with s but not lapse
+                             (*inv_conformal_spatial_metric)(ti::K, ti::L) *
+                                 (*symmetrized_d_field_b)(ti::k, ti::l, ti::I) +
+                             one_third *
+                                 (*inv_conformal_spatial_metric)(ti::I, ti::K) *
+                                 (*contracted_symmetrized_d_field_b)(ti::k));
+
+  // time derivative b^i
+  ::tenex::evaluate<ti::I>(
+      dt_b, (*dt_gamma_hat)(ti::I)-eta() * b(ti::I) +
+                shift(ti::K) * (d_b(ti::k, ti::I) - d_gamma_hat(ti::k, ti::I)));
+
+  // Note that, we do not need to evolve the auxiliary variables in SO-CCZ4.
+}
+}  // namespace detail
+
+/*!
+ * \brief Compute the RHS of the second-order CCZ4 formulation of Einstein's
+ * equations \cite Dumbser2017okk with finite differencing.
+ *
+ * \details The evolution equations are equations 4(a) - 4(i) of
+ * \cite Dumbser2017okk Equations 13 - 27 define identities
+ * used in the evolution equations.
+ *
+ * \note Different from the first-order system, the lapse
+ * and the conformal factor are evolved instead of their natural logs.
+ * The four auxiliary varialbels \f$A_i\f$, \f$B_k{}^{i}\f$,
+ * \f$D_{kij}\f$, and \f$P_i\f$ are NOT evolved.
+ */
+template <size_t Dim, class DbTagsList>
+void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
+  // compute the first spatial derivatives of the evolved variables
+  using evolved_vars_tag = typename System::variables_tag;
+  using gradients_tags = typename System::gradients_tags;
+
+  // only 4-th order accurate second derivatives have been implemented
+  // To keep the same order of accuracy we use the same order for
+  // both first and second derivatives
+  const size_t fd_order = 4;
+  const auto& evolved_vars = db::get<evolved_vars_tag>(*box);
+  const Mesh<Dim>& subcell_mesh =
+      db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(*box);
+  const size_t num_pts = subcell_mesh.number_of_grid_points();
+  Variables<db::wrap_tags_in<::Tags::deriv, gradients_tags, tmpl::size_t<Dim>,
+                             Frame::Inertial>>
+      cell_centered_Ccz4_derivs{num_pts};
+  const auto& cell_centered_logical_to_inertial_inv_jacobian = db::get<
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<Dim>>(
+      *box);
+
+  ::Ccz4::fd::spacetime_derivatives(
+      make_not_null(&cell_centered_Ccz4_derivs), evolved_vars,
+      db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
+          *box),
+      fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+
+  // calculate the four auxiliary fields in eq. 6
+  // auxiliary variables NOT evolved in SO-CCZ4
+  const auto& d_lapse =
+      get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                        Frame::Inertial>>(cell_centered_Ccz4_derivs);
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(evolved_vars);
+  const auto field_a = ::tenex::evaluate<ti::i>(d_lapse(ti::i) / lapse());
+
+  const auto& field_b =
+      get<::Tags::deriv<gr::Tags::Shift<DataVector, Dim>, tmpl::size_t<Dim>,
+                        Frame::Inertial>>(cell_centered_Ccz4_derivs);
+
+  const auto& d_spatial_conformal_metric =
+      get<::Tags::deriv<Tags::ConformalMetric<DataVector, Dim>,
+                        tmpl::size_t<Dim>, Frame::Inertial>>(
+          cell_centered_Ccz4_derivs);
+  tnsr::ijj<DataVector, Dim> field_d;
+  ::tenex::evaluate<ti::i, ti::j, ti::k>(
+      make_not_null(&field_d),
+      0.5 * d_spatial_conformal_metric(ti::i, ti::j, ti::k));
+
+  const auto& conformal_factor =
+      get<Tags::ConformalFactor<DataVector>>(evolved_vars);
+  const auto& d_conformal_factor =
+      get<::Tags::deriv<Tags::ConformalFactor<DataVector>, tmpl::size_t<Dim>,
+                        Frame::Inertial>>(cell_centered_Ccz4_derivs);
+  const auto field_p =
+      ::tenex::evaluate<ti::i>(d_conformal_factor(ti::i) / conformal_factor());
+
+  // compute second derivatives of the evolved variables
+  Variables<db::wrap_tags_in<::Tags::second_deriv, gradients_tags,
+                             tmpl::size_t<Dim>, Frame::Inertial>>
+      cell_centered_Ccz4_second_derivs{num_pts};
+
+  Ccz4::fd::second_spacetime_derivatives(
+      make_not_null(&cell_centered_Ccz4_second_derivs), evolved_vars,
+      db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
+          *box),
+      fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+
+  // compute spatial derivative of the four auxiliary fields
+  const auto& d_d_lapse =
+      get<::Tags::second_deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                               Frame::Inertial>>(
+          cell_centered_Ccz4_second_derivs);
+  tnsr::ii<DataVector, Dim> d_field_a;
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&d_field_a),
+      (d_d_lapse(ti::i, ti::j) - d_lapse(ti::i) * d_lapse(ti::j) / lapse()) /
+          lapse());
+
+  const auto& d_field_b =
+      get<::Tags::second_deriv<gr::Tags::Shift<DataVector, Dim>,
+                               tmpl::size_t<Dim>, Frame::Inertial>>(
+          cell_centered_Ccz4_second_derivs);
+
+  const auto& d_d_conformal_metric =
+      get<::Tags::second_deriv<Tags::ConformalMetric<DataVector, Dim>,
+                               tmpl::size_t<Dim>, Frame::Inertial>>(
+          cell_centered_Ccz4_second_derivs);
+
+  tnsr::iijj<DataVector, Dim> d_field_d;
+  ::tenex::evaluate<ti::i, ti::j, ti::k, ti::l>(
+      make_not_null(&d_field_d),
+      0.5 * d_d_conformal_metric(ti::i, ti::j, ti::k, ti::l));
+
+  const auto& d_d_conformal_factor =
+      get<::Tags::second_deriv<Tags::ConformalFactor<DataVector>,
+                               tmpl::size_t<Dim>, Frame::Inertial>>(
+          cell_centered_Ccz4_second_derivs);
+
+  tnsr::ii<DataVector, Dim> d_field_p;
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&d_field_p),
+      (d_d_conformal_factor(ti::i, ti::j) - d_conformal_factor(ti::i) *
+                                                d_conformal_factor(ti::j) /
+                                                conformal_factor()) /
+          conformal_factor());
+
+  // intialize containers to be supplied in the SO-CCZ4 TimeDerivative.cpp
+  // apply() function quantities we need for computing eq 4, 13 - 27
+  using TempVars = Variables<tmpl::list<
+    Tags::ConformalFactorSquared<DataVector>,
+    Tags::DetConformalSpatialMetric<DataVector>,
+    Tags::InverseConformalMetric<DataVector, Dim>,
+    gr::Tags::InverseSpatialMetric<DataVector, Dim>,
+    Tags::InvATilde<DataVector, Dim>,
+    Tags::ATildeTimesFieldB<DataVector, Dim>,
+    Tags::ATildeMinusOneThirdConformalMetricTimesTraceATilde<DataVector, Dim>,
+    Tags::ContractedFieldB<DataVector>,
+    Tags::SymmetrizedDerivFieldB<DataVector, Dim>,
+    Tags::ContractedSymmetrizedDerivFieldB<DataVector, Dim>,
+    Tags::FieldDUpTimesATilde<DataVector, Dim>,
+    Tags::ContractedFieldDUp<DataVector, Dim>,
+    Tags::HalfConformalFactorSquared<DataVector>,
+    Tags::ConformalMetricTimesFieldB<DataVector, Dim>,
+    Tags::ConformalMetricTimesTraceATilde<DataVector, Dim>,
+    Tags::InverseConformalMetricTimesDerivATilde<DataVector, Dim>,
+    Tags::GammaHatMinusContractedConformalChristoffel<DataVector, Dim>,
+    Tags::DerivGammaHatMinusContractedConformalChristoffel<DataVector, Dim>,
+    Tags::ContractedChristoffelSecondKind<DataVector, Dim>,
+    Tags::ContractedDerivConformalChristoffelDifference<DataVector, Dim>,
+    Tags::KMinus2ThetaC<DataVector>,
+    Tags::KMinusK0Minus2ThetaC<DataVector>,
+    Tags::LapseTimesATilde<DataVector, Dim>,
+    Tags::LapseTimesDerivATilde<DataVector, Dim>,
+    Tags::LapseTimesFieldA<DataVector, Dim>,
+    Tags::LapseTimesConformalMetric<DataVector, Dim>,
+    Tags::LapseTimesSlicingCondition<DataVector>,
+    Tags::LapseTimesRicciScalarPlus2DivergenceZ4Constraint<DataVector>,
+    Tags::ShiftTimesDerivGammaHat<DataVector, Dim>,
+    Tags::InverseTauTimesConformalMetric<DataVector, Dim>,
+    Tags::TraceATilde<DataVector>,
+    Tags::FieldDUp<DataVector, Dim>,
+    Tags::ConformalChristoffelSecondKind<DataVector, Dim>,
+    Tags::DerivConformalChristoffelSecondKind<DataVector, Dim>,
+    Tags::ChristoffelSecondKind<DataVector, Dim>,
+    Tags::SpatialRicciTensor<DataVector, Dim>,
+    Tags::GradGradLapse<DataVector, Dim>,
+    Tags::DivergenceLapse<DataVector>,
+    Tags::ContractedConformalChristoffelSecondKind<DataVector, Dim>,
+    Tags::DerivContractedConformalChristoffelSecondKind<DataVector, Dim>,
+    Tags::SpatialZ4Constraint<DataVector, Dim>,
+    Tags::UpperSpatialZ4Contraint<DataVector, Dim>,
+    Tags::GradSpatialZ4Constraint<DataVector, Dim>,
+    Tags::RicciScalarPlusDivergenceZ4Constraint<DataVector>>>;
+
+  TempVars temp_vars(num_pts);
+
+  // free params
+  const double c = 1.0;               // c = 1.0 in SO-CCZ4
+  const double cleaning_speed = 1.0;  // e in the paper; e = 1.0 for SO-CCZ4
+  const Scalar<DataVector>& eta = get<Tags::Eta<DataVector>>(*box);
+  const double f = get<Tags::GammaDriverParam>(*box);
+  const Scalar<DataVector>& k_0 = get<Tags::K0<DataVector>>(*box);
+  const double kappa_1 = get<Tags::Kappa1>(*box);
+  const double kappa_2 = get<Tags::Kappa2>(*box);
+  const double kappa_3 = get<Tags::Kappa3>(*box);
+  const double one_over_relaxation_time = 0.0;  // \tau^{-1} = 0 in SO-CCZ4
+
+  // we assume the databox already has tags corresponding to dt of the evolved
+  // variables
+  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, evolved_vars_tag>;
+  db::mutate<dt_variables_tag>(
+      [&](const auto dt_vars_ptr) {
+        auto& [
+            conformal_factor_squared,
+            det_conformal_spatial_metric,
+            inv_conformal_spatial_metric,
+            inv_spatial_metric,
+            inv_a_tilde,
+            a_tilde_times_field_b,
+            a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde,
+            contracted_field_b,
+            symmetrized_d_field_b,
+            contracted_symmetrized_d_field_b,
+            field_d_up_times_a_tilde,
+            contracted_field_d_up,
+            half_conformal_factor_squared,
+            conformal_metric_times_field_b,
+            conformal_metric_times_trace_a_tilde,
+            inv_conformal_metric_times_d_a_tilde,
+            gamma_hat_minus_contracted_conformal_christoffel,
+            d_gamma_hat_minus_contracted_conformal_christoffel,
+            contracted_christoffel_second_kind,
+            contracted_d_conformal_christoffel_difference,
+            k_minus_2_theta_c,
+            k_minus_k0_minus_2_theta_c,
+            lapse_times_a_tilde,
+            lapse_times_d_a_tilde,
+            lapse_times_field_a,
+            lapse_times_conformal_spatial_metric,
+            lapse_times_slicing_condition,
+            lapse_times_ricci_scalar_plus_divergence_z4_constraint,
+            shift_times_deriv_gamma_hat,
+            inv_tau_times_conformal_metric,
+            trace_a_tilde,
+            field_d_up,
+            conformal_christoffel_second_kind,
+            d_conformal_christoffel_second_kind,
+            christoffel_second_kind,
+            spatial_ricci_tensor,
+            grad_grad_lapse,
+            divergence_lapse,
+            contracted_conformal_christoffel_second_kind,
+            d_contracted_conformal_christoffel_second_kind,
+            spatial_z4_constraint,
+            upper_spatial_z4_constraint,
+            grad_spatial_z4_constraint,
+            ricci_scalar_plus_divergence_z4_constraint] = temp_vars;
+        detail::apply(
+            // LHS time derivatives of evolved variables: eq 4a - 4i
+            make_not_null(
+                &get<
+                    ::Tags::dt<::Ccz4::Tags::ConformalMetric<DataVector, Dim>>>(
+                    *dt_vars_ptr)),  // eq 4a
+            make_not_null(&get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(
+                *dt_vars_ptr)),  // eq 4g
+            make_not_null(&get<::Tags::dt<gr::Tags::Shift<DataVector, Dim>>>(
+                *dt_vars_ptr)),  // eq 4h
+            make_not_null(
+                &get<::Tags::dt<::Ccz4::Tags::ConformalFactor<DataVector>>>(
+                    *dt_vars_ptr)),  // eq 4c
+            make_not_null(
+                &get<::Tags::dt<::Ccz4::Tags::ATilde<DataVector, Dim>>>(
+                    *dt_vars_ptr)),  // eq 4b
+            make_not_null(
+                &get<::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>>(
+                    *dt_vars_ptr)),  // eq 4d
+            make_not_null(&get<::Tags::dt<::Ccz4::Tags::Theta<DataVector>>>(
+                *dt_vars_ptr)),  // eq 4e
+            make_not_null(
+                &get<::Tags::dt<::Ccz4::Tags::GammaHat<DataVector, Dim>>>(
+                    *dt_vars_ptr)),  // eq 4f
+            make_not_null(
+                &get<
+                    ::Tags::dt<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>>(
+                    *dt_vars_ptr)),  // eq 4i
+
+            // quantities we need for computing eq 4, 13 - 27
+            make_not_null(&conformal_factor_squared),
+            make_not_null(&det_conformal_spatial_metric),
+            make_not_null(&inv_conformal_spatial_metric),
+            make_not_null(&inv_spatial_metric), make_not_null(&inv_a_tilde),
+            // temporary expressions
+            make_not_null(&a_tilde_times_field_b),
+            make_not_null(
+                &a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde),
+            make_not_null(&contracted_field_b),
+            make_not_null(&symmetrized_d_field_b),
+            make_not_null(&contracted_symmetrized_d_field_b),
+            make_not_null(&field_d_up_times_a_tilde),
+            make_not_null(&contracted_field_d_up),  // temp for eq 18 -20
+            make_not_null(&half_conformal_factor_squared),  // temp for eq 25
+            make_not_null(&conformal_metric_times_field_b),
+            make_not_null(&conformal_metric_times_trace_a_tilde),
+            make_not_null(&inv_conformal_metric_times_d_a_tilde),
+            make_not_null(&gamma_hat_minus_contracted_conformal_christoffel),
+            make_not_null(&d_gamma_hat_minus_contracted_conformal_christoffel),
+            make_not_null(
+                &contracted_christoffel_second_kind),  // temp for eq 18 -20
+            make_not_null(
+                &contracted_d_conformal_christoffel_difference),  // temp for eq
+                                                                  // 18 -20
+            make_not_null(&k_minus_2_theta_c),
+            make_not_null(&k_minus_k0_minus_2_theta_c),
+            make_not_null(&lapse_times_a_tilde),
+            make_not_null(&lapse_times_d_a_tilde),
+            make_not_null(&lapse_times_field_a),
+            make_not_null(&lapse_times_conformal_spatial_metric),
+            make_not_null(&lapse_times_slicing_condition),
+            make_not_null(
+                &lapse_times_ricci_scalar_plus_divergence_z4_constraint),
+            make_not_null(&shift_times_deriv_gamma_hat),
+            make_not_null(&inv_tau_times_conformal_metric),
+            // expressions and identities needed for evolution equations: eq 13
+            // - 27
+            make_not_null(&trace_a_tilde),                        // eq 13
+            make_not_null(&field_d_up),                           // eq 14
+            make_not_null(&conformal_christoffel_second_kind),    // eq 15
+            make_not_null(&d_conformal_christoffel_second_kind),  // eq 16
+            make_not_null(&christoffel_second_kind),              // eq 17
+            make_not_null(&spatial_ricci_tensor),                 // eq 18 - 20
+            make_not_null(&grad_grad_lapse),                      // eq 21
+            make_not_null(&divergence_lapse),                     // eq 22
+            make_not_null(
+                &contracted_conformal_christoffel_second_kind),  // eq 23
+            make_not_null(
+                &d_contracted_conformal_christoffel_second_kind),  // eq 24
+            make_not_null(&spatial_z4_constraint),                 // eq 25
+            make_not_null(&upper_spatial_z4_constraint),           // eq 25
+            make_not_null(&grad_spatial_z4_constraint),            // eq 26
+            make_not_null(
+                &ricci_scalar_plus_divergence_z4_constraint),  // eq 27
+            // fixed params
+            c, cleaning_speed,         // e in the paper
+            one_over_relaxation_time,  // \tau^{-1}
+            // free params
+            eta, f, kappa_1, kappa_2, kappa_3, k_0,
+            // evolved variables
+            get<Tags::ConformalMetric<DataVector, Dim>>(evolved_vars),
+            get<gr::Tags::Lapse<DataVector>>(evolved_vars),
+            get<gr::Tags::Shift<DataVector, Dim>>(evolved_vars),
+            get<Tags::ConformalFactor<DataVector>>(evolved_vars),
+            get<Tags::ATilde<DataVector, Dim>>(evolved_vars),
+            get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars),
+            get<Tags::Theta<DataVector>>(evolved_vars),
+            get<Tags::GammaHat<DataVector, Dim>>(evolved_vars),
+            get<Tags::AuxiliaryShiftB<DataVector, Dim>>(evolved_vars),
+
+            field_a,  // auxiliary variables NOT evolved in SO-CCZ4
+            field_b, field_d, field_p,
+            d_field_a,  // spatial derivative of auxiliary variables
+            d_field_b, d_field_d, d_field_p,
+
+            // spatial derivatives of other evolved variables
+            get<::Tags::deriv<Tags::ATilde<DataVector, Dim>, tmpl::size_t<Dim>,
+                              Frame::Inertial>>(cell_centered_Ccz4_derivs),
+            get<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                              tmpl::size_t<Dim>, Frame::Inertial>>(
+                cell_centered_Ccz4_derivs),
+            get<::Tags::deriv<Tags::Theta<DataVector>, tmpl::size_t<Dim>,
+                              Frame::Inertial>>(cell_centered_Ccz4_derivs),
+            get<::Tags::deriv<Tags::GammaHat<DataVector, Dim>,
+                              tmpl::size_t<Dim>, Frame::Inertial>>(
+                cell_centered_Ccz4_derivs),
+            get<::Tags::deriv<Tags::AuxiliaryShiftB<DataVector, Dim>,
+                              tmpl::size_t<Dim>, Frame::Inertial>>(
+                cell_centered_Ccz4_derivs));
+      },
+      box);
+}
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
@@ -18,12 +18,8 @@ struct System {
       gr::Tags::TraceExtrinsicCurvature<DataVector>, Tags::Theta<DataVector>,
       Tags::GammaHat<DataVector, 3>, Tags::AuxiliaryShiftB<DataVector, 3>>>;
 
-  using gradients_tags =
-      tmpl::list<Tags::ConformalMetric<DataVector, 3>,
-                 gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
-                 Tags::ConformalFactor<DataVector>, Tags::ATilde<DataVector, 3>,
-                 gr::Tags::TraceExtrinsicCurvature<DataVector>,
-                 Tags::Theta<DataVector>, Tags::GammaHat<DataVector, 3>,
-                 Tags::AuxiliaryShiftB<DataVector, 3>>;
+  using variables_tag_list = typename variables_tag::tags_list;
+
+  using gradients_tags = variables_tag_list;
 };
 }  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -61,7 +61,7 @@ using ConformalMetric =
  * inverse spatial metric, then we define
  * \f$\bar{\gamma}^{ij} = \phi^{-2} \gamma^{ij}\f$.
  */
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
 using InverseConformalMetric =
     gr::Tags::Conformal<gr::Tags::InverseSpatialMetric<DataType, Dim, Frame>,
                         -2>;

--- a/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/Ccz4/TagsDeclarations.hpp
@@ -105,6 +105,32 @@ template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
 struct InverseTauTimesConformalMetric;
 template <typename DataType>
 struct LapseTimesSlicingCondition;
+template <typename DataType>
+struct DetConformalSpatialMetric;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct InvATilde;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct ATildeTimesFieldB;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct SymmetrizedDerivFieldB;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct ContractedSymmetrizedDerivFieldB;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct ContractedFieldDUp;
+template <typename DataType>
+struct HalfConformalFactorSquared;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct DerivGammaHatMinusContractedConformalChristoffel;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct ContractedChristoffelSecondKind;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct ContractedDerivConformalChristoffelDifference;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct LapseTimesConformalMetric;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct SpatialRicciTensor;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct UpperSpatialZ4Contraint;
 }  // namespace Tags
 
 /// \brief Input option tags for the CCZ4 evolution system

--- a/src/Evolution/Systems/Ccz4/TempTags.hpp
+++ b/src/Evolution/Systems/Ccz4/TempTags.hpp
@@ -228,5 +228,116 @@ template <typename DataType>
 struct LapseTimesSlicingCondition : db::SimpleTag {
   using type = Scalar<DataType>;
 };
+
+/*!
+ * \brief The CCZ4 temporary expression
+ * (\f$ \mathrm{det}\tilde{\gamma}_{ij} \f$)
+ */
+template <typename DataType>
+struct DetConformalSpatialMetric : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ \tilde{A}^{ij} \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct InvATilde : db::SimpleTag {
+  using type = tnsr::II<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ \tilde{A}_{ki}\partial_j\beta^k \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ATildeTimesFieldB : db::SimpleTag {
+  using type = tnsr::ij<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ \partial_k\partial_l\beta^i \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct SymmetrizedDerivFieldB : db::SimpleTag {
+  using type = tnsr::ijK<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ \partial_k\partial_l\beta^l \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ContractedSymmetrizedDerivFieldB : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression
+ * \f$ \tilde{\gamma}^{kn}\tilde{\gamma}^{mj}D_{knm} \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ContractedFieldDUp : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ (1/2)\phi^2 \f$
+ */
+template <typename DataType>
+struct HalfConformalFactorSquared : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression
+ * \f$ \hat{\Gamma}^l-\tilde{\Gamma}^l \f$ in eq. (26) of \cite Dumbser2017okk
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct DerivGammaHatMinusContractedConformalChristoffel : db::SimpleTag {
+  using type = tnsr::iJ<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ \Gamma^k_{ik} \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ContractedChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression
+ * \f$ \partial_m\tilde{\Gamma}^m_{ij}-\partial_j\tilde{Gamma}^m_{im} \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct ContractedDerivConformalChristoffelDifference : db::SimpleTag {
+  using type = tnsr::ij<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ \alpha\tilde{\gamma}_{ij} \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct LapseTimesConformalMetric : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ R_{ij} \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct SpatialRicciTensor : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+/*!
+ * \brief The CCZ4 temporary expression \f$ Z^i \f$
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct UpperSpatialZ4Contraint : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+
+
 }  // namespace Tags
 }  // namespace Ccz4

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Ccz4")
 set(LIBRARY_SOURCES
   FiniteDifference/Test_Derivatives.cpp
   FiniteDifference/Test_SecondPartialDerivatives.cpp
+  FiniteDifference/Test_SoTimeDerivative.cpp
   Test_ATilde.cpp
   Test_Christoffel.cpp
   Test_DerivChristoffel.cpp

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
@@ -1,0 +1,623 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/Systems/Ccz4/ATilde.hpp"
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp"
+#include "Evolution/Systems/Ccz4/System.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+// Test second order CCZ4 in Minkowski spacetime
+void test_minkowski() {
+  // set up subcell grid
+  const size_t SpatialDim = 3;
+  using FrameType = Frame::Inertial;
+  const size_t points_per_dimension = 5;
+  const size_t ghost_zone_size = 2;
+  const Mesh<SpatialDim> subcell_mesh{points_per_dimension,
+                                      Spectral::Basis::FiniteDifference,
+                                      Spectral::Quadrature::CellCentered};
+
+  const std::array<double, SpatialDim> lower_bound{-2., 0., -0.5};
+  const std::array<double, SpatialDim> upper_bound{2., 2., -0.1};
+  const std::array<double, SpatialDim> coords_range = upper_bound - lower_bound;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, FrameType>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+  // set up displaced logical coords
+  const auto logical_coords =
+      TestHelpers::Ccz4::fd::detail::set_logical_coordinates(subcell_mesh);
+  const auto x = coord_map(logical_coords);
+  InverseJacobian<DataVector, SpatialDim, Frame::ElementLogical,
+                  Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_jacobian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    cell_centered_logical_to_inertial_inv_jacobian.get(i, i) =
+        2.0 / gsl::at(coords_range, i);
+  }
+
+  const Element<SpatialDim> element =
+      TestHelpers::Ccz4::fd::detail::set_element();
+
+  const DirectionalIdMap<SpatialDim, evolution::dg::subcell::GhostData>
+      all_ghost_data =
+          TestHelpers::Ccz4::fd::detail::compute_ghost_data<Frame::Inertial>(
+              subcell_mesh, x, element.neighbors(), ghost_zone_size,
+              TestHelpers::Ccz4::fd::detail::Minkowski::
+                  compute_prim_solution_for_Minkowski,
+              coords_range);
+
+  // Get system evolved variables
+  // Use the physical inertial coords
+  const auto evolved_vars = TestHelpers::Ccz4::fd::detail::Minkowski::
+      compute_prim_solution_for_Minkowski(x);
+
+  // get other parameters
+  const double f = 0.1;
+  const double kappa_1 = 0.1;
+  const double kappa_2 = 0.3;
+  const double kappa_3 = 0.4;
+
+  const DataVector used_for_size =
+      DataVector(subcell_mesh.number_of_grid_points(),
+                 std::numeric_limits<double>::signaling_NaN());
+  const auto k_0 = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  const auto eta = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+
+  // put needed quantities into databox
+  using dt_variables_tag =
+      db::add_tag_prefix<::Tags::dt, Ccz4::fd::System::variables_tag>;
+
+  auto box = db::create<db::AddSimpleTags<
+      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
+      ::Ccz4::Tags::K0<DataVector>, ::Ccz4::Tags::GammaDriverParam,
+      ::Ccz4::Tags::Kappa1, ::Ccz4::Tags::Kappa2, ::Ccz4::Tags::Kappa3,
+      dt_variables_tag, evolution::dg::subcell::Tags::Mesh<SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
+          SpatialDim>,
+      evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>>>(
+      evolved_vars, eta, k_0, f, kappa_1, kappa_2, kappa_3,
+      Variables<typename dt_variables_tag::tags_list>{
+          subcell_mesh.number_of_grid_points()},
+      subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
+      all_ghost_data);
+
+  // Check that all time derivatives are 0
+  ::Ccz4::fd::apply<SpatialDim>(make_not_null(&box));
+  const auto zero = DataVector(used_for_size.size(), 0.0);
+
+  tmpl::for_each<Ccz4::fd::System::variables_tag_list>(
+    [&]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+        const std::string tag_name = db::tag_name<::Tags::dt<Tag>>();
+        CAPTURE(tag_name);
+        for (auto& component : get<::Tags::dt<Tag>>(box)) {
+            CHECK_ITERABLE_APPROX(component, zero);
+        }
+  });
+}
+
+// Test second-order CCZ4 in KerrSchild spacetime
+//
+// evolve_shift: whether or not to evolve the shift (always true for SO-CCZ4);
+// slicing_condition_type: which slicing condition to use (always 1+log for
+// SO-CCZ4)
+void test_kerrschild() {
+  const Ccz4::EvolveShift evolve_shift =
+      Ccz4::EvolveShift::True;  // always evolve shift in SO-CCZ4; this is s=1.
+  const Ccz4::SlicingConditionType slicing_condition_type =
+      Ccz4::SlicingConditionType::Log;  // always use 1+log slicing
+
+  // set up subcell grid
+  const size_t SpatialDim = 3;
+  using FrameType = Frame::Inertial;
+  const size_t points_per_dimension = 20;
+  const size_t ghost_zone_size = 2;
+  const Mesh<SpatialDim> subcell_mesh{points_per_dimension,
+                                      Spectral::Basis::FiniteDifference,
+                                      Spectral::Quadrature::CellCentered};
+
+  const std::array<double, SpatialDim> lower_bound{0.8, 1., 1.3};
+  const std::array<double, SpatialDim> upper_bound{1.2, 1.2, 1.4};
+  const std::array<double, SpatialDim> coords_range = upper_bound - lower_bound;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, FrameType>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+  // set up displaced logical coords
+  const auto logical_coords =
+      TestHelpers::Ccz4::fd::detail::set_logical_coordinates(subcell_mesh);
+  const auto x = coord_map(logical_coords);
+  InverseJacobian<DataVector, SpatialDim, Frame::ElementLogical,
+                  Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_jacobian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    cell_centered_logical_to_inertial_inv_jacobian.get(i, i) =
+        2.0 / gsl::at(coords_range, i);
+  }
+
+  const Element<SpatialDim> element =
+      TestHelpers::Ccz4::fd::detail::set_element();
+
+  // Setup solution
+  const double mass = 2.0;
+  const std::array<double, SpatialDim> spin{{0.2, 0.4, 0.8}};
+  const std::array<double, SpatialDim> center{{0.2, 0.5, 0.1}};
+  const gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  const double f = 0.75;
+  const double kappa_1 = 0.1;
+  const double kappa_2 = 0.3;
+  const double kappa_3 = 0.4;
+
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  const DirectionalIdMap<SpatialDim, evolution::dg::subcell::GhostData>
+      all_ghost_data =
+          TestHelpers::Ccz4::fd::detail::compute_ghost_data<Frame::Inertial>(
+              subcell_mesh, x, element.neighbors(), ghost_zone_size,
+              TestHelpers::Ccz4::fd::detail::KerrSchild::
+                  compute_prim_solution_for_KerrSchild,
+              coords_range, t, f, evolve_shift, solution);
+
+  const auto evolved_vars = TestHelpers::Ccz4::fd::detail::KerrSchild::
+      compute_prim_solution_for_KerrSchild(x, t, f, evolve_shift, solution);
+
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(evolved_vars);
+  const auto d_lapse = partial_derivative(
+      lapse, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+  const DataVector used_for_size =
+      DataVector(subcell_mesh.number_of_grid_points(),
+                 std::numeric_limits<double>::signaling_NaN());
+  const auto eta = make_with_value<Scalar<DataVector>>(
+      used_for_size, 0.1);                      // change eta to non-zero later
+  const Scalar<DataVector> slicing_condition =  // g(\alpha)
+      TestHelpers::Ccz4::fd::detail::KerrSchild::get_slicing_condition(
+          slicing_condition_type, lapse);
+  const auto k_0 = TestHelpers::Ccz4::fd::detail::KerrSchild::get_k_0_kerr(
+      get<gr::Tags::Shift<DataVector, SpatialDim>>(evolved_vars), lapse,
+      d_lapse, slicing_condition,
+      get<::Ccz4::Tags::Theta<DataVector>>(evolved_vars),
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars));
+
+  // put needed quantities into databox
+  using dt_variables_tag =
+      db::add_tag_prefix<::Tags::dt, Ccz4::fd::System::variables_tag>;
+
+  auto box = db::create<db::AddSimpleTags<
+      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
+      ::Ccz4::Tags::K0<DataVector>, ::Ccz4::Tags::GammaDriverParam,
+      ::Ccz4::Tags::Kappa1, ::Ccz4::Tags::Kappa2, ::Ccz4::Tags::Kappa3,
+      dt_variables_tag, evolution::dg::subcell::Tags::Mesh<SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
+          SpatialDim>,
+      evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>>>(
+      evolved_vars, eta, k_0, f, kappa_1, kappa_2, kappa_3,
+      Variables<typename dt_variables_tag::tags_list>{
+          subcell_mesh.number_of_grid_points()},
+      subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
+      all_ghost_data);
+
+  // Check that all time derivatives are 0
+  ::Ccz4::fd::apply<SpatialDim>(make_not_null(&box));
+  const auto zero = DataVector(used_for_size.size(), 0.0);
+  const Approx custom_approx =
+      Approx::custom().epsilon(1.0e-9).scale(*std::max_element(
+          evolved_vars.data(), evolved_vars.data() + evolved_vars.size() - 1));
+
+  tmpl::for_each<tmpl::pop_back<Ccz4::fd::System::variables_tag_list>>(
+    [&]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+        const std::string tag_name = db::tag_name<::Tags::dt<Tag>>();
+        CAPTURE(tag_name);
+        for (auto& component : get<::Tags::dt<Tag>>(box)) {
+            CHECK_ITERABLE_CUSTOM_APPROX(component, zero, custom_approx);
+        }
+  });
+
+  // eq 12i
+  // \partial_t b will not be 0 for KerrSchild if evolve_shift == true
+  // since we assume the shift is time-independent for testing
+  // but KerrSchild is not stationary under 1+log slicing
+  const auto d_gamma_hat = partial_derivative(
+      get<::Ccz4::Tags::GammaHat<DataVector, SpatialDim>>(box), subcell_mesh,
+      cell_centered_logical_to_inertial_inv_jacobian);
+  const auto d_b = partial_derivative(
+      get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, SpatialDim>>(box),
+      subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+  const tnsr::I<DataVector, SpatialDim, FrameType> dt_b_expected =
+      TestHelpers::Ccz4::fd::detail::KerrSchild::get_dt_b_kerr_expected(
+          evolve_shift, get<::Ccz4::Tags::Eta<DataVector>>(box),
+          get<gr::Tags::Shift<DataVector, SpatialDim>>(box), d_gamma_hat,
+          get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, SpatialDim>>(box), d_b);
+  const auto& dt_b_actual =
+      get<::Tags::dt<::Ccz4::Tags::AuxiliaryShiftB<DataVector, SpatialDim>>>(
+          box);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_b_actual, dt_b_expected, custom_approx);
+}
+
+// Test second-order CCZ4 in a GaugePlaneWave spacetime
+void test_gauge_plane_wave(
+    const std::array<double, 3>& wave_vector,
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> profile, const double t) {
+  // set up subcell grid
+  const size_t SpatialDim = 3;
+  using FrameType = Frame::Inertial;
+  const size_t points_per_dimension = 20;
+  const size_t ghost_zone_size = 2;
+  const Mesh<SpatialDim> subcell_mesh{points_per_dimension,
+                                      Spectral::Basis::FiniteDifference,
+                                      Spectral::Quadrature::CellCentered};
+  const std::array<double, SpatialDim> lower_bound{-0.5, -2., 1.};
+  const std::array<double, SpatialDim> upper_bound{0.0, 2., 2.};
+  const std::array<double, SpatialDim> coords_range = upper_bound - lower_bound;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, FrameType>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+  // set up displaced logical coords
+  const auto logical_coords =
+      TestHelpers::Ccz4::fd::detail::set_logical_coordinates(subcell_mesh);
+  const auto x = coord_map(logical_coords);
+  InverseJacobian<DataVector, SpatialDim, Frame::ElementLogical,
+                  Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_jacobian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    cell_centered_logical_to_inertial_inv_jacobian.get(i, i) =
+        2.0 / gsl::at(coords_range, i);
+  }
+
+  double omega = 0.0;
+  for (const auto& k : wave_vector) {
+    omega += square(k);
+  }
+  omega = pow(omega, 1.0 / 2.0);
+
+  const DataVector used_for_size =
+      DataVector(subcell_mesh.number_of_grid_points(),
+                 std::numeric_limits<double>::signaling_NaN());
+
+  tnsr::i<DataVector, SpatialDim, FrameType> k_tnsr{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    k_tnsr.get(i) =
+        make_with_value<DataVector>(used_for_size, gsl::at(wave_vector, i));
+  }
+
+  const gr::Solutions::GaugePlaneWave<SpatialDim>::IntermediateVars<DataVector>
+      intermediate_sol(wave_vector, profile, omega, x, t);
+  const Scalar<DataVector> h{intermediate_sol.h};
+  const Scalar<DataVector> du_h{intermediate_sol.du_h};
+  const Scalar<DataVector> du_du_h{intermediate_sol.du_du_h};
+
+  // Setup solutions
+  const gr::Solutions::GaugePlaneWave<SpatialDim> solution(wave_vector,
+                                                           std::move(profile));
+  const auto gauge_plane_wave_vars = solution.variables(
+      x, t,
+      typename gr::Solutions::GaugePlaneWave<SpatialDim>::tags<DataVector>{});
+
+  const Element<SpatialDim> element =
+      TestHelpers::Ccz4::fd::detail::set_element();
+
+  const DirectionalIdMap<SpatialDim, evolution::dg::subcell::GhostData>
+      all_ghost_data = TestHelpers::Ccz4::fd::detail::compute_ghost_data(
+          subcell_mesh, x, element.neighbors(), ghost_zone_size,
+          TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
+              compute_prim_solution_for_GaugePlaneWave,
+          coords_range, t, solution, intermediate_sol);
+
+  const auto evolved_vars = TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
+      compute_prim_solution_for_GaugePlaneWave(x, t, solution,
+                                               intermediate_sol);
+
+  // get other parameters
+  const double f = 0.75;
+  const double kappa_1 = 0.1;
+  const double kappa_2 = 0.3;
+  const double kappa_3 = 0.4;
+
+  const auto& k_0 =
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars);
+
+  const auto eta = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+
+  // put needed quantities into databox
+  using dt_variables_tag =
+      db::add_tag_prefix<::Tags::dt, Ccz4::fd::System::variables_tag>;
+
+  auto box = db::create<db::AddSimpleTags<
+      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
+      ::Ccz4::Tags::K0<DataVector>, ::Ccz4::Tags::GammaDriverParam,
+      ::Ccz4::Tags::Kappa1, ::Ccz4::Tags::Kappa2, ::Ccz4::Tags::Kappa3,
+      dt_variables_tag, evolution::dg::subcell::Tags::Mesh<SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
+          SpatialDim>,
+      evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>>>(
+      evolved_vars, eta, k_0, f, kappa_1, kappa_2, kappa_3,
+      Variables<typename dt_variables_tag::tags_list>{
+          subcell_mesh.number_of_grid_points()},
+      subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
+      all_ghost_data);
+
+  // Check all time derivatives
+  ::Ccz4::fd::apply<SpatialDim>(make_not_null(&box));
+
+  const Approx custom_approx =
+      Approx::custom().epsilon(1.0e-9).scale(*std::max_element(
+          evolved_vars.data(), evolved_vars.data() + evolved_vars.size() - 1));
+  // eq 12a
+  const auto& dt_conformal_spatial_metric_actual =
+      get<::Tags::dt<::Ccz4::Tags::ConformalMetric<DataVector, SpatialDim>>>(
+          box);
+
+  const auto conformal_factor =
+      get(get<::Ccz4::Tags::ConformalFactor<DataVector>>(evolved_vars));
+  Scalar<DataVector> conformal_factor_squared{};
+  get(conformal_factor_squared) = square(conformal_factor);
+  const auto& dt_spatial_metric =
+      get<::Tags::dt<gr::Tags::SpatialMetric<DataVector, SpatialDim>>>(
+          gauge_plane_wave_vars);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<DataVector, SpatialDim, FrameType>>(
+          gauge_plane_wave_vars);
+  const auto& inverse_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, SpatialDim, FrameType>>(
+          gauge_plane_wave_vars);
+  const auto dt_conformal_spatial_metric_expected = TestHelpers::Ccz4::fd::
+      detail::GaugePlaneWave::get_dt_conformal_spatial_metric_gauge_plane_wave(
+          conformal_factor_squared, spatial_metric, inverse_spatial_metric,
+          dt_spatial_metric);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_conformal_spatial_metric_actual,
+                               dt_conformal_spatial_metric_expected,
+                               custom_approx);
+
+  // eq 12b
+  const auto& dt_lapse_actual =
+      get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(box);
+  const auto& d_lapse =
+      get<Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<SpatialDim>,
+                      FrameType>>(gauge_plane_wave_vars);
+  const auto dt_lapse_expected = TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
+      get_dt_lapse_gauge_plane_wave(
+          d_lapse, get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
+                       gauge_plane_wave_vars));
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_lapse_actual, dt_lapse_expected,
+                               custom_approx);
+
+  // eq 12c
+  const auto& dt_shift_actual =
+      get<::Tags::dt<gr::Tags::Shift<DataVector, SpatialDim>>>(box);
+  const auto& d_shift =
+      get<Tags::deriv<gr::Tags::Shift<DataVector, SpatialDim, FrameType>,
+                      tmpl::size_t<SpatialDim>, FrameType>>(
+          gauge_plane_wave_vars);
+  const auto dt_shift_expected = TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
+      get_dt_shift_gauge_plane_wave(
+          get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
+              gauge_plane_wave_vars),
+          d_shift);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_shift_actual, dt_shift_expected,
+                               custom_approx);
+
+  // eq 12d
+  const auto& dt_conformal_factor_actual =
+      get<::Tags::dt<::Ccz4::Tags::ConformalFactor<DataVector>>>(box);
+  const auto dt_conformal_factor_expected = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_conformal_factor_gauge_plane_wave(
+          inverse_spatial_metric, dt_spatial_metric,
+          Scalar<DataVector>(conformal_factor));
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_conformal_factor_actual,
+                               dt_conformal_factor_expected, custom_approx);
+
+  // eq 12e
+  const auto& dt_a_tilde_actual =
+      get<::Tags::dt<::Ccz4::Tags::ATilde<DataVector, SpatialDim>>>(box);
+  const auto dt_conformal_factor = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_conformal_factor_gauge_plane_wave(
+          inverse_spatial_metric, dt_spatial_metric,
+          Scalar<DataVector>(conformal_factor));
+  const auto one_plus_h_times_omega_squared = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_one_plus_h_times_omega_squared(h, omega);
+  const auto dt_extrinsic_curvature = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_extrinsic_curvature_gauge_plane_wave(
+          k_tnsr, du_h, du_du_h, one_plus_h_times_omega_squared, omega);
+
+  const auto dt_inverse_spatial_metric = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_inverse_spatial_metric(inverse_spatial_metric,
+                                                    dt_spatial_metric);
+  const auto dt_trace_extrinsic_curvature_expected = TestHelpers::Ccz4::fd::
+      detail::GaugePlaneWave::get_dt_trace_extrinsic_curvature_gauge_plane_wave(
+          get<gr::Tags::ExtrinsicCurvature<DataVector, SpatialDim>>(
+              gauge_plane_wave_vars),
+          dt_extrinsic_curvature, inverse_spatial_metric,
+          dt_inverse_spatial_metric);
+  const auto dt_a_tilde_expected = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_a_tilde_gauge_plane_wave(
+          Scalar<DataVector>(conformal_factor), conformal_factor_squared,
+          dt_conformal_factor, spatial_metric, dt_spatial_metric,
+          get<gr::Tags::ExtrinsicCurvature<DataVector, SpatialDim>>(
+              gauge_plane_wave_vars),
+          dt_extrinsic_curvature,
+          get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars),
+          dt_trace_extrinsic_curvature_expected);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_a_tilde_actual, dt_a_tilde_expected,
+                               custom_approx);
+
+  // eq 12f
+  const auto& dt_trace_extrinsic_curvature_actual =
+      get<::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>>(box);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_trace_extrinsic_curvature_actual,
+                               dt_trace_extrinsic_curvature_expected,
+                               custom_approx);
+
+  // eq 12g
+  const auto& dt_theta_actual =
+      get<::Tags::dt<::Ccz4::Tags::Theta<DataVector>>>(box);
+  const auto& dt_theta_expected =
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_theta_actual, dt_theta_expected,
+                               custom_approx);
+
+  // eq 12h
+  const auto& dt_gamma_hat_actual =
+      get<::Tags::dt<::Ccz4::Tags::GammaHat<DataVector, SpatialDim>>>(box);
+  const auto dt_conformal_spatial_metric = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_conformal_spatial_metric_gauge_plane_wave(
+          conformal_factor_squared, spatial_metric, inverse_spatial_metric,
+          dt_spatial_metric);
+  const auto inverse_conformal_spatial_metric =
+      determinant_and_inverse(
+          get<::Ccz4::Tags::ConformalMetric<DataVector, SpatialDim>>(
+              evolved_vars))
+          .second;
+  const auto dt_inverse_conformal_spatial_metric = TestHelpers::Ccz4::fd::
+      detail::GaugePlaneWave::get_dt_inverse_conformal_spatial_metric(
+          inverse_conformal_spatial_metric, dt_conformal_spatial_metric);
+  const auto dt_d_spatial_metric =
+      TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
+          get_dt_d_spatial_metric_gauge_plane_wave(k_tnsr, du_du_h, omega);
+  const auto& d_spatial_metric =
+      get<Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
+                      tmpl::size_t<SpatialDim>, FrameType>>(
+          gauge_plane_wave_vars);
+  const auto d_conformal_factor = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_d_conformal_factor_gauge_plane_wave(
+          inverse_spatial_metric, d_spatial_metric,
+          Scalar<DataVector>(conformal_factor));
+  const auto dt_d_conformal_factor = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_d_conformal_factor_gauge_plane_wave(
+          Scalar<DataVector>(conformal_factor), dt_conformal_factor,
+          inverse_spatial_metric, dt_inverse_spatial_metric, d_spatial_metric,
+          dt_d_spatial_metric);
+  const auto dt_d_conformal_spatial_metric = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_d_conformal_spatial_metric_gauge_plane_wave(
+          spatial_metric, dt_spatial_metric, d_spatial_metric,
+          dt_d_spatial_metric, Scalar<DataVector>(conformal_factor),
+          dt_conformal_factor, d_conformal_factor, dt_d_conformal_factor);
+  const auto det_spatial_metric = determinant(spatial_metric);
+  const auto d_det_spatial_metric = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_d_det_spatial_metric_gauge_plane_wave(
+          det_spatial_metric,
+          get<gr::Tags::InverseSpatialMetric<DataVector, SpatialDim,
+                                             FrameType>>(gauge_plane_wave_vars),
+          get<Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
+                          tmpl::size_t<SpatialDim>, FrameType>>(
+              gauge_plane_wave_vars));
+  const tnsr::ijj<DataVector, SpatialDim, FrameType>
+      d_conformal_spatial_metric = TestHelpers::Ccz4::fd::detail::KerrSchild::
+          get_d_conformal_spatial_metric(conformal_factor_squared,
+                                         spatial_metric, d_spatial_metric,
+                                         d_det_spatial_metric);
+  const auto dt_gamma_hat_expected = TestHelpers::Ccz4::fd::detail::
+      GaugePlaneWave::get_dt_gamma_hat_gauge_plane_wave(
+          inverse_conformal_spatial_metric, dt_inverse_conformal_spatial_metric,
+          d_conformal_spatial_metric, dt_d_conformal_spatial_metric);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_gamma_hat_actual, dt_gamma_hat_expected,
+                               custom_approx);
+
+  // eq 12i
+  const tnsr::ijj<DataVector, SpatialDim, FrameType> field_d =
+      TestHelpers::Ccz4::fd::detail::KerrSchild::get_field_d(
+          d_conformal_spatial_metric);
+  const tnsr::iJJ<DataVector, SpatialDim, FrameType> field_d_up =
+      TestHelpers::Ccz4::fd::detail::GaugePlaneWave::get_field_d_up(
+          inverse_conformal_spatial_metric, field_d);
+  const auto d_field_d = partial_derivative(
+      field_d, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+  const auto d_conformal_christoffel_second_kind =
+      ::Ccz4::deriv_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d, d_field_d, field_d_up);
+  const auto conformal_christoffel_second_kind =
+      ::Ccz4::conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d);
+  const auto d_gamma_hat =
+      ::Ccz4::deriv_contracted_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d_up,
+          conformal_christoffel_second_kind,
+          d_conformal_christoffel_second_kind);
+  const tnsr::I<DataVector, SpatialDim, FrameType> dt_b_expected = TestHelpers::
+      Ccz4::fd::detail::GaugePlaneWave::get_dt_b_gauge_plane_wave_expected(
+          dt_gamma_hat_expected, d_gamma_hat,
+          get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
+              gauge_plane_wave_vars));
+  const auto& dt_b_actual =
+      get<::Tags::dt<::Ccz4::Tags::AuxiliaryShiftB<DataVector, SpatialDim>>>(
+          box);
+  CHECK_ITERABLE_CUSTOM_APPROX(dt_b_actual, dt_b_expected, custom_approx);
+}
+
+// Test first order CCZ4 against Minkowski and KerrSchild
+void test() {
+  test_minkowski();
+  test_kerrschild();
+
+  const std::array<double, 3> k{{0.5, 0.1, -0.2}};
+  test_gauge_plane_wave(
+      k,
+      std::make_unique<MathFunctions::Sinusoid<1, Frame::Inertial>>(0.6, 0.8,
+                                                                    2.0),
+      0.4);
+}
+}  // namespace
+
+// The tests run relatively long as we use much higher spatial
+// resolution (~8000 grid points per element) to reach a relative
+// error of 1e-9.
+// [[TimeOut, 20]]
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.TimeDerivative",
+                  "[Unit][Evolution]") {
+  test();
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_TempTags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_TempTags.cpp
@@ -61,6 +61,47 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       Ccz4::Tags::LapseTimesSlicingCondition<DataType>>(
       "LapseTimesSlicingCondition");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::DetConformalSpatialMetric<DataType>>(
+      "DetConformalSpatialMetric");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::InvATilde<DataType, Dim, Frame>>(
+      "InvATilde");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ATildeTimesFieldB<DataType, Dim, Frame>>(
+      "ATildeTimesFieldB");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::SymmetrizedDerivFieldB<DataType, Dim, Frame>>(
+      "SymmetrizedDerivFieldB");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ContractedSymmetrizedDerivFieldB<DataType, Dim, Frame>>(
+      "ContractedSymmetrizedDerivFieldB");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ContractedFieldDUp<DataType, Dim, Frame>>(
+      "ContractedFieldDUp");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::HalfConformalFactorSquared<DataType>>(
+      "HalfConformalFactorSquared");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::DerivGammaHatMinusContractedConformalChristoffel<
+          DataType, Dim, Frame>>(
+      "DerivGammaHatMinusContractedConformalChristoffel");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ContractedChristoffelSecondKind<DataType, Dim, Frame>>(
+      "ContractedChristoffelSecondKind");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::ContractedDerivConformalChristoffelDifference<
+          DataType, Dim, Frame>>(
+      "ContractedDerivConformalChristoffelDifference");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::LapseTimesConformalMetric<DataType, Dim, Frame>>(
+      "LapseTimesConformalMetric");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::SpatialRicciTensor<DataType, Dim, Frame>>(
+      "SpatialRicciTensor");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::Tags::UpperSpatialZ4Contraint<DataType, Dim, Frame>>(
+      "UpperSpatialZ4Contraint");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.TempTags", "[Unit][Evolution]") {

--- a/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
@@ -15,6 +15,8 @@
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
@@ -24,14 +26,26 @@
 #include "Domain/Structure/Neighbors.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/Systems/Ccz4/ATilde.hpp"
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
 #include "Evolution/Systems/Ccz4/System.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Evolution/Systems/Ccz4/TimeDerivative.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -216,4 +230,800 @@ inline tnsr::I<DataVector, 3, Frame::ElementLogical> set_logical_coordinates(
   }
   return logical_coords;
 }
+
+namespace Minkowski {
+inline Variables<
+    ::Ccz4::fd::Tags::spacetime_reconstruction_tags>
+compute_prim_solution_for_Minkowski(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords) {
+  using FrameType = Frame::Inertial;
+  const size_t SpatialDim = 3;
+
+  Variables<typename ::Ccz4::fd::System::variables_tag::tags_list> evolved_vars{
+      get<0>(coords).size()};
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+  // Setup solution
+  const gr::Solutions::Minkowski<SpatialDim> solution{};
+  // Evaluate solution
+  const auto minkowski_vars = solution.variables(
+      coords, t,
+      typename gr::Solutions::Minkowski<SpatialDim>::tags<DataVector>{});
+  const DataVector used_for_size = DataVector(
+      get<0>(coords).size(), std::numeric_limits<double>::signaling_NaN());
+
+  get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(evolved_vars) =
+      get<gr::Tags::SpatialMetric<DataVector, SpatialDim, FrameType>>(
+          minkowski_vars);  // conformal factor is 1
+
+  const auto det_spatial_metric = determinant(
+      get<gr::Tags::SpatialMetric<DataVector, SpatialDim, FrameType>>(
+          minkowski_vars));
+  const auto conformal_factor = pow(get(det_spatial_metric), -1. / 6.);
+  Scalar<DataVector> conformal_factor_squared{};
+  get(conformal_factor_squared) = square(conformal_factor);
+
+  get(get<::Ccz4::Tags::ConformalFactor<DataVector>>(evolved_vars)) =
+      conformal_factor;
+
+  const auto extrinsic_curvature =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, FrameType>>(
+          used_for_size, 0.0);
+  get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars) =
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+
+  get<::Ccz4::Tags::ATilde<DataVector, 3>>(evolved_vars) = ::Ccz4::a_tilde(
+      conformal_factor_squared,
+      get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(evolved_vars),
+      extrinsic_curvature,
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars));
+
+  get<::Ccz4::Tags::Theta<DataVector>>(evolved_vars) =
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+
+  const auto field_d =
+      make_with_value<tnsr::ijj<DataVector, SpatialDim, FrameType>>(
+          used_for_size, 0.0);
+  const auto& inverse_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, SpatialDim, FrameType>>(
+          minkowski_vars);
+  const auto& inverse_conformal_spatial_metric = inverse_spatial_metric;
+  const auto conformal_christoffel_second_kind =
+      ::Ccz4::conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d);
+  const auto contracted_conformal_christoffel_second_kind =
+      ::Ccz4::contracted_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, conformal_christoffel_second_kind);
+  // If Z4 constraint is 0, then \hat{\gamma} == \tilde{\gamma}
+  get<::Ccz4::Tags::GammaHat<DataVector, 3>>(evolved_vars) =
+      contracted_conformal_christoffel_second_kind;
+
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(minkowski_vars);
+
+  get<gr::Tags::Lapse<DataVector>>(evolved_vars) = lapse;
+
+  get<gr::Tags::Shift<DataVector, 3>>(evolved_vars) =
+      get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(minkowski_vars);
+
+  get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(evolved_vars) =
+      make_with_value<tnsr::I<DataVector, SpatialDim, FrameType>>(used_for_size,
+                                                                  0.0);
+  return evolved_vars;
+}
+}  // namespace Minkowski
+
+namespace KerrSchild {
+// Compute the spatial derivative of the conformal spatial metric
+//
+// If \tilde{\gamma}_{ij} is the conformal metric and \phi is the
+// conformal factor, \tilde{\gamma}_{ij} = \phi^2 \gamma_{ij}.
+// Therefore, the derivative of the conformal metric is:
+//   \partial_k \tilde{\gamma}_{ij} =
+//       \phi^2 \partial_k \gamma_{ij} +
+//       \partial_k \phi^2 \gamma_{ij}
+//
+// Since \phi = (det(\gamma_{ij}))^{-1/6}:
+//   \partial_k \phi^2
+//        = \partial_k ((det(\gamma_{ij}))^{-1/6})^2
+//        = \partial_k (det(\gamma_{ij}))^{-1/3}
+//        = -(det(\gamma_{ij}))^{-4/3}  \partial_k (det(\gamma_{ij}))/ 3
+//        = -\phi^4 \partial_k (det(\gamma_{ij})) / 3
+//
+// Therefore:
+//   \partial_k \tilde{\gamma}_{ij} =
+//       \phi^2 \partial_k \gamma_{ij} -
+//       \phi^4 \partial_k (det(\gamma_{ij})) \gamma_{ij} / 3
+template <size_t SpatialDim, typename FrameType>
+tnsr::ijj<DataVector, SpatialDim, FrameType> get_d_conformal_spatial_metric(
+    const Scalar<DataVector>& conformal_factor_squared,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& d_spatial_metric,
+    const tnsr::i<DataVector, SpatialDim, FrameType>& d_det_spatial_metric) {
+  tnsr::ijj<DataVector, SpatialDim, FrameType> d_conformal_spatial_metric(
+      get(conformal_factor_squared));
+  for (size_t k = 0; k < SpatialDim; k++) {
+    for (size_t i = 0; i < SpatialDim; i++) {
+      for (size_t j = i; j < SpatialDim; j++) {
+        d_conformal_spatial_metric.get(k, i, j) =
+            get(conformal_factor_squared) * d_spatial_metric.get(k, i, j) -
+            pow<4>(get(conformal_factor_squared)) *
+                d_det_spatial_metric.get(k) * spatial_metric.get(i, j) / 3.;
+      }
+    }
+  }
+  return d_conformal_spatial_metric;
+}
+
+// Compute D_{kij} from eq 6
+template <size_t SpatialDim, typename FrameType>
+tnsr::ijj<DataVector, SpatialDim, FrameType> get_field_d(
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>&
+        d_conformal_spatial_metric) {
+  tnsr::ijj<DataVector, SpatialDim, FrameType> field_d(
+      get<0, 0, 0>(d_conformal_spatial_metric));
+  for (size_t i = 0; i < field_d.size(); i++) {
+    field_d[i] = 0.5 * d_conformal_spatial_metric[i];
+  }
+  return field_d;
+}
+
+// Compute b^i for KerrSchild
+//
+// Solve eq 12c for b^i, where we assume \partial_t \beta^i = 0:
+//   0 = s f b + s \beta^k \partial_k \beta^i
+template <size_t SpatialDim, typename FrameType>
+tnsr::I<DataVector, SpatialDim, FrameType> get_b_kerr(
+    const ::Ccz4::EvolveShift evolve_shift,
+    const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
+    const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_shift,
+    const double f) {
+  tnsr::I<DataVector, SpatialDim, FrameType> b(get<0>(shift));
+  if (not static_cast<bool>(evolve_shift)) {
+    // s == 0
+    // pick b = 0
+    for (auto& component : b) {
+      component = 0.0;
+    }
+  } else {
+    // s == 1
+    // b = -(\beta^k \partial_k \beta^i) / f
+    for (size_t i = 0; i < SpatialDim; i++) {
+      b.get(i) = -shift.get(0) * d_shift.get(0, i);
+      for (size_t k = 1; k < SpatialDim; k++) {
+        b.get(i) -= shift.get(k) * d_shift.get(k, i);
+      }
+      b.get(i) /= f;
+    }
+  }
+  return b;
+}
+
+// Compute the conformal spatial metric
+//
+// \tilde{\gamma}_{ij} = \phi^2 \gamma_{ij}
+template <size_t SpatialDim, typename FrameType>
+tnsr::ii<DataVector, SpatialDim, FrameType> get_conformal_spatial_metric(
+    const Scalar<DataVector>& conformal_factor_squared,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& spatial_metric) {
+  tnsr::ii<DataVector, SpatialDim, FrameType> conformal_spatial_metric(
+      get(conformal_factor_squared));
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = i; j < SpatialDim; j++) {
+      conformal_spatial_metric.get(i, j) =
+          get(conformal_factor_squared) * spatial_metric.get(i, j);
+    }
+  }
+  return conformal_spatial_metric;
+}
+
+// Compute the trace of the extrinsic curvature K = K_{ij} * \gamma^ij
+template <size_t SpatialDim, typename FrameType>
+Scalar<DataVector> get_trace_extrinsic_curvature(
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& extrinsic_curvature,
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric) {
+  Scalar<DataVector> trace_extrinsic_curvature(get<0, 0>(extrinsic_curvature));
+  get(trace_extrinsic_curvature) = 0.0;
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = 0; j < SpatialDim; j++) {
+      get(trace_extrinsic_curvature) +=
+          extrinsic_curvature.get(i, j) * inverse_spatial_metric.get(i, j);
+    }
+  }
+  return trace_extrinsic_curvature;
+}
+
+// Compute g(\alpha)
+inline Scalar<DataVector> get_slicing_condition(
+    const ::Ccz4::SlicingConditionType slicing_condition_type,
+    const Scalar<DataVector>& lapse) {
+  Scalar<DataVector> slicing_condition(get(lapse));
+  if (slicing_condition_type == ::Ccz4::SlicingConditionType::Harmonic) {
+    // harmonic slicing condition: g(\alpha) = 1.0
+    get(slicing_condition) = 1.0;
+  } else if (slicing_condition_type == ::Ccz4::SlicingConditionType::Log) {
+    // 1 + log slicing condition: g(\alpha) = 2 / \alpha
+    get(slicing_condition) = 2.0 / get(lapse);
+  } else {
+    ERROR("Unknown Ccz4::SlicingConditionType");
+  }
+  return slicing_condition;
+}
+
+// Compute K_0 for KerrSchild
+//
+// Solve eq 4g for K_0, where we assume \partial_t \alpha = 0:
+//    0 = -\alpha^2 g(\alpha) (K - K_0 - 2 \Theta) +
+//       \beta^k \partial_k \alpha
+//   K_0 = -((\beta^k \partial_k \alpha) / (\alpha^2 * g(\alpha)) -
+//           K + 2 \Theta);
+template <size_t SpatialDim, typename FrameType>
+Scalar<DataVector> get_k_0_kerr(
+    const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
+    const Scalar<DataVector>& lapse,
+    const tnsr::i<DataVector, SpatialDim, FrameType>& d_lapse,
+    const Scalar<DataVector>& slicing_condition,
+    const Scalar<DataVector>& theta,
+    const Scalar<DataVector>& trace_extrinsic_curvature) {
+  Scalar<DataVector> k_0(get(lapse));
+  get(k_0) = get<0>(shift) * get<0>(d_lapse);
+  for (size_t k = 1; k < SpatialDim; k++) {
+    get(k_0) += shift.get(k) * d_lapse.get(k);
+  }
+  get(k_0) = -((get(k_0) / (square(get(lapse)) * get(slicing_condition))) -
+               get(trace_extrinsic_curvature) + 2.0 * get(theta));
+  return k_0;
+}
+
+// Compute expected value for LHS of eq 12i
+//
+// \partial_t b will not be 0 for KerrSchild if evolve_shift == true
+template <size_t SpatialDim, typename FrameType>
+tnsr::I<DataVector, SpatialDim, FrameType> get_dt_b_kerr_expected(
+    const ::Ccz4::EvolveShift evolve_shift, const Scalar<DataVector>& eta,
+    const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
+    const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_gamma_hat,
+    const tnsr::I<DataVector, SpatialDim, FrameType>& b,
+    const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_b) {
+  tnsr::I<DataVector, SpatialDim, FrameType> dt_b_kerr_expected(get(eta));
+  if (static_cast<bool>(evolve_shift)) {
+    // s == 1
+    for (size_t i = 0; i < SpatialDim; i++) {
+      dt_b_kerr_expected.get(i) = -get(eta) * b.get(i) +
+                                  shift.get(0) * d_b.get(0, i) -
+                                  shift.get(0) * d_gamma_hat.get(0, i);
+      for (size_t k = 1; k < SpatialDim; k++) {
+        dt_b_kerr_expected.get(i) +=
+            shift.get(k) * d_b.get(k, i) - shift.get(k) * d_gamma_hat.get(k, i);
+      }
+    }
+  } else {
+    // s == 0
+    for (auto& component : dt_b_kerr_expected) {
+      component = 0.0;
+    }
+  }
+  return dt_b_kerr_expected;
+}
+
+inline Variables<
+    ::Ccz4::fd::Tags::spacetime_reconstruction_tags>
+compute_prim_solution_for_KerrSchild(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords, const double t,
+    const double f, const ::Ccz4::EvolveShift& evolve_shift,
+    const gr::Solutions::KerrSchild& solution) {
+  // Evaluate solution
+  const auto kerrschild_vars = solution.variables(
+      coords, t, typename gr::Solutions::KerrSchild::tags<DataVector>{});
+
+  // get system evolved vars
+  Variables<typename ::Ccz4::fd::System::variables_tag::tags_list> evolved_vars{
+      get<0>(coords).size()};
+
+  const DataVector used_for_size = DataVector(
+      get<0>(coords).size(), std::numeric_limits<double>::signaling_NaN());
+
+  const size_t SpatialDim = 3;
+  using FrameType = Frame::Inertial;
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<DataVector, SpatialDim, FrameType>>(
+          kerrschild_vars);
+  const auto det_spatial_metric = determinant(spatial_metric);
+  const auto conformal_factor = pow(get(det_spatial_metric), -1. / 6.);
+  Scalar<DataVector> conformal_factor_squared{};
+  get(conformal_factor_squared) = square(conformal_factor);
+  get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(evolved_vars) =
+      get_conformal_spatial_metric(conformal_factor_squared, spatial_metric);
+
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(kerrschild_vars);
+
+  get<gr::Tags::Shift<DataVector, 3>>(evolved_vars) =
+      get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(kerrschild_vars);
+  const auto& d_shift =
+      get<Tags::deriv<gr::Tags::Shift<DataVector, SpatialDim, FrameType>,
+                      tmpl::size_t<SpatialDim>, FrameType>>(kerrschild_vars);
+
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<DataVector, SpatialDim>>>(
+          kerrschild_vars);
+  const auto& d_spatial_metric =
+      get<Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
+                      tmpl::size_t<SpatialDim>, FrameType>>(kerrschild_vars);
+  const auto& inverse_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, SpatialDim, FrameType>>(
+          kerrschild_vars);
+  const auto extrinsic_curvature = gr::extrinsic_curvature(
+      lapse, get<gr::Tags::Shift<DataVector, 3>>(evolved_vars), d_shift,
+      spatial_metric, dt_spatial_metric, d_spatial_metric);
+  get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars) =
+      get_trace_extrinsic_curvature(extrinsic_curvature,
+                                    inverse_spatial_metric);
+
+  get<::Ccz4::Tags::ATilde<DataVector, 3>>(evolved_vars) = ::Ccz4::a_tilde(
+      conformal_factor_squared, spatial_metric, extrinsic_curvature,
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars));
+
+  get<::Ccz4::Tags::Theta<DataVector>>(evolved_vars) =
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+
+  const auto inverse_conformal_spatial_metric =
+      determinant_and_inverse(
+          get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(evolved_vars))
+          .second;
+  const auto d_det_spatial_metric =
+      get<gr::Tags::DerivDetSpatialMetric<DataVector, SpatialDim, FrameType>>(
+          solution.variables(
+              coords, t,
+              tmpl::list<gr::Tags::DerivDetSpatialMetric<DataVector, SpatialDim,
+                                                         FrameType>>{}));
+  const tnsr::ijj<DataVector, SpatialDim, FrameType>
+      d_conformal_spatial_metric = get_d_conformal_spatial_metric(
+          conformal_factor_squared, spatial_metric, d_spatial_metric,
+          d_det_spatial_metric);
+  const tnsr::ijj<DataVector, SpatialDim, FrameType> field_d =
+      get_field_d(d_conformal_spatial_metric);
+  const auto conformal_christoffel_second_kind =
+      ::Ccz4::conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d);
+  const auto contracted_conformal_christoffel_second_kind =
+      ::Ccz4::contracted_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, conformal_christoffel_second_kind);
+  get<::Ccz4::Tags::GammaHat<DataVector, 3>>(evolved_vars) =
+      contracted_conformal_christoffel_second_kind;  // Z4 constraint is 0
+
+  get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(evolved_vars) =
+      get_b_kerr(evolve_shift,
+                 get<gr::Tags::Shift<DataVector, 3>>(evolved_vars), d_shift, f);
+
+  get<gr::Tags::Lapse<DataVector>>(evolved_vars) = lapse;
+
+  get(get<::Ccz4::Tags::ConformalFactor<DataVector>>(evolved_vars)) =
+      conformal_factor;
+
+  return evolved_vars;
+}
+}  // namespace KerrSchild
+
+namespace GaugePlaneWave {
+// calculate the spatial derivative of the determinant of the spatial metric
+template <size_t SpatialDim, typename FrameType>
+tnsr::i<DataVector, SpatialDim, FrameType>
+get_d_det_spatial_metric_gauge_plane_wave(
+    const Scalar<DataVector>& det_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& d_spatial_metric) {
+  tnsr::i<DataVector, SpatialDim, FrameType> d_det_spatial_metric;
+  ::tenex::evaluate<ti::i>(make_not_null(&d_det_spatial_metric),
+                           det_spatial_metric() *
+                               inverse_spatial_metric(ti::J, ti::K) *
+                               d_spatial_metric(ti::i, ti::j, ti::k));
+  return d_det_spatial_metric;
+}
+
+// calculate the exact time derivative of the gauge plane wave conformal spatial
+// metric
+template <size_t SpatialDim, typename FrameType>
+tnsr::ii<DataVector, SpatialDim, FrameType>
+get_dt_conformal_spatial_metric_gauge_plane_wave(
+    const Scalar<DataVector>& conformal_factor_squared,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& dt_spatial_metric) {
+  tnsr::ii<DataVector, SpatialDim, FrameType> dt_conformal_spatial_metric;
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&dt_conformal_spatial_metric),
+      conformal_factor_squared() * dt_spatial_metric(ti::i, ti::j) -
+          1.0 / 3.0 * conformal_factor_squared() *
+              spatial_metric(ti::i, ti::j) *
+              inverse_spatial_metric(ti::L, ti::K) *
+              dt_spatial_metric(ti::l, ti::k));
+  return dt_conformal_spatial_metric;
+}
+
+// calculate the exact time derivative of the gauge plane wave conforma factor
+template <size_t SpatialDim, typename FrameType>
+Scalar<DataVector> get_dt_conformal_factor_gauge_plane_wave(
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& dt_spatial_metric,
+    const Scalar<DataVector>& conformal_factor) {
+  Scalar<DataVector> dt_conformal_factor;
+  ::tenex::evaluate(make_not_null(&dt_conformal_factor),
+                    -1.0 / 6.0 * conformal_factor() *
+                        inverse_spatial_metric(ti::J, ti::K) *
+                        dt_spatial_metric(ti::j, ti::k));
+  return dt_conformal_factor;
+}
+
+// calculate the exact spatial derivative of the gauge plane wave conformal
+// factor
+template <size_t SpatialDim, typename FrameType>
+tnsr::i<DataVector, SpatialDim, FrameType>
+get_d_conformal_factor_gauge_plane_wave(
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& d_spatial_metric,
+    const Scalar<DataVector>& conformal_factor) {
+  tnsr::i<DataVector, SpatialDim, FrameType> d_conformal_factor;
+  ::tenex::evaluate<ti::i>(make_not_null(&d_conformal_factor),
+                           -1.0 / 6.0 * conformal_factor() *
+                               inverse_spatial_metric(ti::J, ti::K) *
+                               d_spatial_metric(ti::i, ti::j, ti::k));
+  return d_conformal_factor;
+}
+
+// calculate the exact time derivative of the gauge plane wave trace-free
+// part of the extrinsic curvature
+template <size_t SpatialDim, typename FrameType>
+tnsr::ii<DataVector, SpatialDim, FrameType> get_dt_a_tilde_gauge_plane_wave(
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_squared,
+    const Scalar<DataVector>& dt_conformal_factor,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& spatial_metric,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& dt_spatial_metric,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& extrinsic_curvature,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& dt_extrinsic_curvature,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const Scalar<DataVector>& dt_trace_extrinsic_curvature) {
+  tnsr::ii<DataVector, SpatialDim, FrameType> dt_a_tilde;
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&dt_a_tilde),
+      2.0 * conformal_factor() * dt_conformal_factor() *
+              (extrinsic_curvature(ti::i, ti::j) -
+               1.0 / 3.0 * trace_extrinsic_curvature() *
+                   spatial_metric(ti::i, ti::j)) +
+          conformal_factor_squared() *
+              (dt_extrinsic_curvature(ti::i, ti::j) -
+               1.0 / 3.0 * dt_trace_extrinsic_curvature() *
+                   spatial_metric(ti::i, ti::j) -
+               1.0 / 3.0 * trace_extrinsic_curvature() *
+                   dt_spatial_metric(ti::i, ti::j)));
+  return dt_a_tilde;
+}
+
+// calculate the time derivative of the inverse spatial metric
+template <size_t SpatialDim, typename FrameType>
+tnsr::II<DataVector, SpatialDim, FrameType> get_dt_inverse_spatial_metric(
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& dt_spatial_metric) {
+  tnsr::II<DataVector, SpatialDim, FrameType> dt_inverse_spatial_metric;
+  ::tenex::evaluate<ti::L, ti::K>(make_not_null(&dt_inverse_spatial_metric),
+                                  -1.0 * inverse_spatial_metric(ti::I, ti::L) *
+                                      inverse_spatial_metric(ti::J, ti::K) *
+                                      dt_spatial_metric(ti::i, ti::j));
+  return dt_inverse_spatial_metric;
+}
+
+// calculate the time derivative of the inverse conformal spatial metric
+template <size_t SpatialDim, typename FrameType>
+tnsr::II<DataVector, SpatialDim, FrameType>
+get_dt_inverse_conformal_spatial_metric(
+    const tnsr::II<DataVector, SpatialDim, FrameType>&
+        inverse_conformal_spatial_metric,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>&
+        dt_conformal_spatial_metric) {
+  tnsr::II<DataVector, SpatialDim, FrameType>
+      dt_inverse_conformal_spatial_metric;
+  ::tenex::evaluate<ti::L, ti::K>(
+      make_not_null(&dt_inverse_conformal_spatial_metric),
+      -1.0 * inverse_conformal_spatial_metric(ti::I, ti::L) *
+          inverse_conformal_spatial_metric(ti::J, ti::K) *
+          dt_conformal_spatial_metric(ti::i, ti::j));
+  return dt_inverse_conformal_spatial_metric;
+}
+
+// calculate the exact time derivative of the gauge plane wave trace of
+// extrinsic curvature
+template <size_t SpatialDim, typename FrameType>
+Scalar<DataVector> get_dt_trace_extrinsic_curvature_gauge_plane_wave(
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& extrinsic_curvature,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& dt_extrinsic_curvature,
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, FrameType>&
+        dt_inverse_spatial_metric) {
+  Scalar<DataVector> dt_trace_extrinsic_curvature;
+  ::tenex::evaluate(make_not_null(&dt_trace_extrinsic_curvature),
+                    inverse_spatial_metric(ti::I, ti::J) *
+                            dt_extrinsic_curvature(ti::i, ti::j) +
+                        dt_inverse_spatial_metric(ti::I, ti::J) *
+                            extrinsic_curvature(ti::i, ti::j));
+  return dt_trace_extrinsic_curvature;
+}
+
+// calculate 1 + H*\omega^2 in the gauge plane wave
+inline Scalar<DataVector> get_one_plus_h_times_omega_squared(
+    const Scalar<DataVector>& h, const double omega) {
+  Scalar<DataVector> result;
+  ::tenex::evaluate(make_not_null(&result), 1.0 + h() * square(omega));
+  return result;
+}
+
+// calculate the exact time derivative of the gauge plane wave extrinsic
+// curvature
+template <size_t SpatialDim, typename FrameType>
+tnsr::ii<DataVector, SpatialDim, FrameType>
+get_dt_extrinsic_curvature_gauge_plane_wave(
+    const tnsr::i<DataVector, SpatialDim, FrameType>& k,
+    const Scalar<DataVector>& du_h, const Scalar<DataVector>& du_du_h,
+    const Scalar<DataVector>& one_plus_h_times_omega_squared,
+    const double omega) {
+  tnsr::ii<DataVector, SpatialDim, FrameType> dt_extrinsic_curvature;
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&dt_extrinsic_curvature),
+      1.0 / 2.0 * square(omega) * k(ti::i) * k(ti::j) * du_du_h() *
+              Scalar<DataVector>(
+                  pow(get(one_plus_h_times_omega_squared), -1.0 / 2.0))() -
+          1.0 / 4.0 * pow(omega, 4) * k(ti::i) * k(ti::j) * du_h() * du_h() *
+              Scalar<DataVector>(
+                  pow(get(one_plus_h_times_omega_squared), -3.0 / 2.0))());
+  return dt_extrinsic_curvature;
+}
+
+// calculate the exact time derivative of the spatial derivative of the
+// conformal factor
+template <size_t SpatialDim, typename FrameType>
+tnsr::i<DataVector, SpatialDim, FrameType>
+get_dt_d_conformal_factor_gauge_plane_wave(
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& dt_conformal_factor,
+    const tnsr::II<DataVector, SpatialDim, FrameType>& inverse_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, FrameType>&
+        dt_inverse_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& d_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& dt_d_spatial_metric) {
+  tnsr::i<DataVector, SpatialDim, FrameType> dt_d_conformal_factor;
+  ::tenex::evaluate<ti::i>(
+      make_not_null(&dt_d_conformal_factor),
+      -1.0 / 6.0 *
+          (dt_conformal_factor() * inverse_spatial_metric(ti::J, ti::K) *
+               d_spatial_metric(ti::i, ti::j, ti::k) +
+           conformal_factor() * dt_inverse_spatial_metric(ti::J, ti::K) *
+               d_spatial_metric(ti::i, ti::j, ti::k) +
+           conformal_factor() * inverse_spatial_metric(ti::J, ti::K) *
+               dt_d_spatial_metric(ti::i, ti::j, ti::k)));
+  return dt_d_conformal_factor;
+}
+
+// calculate the exact time derivative of the spatial derivative of the
+// spatial metric
+template <size_t SpatialDim, typename FrameType>
+tnsr::ijj<DataVector, SpatialDim, FrameType>
+get_dt_d_spatial_metric_gauge_plane_wave(
+    const tnsr::i<DataVector, SpatialDim, FrameType>& k,
+    const Scalar<DataVector>& du_du_h, const double omega) {
+  tnsr::ijj<DataVector, SpatialDim, FrameType> dt_d_spatial_metric;
+  ::tenex::evaluate<ti::i, ti::j, ti::k>(
+      make_not_null(&dt_d_spatial_metric),
+      -1.0 * omega * k(ti::i) * k(ti::j) * k(ti::k) * du_du_h());
+  return dt_d_spatial_metric;
+}
+
+// calculate the exact time derivative of the spatial derivative of the
+// conformal spatial metric
+template <size_t SpatialDim, typename FrameType>
+tnsr::ijj<DataVector, SpatialDim, FrameType>
+get_dt_d_conformal_spatial_metric_gauge_plane_wave(
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& spatial_metric,
+    const tnsr::ii<DataVector, SpatialDim, FrameType>& dt_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& d_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& dt_d_spatial_metric,
+    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& dt_conformal_factor,
+    const tnsr::i<DataVector, SpatialDim, FrameType>& d_conformal_factor,
+    const tnsr::i<DataVector, SpatialDim, FrameType>& dt_d_conformal_factor) {
+  tnsr::ijj<DataVector, SpatialDim, FrameType> dt_d_conformal_spatial_metric;
+  ::tenex::evaluate<ti::l, ti::j, ti::k>(
+      make_not_null(&dt_d_conformal_spatial_metric),
+      2.0 * dt_spatial_metric(ti::j, ti::k) * conformal_factor() *
+              d_conformal_factor(ti::l) +
+          2.0 * spatial_metric(ti::j, ti::k) * dt_conformal_factor() *
+              d_conformal_factor(ti::l) +
+          2.0 * spatial_metric(ti::j, ti::k) * conformal_factor() *
+              dt_d_conformal_factor(ti::l) +
+          2.0 * conformal_factor() * dt_conformal_factor() *
+              d_spatial_metric(ti::l, ti::j, ti::k) +
+          conformal_factor() * conformal_factor() *
+              dt_d_spatial_metric(ti::l, ti::j, ti::k));
+  return dt_d_conformal_spatial_metric;
+}
+
+// calculate the exact time derivative of the gauge plane wave \hat{\Gamma}^i
+// the Z4 constraint is assumed to be zero
+template <size_t SpatialDim, typename FrameType>
+tnsr::I<DataVector, SpatialDim, FrameType> get_dt_gamma_hat_gauge_plane_wave(
+    const tnsr::II<DataVector, SpatialDim, FrameType>&
+        inverse_conformal_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, FrameType>&
+        dt_inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>&
+        d_conformal_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>&
+        dt_d_conformal_spatial_metric) {
+  tnsr::I<DataVector, SpatialDim, FrameType> dt_gamma_hat;
+  ::tenex::evaluate<ti::I>(
+      make_not_null(&dt_gamma_hat),
+      dt_inverse_conformal_spatial_metric(ti::I, ti::J) *
+              inverse_conformal_spatial_metric(ti::K, ti::L) *
+              d_conformal_spatial_metric(ti::l, ti::j, ti::k) +
+          inverse_conformal_spatial_metric(ti::I, ti::J) *
+              dt_inverse_conformal_spatial_metric(ti::K, ti::L) *
+              d_conformal_spatial_metric(ti::l, ti::j, ti::k) +
+          inverse_conformal_spatial_metric(ti::I, ti::J) *
+              inverse_conformal_spatial_metric(ti::K, ti::L) *
+              dt_d_conformal_spatial_metric(ti::l, ti::j, ti::k));
+  return dt_gamma_hat;
+}
+
+// calculate the exact time derivative of the shift using Gamma driver
+// b^i is assumed to be zero.
+template <size_t SpatialDim, typename FrameType>
+tnsr::I<DataVector, SpatialDim, FrameType> get_dt_shift_gauge_plane_wave(
+    const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
+    const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_shift) {
+  tnsr::I<DataVector, SpatialDim, FrameType> dt_shift;
+  ::tenex::evaluate<ti::I>(make_not_null(&dt_shift),
+                           shift(ti::K) * d_shift(ti::k, ti::I));
+  return dt_shift;
+}
+
+// calculate the exact time derivative of the b^i using Gamma driver
+// b^i is assumed to be zero.
+template <size_t SpatialDim, typename FrameType>
+tnsr::I<DataVector, SpatialDim, FrameType> get_dt_b_gauge_plane_wave_expected(
+    const tnsr::I<DataVector, SpatialDim, FrameType>& dt_gamma_hat,
+    const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_gamma_hat,
+    const tnsr::I<DataVector, SpatialDim, FrameType>& shift) {
+  tnsr::I<DataVector, SpatialDim, FrameType> dt_b;
+  ::tenex::evaluate<ti::I>(
+      make_not_null(&dt_b),
+      dt_gamma_hat(ti::I) - shift(ti::K) * d_gamma_hat(ti::k, ti::I));
+  return dt_b;
+}
+
+// calculate the exact time derivative of the lapse using 1+log slicing
+// theta is assumed to be zero. K0 is the trace extrinsic curvature on the
+// initial time slice
+template <size_t SpatialDim, typename FrameType>
+Scalar<DataVector> get_dt_lapse_gauge_plane_wave(
+    const tnsr::i<DataVector, SpatialDim, FrameType>& d_lapse,
+    const tnsr::I<DataVector, SpatialDim, FrameType>& shift) {
+  Scalar<DataVector> dt_lapse;
+  ::tenex::evaluate(make_not_null(&dt_lapse), shift(ti::I) * d_lapse(ti::i));
+  return dt_lapse;
+}
+
+// Compute D_{k}^{ij} from eq 14
+template <size_t SpatialDim, typename FrameType>
+tnsr::iJJ<DataVector, SpatialDim, FrameType> get_field_d_up(
+    const tnsr::II<DataVector, SpatialDim, FrameType>&
+        inverse_conformal_spatial_metric,
+    const tnsr::ijj<DataVector, SpatialDim, FrameType>& field_d) {
+  tnsr::iJJ<DataVector, SpatialDim, FrameType> field_d_up =
+      gr::deriv_inverse_spatial_metric(inverse_conformal_spatial_metric,
+                                       field_d);
+  for (size_t i = 0; i < field_d.size(); i++) {
+    field_d_up[i] *= -1.0;
+  }
+  return field_d_up;
+}
+
+inline Variables<
+    ::Ccz4::fd::Tags::spacetime_reconstruction_tags>
+compute_prim_solution_for_GaugePlaneWave(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords, const double t,
+    const gr::Solutions::GaugePlaneWave<3>& solution,
+    const gr::Solutions::GaugePlaneWave<3>::IntermediateVars<DataVector>&
+        intermediate_sol) {
+  const Scalar<DataVector> h{intermediate_sol.h};
+  const Scalar<DataVector> du_h{intermediate_sol.du_h};
+  const Scalar<DataVector> du_du_h{intermediate_sol.du_du_h};
+
+  const size_t SpatialDim = 3;
+
+  // Setup solutions
+  const auto gauge_plane_wave_vars = solution.variables(
+      coords, t,
+      typename gr::Solutions::GaugePlaneWave<SpatialDim>::tags<DataVector>{});
+
+  // get system evolved vars
+  Variables<typename ::Ccz4::fd::System::variables_tag::tags_list> evolved_vars{
+      get<0>(coords).size()};
+
+  using FrameType = Frame::Inertial;
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<DataVector, SpatialDim, FrameType>>(
+          gauge_plane_wave_vars);
+
+  const auto det_spatial_metric = determinant(spatial_metric);
+  const auto conformal_factor = pow(get(det_spatial_metric), -1. / 6.);
+  Scalar<DataVector> conformal_factor_squared{};
+  get(conformal_factor_squared) = square(conformal_factor);
+  get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(evolved_vars) =
+      KerrSchild::get_conformal_spatial_metric(conformal_factor_squared,
+                                               spatial_metric);
+
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(gauge_plane_wave_vars);
+
+  get<gr::Tags::Shift<DataVector, 3>>(evolved_vars) =
+      get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
+          gauge_plane_wave_vars);
+
+  get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars) =
+      KerrSchild::get_trace_extrinsic_curvature(
+          get<gr::Tags::ExtrinsicCurvature<DataVector, SpatialDim, FrameType>>(
+              gauge_plane_wave_vars),
+          get<gr::Tags::InverseSpatialMetric<DataVector, SpatialDim,
+                                             FrameType>>(
+              gauge_plane_wave_vars));
+
+  get<::Ccz4::Tags::ATilde<DataVector, 3>>(evolved_vars) = ::Ccz4::a_tilde(
+      conformal_factor_squared, spatial_metric,
+      get<gr::Tags::ExtrinsicCurvature<DataVector, SpatialDim, FrameType>>(
+          gauge_plane_wave_vars),
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars));
+
+  const DataVector used_for_size = DataVector(
+      get<0>(coords).size(), std::numeric_limits<double>::signaling_NaN());
+  get<::Ccz4::Tags::Theta<DataVector>>(evolved_vars) =
+      make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+
+  const auto inverse_conformal_spatial_metric =
+      determinant_and_inverse(
+          get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(evolved_vars))
+          .second;
+  const auto d_det_spatial_metric = get_d_det_spatial_metric_gauge_plane_wave(
+      det_spatial_metric,
+      get<gr::Tags::InverseSpatialMetric<DataVector, SpatialDim, FrameType>>(
+          gauge_plane_wave_vars),
+      get<Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
+                      tmpl::size_t<SpatialDim>, FrameType>>(
+          gauge_plane_wave_vars));
+  const auto& d_spatial_metric =
+      get<Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
+                      tmpl::size_t<SpatialDim>, FrameType>>(
+          gauge_plane_wave_vars);
+  const tnsr::ijj<DataVector, SpatialDim, FrameType>
+      d_conformal_spatial_metric = KerrSchild::get_d_conformal_spatial_metric(
+          conformal_factor_squared, spatial_metric, d_spatial_metric,
+          d_det_spatial_metric);
+  const tnsr::ijj<DataVector, SpatialDim, FrameType> field_d =
+      KerrSchild::get_field_d(d_conformal_spatial_metric);
+  const auto conformal_christoffel_second_kind =
+      ::Ccz4::conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d);
+  const auto contracted_conformal_christoffel_second_kind =
+      ::Ccz4::contracted_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, conformal_christoffel_second_kind);
+  get<::Ccz4::Tags::GammaHat<DataVector, 3>>(evolved_vars) =
+      contracted_conformal_christoffel_second_kind;  // Z4 constraint is 0
+
+  get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(evolved_vars) =
+      make_with_value<tnsr::I<DataVector, SpatialDim, FrameType>>(used_for_size,
+                                                                  0.0);
+
+  get<gr::Tags::Lapse<DataVector>>(evolved_vars) = lapse;
+
+  get(get<::Ccz4::Tags::ConformalFactor<DataVector>>(evolved_vars)) =
+      conformal_factor;
+
+  return evolved_vars;
+}
+}  // namespace GaugePlaneWave
 }  // namespace TestHelpers::Ccz4::fd::detail


### PR DESCRIPTION
Add the time derivative for the second-order Ccz4 (SoCcz4) evolution system. 

In the `SoTimeDerivative.hpp` file, we have two `apply()` functions. The first one is mostly adapted from the first-order Ccz4 system while the second one computes the first and second spatial derivatives of the evolved variables and feed them into the first one.

We provide three test cases for the time derivative: Minkowski, KerrSchild, and GaugePlaneWave. Since we use 4-th order finite differencing with the SoCcz4 system instead of spectral methods, more grid points need to be used in the tests, which take longer to run. The helper functions for the tests are set up in `PrimReconstructor.hpp`.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
