### PR TITLE
Allow YAML floats to be parsed as integer types

### DIFF
--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -28,6 +28,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
+#include "Utilities/TypeTraits/IsInteger.hpp"
 #include "Utilities/WrapText.hpp"
 
 namespace Options::Options_detail {
@@ -318,7 +319,8 @@ struct wrap_create_types_impl<CreateWrapper<T, Metavariables>> {
 };
 
 template <typename T>
-struct wrap_create_types_impl<T, Requires<std::is_fundamental<T>::value>> {
+struct wrap_create_types_impl<
+    T, Requires<std::is_fundamental_v<T> and not tt::is_integer_v<T>>> {
   template <typename Metavariables>
   using wrapped_type = T;
 

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -42,6 +42,7 @@
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
+#include "Utilities/TypeTraits/IsInteger.hpp"
 #include "Utilities/TypeTraits/IsMaplike.hpp"
 #include "Utilities/TypeTraits/IsStdArray.hpp"
 #include "Utilities/TypeTraits/IsStdArrayOfSize.hpp"
@@ -1292,13 +1293,34 @@ struct YAML::convert<Options::Options_detail::CreateWrapper<T, Metavariables>> {
   static bool decode(
       const Node& node,
       Options::Options_detail::CreateWrapper<T, Metavariables>& rhs) {
-    Options::Context context;
-    context.top_level = false;
-    context.append("While creating a " + pretty_type::name<T>());
-    Options::Option options(node, std::move(context));
-    rhs = Options::Options_detail::CreateWrapper<T, Metavariables>{
-        Options::create_from_yaml<T>::template create<Metavariables>(options)};
-    return true;
+    if constexpr (tt::is_integer_v<T>) {
+      // Try parsing integers as floating point to allow scientific
+      // notation for large values.
+      T result{};
+      if (not YAML::convert<T>::decode(node, result)) {
+        double float_result{};
+        if (not YAML::convert<double>::decode(node, float_result) or
+            float_result > static_cast<double>(std::numeric_limits<T>::max()) or
+            float_result < static_cast<double>(std::numeric_limits<T>::min())) {
+          return false;
+        }
+        result = static_cast<T>(float_result);
+        if (static_cast<double>(result) != float_result) {
+          return false;
+        }
+      }
+      rhs = Options::Options_detail::CreateWrapper<T, Metavariables>{result};
+      return true;
+    } else {
+      Options::Context context;
+      context.top_level = false;
+      context.append("While creating a " + pretty_type::name<T>());
+      Options::Option options(node, std::move(context));
+      rhs = Options::Options_detail::CreateWrapper<T, Metavariables>{
+          Options::create_from_yaml<T>::template create<Metavariables>(
+              options)};
+      return true;
+    }
   }
 };
 /// \endcond

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <map>
@@ -21,6 +22,7 @@
 #include "Options/String.hpp"
 #include "Options/Tags.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -1646,6 +1648,51 @@ void test_load_and_check_yaml() {
       }(),
       Catch::Matchers::ContainsSubstring("the running executable is"));
 }
+
+template <typename T>
+struct GenericTag {
+  using type = T;
+  static constexpr Options::String help = "halp";
+};
+
+void test_integer_scientific() {
+  tmpl::for_each<tmpl::list<int, unsigned, size_t, int64_t, uint64_t>>(
+      []<typename T>(tmpl::type_<T> /*meta*/) {
+        INFO(pretty_type::name<T>());
+        const auto check = [](const std::string& input, const T& expected) {
+          CAPTURE(input);
+          Options::Parser<tmpl::list<GenericTag<T>>> parser("");
+          parser.parse("GenericTag: " + input);
+          CHECK(parser.template get<GenericTag<T>>() == expected);
+        };
+        const auto check_fail = [](const std::string& input) {
+          CAPTURE(input);
+          Options::Parser<tmpl::list<GenericTag<T>>> parser("");
+          parser.parse("GenericTag: " + input);
+          CHECK_THROWS_WITH(parser.template get<GenericTag<T>>(),
+                            Catch::Matchers::ContainsSubstring(
+                                "Failed to convert value to type"));
+        };
+
+        check("1234", 1234);
+        check("1e8", 100'000'000);
+        check("1.23e5", 123000);
+        if constexpr (std::is_signed_v<T>) {
+          check("-1234", -1234);
+          check("-1e8", -100'000'000);
+          check("-1.23e5", -123000);
+        } else {
+          check_fail("-1234");
+          check_fail("-1e8");
+          check_fail("-1.23e5");
+        }
+        check_fail("1.2");
+        check_fail("");
+        check_fail("bla");
+        check_fail("1e-3");
+        check_fail("1e100");
+      });
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
@@ -1672,4 +1719,5 @@ SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
   test_options_overlay();
   test_options_serialization();
   test_load_and_check_yaml();
+  test_integer_scientific();
 }


### PR DESCRIPTION
Requested to allow 1e8 instead of the error-prone 100000000.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
