### PR TITLE
Add Spectral Cartoon instantiations

### DIFF
--- a/src/NumericalAlgorithms/Spectral/BarycentricWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/BarycentricWeights.cpp
@@ -44,6 +44,10 @@ const DataVector& barycentric_weights(const size_t num_points) {
 }
 
 template const DataVector&
+    barycentric_weights<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
+template const DataVector&
+    barycentric_weights<Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
+template const DataVector&
     barycentric_weights<Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const DataVector&
     barycentric_weights<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   BoundaryInterpolationMatrices.cpp
   BoundaryInterpolationTerm.cpp
   BoundaryLiftingTerm.cpp
+  Cartoon.cpp
   Chebyshev.cpp
   CollocationPoints.cpp
   CollocationPointsAndWeights.cpp

--- a/src/NumericalAlgorithms/Spectral/Cartoon.cpp
+++ b/src/NumericalAlgorithms/Spectral/Cartoon.cpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionNormalizationSquare.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
+#include "NumericalAlgorithms/Spectral/InverseWeightFunctionValues.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace Spectral {
+
+// There should be no calls to Cartoon basis functions, will error
+// These functions specialize the templates declared in `Spectral.hpp`.
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif
+
+template <>
+DataVector compute_basis_function_value<Basis::Cartoon>(
+    const size_t /*k*/, const DataVector& /*x*/) {
+  ERROR("Invalid to compute a basis on a Cartoon basis.");
+}
+
+template <>
+double compute_basis_function_value<Basis::Cartoon>(const size_t /*k*/,
+                                                    const double& /*x*/) {
+  ERROR("Invalid to compute a basis on a Cartoon basis.");
+}
+
+template <>
+DataVector compute_inverse_weight_function_values<Basis::Cartoon>(
+    const DataVector& /*x*/) {
+  ERROR("Invalid to compute weights on a Cartoon basis.");
+}
+
+template <>
+double compute_basis_function_normalization_square<Basis::Cartoon>(
+    const size_t /*k*/) {
+  ERROR("Invalid to compute weights on a Cartoon basis.");
+}
+
+template <>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
+    Basis::Cartoon, Quadrature::AxialSymmetry>(const size_t /*num_points*/) {
+  ERROR(
+      "Invalid to compute collocation points and weights for a Cartoon "
+      "basis.");
+}
+
+template <>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
+    Basis::Cartoon, Quadrature::SphericalSymmetry>(
+    const size_t /*num_points*/) {
+  ERROR(
+      "Invalid to compute collocation points and weights for a Cartoon "
+      "basis.");
+}
+
+template <Basis BasisTYpe>
+Matrix spectral_indefinite_integral_matrix(size_t num_points);
+
+template <>
+Matrix spectral_indefinite_integral_matrix<Basis::Cartoon>(
+    const size_t /*num_points*/) {
+  ERROR(
+      "Invalid to compute a spectral indefinite integral matrix for  a"
+      "Cartoon basis.");
+}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
@@ -30,6 +30,10 @@ SPECTRAL_QUANTITY_FOR_MESH(collocation_points, DataVector)
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
 template const DataVector&
+    collocation_points<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
+template const DataVector&
+    collocation_points<Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
+template const DataVector&
     collocation_points<Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const DataVector&
     collocation_points<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);

--- a/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
@@ -19,6 +19,10 @@ CollocationPointsAndWeightsGenerator<BasisType, QuadratureType>::operator()(
       num_points);
 }
 
+template struct CollocationPointsAndWeightsGenerator<Basis::Cartoon,
+                                                     Quadrature::AxialSymmetry>;
+template struct CollocationPointsAndWeightsGenerator<
+    Basis::Cartoon, Quadrature::SphericalSymmetry>;
 template struct CollocationPointsAndWeightsGenerator<Basis::Chebyshev,
                                                      Quadrature::Gauss>;
 template struct CollocationPointsAndWeightsGenerator<Basis::Chebyshev,

--- a/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.cpp
@@ -411,6 +411,10 @@ SPECTRAL_QUANTITY_FOR_MESH(weak_flux_differentiation_matrix, Matrix)
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
 template const Matrix&
+    differentiation_matrix<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
+template const Matrix& differentiation_matrix<
+    Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
+template const Matrix&
     differentiation_matrix<Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const Matrix&
     differentiation_matrix<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);

