### PR TITLE
Add function to concatenate tagged tuples.

### DIFF
--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -754,6 +754,27 @@ constexpr decltype(auto) apply(F&& f, const TaggedTuple<Tags...>& t) {
 }
 /// @}
 
+/// @{
+/*!
+ * Constructs a TaggedTuple that is a concatenation of two TaggedTuples.
+ * \example
+ * \snippet Test_TaggedTuple.cpp tagged_tuple_cat_example
+ */
+template <typename... Tags1, typename... Tags2>
+tuples::TaggedTuple<Tags1..., Tags2...> tagged_tuple_cat(
+    const tuples::TaggedTuple<Tags1...>& tuple1,
+    const tuples::TaggedTuple<Tags2...>& tuple2) {
+  return {get<Tags1>(tuple1)..., get<Tags2>(tuple2)...};
+}
+
+template <typename... Tags1, typename... Tags2>
+tuples::TaggedTuple<Tags1..., Tags2...> tagged_tuple_cat(
+    tuples::TaggedTuple<Tags1...>&& tuple1,
+    tuples::TaggedTuple<Tags2...>&& tuple2) {
+  return {std::move(get<Tags1>(tuple1))..., std::move(get<Tags2>(tuple2))...};
+}
+/// @}
+
 }  // namespace tuples
 
 namespace std {

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -44,6 +44,10 @@ constexpr bool operator==(const not_streamable& /*unused*/,
   return true;
 }
 
+struct non_copyable_grades {
+  using type = std::vector<std::unique_ptr<std::string>>;
+};
+
 struct not_streamable_tag {
   using type = not_streamable;
 };
@@ -162,6 +166,30 @@ void test_general() {
         tuples::TaggedTuple<email, not_streamable_tag, parents, age, name>{
             "bla@bla.bla", 0, std::vector<std::string>{"Mom", "Dad"}, 17,
             "Eamonn"});
+
+  // [tagged_tuple_cat_example]
+  const tuples::TaggedTuple<name, age> test5("Eamonn", 17);
+  const tuples::TaggedTuple<email, parents, not_streamable_tag> test6(
+      "bla@bla.bla", std::vector<std::string>{"Mom", "Dad"}, 0);
+  const auto test7 = tuples::tagged_tuple_cat(test5, test6);
+  // [tagged_tuple_cat_example]
+  CHECK(test7 ==
+        tuples::TaggedTuple<name, age, email, parents, not_streamable_tag>{
+            "Eamonn", 17, "bla@bla.bla", std::vector<std::string>{"Mom", "Dad"},
+            0});
+
+  // Test tagged_tuple_cat with a non-copyable type to ensure proper
+  // functionality of rvalue version.
+  std::vector<std::unique_ptr<std::string>> grades{};
+  grades.reserve(2);
+  grades.emplace_back(std::make_unique<std::string>("Aplus"));
+  grades.emplace_back(std::make_unique<std::string>("F"));
+  tuples::TaggedTuple<name, age> test8("Eamonn", 17);
+  tuples::TaggedTuple<non_copyable_grades, parents, not_streamable_tag> test9(
+      std::move(grades), std::vector<std::string>{"Mom", "Dad"}, 0);
+  const auto test10 =
+      tuples::tagged_tuple_cat(std::move(test8), std::move(test9));
+  CHECK(*tuples::get<non_copyable_grades>(test10)[0] == "Aplus");
 
   {
     INFO("Expand tuple");


### PR DESCRIPTION
## Proposed changes

Adds a `tagged_tuple_cat` function which concatenates two tagged tuples together into one.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
