### PR TITLE
Include StdHelpers.hpp when asserts << topologies

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -19,6 +19,7 @@
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 template <size_t VolumeDim>
 Block<VolumeDim>::Block(

--- a/src/Domain/Structure/NeighborIsConforming.cpp
+++ b/src/Domain/Structure/NeighborIsConforming.cpp
@@ -12,6 +12,7 @@
 #include "Domain/Structure/Topology.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 namespace {
 template <size_t VolumeDim>


### PR DESCRIPTION
## Proposed changes

Fix missing includes; this caused linker errors on the `ocean2` cluster, but only when `-DSPECTRE_DEBUG=ON` was passed to `cmake`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
