### PR TITLE
Update bbh pipeline to use higher resolution in initial data

### DIFF
--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -154,7 +154,7 @@ def generate_id(
     linear_velocity: Sequence[float] = [0.0, 0.0, 0.0],
     # Resolution
     refinement_level: int = 1,
-    polynomial_order: int = 6,
+    polynomial_order: int = 9,
     # Scheduling options
     id_input_file_template: Union[str, Path] = ID_INPUT_FILE_TEMPLATE,
     control: bool = False,
@@ -409,7 +409,7 @@ def generate_id(
     "-P",
     type=click.IntRange(1, None),
     help="p-refinement level.",
-    default=6,
+    default=9,
     show_default=True,
 )
 # Scheduling options


### PR DESCRIPTION
## Proposed changes

Update the default p refinement in the BBH pipeline to match the choice used in [arXiv:2410.00265](https://arxiv.org/abs/2410.00265). Currently, the default is 3 points coarser (P-6), which I found led to 10^4 worse constraint energy at t=0 in an evolution than the choice used in the paper (P=9).

Until we know to set this to something better, let's at least set it to by default match what was done in the paper.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
