### PR TITLE
Allow observation of scalar on Ah

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp
@@ -23,6 +23,9 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
+namespace CurvedScalarWave::Tags {
+struct Psi;
+}
 /// \endcond
 
 namespace ah {
@@ -83,7 +86,8 @@ struct ComputeHorizonVolumeQuantities
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
                  gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>,
                  ::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
-                               Frame::Inertial>>;
+                               Frame::Inertial>,
+                 CurvedScalarWave::Tags::Psi>;
 
   using required_src_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
@@ -95,7 +99,8 @@ struct ComputeHorizonVolumeQuantities
       gr::Tags::InverseSpatialMetric<DataVector, 3, TargetFrame>,
       gr::Tags::ExtrinsicCurvature<DataVector, 3, TargetFrame>,
       gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, TargetFrame>,
-      gr::Tags::SpatialRicci<DataVector, 3, TargetFrame>>;
+      gr::Tags::SpatialRicci<DataVector, 3, TargetFrame>,
+      CurvedScalarWave::Tags::Psi>;
 
   template <typename TargetFrame>
   using allowed_dest_tags = tmpl::remove_duplicates<

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp
@@ -136,6 +136,17 @@ void ComputeHorizonVolumeQuantities::apply(
                           Frame::Inertial>>(src_vars),
         inv_metric);
   }
+
+  if constexpr (tmpl::list_contains_v<DestTagList,
+                                      CurvedScalarWave::Tags::Psi>) {
+    static_assert(
+        tmpl::list_contains_v<SrcTagList, CurvedScalarWave::Tags::Psi>,
+        "If the scalar field Psi is requested, SrcTags must include"
+        " CurvedScalarWave::Psi");
+    const auto& psi_scalar = get<CurvedScalarWave::Tags::Psi>(src_vars);
+    *(get<CurvedScalarWave::Tags::Psi>(target_vars, make_not_null(&buffer))) =
+        psi_scalar;
+  }
 }
 
 /// Dual frame case
@@ -322,6 +333,17 @@ void ComputeHorizonVolumeQuantities::apply(
                                     inertial_spatial_ricci,
                                     jac_target_to_inertial);
     }
+  }
+
+  if constexpr (tmpl::list_contains_v<DestTagList,
+                                      CurvedScalarWave::Tags::Psi>) {
+    static_assert(
+        tmpl::list_contains_v<SrcTagList, CurvedScalarWave::Tags::Psi>,
+        "If the scalar field Psi is requested, SrcTags must include"
+        " CurvedScalarWave::Psi");
+    const auto& psi_scalar = get<CurvedScalarWave::Tags::Psi>(src_vars);
+    *(get<CurvedScalarWave::Tags::Psi>(target_vars, make_not_null(&buffer))) =
+        psi_scalar;
   }
 }
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
@@ -17,6 +17,9 @@ struct Grid;
 struct Inertial;
 }  // namespace Frame
 struct DataVector;
