### PR TITLE
Fix registration for interpolator component

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
@@ -87,13 +87,7 @@ struct RegisterElement {
             }
 
             if (blocks_to_interpolate.at(target_name).contains(block_name)) {
-              auto inserted = (*num_elements)[target_name].insert(element_id);
-              if (not inserted.second) {
-                ERROR("Unable to insert element "
-                      << element_id << " into interpolator core "
-                      << Parallel::my_proc<size_t>(cache) << " for target "
-                      << target_name);
-              }
+              (*num_elements)[target_name].insert(element_id);
             }
           });
         },

--- a/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp
@@ -201,7 +201,7 @@ void try_to_interpolate(
 
   // Send interpolated data only if interpolation has been done on all
   // of the local elements.
-  const auto all_num_elements =
+  const auto& all_num_elements =
       db::get<Tags::NumberOfElements<Metavariables::volume_dim>>(*box);
   const std::string& target_name = pretty_type::name<InterpolationTargetTag>();
   if (not all_num_elements.contains(target_name)) {

--- a/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Interpolator.hpp
@@ -74,7 +74,7 @@ struct get_temporal_id {
 template <class Metavariables>
 struct Interpolator {
   using chare_type = Parallel::Algorithms::Group;
-  static constexpr bool checkpoint_data = false;
+  static constexpr bool checkpoint_data = true;
   using metavariables = Metavariables;
   using all_interpolation_target_tags = tmpl::transform<
       tmpl::filter<typename Metavariables::component_list,


### PR DESCRIPTION
## Proposed changes

Fixes a bug where, because the interpolator wasn't checkpointed, a tag in the interpolator was registered incorrectly causing an error down the line during the evolution. Now the interpolator is checkpointed and registered properly.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Technical details: The tag `intrp::Tags::NumberOfElements` is using in `src/ParallelAlgorithms/Interpolation/Actions/TryToInterpolate.hpp:207` to ensure the local interpolator core has received data from all elements it expects to for each target. It must have a key for each target in the metavars, even if the value is an empty set. This is enforced by the initialization action for the interpolator. Then the registration action, is what actually populates the tag. However, before, the interpolator wasn't checkpointed so upon a restart, the tag was empty and the registration wouldn't add keys for all targets in the metavars, only the ones specifically necessary for that core. This then caused the check in `TryToInterpolate.hpp` to fail. The solution is to 1) checkpoint the interpolator, and 2) allow the registration action to be run again. This is just a quick fix. There's probably a cleaner solution which involves changing the logic in `TryToInterpolate`, but a) I unfortunately don't have the time to look at this right now and won't for another week or more, b) this actively is preventing people from running BBHs, and c) this will all be mute once #6699 is merged. So I decided not to implement a "cleaner" solution.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
