### PR TITLE
Implement DG Cartoon partial derivatives

### DIFF
--- a/src/DataStructures/Tags/TempTensor.hpp
+++ b/src/DataStructures/Tags/TempTensor.hpp
@@ -16,6 +16,9 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
+/*!
+ * \brief Contains objects related to Tags
+ */
 namespace Tags {
 template <size_t N, typename T>
 struct TempTensor : db::SimpleTag {
@@ -24,6 +27,31 @@ struct TempTensor : db::SimpleTag {
     return std::string("TempTensor") + std::to_string(N);
   }
 };
+
+/*!
+ * \brief A struct that constructs a `TempTensor` given a label \p N and type
+ * \p TensorType. Call with `make_temp_tensor<N>::apply<Type>`
+ *
+ * \see convert_to_temp_tensors
+ */
+template <size_t N>
+struct make_temp_tensor {
+  template <typename TensorType>
+  struct apply {
+    using type = ::Tags::TempTensor<N, TensorType>;
+  };
+};
+
+/*!
+ * \brief Takes a `tmpl::list` of `Tensor` types and a label \p N which is
+ * applied to all `TempTensor`s in the resulting list.
+ *
+ * \see make_temp_tensor
+ */
+template <typename List, size_t N>
+using convert_to_temp_tensors =
+    tmpl::transform<List,
+                    typename make_temp_tensor<N>::template apply<tmpl::_1>>;
 
 /// @{
 /// \ingroup PeoGroup

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -112,6 +112,79 @@ auto logical_partial_derivative(const Tensor<DataType, SymmList, IndexList>& u,
 /// @}
 
 /// @{
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Compute the partial derivatives of each variable, using the Cartoon
+ * method for directions not in the computational domain.
+ *
+ * For a spacetime with some Killing vector \f$\xi^a\f$, not only does the
+ * metric respect the isometry via \f$\mathcal{L}_\xi g_{ab} = 0\f$, but the
+ * fields must as well.
+ *
+ * In the case of axial symmetry about the \f$y\f$-axis, the Killing vector is
+ * \f$\xi^a = (0, -z, 0, x)\f$, so we have that for a vector \f$V^a\f$,
+ *
+ * \f{align*}{
+ *     \mathcal{L}_\xi V^a &= \xi^b \partial_b V^a - V^b \partial_b \xi^a
+ *       = -z \partial_x V^a + x \partial_z V^a - V^b \partial_b \xi^a = 0.
+ * \f}
+ *
+ * Choosing the computational domain to be the \f$z=0\f$ plane, get the result:
+ *
+ * \f{align*}{
+ *     \partial_z V^a &= \frac{V^b \partial_b \xi^a}{x}.
+ * \f}
+ *
+ * In the case that $x=0$ is in the computational domain, L'H&ocirc;pital's
+ * rule is used. For a general tensor,
+ * \f$T^{a_0,\ldots,a_n}{}_{b_0,\ldots,b_m}\f$ we have
+ *
+ * \f{align*}{
+ *   \partial_z T^{a_0,\ldots,a_n}{}_{b_0,\ldots,b_m} &=
+ *   \left\{
+ *   \begin{array}{ll}
+ *     \partial_x(\sum_k
+ *     T^{a_0,\ldots,c_k,\ldots,a_n}{}_{b_0,\ldots,b_m}\partial_{c_k}
+ *     \xi^{a_k} & \\
+ *     \;\;\;\;\;-\sum_k
+ *     T^{a_0,\ldots,a_n}{}_{b_0,\ldots,c_k,\ldots,b_m}\partial_{b_k}
+ *     \xi^{c_k}
+ *     ) & \mathrm{if} \; x=0  \\
+ *     (\sum_k
+ *     T^{a_0,\ldots,c_k,\ldots,a_n}{}_{b_0,\ldots,b_m}\partial_{c_k}
+ *     \xi^{a_k} & \\
+ *     \;-\sum_k
+ *     T^{a_0,\ldots,a_n}{}_{b_0,\ldots,c_k,\ldots,b_m}\partial_{b_k}
+ *     \xi^{c_k})\frac{1}{x} & \mathrm{otherwise}
+ *   \end{array}\right.
+ * \f}
+ *
+ * In the case of spherical symmetry, another Killing vector
+ * \f$\xi'^a = (0, -y, x, 0) \f$ is used as well, with the above equation
+ * easily generalizing. In that case, the computational domain is only the
+ * \f$x\f$-axis.
+ *
+ * This function computes the partial derivatives of _all_ variables in
+ * `VariableTags`. The additional parameter `inertial_coords` is used for
+ * division by the \f$x\f$ coordinates. If \f$x=0\f$ is included in the domain,
+ * it is assumed to be present only at the first index and is handled by
+ * L'H&ocirc;pital's rule.
+ *
+ * The mesh is required to have the Cartoon basis in the last and potentially
+ * second-to-last coordinates and the inverse Jacobian is accordingly used only
+ * in the first and potentially second dimensions.
+ */
+template <typename ResultTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3> = nullptr>
+void cartoon_partial_derivatives(
+    gsl::not_null<Variables<ResultTags>*> du, const Variables<VariableTags>& u,
+    const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian_3d,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+/// @}
+
+/// @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
 /// the coordinates of `DerivativeFrame`.

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -9,15 +9,21 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Transpose.hpp"
 #include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MemoryHelpers.hpp"
@@ -190,6 +196,425 @@ void partial_derivatives(
       inverse_jacobian);
 }
 
+constexpr tnsr::iab<double, 3> Killing_vector_derivatives() {
+  // holds derivative of both (0,-y,x,0) for \partial_y and (0,-z,0,x) for
+  // \partial_z
+  tnsr::iab<double, 3> da_killing_vectors{};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t KV_deriv_index = 0; KV_deriv_index < 4; ++KV_deriv_index) {
+      for (size_t Killing_index = 0; Killing_index < 4; ++Killing_index) {
+        if (i == 1 and KV_deriv_index == 2 and Killing_index == 1) {
+          // y derivative
+          da_killing_vectors.get(i, KV_deriv_index, Killing_index) = -1.0;
+        } else if (i == 1 and KV_deriv_index == 1 and Killing_index == 2) {
+          // y derivative
+          da_killing_vectors.get(i, KV_deriv_index, Killing_index) = 1.0;
+        } else if (i == 2 and KV_deriv_index == 3 and Killing_index == 1) {
+          // z derivative
+          da_killing_vectors.get(i, KV_deriv_index, Killing_index) = -1.0;
+        } else if (i == 2 and KV_deriv_index == 1 and Killing_index == 3) {
+          // z derivative
+          da_killing_vectors.get(i, KV_deriv_index, Killing_index) = 1.0;
+        } else {
+          da_killing_vectors.get(i, KV_deriv_index, Killing_index) = 0.0;
+        }
+      }
+    }
+  }
+  return da_killing_vectors;
+}
+
+template <typename Symm, typename Indices>
+void cartoon_contraction(
+    const gsl::not_null<Tensor<DataVector, Symm, Indices>*> result_tensor,
+    const Tensor<DataVector, Symm, Indices>& tensor, const size_t deriv_index,
+    const Spectral::Quadrature quad_type) {
+  // This function does the contractions in Eqn. (218) of the SXS book's
+  // Numerical Method's chapter, specifically the thing on the RHS that you take
+  // the derivative of or divide by x.
+  // Note that the result_tensor is written over and will have
+  // (*result_tensor)[0].size() == tensor[0].size()
+  auto& contract_tensor = *result_tensor;
+  ASSERT(quad_type == Spectral::Quadrature::AxialSymmetry or
+             quad_type == Spectral::Quadrature::SphericalSymmetry,
+         "Must pass a valid Cartoon quadrature");
+
+  constexpr tnsr::iab<double, 3> da_killing_vectors =
+      Killing_vector_derivatives();
+  const std::array<UpLo, Tensor<DataVector, Symm, Indices>::rank()> valences =
+      tensor.index_valences();
+  const auto type_index = tensor.index_types();
+
+  const size_t valence_size = valences.size();
+  auto input_tensor_array = make_array<valence_size>(0_st);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  std::array<size_t, 3> Killing_indices;
+  Killing_indices[0] = deriv_index;
+
+  for (size_t i = 0; i < tensor.size(); ++i) {
+    const auto tensor_index = tensor.get_tensor_index(i);
+    contract_tensor.get(tensor_index) = 0.0 * tensor.get(tensor_index);
+    for (size_t rank = 0; rank < valence_size; ++rank) {
+      const double sign = (valences[rank] == UpLo::Up) ? 1.0 : -1.0;
+      const size_t max_dummy = type_index[rank] == IndexType::Spacetime ? 4 : 3;
+      const size_t shift_index =
+          type_index[rank] == IndexType::Spacetime ? 0 : 1;
+
+      // loop over dimension of rank
+      for (size_t dummy = 0; dummy < max_dummy; ++dummy) {
+        if (valences[rank] == UpLo::Lo) {
+          // covariant index
+          Killing_indices[1] = tensor_index[rank] + shift_index;
+          Killing_indices[2] = dummy + shift_index;
+        } else {
+          // contravariant
+          Killing_indices[1] = dummy + shift_index;
+          Killing_indices[2] = tensor_index[rank] + shift_index;
+        }
+        if (da_killing_vectors.get(Killing_indices) != 0) {
+          for (size_t j = 0; j < tensor_index.size(); ++j) {
+            input_tensor_array[j] = tensor_index[j];
+          }
+          input_tensor_array[rank] = dummy;
+
+          contract_tensor.get(tensor_index) +=
+              sign * tensor.get(input_tensor_array) *
+              da_killing_vectors.get(Killing_indices);
+        }
+      }
+    }
+  }
+}
+
+template <typename InputTensorDataType, size_t Dim, typename Frame,
+          Requires<Dim == 3> = nullptr>
+void cartoon_derivative(
+    TensorMetafunctions::prepend_spatial_index<InputTensorDataType, Dim,
+                                               UpLo::Lo, Frame>& d_tensor,
+    const InputTensorDataType& tensor, const DataVector& safe_x_coords,
+    const Spectral::Quadrature quad_type) {
+  // This function assumes `safe_x_coords` does not contain zero (safe in the
+  // sense that having x in the denominator of an expression  will not cause
+  // an FPE).
+  // Therefore, if the domain actually does have zero, the coordinates must be
+  // made safe by replacing all occurances of zero with a non-zero value, and
+  // the output from this function is then not valid at those coords, one must
+  // then manually use L'Hopital's rule
+  ASSERT(quad_type == Spectral::Quadrature::AxialSymmetry or
+             quad_type == Spectral::Quadrature::SphericalSymmetry,
+         "Must pass a valid Cartoon quadrature");
+  ASSERT(
+      not equal_within_roundoff(0.0, safe_x_coords[0],
+                                std::numeric_limits<double>::epsilon() * 100.0,
+                                max(safe_x_coords)),
+      "Invalid coordinate: safe_x_coords[0] is too close to zero ("
+          << safe_x_coords[0]
+          << "). Division by this value may cause an FPE if the value is zero. "
+             "Maximum coordinate: "
+          << max(safe_x_coords));
+
+  const bool spherical_sym =
+      quad_type == Spectral::Quadrature::SphericalSymmetry;
+  const size_t start_deriv_index = spherical_sym ? 1 : 2;
+
+  InputTensorDataType tensor_holder;
+
+  for (size_t deriv_index = start_deriv_index; deriv_index < 3; ++deriv_index) {
+    cartoon_contraction(make_not_null(&tensor_holder), tensor, deriv_index,
+                        quad_type);
+    for (size_t component_index = 0; component_index < tensor_holder.size();
+         ++component_index) {
+      const auto input_index = tensor_holder.get_tensor_index(component_index);
+      const auto output_index = prepend(input_index, deriv_index);
+      d_tensor.get(output_index) =
+          tensor_holder.get(input_index) / safe_x_coords;
+    }
+  }
+}
+
+template <size_t Comp_dim, typename ResultTags, typename VariableTags,
+          size_t Dim, typename DerivativeFrame>
+void cartoon_partial_derivatives_apply(
+    const gsl::not_null<Variables<ResultTags>*> du,
+    const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian_3d,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  using DerivativeTags =
+      tmpl::front<tmpl::split_at<VariableTags, tmpl::size<ResultTags>>>;
+  static_assert(Dim == 3);
+  static_assert(
+      std::is_same_v<
+          tmpl::transform<ResultTags, tmpl::bind<tmpl::type_from, tmpl::_1>>,
+          tmpl::transform<db::wrap_tags_in<Tags::deriv, DerivativeTags,
+                                           tmpl::size_t<Dim>, DerivativeFrame>,
+                          tmpl::bind<tmpl::type_from, tmpl::_1>>>);
+  ASSERT((Comp_dim == 2 and
+          mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry) or
+             (Comp_dim == 1 and
+              (mesh.quadrature(1) == Spectral::Quadrature::SphericalSymmetry and
+               mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry)),
+         "Invalid Quadrature combinations: axial symmetry requires 2 "
+         "non-Cartoon dimensions, spherical symmetry requires 1 non-Cartoon "
+         "dimension. Got: "
+             << mesh.quadrature());
+
+  using ValueType = typename Variables<VariableTags>::value_type;
+  auto& partial_derivatives_of_u = *du;
+
+  if (UNLIKELY(partial_derivatives_of_u.number_of_grid_points() !=
+               mesh.number_of_grid_points())) {
+    partial_derivatives_of_u.initialize(mesh.number_of_grid_points());
+  }
+
+  const size_t vars_size =
+      u.number_of_grid_points() *
+      Variables<DerivativeTags>::number_of_independent_components;
+  const auto logical_derivs_data =
+      cpp20::make_unique_for_overwrite<ValueType[]>(
+          (Comp_dim > 1 ? (Comp_dim + 1) : Comp_dim) * vars_size);
+
+  std::array<ValueType*, Comp_dim> logical_derivs{};
+  for (size_t i = 0; i < Comp_dim; ++i) {
+    gsl::at(logical_derivs, i) = &(logical_derivs_data[i * vars_size]);
+  }
+  Variables<DerivativeTags> temp{};
+  if constexpr (Comp_dim > 1) {
+    temp.set_data_ref(&logical_derivs_data[Comp_dim * vars_size], vars_size);
+  }
+
+  if constexpr (Comp_dim == 1) {
+    partial_derivatives_detail::
+        LogicalImpl<Comp_dim, VariableTags, DerivativeTags>::apply(
+            make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
+            mesh.slice_through(0));
+  } else {
+    partial_derivatives_detail::
+        LogicalImpl<Comp_dim, VariableTags, DerivativeTags>::apply(
+            make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
+            mesh.slice_through(0, 1));
+  }
+
+  std::array<const ValueType*, Comp_dim> const_logical_derivs{};
+  for (size_t i = 0; i < Comp_dim; ++i) {
+    gsl::at(const_logical_derivs, i) = gsl::at(logical_derivs, i);
+  }
+
+  const Spectral::Quadrature quad_type = mesh.quadrature(2);
+  const auto numerical_deriv_in_this_direction = [](const size_t deriv_num) {
+    if constexpr (Comp_dim == 2) {
+      return deriv_num == 0 or deriv_num == 1;
+    } else {
+      return deriv_num == 0;
+    }
+  };
+  // only the 1st (possibly 2nd) dimensions of the Jacobian are relevant here
+  const InverseJacobian<DataVector, Comp_dim, Frame::ElementLogical,
+                        DerivativeFrame>
+      inverse_jacobian{inverse_jacobian_3d.begin()->size()};
+  for (size_t i = 0; i < Comp_dim; ++i) {
+    for (size_t j = 0; j < Comp_dim; ++j) {
+      make_const_view(make_not_null(&inverse_jacobian.get(i, j)),
+                      inverse_jacobian_3d.get(i, j), 0,
+                      inverse_jacobian_3d.begin()->size());
+    }
+  }
+  // pdu points to du
+  double* pdu = du->data();
+  const size_t num_grid_points = du->number_of_grid_points();
+  DataVector lhs{};
+  DataVector logical_du{};
+  DataVector safe_x_coords = get<0>(inertial_coords);
+  const bool element_contains_zero_of_symmetry_axis = equal_within_roundoff(
+      0.0, safe_x_coords[0], std::numeric_limits<double>::epsilon() * 100.0,
+      max(safe_x_coords));
+  // Having x=0 requires both not dividing by zero (done here by setting to
+  // arbitrary non-zero value) and remembering to then do L'Hopital
+  if (element_contains_zero_of_symmetry_axis) {
+    safe_x_coords[0] = 1.0;
+    if constexpr (Comp_dim == 2) {
+      const size_t x_extents = mesh.extents(0);
+      const size_t y_extents = mesh.extents(1);
+      for (size_t i = 1; i < y_extents; ++i) {
+        ASSERT(
+            equal_within_roundoff(
+                0.0, safe_x_coords[i * x_extents],
+                std::numeric_limits<double>::epsilon() * 100.0,
+                max(safe_x_coords)),
+            "The passed inertial coordinates do not follow the required format "
+            "of a rectangular mesh with x=0 being located at the first index "
+            "of each constant-y subdomain of the x DataVector. x="
+                << safe_x_coords);
+        safe_x_coords[i * x_extents] = 1.0;
+      }
+    }
+  }
+  // If doing L'Hopital's rule, we need to store temporary forms of the data
+  // in two different tensors (hence the 0 & 1 labels) for each tensor type
+  // They only have to hold the x=0 positions, so of size y_extents
+  using VariableTypes = tmpl::remove_duplicates<
+      tmpl::transform<VariableTags, tmpl::bind<tmpl::type_from, tmpl::_1>>>;
+
+  using TempTags0 = ::Tags::convert_to_temp_tensors<VariableTypes, 0>;
+  using TempTags1 = ::Tags::convert_to_temp_tensors<VariableTypes, 1>;
+  using VarTags = tmpl::append<TempTags0, TempTags1>;
+
+  Variables<VarTags> temp_vars{};
+  if (element_contains_zero_of_symmetry_axis) {
+    const size_t y_extents = mesh.extents(1);
+    temp_vars.initialize(y_extents);
+  }
+
+  std::array<std::array<size_t, Comp_dim>, Comp_dim> indices{};
+  for (size_t deriv_index = 0; deriv_index < Comp_dim; ++deriv_index) {
+    for (size_t d = 0; d < Comp_dim; ++d) {
+      gsl::at(gsl::at(indices, d), deriv_index) =
+          InverseJacobian<DataVector, Comp_dim, Frame::ElementLogical,
+                          DerivativeFrame>::get_storage_index(d, deriv_index);
+    }
+  }
+
+  // the non-cartoon derivatives need to know where they are within `u` to
+  // contract with the inverse Jacobian to compute the inertial derivatives
+  size_t global_component_index = 0;
+  tmpl::for_each<VariableTags>(
+      [&u, &du, &lhs, &pdu, &num_grid_points, &logical_du,
+       &const_logical_derivs, &inverse_jacobian, &indices, &temp_vars,
+       &global_component_index, &safe_x_coords,
+       &numerical_deriv_in_this_direction, &quad_type, &mesh,
+       &element_contains_zero_of_symmetry_axis]<typename TensorTag>(
+          tmpl::type_<TensorTag> /*meta*/) {
+        auto& tensor = get<TensorTag>(u);
+
+        TensorMetafunctions::prepend_spatial_index<
+            typename TensorTag::type, Dim, UpLo::Lo, Frame::Inertial>
+            cart_deriv_tensor;
+        cartoon_derivative<typename TensorTag::type, 3, Frame::Inertial>(
+            cart_deriv_tensor, tensor, safe_x_coords, quad_type);
+
+        for (size_t component_index = 0;
+             component_index < TensorTag::type::size();
+             ++component_index, ++global_component_index) {
+          for (size_t deriv_index = 0; deriv_index < Dim; ++deriv_index) {
+            // lhs points to pdu (shifts by num grid points below)
+            lhs.set_data_ref(pdu, num_grid_points);
+
+            if (numerical_deriv_in_this_direction(deriv_index)) {
+              // do normal derivative for x (and possibly y) derivative
+              // clang-tidy: const cast is fine since we won't modify the data
+              // and we need it to easily hook into the expression templates.
+              logical_du.set_data_ref(
+                  const_cast<ValueType*>(                  // NOLINT
+                      gsl::at(const_logical_derivs, 0)) +  // NOLINT
+                      global_component_index * num_grid_points,
+                  num_grid_points);
+              lhs = (*(inverse_jacobian.begin() +
+                       gsl::at(indices[0], deriv_index))) *
+                    logical_du;
+              if constexpr (Comp_dim == 2) {
+                // clang-tidy: const cast is fine since we won't modify the data
+                // and we need it to easily hook into the expression templates.
+                logical_du.set_data_ref(
+                    const_cast<ValueType*>(                  // NOLINT
+                        gsl::at(const_logical_derivs, 1)) +  // NOLINT
+                        global_component_index * num_grid_points,
+                    num_grid_points);
+                lhs += (*(inverse_jacobian.begin() +
+                          gsl::at(gsl::at(indices, 1), deriv_index))) *
+                       logical_du;
+              }
+            } else {
+              // do cartoon dervative
+              const auto input_tensor_index =
+                  tensor.get_tensor_index(component_index);
+              const auto output_tensor_index =
+                  prepend(input_tensor_index, size_t{deriv_index});
+              lhs = cart_deriv_tensor.get(output_tensor_index);
+            }
+            // clang-tidy: no pointer arithmetic
+            pdu += num_grid_points;  // NOLINT
+          }
+        }
+        if (element_contains_zero_of_symmetry_axis) {
+          // need to use L'Hopital
+          using dtensor_type =
+              tmpl::at<ResultTags, tmpl::index_of<VariableTags, TensorTag>>;
+          auto& dtensor = get<dtensor_type>(*du);
+
+          // if spherical symmetry,the zero is only at the first index
+          // if axial symmetry, the zero is repeated every x_extents times
+          const size_t x_extents = mesh.extents(0);
+          // for spherical symmetry, y_extents = 1, so we could use a double
+          // type rather than a size 1 DataVector, but it requires a lot of code
+          // reuse
+          const size_t y_extents = mesh.extents(1);
+
+          auto& dx_tensor =
+              get<::Tags::TempTensor<0, typename TensorTag::type>>(temp_vars);
+          auto& contracted_dx_tensor =
+              get<::Tags::TempTensor<1, typename TensorTag::type>>(temp_vars);
+
+          for (size_t component_index = 0; component_index < dx_tensor.size();
+               ++component_index) {
+            const auto output_index =
+                dx_tensor.get_tensor_index(component_index);
+            // the 0 is because we want the x derivative
+            const size_t input_index =
+                dtensor.get_storage_index(prepend(output_index, size_t{0}));
+            for (size_t i = 0; i < y_extents; ++i) {
+              dx_tensor[component_index][i] =
+                  dtensor[input_index][i * x_extents];
+            }
+          }
+
+          const size_t start_index =
+              quad_type == Spectral::Quadrature::SphericalSymmetry ? 1 : 2;
+          for (size_t deriv_index = start_index; deriv_index < 3;
+               ++deriv_index) {
+            cartoon_contraction(make_not_null(&contracted_dx_tensor), dx_tensor,
+                                deriv_index, quad_type);
+            for (size_t component_index = 0;
+                 component_index < contracted_dx_tensor.size();
+                 ++component_index) {
+              const auto input_index =
+                  contracted_dx_tensor.get_tensor_index(component_index);
+              const size_t output_index =
+                  dtensor.get_storage_index(prepend(input_index, deriv_index));
+              for (size_t i = 0; i < y_extents; ++i) {
+                dtensor[output_index][i * x_extents] =
+                    contracted_dx_tensor[component_index][i];
+              }
+            }
+          }
+        }
+      });
+}
+
+template <typename ResultTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3>>
+void cartoon_partial_derivatives(
+    const gsl::not_null<Variables<ResultTags>*> du,
+    const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian_3d,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  if (mesh.basis(0) != Spectral::Basis::Cartoon and
+      mesh.basis(2) == Spectral::Basis::Cartoon) {
+    // computational dimension needs to be a constexpr
+    if (mesh.basis(1) == Spectral::Basis::Cartoon) {
+      cartoon_partial_derivatives_apply<1, ResultTags, VariableTags, Dim,
+                                        DerivativeFrame>(
+          du, u, mesh, inverse_jacobian_3d, inertial_coords);
+    } else {
+      cartoon_partial_derivatives_apply<2, ResultTags, VariableTags, Dim,
+                                        DerivativeFrame>(
+          du, u, mesh, inverse_jacobian_3d, inertial_coords);
+    }
+  } else {
+    ERROR("Bases do not match valid Cartoon pattern.");
+  }
+}
+
 template <typename ResultTags, typename VariableTags, size_t Dim,
           typename DerivativeFrame>
 void partial_derivatives(
@@ -253,8 +678,8 @@ partial_derivatives(
   Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
                              DerivativeFrame>>
       partial_derivatives_of_u(u.number_of_grid_points());
-  partial_derivatives(make_not_null(&partial_derivatives_of_u),
-                                      u, mesh, inverse_jacobian);
+  partial_derivatives(make_not_null(&partial_derivatives_of_u), u, mesh,
+                      inverse_jacobian);
   return partial_derivatives_of_u;
 }
 

--- a/src/NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp
@@ -48,6 +48,23 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f, const Mesh<1>& mesh) {
         default:
           ERROR("Missing quadrature case for spectral quantity");
       }
+    case Basis::Cartoon:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::AxialSymmetry:
+          return f(
+              std::integral_constant<Basis, Basis::Cartoon>{},
+              std::integral_constant<Quadrature, Quadrature::AxialSymmetry>{},
+              num_points);
+        case Quadrature::SphericalSymmetry:
+          return f(std::integral_constant<Basis, Basis::Cartoon>{},
+                   std::integral_constant<Quadrature,
+                                          Quadrature::SphericalSymmetry>{},
+                   num_points);
+        default:
+          ERROR(
+              "Only Axial and Spherical Symmetry quadratures are allowed for "
+              "a Cartoon basis.");
+      }
     case Basis::FiniteDifference:
       switch (mesh.quadrature(0)) {
         case Quadrature::CellCentered:

--- a/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
+++ b/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
@@ -65,6 +65,15 @@ void logical_coordinates(
         }
         break;
       }