--- a/src/NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp
+++ b/src/NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -24,7 +25,13 @@ constexpr size_t minimum_number_of_points(const Basis /*basis*/,
     // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (quadrature == Quadrature::FaceCentered) {
     return 2;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (quadrature == Quadrature::Equiangular) {
+    return 1;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+  } else if (quadrature == Quadrature::AxialSymmetry) {
+    return 1;
+  } else if (quadrature == Quadrature::SphericalSymmetry) {
     return 1;
   }
   return std::numeric_limits<size_t>::max();

--- a/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
@@ -49,6 +49,10 @@ SPECTRAL_QUANTITY_FOR_MESH(modal_to_nodal_matrix, Matrix)
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
 template const Matrix&
+    modal_to_nodal_matrix<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
+template const Matrix& modal_to_nodal_matrix<
+    Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
+template const Matrix&
     modal_to_nodal_matrix<Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const Matrix&
     modal_to_nodal_matrix<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);

--- a/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
@@ -67,6 +67,10 @@ SPECTRAL_QUANTITY_FOR_MESH(nodal_to_modal_matrix, Matrix)
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
 template const Matrix&
+    nodal_to_modal_matrix<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
+template const Matrix& nodal_to_modal_matrix<
+    Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
+template const Matrix&
     nodal_to_modal_matrix<Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const Matrix&
     nodal_to_modal_matrix<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);

--- a/src/NumericalAlgorithms/Spectral/QuadratureWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/QuadratureWeights.cpp
@@ -41,6 +41,10 @@ SPECTRAL_QUANTITY_FOR_MESH(quadrature_weights, DataVector)
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
 template const DataVector&
+    quadrature_weights<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
+template const DataVector&
+    quadrature_weights<Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
+template const DataVector&
     quadrature_weights<Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const DataVector&
     quadrature_weights<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY "Test_Spectral")
 
 set(LIBRARY_SOURCES
   Test_Basis.cpp
+  Test_Cartoon.cpp
   Test_ChebyshevGauss.cpp
   Test_ChebyshevGaussLobatto.cpp
   Test_Clenshaw.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Cartoon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Cartoon.cpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/QuadratureWeights.hpp"
+
+// The Basis::Cartoon should never be called to generate collocation points or
+// weights, so it errors on everything
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.Spectral.CartoonAxialSymmetry.PointsAndWeights",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::collocation_points<Spectral::Basis::Cartoon,
+                                    Spectral::Quadrature::AxialSymmetry>(1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+  CHECK_THROWS_WITH(
+      (Spectral::quadrature_weights<Spectral::Basis::Cartoon,
+                                    Spectral::Quadrature::AxialSymmetry>(1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.CartoonAxialSymmetry.DiffMatrix",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::differentiation_matrix<
+          Spectral::Basis::Cartoon, Spectral::Quadrature::AxialSymmetry>(1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.CartoonAxialSymmetry.ModalToNodal",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::modal_to_nodal_matrix<Spectral::Basis::Cartoon,
+                                       Spectral::Quadrature::AxialSymmetry>(1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.CartoonAxialSymmetry.NodalToModal",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::nodal_to_modal_matrix<Spectral::Basis::Cartoon,
+                                       Spectral::Quadrature::AxialSymmetry>(1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.Spectral.CartoonSphericalSymmetry.PointsAndWeights",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::collocation_points<Spectral::Basis::Cartoon,
+                                    Spectral::Quadrature::SphericalSymmetry>(
+          1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+  CHECK_THROWS_WITH(
+      (Spectral::quadrature_weights<Spectral::Basis::Cartoon,
+                                    Spectral::Quadrature::SphericalSymmetry>(
+          1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.CartoonSphericalSymmetry.DiffMatrix",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::differentiation_matrix<
+          Spectral::Basis::Cartoon, Spectral::Quadrature::SphericalSymmetry>(
+          1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.Spectral.CartoonSphericalSymmetry.ModalToNodal",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::modal_to_nodal_matrix<Spectral::Basis::Cartoon,
+                                       Spectral::Quadrature::SphericalSymmetry>(
+          1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.Spectral.CartoonSphericalSymmetry.NodalToModal",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK_THROWS_WITH(
+      (Spectral::nodal_to_modal_matrix<Spectral::Basis::Cartoon,
+                                       Spectral::Quadrature::SphericalSymmetry>(
+          1)),
+      Catch::Matchers::ContainsSubstring(
+          "Invalid to compute collocation points and weights for a Cartoon "
+          "basis."));
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This instantiates the `Cartoon` Basis choice (with either `AxialSymmetry` or `SphericalSymmetry` Quadrature) within the relevant functions in the `/NumericalAlgorithms/Spectral/` directory that use collocation points / weights. As these quadratures are never used in the computation, any calls to their potential values error.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
