### PR TITLE
Add adaptive horizon criterion for residual

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   IncreaseResolution.cpp
+  Residual.cpp
   )
 
 spectre_target_headers(
@@ -19,6 +20,7 @@ spectre_target_headers(
   Criterion.hpp
   Factory.hpp
   IncreaseResolution.hpp
+  Residual.hpp
   )
 
 add_dependencies(

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp
@@ -4,8 +4,9 @@
 #pragma once
 
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace ah::Criteria {
-using standard_criteria = tmpl::list<>;
+using standard_criteria = tmpl::list<Residual>;
 }  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
+
+#include <cstddef>
+#include <pup.h>
+
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace ah::Criteria {
+Residual::Residual(double min_residual, double max_residual,
+                   size_t min_resolution_l, size_t max_resolution_l,
+                   const Options::Context& context)
+    : min_residual_(min_residual),
+      max_residual_(max_residual),
+      min_resolution_l_(min_resolution_l),
+      max_resolution_l_(max_resolution_l) {
+  if (min_residual_ >= max_residual_) {
+    PARSE_ERROR(context, "MinResidual must be less than MaxResidual");
+  }
+  if (min_resolution_l_ < 2) {
+    PARSE_ERROR(context, "MinResolutionL must not be less than 2");
+  }
+  if (max_resolution_l_ < 2) {
+    PARSE_ERROR(context, "MaxResolutionL must not be less than 2");
+  }
+  if (min_resolution_l_ > max_resolution_l_) {
+    PARSE_ERROR(context,
+                "MinResolutionL must not be greater than MaxResolutionL");
+  }
+}
+
+void Residual::pup(PUP::er& p) {
+  p | min_residual_;
+  p | max_residual_;
+  p | min_resolution_l_;
+  p | max_resolution_l_;
+}
+Residual::Residual(CkMigrateMessage* msg) : Criterion(msg) {}
+
+PUP::able::PUP_ID ah::Criteria::Residual::my_PUP_ID = 0;  // NOLINT
+}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <string>
+
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+/*!
+ * \brief Recommend an updated resolution $L_{\rm new}$ based on the
+ * resolution $L$ of the Strahlkorper and its residual $\delta$.
+ *
+ * \details The returned recommended resolution $L_{\rm new}$ depends on
+ * the following options:
+ * - MinResidual: a minimum residual $\delta_{\rm min}$
+ * - MaxResidual: a maximum residual $\delta_{\rm max}$
+ * - MinResolutionL: a minimum resolution $L_{\rm min}$
+ * - MaxResolutionL: a maximum resolution $L_{\rm max}$
+ * The value returned for $L_{\rm new}$ is then determined as follows:
+ * - If $L > L_{\rm min}$ and $\delta < \delta_{\rm min}$, then
+ * $L_{\rm new} = L - 1$
+ * - If $L < L_{\rm max}$ and $\delta > \delta_{\rm max}$, then
+ * $L_{\rm new} = L + 1$
+ * - Otherwise, $L_{\rm new} = L$
+ * Note that the residual is obtained from the provided FastFlow::IterInfo. The
+ * residual is the gr::surfaces::expansion weighted by the FastFlow weights.
+ */
+class Residual : public Criterion {
+ public:
+  struct MinResidual {
+    using type = double;
+    static constexpr Options::String help = {"The minimum residual."};
+    static type lower_bound() { return 0.0; }
+  };
+  struct MaxResidual {
+    using type = double;
+    static constexpr Options::String help = {"The maximum residual."};
+    static type lower_bound() { return 0.0; }
+  };
+  struct MinResolutionL {
+    using type = size_t;
+    static constexpr Options::String help = {"The minimum resolution."};
+    // Strahlkorper default constructor sets L=2, so don't allow L below that
+    static type lower_bound() { return 2; }
+  };
+  struct MaxResolutionL {
+    using type = size_t;
+    static constexpr Options::String help = {"The maximum resolution."};
+    // Strahlkorper default constructor sets L=2, so don't allow L below that
+    static type lower_bound() { return 2; }
+  };
+
+  using options =
+      tmpl::list<MinResidual, MaxResidual, MinResolutionL, MaxResolutionL>;
+  static constexpr Options::String help = {
+      "Use Strahlkorper residual and resolution to suggest a new "
+      "resolution."};
+
+  Residual() = default;
+  Residual(double min_residual, double max_residual, size_t min_resolution_l,
+           size_t max_resolution_l, const Options::Context& context = {});
+
+  /// \cond
+  explicit Residual(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Residual);  // NOLINT
+  /// \endcond
+
+  std::string observation_name() override { return "Residual"; }
+
+  using argument_tags = tmpl::list<>;
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  template <typename Metavariables, typename Frame>
+  size_t operator()(const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ylm::Strahlkorper<Frame>& strahlkorper,
+                    const FastFlow::IterInfo& info) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  double min_residual_{std::numeric_limits<double>::signaling_NaN()};
+  double max_residual_{std::numeric_limits<double>::signaling_NaN()};
+  size_t min_resolution_l_{};
+  size_t max_resolution_l_{};
+};
+
+// Out-of-line definition
+/// \cond
+template <typename Metavariables, typename Frame>
+size_t Residual::operator()(
+    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ylm::Strahlkorper<Frame>& strahlkorper,
+    const FastFlow::IterInfo& info) const {
+  if (UNLIKELY(min_resolution_l_ == max_resolution_l_)) {
+    ASSERT(min_resolution_l_ == strahlkorper.l_max(),
+           "If MinResolutionL == MaxResolutionL, strahlkorper resolution must "
+           "also equal MinResolution L, but here MinResolutionL is "
+               << min_resolution_l_ << ", MaxResolutionL is "
+               << max_resolution_l_ << ", and the current resolution is "
+               << strahlkorper.l_max());
+    return strahlkorper.l_max();
+  }
+  if (strahlkorper.l_max() > min_resolution_l_ and
+      info.residual_ylm < min_residual_ and strahlkorper.l_max() > 0) {
+    return strahlkorper.l_max() - 1;
+  }
+  if (strahlkorper.l_max() < max_resolution_l_ and
+      info.residual_ylm > max_residual_) {
+    return strahlkorper.l_max() + 1;
+  }
+  return strahlkorper.l_max();
+}
+/// \endcond
+}  // namespace ah::Criteria

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ApparentHorizonFinderCriteria")
 set(LIBRARY_SOURCES
   Test_Criterion.cpp
   Test_IncreaseResolution.cpp
+  Test_Residual.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Residual.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Residual.cpp
@@ -1,0 +1,271 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+namespace {
+template <typename Frame>
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<ah::Criterion, tmpl::list<Residual>>>;
+  };
+};
+
+FastFlow::IterInfo make_iter_info(double residual_ylm) {
+  FastFlow::IterInfo info{};
+  info.residual_ylm = residual_ylm;
+  return info;
+}
+
+template <typename Fr>
+ylm::Strahlkorper<Fr> make_strahlkorper(size_t l_max) {
+  return ylm::Strahlkorper<Fr>(l_max, 4.5, {{0.4, 0.5, 0.6}});
+}
+
+template <typename Fr>
+void test_criterion_evaluation(
+    const std::unique_ptr<ah::Criterion>& criterion,
+    const ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>>& box,
+    Parallel::GlobalCache<Metavariables<Frame::Inertial>>& cache, size_t l_max,
+    double residual_ylm, size_t expected_new_l_max) {
+  const ylm::Strahlkorper<Fr> strahlkorper = make_strahlkorper<Fr>(l_max);
+  const FastFlow::IterInfo iter_info = make_iter_info(residual_ylm);
+  const size_t new_l_max =
+      criterion->evaluate(box, cache, strahlkorper, iter_info);
+  CHECK(new_l_max == expected_new_l_max);
+}
+
+void test_residual() {
+  TestHelpers::db::test_simple_tag<ah::Criteria::Tags::Criteria>("Criteria");
+  const auto criterion{
+      TestHelpers::test_factory_creation<ah::Criterion, Residual>(
+          "Residual:\n"
+          "  MinResidual: 1.0e-6\n"
+          "  MaxResidual: 1.0e-4\n"
+          "  MinResolutionL: 4\n"
+          "  MaxResolutionL: 12")};
+  // Test observation_name
+  CHECK(criterion->observation_name() == "Residual");
+
+  Parallel::GlobalCache<Metavariables<Frame::Inertial>> empty_cache{};
+  auto databox = db::create<tmpl::list<>>();
+  const ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> box{
+      make_not_null(&databox)};
+
+  constexpr double min_residual{1.0e-6};
+  constexpr double max_residual{1.0e-4};
+  constexpr size_t min_resolution_l{4};
+  constexpr size_t max_resolution_l{12};
+  constexpr size_t mid_l{8};
+  constexpr size_t min_l_allowed_by_strahlkorper{2};
+  constexpr double eps{std::numeric_limits<double>::epsilon()};
+
+  // Normal case - decrease resolution when residual is low
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             0.5 * min_residual, mid_l - 1);
+
+  // Normal case - increase resolution when residual is high
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             2.0 * max_residual, mid_l + 1);
+
+  // Normal case - keep resolution when residual is in range
+  const double in_range_residual{(0.3 * min_residual) + (0.7 * max_residual)};
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             in_range_residual, mid_l);
+
+  // Edge case - at minimum resolution, low residual
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion, box, empty_cache, min_resolution_l, 0.5 * min_residual,
+      min_resolution_l);
+
+  // Edge case - at maximum resolution, high residual
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion, box, empty_cache, max_resolution_l, 2.0 * max_residual,
+      max_resolution_l);
+
+  // Edge case - at minimum resolution, high residual
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion, box, empty_cache, min_resolution_l, 2.0 * max_residual,
+      min_resolution_l + 1);
+
+  // Edge case - at maximum resolution, low residual
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion, box, empty_cache, max_resolution_l, 0.5 * min_residual,
+      max_resolution_l - 1);
+
+  // Edge case - residual exactly at min_residual
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             min_residual, mid_l);
+
+  // Edge case - residual exactly at max_residual
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             max_residual, mid_l);
+
+  // Edge case - residual just below min_residual
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             min_residual - eps, mid_l - 1);
+
+  // Edge case - residual just above min_residual
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             min_residual + eps, mid_l);
+
+  // Edge case - residual just below max_residual
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             max_residual - eps, mid_l);
+
+  // Edge case - residual just above max_residual
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             max_residual + eps, mid_l + 1);
+
+  // Edge case - l_max = 2 (minimum allowed by Strahlkorper)
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion, box, empty_cache, min_l_allowed_by_strahlkorper,
+      0.5 * min_residual, min_l_allowed_by_strahlkorper);
+
+  // Edge case - l_max = 2, high residual
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion, box, empty_cache, min_l_allowed_by_strahlkorper,
+      2.0 * max_residual, min_l_allowed_by_strahlkorper + 1);
+
+  // Edge case - min_resolution_l == max_resolution_l
+  const std::unique_ptr<ah::Criterion> fixed_criterion{
+      std::make_unique<Residual>(min_residual, max_residual, mid_l, mid_l)};
+  test_criterion_evaluation<Frame::Inertial>(fixed_criterion, box, empty_cache,
+                                             mid_l, 0.5 * min_residual, mid_l);
+
+  // Edge case - min_resolution_l == max_resolution_l but
+  // different from strahlkorper
+#ifdef SPECTRE_DEBUG
+  const ylm::Strahlkorper<Frame::Inertial> debug_strahlkorper{
+      make_strahlkorper<Frame::Inertial>(mid_l - 2)};
+  const FastFlow::IterInfo debug_iter_info{make_iter_info(0.5 * min_residual)};
+  CHECK_THROWS_WITH(fixed_criterion->evaluate(
+                        box, empty_cache, debug_strahlkorper, debug_iter_info),
+                    Catch::Matchers::ContainsSubstring(
+                        "If MinResolutionL == MaxResolutionL"));
+#endif
+
+  // Very large l_max
+  const size_t very_large_l{100};
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache,
+                                             very_large_l, 0.5 * min_residual,
+                                             very_large_l - 1);
+
+  // Very small residual
+  const double very_small_residual{1.0e-12};
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             very_small_residual, mid_l - 1);
+
+  // Very large residual
+  const double very_large_residual{1.0};
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             very_large_residual, mid_l + 1);
+
+  // Test with different frame
+  test_criterion_evaluation<Frame::Grid>(criterion, box, empty_cache, mid_l,
+                                         0.5 * min_residual, mid_l - 1);
+
+  // Test serialization
+  {
+    const Residual original{min_residual, max_residual, min_resolution_l,
+                            max_resolution_l};
+    const auto serialized{serialize_and_deserialize(original)};
+
+    // Test that the serialized object produces the same results
+    const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+        make_strahlkorper<Frame::Inertial>(mid_l)};
+    const FastFlow::IterInfo iter_info{make_iter_info(in_range_residual)};
+
+    const size_t recommended_l_original{
+        original.operator()(empty_cache, strahlkorper, iter_info)};
+    const size_t recommended_l_serialized{
+        serialized.operator()(empty_cache, strahlkorper, iter_info)};
+    CHECK(recommended_l_original == recommended_l_serialized);
+  }
+}
+
+void test_residual_constructor_validation() {
+  // Define test constants
+  constexpr double min_residual = 1.0e-6;
+  constexpr double max_residual = 1.0e-4;
+  constexpr double zero = 0.0;
+  constexpr size_t min_resolution_l = 4;
+  constexpr size_t max_resolution_l = 12;
+  constexpr size_t min_allowed_resolution = 2;
+
+  // Test valid construction
+  CHECK_NOTHROW((Residual{min_residual, max_residual, min_resolution_l,
+                          max_resolution_l}));
+
+  // Test invalid construction - min_residual >= max_residual
+  CHECK_THROWS_WITH((Residual{max_residual, min_residual, min_resolution_l,
+                              max_resolution_l}),
+                    Catch::Matchers::ContainsSubstring(
+                        "MinResidual must be less than MaxResidual"));
+
+  // Test invalid construction - min_residual == max_residual
+  CHECK_THROWS_WITH((Residual{min_residual, min_residual, min_resolution_l,
+                              max_resolution_l}),
+                    Catch::Matchers::ContainsSubstring(
+                        "MinResidual must be less than MaxResidual"));
+
+  // Test invalid construction - min_resolution_l > max_resolution_l
+  CHECK_THROWS_WITH(
+      (Residual{min_residual, max_residual, max_resolution_l,
+                min_resolution_l}),
+      Catch::Matchers::ContainsSubstring(
+          "MinResolutionL must not be greater than MaxResolutionL"));
+
+  // Test edge case - zero max_residual (should fail)
+  CHECK_THROWS_WITH(
+      (Residual{min_residual, zero, min_resolution_l, max_resolution_l}),
+      Catch::Matchers::ContainsSubstring(
+          "MinResidual must be less than MaxResidual"));
+
+  // Test edge case - min_resolution_l below minimum allowed value (2)
+  CHECK_THROWS_WITH((Residual{min_residual, max_residual,
+                              min_allowed_resolution - 1, max_resolution_l}),
+                    Catch::Matchers::ContainsSubstring(
+                        "MinResolutionL must not be less than 2"));
+
+  // Test edge case - max_resolution_l below minimum allowed value (2)
+  CHECK_THROWS_WITH(
+      (Residual{min_residual, max_residual, min_allowed_resolution,
+                min_allowed_resolution - 1}),
+      Catch::Matchers::ContainsSubstring(
+          "MaxResolutionL must not be less than 2"));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Criteria.Residual",
+                  "[ApparentHorizonFinder][Unit]") {
+  test_residual();
+  test_residual_constructor_validation();
+}
+}  // namespace ah::Criteria


### PR DESCRIPTION
## Proposed changes

Adds a criterion for adaptive horizon finding that adjusts resolution based on the residual of the most recent horizon find.

Depends on #6689 .

Note: I used the Cursor AI editor when preparing this PR, including tab completions and (for developing the first draft of the unit tests) agent mode. I reviewed all suggested code changes for correctness, and to the best of my knowledge, none of the code in this PR is from another codebase or violates any copyright or license.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
