### PR TITLE
Add Cartoon to Basis and Quadrature

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Basis.cpp
+++ b/src/NumericalAlgorithms/Spectral/Basis.cpp
@@ -15,11 +15,11 @@
 
 namespace Spectral {
 
-std::array<Basis, 7> all_bases() {
+std::array<Basis, 8> all_bases() {
   return std::array{Basis::Uninitialized,     Basis::Chebyshev,
                     Basis::Legendre,          Basis::FiniteDifference,
                     Basis::SphericalHarmonic, Basis::Fourier,
-                    Basis::B2Marcus};
+                    Basis::B2Marcus,          Basis::Cartoon};
 }
 
 Basis to_basis(const std::string& basis) {
@@ -50,6 +50,8 @@ std::ostream& operator<<(std::ostream& os, const Basis& basis) {
       return os << "Fourier";
     case Basis::B2Marcus:
       return os << "B2Marcus";
+    case Basis::Cartoon:
+      return os << "Cartoon";
     default:
       ERROR("Invalid basis");
   }

--- a/src/NumericalAlgorithms/Spectral/Basis.hpp
+++ b/src/NumericalAlgorithms/Spectral/Basis.hpp
@@ -70,11 +70,12 @@ enum class Basis : uint8_t {
   FiniteDifference = 3 << basis_shift,
   SphericalHarmonic = 4 << basis_shift,
   Fourier = 5 << basis_shift,
-  B2Marcus = 6 << basis_shift
+  B2Marcus = 6 << basis_shift,
+  Cartoon = 7 << basis_shift
 };
 
 /// All possible values of Basis
-std::array<Basis, 7> all_bases();
+std::array<Basis, 8> all_bases();
 
 /// Convert a string to a Basis enum.
 Basis to_basis(const std::string& basis);

--- a/src/NumericalAlgorithms/Spectral/Quadrature.cpp
+++ b/src/NumericalAlgorithms/Spectral/Quadrature.cpp
@@ -14,11 +14,12 @@
 #include "Utilities/StdHelpers.hpp"
 
 namespace Spectral {
-std::array<Quadrature, 8> all_quadratures() {
+std::array<Quadrature, 10> all_quadratures() {
   return std::array{Quadrature::Uninitialized,   Quadrature::Gauss,
                     Quadrature::GaussLobatto,    Quadrature::CellCentered,
                     Quadrature::FaceCentered,    Quadrature::Equiangular,
-                    Quadrature::GaussRadauLower, Quadrature::GaussRadauUpper};
+                    Quadrature::GaussRadauLower, Quadrature::GaussRadauUpper,
+                    Quadrature::AxialSymmetry,   Quadrature::SphericalSymmetry};
 }
 
 Quadrature to_quadrature(const std::string& quadrature) {
@@ -51,6 +52,10 @@ std::ostream& operator<<(std::ostream& os, const Quadrature& quadrature) {
       return os << "GaussRadauLower";
     case Quadrature::GaussRadauUpper:
       return os << "GaussRadauUpper";
+    case Quadrature::AxialSymmetry:
+      return os << "AxialSymmetry";
+    case Quadrature::SphericalSymmetry:
+      return os << "SphericalSymmetry";
     default:
       ERROR("Invalid quadrature");
   }

--- a/src/NumericalAlgorithms/Spectral/Quadrature.hpp
+++ b/src/NumericalAlgorithms/Spectral/Quadrature.hpp
@@ -63,11 +63,13 @@ enum class Quadrature : uint8_t {
   FaceCentered,
   Equiangular,
   GaussRadauLower,
-  GaussRadauUpper
+  GaussRadauUpper,
+  AxialSymmetry,
+  SphericalSymmetry
 };
 
 /// All possible values of Quadrature
-std::array<Quadrature, 8> all_quadratures();
+std::array<Quadrature, 10> all_quadratures();
 
 /// Convert a string to a Quadrature enum.
 Quadrature to_quadrature(const std::string& quadrature);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Basis.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Basis.cpp
@@ -18,6 +18,7 @@ SPECTRE_TEST_CASE("Unit.Spectral.Basis", "[NumericalAlgorithms][Unit]") {
   CHECK(get_output(Spectral::Basis::SphericalHarmonic) == "SphericalHarmonic");
   CHECK(get_output(Spectral::Basis::Fourier) == "Fourier");
   CHECK(get_output(Spectral::Basis::B2Marcus) == "B2Marcus");
+  CHECK(get_output(Spectral::Basis::Cartoon) == "Cartoon");
 
   for (const auto basis : Spectral::all_bases()) {
     CHECK(basis ==

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Quadrature.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Quadrature.cpp
@@ -20,7 +20,9 @@ SPECTRE_TEST_CASE("Unit.SpatialDiscreitization.Quadrature",
   CHECK(get_output(Spectral::Quadrature::Equiangular) == "Equiangular");
   CHECK(get_output(Spectral::Quadrature::GaussRadauLower) == "GaussRadauLower");
   CHECK(get_output(Spectral::Quadrature::GaussRadauUpper) == "GaussRadauUpper");
-
+  CHECK(get_output(Spectral::Quadrature::AxialSymmetry) == "AxialSymmetry");
+  CHECK(get_output(Spectral::Quadrature::SphericalSymmetry) ==
+        "SphericalSymmetry");
   for (const auto quadrature : Spectral::all_quadratures()) {
     CHECK(quadrature == TestHelpers::test_creation<Spectral::Quadrature>(
                             get_output(quadrature)));


### PR DESCRIPTION
## Proposed changes

Add `Cartoon` to `Spectral::Basis` options as well as `AxialSymmetry` and `SphericalSymmetry` to `Spectral::Quadrature` options, to be used in Cartoon codes.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
