### PR TITLE
Allow reconstructing rho*T instead of just T

### DIFF
--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -285,7 +285,7 @@ struct TciAndSwitchToDg {
         not cell_is_troubled and
 
         (((is_substep_method and
-           tci_history.size() == subcell_options.min_clear_tci_before_dg() - 1)
+           tci_history.size() >= subcell_options.min_clear_tci_before_dg() - 1)
 
           or
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -27,10 +27,13 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -203,6 +206,86 @@ void BoundaryConditionGhostData<System>::apply(
                   << " when using finite-difference");
           }
         });
-  }
+    if (dynamic_cast<const BoundaryConditions::DirichletAnalytic<System>*>(
+            &boundary_condition_at_direction) != nullptr and
+        reconstructor.reconstruct_rho_times_temperature()) {
+      // If we reconstruct rho*T we end up having to divide by rho to compute
+      // T. In some cases, like when evolving a TOV star with an analytic
+      // boundary condition, the boundary condition sets rho=0. While
+      // unphysical in general, this is how we have implemented the
+      // solutions. We deal with this by applying our atmosphere treatment to
+      // the reconstructed stated.
+
+      const auto& atmosphere_fixer =
+          db::get<::Tags::VariableFixer<VariableFixing::FixToAtmosphere<3>>>(
+              *box);
+      const auto& equation_of_state =
+          db::get<hydro::Tags::GrmhdEquationOfState>(*box);
+
+      tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric{};
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = i; j < 3; ++j) {
+          spatial_metric.get(i, j).set_data_ref(
+              &get<SpacetimeMetric>(ghost_data_vars).get(i + 1, j + 1));
+        }
+      }
+
+      Variables<tmpl::list<hydro::Tags::SpatialVelocity<DataVector, 3>,
+                           hydro::Tags::LorentzFactor<DataVector>,
+                           hydro::Tags::SpecificInternalEnergy<DataVector>,
+                           hydro::Tags::Pressure<DataVector>>>
+          temp_hydro_vars{ghost_data_vars.number_of_grid_points()};
+
+      const auto& lorentz_factor_times_spatial_velocity =
+          get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
+              ghost_data_vars);
+      auto& lorentz_factor =
+          get<hydro::Tags::LorentzFactor<DataVector>>(temp_hydro_vars);
+      get(lorentz_factor) = 0.0;
+      for (size_t i = 0; i < 3; ++i) {
+        get(lorentz_factor) +=
+            spatial_metric.get(i, i) *
+            square(lorentz_factor_times_spatial_velocity.get(i));
+        for (size_t j = i + 1; j < 3; ++j) {
+          get(lorentz_factor) += 2.0 * spatial_metric.get(i, j) *
+                                 lorentz_factor_times_spatial_velocity.get(i) *
+                                 lorentz_factor_times_spatial_velocity.get(j);
+        }
+      }
+      get(lorentz_factor) = sqrt(1.0 + get(lorentz_factor));
+      auto& spatial_velocity =
+          get<hydro::Tags::SpatialVelocity<DataVector, 3>>(temp_hydro_vars) =
+              lorentz_factor_times_spatial_velocity;
+      for (size_t i = 0; i < 3; ++i) {
+        spatial_velocity.get(i) /= get(lorentz_factor);
+      }
+
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(temp_hydro_vars) =
+          equation_of_state
+              .specific_internal_energy_from_density_and_temperature(
+                  get<RestMassDensity>(ghost_data_vars),
+                  get<Temperature>(ghost_data_vars),
+                  get<ElectronFraction>(ghost_data_vars));
+      get<hydro::Tags::Pressure<DataVector>>(temp_hydro_vars) =
+          equation_of_state.pressure_from_density_and_temperature(
+              get<RestMassDensity>(ghost_data_vars),
+              get<Temperature>(ghost_data_vars),
+              get<ElectronFraction>(ghost_data_vars));
+
+      atmosphere_fixer(
+          make_not_null(&get<RestMassDensity>(ghost_data_vars)),
+          make_not_null(&get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+              temp_hydro_vars)),
+          make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+              temp_hydro_vars)),
+          make_not_null(
+              &get<hydro::Tags::LorentzFactor<DataVector>>(temp_hydro_vars)),
+          make_not_null(
+              &get<hydro::Tags::Pressure<DataVector>>(temp_hydro_vars)),
+          make_not_null(&get<Temperature>(ghost_data_vars)),
+          get<ElectronFraction>(ghost_data_vars), spatial_metric,
+          equation_of_state);
+    }
+  }  // for (direction : external boundaries)
 }
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -48,9 +48,11 @@ namespace grmhd::GhValenciaDivClean::fd {
 template <typename System>
 MonotonisedCentralPrim<System>::MonotonisedCentralPrim(
     const ::VariableFixing::FixReconstructedStateToAtmosphere
-        fix_reconstructed_state_to_atmosphere)
+        fix_reconstructed_state_to_atmosphere,
+    const bool reconstruct_rho_times_temperature)
     : fix_reconstructed_state_to_atmosphere_(
-          fix_reconstructed_state_to_atmosphere) {}
+          fix_reconstructed_state_to_atmosphere),
+      reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {}
 
 template <typename System>
 MonotonisedCentralPrim<System>::MonotonisedCentralPrim(
@@ -67,6 +69,7 @@ template <typename System>
 void MonotonisedCentralPrim<System>::pup(PUP::er& p) {
   Reconstructor<System>::pup(p);
   p | fix_reconstructed_state_to_atmosphere_;
+  p | reconstruct_rho_times_temperature_;
 }
 
 template <typename System>
@@ -143,6 +146,7 @@ void MonotonisedCentralPrim<System>::reconstruct(
       },
       volume_prims, volume_spacetime_and_cons_vars, eos, element,
       neighbor_variables_data, subcell_mesh, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature(),
       (fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::Always or
                fix_reconstructed_state_to_atmosphere_ ==
@@ -252,7 +256,7 @@ void MonotonisedCentralPrim<System>::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, subcell_volume_spacetime_metric, eos, element,
       ghost_data, subcell_mesh, direction_to_reconstruct, ghost_zone_size(),
-      true,
+      true, reconstruct_rho_times_temperature(),
       (fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::Always or
                fix_reconstructed_state_to_atmosphere_ ==
@@ -262,10 +266,17 @@ void MonotonisedCentralPrim<System>::reconstruct_fd_neighbor(
 }
 
 template <typename System>
+bool MonotonisedCentralPrim<System>::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
+}
+
+template <typename System>
 bool operator==(const MonotonisedCentralPrim<System>& lhs,
                 const MonotonisedCentralPrim<System>& rhs) {
   return lhs.fix_reconstructed_state_to_atmosphere_ ==
-         rhs.fix_reconstructed_state_to_atmosphere_;
+             rhs.fix_reconstructed_state_to_atmosphere_ and
+         lhs.reconstruct_rho_times_temperature() ==
+             rhs.reconstruct_rho_times_temperature();
 }
 
 template <typename System>

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -80,15 +80,22 @@ class MonotonisedCentralPrim : public Reconstructor<System> {
     static constexpr Options::String help = {
         "What reconstructed states to fix to their atmosphere values."};
   };
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
 
-  using options = tmpl::list<AtmosphereTreatment>;
+  using options =
+      tmpl::list<AtmosphereTreatment, ReconstructRhoTimesTemperature>;
   static constexpr Options::String help{
       "Monotonised central reconstruction scheme using primitive variables and "
       "the metric variables."};
 
-  explicit MonotonisedCentralPrim(
-      ::VariableFixing::FixReconstructedStateToAtmosphere
-          fix_reconstructed_state_to_atmosphere);
+  MonotonisedCentralPrim(::VariableFixing::FixReconstructedStateToAtmosphere
+                             fix_reconstructed_state_to_atmosphere,
+                         bool reconstruct_rho_times_temperature);
 
   MonotonisedCentralPrim() = default;
   MonotonisedCentralPrim(MonotonisedCentralPrim&&) = default;
@@ -148,6 +155,8 @@ class MonotonisedCentralPrim : public Reconstructor<System> {
       const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
       Direction<dim> direction_to_reconstruct) const;
 
+  bool reconstruct_rho_times_temperature() const override;
+
  private:
   template <typename LocalSystem>
   friend bool operator==(const MonotonisedCentralPrim<LocalSystem>& lhs,
@@ -159,5 +168,6 @@ class MonotonisedCentralPrim : public Reconstructor<System> {
   ::VariableFixing::FixReconstructedStateToAtmosphere
       fix_reconstructed_state_to_atmosphere_{
           ::VariableFixing::FixReconstructedStateToAtmosphere::Never};
+  bool reconstruct_rho_times_temperature_{false};
 };
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -63,11 +63,13 @@ PositivityPreservingAdaptiveOrderPrim<System>::
             low_order_reconstructor,
         const ::VariableFixing::FixReconstructedStateToAtmosphere
             fix_reconstructed_state_to_atmosphere,
+        const bool reconstruct_rho_times_temperature,
         const Options::Context& context)
     : four_to_the_alpha_5_(pow(4.0, alpha_5)),
       low_order_reconstructor_(low_order_reconstructor),
       fix_reconstructed_state_to_atmosphere_(
-          fix_reconstructed_state_to_atmosphere) {
+          fix_reconstructed_state_to_atmosphere),
+      reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {
   if (low_order_reconstructor_ ==
       ::fd::reconstruction::FallbackReconstructorType::None) {
     PARSE_ERROR(context, "None is not an allowed low-order reconstructor.");
@@ -111,6 +113,7 @@ void PositivityPreservingAdaptiveOrderPrim<System>::pup(PUP::er& p) {
   p | eight_to_the_alpha_9_;
   p | low_order_reconstructor_;
   p | fix_reconstructed_state_to_atmosphere_;
+  p | reconstruct_rho_times_temperature_;
   if (p.isUnpacking()) {
     set_function_pointers();
   }
@@ -195,7 +198,8 @@ void PositivityPreservingAdaptiveOrderPrim<System>::reconstruct(
             shift, spacetime_metric);
       },
       volume_prims, volume_spacetime_and_cons_vars, eos, element,
-      neighbor_variables_data, subcell_mesh, ghost_zone_size(), false, nullptr);
+      neighbor_variables_data, subcell_mesh, ghost_zone_size(), false,
+      reconstruct_rho_times_temperature(), nullptr);
 
   reconstruct_prims_work<tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>>,
                          non_positive_tags>(
@@ -244,6 +248,7 @@ void PositivityPreservingAdaptiveOrderPrim<System>::reconstruct(
       },
       volume_prims, volume_spacetime_and_cons_vars, eos, element,
       neighbor_variables_data, subcell_mesh, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature(),
       (fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::Always or
                fix_reconstructed_state_to_atmosphere_ ==
@@ -361,13 +366,19 @@ void PositivityPreservingAdaptiveOrderPrim<System>::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, subcell_volume_spacetime_metric, eos, element,
       ghost_data, subcell_mesh, direction_to_reconstruct, ghost_zone_size(),
-      true,
+      true, reconstruct_rho_times_temperature(),
       (fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::Always or
                fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::AtDgFdInterfaceOnly
            ? &fix_to_atmosphere
            : nullptr));
+}
+
+template <typename System>
+bool PositivityPreservingAdaptiveOrderPrim<
+    System>::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
 }
 
 template <typename System>
@@ -380,7 +391,9 @@ bool operator==(const PositivityPreservingAdaptiveOrderPrim<System>& lhs,
          lhs.eight_to_the_alpha_9_ == rhs.eight_to_the_alpha_9_ and
          lhs.low_order_reconstructor_ == rhs.low_order_reconstructor_ and
          lhs.fix_reconstructed_state_to_atmosphere_ ==
-             rhs.fix_reconstructed_state_to_atmosphere_;
+             rhs.fix_reconstructed_state_to_atmosphere_ and
+         lhs.reconstruct_rho_times_temperature() ==
+             rhs.reconstruct_rho_times_temperature();
 }
 
 template <typename System>

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -121,9 +121,16 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor<System> {
     static constexpr Options::String help = {
         "What reconstructed states to fix to their atmosphere values."};
   };
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
 
-  using options = tmpl::list<Alpha5, Alpha7, Alpha9, LowOrderReconstructor,
-                             AtmosphereTreatment>;
+  using options =
+      tmpl::list<Alpha5, Alpha7, Alpha9, LowOrderReconstructor,
+                 AtmosphereTreatment, ReconstructRhoTimesTemperature>;
 
   static constexpr Options::String help{
       "Positivity-preserving adaptive-order reconstruction."};
@@ -145,6 +152,7 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor<System> {
       FallbackReconstructorType low_order_reconstructor,
       ::VariableFixing::FixReconstructedStateToAtmosphere
           fix_reconstructed_state_to_atmosphere,
+      bool reconstruct_rho_times_temperature,
       const Options::Context& context = {});
 
   explicit PositivityPreservingAdaptiveOrderPrim(CkMigrateMessage* msg);
@@ -205,6 +213,8 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor<System> {
       const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
       Direction<dim> direction_to_reconstruct) const;
 
+  bool reconstruct_rho_times_temperature() const override;
+
  private:
   template <typename LocalSystem>
   // NOLINTNEXTLINE(readability-redundant-declaration)
@@ -227,6 +237,7 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor<System> {
   ::VariableFixing::FixReconstructedStateToAtmosphere
       fix_reconstructed_state_to_atmosphere_{
           ::VariableFixing::FixReconstructedStateToAtmosphere::Never};
+  bool reconstruct_rho_times_temperature_{false};
 
   using PointerReconsOrder = void (*)(
       gsl::not_null<std::array<gsl::span<double>, dim>*>,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -97,7 +97,7 @@ void reconstruct_prims_work(
     const DirectionalIdMap<3, Variables<PrimsTagsSentByNeighbor>>&
         neighbor_data,
     const Mesh<3>& subcell_mesh, size_t ghost_zone_size,
-    bool compute_conservatives,
+    bool compute_conservatives, bool reconstruct_density_times_temperature,
     const VariableFixing::FixToAtmosphere<3>* fix_to_atmosphere);
 
 /*!
@@ -134,5 +134,6 @@ void reconstruct_fd_neighbor_work(
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     size_t ghost_zone_size, bool compute_conservatives,
+    bool reconstruct_density_times_temperature,
     const VariableFixing::FixToAtmosphere<3>* fix_to_atmosphere);
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -60,6 +60,7 @@ void reconstruct_prims_work(
         neighbor_data,
     const Mesh<3>& subcell_mesh, const size_t ghost_zone_size,
     const bool compute_conservatives,
+    const bool reconstruct_density_times_temperature,
     const VariableFixing::FixToAtmosphere<3>* fix_to_atmosphere) {
   ASSERT(Mesh<3>(subcell_mesh.extents(0), subcell_mesh.basis(0),
                  subcell_mesh.quadrature(0)) == subcell_mesh,
@@ -71,20 +72,25 @@ void reconstruct_prims_work(
   const size_t neighbor_num_pts =
       ghost_zone_size * subcell_mesh.extents().slice_away(0).product();
   size_t vars_in_neighbor_count = 0;
-  tmpl::for_each<PrimTagsForReconstruction>([&element, &neighbor_data,
-                                             neighbor_num_pts,
-                                             &hydro_reconstructor,
-                                             reconstructed_num_pts,
-                                             volume_num_pts, &volume_prims,
-                                             &vars_in_neighbor_count,
-                                             &vars_on_lower_face,
-                                             &vars_on_upper_face,
-                                             &subcell_mesh](auto tag_v) {
+  const size_t number_of_pts_for_thermodynamic_var =
+      6 * neighbor_num_pts + volume_num_pts;
+  DataVector buffer_for_recons_vars{
+      std::max(number_of_pts_for_thermodynamic_var, 3 * volume_num_pts)};
+  tmpl::for_each<
+      PrimTagsForReconstruction>([&buffer_for_recons_vars, &element,
+                                  &neighbor_data, neighbor_num_pts,
+                                  &hydro_reconstructor,
+                                  reconstruct_density_times_temperature,
+                                  reconstructed_num_pts, volume_num_pts,
+                                  &volume_prims, &vars_in_neighbor_count,
+                                  &vars_on_lower_face, &vars_on_upper_face,
+                                  &subcell_mesh](auto tag_v) {
     using tag = tmpl::type_from<decltype(tag_v)>;
     const typename tag::type* volume_tensor_ptr = nullptr;
     Variables<tmpl::list<
         hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>>
         lorentz_factor_times_v_I{};
+    Scalar<DataVector> thermo_volume_var{};
     if constexpr (std::is_same_v<tag,
                                  hydro::Tags::LorentzFactorTimesSpatialVelocity<
                                      DataVector, 3>>) {
@@ -96,7 +102,8 @@ void reconstruct_prims_work(
           get<hydro::Tags::SpatialVelocity<DataVector, 3>>(volume_prims);
       const auto& lorentz_factor =
           get<hydro::Tags::LorentzFactor<DataVector>>(volume_prims);
-      lorentz_factor_times_v_I.initialize(get(lorentz_factor).size());
+      lorentz_factor_times_v_I.set_data_ref(buffer_for_recons_vars.data(),
+                                            3 * volume_num_pts);
       auto& volume_tensor =
           get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
               lorentz_factor_times_v_I) = spatial_velocity;
@@ -104,6 +111,18 @@ void reconstruct_prims_work(
         volume_tensor.get(i) *= get(lorentz_factor);
       }
       volume_tensor_ptr = &volume_tensor;
+    } else if constexpr (std::is_same_v<tag,
+                                        hydro::Tags::Temperature<DataVector>>) {
+      if (reconstruct_density_times_temperature) {
+        get(thermo_volume_var)
+            .set_data_ref(buffer_for_recons_vars.data(), volume_num_pts);
+        get(thermo_volume_var) =
+            get(get<tag>(volume_prims)) *
+            get(get<hydro::Tags::RestMassDensity<DataVector>>(volume_prims));
+        volume_tensor_ptr = &thermo_volume_var;
+      } else {
+        volume_tensor_ptr = &get<tag>(volume_prims);
+      }
     } else {
       volume_tensor_ptr = &get<tag>(volume_prims);
     }
@@ -124,6 +143,7 @@ void reconstruct_prims_work(
 
     DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
     for (const auto& direction : Direction<3>::all_directions()) {
+      DirectionalId<3> id{};
       if (element.neighbors().contains(direction)) {
         const auto& neighbors_in_direction = element.neighbors().at(direction);
         ASSERT(neighbors_in_direction.size() == 1,
@@ -131,29 +151,57 @@ void reconstruct_prims_work(
                "got "
                    << neighbors_in_direction.size() << " in direction "
                    << direction);
-        ghost_cell_vars[direction] =
-            gsl::make_span(get<tag>(neighbor_data.at(DirectionalId<3>{
-                               direction, *neighbors_in_direction.begin()}))[0]
-                               .data(),
-                           number_of_variables * neighbor_num_pts);
+        id = DirectionalId<3>{direction, *neighbors_in_direction.begin()};
       } else {
         // retrieve boundary ghost data from neighbor_data
         ASSERT(
             element.external_boundaries().count(direction) == 1,
-            "Element has neither neighbor nor external boundary to direction : "
+            "Element has neither neighbor nor external boundary to direction: "
                 << direction);
-        ghost_cell_vars[direction] = gsl::make_span(
-            get<tag>(neighbor_data.at(DirectionalId<3>{
-                direction, ElementId<3>::external_boundary_id()}))[0]
-                .data(),
-            number_of_variables * neighbor_num_pts);
+        id = DirectionalId<3>{direction, ElementId<3>::external_boundary_id()};
       }
+      if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
+        ASSERT(number_of_variables == 1,
+               "Should only have one tensor component for a Scalar");
+        if (reconstruct_density_times_temperature) {
+          DataVector view{
+              &buffer_for_recons_vars[volume_num_pts +
+                                      (2 * direction.dimension() +
+                                       (direction.side() == Side::Upper ? 1
+                                                                        : 0)) *
+                                          neighbor_num_pts],
+              number_of_variables * neighbor_num_pts};
+          const auto& data_in_dir = neighbor_data.at(id);
+          view =
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(data_in_dir)) *
+              get(get<tag>(data_in_dir));
+
+          ghost_cell_vars[direction] = gsl::make_span(view.data(), view.size());
+          continue;
+        }
+      }
+      ghost_cell_vars[direction] =
+          gsl::make_span(get<tag>(neighbor_data.at(id))[0].data(),
+                         number_of_variables * neighbor_num_pts);
     }
 
     hydro_reconstructor(make_not_null(&upper_face_vars),
                         make_not_null(&lower_face_vars), volume_vars,
                         ghost_cell_vars, subcell_mesh.extents(),
                         number_of_variables);
+
+    if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
+      if (reconstruct_density_times_temperature) {
+        for (size_t i = 0; i < 3; ++i) {
+          get(get<tag>(gsl::at(*vars_on_upper_face, i))) /=
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                  gsl::at(*vars_on_upper_face, i)));
+          get(get<tag>(gsl::at(*vars_on_lower_face, i))) /=
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                  gsl::at(*vars_on_lower_face, i)));
+        }
+      }
+    }
 
     vars_in_neighbor_count += number_of_variables;
   });
@@ -259,6 +307,7 @@ void reconstruct_fd_neighbor_work(
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, const bool compute_conservatives,
+    const bool reconstruct_density_times_temperature,
     const VariableFixing::FixToAtmosphere<3>* const fix_to_atmosphere) {
   const DirectionalId<3> mortar_id{
       direction_to_reconstruct,
@@ -280,9 +329,13 @@ void reconstruct_fd_neighbor_work(
               neighbor_prims.data());
   }
 
+  DataVector buffer{3 * subcell_volume_prims.number_of_grid_points() +
+                    ghost_data_extents.product()};
+  Scalar<DataVector> rho_times_temperature_neighbor{};
   tmpl::for_each<PrimTagsForReconstruction>(
-      [&direction_to_reconstruct, &ghost_data_extents, &neighbor_prims,
-       &reconstruct_lower_neighbor_hydro, &reconstruct_upper_neighbor_hydro,
+      [&buffer, &direction_to_reconstruct, &ghost_data_extents, &neighbor_prims,
+       reconstruct_density_times_temperature, &reconstruct_lower_neighbor_hydro,
+       &reconstruct_upper_neighbor_hydro, &rho_times_temperature_neighbor,
        &subcell_mesh, &subcell_volume_prims, &vars_on_face](auto tag_v) {
         using tag = tmpl::type_from<decltype(tag_v)>;
         const typename tag::type* volume_tensor_ptr = nullptr;
@@ -299,16 +352,63 @@ void reconstruct_fd_neighbor_work(
                   subcell_volume_prims);
           const auto& lorentz_factor =
               get<hydro::Tags::LorentzFactor<DataVector>>(subcell_volume_prims);
+          for (size_t i = 0; i < 3; ++i) {
+            volume_tensor.get(i).set_data_ref(
+                &buffer[i * subcell_volume_prims.number_of_grid_points()],
+                subcell_volume_prims.number_of_grid_points());
+          }
           volume_tensor = spatial_velocity;
           for (size_t i = 0; i < 3; ++i) {
             volume_tensor.get(i) *= get(lorentz_factor);
           }
           volume_tensor_ptr = &volume_tensor;
         } else {
-          volume_tensor_ptr = &get<tag>(subcell_volume_prims);
+          if constexpr (std::is_same_v<tag,
+                                       hydro::Tags::Temperature<DataVector>>) {
+            if (reconstruct_density_times_temperature) {
+              get(volume_tensor)
+                  .set_data_ref(buffer.data(),
+                                subcell_volume_prims.number_of_grid_points());
+              get(volume_tensor) =
+                  get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                      subcell_volume_prims)) *
+                  get(get<tag>(subcell_volume_prims));
+              volume_tensor_ptr = &volume_tensor;
+            } else {
+              volume_tensor_ptr = &get<tag>(subcell_volume_prims);
+            }
+          } else {
+            volume_tensor_ptr = &get<tag>(subcell_volume_prims);
+          }
         }
 
-        const auto& tensor_neighbor = get<tag>(neighbor_prims);
+        const auto& tensor_neighbor =
+            [&buffer, &neighbor_prims, reconstruct_density_times_temperature,
+             &rho_times_temperature_neighbor,
+             &subcell_volume_prims]() -> typename tag::type& {
+          if constexpr (std::is_same_v<tag,
+                                       hydro::Tags::Temperature<DataVector>>) {
+            if (reconstruct_density_times_temperature) {
+              get(rho_times_temperature_neighbor)
+                  .set_data_ref(
+                      &buffer[subcell_volume_prims.number_of_grid_points()],
+                      get(get<tag>(neighbor_prims)).size());
+              get(rho_times_temperature_neighbor) =
+                  get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                      neighbor_prims)) *
+                  get(get<tag>(neighbor_prims));
+              return rho_times_temperature_neighbor;
+            } else {
+              (void)buffer, (void)reconstruct_density_times_temperature;
+              (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
+              return get<tag>(neighbor_prims);
+            }
+          } else {
+            (void)buffer, (void)reconstruct_density_times_temperature;
+            (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
+            return get<tag>(neighbor_prims);
+          }
+        }();
         auto& tensor_on_face = get<tag>(*vars_on_face);
         if (direction_to_reconstruct.side() == Side::Upper) {
           for (size_t tensor_index = 0; tensor_index < tensor_on_face.size();
@@ -327,6 +427,13 @@ void reconstruct_fd_neighbor_work(
                 (*volume_tensor_ptr)[tensor_index],
                 tensor_neighbor[tensor_index], subcell_mesh.extents(),
                 ghost_data_extents, direction_to_reconstruct);
+          }
+        }
+        if constexpr (std::is_same_v<tag,
+                                     hydro::Tags::Temperature<DataVector>>) {
+          if (reconstruct_density_times_temperature) {
+            get(tensor_on_face) /= get(
+                get<hydro::Tags::RestMassDensity<DataVector>>(*vars_on_face));
           }
         }
       });

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp
@@ -57,6 +57,8 @@ class Reconstructor : public PUP::able {
 
   virtual bool supports_adaptive_order() const { return false; }
 
+  virtual bool reconstruct_rho_times_temperature() const = 0;
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;
 };

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -49,13 +49,15 @@ Wcns5zPrim<System>::Wcns5zPrim(
         fallback_reconstructor,
     const size_t max_number_of_extrema,
     const ::VariableFixing::FixReconstructedStateToAtmosphere
-        fix_reconstructed_state_to_atmosphere)
+        fix_reconstructed_state_to_atmosphere,
+    const bool reconstruct_rho_times_temperature)
     : nonlinear_weight_exponent_(nonlinear_weight_exponent),
       epsilon_(epsilon),
       fallback_reconstructor_(fallback_reconstructor),
       max_number_of_extrema_(max_number_of_extrema),
       fix_reconstructed_state_to_atmosphere_(
-          fix_reconstructed_state_to_atmosphere) {
+          fix_reconstructed_state_to_atmosphere),
+      reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {
   std::tie(reconstruct_, reconstruct_lower_neighbor_,
            reconstruct_upper_neighbor_) =
       ::fd::reconstruction::wcns5z_function_pointers<3>(
@@ -79,6 +81,7 @@ void Wcns5zPrim<System>::pup(PUP::er& p) {
   p | fallback_reconstructor_;
   p | max_number_of_extrema_;
   p | fix_reconstructed_state_to_atmosphere_;
+  p | reconstruct_rho_times_temperature_;
   if (p.isUnpacking()) {
     std::tie(reconstruct_, reconstruct_lower_neighbor_,
              reconstruct_upper_neighbor_) =
@@ -159,6 +162,7 @@ void Wcns5zPrim<System>::reconstruct(
       },
       volume_prims, volume_spacetime_and_cons_vars, eos, element,
       neighbor_variables_data, subcell_mesh, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature(),
       (fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::Always or
                fix_reconstructed_state_to_atmosphere_ ==
@@ -265,13 +269,18 @@ void Wcns5zPrim<System>::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, subcell_volume_spacetime_metric, eos, element,
       ghost_data, subcell_mesh, direction_to_reconstruct, ghost_zone_size(),
-      true,
+      true, reconstruct_rho_times_temperature(),
       (fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::Always or
                fix_reconstructed_state_to_atmosphere_ ==
                    FixReconstructedStateToAtmosphere::AtDgFdInterfaceOnly
            ? &fix_to_atmosphere
            : nullptr));
+}
+
+template <typename System>
+bool Wcns5zPrim<System>::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
 }
 
 template <typename System>
@@ -283,7 +292,9 @@ bool operator==(const Wcns5zPrim<System>& lhs, const Wcns5zPrim<System>& rhs) {
          lhs.fallback_reconstructor_ == rhs.fallback_reconstructor_ and
          lhs.max_number_of_extrema_ == rhs.max_number_of_extrema_ and
          lhs.fix_reconstructed_state_to_atmosphere_ ==
-             rhs.fix_reconstructed_state_to_atmosphere_;
+             rhs.fix_reconstructed_state_to_atmosphere_ and
+         lhs.reconstruct_rho_times_temperature() ==
+             rhs.reconstruct_rho_times_temperature();
 }
 
 template <typename System>

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.hpp
@@ -113,9 +113,17 @@ class Wcns5zPrim : public Reconstructor<System> {
         "What reconstructed states to fix to their atmosphere values."};
   };
 
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
+
   using options =
       tmpl::list<NonlinearWeightExponent, Epsilon, FallbackReconstructor,
-                 MaxNumberOfExtrema, AtmosphereTreatment>;
+                 MaxNumberOfExtrema, AtmosphereTreatment,
+                 ReconstructRhoTimesTemperature>;
 
   static constexpr Options::String help{
       "WCNS 5Z reconstruction scheme using primitive variables."};
@@ -131,7 +139,8 @@ class Wcns5zPrim : public Reconstructor<System> {
              FallbackReconstructorType fallback_reconstructor,
              size_t max_number_of_extrema,
              ::VariableFixing::FixReconstructedStateToAtmosphere
-                 fix_reconstructed_state_to_atmosphere);
+                 fix_reconstructed_state_to_atmosphere,
+             bool reconstruct_rho_times_temperature);
 
   explicit Wcns5zPrim(CkMigrateMessage* msg);
 
@@ -182,6 +191,8 @@ class Wcns5zPrim : public Reconstructor<System> {
       const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
       const Direction<dim>& direction_to_reconstruct) const;
 
+  bool reconstruct_rho_times_temperature() const override;
+
  private:
   template <typename LocalSystem>
   // NOLINTNEXTLINE(readability-redundant-declaration)
@@ -200,6 +211,7 @@ class Wcns5zPrim : public Reconstructor<System> {
   ::VariableFixing::FixReconstructedStateToAtmosphere
       fix_reconstructed_state_to_atmosphere_{
           ::VariableFixing::FixReconstructedStateToAtmosphere::Never};
+  bool reconstruct_rho_times_temperature_{false};
 
   void (*reconstruct_)(gsl::not_null<std::array<gsl::span<double>, dim>*>,
                        gsl::not_null<std::array<gsl::span<double>, dim>*>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -31,8 +31,11 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -55,7 +58,7 @@ namespace grmhd::ValenciaDivClean::fd {
  */
 struct BoundaryConditionGhostData {
   template <typename DbTagsList>
-  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box,
+  static void apply(gsl::not_null<db::DataBox<DbTagsList>*> box,
                     const Element<3>& element,
                     const Reconstructor& reconstructor);
 
@@ -267,6 +270,87 @@ void BoundaryConditionGhostData::apply(
                   << " when using finite-difference");
           }
         });
+    if (dynamic_cast<const BoundaryConditions::DirichletAnalytic*>(
+            &boundary_condition_at_direction) != nullptr and
+        reconstructor.reconstruct_rho_times_temperature()) {
+      // If we reconstruct rho*T we end up having to divide by rho to compute
+      // T. In some cases, like when evolving a TOV star with an analytic
+      // boundary condition, the boundary condition sets rho=0. While
+      // unphysical in general, this is how we have implemented the
+      // solutions. We deal with this by applying our atmosphere treatment to
+      // the reconstructed state.
+
+      const auto& atmosphere_fixer =
+          db::get<::Tags::VariableFixer<VariableFixing::FixToAtmosphere<3>>>(
+              *box);
+      const auto& equation_of_state =
+          db::get<hydro::Tags::GrmhdEquationOfState>(*box);
+
+      Variables<tmpl::list<gr::Tags::SpatialMetric<DataVector, 3>,
+                           hydro::Tags::SpatialVelocity<DataVector, 3>,
+                           hydro::Tags::LorentzFactor<DataVector>,
+                           hydro::Tags::SpecificInternalEnergy<DataVector>,
+                           hydro::Tags::Pressure<DataVector>>>
+          temp_hydro_vars{ghost_data_vars.number_of_grid_points()};
+
+      tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric =
+          get<gr::Tags::SpatialMetric<DataVector, 3>>(temp_hydro_vars);
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = i; j < 3; ++j) {
+          spatial_metric.get(i, j) = (i == j ? 1.0 : 0.0);
+        }
+      }
+
+      const auto& lorentz_factor_times_spatial_velocity =
+          get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
+              ghost_data_vars);
+      auto& lorentz_factor =
+          get<hydro::Tags::LorentzFactor<DataVector>>(temp_hydro_vars);
+      get(lorentz_factor) = 0.0;
+      for (size_t i = 0; i < 3; ++i) {
+        get(lorentz_factor) +=
+            spatial_metric.get(i, i) *
+            square(lorentz_factor_times_spatial_velocity.get(i));
+        for (size_t j = i + 1; j < 3; ++j) {
+          get(lorentz_factor) += 2.0 * spatial_metric.get(i, j) *
+                                 lorentz_factor_times_spatial_velocity.get(i) *
+                                 lorentz_factor_times_spatial_velocity.get(j);
+        }
+      }
+      get(lorentz_factor) = sqrt(1.0 + get(lorentz_factor));
+      auto& spatial_velocity =
+          get<hydro::Tags::SpatialVelocity<DataVector, 3>>(temp_hydro_vars) =
+              lorentz_factor_times_spatial_velocity;
+      for (size_t i = 0; i < 3; ++i) {
+        spatial_velocity.get(i) /= get(lorentz_factor);
+      }
+
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(temp_hydro_vars) =
+          equation_of_state
+              .specific_internal_energy_from_density_and_temperature(
+                  get<RestMassDensity>(ghost_data_vars),
+                  get<Temperature>(ghost_data_vars),
+                  get<ElectronFraction>(ghost_data_vars));
+      get<hydro::Tags::Pressure<DataVector>>(temp_hydro_vars) =
+          equation_of_state.pressure_from_density_and_temperature(
+              get<RestMassDensity>(ghost_data_vars),
+              get<Temperature>(ghost_data_vars),
+              get<ElectronFraction>(ghost_data_vars));
+
+      atmosphere_fixer(
+          make_not_null(&get<RestMassDensity>(ghost_data_vars)),
+          make_not_null(&get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+              temp_hydro_vars)),
+          make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+              temp_hydro_vars)),
+          make_not_null(
+              &get<hydro::Tags::LorentzFactor<DataVector>>(temp_hydro_vars)),
+          make_not_null(
+              &get<hydro::Tags::Pressure<DataVector>>(temp_hydro_vars)),
+          make_not_null(&get<Temperature>(ghost_data_vars)),
+          get<ElectronFraction>(ghost_data_vars), spatial_metric,
+          equation_of_state);
+    }
   }
 }
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
@@ -30,9 +30,12 @@
 
 namespace grmhd::ValenciaDivClean::fd {
 
-MonotonicityPreserving5Prim::MonotonicityPreserving5Prim(const double alpha,
-                                                         const double epsilon)
-    : alpha_(alpha), epsilon_(epsilon) {}
+MonotonicityPreserving5Prim::MonotonicityPreserving5Prim(
+    const double alpha, const double epsilon,
+    const bool reconstruct_rho_times_temperature)
+    : alpha_(alpha),
+      epsilon_(epsilon),
+      reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {}
 
 MonotonicityPreserving5Prim::MonotonicityPreserving5Prim(
     CkMigrateMessage* const msg)
@@ -46,6 +49,7 @@ void MonotonicityPreserving5Prim::pup(PUP::er& p) {
   Reconstructor::pup(p);
   p | alpha_;
   p | epsilon_;
+  p | reconstruct_rho_times_temperature_;
 }
 
 // NOLINTNEXTLINE
@@ -79,7 +83,7 @@ void MonotonicityPreserving5Prim::reconstruct(
             epsilon_);
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true);
+      ghost_zone_size(), true, reconstruct_rho_times_temperature());
 }
 
 template <size_t ThermodynamicDim>
