### PR TITLE
AH rewrite: Add initialization action and component

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -27,6 +27,7 @@ spectre_target_headers(
   Destination.hpp
   FastFlow.hpp
   HorizonAliases.hpp
+  Initialization.hpp
   InterpolationTarget.hpp
   OptionTags.hpp
   Storage.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ApparentHorizon.hpp
+  Component.hpp
   ComputeExcisionBoundaryVolumeQuantities.hpp
   ComputeExcisionBoundaryVolumeQuantities.tpp
   ComputeHorizonVolumeQuantities.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Component.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Component.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+#include <tuple>
+
+#include "Parallel/Algorithms/AlgorithmSingleton.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+/*!
+ * \brief The singleton parallel component responsible for finding horizons.
+ */
+template <class Metavariables, typename HorizonMetavars>
+struct Component {
+  static_assert(tt::assert_conforms_to_v<HorizonMetavars,
+                                         ah::protocols::HorizonMetavars>);
+  using horizon_metavars = HorizonMetavars;
+  using chare_type = Parallel::Algorithms::Singleton;
+  static constexpr bool checkpoint_data = true;
+
+  static std::string name() { return HorizonMetavars::name(); }
+
+  using metavariables = Metavariables;
+
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<Initialization::Actions::InitializeItems<
+                     ::ah::Initialize<HorizonMetavars>>,
+                 Parallel::Actions::TerminatePhase>>>;
+
+  using simple_tags_from_options = Parallel::get_simple_tags_from_options<
+      Parallel::get_initialization_actions_list<phase_dependent_action_list>>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<Component>(local_cache)
+        .start_phase(next_phase);
+  }
+};
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+/*!
+ * \brief Initialize items related to the horizon finder
+ *
+ * GlobalCache:
+ * - Uses:
+ *   - `ah::Tags::ApparentHorizonOptions`
+ *
+ * DataBox:
+ * - Uses: Nothing
+ * - Adds:
+ *   - `ah::Tags::Verbosity`
+ *   - `ah::Tags::FastFlow`
+ *   - `ah::Tags::CurrentTime`
+ *   - `ah::Tags::PendingTimes`
+ *   - `ah::Tags::CompletedTimes`
+ *   - `ah::Tags::Storage`
+ *   - `ah::Tags::PreviousSurfaces`
+ *   - `ah::Tags::Strahlkorper`
+ *   - `ah::Tags::TimeDerivStrahlkorper`
+ *   - `ah::Tags::Dependency`
+ *   - `::Tags::Variables<ah::vars_to_interpolate_to_target>`
+ * - Modifies:
+ *   - `ah::Tags::Verbosity`
+ *   - `ah::Tags::FastFlow`
+ *   - `ah::Tags::CurrentTime`
+ */
+template <typename HorizonMetavars>
+struct Initialize {
+  using Fr = typename HorizonMetavars::frame;
+
+  using simple_tags_from_options = tmpl::list<>;
+
+  using simple_tags = tmpl::append<
+      tmpl::list<Tags::Verbosity, Tags::FastFlow, Tags::CurrentTime,
+                 Tags::PendingTimes, Tags::CompletedTimes, Tags::Storage<Fr>,
+                 Tags::PreviousSurfaces<Fr>, ylm::Tags::Strahlkorper<Fr>,
+                 ylm::Tags::TimeDerivStrahlkorper<Fr>, ah::Tags::Dependency,
+                 ::Tags::Variables<ah::vars_to_interpolate_to_target<3, Fr>>>,
+      tmpl::conditional_t<
+          std::is_same_v<Fr, Frame::Inertial>, tmpl::list<>,
+          tmpl::list<ylm::Tags::CartesianCoords<Frame::Inertial>>>>;
+
+  using const_global_cache_tags =
+      tmpl::remove_duplicates<tmpl::flatten<tmpl::append<
+          tmpl::list<Tags::ApparentHorizonOptions<HorizonMetavars>>,
+          Parallel::get_const_global_cache_tags_from_actions<tmpl::flatten<
+              tmpl::list<typename HorizonMetavars::horizon_find_callbacks,
+                         typename HorizonMetavars::
+                             horizon_find_failure_callbacks>>>>>>;
+
+  using mutable_global_cache_tags = tmpl::list<>;
+
+  using compute_tags = ah::compute_items_on_target<3, Fr>;
+
+  using return_tags =
+      tmpl::list<Tags::Verbosity, Tags::FastFlow, Tags::CurrentTime>;
+
+  using argument_tags =
+      tmpl::list<Tags::ApparentHorizonOptions<HorizonMetavars>>;
+
+  static void apply(
+      const gsl::not_null<::Verbosity*> verbosity,
+      const gsl::not_null<::FastFlow*> fast_flow,
+      const gsl::not_null<std::optional<LinkedMessageId<double>>*> current_time,
+      const HorizonOptions<Fr>& options) {
+    (*verbosity) = options.verbosity;
+    (*fast_flow) = options.fast_flow;
+    current_time->reset();
+  }
+};
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_ComputeHorizonVolumeQuantities.cpp
   Test_Destination.cpp
   Test_FastFlow.cpp
+  Test_Initialization.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_ObserveCenters.cpp
   Test_OptionTags.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Initialization.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Initialization.cpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct MockHorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using time_tag = ::Tags::TimeAndPrevious<0>;
+
+  using frame = ::Frame::Grid;
+
+  // Don't need callbacks
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() { return "MockHorizonMetavars"; }
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Initialization",
+                  "[ApparentHorizonFinder][Unit]") {
+  (void)MockHorizonMetavars::destination;
+
+  const FastFlow expected_fast_flow{
+      FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100};
+  const ah::HorizonOptions<Frame::Grid> horizon_options{
+      ylm::Strahlkorper<Frame::Grid>{4, 2.0, std::array{0.0, 0.0, 0.0}},
+      expected_fast_flow, ::Verbosity::Debug, 3, std::nullopt};
+
+  ::Verbosity verbosity{};
+  std::optional<LinkedMessageId<double>> current_time =
+      LinkedMessageId<double>{1.0, std::nullopt};
+  FastFlow fast_flow{};
+
+  ah::Initialize<MockHorizonMetavars>::apply(
+      make_not_null(&verbosity), make_not_null(&fast_flow),
+      make_not_null(&current_time), horizon_options);
+
+  CHECK(verbosity == ::Verbosity::Debug);
+  CHECK_FALSE(current_time.has_value());
+  CHECK(fast_flow == expected_fast_flow);
+}


### PR DESCRIPTION
## Proposed changes

Fifth PR in the horizon finder changes. Adds an initialization action with adds all the tags to the box, and the component for the horizon finder.

~Depends on and includes #6751.~

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
