### PR TITLE
Print ASSERT and ERROR captures at high precision

### DIFF
--- a/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/Utilities/ErrorHandling/AbortWithErrorMessage.cpp
@@ -6,6 +6,7 @@
 #include <boost/stacktrace.hpp>
 #include <charm++.h>
 #include <cstdlib>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -24,6 +25,7 @@ template <bool ShowTrace, typename ExceptionTypeToThrow>
                                                 const char* pretty_function,
                                                 const std::string& message) {
   std::ostringstream os;
+  os.precision(std::numeric_limits<double>::max_digits10 - 1);
   os << "\n"
      << "############ ERROR ############\n";
   if constexpr (ShowTrace) {
@@ -47,6 +49,7 @@ void abort_with_error_message(const char* expression, const char* file,
                               const int line, const char* pretty_function,
                               const std::string& message) {
   std::ostringstream os;
+  os.precision(std::numeric_limits<double>::max_digits10 - 1);
   os << "\n"
      << "############ ASSERT FAILED ############\n"
      << "Stack trace:\n\n"

--- a/tests/Unit/Utilities/ErrorHandling/Test_CaptureForError.cpp
+++ b/tests/Unit/Utilities/ErrorHandling/Test_CaptureForError.cpp
@@ -47,6 +47,12 @@ SPECTRE_TEST_CASE("Unit.ErrorHandling.CaptureForError",
   CHECK_THROWS_WITH([]() { ERROR("Boom"); }(),
                     not Catch::Matchers::ContainsSubstring("another_int"));
 
+  // Check precision
+  const double high_precision = 1.2345678901234;
+  CAPTURE_FOR_ERROR(high_precision);
+  CHECK_THROWS_WITH([]() { ERROR("Boom"); }(),
+                    Catch::Matchers::ContainsSubstring("234567890123"));
+
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       []() { ASSERT(false, "Boom"); }(),


### PR DESCRIPTION
The main message was already set to high-precision in the macros, but other information, most notably the CAPTURE_FOR_ERROR values, was not.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