@@ -121,12 +125,19 @@ void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(
             local_direction_to_reconstruct, alpha_, epsilon_);
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size(), true);
+      direction_to_reconstruct, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature());
+}
+
+bool MonotonicityPreserving5Prim::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
 }
 
 bool operator==(const MonotonicityPreserving5Prim& lhs,
                 const MonotonicityPreserving5Prim& rhs) {
-  return lhs.alpha_ == rhs.alpha_ and lhs.epsilon_ == rhs.epsilon_;
+  return lhs.alpha_ == rhs.alpha_ and lhs.epsilon_ == rhs.epsilon_ and
+         lhs.reconstruct_rho_times_temperature() ==
+             rhs.reconstruct_rho_times_temperature();
 }
 
 bool operator!=(const MonotonicityPreserving5Prim& lhs,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
@@ -88,8 +88,14 @@ class MonotonicityPreserving5Prim : public Reconstructor {
         "off. Suresh & Huynh (1997) suggests 1e-10, but for hydro simulations "
         "with atmosphere treatment setting Epsilon=0.0 would be safe."};
   };
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
 
-  using options = tmpl::list<Alpha, Epsilon>;
+  using options = tmpl::list<Alpha, Epsilon, ReconstructRhoTimesTemperature>;
   static constexpr Options::String help{
       "MP5 reconstruction scheme using primitive variables."};
 
