### PR TITLE
Parameterized Deleptonization Runtime Option for GH

### DIFF
--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -238,7 +238,7 @@ function(add_input_file_tests INPUT_FILE_DIR INPUT_FILE_WHITELIST)
       string(STRIP "${INPUT_FILE_TIMEOUT}" INPUT_FILE_TIMEOUT)
     endif()
 
-    # Read out the semicolon list of of files to copy to the run directory.
+    # Read out the semicolon list of files to copy to the run directory.
     # The files are currently restricted to being in the same location
     # as the input file. This can be relaxed if necessary.
     set(COPY_FILES "")

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -44,7 +44,7 @@ set(LIBS_TO_LINK_WITH_CONTROL_SYSTEM
   ControlSystemMeasurements
   )
 
-function(add_ghmhd_executable SUFFIX USE_CONTROL_SYSTEMS)
+function(add_ghmhd_executable SUFFIX USE_CONTROL_SYSTEMS USE_PARAMETRIZED_DELEPTONIZATION)
   set(EXECUTABLE "EvolveGhValenciaDivClean${SUFFIX}")
   add_spectre_executable(
     ${EXECUTABLE}
@@ -55,6 +55,7 @@ function(add_ghmhd_executable SUFFIX USE_CONTROL_SYSTEMS)
     ${EXECUTABLE}
     PRIVATE
     USE_CONTROL_SYSTEMS=${USE_CONTROL_SYSTEMS}
+    USE_PARAMETRIZED_DELEPTONIZATION=${USE_PARAMETRIZED_DELEPTONIZATION}
     )
   target_link_libraries(${EXECUTABLE} PRIVATE ${LIBS_TO_LINK})
   if (USE_CONTROL_SYSTEMS STREQUAL "true")
@@ -69,10 +70,17 @@ endfunction()
 add_ghmhd_executable(
   ""
   "false"
+  "false"
   )
 
 add_ghmhd_executable(
   "Bns"
+   "true"
+   "false"
+  )
+add_ghmhd_executable(
+  "CoreCollapseSupernova"
+   "false"
    "true"
   )
 

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.cpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.cpp
@@ -16,7 +16,9 @@
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // Parameters chosen in CMakeLists.txt
-using metavariables = EvolutionMetavars<USE_CONTROL_SYSTEMS, BondiSachs>;
+using metavariables =
+    EvolutionMetavars<USE_CONTROL_SYSTEMS, USE_PARAMETRIZED_DELEPTONIZATION,
+                      BondiSachs>;
 
 extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivClean.hpp
@@ -20,14 +20,17 @@
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <bool UseControlSystems, typename... InterpolationTargetTags>
+template <bool UseControlSystems, bool UseParametrizedDeleptonization,
+          typename... InterpolationTargetTags>
 struct EvolutionMetavars
     : public GhValenciaDivCleanTemplateBase<
