### PR TITLE
Move FD SecondPartialDerivatives to NumericalAlgorithms

### DIFF
--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -9,7 +9,6 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Derivatives.cpp
-  SecondPartialDerivatives.cpp
   )
 
 spectre_target_headers(
@@ -17,8 +16,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Derivatives.hpp
-  SecondPartialDerivatives.hpp
-  SecondPartialDerivatives.tpp
   SoTimeDerivative.hpp
   System.hpp
   Tags.hpp

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
@@ -15,12 +15,12 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
-#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
-#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp"
 #include "Evolution/Systems/Ccz4/System.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
 #include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp"
+#include "NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -154,7 +154,7 @@ void second_spacetime_derivatives(
                      number_of_Ccz4_components *
                          volume_evolved_variables.number_of_grid_points());
 
-  second_partial_derivatives<gradients_tags>(
+  ::fd::second_partial_derivatives<gradients_tags>(
       result, volume_Ccz4_vars, ghost_cell_vars, volume_mesh,
       number_of_Ccz4_components, deriv_order,
       cell_centered_logical_to_inertial_inv_jacobian);

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
@@ -58,7 +58,8 @@ void spacetime_derivatives(
  * \details
  * The derivatives are computed using FD of order deriv_order.
  *
- * \note Only 3D 4-th order second derivatives are implemented.
+ * \note Only 3D 4-th order second derivatives are implemented
+ * in this stencil
  */
 void second_spacetime_derivatives(
     gsl::not_null<Variables<

--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   NonUniform1D.cpp
   PartialDerivatives.cpp
   PositivityPreservingAdaptiveOrder.cpp
+  SecondPartialDerivatives.cpp
   Unlimited.cpp
   Wcns5z.cpp
   )
@@ -42,6 +43,8 @@ spectre_target_headers(
   PositivityPreservingAdaptiveOrder.hpp
   Reconstruct.hpp
   Reconstruct.tpp
+  SecondPartialDerivatives.hpp
+  SecondPartialDerivatives.tpp
   Unlimited.hpp
   Wcns5z.hpp
   )

--- a/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
+#include "NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp"
 
 #include <array>
 #include <cstddef>
@@ -21,7 +21,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-namespace Ccz4::fd {
+namespace fd {
 namespace {
 template <size_t Order, bool UnitStride>
 struct ComputeImpl;
@@ -1097,7 +1097,7 @@ void second_logical_partial_derivatives_impl(
     const size_t fd_order) {
   switch (fd_order) {
     case 4:
-      ::Ccz4::fd::second_logical_partial_derivatives_impl<ComputeImpl<4, true>>(
+      ::fd::second_logical_partial_derivatives_impl<ComputeImpl<4, true>>(
           pure_second_logical_derivatives, mixed_second_logical_derivatives,
           buffer, volume_vars, ghost_cell_vars, volume_mesh,
           number_of_variables);
@@ -1152,4 +1152,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (3))
 #undef GET_DIM
 #undef INSTANTIATION
 
-}  // namespace Ccz4::fd
+}  // namespace fd

--- a/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp
@@ -21,10 +21,10 @@ class Variables;
 /// \endcond
 
 /*!
-* \brief The finite difference second derivatives for implementing the CCZ4
-* system.
+* \brief The finite difference second derivatives originally
+* designed for implementing the CCZ4 system.
 */
-namespace Ccz4::fd {
+namespace fd {
 /*!
  * \brief Compute the pure and mixed second logical partial derivatives using
  * finite difference derivatives. Only 3 dimensions 4th-order fd is supported.
@@ -81,7 +81,7 @@ void second_logical_partial_derivatives(
  *
  * First and second logical partial derivatives are first computed using the
  * `fd::logical_partial_derivatives()` and
- * `Ccz4::fd::second_logical_partial_derivatives()` function.
+ * `fd::second_logical_partial_derivatives()` function.
  *
  * \note The `inverse_hessian` has not been implemented, so currently inertial
  * coordinates cannot mix logical coordinates.
@@ -98,4 +98,4 @@ void second_partial_derivatives(
     size_t fd_order,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian);
-}  // namespace Ccz4::fd
+}  // namespace fd

--- a/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.tpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
+#include "NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp"
 
 #include <array>
 
@@ -18,7 +18,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-namespace Ccz4::fd {
+namespace fd {
 namespace detail {
 template <size_t Dim>
 void second_logical_partial_derivatives_impl(
@@ -247,4 +247,4 @@ void second_partial_derivatives(
       Variables<DerivativeTags>::number_of_independent_components,
       inverse_jacobian);
 }
-}  // namespace Ccz4::fd
+}  // namespace fd

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -5,7 +5,6 @@ set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
   FiniteDifference/Test_Derivatives.cpp
-  FiniteDifference/Test_SecondPartialDerivatives.cpp
   FiniteDifference/Test_SoTimeDerivative.cpp
   Test_ATilde.cpp
   Test_Christoffel.cpp

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_NonUniform1D.cpp
   Test_PartialDerivatives.cpp
   Test_PositivityPreservingAdaptiveOrder.cpp
+  Test_SecondPartialDerivatives.cpp
   Test_Unlimited.cpp
   Test_Wcns5z.cpp
   )

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_SecondPartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_SecondPartialDerivatives.cpp
@@ -12,10 +12,10 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
-#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.hpp"
-#include "Evolution/Systems/Ccz4/FiniteDifference/SecondPartialDerivatives.tpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp"
+#include "NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -207,7 +207,7 @@ void test(const size_t points_per_dimension, const size_t fd_order) {
     ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
   }
 
-  ::Ccz4::fd::second_logical_partial_derivatives(
+  ::fd::second_logical_partial_derivatives(
       make_not_null(&pure_second_logical_derivative_view),
       make_not_null(&mixed_second_logical_derivative_view),
       gsl::make_span(volume_vars.data(), volume_vars.size()), ghost_cell_vars,
@@ -339,7 +339,7 @@ void test(const size_t points_per_dimension, const size_t fd_order) {
     ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
   }
 
-  ::Ccz4::fd::second_partial_derivatives<derivative_tags>(
+  ::fd::second_partial_derivatives<derivative_tags>(
       make_not_null(&second_partial_derivatives),
       gsl::make_span(volume_vars_for_tensor.data(),
                      volume_vars_for_tensor.size()),


### PR DESCRIPTION
## Proposed changes
The 4th-order accurate finite difference stencils for second partial derivatives, originally designed for implementing the SoCcz4 system, are not limited to the SoCcz4 system. Therefore, it makes more sense to move their code from `Ccz4/FiniteDifference` to `NumericalAlgorithms/FiniteDifference`. I made no change that affects any of the functionality; just fixing `#include`, namespaces, comments, etc.


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
