### PR TITLE
Define resolution levels and use in inspiral command

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -20,6 +20,17 @@ logger = logging.getLogger(__name__)
 
 INSPIRAL_INPUT_FILE_TEMPLATE = Path(__file__).parent / "Inspiral.yaml"
 
+# Resolution levels defined in terms of p-refinement
+# To be replaced once AMR is used.
+INSPIRAL_LEVS = {
+    lev_number: {
+        "label": f"Lev{lev_number}",
+        "refinement_level": 1,
+        "polynomial_order": 7 + lev_number,
+    }
+    for lev_number in range(-2, 11)
+}
+
 
 # These parameters come from empirically tested values in SpEC and SpECTRE
 def _control_system_params(
@@ -363,8 +374,9 @@ def inspiral_parameters_spec(
 
 def start_inspiral(
     id_input_file_path: Union[str, Path],
-    refinement_level: int = 1,
-    polynomial_order: int = 8,
+    lev: Optional[int] = None,
+    refinement_level: Optional[int] = None,
+    polynomial_order: Optional[int] = None,
     id_run_dir: Optional[Union[str, Path]] = None,
     inspiral_input_file_template: Union[
         str, Path
@@ -400,6 +412,22 @@ def start_inspiral(
         "Cannot enable both 'continue_with_ringdown' and"
         " 'eccentricity_control'. Choose which of the two to perform next."
     )
+
+    if lev is not None:
+        assert (refinement_level is None) and (polynomial_order is None), (
+            "The option 'lev' is mutaully exclusive with 'refinement_level' and"
+            " 'polynomial_order'."
+        )
+        selected_lev = INSPIRAL_LEVS[lev]
+        refinement_level = selected_lev["refinement_level"]
+        polynomial_order = selected_lev["polynomial_order"]
+    else:
+        assert (refinement_level is not None) and (
+            polynomial_order is not None
+        ), (
+            "Resolution not specified. Provide either 'lev' or both"
+            " 'refinement_level' and 'polynomial_order'."
+        )
 
     # Determine inspiral parameters from initial data
     if id_run_dir is None:
@@ -542,20 +570,26 @@ def start_inspiral(
     ),
 )
 @click.option(
+    "--lev",
+    type=int,
+    help=(
+        "Resolution levels defined in terms of h and p refinement. Can be"
+        " specified multiple times. For integer N, LevN corresponds to"
+        " refinement level L = 1 and polynomial order P = 7 + N. Mutually"
+        " exclusive with options '-L' and '-P'"
+    ),
+)
+@click.option(
     "--refinement-level",
     "-L",
     type=int,
     help="h-refinement level.",
-    default=1,
-    show_default=True,
 )
 @click.option(
     "--polynomial-order",
     "-P",
     type=int,
     help="p-refinement level.",
-    default=8,
-    show_default=True,
 )
 @click.option(
     "--continue-with-ringdown",

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -182,6 +182,7 @@ def postprocess_id(
             continue_with_ringdown=not eccentricity_control,
             eccentricity_control=eccentricity_control,
             pipeline_dir=pipeline_dir,
+            lev=1,
             **scheduler_kwargs,
         )
 

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -121,10 +121,6 @@ class TestInspiral(unittest.TestCase):
     def test_cli(self):
         common_args = [
             str(self.id_dir / "InitialData.yaml"),
-            "--refinement-level",
-            "1",
-            "--polynomial-order",
-            "5",
             "--id-horizons-path",
             str(self.horizons_filename),
             "-E",
@@ -139,6 +135,10 @@ class TestInspiral(unittest.TestCase):
             start_inspiral_command(
                 common_args
                 + [
+                    "--refinement-level",
+                    "1",
+                    "--polynomial-order",
+                    "5",
                     "-O",
                     str(self.test_dir / "Inspiral"),
                     "--no-submit",
@@ -149,11 +149,13 @@ class TestInspiral(unittest.TestCase):
         self.assertTrue(
             (self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml").exists()
         )
-        # Test with pipeline directory
+        # Test with pipeline directory and lev specified
         try:
             start_inspiral_command(
                 common_args
                 + [
+                    "--lev",
+                    "-2",
                     "-d",
                     str(self.test_dir / "Pipeline"),
                     "--continue-with-ringdown",
@@ -189,6 +191,8 @@ class TestInspiral(unittest.TestCase):
             start_inspiral_command(
                 common_args
                 + [
+                    "--lev",
+                    "-2",
                     "-d",
                     str(self.test_dir / "Pipeline"),
                     "--eccentricity-control",


### PR DESCRIPTION
## Proposed changes

Define resolution levels as in the bbh paper (arXiv: 2410.00265): For N integer, LevN corresponds to h-refinement L = 1 and p-refinement P = 7 + N (to be replaced once AMR is used). Use in inspiral command.  Specify default in terms of a level when the 'evolve' flag is passed to 'generate-id'.

Shall I apply these changes to 'start-ringdown'?

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
