### PR TITLE
Do not delete sets in interpolator deregistration

### DIFF
--- a/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Actions/InterpolatorRegisterElement.hpp
@@ -150,10 +150,6 @@ struct DeregisterElement {
                       << Parallel::my_proc<size_t>(cache) << " for target "
                       << target_name);
               }
-
-              if (num_elements->at(target_name).empty()) {
-                num_elements->erase(target_name);
-              }
             }
           });
         },

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -184,7 +184,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
     CHECK_FALSE(number_of_elements.at(target_name).contains(id_1));
     runner.simple_action<interp_component, ::intrp::Actions::DeregisterElement>(
         0, id_2);
-    CHECK(number_of_elements.empty());
+    CHECK(number_of_elements.contains(target_name));
+    CHECK(number_of_elements.at(target_name).empty());
   }
 }
 


### PR DESCRIPTION
The try_to_interpolate function assumes they exist.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