+namespace CurvedScalarWave::Tags {
+struct Psi;
+}
 /// \endcond
 
 namespace ah {
@@ -25,7 +28,8 @@ using source_vars =
     tmpl::list<gr::Tags::SpacetimeMetric<DataVector, Dim>,
                gh::Tags::Pi<DataVector, Dim>, gh::Tags::Phi<DataVector, Dim>,
                ::Tags::deriv<gh::Tags::Phi<DataVector, Dim>, tmpl::size_t<Dim>,
-                             Frame::Inertial>>;
+                             Frame::Inertial>,
+               CurvedScalarWave::Tags::Psi>;
 
 template <size_t Dim, typename Frame>
 using vars_to_interpolate_to_target =
@@ -33,7 +37,8 @@ using vars_to_interpolate_to_target =
                gr::Tags::InverseSpatialMetric<DataVector, Dim, Frame>,
                gr::Tags::ExtrinsicCurvature<DataVector, Dim, Frame>,
                gr::Tags::SpatialChristoffelSecondKind<DataVector, Dim, Frame>,
-               gr::Tags::SpatialRicci<DataVector, Dim, Frame>>;
+               gr::Tags::SpatialRicci<DataVector, Dim, Frame>,
+               CurvedScalarWave::Tags::Psi>;
 
 template <typename Frame>
 using tags_for_observing = tmpl::list<
@@ -42,10 +47,12 @@ using tags_for_observing = tmpl::list<
     ylm::Tags::MaxRicciScalarCompute, ylm::Tags::MinRicciScalarCompute,
     gr::surfaces::Tags::ChristodoulouMassCompute<Frame>,
     gr::surfaces::Tags::DimensionlessSpinMagnitudeCompute<Frame>,
-    gr::surfaces::Tags::DimensionfulSpinVectorCompute<Frame, Frame>
-    >;
+    gr::surfaces::Tags::DimensionfulSpinVectorCompute<Frame, Frame>,
+    gr::surfaces::Tags::SurfaceAverageCompute<CurvedScalarWave::Tags::Psi,
+                                              Frame>>;
 
-using surface_tags_for_observing = tmpl::list<ylm::Tags::RicciScalar>;
+using surface_tags_for_observing =
+    tmpl::list<ylm::Tags::RicciScalar, CurvedScalarWave::Tags::Psi>;
 
 template <size_t Dim, typename Frame>
 using compute_items_on_target = tmpl::append<

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.cpp
@@ -16,11 +16,28 @@ double surface_integral_of_scalar(
   const DataVector integrand = get(area_element) * get(scalar);
   return strahlkorper.ylm_spherepack().definite_integral(integrand.data());
 }
+
+template <typename Frame>
+double surface_average_of_scalar(const Scalar<DataVector>& area_element,
+                                 const Scalar<DataVector>& scalar,
+                                 const ylm::Strahlkorper<Frame>& strahlkorper) {
+  const DataVector integrand = get(area_element) * get(scalar);
+
+  const double surface_integral =
+      strahlkorper.ylm_spherepack().definite_integral(integrand.data());
+  const double surface_area =
+      strahlkorper.ylm_spherepack().definite_integral(get(area_element).data());
+  return surface_integral / surface_area;
+}
 }  // namespace gr::surfaces
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define INSTANTIATE(_, data)                                \
   template double gr::surfaces::surface_integral_of_scalar( \
+      const Scalar<DataVector>& area_element,               \
+      const Scalar<DataVector>& scalar,                     \
+      const ylm::Strahlkorper<FRAME(data)>& strahlkorper);  \
+  template double gr::surfaces::surface_average_of_scalar(  \
       const Scalar<DataVector>& area_element,               \
       const Scalar<DataVector>& scalar,                     \
       const ylm::Strahlkorper<FRAME(data)>& strahlkorper);

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.hpp
@@ -26,4 +26,14 @@ template <typename Frame>
 double surface_integral_of_scalar(const Scalar<DataVector>& area_element,
                                   const Scalar<DataVector>& scalar,
                                   const ylm::Strahlkorper<Frame>& strahlkorper);
+
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Surface average of a scalar on a 2D `Strahlkorper`
+ *
+ */
+template <typename Frame>
+double surface_average_of_scalar(const Scalar<DataVector>& area_element,
+                                 const Scalar<DataVector>& scalar,
+                                 const ylm::Strahlkorper<Frame>& strahlkorper);
 }  // namespace gr::surfaces


### PR DESCRIPTION
## Proposed changes

This is what I've done to interpolate the scalar field at the horizon. However, this implementation breaks things in gh since it adds the `CurvedScalarWave::Tags::Psi` tag to certain lists. 

It seems to me that currently, any extra tags to be interpolated to the horizon (regardless of whether additional spatial gradients in the volume are required) have to go through `ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp`. There is no additional computations needed for the scalar field so maybe it could be avoided.  In the docx of `ComputeHorizonVolumeQuantities`  it even says that "...most computations (e.g. for observers) should be done only on the horizon surface (i.e. after interpolation) as opposed to in the volume; only those computations that require data in the volume (e.g. volume numerical derivatives) should be done here."

I also could not isolate these computations only to the observed Ah (avoiding to do them in the control systems). I tried to do this by passing the relevant source variables to interpolate with template parameter in the apparent horizon aliases (`ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp)` and in the `interpolator_source_vars` in the executable. This fails to compile because of an assert in Events/Interpolate.hpp:
```
    static_assert(
        std::is_same_v<typename Metavariables::interpolator_source_vars,
                       tmpl::list<InterpolatorSourceVarTags...>>);
```

Maybe one isolate such computations to the ScalarTensor system by passing a flag everywhere in the code where such the horizon aliases are used (including control systems)? 

I don't know much about the interpolation infrastructure so any suggestions would be helpful.


<!--
At a high level, describe what this PR does
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
