### PR TITLE
AH rewrite: Add option and simple tags

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Destination.cpp
   FastFlow.cpp
   InterpolationTarget.cpp
+  OptionTags.cpp
   Storage.cpp
   )
 
@@ -27,6 +28,7 @@ spectre_target_headers(
   FastFlow.hpp
   HorizonAliases.hpp
   InterpolationTarget.hpp
+  OptionTags.hpp
   Storage.hpp
   Tags.hpp
   )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "Options/Context.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+
+namespace ah {
+template <typename Fr>
+HorizonOptions<Fr>::HorizonOptions(
+    ylm::Strahlkorper<Fr> initial_guess_in, ::FastFlow fast_flow_in,
+    ::Verbosity verbosity_in, const size_t max_interpolation_retries_in,
+    std::optional<std::vector<std::string>> blocks_for_horizon_find_in)
+    : initial_guess(std::move(initial_guess_in)),
+      fast_flow(std::move(fast_flow_in)),  // NOLINT
+      verbosity(std::move(verbosity_in)),  // NOLINT
+      max_interpolation_retries(max_interpolation_retries_in),
+      blocks_for_horizon_find(std::move(blocks_for_horizon_find_in)) {}
+
+template <typename Fr>
+void HorizonOptions<Fr>::pup(PUP::er& p) {
+  p | initial_guess;
+  p | fast_flow;
+  p | verbosity;
+  p | max_interpolation_retries;
+  p | blocks_for_horizon_find;
+}
+
+template <typename Fr>
+bool operator==(const HorizonOptions<Fr>& lhs, const HorizonOptions<Fr>& rhs) {
+  return lhs.initial_guess == rhs.initial_guess and
+         lhs.fast_flow == rhs.fast_flow and lhs.verbosity == rhs.verbosity and
+         lhs.max_interpolation_retries == rhs.max_interpolation_retries and
+         lhs.blocks_for_horizon_find == rhs.blocks_for_horizon_find;
+}
+
+template <typename Fr>
+bool operator!=(const HorizonOptions<Fr>& lhs, const HorizonOptions<Fr>& rhs) {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template struct HorizonOptions<FRAME(data)>;                      \
+  template bool operator==(const HorizonOptions<FRAME(data)>& lhs,  \
+                           const HorizonOptions<FRAME(data)>& rhs); \
+  template bool operator!=(const HorizonOptions<FRAME(data)>& lhs,  \
+                           const HorizonOptions<FRAME(data)>& rhs);
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+/// Options for finding an apparent horizon.
+template <typename Fr>
+struct HorizonOptions {
+ private:
+  struct All {};
+
+ public:
+  /// See Strahlkorper for suboptions.
+  struct InitialGuess {
+    static constexpr Options::String help = {"Initial guess"};
+    using type = ylm::Strahlkorper<Fr>;
+  };
+  /// See ::FastFlow for suboptions.
+  struct FastFlow {
+    static constexpr Options::String help = {"FastFlow options"};
+    using type = ::FastFlow;
+  };
+  struct Verbosity {
+    static constexpr Options::String help = {"Verbosity"};
+    using type = ::Verbosity;
+  };
+  struct MaxInterpolationRetries {
+    static constexpr Options::String help = {
+        "Number of times to retry the interpolation where, with each retry, "
+        "the two previous surfaces are averaged and that new surface is used."};
+    using type = size_t;
+  };
+  struct BlocksForHorizonFind {
+    static constexpr Options::String help = {
+        "Volume data will be sent to the horizon finder from these block group "
+        "names. Set to 'All' to send volume data from the entire domain."};
+    using type = Options::Auto<std::vector<std::string>, All>;
+  };
+  using options = tmpl::list<InitialGuess, FastFlow, Verbosity,
+                             MaxInterpolationRetries, BlocksForHorizonFind>;
+  static constexpr Options::String help = {
+      "Provide an initial guess for the apparent horizon surface\n"
+      "(Strahlkorper) and apparent-horizon-finding-algorithm (FastFlow)\n"
+      "options."};
+
+  HorizonOptions(
+      ylm::Strahlkorper<Fr> initial_guess_in, ::FastFlow fast_flow_in,
+      ::Verbosity verbosity_in, size_t max_interpolation_retries_in,
+      std::optional<std::vector<std::string>> blocks_for_horizon_find_in);
+
+  HorizonOptions() = default;
+  HorizonOptions(const HorizonOptions& /*rhs*/) = default;
+  HorizonOptions& operator=(const HorizonOptions& /*rhs*/) = delete;
+  HorizonOptions(HorizonOptions&& /*rhs*/) = default;
+  HorizonOptions& operator=(HorizonOptions&& /*rhs*/) = default;
+  ~HorizonOptions() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  ylm::Strahlkorper<Fr> initial_guess{};
+  ::FastFlow fast_flow;
+  ::Verbosity verbosity{::Verbosity::Quiet};
+  size_t max_interpolation_retries{};
+  std::optional<std::vector<std::string>> blocks_for_horizon_find;
+};
+
+template <typename Fr>
+bool operator==(const HorizonOptions<Fr>& lhs, const HorizonOptions<Fr>& rhs);
+template <typename Fr>
+bool operator!=(const HorizonOptions<Fr>& lhs, const HorizonOptions<Fr>& rhs);
+
+namespace OptionTags {
+struct ApparentHorizonGroup {
+  static constexpr Options::String help{"Options for apparent horizon finders"};
+  static std::string name() { return "ApparentHorizons"; }
+};
+
+template <typename HorizonMetavars>
+struct ApparentHorizonOptions {
+  using type = HorizonOptions<typename HorizonMetavars::frame>;
+  static constexpr Options::String help{
+      "Options for interpolation onto apparent horizon."};
+  static std::string name() { return pretty_type::name<HorizonMetavars>(); }
+  using group = ApparentHorizonGroup;
+};
+}  // namespace OptionTags
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -3,7 +3,17 @@
 
 #pragma once
 
+#include <deque>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
 
 /// \cond
 class FastFlow;
@@ -17,8 +27,82 @@ class Strahlkorper;
  * \brief Tags for the apparent horizon finder.
  */
 namespace ah::Tags {
+/*!
+ * \brief Verbosity of horizon finder
+ */
+struct Verbosity : db::SimpleTag {
+  using type = ::Verbosity;
+};
+
+/*!
+ * \brief Holds a `::FastFlow` object. Needs to be reset after each horizon
+ * find.
+ */
 struct FastFlow : db::SimpleTag {
   using type = ::FastFlow;
+};
+
+/*!
+ * \brief Tag that holds the current time.
+ *
+ * \details The value of this tag is `std::nullopt` if the current time isn't
+ * set.
+ */
+struct CurrentTime : db::SimpleTag {
+  using type = std::optional<LinkedMessageId<double>>;
+};
+
+/*!
+ * \brief List of times waiting for previous horizon finds to finish
+ * before they can be started.
+ */
+struct PendingTimes : db::SimpleTag {
+  using type = std::set<LinkedMessageId<double>>;
+};
+
+/*!
+ * \brief Tag that holds all completed times
+ */
+struct CompletedTimes : db::SimpleTag {
+  using type = std::set<LinkedMessageId<double>>;
+};
+
+/*!
+ * \brief Holds potential dependency for apparent horizon callbacks.
+ */
+struct Dependency : db::SimpleTag {
+  using type = std::optional<std::string>;
+};
+
+/*!
+ * \brief Storage of all variables (volume or interpolated) for all times of the
+ * horizon finder.
+ */
+template <typename Fr>
+struct Storage : db::SimpleTag {
+  using type = std::unordered_map<LinkedMessageId<double>,
+                                  ah::Storage::SingleTimeStorage<Fr>>;
+};
+
+/*!
+ * \brief Deque of `ah::Storage::PreviousSurface`s.
+ */
+template <typename Fr>
+struct PreviousSurfaces : db::SimpleTag {
+  using type = std::deque<ah::Storage::PreviousSurface<Fr>>;
+};
+
+/*!
+ * \brief Global cache tag that holds horizon finder options
+ */
+template <typename HorizonMetavars>
+struct ApparentHorizonOptions : db::SimpleTag {
+  using type = HorizonOptions<typename HorizonMetavars::frame>;
+  using option_tags =
+      tmpl::list<OptionTags::ApparentHorizonOptions<HorizonMetavars>>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
 };
 
 /*!

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_FastFlow.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_ObserveCenters.cpp
+  Test_OptionTags.cpp
   Test_Storage.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Framework/TestCreation.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
+                  "[ApparentHorizonFinder][Unit]") {
+  // Constants used in this test.
+  const size_t l_max = 12;
+  const double radius = 2.0;
+  const std::array<double, 3> center = {{0.05, 0.06, 0.07}};
+
+  // Options for ApparentHorizon
+  ah::HorizonOptions<::Frame::Grid> apparent_horizon_opts(
+      ylm::Strahlkorper<Frame::Grid>{l_max, radius, center}, FastFlow{},
+      Verbosity::Verbose, 3_st, std::nullopt);
+
+  // Test creation of options
+  const auto created_opts =
+      TestHelpers::test_creation<ah::HorizonOptions<Frame::Grid>>(
+          "FastFlow:\n"
+          "  Flow: Fast\n"
+          "  Alpha: 1.0\n"
+          "  Beta: 0.5\n"
+          "  AbsTol: 1e-12\n"
+          "  TruncationTol: 1e-2\n"
+          "  DivergenceTol: 1.2\n"
+          "  DivergenceIter: 5\n"
+          "  MaxIts: 100\n"
+          "Verbosity: Verbose\n"
+          "InitialGuess:\n"
+          "  Center: [0.05, 0.06, 0.07]\n"
+          "  Radius: 2.0\n"
+          "  LMax: 12\n"
+          "MaxInterpolationRetries: 3\n"
+          "BlocksForHorizonFind: All");
+  CHECK(created_opts == apparent_horizon_opts);
+}

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
@@ -5,13 +5,49 @@
 
 #include <string>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace {
+struct MockHorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using time_tag = ::Tags::TimeAndPrevious<0>;
+
+  using frame = ::Frame::Grid;
+
+  // Don't need callbacks
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() { return "MockHorizonMetavars"; }
+};
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Tags",
                   "[ApparentHorizonFinder][Unit]") {
+  (void)MockHorizonMetavars::destination;
+
+  TestHelpers::db::test_simple_tag<ah::Tags::Verbosity>("Verbosity");
   TestHelpers::db::test_simple_tag<ah::Tags::FastFlow>("FastFlow");
+  TestHelpers::db::test_simple_tag<ah::Tags::CurrentTime>("CurrentTime");
+  TestHelpers::db::test_simple_tag<ah::Tags::PendingTimes>("PendingTimes");
+  TestHelpers::db::test_simple_tag<ah::Tags::CompletedTimes>("CompletedTimes");
+  TestHelpers::db::test_simple_tag<ah::Tags::Storage<::Frame::Distorted>>(
+      "Storage");
+  TestHelpers::db::test_simple_tag<
+      ah::Tags::PreviousSurfaces<::Frame::Distorted>>("PreviousSurfaces");
+  TestHelpers::db::test_simple_tag<
+      ah::Tags::ApparentHorizonOptions<MockHorizonMetavars>>(
+      "ApparentHorizonOptions");
   TestHelpers::db::test_simple_tag<
       ah::Tags::PreviousIterationStrahlkorper<::Frame::Distorted>>(
       "PreviousIterationStrahlkorper");


### PR DESCRIPTION
## Proposed changes

Fourth PR in horizon finder changes. Adds option tags and simple tags that will be needed for the horizon finder.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