-          EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>,
-          true, UseControlSystems, false> {
+          EvolutionMetavars<UseControlSystems, UseParametrizedDeleptonization,
+                            InterpolationTargetTags...>,
+          true, UseControlSystems, UseParametrizedDeleptonization, false> {
   using base = GhValenciaDivCleanTemplateBase<
-      EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>, true,
-      UseControlSystems, false>;
+      EvolutionMetavars<UseControlSystems, UseParametrizedDeleptonization,
+                        InterpolationTargetTags...>,
+      true, UseControlSystems, UseParametrizedDeleptonization, false>;
   using const_global_cache_tags = typename base::const_global_cache_tags;
   using observed_reduction_data_tags =
       typename base::observed_reduction_data_tags;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.cpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.cpp
@@ -16,7 +16,7 @@
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 // Parameters chosen in CMakeLists.txt
-using metavariables = EvolutionMetavars<false, BondiSachs>;
+using metavariables = EvolutionMetavars<false, false, BondiSachs>;
 
 extern "C" void CkRegisterMainModule() {
   Parallel::charmxx::register_main_module<metavariables>();

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -39,18 +39,22 @@
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <bool UseControlSystems, typename... InterpolationTargetTags>
+template <bool UseControlSystems, bool UseParametrizedDeleptonization,
+          typename... InterpolationTargetTags>
 struct EvolutionMetavars
     : public GhValenciaDivCleanTemplateBase<
-          EvolutionMetavars<UseControlSystems, InterpolationTargetTags...>,
-          false, false, true> {
+          EvolutionMetavars<UseControlSystems, UseParametrizedDeleptonization,
+                            InterpolationTargetTags...>,
+          false, false, UseParametrizedDeleptonization, true> {
   static_assert(not UseControlSystems,
                 "GhValenciaWithHorizon doesn't support control systems yet.");
   static constexpr bool use_dg_subcell = false;
 
   using defaults = GhValenciaDivCleanDefaults<use_dg_subcell>;
-  using base = GhValenciaDivCleanTemplateBase<EvolutionMetavars, use_dg_subcell,
-                                              UseControlSystems, true>;
+  using base =
+      GhValenciaDivCleanTemplateBase<EvolutionMetavars, use_dg_subcell,
+                                     UseControlSystems,
+                                     UseParametrizedDeleptonization, true>;
   static constexpr size_t volume_dim = defaults::volume_dim;
   using domain_frame = typename defaults::domain_frame;
   static constexpr bool use_damped_harmonic_rollon =

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -113,6 +113,7 @@
 #include "Evolution/VariableFixing/Actions.hpp"
 #include "Evolution/VariableFixing/FixToAtmosphere.hpp"
 #include "Evolution/VariableFixing/LimitLorentzFactor.hpp"
+#include "Evolution/VariableFixing/ParameterizedDeleptonization.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
 #include "IO/Importers/Actions/ReadVolumeData.hpp"
 #include "IO/Importers/Actions/ReceiveVolumeData.hpp"
@@ -339,18 +340,23 @@ struct GhValenciaDivCleanDefaults {
 };
 
 template <typename EvolutionMetavarsDerived, bool UseDgSubcell,
-          bool UseControlSystems, bool WithHorizon>
+          bool UseControlSystems, bool UseParametrizedDeleptonization,
+          bool WithHorizon>
 struct GhValenciaDivCleanTemplateBase;
 
-template <bool UseDgSubcell, bool UseControlSystems, bool WithHorizon,
-          template <bool, typename...> class EvolutionMetavarsDerived,
+template <bool UseDgSubcell, bool UseControlSystems,
+          bool UseParametrizedDeleptonization, bool WithHorizon,
+          template <bool, bool, typename...> class EvolutionMetavarsDerived,
           typename... InterpolationTargetTags>
 struct GhValenciaDivCleanTemplateBase<
-    EvolutionMetavarsDerived<UseControlSystems, InterpolationTargetTags...>,
-    UseDgSubcell, UseControlSystems, WithHorizon>
-    : public virtual GhValenciaDivCleanDefaults<UseDgSubcell> {
+    EvolutionMetavarsDerived<UseControlSystems, UseParametrizedDeleptonization,
+                             InterpolationTargetTags...>,
+    UseDgSubcell, UseControlSystems, UseParametrizedDeleptonization,
+    WithHorizon> : public virtual GhValenciaDivCleanDefaults<UseDgSubcell> {
   using derived_metavars =
-      EvolutionMetavarsDerived<UseControlSystems, InterpolationTargetTags...>;
+      EvolutionMetavarsDerived<UseControlSystems,
+                               UseParametrizedDeleptonization,
+                               InterpolationTargetTags...>;
   using defaults = GhValenciaDivCleanDefaults<UseDgSubcell>;
   static constexpr size_t volume_dim = defaults::volume_dim;
   using domain_frame = typename defaults::domain_frame;
@@ -362,7 +368,7 @@ struct GhValenciaDivCleanTemplateBase<
   static constexpr bool use_dg_element_collection =
       defaults::use_dg_element_collection;
   using system = typename defaults::system;
-  // using neutrino_system = typename defaults::neutrino_system;
+
   using analytic_variables_tags = typename defaults::analytic_variables_tags;
   using analytic_solution_fields = typename defaults::analytic_solution_fields;
   using ordered_list_of_primitive_recovery_schemes =
@@ -373,9 +379,16 @@ struct GhValenciaDivCleanTemplateBase<
 
   static constexpr bool use_dg_subcell = UseDgSubcell;
   static constexpr bool use_control_systems = UseControlSystems;
-
   using initial_data_list =
       ghmhd::GhValenciaDivClean::InitialData::initial_data_list;
+
+  // Boolean verifying if parameterized deleptonization will be active.  This
+  // will only be active for CCSN evolution.
+  using parameterized_deleptonization =
+      tmpl::conditional_t<UseParametrizedDeleptonization,
+                          VariableFixing::Actions::FixVariables<
+                              VariableFixing::ParameterizedDeleptonization>,
+                          tmpl::list<>>;
 
   using initial_data_tag = evolution::initial_data::Tags::InitialData;
   using equation_of_state_tag = hydro::Tags::GrmhdEquationOfState;
@@ -786,6 +799,7 @@ struct GhValenciaDivCleanTemplateBase<
           grmhd::GhValenciaDivClean::subcell::TciOnDgGrid<
               tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
       Actions::CleanHistory<system, local_time_stepping>,
+      parameterized_deleptonization,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
       VariableFixing::Actions::FixVariables<VariableFixing::LimitLorentzFactor>,
@@ -823,6 +837,7 @@ struct GhValenciaDivCleanTemplateBase<
       Actions::MutateApply<
           grmhd::GhValenciaDivClean::subcell::ResizeAndComputePrims<
               ordered_list_of_primitive_recovery_schemes>>,
+      parameterized_deleptonization,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
       VariableFixing::Actions::FixVariables<VariableFixing::LimitLorentzFactor>,
@@ -898,6 +913,7 @@ struct GhValenciaDivCleanTemplateBase<
               Parallel::Phase::Evolve,
               tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
+                  parameterized_deleptonization,
                   VariableFixing::Actions::FixVariables<
                       VariableFixing::FixToAtmosphere<volume_dim>>,
                   VariableFixing::Actions::FixVariables<

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -1,0 +1,298 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+Executable: EvolveGhValenciaDivCleanCoreCollapseSupernova
+Testing:
+  Check: parse
+  Timeout: 8
+  Priority: High
+  CopyFiles: ../../../../tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapseID.dat; ../../../../tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/dd2_unit_test.h5
+ExpectedOutput:
+  - GhMhdCCSNVolume0.h5
+  - GhMhdCCSNReductions.h5
+
+---
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 1.0e-5
+  MinimumTimeStep: 1.0e-7
+  TimeStepper:
+    Rk3HesthavenSsp:
+
+PhaseChangeAndTriggers:
+
+InitialData: &InitialData
+  GeneralizedHarmonic(CcsnCollapse):
+    ProgenitorFilename: "./CcsnCollapseID.dat"
+    TableFilename: "./dd2_unit_test.h5"
+    TableSubFilename: "/dd2"
+    CentralAngularVelocity: 0.0 #2.4635e-5 #5 rad/s
+    DifferentialRotationParameter: 338.53
+    MaxDensityRatioForLinearInterpolation: 100
+
+EquationOfState:
+  FromInitialData
+
+# Note: this domain is chosen so that we only need to simulate the interior
+# of the star
+DomainCreator:
+  AlignedLattice:
+    BlockBounds: [[0.0, 33.853, 13541.2],
+                  [-1.0, 1.0],
+                  [-1.0, 1.0]]
+    InitialGridPoints: [1, 1, 1]
+    InitialLevels: [1, 0, 0]
+    RefinedLevels:
+      # inner block
+      - LowerCornerIndex: [0, 0, 0]
+        UpperCornerIndex: [1, 1, 1]
+        Refinement: [1, 0, 0]
+      #outer block
+      - LowerCornerIndex: [1, 0, 0]
+        UpperCornerIndex: [2, 1, 1]
+        Refinement: [1, 0, 0]
+    RefinedGridPoints: []
+    BlocksToExclude: []
+    BoundaryConditions:
+        - DirichletAnalytic:
+            AnalyticPrescription: *InitialData
+        - DirichletAnalytic:
+            AnalyticPrescription: *InitialData
+        - DirichletAnalytic:
+            AnalyticPrescription: *InitialData
+
+VariableFixing:
+  FixConservatives:
+    Enable: false # Only needed when not using Kastaun for recovery
+    CutoffD: &CutoffD 1.0e-16
+    MinimumValueOfD: &MinimumD 1.0e-16
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
+    SafetyFactorForB: 1.0e-12
+    SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-12
+    SafetyFactorForSSlope: 0.0
+    MagneticField: AssumeZero
+  FixToAtmosphere:
+    DensityOfAtmosphere: 1.0e-15
+    DensityCutoff: &AtmosphereDensityCutoff 1.1e-15
+    VelocityLimiting:
+      AtmosphereMaxVelocity: 0
+      NearAtmosphereMaxVelocity: 1.0e-4
+      AtmosphereDensityCutoff: 3.0e-15
+      TransitionDensityBound: 3.0e-14
+    KappaLimiting:
+      DensityLowerBound: 2.0e-14
+      EplisonKappaMinus: 1.0e-3
+      DensityUpperBound: 2.0e-13
+      EpsilonKappaMax: 0.01
+      LimitAboveDensityUpperBound: False
+      MinTemperature: FromEos
+  LimitLorentzFactor:
+    Enable: false # Only needed when not using Kastaun for recovery
+    MaxDensityCutoff: 1.0e-12
+    LorentzFactorCap: 1.0
+  ParameterizedDeleptonization:
+    Enable: true
+    HighDensityScale: 3.24e-5
+    LowDensityScale: 3.24e-11
+    ElectronFractionAtHighDensity: 0.285
+    ElectronFractionAtLowDensity: 0.5
+    ElectronFractionCorrectionScale: 0.035
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
+
+
+EvolutionSystem:
+  ValenciaDivClean:
+    DampingParameter: 0.0
+  GeneralizedHarmonic:
+    GaugeCondition:
+      Harmonic:
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 0
+        Amplitude: 0
+        Width: 90
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: 0
+        Amplitude: 0
+        Width: 210
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 0.01
+        Amplitude: 4
+        Width: 90
+        Center: [0.0, 0.0, 0.0]
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    ProductUpwindPenaltyAndHll:
+      UpwindPenalty:
+      Hll:
+        MagneticFieldMagnitudeForHydro: 1.0e-16
+        LightSpeedDensityCutoff: 1.0e-8
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: Gauss
+    Subcell:
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: true
+        EnableExtensionDirections: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None
+      SubcellToDgReconstructionMethod: DimByDim
+      FiniteDifferenceDerivativeOrder: 6
+    TciOptions:
+      MinimumValueOfD: 1.0e-15
+      MinimumValueOfYe: 1.0e-20
+      MinimumValueOfTildeTau: 1.0e-40
+      AtmosphereDensity: 1.0e-15
+      SafetyFactorForB: 1.0e-12
+      MagneticFieldCutoff: DoNotCheckMagneticField
+  SubcellSolver:
+    Reconstructor:
+      MonotonisedCentralPrim:
+        AtmosphereTreatment: Never
+        ReconstructRhoTimesTemperature: true
+    FilterOptions:
+      SpacetimeDissipation: 0.9
+
+Filtering:
+  ExpFilter0:
+    Alpha: 36
+    HalfPower: 64
+    Enable: true
+    BlocksToFilter: All
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 1
+    Events:
+      - ChangeSlabSize:
+          DelayChange: 5
+          StepChoosers:
+            - ErrorControl:
+                AbsoluteTolerance: 1.0e-6
+                RelativeTolerance: 1.0e-4
+                MaxFactor: 2
+                MinFactor: 0.25
+                SafetyFactor: 0.95
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 40
+          Offset: 0
+    Events:
+      - ObserveNorms:
+          SubfileName: max_density
+          TensorsToObserve:
+            - Name: RestMassDensity
+              NormType: Max
+              Components: Individual
+      - ObserveNorms:
+          SubfileName: min_data_lapse
+          TensorsToObserve:
+            - Name: Lapse
+              NormType: Min
+              Components: Individual
+      - ObserveNorms:
+          SubfileName: max_three_index_constraint
+          TensorsToObserve:
+            - Name: PointwiseL2Norm(ThreeIndexConstraint)
+              NormType: Max
+              Components: Individual
+
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 100
+          Offset: 0
+    Events:
+      - ObserveTimeStep:
+            SubfileName: TimeSteps
+            PrintTimeToTerminal: True
+            ObservePerCore: False
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1000
+          Offset: 0
+    Events:
+      - ObserveFields:
+          SubfileName: VolumeData
+          BlocksToObserve: All
+          VariablesToObserve:
+            - SpacetimeMetric
+            - RestMassDensity
+            - Pressure
+            - ElectronFraction
+            - MagneticField
+            - Temperature
+            - SpatialVelocity
+            - SpecificInternalEnergy
+            - PointwiseL2Norm(GaugeConstraint)
+            - TildeD
+            - TildeS
+            - TildeTau
+            - Phi
+            - Pi
+            - Lapse
+            - PointwiseL2Norm(ThreeIndexConstraint)
+            - ThreeIndexConstraint
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - Trigger:
+      TimeCompares:
+        Comparison: GreaterThanOrEqualTo
+        Value: 40592
+    Events:
+      - Completion
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [1]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
+
+Observers:
+  VolumeFileName: "GhMhdCCSNVolume"
+  ReductionFileName: "GhMhdCCSNReductions"
+
+Interpolator:
+  Verbosity: Silent
+EventsAndDenseTriggers:
+
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -259,7 +259,8 @@ long_lines_exclude() {
         grep -v '"""' | \
         grep -v 'import' | \
         grep -v '\\link' | \
-        grep -v '\\endlink'
+        grep -v '\\endlink' | \
+        grep -v 'CopyFiles:'
 }
 long_lines() {
     whitelist "$1" \


### PR DESCRIPTION
## Proposed changes

Allows runtime option of parameterized deleptonization only for the core collapse application in GH.  Also adds sample supernova input file to parse.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