+      case Spectral::Basis::Cartoon: {
+        if (mesh.extents(d) != 1) {
+          ERROR("Only 1 grid point is allowed in a Cartoon basis.");
+        }
+        for (IndexIterator<VolumeDim> index(mesh.extents()); index; ++index) {
+          logical_coords->get(d)[index.collapsed_index()] = 0.0;
+        }
+        break;
+      }
       // NOLINTNEXTLINE(bugprone-branch-clone)
       case Spectral::Basis::Chebyshev:
         [[fallthrough]];

--- a/src/NumericalAlgorithms/Spectral/LogicalCoordinates.hpp
+++ b/src/NumericalAlgorithms/Spectral/LogicalCoordinates.hpp
@@ -57,7 +57,8 @@ struct not_null;
  * corresponding to the Legendre Gauss points of \f$\cos \theta\f$ (and thus
  * have no points at the poles), while the azimuth has Equiangular quadrature
  * which are distributed uniformly including the left endpoint, but not the
- * right.
+ * right.  For the Cartoon basis, only one logical coordinate is allowed and it
+ * is never used for computations.
  *
  * \example
  * \snippet Test_LogicalCoordinates.cpp logical_coordinates_example

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -21,6 +21,8 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
@@ -648,6 +650,360 @@ void test_partial_derivatives_spherical_shell() {
     }
   }
 }
