### PR TITLE
Revert reordering of tildeB fluxes and sources in ValenciaDivClean

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
@@ -61,9 +61,9 @@ void fluxes_impl(
       tilde_s_flux->get(i, j) = tilde_s.get(j) * transport_velocity->get(i) -
                                 lapse_b_over_w.get(j) * tilde_b.get(i);
       tilde_b_flux->get(i, j) =
-          tilde_b.get(j) * transport_velocity->get(i) -
-          transport_velocity->get(j) * tilde_b.get(i) +
-          get(lapse) * (get(tilde_phi) * inv_spatial_metric.get(i, j));
+        tilde_b.get(j) * transport_velocity->get(i) +
+        get(lapse) * (get(tilde_phi) * inv_spatial_metric.get(i, j) -
+        spatial_velocity.get(j) * tilde_b.get(i));
     }
     tilde_s_flux->get(i, i) += get(pressure_star_lapse_sqrt_det_spatial_metric);
   }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -58,7 +58,7 @@ void fluxes_impl(
  * B^m v_m\\
  * F^i({\tilde \tau}) = &~  {\tilde \tau} v^i_{tr} + \sqrt{\gamma} \alpha \left(
  * p + p_m \right) v^i - \alpha {\tilde B}^i B^m v_m \\
- * F^i({\tilde B}^j) = &~  {\tilde B}^j v^i_{tr} - v^j_{tr} {\tilde B}^i +
+ * F^i({\tilde B}^j) = &~  {\tilde B}^j v^i_{tr} - \alpha v^j {\tilde B}^i +
  * \alpha \gamma^{ij} {\tilde \Phi} \\
  * F^i({\tilde \Phi}) = &~ \alpha {\tilde B^i} - \beta^i {\tilde \Phi}
  * \f}

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
@@ -153,6 +153,9 @@ void sources_impl(
     source_tilde_b->get(i) *= get(tilde_phi);
     source_tilde_b->get(i) -=
         get(lapse) * get(tilde_phi) * trace_spatial_christoffel_second.get(i);
+    for (size_t m = 0; m < 3; ++m) {
+      source_tilde_b->get(i) -= tilde_b.get(m) * d_shift.get(m, i);
+    }
   }
 
   trace(source_tilde_phi, extrinsic_curvature, inv_spatial_metric);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
@@ -83,7 +83,7 @@ void sources_impl(
  * \alpha \\
  * S({\tilde \tau}) = & \alpha {\tilde S}^{mn} K_{mn} - {\tilde S}^m \partial_m
  * \alpha \\
- * S({\tilde B}^i) = & {\tilde \Phi}
+ * S({\tilde B}^i) = & -{\tilde B}^m \partial_m \beta^i + {\tilde \Phi}
  * \gamma^{im} \partial_m \alpha + \alpha {\tilde \Phi} \left( \frac{1}{2}
  * \gamma^{il} \gamma^{jk} - \gamma^{ij} \gamma^{lk} \right) \partial_l
  * \gamma_{jk} \\ S({\tilde \Phi}) = & {\tilde B}^k \partial_k \alpha - \alpha K

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -32,8 +32,6 @@ namespace grmhd {
 /// - Black hole-neutron star mergers with a hot nuclear equation of state:
 /// outflow and neutrino-cooled disk for a low-mass, high-spin case
 /// \cite Deaton2013
-/// - A Simflowny-based finite-difference code for high-performance computing
-/// in Relativity \cite Palenzuela2018
 ///
 namespace ValenciaDivClean {
 
@@ -136,7 +134,7 @@ namespace ValenciaDivClean {
  *      \delta^i_j - \alpha b_j \tilde{B}^i / W \\
  * F^i({\tilde \tau}) &= {\tilde \tau} v^i_{tr} + \alpha \sqrt{\gamma} p^* v^i
  *      - \alpha^2 b^0 \tilde{B}^i / W \\
- * F^i({\tilde B}^j) &= {\tilde B}^j v^i_{tr} - v^j_{tr} {\tilde B}^i
+ * F^i({\tilde B}^j) &= {\tilde B}^j v^i_{tr} - \alpha v^j {\tilde B}^i
  *      + \alpha \gamma^{ij} {\tilde \Phi} \\
  * F^i({\tilde \Phi}) &= \alpha {\tilde B^i} - {\tilde \Phi} \beta^i
  * \f}
@@ -151,7 +149,8 @@ namespace ValenciaDivClean {
  *      + {\tilde \tau}) \partial_j \alpha \\
  * S({\tilde \tau}) &= \alpha {\tilde S}^{mn} K_{mn}
  *      - {\tilde S}^m \partial_m \alpha \\
- * S({\tilde B}^j) &= \Phi \partial_k (\alpha \sqrt{\gamma}\gamma^{jk}) \\
+ * S({\tilde B}^j) &= -{\tilde B}^m \partial_m \beta^j
+ *      + \Phi \partial_k (\alpha \sqrt{\gamma}\gamma^{jk}) \\
  * S({\tilde \Phi}) &= {\tilde B}^k \partial_k \alpha - \alpha K
  *      {\tilde \Phi} - \alpha \kappa {\tilde \Phi}
  * \f}
@@ -166,9 +165,6 @@ namespace ValenciaDivClean {
  * \f$\kappa\f$ is a damping parameter that damps violations of the
  * divergence-free (no-monopole) condition \f$\Phi = \partial_i {\tilde B}^i =
  * 0\f$.
- *
- * \note The fluxes and sources of ${\tilde B}$ follow eq. 32 of
- * \cite Palenzuela2018 rather than eq. 87 of \cite Moesta2014
  *
  * \note On the electron fraction side, the source term is currently set to
  * \f$S(\tilde{Y}_e) = 0\f$. Implementing the source term using neutrino scheme

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.py
@@ -159,8 +159,8 @@ def tilde_b_flux(
     magnetic_field,
 ):
     result = np.outer(lapse * spatial_velocity - shift, tilde_b)
-    result -= np.outer(tilde_b, lapse * spatial_velocity - shift)
     result += lapse * inv_spatial_metric * tilde_phi
+    result -= lapse * np.outer(tilde_b, spatial_velocity)
     return result
 
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.py
@@ -159,11 +159,15 @@ def source_tilde_b(
 ):
     term_one = np.einsum("ab, iab", inv_spatial_metric, d_spatial_metric)
     term_two = np.einsum("ab, aib", inv_spatial_metric, d_spatial_metric)
-    return tilde_phi * np.einsum(
-        "a, ia", d_lapse, inv_spatial_metric
-    ) + lapse * tilde_phi * (
-        0.5 * np.einsum("ia, a", inv_spatial_metric, term_one)
-        - np.einsum("ia, a", inv_spatial_metric, term_two)
+    return (
+        tilde_phi * np.einsum("a, ia", d_lapse, inv_spatial_metric)
+        - np.einsum("a, ai", tilde_b, d_shift)
+        + lapse
+        * tilde_phi
+        * (
+            0.5 * np.einsum("ia, a", inv_spatial_metric, term_one)
+            - np.einsum("ia, a", inv_spatial_metric, term_two)
+        )
     )
 
 


### PR DESCRIPTION
## Proposed changes

An earlier PR (#5960) had reordered the source and flux terms in `ValenciaDivClean` in an attempt to make the system better-behaved. However, it was empirically found that this reduced the quality of the magnetic field evolution. Additionally, convergence tests for higher order FD do not work properly unless this change is undone.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->


<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

@jyoo1042 This PR should merge into develop a change that you are already using. Please confirm that this is indeed the case. And if so, this will formally implement it, so you can disregard the local change that you are using.
