### PR TITLE
Add adaptive horizon finder criteria

### DIFF
--- a/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
@@ -37,7 +37,7 @@ namespace amr {
 /// `compute_tags_for_observation_box`.
 ///
 /// \example
-/// \snippet Test_Criterion.cpp criterion_examples
+/// \snippet Amr/Criteria/Test_Criterion.cpp criterion_examples
 class Criterion : public PUP::able {
  protected:
   /// \cond

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -51,5 +51,6 @@ target_link_libraries(
   )
 
 add_subdirectory(Callbacks)
+add_subdirectory(Criteria)
 add_subdirectory(Events)
 add_subdirectory(Python)

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY ApparentHorizonFinderCriteria)
+
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  IncreaseResolution.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Criteria.hpp
+  Criterion.hpp
+  Factory.hpp
+  IncreaseResolution.hpp
+  )
+
+add_dependencies(
+  ${LIBRARY}
+  module_GlobalCache
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  SphericalHarmonics
+  Parallel
+  Serialization
+  )
+
+add_subdirectory(Tags)

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criteria.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criteria.hpp
@@ -1,0 +1,9 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup SurfacesGroup
+/// \brief Criteria for deciding how resolution of an apparent horizon should be
+/// adapted
+namespace ah::Criteria {}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+namespace ah {
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Base class for criteria that determine how the resolution of an
+ * apparent horizon should be changed
+ *
+ * \details Each class derived from this class should
+ * - Be option-creatable
+ * - Be serializable
+ * - Define the type aliases `argument_tags` and
+ *   `compute_tags_for_observation_box` that are type lists of tags used in the
+ *   call operator
+ * - Define a call operator that returns a `size_t` that is the recommended
+ *   resolution $L$ for the Strahlkorper representing the apparent horizon
+ *
+ * The call operator should take the following arguments, in order:
+ * - An argument for each tag in `argument_tags`
+ * - The Parallel::GlobalCache
+ * - The Strahlkorper representing the apparent horizon
+ * - A FastFlow::IterInfo corresponding to the horizon find that found the
+ *   Strahlkorper
+ */
+class Criterion : public PUP::able {
+ protected:
+  /// \cond
+  Criterion() = default;
+  Criterion(const Criterion&) = default;
+  Criterion(Criterion&&) = default;
+  Criterion& operator=(const Criterion&) = default;
+  Criterion& operator=(Criterion&&) = default;
+  /// \endcond
+ public:
+  ~Criterion() override = default;
+  explicit Criterion(CkMigrateMessage* msg) : PUP::able(msg) {}
+
+  WRAPPED_PUPable_abstract(Criterion);
+
+  virtual std::string observation_name() = 0;
+
+  /// Evaluates the apparent horizon criteria by selecting the appropriate
+  /// derived class and forwarding its `argument_tags` from the ObservationBox
+  /// (along with the GlobalCache) to the call operator of the
+  /// derived class
+  ///
+  /// \note In order to be available, a derived Criterion must be listed in
+  /// the entry for Criterion in
+  /// Metavarialbes::factory_creation::factory_classes
+  ///
+  /// \note The ComputeTagsList of the ObservationBox should contain the union
+  /// of the tags listed in `compute_tags_for_observation_box` for each derived
+  /// Criterion listed in the `factory_classes`.
+  template <typename ComputeTagsList, typename DataBoxType,
+            typename Metavariables, typename Frame>
+  auto evaluate(const ObservationBox<ComputeTagsList, DataBoxType>& box,
+                Parallel::GlobalCache<Metavariables>& cache,
+                const ylm::Strahlkorper<Frame>& strahlkorper,
+                const FastFlow::IterInfo& info) const {
+    using factory_classes =
+        typename std::decay_t<Metavariables>::factory_creation::factory_classes;
+    return call_with_dynamic_type<size_t, tmpl::at<factory_classes, Criterion>>(
+        this, [&box, &cache, &strahlkorper, &info](auto* const criterion) {
+          return apply(*criterion, box, cache, strahlkorper, info);
+        });
+  }
+};
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+using standard_criteria = tmpl::list<>;
+}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.cpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp"
+
+namespace ah::Criteria {
+IncreaseResolution::IncreaseResolution(CkMigrateMessage* msg)
+    : Criterion(msg) {}
+
+PUP::able::PUP_ID IncreaseResolution::my_PUP_ID = 0;  // NOLINT
+}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+/*!
+ * \brief Increases the resolution of the Strahlkorper by 2.
+ *
+ * Useful to force the horizon finder to adopt the maximum allowed resolution
+ * and as a simple criterion for testing.
+ */
+class IncreaseResolution : public Criterion {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Increases the resolution of the Strahlkorper by 2."};
+
+  IncreaseResolution() = default;
+
+  /// \cond
+  explicit IncreaseResolution(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(IncreaseResolution);  // NOLINT
+  /// \endcond
+
+  std::string observation_name() override { return "IncreaseResolution"; }
+
+  using argument_tags = tmpl::list<>;
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  template <typename Metavariables, typename Frame>
+  size_t operator()(const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ylm::Strahlkorper<Frame>& strahlkorper,
+                    const FastFlow::IterInfo& /*info*/) const {
+    return strahlkorper.l_max() + 2;
+  }
+};
+}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Criteria.hpp
+  Tags.hpp
+  )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Criteria.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Criteria.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+/// Option tags for adaptive horizon finding criteria
+namespace OptionTags {
+/// \ingroup OptionTagsGroup
+/// Options for adaptive horizon finding criteria
+struct Criteria {
+  static constexpr Options::String help =
+      "Options for adaptive horizon finding criteria";
+  using type = std::vector<std::unique_ptr<ah::Criterion>>;
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/// The set of adaptive horizon finding criteria
+struct Criteria : db::SimpleTag {
+  using type = std::vector<std::unique_ptr<ah::Criterion>>;
+  using option_tags = tmpl::list<ah::Criteria::OptionTags::Criteria>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& value) {
+    return {deserialize<type>(serialize<type>(value).data())};
+  }
+};
+}  // namespace Tags
+}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Tags.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \ingroup SurfacesGroup
+/// \brief Tags for adaptive apparent horizon finding criteria
+namespace ah::Criteria::Tags {}  // namespace ah::Criteria::Tags

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_IncreaseResolution.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_IncreaseResolution.cpp
@@ -41,7 +41,7 @@ SPECTRE_TEST_CASE("Unit.Amr.Criteria.IncreaseResolution",
           "IncreaseResolution");
   Parallel::GlobalCache<Metavariables<2>> empty_cache{};
   auto databox = db::create<tmpl::list<>>();