+
+template <bool Spherical>
+DataVector cartoon_func(const tnsr::I<DataVector, 3, Frame::Grid>& coords) {
+  if constexpr (Spherical) {
+    // a radial function, f(r) = f(x) because the computational domain is the x
+    // axis
+    return 0.01 * pow(get<0>(coords), 4) + 0.3 * pow(get<0>(coords), 3) -
+           0.1 * pow(get<0>(coords), 2) - 2.0 * get<0>(coords) - 1.5;
+  } else {
+    // an axially symmetric function about the y axis,
+    // f(\sqrt{x^2 + z^2}, y) = f(x, y) because the computational domain is the
+    // x-y plane
+    return square(get<1>(coords)) + square(get<0>(coords)) * get<1>(coords);
+  }
+}
+
+template <bool Spherical>
+DataVector cartoon_dfunc(size_t deriv_index,
+                         const tnsr::I<DataVector, 3, Frame::Grid>& coords) {
+  if constexpr (Spherical) {
+    if (deriv_index == 0) {
+      return 0.04 * pow(get<0>(coords), 3) + 0.9 * pow(get<0>(coords), 2) -
+             0.2 * get<0>(coords) - 2.0;
+    } else {
+      return {get<0>(coords).size(), 0.0};
+    }
+  } else {
+    if (deriv_index == 0) {
+      return 2.0 * get<0>(coords) * get<1>(coords);
+    } else if (deriv_index == 1) {
+      return 2.0 * get<1>(coords) + square(get<0>(coords));
+    } else {
+      return {get<0>(coords).size(), 0.0};
+    }
+  }
+}
+
+template <bool Spherical>
+void test_cartoon(const double x_start) {
+  Mesh<3> mesh;
+  tnsr::I<DataVector, 3, Frame::Grid> coords;
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>
+      inv_jacobian;
+
+  using Identity1D = domain::CoordinateMaps::Identity<1>;
+  const Identity1D identity_cartoon_map;
+
+  if constexpr (Spherical) {
+    // spherical  symmetry
+    const size_t num_grid_pts = 8;
+    const double x_end = 4.0;
+
+    mesh = Mesh<3>{{{num_grid_pts, 1, 1}},
+                   {{Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+                     Spectral::Basis::Cartoon}},
+                   {{Spectral::Quadrature::GaussLobatto,
+                     Spectral::Quadrature::SphericalSymmetry,
+                     Spectral::Quadrature::SphericalSymmetry}}};
+
+    const Affine affine_x_map(-1.0, 1.0, x_start, x_end);
+
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Grid,
+                                Cartoon_map_combination>
+        map{{affine_x_map, identity_cartoon_map, identity_cartoon_map}};
+    inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+    coords = map(logical_coordinates(mesh));
+  } else {
+    // axial symmetry
+    const size_t num_x_grid_pts = 6;
+    const double x_end = 3.25;
+    const size_t num_y_grid_pts = 7;
+    const double y_start = -2.5;
+    const double y_end = 4.0;
+
+    mesh = Mesh<3>{{{num_x_grid_pts, num_y_grid_pts, 1}},
+                   {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                     Spectral::Basis::Cartoon}},
+                   {{Spectral::Quadrature::GaussLobatto,
+                     Spectral::Quadrature::GaussLobatto,
+                     Spectral::Quadrature::AxialSymmetry}}};
+
+    const Affine affine_x_map(-1.0, 1.0, x_start, x_end);
+    const Affine affine_y_map(-1.0, 1.0, y_start, y_end);
+
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Grid,
+                                Cartoon_map_combination>
+        map{{affine_x_map, affine_y_map, identity_cartoon_map}};
+    inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+    coords = map(logical_coordinates(mesh));
+  }
+
+  using Tempabc =
+      ::Tags::TempTensor<0, tnsr::abc<DataVector, 3, Frame::Inertial>>;
+
+  using VarTags =
+      tmpl::list<::Tags::TempScalar<0>, ::Tags::Tempa<0, 3, Frame::Inertial>,
+                 ::Tags::TempA<0, 3, Frame::Inertial>,
+                 ::Tags::TempAb<0, 3, Frame::Inertial>,
+                 ::Tags::Tempab<0, 3, Frame::Inertial>, Tempabc>;
+
+  Variables<VarTags> vars{mesh.number_of_grid_points()};
+
+  using d_VarTags =
+      tmpl::transform<VarTags, tmpl::bind<::Tags::deriv, tmpl::_1,
+                                          tmpl::size_t<3>, Frame::Grid>>;
+
+  Variables<d_VarTags> expected_d_vars{mesh.number_of_grid_points()};
+
+  // Here we create "prefactors", which serve to fill out our tensors by being
+  // multiplied by our cartoon_func(), which themselves make our tensors have
+  // some nontrivial spatial derivative
+  // The point of these prefactors is to ensure the tensors respect the
+  // symmetry of the spacetime: it is not sufficient that each component
+  // follows the symmetry, rather the entire tensor must satisfy
+  // \mathcal{L}_\xi (tensor) = 0. Each rank has it's own form of prefactor
+  Variables<VarTags> prefactor_vars{mesh.number_of_grid_points()};
+
+  using TempiA =
+      ::Tags::TempTensor<0, tnsr::iA<DataVector, 3, Frame::Inertial>>;
+  using TempiAb =
+      ::Tags::TempTensor<0, tnsr::iAb<DataVector, 3, Frame::Inertial>>;
+  using Tempiab =
+      ::Tags::TempTensor<0, tnsr::iab<DataVector, 3, Frame::Inertial>>;
+  using Tempiabc =
+      ::Tags::TempTensor<0, TensorMetafunctions::prepend_spatial_index<
+                                tnsr::abc<DataVector, 3, Frame::Inertial>, 3,
+                                UpLo::Lo, Frame::Inertial>>;
+
+  // prepending a spatial index to VarTags (= PrefactorVarTags if it existed)
+  using d_PrefactorVarTags = tmpl::list<::Tags::Tempi<0, 3, Frame::Inertial>,
+                                        ::Tags::Tempia<0, 3, Frame::Inertial>,
+                                        TempiA, TempiAb, Tempiab, Tempiabc>;
+
+  Variables<d_PrefactorVarTags> d_prefactor_vars{mesh.number_of_grid_points()};
+
+  const size_t dv_size = get<0>(coords).size();
+
+  // in the following, the time component of the indices is arbirarily taken
+  // to be 1
+  auto& scalar = get<::Tags::TempScalar<0>>(prefactor_vars);
+  auto& d_scalar = get<::Tags::Tempi<0, 3>>(d_prefactor_vars);
+  // scalar, doing nothing
+  scalar.get() = DataVector(dv_size, 1.0);
+  // \partial_i of 1 is zero
+  for (size_t i = 0; i < index_dim<0>(d_scalar); ++i) {
+    d_scalar.get(i) = DataVector(dv_size, 0.0);
+  }
+
+  auto& one_form = get<::Tags::Tempa<0, 3>>(prefactor_vars);
+  auto& d_one_form = get<::Tags::Tempia<0, 3>>(d_prefactor_vars);
+  auto& vector = get<::Tags::TempA<0, 3>>(prefactor_vars);
+  auto& d_vector = get<TempiA>(d_prefactor_vars);
+  if constexpr (Spherical) {
+    // spherical case, vector/one form, using x^a
+    get<0>(vector) = get<0>(one_form) = DataVector(dv_size, 1.0);
+    for (size_t i = 1; i < index_dim<0>(vector); ++i) {
+      vector.get(i) = one_form.get(i) = coords.get(i - 1);
+    }
+    // partial_i of x_a is \delta_ia
+    for (size_t i = 0; i < index_dim<0>(d_vector); ++i) {
+      for (size_t a = 0; a < index_dim<1>(d_vector); ++a) {
+        if ((i + 1) == a and a != 0) {
+          d_vector.get(i, a) = d_one_form.get(i, a) = DataVector(dv_size, 1.0);
+        } else {
+          d_vector.get(i, a) = d_one_form.get(i, a) = DataVector(dv_size, 0.0);
+        }
+      }
+    }
+  } else {
+    // axial case, vector/one form, using x^a = (0, -z, 0, x) (pure rotation)
+    get<0>(vector) = get<0>(one_form) = DataVector(dv_size, 0.0);
+    get<1>(vector) = get<1>(one_form) = -1.0 * coords.get(2);
+    get<2>(vector) = get<2>(one_form) = DataVector(dv_size, 0.0);
+    get<3>(vector) = get<3>(one_form) = get<0>(coords);
+
+    // \partial_i of x_a is (0, \delta_i2, 0, \delta_i0)
+    for (size_t i = 0; i < index_dim<0>(d_vector); ++i) {
+      for (size_t a = 0; a < index_dim<1>(d_vector); ++a) {
+        if (i == 2 and a == 1) {
+          d_vector.get(i, a) = d_one_form.get(i, a) = DataVector(dv_size, -1.0);
+        } else if (i == 0 and a == 3) {
+          d_vector.get(i, a) = d_one_form.get(i, a) = DataVector(dv_size, 1.0);
+        } else {
+          d_vector.get(i, a) = d_one_form.get(i, a) = DataVector(dv_size, 0.0);
+        }
+      }
+    }
+  }
+
+  auto& mixed = get<::Tags::TempAb<0, 3>>(prefactor_vars);
+  auto& d_mixed = get<TempiAb>(d_prefactor_vars);
+  auto& rank2 = get<::Tags::Tempab<0, 3>>(prefactor_vars);
+  auto& d_rank2 = get<Tempiab>(d_prefactor_vars);
+  // filling space with (essenially) projector to tangent space of sphere
+  // P_ab = \delta_ab + x_a x_b
+  // can have arbitrary function in from of each term, not doing here
+  // (the real projector is \delta_ij - x_i x_j / r^2)
+  for (size_t a = 0; a < index_dim<0>(rank2); ++a) {
+    for (size_t b = 0; b < index_dim<1>(rank2); ++b) {
+      if (a == 0 and b == 0) {
+        mixed.get(a, b) = rank2.get(a, b) = DataVector(dv_size, 1.0);
+      } else if (a == 0) {
+        mixed.get(a, b) = rank2.get(a, b) = coords.get(b - 1);
+      } else if (b == 0) {
+        mixed.get(a, b) = rank2.get(a, b) = coords.get(a - 1);
+      } else {
+        if (a == b) {
+          mixed.get(a, b) = rank2.get(a, b) =
+              DataVector(dv_size, 1.0) + coords.get(a - 1) * coords.get(b - 1);
+        } else {
+          mixed.get(a, b) = rank2.get(a, b) =
+              coords.get(a - 1) * coords.get(b - 1);
+        }
+      }
+    }
+  }
+  // \partial_i of (\delta_ab + x_a x_b) is (x_a \delta_ib + x_b \delta_ia)
+  for (size_t i = 0; i < index_dim<0>(d_rank2); ++i) {
+    for (size_t a = 0; a < index_dim<1>(d_rank2); ++a) {
+      for (size_t b = 0; b < index_dim<2>(d_rank2); ++b) {
+        d_mixed.get(i, a, b) = d_rank2.get(i, a, b) = DataVector(dv_size, 0.0);
+        if ((i + 1) == b) {
+          if (a == 0) {
+            d_mixed.get(i, a, b) += 1.0;
+            d_rank2.get(i, a, b) += 1.0;
+          } else {
+            d_mixed.get(i, a, b) += coords.get(a - 1);
+            d_rank2.get(i, a, b) += coords.get(a - 1);
+          }
+        }
+        if ((i + 1) == a) {
+          if (b == 0) {
+            d_mixed.get(i, a, b) += 1.0;
+            d_rank2.get(i, a, b) += 1.0;
+          } else {
+            d_mixed.get(i, a, b) += coords.get(b - 1);
+            d_rank2.get(i, a, b) += coords.get(b - 1);
+          }
+        }
+      }
+    }
+  }
+
+  auto& rank3 = get<Tempabc>(prefactor_vars);
+  auto& d_rank3 = get<Tempiabc>(d_prefactor_vars);
+  // Rank 3 is important because of \Phi_iab, the spatial derivative of the
+  // metric, which though not a tensor mathematically still must obey
+  // \mathcal{L}_\xi \Phi_{iab} = 0
+  // Using the form
+  // x_a x_b x_c + \delta_ab x_c \delta_ac x_b \delta_bc x_a
+  for (size_t a = 0; a < index_dim<0>(rank3); ++a) {
+    for (size_t b = 0; b < index_dim<1>(rank3); ++b) {
+      for (size_t c = 0; c < index_dim<2>(rank3); ++c) {
+        rank3.get(a, b, c) =
+            (a == 0 ? DataVector(dv_size, 1.0) : coords.get(a - 1)) *
+            (b == 0 ? DataVector(dv_size, 1.0) : coords.get(b - 1)) *
+            (c == 0 ? DataVector(dv_size, 1.0) : coords.get(c - 1));
+        if (a == b) {
+          rank3.get(a, b, c) +=
+              (c == 0 ? DataVector(dv_size, 1.0) : coords.get(c - 1));
+        }
+        if (a == c) {
+          rank3.get(a, b, c) +=
+              (b == 0 ? DataVector(dv_size, 1.0) : coords.get(b - 1));
+        }
+        if (b == c) {
+          rank3.get(a, b, c) +=
+              (a == 0 ? DataVector(dv_size, 1.0) : coords.get(a - 1));
+        }
+      }
+    }
+  }
+  // \partial_i of (x_a x_b x_c + \delta_ab x_c \delta_ac x_b \delta_bc x_a) is
+  // \delta_ia x_b x_c + \delta_ib x_a x_c + \delta_ic x_a x_b +
+  //   \delta_ab \delta_ic + \delta_ac \delta_ib + \delta_bc \delta_ia
+  for (size_t i = 0; i < index_dim<0>(d_rank3); ++i) {
+    for (size_t a = 0; a < index_dim<1>(d_rank3); ++a) {
+      for (size_t b = 0; b < index_dim<2>(d_rank3); ++b) {
+        for (size_t c = 0; c < index_dim<3>(d_rank3); ++c) {
+          d_rank3.get(i, a, b, c) = DataVector(dv_size, 0.0);
+          if ((i + 1) == a) {
+            d_rank3.get(i, a, b, c) +=
+                (b == 0 ? DataVector(dv_size, 1.0) : coords.get(b - 1)) *
+                (c == 0 ? DataVector(dv_size, 1.0) : coords.get(c - 1));
+          }
+          if ((i + 1) == b) {
+            d_rank3.get(i, a, b, c) +=
+                (a == 0 ? DataVector(dv_size, 1.0) : coords.get(a - 1)) *
+                (c == 0 ? DataVector(dv_size, 1.0) : coords.get(c - 1));
+          }
+          if ((i + 1) == c) {
+            d_rank3.get(i, a, b, c) +=
+                (a == 0 ? DataVector(dv_size, 1.0) : coords.get(a - 1)) *
+                (b == 0 ? DataVector(dv_size, 1.0) : coords.get(b - 1));
+          }
+          if (a == b and (i + 1) == c) {
+            d_rank3.get(i, a, b, c) += 1.0;
+          }
+          if (a == c and (i + 1) == b) {
+            d_rank3.get(i, a, b, c) += 1.0;
+          }
+          if (b == c and (i + 1) == a) {
+            d_rank3.get(i, a, b, c) += 1.0;
+          }
+        }
+      }
+    }
+  }
+
+  tmpl::for_each<VarTags>([&vars, &prefactor_vars, &expected_d_vars,
+                           &d_prefactor_vars, &coords]<typename tensor_tag>(
+                              tmpl::type_<tensor_tag> /*meta*/) {
+    auto& tensor = get<tensor_tag>(vars);
+    const auto& prefactor_tensor = get<tensor_tag>(prefactor_vars);
+    using deriv_tag = tmpl::apply<
+        tmpl::bind<::Tags::deriv, tmpl::_1, tmpl::size_t<3>, Frame::Grid>,
+        tensor_tag>;
+    auto& d_tensor = get<deriv_tag>(expected_d_vars);
+    const auto& d_prefactor_tensor =
+        get<tmpl::at<d_PrefactorVarTags, tmpl::index_of<VarTags, tensor_tag>>>(
+            d_prefactor_vars);
+
+    for (size_t storage_index = 0; storage_index < tensor.size();
+         ++storage_index) {
+      tensor[storage_index] =
+          prefactor_tensor[storage_index] * cartoon_func<Spherical>(coords);
+
+      const auto input_index = tensor.get_tensor_index(storage_index);
+      for (size_t deriv_index = 0; deriv_index < 3; ++deriv_index) {
+        const auto output_index = prepend(input_index, size_t{deriv_index});
+
+        d_tensor.get(output_index) =
+            prefactor_tensor.get(input_index) *
+                cartoon_dfunc<Spherical>(deriv_index, coords) +
+            cartoon_func<Spherical>(coords) *
+                d_prefactor_tensor.get(output_index);
+      }
+    }
+  });
+
+  const auto to_inertial =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                            domain::CoordinateMaps::Identity<3>>{};
+  Variables<d_VarTags> d_vars{mesh.number_of_grid_points()};
+  cartoon_partial_derivatives(make_not_null(&d_vars), vars, mesh, inv_jacobian,
+                              to_inertial(coords));
+  // `d_vars` holds our partial derivatives we want to test against the truth
+  const Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
+  CHECK_VARIABLES_CUSTOM_APPROX(d_vars, expected_d_vars, local_approx);
+}
 }  // namespace
 
 // [[Timeout, 60]]