@@ -102,7 +108,8 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       default;
   ~MonotonicityPreserving5Prim() override = default;
 
-  MonotonicityPreserving5Prim(double alpha, double epsilon);
+  MonotonicityPreserving5Prim(double alpha, double epsilon,
+                              bool reconstruct_rho_times_temperature);
 
   explicit MonotonicityPreserving5Prim(CkMigrateMessage* msg);
 
@@ -145,7 +152,9 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
-      const Direction<dim> direction_to_reconstruct) const;
+      Direction<dim> direction_to_reconstruct) const;
+
+  bool reconstruct_rho_times_temperature() const override;
 
  private:
   // NOLINTNEXTLINE(readability-redundant-declaration)
@@ -156,6 +165,7 @@ class MonotonicityPreserving5Prim : public Reconstructor {
 
   double alpha_ = std::numeric_limits<double>::signaling_NaN();
   double epsilon_ = std::numeric_limits<double>::signaling_NaN();
+  bool reconstruct_rho_times_temperature_{false};
 };
 
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -29,6 +29,10 @@
 #include "Utilities/TMPL.hpp"
 
 namespace grmhd::ValenciaDivClean::fd {
+MonotonisedCentralPrim::MonotonisedCentralPrim(
+    const bool reconstruct_rho_times_temperature)
+    : reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {}
+
 MonotonisedCentralPrim::MonotonisedCentralPrim(CkMigrateMessage* const msg)
     : Reconstructor(msg) {}
 
@@ -36,7 +40,10 @@ std::unique_ptr<Reconstructor> MonotonisedCentralPrim::get_clone() const {
   return std::make_unique<MonotonisedCentralPrim>(*this);
 }
 
-void MonotonisedCentralPrim::pup(PUP::er& p) { Reconstructor::pup(p); }
+void MonotonisedCentralPrim::pup(PUP::er& p) {
+  Reconstructor::pup(p);
+  p | reconstruct_rho_times_temperature_;
+}
 
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MonotonisedCentralPrim::my_PUP_ID = 0;
@@ -67,7 +74,7 @@ void MonotonisedCentralPrim::reconstruct(
             ghost_cell_vars, subcell_extents, number_of_variables);
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true);
+      ghost_zone_size(), true, reconstruct_rho_times_temperature());
 }
 
 template <size_t ThermodynamicDim>