-  ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> box{
+  const ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> box{
       make_not_null(&databox)};
   const ElementId<2> element_id{0};
   const auto flags = criterion->evaluate(box, empty_cache, element_id);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -36,4 +36,5 @@ target_link_libraries(
   Utilities
   )
 
+add_subdirectory(Criteria)
 add_subdirectory(Python)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_ApparentHorizonFinderCriteria")
+
+set(LIBRARY_SOURCES
+  Test_Criterion.cpp
+  Test_IncreaseResolution.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  ApparentHorizonFinder
+  ApparentHorizonFinderCriteria
+  Options
+  SphericalHarmonics
+  )

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Criterion.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Criterion.cpp
@@ -1,0 +1,206 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct FactorOne : db::SimpleTag {
+  using type = double;
+};
+
+struct FactorTwo : db::SimpleTag {
+  using type = double;
+};
+
+struct Product : db::SimpleTag {
+  using type = double;
+};
+
+struct ProductCompute : db::ComputeTag, Product {
+  using base = Product;
+  using return_type = double;
+  using argument_tags = tmpl::list<FactorOne, FactorTwo>;
+
+  static void function(const gsl::not_null<double*> result,
+                       const double field_one, const double field_two) {
+    *result = field_one * field_two;
+  }
+};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+class CriterionOne : public ah::Criterion {
+ public:
+  struct TargetValue {
+    using type = double;
+    static constexpr Options::String help = {"The target value."};
+  };
+  using options = tmpl::list<TargetValue>;
+
+  static constexpr Options::String help = {
+      "Increase surface resolution if the factor one is above a target value; "
+      "otherwise decreases the resolution"};
+
+  CriterionOne() = default;
+  explicit CriterionOne(const double target_value)
+      : target_value_(target_value) {}
+  explicit CriterionOne(CkMigrateMessage* /*msg*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(CriterionOne);  // NOLINT
+
+  std::string observation_name() override { return "CriterionOne"; }
+
+  using compute_tags_for_observartion_box = tmpl::list<>;
+  using argument_tags = tmpl::list<FactorOne>;
+
+  template <typename Metavariables, typename Fr>
+  size_t operator()(const double field_one,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ylm::Strahlkorper<Fr>& strahlkorper,
+                    const FastFlow::IterInfo& /*info*/) const {
+    return field_one > target_value_ ? strahlkorper.l_max() + 1
+                                     : strahlkorper.l_max() - 1;
+  }
+
+  void pup(PUP::er& p) override {
+    Criterion::pup(p);
+    p | target_value_;
+  }
+
+ private:
+  double target_value_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+PUP::able::PUP_ID CriterionOne::my_PUP_ID = 0;  // NOLINT
+
+class CriterionTwo : public ah::Criterion {
+ public:
+  struct TargetValue {
+    using type = double;
+    static constexpr Options::String help = {"The target value."};
+  };
+  using options = tmpl::list<TargetValue>;
+
+  static constexpr Options::String help = {
+      "Increase surface resolution if the product of the two factors times the "
+      "(simulated) residual of a surface find is above "
+      "a target value; decrease resolution otherwise."};
+
+  CriterionTwo() = default;
+  explicit CriterionTwo(const double target_value)
+      : target_value_(target_value) {}
+  explicit CriterionTwo(CkMigrateMessage* /*msg*/) {}
+  using PUP::able::register_constructor;        // NOLINT
+  WRAPPED_PUPable_decl_template(CriterionTwo);  // NOLINT
+
+  std::string observation_name() override { return "CriterionTwo"; }
+
+  using compute_tags_for_observartion_box = tmpl::list<ProductCompute>;
+  using argument_tags = tmpl::list<Product>;
+
+  template <typename Metavariables, typename Fr>
+  size_t operator()(const double product,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ylm::Strahlkorper<Fr>& strahlkorper,
+                    const FastFlow::IterInfo& info) const {
+    return product * info.max_residual > target_value_
+               ? strahlkorper.l_max() + 1
+               : strahlkorper.l_max() - 1;
+  }
+
+  void pup(PUP::er& p) override {
+    Criterion::pup(p);
+    p | target_value_;
+  }
+
+ private:
+  double target_value_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+PUP::able::PUP_ID CriterionTwo::my_PUP_ID = 0;  // NOLINT
+#pragma GCC diagnostic pop
+
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<ah::Criterion, tmpl::list<CriterionOne, CriterionTwo>>>;
+  };
+};
+
+template <typename Fr>
+void test_criterion(const ah::Criterion& criterion, const double field_one,
+                    const double field_two, const size_t expected_l_max,
+                    const ylm::Strahlkorper<Fr>& strahlkorper,
+                    const FastFlow::IterInfo& info) {
+  Parallel::GlobalCache<Metavariables> empty_cache{};
+  using simple_tags = tmpl::list<FactorOne, FactorTwo>;
+  auto databox = db::create<simple_tags>(field_one, field_two);
+  using compute_tags = tmpl::list<ProductCompute>;
+  const auto box = make_observation_box<compute_tags>(make_not_null(&databox));
+
+  auto new_l_max = criterion.evaluate(box, empty_cache, strahlkorper, info);
+  CHECK(new_l_max == expected_l_max);
+}
+
+void test() {
+  register_factory_classes_with_charm<Metavariables>();
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+      11, 4.5, {{0.1, 0.2, 0.3}}};
+  FastFlow::IterInfo info{};
+  info.max_residual = 1.e-6;
+
+  const CriterionOne criterion_one{2.3};
+  test_criterion(criterion_one, 3.4, 0.0, strahlkorper.l_max() + 1,
+                 strahlkorper, info);
+  test_criterion(serialize_and_deserialize(criterion_one), 3.4, 0.0,
+                 strahlkorper.l_max() + 1, strahlkorper, info);
+  const auto criterion_one_option =
+      TestHelpers::test_creation<std::unique_ptr<ah::Criterion>, Metavariables>(
+          "CriterionOne:\n"
+          "  TargetValue: 2.3\n");
+  test_criterion(*criterion_one_option, 1.8, 0.0, strahlkorper.l_max() - 1,
+                 strahlkorper, info);
+  test_criterion(*serialize_and_deserialize(criterion_one_option), 2.2, 0.0,
+                 strahlkorper.l_max() - 1, strahlkorper, info);
+
+  const CriterionTwo criterion_two{4.0e-6};
+  test_criterion(criterion_two, 2.0, 1.5, strahlkorper.l_max() - 1,
+                 strahlkorper, info);
+  test_criterion(serialize_and_deserialize(criterion_two), 2.0, 1.5,
+                 strahlkorper.l_max() - 1, strahlkorper, info);
+  const auto criterion_two_option =
+      TestHelpers::test_creation<std::unique_ptr<ah::Criterion>, Metavariables>(
+          "CriterionTwo:\n"
+          "  TargetValue: 4.0e-6\n");
+  test_criterion(*criterion_two_option, 2.0, 1.5, strahlkorper.l_max() - 1,
+                 strahlkorper, info);
+  test_criterion(*serialize_and_deserialize(criterion_two_option), 2.0, 1.5,
+                 strahlkorper.l_max() - 1, strahlkorper, info);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Criteria.Criterion",
+                  "[Unit][ParallelAlgorithms]") {
+  test();
+}

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_IncreaseResolution.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_IncreaseResolution.cpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+namespace {
+template <typename Frame>
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<ah::Criterion, tmpl::list<IncreaseResolution>>>;
+  };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Criteria.IncreaseResolution",
+                  "[Unit][ParallelAlgorithms]") {
+  TestHelpers::db::test_simple_tag<ah::Criteria::Tags::Criteria>("Criteria");
+  const auto criterion =
+      TestHelpers::test_factory_creation<ah::Criterion, IncreaseResolution>(
+          "IncreaseResolution");
+  Parallel::GlobalCache<Metavariables<Frame::Inertial>> empty_cache{};
+  auto databox = db::create<tmpl::list<>>();
+  const ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> box{
+      make_not_null(&databox)};
+
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+      11, 4.5, {{0.1, 0.2, 0.3}}};
+  const FastFlow::IterInfo iter_info{};
+
+  const size_t new_l_max =
+      criterion->evaluate(box, empty_cache, strahlkorper, iter_info);
+  CHECK(new_l_max == strahlkorper.l_max() + 2);
+}
+}  // namespace ah::Criteria


### PR DESCRIPTION
## Proposed changes

Adds a base class and a simple example derived class for criteria for adjusting the resolution adaptively when finding an apparent horizon. A future PR will implement the actual criteria intended to be used in real binary-black-hole simulations. Another future PR (or set or PRs) will take care of implementing adaptivity in the apparent horizon finder.

The design and implementation are based on how adaptive mesh refinement criteria are implemented in spectre but enables the criteria to work with output of a horizon find (Strahlkorper and FastFlow::IterInfo) instead of an ElementId.

**NOTE**: I used [Cursor](https://cursor.com) generative AI (tab completion, review, fixing compiler errors) when preparing this PR. I examined all code suggestions, and to the best of my knowledge, this PR contains no code either copyrighted by someone else or used in violation of any code's license agreement. Please note in your review any concerns about this.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
