### PR TITLE
Add polar to cartesian coordinate map

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -30,6 +30,7 @@ spectre_target_sources(
   Identity.cpp
   Interval.cpp
   KerrHorizonConforming.cpp
+  PolarToCartesian.cpp
   Rotation.cpp
   SpecialMobius.cpp
   SphericalToCartesianPfaffian.cpp
@@ -69,6 +70,7 @@ spectre_target_headers(
   Interval.hpp
   KerrHorizonConforming.hpp
   MapInstantiationMacros.hpp
+  PolarToCartesian.hpp
   ProductMaps.hpp
   ProductMaps.tpp
   Rotation.hpp

--- a/src/Domain/CoordinateMaps/PolarToCartesian.cpp
+++ b/src/Domain/CoordinateMaps/PolarToCartesian.cpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/PolarToCartesian.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace domain::CoordinateMaps {
+PolarToCartesian::PolarToCartesian() = default;
+PolarToCartesian::PolarToCartesian(PolarToCartesian&&) = default;
+PolarToCartesian::PolarToCartesian(const PolarToCartesian&) = default;
+PolarToCartesian& PolarToCartesian::operator=(const PolarToCartesian&) =
+    default;
+PolarToCartesian& PolarToCartesian::operator=(PolarToCartesian&&) = default;
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 2> PolarToCartesian::operator()(
+    const std::array<T, 2>& source_coords) const {
+  const auto& [r, phi] = source_coords;
+  return {{r * cos(phi), r * sin(phi)}};
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::optional<std::array<double, 2>> PolarToCartesian::inverse(
+    const std::array<double, 2>& target_coords) const {
+  const auto& [x, y] = target_coords;
+  if (UNLIKELY(y == 0.0 and x == 0.0)) {
+    return std::array{0.0, 0.0};
+  } else {
+    const double r = std::hypot(x, y);
+    const double phi = atan2(y, x);
+    return std::array{r, phi < 0.0 ? phi + 2.0 * M_PI : phi};
+  }
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame>
+PolarToCartesian::jacobian(const std::array<T, 2>& source_coords) const {
+  const auto& [r, phi] = source_coords;
+  using DataType = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<DataType, 2, Frame::NoFrame> jacobian_matrix{
+      make_with_value<DataType>(dereference_wrapper(r), 0.0)};
+  const auto& cos_phi = get<0, 0>(jacobian_matrix) = cos(phi);
+  const auto& sin_phi = get<1, 0>(jacobian_matrix) = sin(phi);
+  get<0, 1>(jacobian_matrix) = -r * sin_phi;
+  get<1, 1>(jacobian_matrix) = r * cos_phi;
+  return jacobian_matrix;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame>
+PolarToCartesian::inv_jacobian(const std::array<T, 2>& source_coords) const {
+  const auto& [r, phi] = source_coords;
+  using DataType = tt::remove_cvref_wrap_t<T>;
+  tnsr::Ij<DataType, 2, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<DataType>(dereference_wrapper(r), 0.0)};
+  const auto& cos_phi = get<0, 0>(inv_jacobian_matrix) = cos(phi);
+  const auto& sin_phi = get<0, 1>(inv_jacobian_matrix) = sin(phi);
+  const auto& one_over_r = get<1, 1>(inv_jacobian_matrix) = 1.0 / r;
+  get<1, 0>(inv_jacobian_matrix) = -one_over_r * sin_phi;
+  get<1, 1>(inv_jacobian_matrix) *= cos_phi;
+  return inv_jacobian_matrix;
+}
+
+void PolarToCartesian::pup(PUP::er& /*p*/) {}
+
+bool operator==(const PolarToCartesian& /*lhs*/,
+                const PolarToCartesian& /*rhs*/) {
+  return true;
+}
+
+bool operator!=(const PolarToCartesian& lhs, const PolarToCartesian& rhs) {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE_DTYPE(_, data)                                            \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 2>                \
+  PolarToCartesian::operator()(                                               \
+      const std::array<DTYPE(data), 2>& source_coords) const;                 \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 2, Frame::NoFrame>  \
+  PolarToCartesian::jacobian(const std::array<DTYPE(data), 2>& source_coords) \
+      const;                                                                  \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 2, Frame::NoFrame>  \
+  PolarToCartesian::inv_jacobian(                                             \
+      const std::array<DTYPE(data), 2>& source_coords) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE,
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/PolarToCartesian.hpp
+++ b/src/Domain/CoordinateMaps/PolarToCartesian.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Transformation from polar to Cartesian coordinates.
+ *
+ * \details This is a mapping from \f$(r,\phi) \rightarrow (x,y) \f$.
+ *
+ * The formula for the mapping is...
+ * \f{eqnarray*}
+ *     x &=& r \cos\phi \\
+ *     y &=& r \sin\phi
+ * \f}
+ */
+class PolarToCartesian {
+ public:
+  static constexpr size_t dim = 2;
+  PolarToCartesian();
+  ~PolarToCartesian() = default;
+  PolarToCartesian(PolarToCartesian&&);
+  PolarToCartesian(const PolarToCartesian&);
+  PolarToCartesian& operator=(const PolarToCartesian&);
+  PolarToCartesian& operator=(PolarToCartesian&&);
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
+      const std::array<T, 2>& source_coords) const;
+
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+  std::optional<std::array<double, 2>> inverse(
+      const std::array<double, 2>& target_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian(
+      const std::array<T, 2>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 2>& source_coords) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  static constexpr bool is_identity() { return false; }
+};
+
+bool operator==(const PolarToCartesian& lhs, const PolarToCartesian& rhs);
+
+bool operator!=(const PolarToCartesian& lhs, const PolarToCartesian& rhs);
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/SphericalToCartesianPfaffian.cpp
+++ b/src/Domain/CoordinateMaps/SphericalToCartesianPfaffian.cpp
@@ -45,8 +45,8 @@ std::optional<std::array<double, 3>> SphericalToCartesianPfaffian::inverse(
     }
   } else {
     const double r = std::hypot(x, y, z);
-    return std::array{r, acos(z / r),
-                      x > 0.0 ? atan2(y, x) : atan2(y, x) + 2.0 * M_PI};
+    const double phi = atan2(y, x);
+    return std::array{r, acos(z / r), phi < 0.0 ? phi + 2.0 * M_PI : phi};
   }
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_Identity.cpp
   Test_Interval.cpp
   Test_KerrHorizonConforming.cpp
+  Test_PolarToCartesian.cpp
   Test_ProductMaps.cpp
   Test_Rotation.cpp
   Test_SpecialMobius.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_PolarToCartesian.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_PolarToCartesian.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/PolarToCartesian.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace domain {
+namespace {
+void test_map_at_point(const CoordinateMaps::PolarToCartesian& map,
+                       const std::array<double, 2>& source_point,
+                       const std::array<double, 2>& target_point) {
+  test_inverse_map(map, source_point);
+  if (source_point != std::array{0.0, 0.0}) {  // inv jac singular at origin
+    test_coordinate_map_argument_types(map, source_point);
+    test_inv_jacobian(map, source_point);
+  }
+  CAPTURE(source_point);
+  CAPTURE(target_point);
+  CHECK_ITERABLE_APPROX(map(source_point), target_point);
+  CHECK_ITERABLE_APPROX(map.inverse(target_point).value(), source_point);
+}
+
+void test_map(const CoordinateMaps::PolarToCartesian& map) {
+  CHECK(not map.is_identity());
+  CHECK_FALSE(map != map);
+  test_serialization(map);
+  test_map_at_point(map, {{0.0, 0.0}}, {{0.0, 0.0}});
+  test_map_at_point(map, {{1.0, 0.0}}, {{1.0, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_4}}, {{M_SQRT1_2, M_SQRT1_2}});
+  test_map_at_point(map, {{1.0, M_PI_2}}, {{0.0, 1.0}});
+  test_map_at_point(map, {{1.0, 3.0 * M_PI_4}}, {{-M_SQRT1_2, M_SQRT1_2}});
+  test_map_at_point(map, {{1.0, M_PI}}, {{-1.0, 0.0}});
+  test_map_at_point(map, {{1.0, 5.0 * M_PI_4}}, {{-M_SQRT1_2, -M_SQRT1_2}});
+  test_map_at_point(map, {{1.0, 3.0 * M_PI_2}}, {{0.0, -1.0}});
+  test_map_at_point(map, {{1.0, 7.0 * M_PI_4}}, {{M_SQRT1_2, -M_SQRT1_2}});
+  test_map_at_point(map, {{1.0, M_PI}}, {{-1.0, std::copysign(0.0, -1.0)}});
+}
+
+void test() {
+  const CoordinateMaps::PolarToCartesian original_map{};
+  test_map(original_map);
+  const auto serialized_map = serialize_and_deserialize(original_map);
+  test_map(serialized_map);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.PolarToCartesian",
+                  "[Domain][Unit]") {
+  test();
+}
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_SphericalToCartesianPfaffian.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SphericalToCartesianPfaffian.cpp
@@ -43,6 +43,21 @@ void test_map(const CoordinateMaps::SphericalToCartesianPfaffian& map) {
   const std::array<double, 3> source_south_pole{{0.25, M_PI, 0.0}};
   const std::array<double, 3> target_south_pole{{0.0, 0.0, -0.25}};
   test_map_at_point(map, source_south_pole, target_south_pole);
+  test_map_at_point(map, {{0.0, M_PI_2, 0.0}}, {{0.0, 0.0, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, 0.0}}, {{1.0, 0.0, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, M_PI_4}},
+                    {{M_SQRT1_2, M_SQRT1_2, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, M_PI_2}}, {{0.0, 1.0, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, 3.0 * M_PI_4}},
+                    {{-M_SQRT1_2, M_SQRT1_2, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, M_PI}}, {{-1.0, 0.0, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, 5.0 * M_PI_4}},
+                    {{-M_SQRT1_2, -M_SQRT1_2, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, 3.0 * M_PI_2}}, {{0.0, -1.0, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, 7.0 * M_PI_4}},
+                    {{M_SQRT1_2, -M_SQRT1_2, 0.0}});
+  test_map_at_point(map, {{1.0, M_PI_2, M_PI}},
+                    {{-1.0, std::copysign(0.0, -1.0), 0.0}});
   const Mesh<3> mesh{
       {5, 3, 5},
       {Spectral::Basis::Legendre, Spectral::Basis::SphericalHarmonic,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
@@ -10,6 +10,7 @@
 #include "Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp"
 #include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
 
+// [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.PpaoPrim",
                   "[Unit][Evolution]") {
   namespace helpers = TestHelpers::grmhd::ValenciaDivClean::fd;


### PR DESCRIPTION
## Proposed changes

Adds a polar to cartesian coordinate map.  This will be needed for annuli, disks, cylindrical shells, and cylinders that use topologies S1 or B2.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