@@ -109,12 +116,18 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
             local_direction_to_reconstruct);
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size(), true);
+      direction_to_reconstruct, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature());
 }
 
-bool operator==(const MonotonisedCentralPrim& /*lhs*/,
-                const MonotonisedCentralPrim& /*rhs*/) {
-  return true;
+bool MonotonisedCentralPrim::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
+}
+
+bool operator==(const MonotonisedCentralPrim& lhs,
+                const MonotonisedCentralPrim& rhs) {
+  return lhs.reconstruct_rho_times_temperature() ==
+         rhs.reconstruct_rho_times_temperature();
 }
 
 bool operator!=(const MonotonisedCentralPrim& lhs,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -71,7 +71,14 @@ class MonotonisedCentralPrim : public Reconstructor {
  public:
   static constexpr size_t dim = 3;
 
-  using options = tmpl::list<>;
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
+
+  using options = tmpl::list<ReconstructRhoTimesTemperature>;
   static constexpr Options::String help{
       "Monotonised central reconstruction scheme using primitive variables."};
 
@@ -81,6 +88,8 @@ class MonotonisedCentralPrim : public Reconstructor {
   MonotonisedCentralPrim(const MonotonisedCentralPrim&) = default;
   MonotonisedCentralPrim& operator=(const MonotonisedCentralPrim&) = default;
   ~MonotonisedCentralPrim() override = default;
+
+  explicit MonotonisedCentralPrim(bool reconstruct_rho_times_temperature);
 
   explicit MonotonisedCentralPrim(CkMigrateMessage* msg);
 
@@ -123,11 +132,16 @@ class MonotonisedCentralPrim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
-      const Direction<dim> direction_to_reconstruct) const;
+      Direction<dim> direction_to_reconstruct) const;
+
+  bool reconstruct_rho_times_temperature() const override;
+
+ private:
+  bool reconstruct_rho_times_temperature_{false};
 };
 
-bool operator==(const MonotonisedCentralPrim& /*lhs*/,
-                const MonotonisedCentralPrim& /*rhs*/);
+bool operator==(const MonotonisedCentralPrim& lhs,
+                const MonotonisedCentralPrim& rhs);
 
 bool operator!=(const MonotonisedCentralPrim& lhs,
                 const MonotonisedCentralPrim& rhs);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -42,9 +42,11 @@ PositivityPreservingAdaptiveOrderPrim::PositivityPreservingAdaptiveOrderPrim(
     const std::optional<double> alpha_9,
     const ::fd::reconstruction::FallbackReconstructorType
         low_order_reconstructor,
+    const bool reconstruct_rho_times_temperature,
     const Options::Context& context)
     : four_to_the_alpha_5_(pow(4.0, alpha_5)),
-      low_order_reconstructor_(low_order_reconstructor) {
+      low_order_reconstructor_(low_order_reconstructor),
+      reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {
   if (low_order_reconstructor_ ==
       ::fd::reconstruction::FallbackReconstructorType::None) {
     PARSE_ERROR(context, "None is not an allowed low-order reconstructor.");
@@ -86,6 +88,7 @@ void PositivityPreservingAdaptiveOrderPrim::pup(PUP::er& p) {
   p | six_to_the_alpha_7_;
   p | eight_to_the_alpha_9_;
   p | low_order_reconstructor_;
+  p | reconstruct_rho_times_temperature_;
   if (p.isUnpacking()) {
     set_function_pointers();
   }
@@ -129,7 +132,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
                             std::numeric_limits<double>::signaling_NaN()));
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), false);
+      ghost_zone_size(), false, reconstruct_rho_times_temperature());
   reconstruct_prims_work<non_positive_tags>(
       vars_on_lower_face, vars_on_upper_face,
       [this](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
@@ -144,7 +147,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
                          std::numeric_limits<double>::signaling_NaN()));
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true);
+      ghost_zone_size(), true, reconstruct_rho_times_temperature());
 }
 
 template <size_t ThermodynamicDim>
@@ -190,7 +193,8 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
                 std::numeric_limits<double>::signaling_NaN()));
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size(), false);
+      direction_to_reconstruct, ghost_zone_size(), false,
+      reconstruct_rho_times_temperature());
   reconstruct_fd_neighbor_work<non_positive_tags, prims_to_reconstruct_tags>(
       vars_on_face,
       [this](const auto tensor_component_on_face_ptr,
@@ -224,7 +228,13 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
                 std::numeric_limits<double>::signaling_NaN()));
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size(), true);
+      direction_to_reconstruct, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature());
+}
+
+bool PositivityPreservingAdaptiveOrderPrim::reconstruct_rho_times_temperature()
+    const {
+  return reconstruct_rho_times_temperature_;
 }
 
 bool operator==(const PositivityPreservingAdaptiveOrderPrim& lhs,
@@ -234,7 +244,9 @@ bool operator==(const PositivityPreservingAdaptiveOrderPrim& lhs,
   return lhs.four_to_the_alpha_5_ == rhs.four_to_the_alpha_5_ and
          lhs.six_to_the_alpha_7_ == rhs.six_to_the_alpha_7_ and
          lhs.eight_to_the_alpha_9_ == rhs.eight_to_the_alpha_9_ and
-         lhs.low_order_reconstructor_ == rhs.low_order_reconstructor_;
+         lhs.low_order_reconstructor_ == rhs.low_order_reconstructor_ and
+         lhs.reconstruct_rho_times_temperature() ==
+             rhs.reconstruct_rho_times_temperature();
 }
 
 bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -112,8 +112,15 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
         "The 2nd/3rd-order reconstruction scheme to use if unlimited 5th-order "
         "isn't okay."};
   };
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
 
