### PR TITLE
AH rewrite: Add AH storage and destination

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Destination.cpp
   FastFlow.cpp
   InterpolationTarget.cpp
   )
@@ -21,6 +22,7 @@ spectre_target_headers(
   ComputeExcisionBoundaryVolumeQuantities.tpp
   ComputeHorizonVolumeQuantities.hpp
   ComputeHorizonVolumeQuantities.tpp
+  Destination.hpp
   FastFlow.hpp
   HorizonAliases.hpp
   InterpolationTarget.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Destination.cpp
   FastFlow.cpp
   InterpolationTarget.cpp
+  Storage.cpp
   )
 
 spectre_target_headers(
@@ -26,6 +27,7 @@ spectre_target_headers(
   FastFlow.hpp
   HorizonAliases.hpp
   InterpolationTarget.hpp
+  Storage.hpp
   Tags.hpp
   )
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Destination.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Destination.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+
+#include <ostream>
+#include <string>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace ah {
+std::ostream& operator<<(std::ostream& os, const Destination destination) {
+  switch (destination) {
+    case Destination::Observation:
+      return os << "Observation";
+    case Destination::ControlSystem:
+      return os << "ControlSystem";
+    default:
+      ERROR("Unknown Destination type");
+  }
+}
+}  // namespace ah
+
+template <>
+ah::Destination Options::create_from_yaml<ah::Destination>::create<void>(
+    const Options::Option& options) {
+  const auto destination = options.parse_as<std::string>();
+  if (destination == "Observation") {
+    return ah::Destination::Observation;
+  } else if (destination == "ControlSystem") {
+    return ah::Destination::ControlSystem;
+  }
+  PARSE_ERROR(options.context(),
+              "Destination must be 'Observation' or 'ControlSystem'");
+}

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <ostream>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace ah {
+/*!
+ * \brief Label for what a horizon find will be used for.
+ */
+enum class Destination { Observation, ControlSystem };
+std::ostream& operator<<(std::ostream& os, Destination destination);
+}  // namespace ah
+
+template <>
+struct Options::create_from_yaml<ah::Destination> {
+  template <typename Metavariables>
+  static ah::Destination create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+ah::Destination Options::create_from_yaml<ah::Destination>::create<void>(
+    const Options::Option& options);

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintDampingTags.hpp"

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp
@@ -36,14 +36,14 @@ using vars_to_interpolate_to_target =
                gr::Tags::SpatialRicci<DataVector, Dim, Frame>>;
 
 template <typename Frame>
-using tags_for_observing = tmpl::list<
-    gr::surfaces::Tags::AreaCompute<Frame>,
-    gr::surfaces::Tags::IrreducibleMassCompute<Frame>,
-    ylm::Tags::MaxRicciScalarCompute, ylm::Tags::MinRicciScalarCompute,
-    gr::surfaces::Tags::ChristodoulouMassCompute<Frame>,
-    gr::surfaces::Tags::DimensionlessSpinMagnitudeCompute<Frame>,
-    gr::surfaces::Tags::DimensionfulSpinVectorCompute<Frame, Frame>
-    >;
+using tags_for_observing =
+    tmpl::list<gr::surfaces::Tags::AreaCompute<Frame>,
+               gr::surfaces::Tags::IrreducibleMassCompute<Frame>,
+               ylm::Tags::MaxRicciScalarCompute,
+               ylm::Tags::MinRicciScalarCompute,
+               gr::surfaces::Tags::ChristodoulouMassCompute<Frame>,
+               gr::surfaces::Tags::DimensionlessSpinMagnitudeCompute<Frame>,
+               gr::surfaces::Tags::DimensionfulSpinVectorCompute<Frame, Frame>>;
 
 using surface_tags_for_observing = tmpl::list<ylm::Tags::RicciScalar>;
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace ah::Storage {
+template <typename Fr>
+void VolumeVariables<Fr>::pup(PUP::er& p) {
+  p | mesh;
+  p | source_vars;
+  p | vars_to_interpolate_to_target;
+}
+
+template <typename Fr>
+bool operator==(const VolumeVariables<Fr>& lhs,
+                const VolumeVariables<Fr>& rhs) {
+  return lhs.mesh == rhs.mesh and lhs.source_vars == rhs.source_vars and
+         lhs.vars_to_interpolate_to_target == rhs.vars_to_interpolate_to_target;
+}
+template <typename Fr>
+bool operator!=(const VolumeVariables<Fr>& lhs,
+                const VolumeVariables<Fr>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <typename Fr>
+void Iteration<Fr>::reset_for_next_iteration() {
+  // Leave the strahlkorper because this was set by FastFlow and is already
+  // the next surface
+  this->block_coord_holders.reset();
+  this->indicies_interpolated_to_thus_far.clear();
+  this->interpolation_is_done_for_these_elements.clear();
+  this->interpolation_retries = 0;
+}
+
+template <typename Fr>
+void Iteration<Fr>::pup(PUP::er& p) {
+  p | strahlkorper;
+  p | block_coord_holders;
+  p | interpolated_vars;
+  p | indicies_interpolated_to_thus_far;
+  p | interpolation_is_done_for_these_elements;
+  p | interpolation_retries;
+}
+
+template <typename Fr>
+bool operator==(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {
+  return lhs.strahlkorper == rhs.strahlkorper and
+         lhs.block_coord_holders == rhs.block_coord_holders and
+         lhs.interpolated_vars == rhs.interpolated_vars and
+         lhs.indicies_interpolated_to_thus_far ==
+             rhs.indicies_interpolated_to_thus_far and
+         lhs.interpolation_is_done_for_these_elements ==
+             rhs.interpolation_is_done_for_these_elements and
+         lhs.interpolation_retries == rhs.interpolation_retries;
+}
+template <typename Fr>
+bool operator!=(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <typename Fr>
+void SingleTimeStorage<Fr>::pup(PUP::er& p) {
+  p | all_volume_variables;
+  p | current_iteration;
+  p | previous_iteration_surface;
+  p | destination;
+  p | time_is_ready;
+}
+
+template <typename Fr>
+bool operator==(const SingleTimeStorage<Fr>& lhs,
+                const SingleTimeStorage<Fr>& rhs) {
+  return lhs.all_volume_variables == rhs.all_volume_variables and
+         lhs.current_iteration == rhs.current_iteration and
+         lhs.previous_iteration_surface == rhs.previous_iteration_surface and
+         lhs.destination == rhs.destination and
+         lhs.time_is_ready == rhs.time_is_ready;
+}
+template <typename Fr>
+bool operator!=(const SingleTimeStorage<Fr>& lhs,
+                const SingleTimeStorage<Fr>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <typename Fr>
+void PreviousSurface<Fr>::pup(PUP::er& p) {
+  p | time;
+  p | surface;
+}
+
+template <typename Fr>
+bool operator==(const PreviousSurface<Fr>& lhs,
+                const PreviousSurface<Fr>& rhs) {
+  return lhs.time == rhs.time and lhs.surface == rhs.surface;
+}
+template <typename Fr>
+bool operator!=(const PreviousSurface<Fr>& lhs,
+                const PreviousSurface<Fr>& rhs) {
+  return not(lhs == rhs);
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template struct VolumeVariables<FRAME(data)>;                    \
+  template struct Iteration<FRAME(data)>;                          \
+  template struct SingleTimeStorage<FRAME(data)>;                  \
+  template struct PreviousSurface<FRAME(data)>;                    \
+  template bool operator==(const VolumeVariables<FRAME(data)>&,    \
+                           const VolumeVariables<FRAME(data)>&);   \
+  template bool operator!=(const VolumeVariables<FRAME(data)>&,    \
+                           const VolumeVariables<FRAME(data)>&);   \
+  template bool operator==(const Iteration<FRAME(data)>&,          \
+                           const Iteration<FRAME(data)>&);         \
+  template bool operator!=(const Iteration<FRAME(data)>&,          \
+                           const Iteration<FRAME(data)>&);         \
+  template bool operator==(const SingleTimeStorage<FRAME(data)>&,  \
+                           const SingleTimeStorage<FRAME(data)>&); \
+  template bool operator!=(const SingleTimeStorage<FRAME(data)>&,  \
+                           const SingleTimeStorage<FRAME(data)>&); \
+  template bool operator==(const PreviousSurface<FRAME(data)>&,    \
+                           const PreviousSurface<FRAME(data)>&);   \
+  template bool operator!=(const PreviousSurface<FRAME(data)>&,    \
+                           const PreviousSurface<FRAME(data)>&);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Inertial, Frame::Distorted, Frame::Grid))
+
+#undef INSTANTIATE
+#undef FRAME
+}  // namespace ah::Storage

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -1,0 +1,171 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+
+namespace ah::Storage {
+/*!
+ * \brief Holds the `ah::source_vars`, mesh, and other variables on the horizon
+ * finder for a given element.
+ */
+template <typename Fr>
+struct VolumeVariables {
+  /*!
+   * \brief The mesh that corresponds to the volume vars.
+   */
+  Mesh<3> mesh;
+
+  /*!
+   * \brief A `Variables` of the  `ah::source_vars` in the volume.
+   */
+  Variables<ah::source_vars<3>> source_vars;
+
+  /*!
+   * \brief A `Variables` of the tensors in the volume that we need to
+   * interpolate onto the horizon.
+   */
+  Variables<ah::vars_to_interpolate_to_target<3, Fr>>
+      vars_to_interpolate_to_target{};
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+};
+
+template <typename Fr>
+bool operator==(const VolumeVariables<Fr>& lhs, const VolumeVariables<Fr>& rhs);
+template <typename Fr>
+bool operator!=(const VolumeVariables<Fr>& lhs, const VolumeVariables<Fr>& rhs);
+
+/*!
+ * \brief Holds the `ylm::Strahlkorper` and associated quantities for a single
+ * `FastFlow` iteration.
+ */
+template <typename Fr>
+struct Iteration {
+  /*!
+   * \brief The surface for this iteration
+   */
+  ylm::Strahlkorper<Fr> strahlkorper;
+  /*!
+   *  \brief Holds the list of all points (in block logical coordinates) that
+   *  need to be interpolated onto.
+   *
+   * \details If an element of the vector is `std::nullopt`, then that point is
+   * outside the domain.
+   */
+  std::optional<std::vector<BlockLogicalCoords<3>>> block_coord_holders;
+  /*!
+   * \brief Holds the interpolated `Variables` on the points in
+   * `block_coord_holders`.
+   *
+   * \details The grid points inside are indexed according to
+   * `block_coord_holders`.
+   */
+  Variables<ah::vars_to_interpolate_to_target<3, Fr>> interpolated_vars{};
+  /*!
+   * \brief Keeps track of the indices in `interpolated_vars` that have
+   * already beed interpolated to.
+   */
+  std::set<size_t> indicies_interpolated_to_thus_far;
+  /*!
+   * \brief Holds the `ElementId`s of `Element`s for which interpolation has
+   * already been done.
+   */
+  std::unordered_set<ElementId<3>> interpolation_is_done_for_these_elements;
+
+  /*!
+   * \brief How many times we've tried to reinterpolate the volume variables for
+   * this iteration.
+   */
+  size_t interpolation_retries = 0;
+
+  void reset_for_next_iteration();
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+};
+
+template <typename Fr>
+bool operator==(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs);
+template <typename Fr>
+bool operator!=(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs);
+
+/*!
+ * \brief Holds all data necessary for a single horizon find.
+ *
+ * \details This includes volume variables which persist for the entire horizon
+ * find, and also interpolated variables that are updated for each iteration.
+ */
+template <typename Fr>
+struct SingleTimeStorage {
+  /*!
+   * \brief Map between `ElementId`s and the volume variables from that element.
+   */
+  std::unordered_map<ElementId<3>, VolumeVariables<Fr>> all_volume_variables;
+
+  /*!
+   * \brief The `Iteration` data for the current fast flow iteration.
+   */
+  Iteration<Fr> current_iteration;
+  /*!
+   * \brief The previous iteration surface, used if interpolation fails.
+   */
+  ylm::Strahlkorper<Fr> previous_iteration_surface;
+  /*!
+   * \brief The `ah::Destination` for this horizon find.
+   */
+  Destination destination{};
+  /*!
+   * \brief Whether we have checked if the functions of time are up to date for
+   * this horizon find.
+   */
+  bool time_is_ready = false;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+};
+
+template <typename Fr>
+bool operator==(const SingleTimeStorage<Fr>& lhs,
+                const SingleTimeStorage<Fr>& rhs);
+template <typename Fr>
+bool operator!=(const SingleTimeStorage<Fr>& lhs,
+                const SingleTimeStorage<Fr>& rhs);
+
+/*!
+ * \brief The time and final surface for a previous horizon find.
+ */
+template <typename Fr>
+struct PreviousSurface {
+  LinkedMessageId<double> time;
+  ylm::Strahlkorper<Fr> surface;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+};
+
+template <typename Fr>
+bool operator==(const PreviousSurface<Fr>& lhs, const PreviousSurface<Fr>& rhs);
+template <typename Fr>
+bool operator!=(const PreviousSurface<Fr>& lhs, const PreviousSurface<Fr>& rhs);
+}  // namespace ah::Storage

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_ApparentHorizonFinder.cpp
   Test_ComputeExcisionBoundaryVolumeQuantities.cpp
   Test_ComputeHorizonVolumeQuantities.cpp
+  Test_Destination.cpp
   Test_FastFlow.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_ObserveCenters.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_FastFlow.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_ObserveCenters.cpp
+  Test_Storage.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Destination.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Destination.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Framework/TestCreation.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace ah {
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Destination",
+                  "[ApparentHorizonFinder][Unit]") {
+  CHECK(get_output(Destination::ControlSystem) == "ControlSystem");
+  CHECK(get_output(Destination::Observation) == "Observation");
+  CHECK(TestHelpers::test_creation<Destination>("ControlSystem") ==
+        Destination::ControlSystem);
+  CHECK(TestHelpers::test_creation<Destination>("Observation") ==
+        Destination::Observation);
+}
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+
+namespace ah {
+namespace {
+// The only thing to test with the storage is the serialization since it's just
+// structs with public members
+template <typename Fr>
+void test_storage() {
+  const ah::Storage::VolumeVariables<Fr> volume_variables{
+      Mesh<3>{3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
+      Variables<ah::source_vars<3>>{4, 1.234},
+      Variables<ah::vars_to_interpolate_to_target<3, Fr>>{4, 4.321}};
+  test_serialization(volume_variables);
+
+  const ah::Storage::Iteration<Fr> iteration{
+      ylm::Strahlkorper<Fr>{4_st, 3.0, std::array{0.0, 0.1, 0.2}},
+      std::optional<std::vector<BlockLogicalCoords<3>>>{{std::nullopt}},
+      Variables<ah::vars_to_interpolate_to_target<3, Fr>>{6, 9.876},
+      std::set<size_t>{1_st, 4_st, 5_st},
+      std::unordered_set<ElementId<3>>{ElementId<3>{0}, ElementId<3>{1}},
+      {2}};
+  test_serialization(iteration);
+
+  const ah::Storage::SingleTimeStorage<Fr> single_time_storage{
+      std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>{
+          {ElementId<3>{0}, volume_variables}},
+      iteration, iteration.strahlkorper, Destination::ControlSystem};
+  test_serialization(single_time_storage);
+
+  const ah::Storage::PreviousSurface<Fr> previous_surface{
+      LinkedMessageId<double>{3.0, {2.0}}, iteration.strahlkorper};
+  test_serialization(previous_surface);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Storage",
+                  "[ApparentHorizonFinder][Unit]") {
+  test_storage<::Frame::Grid>();
+  test_storage<::Frame::Distorted>();
+  test_storage<::Frame::Inertial>();
+}
+}  // namespace ah


### PR DESCRIPTION
## Proposed changes

Second PR of horizon finder rewrite which adds the storage structs for all the data of the horizon finder, and an enum for the destination (either "Observation" or "ControlSystem").

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