@@ -771,6 +1127,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
       mesh_3d);
   test_partial_derivatives_3d<two_vars<ComplexDataVector, 3>,
                               one_var<ComplexDataVector, 3>>(mesh_3d);
+
+  // testing with L'Hopital
+  test_cartoon<true>(0.0);
+  test_cartoon<false>(0.0);
+  // testing without L'Hopital
+  test_cartoon<true>(1.0);
+  test_cartoon<false>(1.0);
 
   TestHelpers::db::test_prefix_tag<
       Tags::deriv<Var1<DataVector, 3>, tmpl::size_t<3>, Frame::Grid>>(

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LogicalCoordinates.cpp
@@ -13,6 +13,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Structure/Direction.hpp"
@@ -105,6 +106,53 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.LogicalCoordinates",
 
   CHECK(x_3d[2][0] == -32.0);
   CHECK(x_3d[2][15] == 74.0);
+
+  const Mesh<3> mesh_spherical{
+      {3, 1, 1},
+      {Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+       Spectral::Basis::Cartoon},
+      {Spectral::Quadrature::GaussLobatto,
+       Spectral::Quadrature::SphericalSymmetry,
+       Spectral::Quadrature::SphericalSymmetry}};
+  using Affine = domain::CoordinateMaps::Affine;
+  using Identity = domain::CoordinateMaps::Identity<1>;
+  const Identity identity_cartoon_map;
+  const Affine affine_x_map(-1.0, 1.0, -1.0, 1.0);
+  const domain::CoordinateMap<
+      Frame::ElementLogical, Frame::Grid,
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Identity, Identity>>
+      map_spherical{{affine_x_map, identity_cartoon_map, identity_cartoon_map}};
+  const auto x_spherical = map_spherical(logical_coordinates(mesh_spherical));
+  CHECK(x_spherical[1][0] == 0.0);
+  CHECK(x_spherical[1][1] == 0.0);
+  CHECK(x_spherical[1][2] == 0.0);
+  CHECK(x_spherical[2][0] == 0.0);
+  CHECK(x_spherical[2][1] == 0.0);
+  CHECK(x_spherical[2][2] == 0.0);
+
+  const Mesh<3> mesh_axial{
+      {2, 3, 1},
+      {Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+       Spectral::Basis::Cartoon},
+      {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+       Spectral::Quadrature::AxialSymmetry}};
+  const domain::CoordinateMap<
+      Frame::ElementLogical, Frame::Grid,
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity>>
+      map_axial{{affine_x_map, affine_x_map, identity_cartoon_map}};
+  const auto x_axial = map_axial(logical_coordinates(mesh_axial));
+  CHECK(x_axial[2][0] == 0.0);
+  CHECK(x_axial[2][1] == 0.0);
+  CHECK(x_axial[2][2] == 0.0);
+  CHECK(x_axial[2][3] == 0.0);
+  CHECK(x_axial[2][4] == 0.0);
+  CHECK(x_axial[2][5] == 0.0);
+
+  const Mesh<1> mesh_cartoon_error{2, Spectral::Basis::Cartoon,
+                                   Spectral::Quadrature::AxialSymmetry};
+  CHECK_THROWS_WITH((logical_coordinates(mesh_cartoon_error)),
+                    Catch::Matchers::ContainsSubstring(
+                        "Only 1 grid point is allowed in a Cartoon basis."));
 
   TestHelpers::db::test_compute_tag<domain::Tags::LogicalCoordinates<1>>(
       "ElementLogicalCoordinates");


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

The first commit is to allow a Mesh to take a `Cartoon` basis which can only ever have one grid point.

The second commit uses Michael Pajkos's Cartoon code to find partial derivatives not in the computational domain. As we divide by the coordinates, if there is a zero value, L'Hopital's rule is used to evaluate the derivative at that point.

Within `PartialDeriatives.tpp`, `cartoon_contraction()` does the contractions in Eqn. (218) of the SXS book's Numerical Method's chapter, specifically the thing on the RHS that you take the derivative of or divide by x. The `cartoon_derivative()` function does the bottom choice of Eqn. 218 (dividing by x) while the top choice is evaluated if needed at the bottom of `cartoon_partial_derivatives_apply()`. One only ever calls `cartoon_partial_derivatives()`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