-  using options = tmpl::list<Alpha5, Alpha7, Alpha9, LowOrderReconstructor>;
+  using options = tmpl::list<Alpha5, Alpha7, Alpha9, LowOrderReconstructor,
+                             ReconstructRhoTimesTemperature>;
 
   static constexpr Options::String help{
       "Positivity-preserving adaptive-order reconstruction."};
@@ -133,6 +140,7 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       double alpha_5, std::optional<double> alpha_7,
       std::optional<double> alpha_9,
       FallbackReconstructorType low_order_reconstructor,
+      bool reconstruct_rho_times_temperature,
       const Options::Context& context = {});
 
   explicit PositivityPreservingAdaptiveOrderPrim(CkMigrateMessage* msg);
@@ -183,7 +191,9 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
-      const Direction<dim> direction_to_reconstruct) const;
+      Direction<dim> direction_to_reconstruct) const;
+
+  bool reconstruct_rho_times_temperature() const override;
 
  private:
   // NOLINTNEXTLINE(readability-redundant-declaration)
@@ -198,6 +208,7 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
   std::optional<double> eight_to_the_alpha_9_{};
   FallbackReconstructorType low_order_reconstructor_ =
       FallbackReconstructorType::None;
+  bool reconstruct_rho_times_temperature_{false};
 
   using PointerReconsOrder = void (*)(
       gsl::not_null<std::array<gsl::span<double>, dim>*>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -107,7 +107,7 @@ void reconstruct_prims_work(
     const DirectionalIdMap<3, Variables<PrimsTagsSentByNeighbor>>&
         neighbor_data,
     const Mesh<3>& subcell_mesh, size_t ghost_zone_size,
-    bool compute_conservatives);
+    bool compute_conservatives, bool reconstruct_density_times_temperature);
 
 /*!
  * \brief Reconstructs the `PrimTagsForReconstruction` and if
@@ -134,5 +134,6 @@ void reconstruct_fd_neighbor_work(
     const Element<3>& element,
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
-    const size_t ghost_zone_size, bool compute_conservatives);
+    size_t ghost_zone_size, bool compute_conservatives,
+    bool reconstruct_density_times_temperature);
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -156,7 +156,8 @@ void reconstruct_prims_work(
     const DirectionalIdMap<3, Variables<PrimsTagsSentByNeighbor>>&
         neighbor_data,
     const Mesh<3>& subcell_mesh, const size_t ghost_zone_size,
-    const bool compute_conservatives) {
+    const bool compute_conservatives,
+    const bool reconstruct_density_times_temperature) {
   ASSERT(Mesh<3>(subcell_mesh.extents(0), subcell_mesh.basis(0),
                  subcell_mesh.quadrature(0)) == subcell_mesh,
          "The subcell mesh should be isotropic but got " << subcell_mesh);
@@ -166,18 +167,26 @@ void reconstruct_prims_work(
       subcell_mesh.extents().slice_away(0).product();
   const size_t neighbor_num_pts =
       ghost_zone_size * subcell_mesh.extents().slice_away(0).product();
-  tmpl::for_each<PrimTagsForReconstruction>([&element, &neighbor_data,
-                                             neighbor_num_pts, &reconstruct,
-                                             reconstructed_num_pts,
-                                             volume_num_pts, &volume_prims,
-                                             &vars_on_lower_face,
-                                             &vars_on_upper_face,
-                                             &subcell_mesh](auto tag_v) {
+  const size_t number_of_pts_for_thermodynamic_var =
+      6 * neighbor_num_pts + volume_num_pts;
+  DataVector buffer_for_recons_vars{
+      std::max(number_of_pts_for_thermodynamic_var, 3 * volume_num_pts)};
+  tmpl::for_each<
+      PrimTagsForReconstruction>([&buffer_for_recons_vars, &element,
+                                  &neighbor_data, neighbor_num_pts,
+                                  &reconstruct,
+                                  reconstruct_density_times_temperature,
+                                  reconstructed_num_pts, volume_num_pts,
+                                  &volume_prims, &vars_on_lower_face,
+                                  &vars_on_upper_face,
+                                  &subcell_mesh](auto tag_v) {
+    (void)reconstruct_density_times_temperature;
     using tag = tmpl::type_from<decltype(tag_v)>;
     const typename tag::type* volume_tensor_ptr = nullptr;
     Variables<tmpl::list<
         hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>>
         lorentz_factor_times_v_I{};
+    Scalar<DataVector> thermo_volume_var{};
     if constexpr (std::is_same_v<tag,
                                  hydro::Tags::LorentzFactorTimesSpatialVelocity<
                                      DataVector, 3>>) {
@@ -189,7 +198,8 @@ void reconstruct_prims_work(
           get<hydro::Tags::SpatialVelocity<DataVector, 3>>(volume_prims);
       const auto& lorentz_factor =
           get<hydro::Tags::LorentzFactor<DataVector>>(volume_prims);
-      lorentz_factor_times_v_I.initialize(get(lorentz_factor).size());
+      lorentz_factor_times_v_I.set_data_ref(buffer_for_recons_vars.data(),
+                                            3 * volume_num_pts);
       auto& volume_tensor =
           get<hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>(
               lorentz_factor_times_v_I) = spatial_velocity;
@@ -197,6 +207,18 @@ void reconstruct_prims_work(
         volume_tensor.get(i) *= get(lorentz_factor);
       }
       volume_tensor_ptr = &volume_tensor;
+    } else if constexpr (std::is_same_v<tag,
+                                        hydro::Tags::Temperature<DataVector>>) {
+      if (reconstruct_density_times_temperature) {
+        get(thermo_volume_var)
+            .set_data_ref(buffer_for_recons_vars.data(), volume_num_pts);
+        get(thermo_volume_var) =
+            get(get<tag>(volume_prims)) *
+            get(get<hydro::Tags::RestMassDensity<DataVector>>(volume_prims));
+        volume_tensor_ptr = &thermo_volume_var;
+      } else {
+        volume_tensor_ptr = &get<tag>(volume_prims);
+      }
     } else {
       volume_tensor_ptr = &get<tag>(volume_prims);
     }
@@ -218,6 +240,7 @@ void reconstruct_prims_work(
     DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
 
     for (const auto& direction : Direction<3>::all_directions()) {
+      DirectionalId<3> id{};
       if (element.neighbors().contains(direction)) {
         const auto& neighbors_in_direction = element.neighbors().at(direction);
         ASSERT(neighbors_in_direction.size() == 1,
@@ -225,28 +248,54 @@ void reconstruct_prims_work(
                "got "
                    << neighbors_in_direction.size() << " in direction "
                    << direction);
-        ghost_cell_vars[direction] =
-            gsl::make_span(get<tag>(neighbor_data.at(DirectionalId<3>{
-                               direction, *neighbors_in_direction.begin()}))[0]
-                               .data(),
-                           number_of_variables * neighbor_num_pts);
+        id = DirectionalId<3>{direction, *neighbors_in_direction.begin()};
       } else {
         // retrieve boundary ghost data from neighbor_data
         ASSERT(
             element.external_boundaries().count(direction) == 1,
-            "Element has neither neighbor nor external boundary to direction : "
+            "Element has neither neighbor nor external boundary to direction: "
                 << direction);
-        ghost_cell_vars[direction] = gsl::make_span(
-            get<tag>(neighbor_data.at(DirectionalId<3>{
-                direction, ElementId<3>::external_boundary_id()}))[0]
-                .data(),
-            number_of_variables * neighbor_num_pts);
+        id = DirectionalId<3>{direction, ElementId<3>::external_boundary_id()};
       }
+      if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
+        ASSERT(number_of_variables == 1,
+               "Should only have one tensor component for a Scalar");
+        if (reconstruct_density_times_temperature) {
+          DataVector view{
+              &buffer_for_recons_vars[volume_num_pts +
+                                      (2 * direction.dimension() +
+                                       (direction.side() == Side::Upper ? 1
+                                                                        : 0)) *
+                                          neighbor_num_pts],
+              number_of_variables * neighbor_num_pts};
+          const auto& data_in_dir = neighbor_data.at(id);
+          view =
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(data_in_dir)) *
+              get(get<tag>(data_in_dir));
+          ghost_cell_vars[direction] = gsl::make_span(view.data(), view.size());
+          continue;
+        }
+      }
+      ghost_cell_vars[direction] =
+          gsl::make_span(get<tag>(neighbor_data.at(id))[0].data(),
+                         number_of_variables * neighbor_num_pts);
     }
 
     reconstruct(make_not_null(&upper_face_vars),
                 make_not_null(&lower_face_vars), volume_vars, ghost_cell_vars,
                 subcell_mesh.extents(), number_of_variables);
+    if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
+      if (reconstruct_density_times_temperature) {
+        for (size_t i = 0; i < 3; ++i) {
+          get(get<tag>(gsl::at(*vars_on_upper_face, i))) /=
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                  gsl::at(*vars_on_upper_face, i)));
+          get(get<tag>(gsl::at(*vars_on_lower_face, i))) /=
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                  gsl::at(*vars_on_lower_face, i)));
+        }
+      }
+    }
   });
 
   for (size_t i = 0; compute_conservatives and i < 3; ++i) {
@@ -267,7 +316,8 @@ void reconstruct_fd_neighbor_work(
     const Element<3>& element,
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
-    const size_t ghost_zone_size, const bool compute_conservatives) {
+    const size_t ghost_zone_size, const bool compute_conservatives,
+    const bool reconstruct_density_times_temperature) {
   const DirectionalId<3> mortar_id{
       direction_to_reconstruct,
       *element.neighbors().at(direction_to_reconstruct).begin()};
@@ -280,15 +330,20 @@ void reconstruct_fd_neighbor_work(
     const DataVector& neighbor_data_on_mortar =
         ghost_data.at(mortar_id).neighbor_ghost_data_for_reconstruction();
     neighbor_prims.set_data_ref(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         const_cast<double*>(neighbor_data_on_mortar.data()),
         neighbor_prims.number_of_independent_components *
             ghost_data_extents.product());
   }
 
+  DataVector buffer{3 * subcell_volume_prims.number_of_grid_points() +
+                    ghost_data_extents.product()};
+  Scalar<DataVector> rho_times_temperature_neighbor{};
   tmpl::for_each<PrimTagsForReconstruction>(
-      [&direction_to_reconstruct, &ghost_data_extents, &neighbor_prims,
-       &reconstruct_lower_neighbor, &reconstruct_upper_neighbor, &subcell_mesh,
-       &subcell_volume_prims, &vars_on_face](auto tag_v) {
+      [&buffer, &direction_to_reconstruct, &ghost_data_extents, &neighbor_prims,
+       reconstruct_density_times_temperature, &reconstruct_lower_neighbor,
+       &reconstruct_upper_neighbor, &rho_times_temperature_neighbor,
+       &subcell_mesh, &subcell_volume_prims, &vars_on_face](auto tag_v) {
         using tag = tmpl::type_from<decltype(tag_v)>;
         const typename tag::type* volume_tensor_ptr = nullptr;
         typename tag::type volume_tensor{};
@@ -304,16 +359,63 @@ void reconstruct_fd_neighbor_work(
                   subcell_volume_prims);
           const auto& lorentz_factor =
               get<hydro::Tags::LorentzFactor<DataVector>>(subcell_volume_prims);
+          for (size_t i = 0; i < 3; ++i) {
+            volume_tensor.get(i).set_data_ref(
+                &buffer[i * subcell_volume_prims.number_of_grid_points()],
+                subcell_volume_prims.number_of_grid_points());
+          }
           volume_tensor = spatial_velocity;
           for (size_t i = 0; i < 3; ++i) {
             volume_tensor.get(i) *= get(lorentz_factor);
           }
           volume_tensor_ptr = &volume_tensor;
         } else {
-          volume_tensor_ptr = &get<tag>(subcell_volume_prims);
+          if constexpr (std::is_same_v<tag,
+                                       hydro::Tags::Temperature<DataVector>>) {
+            if (reconstruct_density_times_temperature) {
+              get(volume_tensor)
+                  .set_data_ref(buffer.data(),
+                                subcell_volume_prims.number_of_grid_points());
+              get(volume_tensor) =
+                  get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                      subcell_volume_prims)) *
+                  get(get<tag>(subcell_volume_prims));
+              volume_tensor_ptr = &volume_tensor;
+            } else {
+              volume_tensor_ptr = &get<tag>(subcell_volume_prims);
+            }
+          } else {
+            volume_tensor_ptr = &get<tag>(subcell_volume_prims);
+          }
         }
 
-        const auto& tensor_neighbor = get<tag>(neighbor_prims);
+        const auto& tensor_neighbor =
+            [&buffer, &neighbor_prims, reconstruct_density_times_temperature,
+             &rho_times_temperature_neighbor,
+             &subcell_volume_prims]() -> typename tag::type& {
+          if constexpr (std::is_same_v<tag,
+                                       hydro::Tags::Temperature<DataVector>>) {
+            if (reconstruct_density_times_temperature) {
+              get(rho_times_temperature_neighbor)
+                  .set_data_ref(
+                      &buffer[subcell_volume_prims.number_of_grid_points()],
+                      get(get<tag>(neighbor_prims)).size());
+              get(rho_times_temperature_neighbor) =
+                  get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                      neighbor_prims)) *
+                  get(get<tag>(neighbor_prims));
+              return rho_times_temperature_neighbor;
+            } else {
+              (void)buffer, (void)reconstruct_density_times_temperature;
+              (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
+              return get<tag>(neighbor_prims);
+            }
+          } else {
+            (void)buffer, (void)reconstruct_density_times_temperature;
+            (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
+            return get<tag>(neighbor_prims);
+          }
+        }();
         auto& tensor_on_face = get<tag>(*vars_on_face);
         if (direction_to_reconstruct.side() == Side::Upper) {
           for (size_t tensor_index = 0; tensor_index < tensor_on_face.size();
@@ -332,6 +434,13 @@ void reconstruct_fd_neighbor_work(
                 (*volume_tensor_ptr)[tensor_index],
                 tensor_neighbor[tensor_index], subcell_mesh.extents(),
                 ghost_data_extents, direction_to_reconstruct);
+          }
+        }
+        if constexpr (std::is_same_v<tag,
+                                     hydro::Tags::Temperature<DataVector>>) {
+          if (reconstruct_density_times_temperature) {
+            get(tensor_on_face) /= get(
+                get<hydro::Tags::RestMassDensity<DataVector>>(*vars_on_face));
           }
         }
       });

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp
@@ -44,6 +44,8 @@ class Reconstructor : public PUP::able {
 
   virtual bool supports_adaptive_order() const { return false; }
 
+  virtual bool reconstruct_rho_times_temperature() const = 0;
+
   void pup(PUP::er& p) override;
 };
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -40,11 +40,13 @@ Wcns5zPrim::Wcns5zPrim(const size_t nonlinear_weight_exponent,
                        const double epsilon,
                        const ::fd::reconstruction::FallbackReconstructorType
                            fallback_reconstructor,
-                       const size_t max_number_of_extrema)
+                       const size_t max_number_of_extrema,
+                       const bool reconstruct_rho_times_temperature)
     : nonlinear_weight_exponent_(nonlinear_weight_exponent),
       epsilon_(epsilon),
       fallback_reconstructor_(fallback_reconstructor),
-      max_number_of_extrema_(max_number_of_extrema) {
+      max_number_of_extrema_(max_number_of_extrema),
+      reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {
   std::tie(reconstruct_, reconstruct_lower_neighbor_,
            reconstruct_upper_neighbor_) =
       ::fd::reconstruction::wcns5z_function_pointers<3>(
@@ -63,6 +65,7 @@ void Wcns5zPrim::pup(PUP::er& p) {
   p | epsilon_;
   p | fallback_reconstructor_;
   p | max_number_of_extrema_;
+  p | reconstruct_rho_times_temperature_;
   if (p.isUnpacking()) {
     std::tie(reconstruct_, reconstruct_lower_neighbor_,
              reconstruct_upper_neighbor_) =
@@ -101,7 +104,7 @@ void Wcns5zPrim::reconstruct(
                      epsilon_, max_number_of_extrema_);
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true);
+      ghost_zone_size(), true, reconstruct_rho_times_temperature());
 }
 
 template <size_t ThermodynamicDim>
@@ -139,7 +142,12 @@ void Wcns5zPrim::reconstruct_fd_neighbor(
             local_direction_to_reconstruct, epsilon_, max_number_of_extrema_);
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
-      direction_to_reconstruct, ghost_zone_size(), true);
+      direction_to_reconstruct, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature());
+}
+
+bool Wcns5zPrim::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
 }
 
 bool operator==(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
@@ -148,7 +156,9 @@ bool operator==(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
   return lhs.nonlinear_weight_exponent_ == rhs.nonlinear_weight_exponent_ and
          lhs.epsilon_ == rhs.epsilon_ and
          lhs.fallback_reconstructor_ == rhs.fallback_reconstructor_ and
-         lhs.max_number_of_extrema_ == rhs.max_number_of_extrema_;
+         lhs.max_number_of_extrema_ == rhs.max_number_of_extrema_ and
+         lhs.reconstruct_rho_times_temperature() ==
+             rhs.reconstruct_rho_times_temperature();
 }
 
 bool operator!=(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
@@ -97,9 +97,16 @@ class Wcns5zPrim : public Reconstructor {
         "reconstruction before switching to a low-order reconstruction. If "
         "FallbackReconstructor=None, this option is ignored"};
   };
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
 
-  using options = tmpl::list<NonlinearWeightExponent, Epsilon,
-                             FallbackReconstructor, MaxNumberOfExtrema>;
+  using options =
+      tmpl::list<NonlinearWeightExponent, Epsilon, FallbackReconstructor,
+                 MaxNumberOfExtrema, ReconstructRhoTimesTemperature>;
 
   static constexpr Options::String help{
       "WCNS 5Z reconstruction scheme using primitive variables."};
@@ -113,7 +120,8 @@ class Wcns5zPrim : public Reconstructor {
 
   Wcns5zPrim(size_t nonlinear_weight_exponent, double epsilon,
              FallbackReconstructorType fallback_reconstructor,
-             size_t max_number_of_extrema);
+             size_t max_number_of_extrema,
+             bool reconstruct_rho_times_temperature);
 
   explicit Wcns5zPrim(CkMigrateMessage* msg);
 
@@ -155,7 +163,9 @@ class Wcns5zPrim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
-      const Direction<dim> direction_to_reconstruct) const;
+      Direction<dim> direction_to_reconstruct) const;
+
+  bool reconstruct_rho_times_temperature() const override;
 
  private:
   // NOLINTNEXTLINE(readability-redundant-declaration)
@@ -167,6 +177,7 @@ class Wcns5zPrim : public Reconstructor {
   FallbackReconstructorType fallback_reconstructor_ =
       FallbackReconstructorType::None;
   size_t max_number_of_extrema_ = 0;
+  bool reconstruct_rho_times_temperature_{false};
 
   void (*reconstruct_)(gsl::not_null<std::array<gsl::span<double>, dim>*>,
                        gsl::not_null<std::array<gsl::span<double>, dim>*>,

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -257,6 +257,7 @@ SpatialDiscretization:
         Alpha9: None
         LowOrderReconstructor: MonotonisedCentral
         AtmosphereTreatment: Never
+        ReconstructRhoTimesTemperature: true
     FilterOptions:
       SpacetimeDissipation: 0.3
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -4,7 +4,7 @@
 Executable: EvolveGhValenciaDivClean
 Testing:
   Check: parse;execute
-  Timeout: 8
+  Timeout: 30
   Priority: High
 ExpectedOutput:
   - GhMhdTovStarVolume0.h5
@@ -24,8 +24,11 @@ Evolution:
   InitialTimeStep: 0.0001
   MinimumTimeStep: 1e-7
   TimeStepper:
-    AdamsMoultonPc:
-      Order: 3
+    # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers
+    # for spectre for hydro right now.
+    Rk3HesthavenSsp:
+    # AdamsMoultonPc:
+    #   Order: 3
 
 PhaseChangeAndTriggers:
   - Trigger:
@@ -55,7 +58,7 @@ DomainCreator:
     UpperBound: [5.0, 5.0, 5.0]
     Distribution: [Linear, Linear, Linear]
     InitialRefinement: [1, 1, 1]
-    InitialGridPoints: [3, 3, 3]
+    InitialGridPoints: [5, 5, 5]
     TimeDependence: None
     BoundaryConditions:
       - DirichletAnalytic:
@@ -170,6 +173,7 @@ SpatialDiscretization:
     Reconstructor:
       MonotonisedCentralPrim:
         AtmosphereTreatment: Never
+        ReconstructRhoTimesTemperature: true
     FilterOptions:
       SpacetimeDissipation: 0.1
 

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -80,6 +80,7 @@ SpatialDiscretization:
         Epsilon: 1.0e-15
         FallbackReconstructor: MonotonisedCentral
         MaxNumberOfExtrema: 0
+        ReconstructRhoTimesTemperature: true
 
 InitialData:
   BlastWave:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -111,6 +111,7 @@ SpatialDiscretization:
   SubcellSolver:
     Reconstructor:
       MonotonisedCentralPrim:
+        ReconstructRhoTimesTemperature: true
 
 
 EvolutionSystem:

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
@@ -51,6 +52,7 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/RadiationTransport/NoNeutrinos/System.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
 #include "Framework/Pypp.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
@@ -231,22 +233,27 @@ void test(const BoundaryConditionType& boundary_condition,
   }
   get(get<DivergenceCleaningField>(volume_prim_vars)) = 1e-2;
 
+  using Vlo =
+      typename VariableFixing::FixToAtmosphere<3>::VelocityLimitingOptions;
+  const VariableFixing::FixToAtmosphere<3> variable_fixer{
+      1.e-12, 3.e-12, Vlo{0.0, 1.e-4, 3.e-12, 1.e-11}, std::nullopt};
+
   // create a box for test
   auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::MetavariablesImpl<
-          EvolutionMetaVars<System>>,
+      Parallel::Tags::MetavariablesImpl<EvolutionMetaVars<System>>,
       domain::Tags::Domain<3>, domain::Tags::ExternalBoundaryConditions<3>,
       evolution::dg::subcell::Tags::Mesh<3>,
       evolution::dg::subcell::Tags::Coordinates<3, Frame::ElementLogical>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<3>,
-      fd::Tags::Reconstructor<System>,
-      domain::Tags::MeshVelocity<3>,
+      fd::Tags::Reconstructor<System>, domain::Tags::MeshVelocity<3>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<3>, ::Tags::Time,
       domain::Tags::FunctionsOfTimeInitialize,
       domain::Tags::ElementMap<3, Frame::Grid>,
       domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
                                                   Frame::Inertial>,
-      typename System::primitive_variables_tag>>(
+      typename System::primitive_variables_tag,
+      ::Tags::VariableFixer<::VariableFixing::FixToAtmosphere<3>>,
+      hydro::Tags::GrmhdEquationOfState>>(
       EvolutionMetaVars<System>{}, std::move(domain),
       std::move(boundary_conditions), subcell_mesh, subcell_logical_coords,
       neighbor_data,
@@ -260,7 +267,8 @@ void test(const BoundaryConditionType& boundary_condition,
               domain::CoordinateMaps::Identity<3>{})},
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{}),
-      volume_prim_vars);
+      volume_prim_vars, variable_fixer,
+      solution.equation_of_state().promote_to_3d_eos());
 
   // compute FD ghost data and retrieve the result
   fd::BoundaryConditionGhostData<System>::apply(

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_MonotonisedCentral.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_MonotonisedCentral.cpp
@@ -23,32 +23,33 @@ SPECTRE_TEST_CASE(
                          System>));
   const auto mc_from_options_base = TestHelpers::test_factory_creation<
       grmhd::GhValenciaDivClean::fd::Reconstructor<System>,
-      grmhd::GhValenciaDivClean::fd::OptionTags::Reconstructor<
-          System>>(
+      grmhd::GhValenciaDivClean::fd::OptionTags::Reconstructor<System>>(
       "MonotonisedCentralPrim:\n"
-      "  AtmosphereTreatment: Never\n");
+      "  AtmosphereTreatment: Never\n"
+      "  ReconstructRhoTimesTemperature: false\n");
   const auto mc_deserialized = serialize_and_deserialize(mc_from_options_base);
   auto* const mc_from_options =
       dynamic_cast<const grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<
           System>*>(mc_deserialized.get());
   REQUIRE(mc_from_options != nullptr);
-  CHECK(grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<
-            System>{
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Always} !=
-        grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<
-            System>{
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+  CHECK(
+      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false} !=
+      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false});
+  CHECK(
+      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false} !=
+      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, true});
   CHECK(*mc_from_options ==
-        grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<
-            System>{
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+        grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<System>{
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false});
   test_move_semantics(
-      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<
-          System>{
-          ::VariableFixing::FixReconstructedStateToAtmosphere::Never},
-      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<
-          System>{
-          ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false},
+      grmhd::GhValenciaDivClean::fd::MonotonisedCentralPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false});
 
   helpers::test_prim_reconstructor(5, *mc_from_options);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
@@ -25,14 +25,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Fd.Ppao",
           System>));
   const auto ppao_from_options_base = TestHelpers::test_factory_creation<
       grmhd::GhValenciaDivClean::fd::Reconstructor<System>,
-      grmhd::GhValenciaDivClean::fd::OptionTags::Reconstructor<
-          System>>(
+      grmhd::GhValenciaDivClean::fd::OptionTags::Reconstructor<System>>(
       "PositivityPreservingAdaptiveOrderPrim:\n"
       "  Alpha5: 3.7\n"
       "  Alpha7: None\n"
       "  Alpha9: None\n"
       "  LowOrderReconstructor: MonotonisedCentral\n"
-      "  AtmosphereTreatment: Never\n");
+      "  AtmosphereTreatment: Never\n"
+      "  ReconstructRhoTimesTemperature: true\n");
   const auto ppao_deserialized =
       serialize_and_deserialize(ppao_from_options_base);
   auto* const ppao_from_options = dynamic_cast<
@@ -44,28 +44,79 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Fd.Ppao",
             System>{
             3.7, std::nullopt, std::nullopt,
             fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Always} !=
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+            false} !=
         grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
             System>{
             3.7, std::nullopt, std::nullopt,
             fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false});
+  CHECK(
+      grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+          System>{
+          3.7, std::nullopt, std::nullopt,
+          fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false} !=
+      grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+          System>{
+          3.8, std::nullopt, std::nullopt,
+          fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false});
+  // Can't use high-order reconstruction yet. We'll enable these tests later.
+  //
+  // CHECK(
+  //     grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+  //         System>{
+  //         3.7, std::nullopt, std::nullopt,
+  //         fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+  //         ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false}
+  //         !=
+  //     grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+  //         System>{
+  //         3.7, 3.5, std::nullopt,
+  //         fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+  //         ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+  //         false});
+  // CHECK(
+  //     grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+  //         System>{
+  //         3.7, std::nullopt, std::nullopt,
+  //         fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+  //         ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false}
+  //         !=
+  //     grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+  //         System>{
+  //         3.7, std::nullopt, 3.6,
+  //         fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+  //         ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+  //         false});
+  CHECK(grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+            System>{
+            3.7, std::nullopt, std::nullopt,
+            fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+            false} !=
+        grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
+            System>{
+            3.7, std::nullopt, std::nullopt,
+            fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always, true});
   CHECK(*ppao_from_options ==
         grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
             System>{
             3.7, std::nullopt, std::nullopt,
             fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Never, true});
   test_move_semantics(
       grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
           System>{
           3.7, std::nullopt, std::nullopt,
           fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
-          ::VariableFixing::FixReconstructedStateToAtmosphere::Never},
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, true},
       grmhd::GhValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim<
           System>{
           3.7, std::nullopt, std::nullopt,
           fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
-          ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, true});
   helpers::test_prim_reconstructor(10, *ppao_from_options);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Wcns5z.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Wcns5z.cpp
@@ -23,14 +23,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Fd.Wcns5z",
       grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>));
   const auto wcns5z_from_options_base = TestHelpers::test_factory_creation<
       grmhd::GhValenciaDivClean::fd::Reconstructor<System>,
-      grmhd::GhValenciaDivClean::fd::OptionTags::Reconstructor<
-          System>>(
+      grmhd::GhValenciaDivClean::fd::OptionTags::Reconstructor<System>>(
       "Wcns5zPrim:\n"
       "  NonlinearWeightExponent: 2\n"
       "  Epsilon: 1.e-42\n"
       "  FallbackReconstructor: None\n"
       "  MaxNumberOfExtrema: 0\n"
-      "  AtmosphereTreatment: Never\n");
+      "  AtmosphereTreatment: Never\n"
+      "  ReconstructRhoTimesTemperature: true\n");
   const auto wcns5z_deserialized =
       serialize_and_deserialize(wcns5z_from_options_base);
   auto* const wcns5z_from_options =
@@ -39,20 +39,49 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Fd.Wcns5z",
   REQUIRE(wcns5z_from_options != nullptr);
   CHECK(grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
             2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Always} !=
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+            true} !=
         grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
             2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Never, true});
+  CHECK(grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+            true} !=
+        grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            1, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always, true});
+  CHECK(grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+            true} !=
+        grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            2, 2.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always, true});
+  CHECK(grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+            true} !=
+        grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            2, 1.e-42, fd::reconstruction::FallbackReconstructorType::Minmod, 0,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always, true});
+  CHECK(grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always,
+            true} !=
+        grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
+            2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 1,
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Always, true});
   CHECK(*wcns5z_from_options ==
         grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
             2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
-            ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Never, true});
   test_move_semantics(
       grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
           2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
-          ::VariableFixing::FixReconstructedStateToAtmosphere::Never},
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, true},
       grmhd::GhValenciaDivClean::fd::Wcns5zPrim<System>{
           2, 1.e-42, fd::reconstruction::FallbackReconstructorType::None, 0,
-          ::VariableFixing::FixReconstructedStateToAtmosphere::Never});
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, true});
   helpers::test_prim_reconstructor(7, *wcns5z_from_options);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -301,6 +301,11 @@ void test(const BoundaryConditionType& boundary_condition,
         get<hydro::Tags::MagneticField<DataVector, 3>>(volume_prim_vars));
   }
 
+  using Vlo =
+      typename VariableFixing::FixToAtmosphere<3>::VelocityLimitingOptions;
+  const VariableFixing::FixToAtmosphere<3> variable_fixer{
+      1.e-12, 3.e-12, Vlo{0.0, 1.e-4, 3.e-12, 1.e-11}, std::nullopt};
+
   // create a box for test
   auto box = db::create<db::AddSimpleTags<
       Parallel::Tags::MetavariablesImpl<EvolutionMetaVars>,
@@ -317,7 +322,9 @@ void test(const BoundaryConditionType& boundary_condition,
       typename System::spacetime_variables_tag,
       typename System::primitive_variables_tag,
       evolution::dg::subcell::Tags::CellCenteredFlux<
-          typename System::flux_variables, 3>>>(
+          typename System::flux_variables, 3>,
+      ::Tags::VariableFixer<::VariableFixing::FixToAtmosphere<3>>,
+      hydro::Tags::GrmhdEquationOfState>>(
       EvolutionMetaVars{}, std::move(domain), std::move(boundary_conditions),
       subcell_mesh, subcell_logical_coords, neighbor_data,
       std::unique_ptr<fd::Reconstructor>{
@@ -330,7 +337,8 @@ void test(const BoundaryConditionType& boundary_condition,
               domain::CoordinateMaps::Identity<3>{})},
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{}),
-      volume_spacetime_vars, volume_prim_vars, cell_centered_fluxes);
+      volume_spacetime_vars, volume_prim_vars, cell_centered_fluxes,
+      variable_fixer, solution.equation_of_state().promote_to_3d_eos());
 
   {
     // compute FD ghost data and retrieve the result

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_MonotonicityPreserving5.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_MonotonicityPreserving5.cpp
@@ -12,24 +12,33 @@
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.Mp5Prim",
                   "[Unit][Evolution]") {
   namespace helpers = TestHelpers::grmhd::ValenciaDivClean::fd;
+  // Test reconstructing T and rho*T. For low-order reconstructors this can
+  // fail (like MC) because the nonlinear terms (quadratics) aren't captured
+  // accurately enough.
   const grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim mp5_recons{
-      4.0, 1e-10};
+      4.0, 1e-10, false};
   helpers::test_prim_reconstructor(4, mp5_recons);
+  helpers::test_prim_reconstructor(
+      4, grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim{4.0, 1e-10,
+                                                                  true});
 
   const auto wcns5z_from_options_base = TestHelpers::test_factory_creation<
       grmhd::ValenciaDivClean::fd::Reconstructor,
       grmhd::ValenciaDivClean::fd::OptionTags::Reconstructor>(
       "MonotonicityPreserving5Prim:\n"
       "  Alpha: 4.0\n"
-      "  Epsilon: 1.0e-10\n");
+      "  Epsilon: 1.0e-10\n"
+      "  ReconstructRhoTimesTemperature: false\n");
   auto* const mp5_from_options = dynamic_cast<
       const grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim*>(
       wcns5z_from_options_base.get());
   REQUIRE(mp5_from_options != nullptr);
   CHECK(*mp5_from_options == mp5_recons);
 
-  CHECK(mp5_recons !=
-        grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim(3.0, 1e-10));
-  CHECK(mp5_recons !=
-        grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim(4.0, 2e-10));
+  CHECK(mp5_recons != grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim(
+                          3.0, 1e-10, false));
+  CHECK(mp5_recons != grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim(
+                          4.0, 2e-10, false));
+  CHECK(mp5_recons != grmhd::ValenciaDivClean::fd::MonotonicityPreserving5Prim(
+                          4.0, 1e-10, true));
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_MonotonisedCentral.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_MonotonisedCentral.cpp
@@ -13,15 +13,22 @@ SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.MonotonisedCentralPrim",
     "[Unit][Evolution]") {
   namespace helpers = TestHelpers::grmhd::ValenciaDivClean::fd;
-  const grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim mc_recons{};
+  // We only test reconstructing T because for low-order reconstructors this
+  // fails because the nonlinear terms (quadratics) aren't captured
+  // accurately enough.
+  const grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim mc_recons{false};
   helpers::test_prim_reconstructor(5, mc_recons);
   const auto mc_from_options_base = TestHelpers::test_factory_creation<
       grmhd::ValenciaDivClean::fd::Reconstructor,
       grmhd::ValenciaDivClean::fd::OptionTags::Reconstructor>(
-      "MonotonisedCentralPrim:\n");
+      "MonotonisedCentralPrim:\n"
+      "  ReconstructRhoTimesTemperature: false\n");
   auto* const mc_from_options =
       dynamic_cast<const grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim*>(
           mc_from_options_base.get());
   REQUIRE(mc_from_options != nullptr);
   CHECK(*mc_from_options == mc_recons);
+  const grmhd::ValenciaDivClean::fd::MonotonisedCentralPrim mc_recons_recon_T{
+      true};
+  CHECK_FALSE(mc_recons_recon_T == mc_recons);
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
@@ -15,18 +15,24 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.PpaoPrim",
   namespace helpers = TestHelpers::grmhd::ValenciaDivClean::fd;
   auto mc = fd::reconstruction::FallbackReconstructorType::MonotonisedCentral;
 
-  helpers::test_prim_reconstructor(
-      6, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
-             4.0, 4.0, std::nullopt, mc});
-  helpers::test_prim_reconstructor(
-      8, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
-             4.0, std::nullopt, 4.0, mc});
-  helpers::test_prim_reconstructor(
-      8, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
-             4.0, 4.0, 4.0, mc});
+  // Test reconstructing T and rho*T. For low-order reconstructors this can
+  // fail (like MC) because the nonlinear terms (quadratics) aren't captured
+  // accurately enough.
+  for (const bool reconstruct_rho_times_T : {false, true}) {
+    CAPTURE(reconstruct_rho_times_T);
+    helpers::test_prim_reconstructor(
+        6, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
+               4.0, 4.0, std::nullopt, mc, reconstruct_rho_times_T});
+    helpers::test_prim_reconstructor(
+        8, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
+               4.0, std::nullopt, 4.0, mc, reconstruct_rho_times_T});
+    helpers::test_prim_reconstructor(
+        8, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim{
+               4.0, 4.0, 4.0, mc, reconstruct_rho_times_T});
+  }
 
   const grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim
-      ppao_recons{4.0, std::nullopt, std::nullopt, mc};
+      ppao_recons{4.0, std::nullopt, std::nullopt, mc, false};
   helpers::test_prim_reconstructor(4, ppao_recons);
 
   const auto ppao_from_options_base = TestHelpers::test_factory_creation<
@@ -36,7 +42,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.PpaoPrim",
       "  Alpha5: 4.0\n"
       "  Alpha7: None\n"
       "  Alpha9: None\n"
-      "  LowOrderReconstructor: MonotonisedCentral\n");
+      "  LowOrderReconstructor: MonotonisedCentral\n"
+      "  ReconstructRhoTimesTemperature: false\n");
   auto* const ppao_from_options =
       dynamic_cast<const grmhd::ValenciaDivClean::fd::
                        PositivityPreservingAdaptiveOrderPrim*>(
@@ -46,55 +53,59 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.PpaoPrim",
 
   CHECK(ppao_recons !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.5, std::nullopt, std::nullopt, mc));
+            4.5, std::nullopt, std::nullopt, mc, false));
   CHECK(ppao_recons !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.0, 4.0, std::nullopt, mc));
+            4.0, 4.0, std::nullopt, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.0, 4.0, std::nullopt, mc) !=
+            4.0, 4.0, std::nullopt, mc, false) !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.0, 4.1, std::nullopt, mc));
+            4.0, 4.1, std::nullopt, mc, false));
   CHECK(ppao_recons !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.0, std::nullopt, 4.0, mc));
+            4.0, std::nullopt, 4.0, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.0, std::nullopt, 4.0, mc) !=
+            4.0, std::nullopt, 4.0, mc, false) !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            4.0, std::nullopt, 4.1, mc));
+            4.0, std::nullopt, 4.1, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, std::nullopt, 4.0, mc) ==
+            5.0, std::nullopt, 4.0, mc, false) ==
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, std::nullopt, 4.0, mc));
+            5.0, std::nullopt, 4.0, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.0, 4.0, mc) ==
+            5.0, 6.0, 4.0, mc, false) ==
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.0, 4.0, mc));
+            5.0, 6.0, 4.0, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.0, 4.0, mc) !=
+            5.0, 6.0, 4.0, mc, false) !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.1, 6.0, 4.0, mc));
+            5.1, 6.0, 4.0, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.0, 4.0, mc) !=
+            5.0, 6.0, 4.0, mc, false) !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.1, 4.0, mc));
+            5.0, 6.1, 4.0, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.0, 4.0, mc) !=
+            5.0, 6.0, 4.0, mc, false) !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.0, 4.1, mc));
+            5.0, 6.0, 4.1, mc, false));
   CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
-            5.0, 6.0, 4.0, mc) !=
+            5.0, 6.0, 4.0, mc, false) !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
             5.0, 6.0, 4.0,
-            fd::reconstruction::FallbackReconstructorType::Minmod));
+            fd::reconstruction::FallbackReconstructorType::Minmod, false));
   CHECK(ppao_recons !=
         grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
             4.0, std::nullopt, std::nullopt,
-            fd::reconstruction::FallbackReconstructorType::Minmod));
+            fd::reconstruction::FallbackReconstructorType::Minmod, false));
+  CHECK(grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc, false) !=
+        grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
+            5.0, 6.0, 4.0, mc, true));
 
   CHECK_THROWS_WITH(
       grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim(
           4.5, std::nullopt, std::nullopt,
-          fd::reconstruction::FallbackReconstructorType::None),
+          fd::reconstruction::FallbackReconstructorType::None, false),
       Catch::Matchers::ContainsSubstring(
           "None is not an allowed low-order reconstructor."));
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_Wcns5z.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_Wcns5z.cpp
@@ -15,9 +15,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.Wcns5zPrim",
   namespace helpers = TestHelpers::grmhd::ValenciaDivClean::fd;
   auto mc = fd::reconstruction::FallbackReconstructorType::MonotonisedCentral;
 
-  const grmhd::ValenciaDivClean::fd::Wcns5zPrim wcns5z_recons{2, 2.0e-16, mc,
-                                                              1};
+  // Test reconstructing T and rho*T. For low-order reconstructors this can
+  // fail (like MC) because the nonlinear terms (quadratics) aren't captured
+  // accurately enough.
+  const grmhd::ValenciaDivClean::fd::Wcns5zPrim wcns5z_recons{2, 2.0e-16, mc, 1,
+                                                              false};
   helpers::test_prim_reconstructor(4, wcns5z_recons);
+  helpers::test_prim_reconstructor(
+      4, grmhd::ValenciaDivClean::fd::Wcns5zPrim{2, 2.0e-16, mc, 1, true});
 
   const auto wcns5z_from_options_base = TestHelpers::test_factory_creation<
       grmhd::ValenciaDivClean::fd::Reconstructor,
@@ -26,7 +31,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.Wcns5zPrim",
       "  NonlinearWeightExponent: 2\n"
       "  Epsilon: 2.0e-16\n"
       "  FallbackReconstructor: MonotonisedCentral\n"
-      "  MaxNumberOfExtrema: 1\n");
+      "  MaxNumberOfExtrema: 1\n"
+      "  ReconstructRhoTimesTemperature: false\n");
   auto* const wcns5z_from_options =
       dynamic_cast<const grmhd::ValenciaDivClean::fd::Wcns5zPrim*>(
           wcns5z_from_options_base.get());
@@ -34,13 +40,15 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.Wcns5zPrim",
   CHECK(*wcns5z_from_options == wcns5z_recons);
 
   CHECK(wcns5z_recons !=
-        grmhd::ValenciaDivClean::fd::Wcns5zPrim(1, 2.0e-16, mc, 1));
+        grmhd::ValenciaDivClean::fd::Wcns5zPrim(1, 2.0e-16, mc, 1, false));
   CHECK(wcns5z_recons !=
-        grmhd::ValenciaDivClean::fd::Wcns5zPrim(2, 1.0e-16, mc, 1));
-  CHECK(
-      wcns5z_recons !=
-      grmhd::ValenciaDivClean::fd::Wcns5zPrim(
-          2, 2.0e-16, fd::reconstruction::FallbackReconstructorType::None, 1));
+        grmhd::ValenciaDivClean::fd::Wcns5zPrim(2, 1.0e-16, mc, 1, false));
   CHECK(wcns5z_recons !=
-        grmhd::ValenciaDivClean::fd::Wcns5zPrim(2, 2.0e-16, mc, 2));
+        grmhd::ValenciaDivClean::fd::Wcns5zPrim(
+            2, 2.0e-16, fd::reconstruction::FallbackReconstructorType::None, 1,
+            false));
+  CHECK(wcns5z_recons !=
+        grmhd::ValenciaDivClean::fd::Wcns5zPrim(2, 2.0e-16, mc, 2, false));
+  CHECK(wcns5z_recons !=
+        grmhd::ValenciaDivClean::fd::Wcns5zPrim(2, 2.0e-16, mc, 1, true));
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -159,7 +159,8 @@ std::array<double, 5> test(const size_t num_dg_pts,
   const grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim
       recons{
           3.8, std::nullopt, 4.0,
-          ::fd::reconstruction::FallbackReconstructorType::MonotonisedCentral};
+          ::fd::reconstruction::FallbackReconstructorType::MonotonisedCentral,
+          true};
   REQUIRE((static_cast<int>(fd_derivative_order) < 0 or
            (static_cast<size_t>(fd_derivative_order) / 2 <=
             recons.ghost_zone_size())));


### PR DESCRIPTION
## Proposed changes

This is necessary to get reasonable results with problems like the KH instability. We'll want to experiment and compare what we reconstruct for BNS as well. We probably only need to initially test the first orbit or so.

The improvement in the KH instability comes from that rho*T is basically the pressure. The temperature is very large outside of the central strip and very small inside the central strip, while the product `rho*T` is essentially constant across the domain.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
