### PR TITLE
Convert ArrayIndex base tag to a simple tag

### DIFF
--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -87,7 +87,7 @@ struct Domain {
   /// Tags for items fetched by the DataBox and passed to the apply function
   using argument_tags =
       tmpl::append<const_global_cache_tags, simple_tags_from_options,
-                   tmpl::list<::Parallel::Tags::ArrayIndex>>;
+                   tmpl::list<::Parallel::Tags::ArrayIndex<ElementId<dim>>>>;
 
   /// Tags for items in the DataBox that are mutated by the apply function
   using return_tags =

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -176,7 +176,7 @@ struct ProjectTimeStepping : tt::ConformsTo<amr::protocols::Projector> {
                  ::Tags::TimeStep, ::Tags::Time, ::Tags::StepNumberWithinSlab,
                  ::Tags::AdaptiveSteppingDiagnostics,
                  ::Tags::ChangeSlabSize::SlabSizeGoal>;
-  using argument_tags = tmpl::list<Parallel::Tags::ArrayIndex>;
+  using argument_tags = tmpl::list<Parallel::Tags::ArrayIndex<ElementId<Dim>>>;
 
   static void apply(
       const gsl::not_null<TimeStepId*> /*time_step_id*/,
@@ -218,7 +218,7 @@ struct ProjectTimeStepping : tt::ConformsTo<amr::protocols::Projector> {
     const auto& parent_amr_flags =
         get<amr::Tags::Info<Dim>>(parent_items).flags;
     const auto& parent_id =
-        get<Parallel::Tags::ArrayIndexImpl<ElementId<Dim>>>(parent_items);
+        get<Parallel::Tags::ArrayIndex<ElementId<Dim>>>(parent_items);
     auto children_ids = amr::ids_of_children(parent_id, parent_amr_flags);
     if (element_id == children_ids.front()) {
       *adaptive_stepping_diagnostics = parent_diagnostics;
@@ -343,8 +343,8 @@ struct ProjectTimeStepperHistory : tt::ConformsTo<amr::protocols::Projector> {
   using history_tag = ::Tags::HistoryEvolvedVariables<variables_tag>;
 
   using return_tags = tmpl::list<dt_variables_tag, history_tag>;
-  using argument_tags =
-      tmpl::list<domain::Tags::Mesh<dim>, Parallel::Tags::ArrayIndex>;
+  using argument_tags = tmpl::list<domain::Tags::Mesh<dim>,
+                                   Parallel::Tags::ArrayIndex<ElementId<dim>>>;
 
   static void apply(
       const gsl::not_null<typename dt_variables_tag::type*> dt_vars,

--- a/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
+++ b/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
@@ -45,7 +45,7 @@ struct Domain {
 
   using argument_tags =
       tmpl::append<const_global_cache_tags, simple_tags_from_options,
-                   tmpl::list<::Parallel::Tags::ArrayIndex>>;
+                   tmpl::list<::Parallel::Tags::ArrayIndex<ElementId<Dim>>>>;
 
   using return_tags =
       tmpl::list<::domain::Tags::Mesh<Dim>, ::domain::Tags::Element<Dim>>;

--- a/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
@@ -27,6 +27,11 @@
 #include "Utilities/Serialization/PupStlCpp17.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+template <size_t VolumeDim>
+class ElementId;
+/// \endcond
+
 namespace LinearSolver::Serial {
 
 /// \cond
@@ -206,26 +211,25 @@ ExplicitInverse<ValueType, LinearSolverRegistrars>::solve(
                  make_not_null(&result_buffer), linear_operator, operator_args);
     // Write to file before inverting
     if (UNLIKELY(matrix_filename_.has_value())) {
-      const auto filename_suffix =
-          [&operator_args]() -> std::optional<std::string> {
-        using DataBoxType =
-            std::decay_t<tmpl::front<tmpl::list<OperatorArgs..., NoSuchType>>>;
-        if constexpr (tt::is_a_v<db::DataBox, DataBoxType>) {
-          if constexpr (db::tag_is_retrievable_v<Parallel::Tags::ArrayIndex,
-                                                 DataBoxType>) {
-            const auto& box = std::get<0>(operator_args);
-            return "_" + get_output(db::get<Parallel::Tags::ArrayIndex>(box));
-          } else {
-            (void)operator_args;
-            return std::nullopt;
-          }
-        } else {
-          (void)operator_args;
-          return std::nullopt;
-        }
-      }();
-      std::ofstream matrix_file(matrix_filename_.value() +
-                                filename_suffix.value_or("") + ".txt");
+      std::string filename_suffix{};
+      using DataBoxType =
+          std::decay_t<tmpl::front<tmpl::list<OperatorArgs..., NoSuchType>>>;
+      if constexpr (tt::is_a_v<db::DataBox, DataBoxType>) {
+        tmpl::for_each<tmpl::range<size_t, 1, 4>>(
+            [&]<size_t Dim>(tmpl::type_<tmpl::size_t<Dim>> /*meta*/) {
+              using index_tag = Parallel::Tags::ArrayIndex<ElementId<Dim>>;
+              if constexpr (db::tag_is_retrievable_v<index_tag, DataBoxType>) {
+                const auto& box = std::get<0>(operator_args);
+                filename_suffix = "_" + get_output(db::get<index_tag>(box));
+              } else {
+                (void)operator_args;
+              }
+            });
+      } else {
+        (void)operator_args;
+      }
+      std::ofstream matrix_file(matrix_filename_.value() + filename_suffix +
+                                ".txt");
       write_csv(matrix_file, inverse_, " ");
     }
     // Directly invert the matrix

--- a/src/Parallel/ArrayCollection/DgElementArrayMember.hpp
+++ b/src/Parallel/ArrayCollection/DgElementArrayMember.hpp
@@ -85,8 +85,7 @@ class DgElementArrayMember<Dim, Metavariables,
   using all_cache_tags = get_const_global_cache_tags<metavariables>;
 
   using databox_type = db::compute_databox_type<tmpl::flatten<tmpl::list<
-      Tags::MetavariablesImpl<metavariables>,
-      Tags::ArrayIndexImpl<ElementId<Dim>>,
+      Tags::MetavariablesImpl<metavariables>, Tags::ArrayIndex<ElementId<Dim>>,
       Tags::GlobalCacheProxy<metavariables>, SimpleTagsFromOptions,
       Tags::GlobalCacheCompute<metavariables>,
       Tags::ResourceInfoReference<metavariables>,
@@ -223,8 +222,8 @@ DgElementArrayMember<Dim, Metavariables, tmpl::list<PhaseDepActionListsPack...>,
       global_cache_proxy_(global_cache_proxy) {
   (void)initialization_items;  // avoid potential compiler warnings if unused
   ::Initialization::mutate_assign<
-      tmpl::list<Tags::ArrayIndex, Tags::GlobalCacheProxy<Metavariables>,
-                 InitializationTags...>>(
+      tmpl::list<Tags::ArrayIndex<ElementId<Dim>>,
+                 Tags::GlobalCacheProxy<Metavariables>, InitializationTags...>>(
       make_not_null(&box_), this->element_id_, global_cache_proxy_,
       std::move(get<InitializationTags>(initialization_items))...);
 }

--- a/src/Parallel/Tags/ArrayIndex.hpp
+++ b/src/Parallel/Tags/ArrayIndex.hpp
@@ -9,11 +9,8 @@ namespace Parallel::Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ParallelGroup
 /// Tag to retrieve the `ArrayIndex` from the DataBox.
-struct ArrayIndex : db::BaseTag {};
-
 template <typename Index>
-struct ArrayIndexImpl : ArrayIndex, db::SimpleTag {
-  using base = ArrayIndex;
+struct ArrayIndex : db::SimpleTag {
   using type = Index;
 };
 }  // namespace Parallel::Tags

--- a/src/Parallel/Tags/DistributedObjectTags.hpp
+++ b/src/Parallel/Tags/DistributedObjectTags.hpp
@@ -8,7 +8,7 @@
 namespace Parallel::Tags {
 /// \cond
 template <typename Index>
-struct ArrayIndexImpl;
+struct ArrayIndex;
 template <typename Metavariables>
 struct GlobalCacheProxy;
 template <typename Metavariables>
@@ -22,7 +22,6 @@ struct MetavariablesImpl;
 /// mutable items corresponding to these tags.
 template <typename Metavariables, typename Index>
 using distributed_object_tags =
-    tmpl::list<Tags::MetavariablesImpl<Metavariables>,
-               Tags::ArrayIndexImpl<Index>,
+    tmpl::list<Tags::MetavariablesImpl<Metavariables>, Tags::ArrayIndex<Index>,
                Tags::GlobalCacheProxy<Metavariables>>;
 }  // namespace Parallel::Tags

--- a/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
@@ -169,13 +169,13 @@ void test_lts() {
         initial_slab_size);
 }
 using items_type = tuples::TaggedTuple<
-    Parallel::Tags::ArrayIndexImpl<ElementId<1>>, ::Tags::TimeStepId,
+    Parallel::Tags::ArrayIndex<ElementId<1>>, ::Tags::TimeStepId,
     ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep, ::Tags::Time,
     ::Tags::StepNumberWithinSlab, ::Tags::AdaptiveSteppingDiagnostics,
     ::Tags::ChangeSlabSize::SlabSizeGoal>;
 
 using parent_items_type = tuples::TaggedTuple<
-    Parallel::Tags::ArrayIndexImpl<ElementId<1>>, ::Tags::TimeStepId,
+    Parallel::Tags::ArrayIndex<ElementId<1>>, ::Tags::TimeStepId,
     ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep, ::Tags::Time,
     ::Tags::StepNumberWithinSlab, ::Tags::AdaptiveSteppingDiagnostics,
     ::Tags::ChangeSlabSize::SlabSizeGoal, ::amr::Tags::Info<1>>;
@@ -218,7 +218,7 @@ void test_p_refine() {
   const double slab_size_goal = 1.34;
 
   auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::ArrayIndexImpl<ElementId<1>>, ::Tags::TimeStepId,
+      Parallel::Tags::ArrayIndex<ElementId<1>>, ::Tags::TimeStepId,
       ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep, ::Tags::Time,
       ::Tags::StepNumberWithinSlab, ::Tags::AdaptiveSteppingDiagnostics,
       ::Tags::ChangeSlabSize::SlabSizeGoal>>(
@@ -260,7 +260,7 @@ void test_split() {
       ::amr::Info<1>{std::array{::amr::Flag::Split}, Mesh<1>{}}};
 
   auto child_1_box = db::create<db::AddSimpleTags<
-      Parallel::Tags::ArrayIndexImpl<ElementId<1>>, ::Tags::TimeStepId,
+      Parallel::Tags::ArrayIndex<ElementId<1>>, ::Tags::TimeStepId,
       ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep, ::Tags::Time,
       ::Tags::StepNumberWithinSlab, ::Tags::AdaptiveSteppingDiagnostics,
       ::Tags::ChangeSlabSize::SlabSizeGoal>>(
@@ -269,7 +269,7 @@ void test_split() {
       std::numeric_limits<double>::signaling_NaN());
 
   auto child_2_box = db::create<db::AddSimpleTags<
-      Parallel::Tags::ArrayIndexImpl<ElementId<1>>, ::Tags::TimeStepId,
+      Parallel::Tags::ArrayIndex<ElementId<1>>, ::Tags::TimeStepId,
       ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep, ::Tags::Time,
       ::Tags::StepNumberWithinSlab, ::Tags::AdaptiveSteppingDiagnostics,
       ::Tags::ChangeSlabSize::SlabSizeGoal>>(
@@ -333,7 +333,7 @@ void test_join() {
                  slab_size_goal_2});
 
   auto parent_box = db::create<db::AddSimpleTags<
-      Parallel::Tags::ArrayIndexImpl<ElementId<1>>, ::Tags::TimeStepId,
+      Parallel::Tags::ArrayIndex<ElementId<1>>, ::Tags::TimeStepId,
       ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep, ::Tags::Time,
       ::Tags::StepNumberWithinSlab, ::Tags::AdaptiveSteppingDiagnostics,
       ::Tags::ChangeSlabSize::SlabSizeGoal>>(
@@ -606,7 +606,7 @@ void compare_p_refine() {
   const auto old_data =
       element_data(&gen, element_id, old_mesh, time_step_id0, time_step_id1);
   auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::ArrayIndexImpl<ElementId<3>>, domain::Tags::Element<3>,
+      Parallel::Tags::ArrayIndex<ElementId<3>>, domain::Tags::Element<3>,
       domain::Tags::Mesh<3>, dt_variables_tag,
       Tags::HistoryEvolvedVariables<variables_tag>, HistoryEntry<0>,
       HistoryDeriv<0>, HistoryDeriv<1>>>(
@@ -660,7 +660,7 @@ void compare_h_refine() {
 
   {
     auto box = db::create<db::AddSimpleTags<
-        Parallel::Tags::ArrayIndexImpl<ElementId<3>>, domain::Tags::Element<3>,
+        Parallel::Tags::ArrayIndex<ElementId<3>>, domain::Tags::Element<3>,
         domain::Tags::Mesh<3>, dt_variables_tag,
         Tags::HistoryEvolvedVariables<variables_tag>, HistoryEntry<0>,
         HistoryDeriv<0>, HistoryDeriv<1>>>(
@@ -693,7 +693,7 @@ void compare_h_refine() {
 
   {
     auto box = db::create<db::AddSimpleTags<
-        Parallel::Tags::ArrayIndexImpl<ElementId<3>>, domain::Tags::Element<3>,
+        Parallel::Tags::ArrayIndex<ElementId<3>>, domain::Tags::Element<3>,
         domain::Tags::Mesh<3>, dt_variables_tag,
         Tags::HistoryEvolvedVariables<variables_tag>, HistoryEntry<0>,
         HistoryDeriv<0>, HistoryDeriv<1>>>(
@@ -752,7 +752,7 @@ void compare_nonuniform_join() {
       element_data(&gen, child1_id, child1_mesh, time_step_id0, time_step_id1);
 
   auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::ArrayIndexImpl<ElementId<3>>, domain::Tags::Element<3>,
+      Parallel::Tags::ArrayIndex<ElementId<3>>, domain::Tags::Element<3>,
       domain::Tags::Mesh<3>, dt_variables_tag,
       Tags::HistoryEvolvedVariables<variables_tag>, HistoryEntry<0>,
       HistoryDeriv<0>, HistoryDeriv<1>>>(

--- a/tests/Unit/Framework/MockDistributedObject.hpp
+++ b/tests/Unit/Framework/MockDistributedObject.hpp
@@ -335,7 +335,7 @@ class MockDistributedObject {
           Component>::type;
   using initial_tags = tmpl::flatten<tmpl::list<
       Parallel::Tags::MetavariablesImpl<metavariables>,
-      Parallel::Tags::ArrayIndexImpl<array_index>,
+      Parallel::Tags::ArrayIndex<array_index>,
       Parallel::Tags::GlobalCache<metavariables>, simple_tags_from_options,
       db::wrap_tags_in<Parallel::Tags::FromGlobalCache, all_cache_tags,
                        metavariables>,
@@ -363,9 +363,9 @@ class MockDistributedObject {
         array_index_(index),
         global_cache_(cache),
         inboxes_(inboxes) {
-    ::Initialization::mutate_assign<
-        tmpl::push_front<simple_tags_from_options, Parallel::Tags::ArrayIndex,
-                         Parallel::Tags::GlobalCache<metavariables>>>(
+    ::Initialization::mutate_assign<tmpl::push_front<
+        simple_tags_from_options, Parallel::Tags::ArrayIndex<array_index>,
+        Parallel::Tags::GlobalCache<metavariables>>>(
         make_not_null(&box_), array_index_, global_cache_,
         std::forward<Options>(opts)...);
   }

--- a/tests/Unit/Parallel/Tags/Test_ArrayIndex.cpp
+++ b/tests/Unit/Parallel/Tags/Test_ArrayIndex.cpp
@@ -13,7 +13,6 @@ struct TestArrayIndex;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Parallel.Tags.ArrayIndex", "[Unit][Parallel]") {
-  TestHelpers::db::test_base_tag<Parallel::Tags::ArrayIndex>("ArrayIndex");
-  TestHelpers::db::test_simple_tag<
-      Parallel::Tags::ArrayIndexImpl<TestArrayIndex>>("ArrayIndex");
+  TestHelpers::db::test_simple_tag<Parallel::Tags::ArrayIndex<TestArrayIndex>>(
+      "ArrayIndex");
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -262,7 +262,7 @@ void test() {
 
   using TaggedTupleType =
       tuples::TaggedTuple<Parallel::Tags::MetavariablesImpl<Metavariables>,
-                          Parallel::Tags::ArrayIndexImpl<ElementId<3>>,
+                          Parallel::Tags::ArrayIndex<ElementId<3>>,
                           Parallel::Tags::GlobalCache<Metavariables>,
                           domain::Tags::Element<3>, domain::Tags::Mesh<3>,
                           domain::Tags::NeighborMesh<3>, amr::Tags::Info<3>,


### PR DESCRIPTION
Depends on #6745 because that one renamed a variable.  Only the last commit is new.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
