### PR TITLE
Add density check for param delep

### DIFF
--- a/src/Evolution/VariableFixing/ParameterizedDeleptonization.cpp
+++ b/src/Evolution/VariableFixing/ParameterizedDeleptonization.cpp
@@ -68,7 +68,13 @@ void ParameterizedDeleptonization::operator()(
     const Scalar<DataVector>& rest_mass_density,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) const {
-  if (LIKELY(enable_)) {
+  // Turn off param deleptonization if:
+  // i) disabled
+  // ii) if max rest mass density > 2e14 g/cm^3.  Note, at this point, bounce
+  // has occured/is close and one should switch to proper neutrino transport.
+  // Formally, it should disable when rest mass density > 2e14 g/cm^3 AND
+  // entropy is also > 3 k_B/baryon, but entropy is not a variable yet.
+  if (LIKELY(enable_) and max(rest_mass_density.get()) < 3.24e-4) {
     for (size_t i = 0; i < rest_mass_density.get().size(); i++) {
       correct_electron_fraction(specific_internal_energy, electron_fraction,
                                 pressure, temperature, rest_mass_density,

--- a/tests/Unit/Evolution/VariableFixing/Test_ParameterizedDeleptonization.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_ParameterizedDeleptonization.cpp
@@ -99,6 +99,7 @@ void test_variable_fixer(
     const VariableFixing::ParameterizedDeleptonization& variable_fixer,
     const EquationsOfState::EquationOfState<true, 3>& equation_of_state) {
   const Scalar<DataVector> density{DataVector{3.0e-9, 3.7e-9, 4.0e-9}};
+  const Scalar<DataVector> high_density{DataVector{5.0e-4, 2.5e-9, 3.0e-9}};
   const Scalar<DataVector> initial_density = density;
   Scalar<DataVector> electron_fraction{DataVector{0.5, 0.5, 0.5}};
   Scalar<DataVector> temperature{DataVector{1.0, 1.0, 1.0}};
@@ -140,10 +141,28 @@ void test_variable_fixer(
   CHECK_ITERABLE_APPROX(specific_internal_energy,
                         initial_specific_internal_energy);
 
-  // pressure should change
+  // pressure should not change
   CHECK_FALSE(pressure == initial_pressure);
 
-  // temperature should change
+  // temperature should not change
+  CHECK_FALSE(temperature == initial_temperature);
+
+  // Check parameterized deleptonization does not activate if density is too
+  // high, simulating post bounce phase of supernova.
+  const auto electron_fraction_compare = electron_fraction;
+
+  variable_fixer(&specific_internal_energy, &electron_fraction, &pressure,
+                 &temperature, high_density, equation_of_state);
+
+  // Ye, eint, pressure, & temperature should not change b/c the density is too
+  // high
+  CHECK(electron_fraction == electron_fraction_compare);
+
+  CHECK_ITERABLE_APPROX(specific_internal_energy,
+                        initial_specific_internal_energy);
+
+  CHECK_FALSE(pressure == initial_pressure);
+
   CHECK_FALSE(temperature == initial_temperature);
 
 }  // end 3D


### PR DESCRIPTION
## Proposed changes

Add a check that turns off parameterized deleptonization after a certain density threshold.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
