### PR TITLE
Adapt BBH ID for high spins

### DIFF
--- a/support/Pipelines/Bbh/FindHorizon.py
+++ b/support/Pipelines/Bbh/FindHorizon.py
@@ -167,7 +167,7 @@ def find_horizon(
             truncation_tol=0.01,
             divergence_tol=1.2,
             divergence_iter=5,
-            max_its=100,
+            max_its=300,
         )
     strahlkorper = initial_guess
     while True:

--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -103,6 +103,9 @@ def id_parameters(
     extra_radial_refinement_p = (
         round(mass_ratio / 5.0) if (mass_ratio > 5.0) else 0
     )
+    horizon_l_max = (
+        40 if max(np.linalg.norm(chi_A), np.linalg.norm(chi_B)) > 0.9 else 20
+    )
     return {
         "ConformalMassRight": conformal_mass_a,
         "ConformalMassLeft": conformal_mass_b,
@@ -138,6 +141,7 @@ def id_parameters(
         "P": polynomial_order,
         "ExtraRadRef": extra_radial_refinement_l,
         "ExtraRadPoints": extra_radial_refinement_p,
+        "HorizonLMax": horizon_l_max,
     }
 
 

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -12,6 +12,7 @@ Next:
     id_input_file_path: __file__
     id_run_dir: ./
     pipeline_dir: {{ pipeline_dir | default("None") }}
+    horizon_l_max: {{ HorizonLMax }}
     control: {{ control }}
     control_refinement_level: {{ L }}
     control_polynomial_order: {{ P }}
@@ -146,18 +147,18 @@ DomainCreator:
       TranslationMap: None
       SkewMap: None
       ShapeMapA:
-        LMax: 20
+        LMax: {{ HorizonLMax }}
         InitialValues:
           Mass: *mass_right
           Spin: *spin_right
-        SizeInitialValues: [0, 0, 0]
+        SizeInitialValues: Auto
         TransitionEndsAtCube: False
       ShapeMapB:
-        LMax: 20
+        LMax: {{ HorizonLMax }}
         InitialValues:
           Mass: *mass_left
           Spin: *spin_left
-        SizeInitialValues: [0, 0, 0]
+        SizeInitialValues: Auto
         TransitionEndsAtCube: False
       GridCenters: None
 

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -171,6 +171,7 @@ class TestInitialData(unittest.TestCase):
                     "id_input_file_path": "__file__",
                     "id_run_dir": "./",
                     "pipeline_dir": str(self.test_dir.resolve() / "Pipeline"),
+                    "horizon_l_max": 20,
                     "control": True,
                     "control_refinement_level": 1,
                     "control_polynomial_order": 5,


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR makes 3 changes to BBH ID so that it is capable of reproducing a solution from SpEC with q = 10 and spin ~ 0.99.

1. Set the (l,m)=(0,0) coefficient of the shape maps to the transformation from Boyer-Lindquist to Kerr-Schild. Before, this was set to 0, which meant that our excisions didn't have a size distortion.
2. Use a higher `l_max` for horizon finding and shape maps when spin > 0.9. In the run mentioned above, SpEC uses Lmesh = 36. Ideally, this should be chosen based on some automatic criterion, but here we set it to 40 as a temporary solution.
3. Increase the maximum number of horizon finder iterations. When running the case above with L=1 and P=10, the horizon finder needed 219 iterations. So, here we default to a maximum of 300 iterations.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
