### PR TITLE
some necessary changes for building on frontera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,22 +75,27 @@ include(SpectreSetSiteName)
 
 # We need Python in the build system and throughout the code. Setting it up
 # early so we can rely on a consistent Python version in the build system.
-find_package(Python 3.8 REQUIRED)
-
-# Define the location of Python code in the build directory. Unit tests etc. can
-# add this location to their `PYTHONPATH`.
-set(SPECTRE_PYTHON_PREFIX_PARENT "${CMAKE_BINARY_DIR}/bin/python")
-get_filename_component(
-  SPECTRE_PYTHON_PREFIX_PARENT "${SPECTRE_PYTHON_PREFIX_PARENT}" ABSOLUTE)
-set(SPECTRE_PYTHON_SITE_PACKAGES "${CMAKE_BINARY_DIR}/lib/\
+option(ENABLE_PYTHON "Enable Python" ON)
+if (ENABLE_PYTHON)
+  find_package(Python 3.8 REQUIRED)
+  # Define the location of Python code in the build directory. Unit tests etc. can
+  # add this location to their `PYTHONPATH`.
+  set(SPECTRE_PYTHON_PREFIX_PARENT "${CMAKE_BINARY_DIR}/bin/python")
+  get_filename_component(
+    SPECTRE_PYTHON_PREFIX_PARENT "${SPECTRE_PYTHON_PREFIX_PARENT}" ABSOLUTE)
+  set(SPECTRE_PYTHON_SITE_PACKAGES "${CMAKE_BINARY_DIR}/lib/\
 python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
-set(PYTHONPATH "${SPECTRE_PYTHON_PREFIX_PARENT}:\
+  set(PYTHONPATH "${SPECTRE_PYTHON_PREFIX_PARENT}:\
 ${SPECTRE_PYTHON_SITE_PACKAGES}")
-if(DEFINED ENV{PYTHONPATH})
-  set(PYTHONPATH "${PYTHONPATH}:$ENV{PYTHONPATH}")
+  if(DEFINED ENV{PYTHONPATH})
+    set(PYTHONPATH "${PYTHONPATH}:$ENV{PYTHONPATH}")
+  endif()
+  message(STATUS "PYTHONPATH: ${PYTHONPATH}")
+  include(BootstrapPyDeps)
+else()
+  # We still need minimal Python for linking purpose.
+  find_package(Python REQUIRED)
 endif()
-message(STATUS "PYTHONPATH: ${PYTHONPATH}")
-include(BootstrapPyDeps)
 
 option(BUILD_DOCS "Enable building documentation" ON)
 option(

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -1,120 +1,121 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-spectre_define_test_timeout_factor_option(PYTHON "Python")
+if (ENABLE_PYTHON)
+  spectre_define_test_timeout_factor_option(PYTHON "Python")
 
-option(PY_DEV_MODE "Enable development mode for the Python package, meaning \
-that Python files are symlinked rather than copied to the build directory" OFF)
-function(configure_or_symlink_py_file SOURCE_FILE TARGET_FILE)
-  if(PY_DEV_MODE)
-    get_filename_component(_TARGET_FILE_DIR ${TARGET_FILE} DIRECTORY)
-    execute_process(COMMAND
-      ${CMAKE_COMMAND} -E make_directory ${_TARGET_FILE_DIR})
-    execute_process(COMMAND
-      ${CMAKE_COMMAND} -E create_symlink ${SOURCE_FILE} ${TARGET_FILE})
-  else()
-    configure_file(${SOURCE_FILE} ${TARGET_FILE} @ONLY)
-  endif()
-endfunction()
+  option(PY_DEV_MODE "Enable development mode for the Python package, meaning \
+  that Python files are symlinked rather than copied to the build directory" OFF)
+  function(configure_or_symlink_py_file SOURCE_FILE TARGET_FILE)
+    if(PY_DEV_MODE)
+      get_filename_component(_TARGET_FILE_DIR ${TARGET_FILE} DIRECTORY)
+      execute_process(COMMAND
+        ${CMAKE_COMMAND} -E make_directory ${_TARGET_FILE_DIR})
+      execute_process(COMMAND
+        ${CMAKE_COMMAND} -E create_symlink ${SOURCE_FILE} ${TARGET_FILE})
+    else()
+      configure_file(${SOURCE_FILE} ${TARGET_FILE} @ONLY)
+    endif()
+  endfunction()
 
-set(SPECTRE_PYTHON_PREFIX "${SPECTRE_PYTHON_PREFIX_PARENT}/spectre")
+  set(SPECTRE_PYTHON_PREFIX "${SPECTRE_PYTHON_PREFIX_PARENT}/spectre")
 
-# Create the root __init__.py file
-configure_or_symlink_py_file(
-  "${CMAKE_SOURCE_DIR}/support/Python/__init__.py"
-  "${SPECTRE_PYTHON_PREFIX}/__init__.py"
-)
-
-# Create the root __main__.py entry point
-configure_or_symlink_py_file(
-  "${CMAKE_SOURCE_DIR}/support/Python/__main__.py"
-  "${SPECTRE_PYTHON_PREFIX}/__main__.py"
-)
-# Also link the main entry point to bin/
-set(PYTHON_EXE_COMMAND "-m spectre")
-set(PYTHON_EXEC_ENV_VARS "")
-# At some point we needed to preload jemalloc for the Python bindings to work,
-# otherwise we got "cannot allocate memory in static TLS block" errors when
-# using jemalloc. This is fixed by avoiding to link jemalloc into libraries in
-# the first place (we only dynamically link it into executables). If we want to
-# link jemalloc into libraries again (e.g. to use jemalloc features explicitly
-# in the code), the best way to do this would be to build jemalloc with a prefix
-# and use it as a custom allocator where needed, instead of generically
-# replacing the system allocator.
-#
-# ParaView needs specific environment variables set, e.g. 'LD_LIBRARY_PATH', but
-# they can interfere with simulations, e.g. when they point to ParaView's
-# bundled MPI which may be different to the MPI we built with. Therefore we
-# disable this for now. This means we can't use the pre-built ParaView binaries
-# that bundle their own MPI and Python, unless we find a way to set the needed
-# environment variables only when running ParaView. Everything should work
-# when using a ParaView built with the same MPI and Python as the rest of
-# SpECTRE.
-# if(PARAVIEW_PYTHON_ENV_VARS)
-#   string(APPEND PYTHON_EXEC_ENV_VARS " ${PARAVIEW_PYTHON_ENV_VARS}")
-# endif()
-configure_file(
-  "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
-  "${CMAKE_BINARY_DIR}/tmp/spectre")
-file(COPY "${CMAKE_BINARY_DIR}/tmp/spectre"
-  DESTINATION "${CMAKE_BINARY_DIR}/bin"
-  FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
-    GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-
-# Also link the Python interpreter to bin/python-spectre as an easy way to jump
-# into a Python shell or run a script that uses pybindings
-set(PYTHON_EXE_COMMAND "")
-configure_file(
-  "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
-  "${CMAKE_BINARY_DIR}/tmp/python-spectre")
-file(COPY "${CMAKE_BINARY_DIR}/tmp/python-spectre"
-  DESTINATION "${CMAKE_BINARY_DIR}/bin"
-  FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
-    GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-
-# Write configuration files for installing the Python modules
-file(STRINGS
-  ${CMAKE_SOURCE_DIR}/support/Python/requirements.txt
-  SPECTRE_PY_DEPS)
-file(STRINGS
-  ${CMAKE_SOURCE_DIR}/support/Python/dev_requirements.txt
-  SPECTRE_PY_DEV_DEPS)
-list(FILTER SPECTRE_PY_DEPS EXCLUDE REGEX "^#")
-list(FILTER SPECTRE_PY_DEV_DEPS EXCLUDE REGEX "^#")
-list(REMOVE_ITEM SPECTRE_PY_DEPS "")
-list(REMOVE_ITEM SPECTRE_PY_DEV_DEPS "")
-list(JOIN SPECTRE_PY_DEPS "\n    " SPECTRE_PY_DEPS_OUTPUT)
-list(JOIN SPECTRE_PY_DEV_DEPS "\n    " SPECTRE_PY_DEV_DEPS_OUTPUT)
-configure_or_symlink_py_file(
-  "${CMAKE_SOURCE_DIR}/pyproject.toml"
-  "${SPECTRE_PYTHON_PREFIX_PARENT}/pyproject.toml")
-configure_or_symlink_py_file(
-  "${CMAKE_SOURCE_DIR}/setup.cfg"
-  "${SPECTRE_PYTHON_PREFIX_PARENT}/setup.cfg")
-
-# Write a file to be able to set up the new python path.
-file(WRITE
-  "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"
-  "#!/bin/sh\n"
-  "export PYTHONPATH=${PYTHONPATH}\n"
-  )
-configure_file(
-  "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"
-  "${CMAKE_BINARY_DIR}/bin/LoadPython.sh")
-
-# Install the SpECTRE Python package to the CMAKE_INSTALL_PREFIX, using pip.
-# This will install the package into the expected subdirectory, typically
-# `lib/pythonX.Y/site-packages/`. It also creates symlinks to entry points
-# specified in `setup.py`.
-install(
-  CODE "execute_process(\
-    COMMAND ${Python_EXECUTABLE} -m pip install \
-      --no-deps --no-input --no-cache-dir --no-index --ignore-installed \
-      --disable-pip-version-check --no-build-isolation \
-      --prefix ${CMAKE_INSTALL_PREFIX} ${SPECTRE_PYTHON_PREFIX_PARENT} \
-    )"
+  # Create the root __init__.py file
+  configure_or_symlink_py_file(
+    "${CMAKE_SOURCE_DIR}/support/Python/__init__.py"
+    "${SPECTRE_PYTHON_PREFIX}/__init__.py"
   )
 
+  # Create the root __main__.py entry point
+  configure_or_symlink_py_file(
+    "${CMAKE_SOURCE_DIR}/support/Python/__main__.py"
+    "${SPECTRE_PYTHON_PREFIX}/__main__.py"
+  )
+  # Also link the main entry point to bin/
+  set(PYTHON_EXE_COMMAND "-m spectre")
+  set(PYTHON_EXEC_ENV_VARS "")
+  # At some point we needed to preload jemalloc for the Python bindings to work,
+  # otherwise we got "cannot allocate memory in static TLS block" errors when
+  # using jemalloc. This is fixed by avoiding to link jemalloc into libraries in
+  # the first place (we only dynamically link it into executables). If we want to
+  # link jemalloc into libraries again (e.g. to use jemalloc features explicitly
+  # in the code), the best way to do this would be to build jemalloc with a prefix
+  # and use it as a custom allocator where needed, instead of generically
+  # replacing the system allocator.
+  #
+  # ParaView needs specific environment variables set, e.g. 'LD_LIBRARY_PATH', but
+  # they can interfere with simulations, e.g. when they point to ParaView's
+  # bundled MPI which may be different to the MPI we built with. Therefore we
+  # disable this for now. This means we can't use the pre-built ParaView binaries
+  # that bundle their own MPI and Python, unless we find a way to set the needed
+  # environment variables only when running ParaView. Everything should work
+  # when using a ParaView built with the same MPI and Python as the rest of
+  # SpECTRE.
+  # if(PARAVIEW_PYTHON_ENV_VARS)
+  #   string(APPEND PYTHON_EXEC_ENV_VARS " ${PARAVIEW_PYTHON_ENV_VARS}")
+  # endif()
+  configure_file(
+    "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
+    "${CMAKE_BINARY_DIR}/tmp/spectre")
+  file(COPY "${CMAKE_BINARY_DIR}/tmp/spectre"
+    DESTINATION "${CMAKE_BINARY_DIR}/bin"
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
+      GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+  # Also link the Python interpreter to bin/python-spectre as an easy way to jump
+  # into a Python shell or run a script that uses pybindings
+  set(PYTHON_EXE_COMMAND "")
+  configure_file(
+    "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
+    "${CMAKE_BINARY_DIR}/tmp/python-spectre")
+  file(COPY "${CMAKE_BINARY_DIR}/tmp/python-spectre"
+    DESTINATION "${CMAKE_BINARY_DIR}/bin"
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
+      GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+  # Write configuration files for installing the Python modules
+  file(STRINGS
+    ${CMAKE_SOURCE_DIR}/support/Python/requirements.txt
+    SPECTRE_PY_DEPS)
+  file(STRINGS
+    ${CMAKE_SOURCE_DIR}/support/Python/dev_requirements.txt
+    SPECTRE_PY_DEV_DEPS)
+  list(FILTER SPECTRE_PY_DEPS EXCLUDE REGEX "^#")
+  list(FILTER SPECTRE_PY_DEV_DEPS EXCLUDE REGEX "^#")
+  list(REMOVE_ITEM SPECTRE_PY_DEPS "")
+  list(REMOVE_ITEM SPECTRE_PY_DEV_DEPS "")
+  list(JOIN SPECTRE_PY_DEPS "\n    " SPECTRE_PY_DEPS_OUTPUT)
+  list(JOIN SPECTRE_PY_DEV_DEPS "\n    " SPECTRE_PY_DEV_DEPS_OUTPUT)
+  configure_or_symlink_py_file(
+    "${CMAKE_SOURCE_DIR}/pyproject.toml"
+    "${SPECTRE_PYTHON_PREFIX_PARENT}/pyproject.toml")
+  configure_or_symlink_py_file(
+    "${CMAKE_SOURCE_DIR}/setup.cfg"
+    "${SPECTRE_PYTHON_PREFIX_PARENT}/setup.cfg")
+
+  # Write a file to be able to set up the new python path.
+  file(WRITE
+    "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"
+    "#!/bin/sh\n"
+    "export PYTHONPATH=${PYTHONPATH}\n"
+    )
+  configure_file(
+    "${CMAKE_BINARY_DIR}/tmp/LoadPython.sh"
+    "${CMAKE_BINARY_DIR}/bin/LoadPython.sh")
+
+  # Install the SpECTRE Python package to the CMAKE_INSTALL_PREFIX, using pip.
+  # This will install the package into the expected subdirectory, typically
+  # `lib/pythonX.Y/site-packages/`. It also creates symlinks to entry points
+  # specified in `setup.py`.
+  install(
+    CODE "execute_process(\
+      COMMAND ${Python_EXECUTABLE} -m pip install \
+        --no-deps --no-input --no-cache-dir --no-index --ignore-installed \
+        --disable-pip-version-check --no-build-isolation \
+        --prefix ${CMAKE_INSTALL_PREFIX} ${SPECTRE_PYTHON_PREFIX_PARENT} \
+      )"
+    )
+endif()
 add_custom_target(all-pybindings)
 
 # Add a python module, either with or without python bindings and with
@@ -137,6 +138,9 @@ add_custom_target(all-pybindings)
 #                 ${CMAKE_SOURCE_DIR}/src) to add to the module. Omit if
 #                 no python files are to be provided.
 function(SPECTRE_PYTHON_ADD_MODULE MODULE_NAME)
+  if (NOT ENABLE_PYTHON)
+    return()
+  endif()
   set(SINGLE_VALUE_ARGS MODULE_PATH LIBRARY_NAME)
   set(MULTI_VALUE_ARGS SOURCES PYTHON_FILES)
   cmake_parse_arguments(

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -143,6 +143,13 @@ alphabetical order):
 - ENABLE_PROFILING
   - Enables various options to make profiling SpECTRE easier
     (default is `OFF`)
+- ENABLE_PYTHON
+  - Enables Python. (default is `ON`)
+  - Set to `OFF` for a minimal build on systems without a recent Python
+    installation. Warning: Many things will not work!!
+  - Note: Even when disabled, a minimal Python installation
+    (Python ≥ 2.7) is still required.
+  - BUILD_PYTHON_BINDINGS, BUILD_TESTING, BUILD_DOCS should be `OFF`.
 - ENABLE_WARNINGS
   - Whether or not warning flags are enabled (default is `ON`)
 - FUKA_ROOT

--- a/support/Environments/frontera_gcc.sh
+++ b/support/Environments/frontera_gcc.sh
@@ -7,21 +7,23 @@
 spectre_load_sys_modules() {
     # impi is loaded, which it should be by default
     # but explicitly load it in just in case
-    module load impi/19.0.9
-    module load gcc/9.1.0
-    module load mkl/19.0.5
+    module load gcc/13.2.0
+    module load impi
+    module load mkl
     module load gsl
     module load hdf5
     module load boost
+    module load cmake/3.24.2
 }
 
 # Unload system modules
 spectre_unload_sys_modules() {
+    module unload cmake
     module unload boost
     module unload hdf5
     module unload gsl
-    module unload mkl/19.0.5
-    module unload gcc/9.1.0
+    module unload mkl
+    module unload gcc/13.2.0
     # Don't unload impi as this is one of the default system modules
 }
 
@@ -48,7 +50,6 @@ spectre_unload_modules() {
     module unload spectre_boost
     module unload libxsmm
     module unload libsharp
-    module unload catch
     module unload brigand
     module unload blaze
 
@@ -60,7 +61,6 @@ spectre_load_modules() {
 
     module load blaze
     module load brigand
-    module load catch
     module load libsharp
     module load libxsmm
     module load spectre_boost
@@ -76,14 +76,16 @@ spectre_run_cmake() {
     fi
     spectre_load_modules
     # -D USE_LD=ld - ld.gold seems to hang linking the main executables
+    # no functioning Python 3.8 with newer gcc version
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D MEMORY_ALLOCATOR=SYSTEM \
-          -D BUILD_PYTHON_BINDINGS=ON \
-          -D Python_EXECUTABLE=`which python3` \
+          -D ENABLE_PYTHON=OFF \
+          -D BUILD_TESTING=OFF \
+          -D BUILD_PYTHON_BINDINGS=OFF \
+          -D BUILD_DOCS=OFF \
           -D USE_LD=ld \
-          -D SPECTRE_TEST_RUNNER="$(pwd)/bin/charmrun" \
           "$@" \
           $SPECTRE_HOME
 }

--- a/support/Python/CMakeLists.txt
+++ b/support/Python/CMakeLists.txt
@@ -1,9 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+if (NOT ENABLE_PYTHON)
+  return()
+endif()
+
 option(MACHINE "Select a machine that we know how to run on, such as a \
 particular supercomputer" OFF)
-
 spectre_python_add_module(
   support
   PYTHON_FILES


### PR DESCRIPTION
## Proposed changes

- The default gcc version on Frontera is too outdated for building latest version of SpECTRE.
- More recent versions of gcc are available on Frontera; however, they do not have any recent version of Python installed.
- Add a new option ENABLE_PYTHON (default is ON) so that we can easily disable usage of Python
  for minimal building on Frontera without recent installation of Python. We still need some version of
Python (>=2.7) for linking purpose.
- Modify default version of modules and default cmake options for the Frontera environment file.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
