### PR TITLE
Add h-projector for RunEventsAndDenseTriggers

### DIFF
--- a/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndDenseTriggers.hpp
@@ -344,21 +344,27 @@ struct ProjectRunEventsAndDenseTriggers
 
   template <typename... Tags>
   static void apply(
-      const gsl::not_null<
-          EventsAndDenseTriggers*> /*events_and_dense_triggers*/,
+      const gsl::not_null<EventsAndDenseTriggers*> events_and_dense_triggers,
       const gsl::not_null<std::optional<double>*> /*previous_trigger_time*/,
-      const tuples::TaggedTuple<Tags...>& /*parent_items*/) {
-    ERROR("h-refinement not implemented yet");
+      const tuples::TaggedTuple<Tags...>& parent_items) {
+    *events_and_dense_triggers = deserialize<EventsAndDenseTriggers>(
+        serialize(get<::Tags::EventsAndDenseTriggers>(parent_items)).data());
   }
 
   template <size_t Dim, typename... Tags>
   static void apply(
-      const gsl::not_null<
-          EventsAndDenseTriggers*> /*events_and_dense_triggers*/,
+      const gsl::not_null<EventsAndDenseTriggers*> events_and_dense_triggers,
       const gsl::not_null<std::optional<double>*> /*previous_trigger_time*/,
       const std::unordered_map<ElementId<Dim>, tuples::TaggedTuple<Tags...>>&
-      /*children_items*/) {
-    ERROR("h-refinement not implemented yet");
+          children_items) {
+    // Serialization of equivalent Events and DenseTriggers is not
+    // guaranteed to produce the same byte stream when there are
+    // things like unordered containers involved, so we can't compare
+    // with other children.
+    *events_and_dense_triggers = deserialize<EventsAndDenseTriggers>(
+        serialize(
+            get<::Tags::EventsAndDenseTriggers>(children_items.begin()->second))
+            .data());
   }
 };
 }  // namespace evolution::Actions

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -766,8 +767,14 @@ EventsAndDenseTriggers make_events_and_dense_triggers() {
 
 void test_p_refine() {
   auto box = db::create<db::AddSimpleTags<::Tags::EventsAndDenseTriggers,
-                                          ::Tags::PreviousTriggerTime>>(
-      make_events_and_dense_triggers(), std::optional<double>{});
+                                          ::Tags::PreviousTriggerTime,
+                                          ::Tags::TimeStepId, ::Tags::Time>>(
+      make_events_and_dense_triggers(), std::optional<double>{},
+      TimeStepId(true, 5, Slab(0.0, 4.0).start()), 0.0);
+  const double next_trigger_time =
+      db::get_mutable_reference<::Tags::EventsAndDenseTriggers>(
+          make_not_null(&box))
+          .next_trigger(box);
 
   const Element<1> element{ElementId<1>{0}, DirectionMap<1, Neighbors<1>>{}};
   const Mesh<1> mesh{2, Spectral::Basis::Legendre,
@@ -776,10 +783,61 @@ void test_p_refine() {
       make_not_null(&box), std::make_pair(mesh, element));
 
   // There is no comparison operator for EventsAndDenseTriggers
-  // const auto expected_events_and_dense_triggers =
-  //     make_events_and_dense_triggers();
-  // CHECK(db::get<::Tags::EventsAndDenseTriggers>(box) ==
-  //       expected_events_and_dense_triggers);
+  CHECK(db::get_mutable_reference<::Tags::EventsAndDenseTriggers>(
+            make_not_null(&box))
+            .next_trigger(box) == next_trigger_time);
+  CHECK(db::get<::Tags::PreviousTriggerTime>(box) == std::nullopt);
+}
+
+void test_h_split() {
+  tuples::TaggedTuple<::Tags::EventsAndDenseTriggers> parent_items{
+      make_events_and_dense_triggers()};
+  auto box = db::create<db::AddSimpleTags<::Tags::EventsAndDenseTriggers,
+                                          ::Tags::PreviousTriggerTime,
+                                          ::Tags::TimeStepId, ::Tags::Time>>(
+      EventsAndDenseTriggers{}, std::optional<double>{},
+      TimeStepId(true, 5, Slab(0.0, 4.0).start()), 0.0);
+  const double next_trigger_time =
+      get<::Tags::EventsAndDenseTriggers>(parent_items).next_trigger(box);
+
+  db::mutate_apply<evolution::Actions::ProjectRunEventsAndDenseTriggers>(
+      make_not_null(&box), std::as_const(parent_items));
+
+  // There is no comparison operator for EventsAndDenseTriggers
+  CHECK(db::get_mutable_reference<::Tags::EventsAndDenseTriggers>(
+            make_not_null(&box))
+            .next_trigger(box) == next_trigger_time);
+  CHECK(db::get<::Tags::PreviousTriggerTime>(box) == std::nullopt);
+}
+
+void test_h_join() {
+  std::unordered_map<ElementId<1>,
+                     tuples::TaggedTuple<::Tags::EventsAndDenseTriggers>>
+      children_items{};
+  children_items.emplace(ElementId<1>(2, {{{2, 2}}}),
+                         make_events_and_dense_triggers());
+  children_items.emplace(ElementId<1>(2, {{{2, 3}}}),
+                         make_events_and_dense_triggers());
+  auto box = db::create<db::AddSimpleTags<::Tags::EventsAndDenseTriggers,
+                                          ::Tags::PreviousTriggerTime,
+                                          ::Tags::TimeStepId, ::Tags::Time>>(
+      EventsAndDenseTriggers{}, std::optional<double>{},
+      TimeStepId(true, 5, Slab(0.0, 4.0).start()), 0.0);
+  const double next_trigger_time =
+      get<::Tags::EventsAndDenseTriggers>(children_items.begin()->second)
+          .next_trigger(box);
+  for (auto& child_items : children_items) {
+    REQUIRE(get<::Tags::EventsAndDenseTriggers>(child_items.second)
+                .next_trigger(box) == next_trigger_time);
+  }
+
+  db::mutate_apply<evolution::Actions::ProjectRunEventsAndDenseTriggers>(
+      make_not_null(&box), std::as_const(children_items));
+
+  // There is no comparison operator for EventsAndDenseTriggers
+  CHECK(db::get_mutable_reference<::Tags::EventsAndDenseTriggers>(
+            make_not_null(&box))
+            .next_trigger(box) == next_trigger_time);
   CHECK(db::get<::Tags::PreviousTriggerTime>(box) == std::nullopt);
 }
 }  // namespace
@@ -801,4 +859,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.RunEventsAndDenseTriggers",
                 evolution::Actions::ProjectRunEventsAndDenseTriggers,
                 amr::protocols::Projector>);
   test_p_refine();
+  test_h_split();
+  test_h_join();
 }


### PR DESCRIPTION
Implemented using serialization.  Writing equality comparisons and clones for all Events and DenseTriggers is not worth the effort.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
