### PR TITLE
Improve numerical precision when constraining BBH ID spins

### DIFF
--- a/support/Pipelines/Bbh/ControlId.py
+++ b/support/Pipelines/Bbh/ControlId.py
@@ -422,7 +422,7 @@ def control_id(
                 param == "DimensionlessSpinA" or param == "DimensionlessSpinB"
             ) and np.linalg.norm((u + Delta_u)[index : index + 3]) > 1.0:
                 # Solve for alpha in a*alpha^2 + b*alpha + c = 0, which comes
-                # from enforcing ||u + alpha * Delta_u|| = 1 - epsilon
+                # from enforcing (u + alpha * Delta_u)^2 = 1 - epsilon
                 epsilon = 1.0e-14
                 a = np.dot(
                     Delta_u[index : index + 3], Delta_u[index : index + 3]
@@ -443,7 +443,10 @@ def control_id(
                         " doesn't violate the spin constraint."
                     )
                 else:
-                    alpha = (-b + np.sqrt(discriminant)) / (2 * a)
+                    if b < 0:
+                        alpha = (-b + np.sqrt(discriminant)) / (2 * a)
+                    else:
+                        alpha = (2 * c) / (-b - np.sqrt(discriminant))
                     prev_spin = np.linalg.norm((u + Delta_u)[index : index + 3])
                     Delta_u[index : index + 3] *= alpha
                     new_spin = np.linalg.norm((u + Delta_u)[index : index + 3])


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds a more numerically precise solution of the quadratic equation that constrains BBH ID conformal spins to magnitudes < 1.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
