### PR TITLE
Get rid of more base tags

### DIFF
--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
@@ -46,10 +46,8 @@ void check_expiration_time_consistency(
 /// \ingroup ControlSystemGroup
 /// The FunctionsOfTime initialized from a DomainCreator, initial time, and
 /// control system OptionHolders.
-struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime,
-                                   db::SimpleTag {
-  using type = std::unordered_map<
-      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime {
+  using base = domain::Tags::FunctionsOfTime;
 
   static constexpr bool pass_metavariables = true;
 

--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -62,19 +62,7 @@ struct WriteDataToDisk : db::SimpleTag {
   static type create_from_options(const type& option) { return option; }
 };
 
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ControlSystemGroup
-/// DataBox tag for writing the centers of the horizons to disk.
-///
-/// This is controlled by the `control_system::OptionTags::WriteDataToDisk`
-/// option in the input file.
-struct ObserveCenters : ::ah::Tags::ObserveCentersBase, db::SimpleTag {
-  using type = bool;
-  using option_tags = tmpl::list<OptionTags::WriteDataToDisk>;
-
-  static constexpr bool pass_metavariables = false;
-  static type create_from_options(const type& option) { return option; }
-};
+using ObserveCenters = ah::Tags::ObserveCenters;
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -870,8 +870,9 @@ auto DataBox<tmpl::list<Tags...>>::compute_tag_graphs() -> TagGraphs {
       });
 
   // Set mutation function
-  tmpl::for_each<mutable_item_tags>([&result](auto tag_v) {
-    using tag = tmpl::type_from<decltype(tag_v)>;
+  tmpl::for_each<mutable_item_tags>([&result]<typename Tag>(
+                                        tmpl::type_<Tag> /*meta*/) {
+    using tag = detail::get_base<Tag>;
     const std::string tag_name = pretty_type::get_name<tag>();
     if (result.tag_mutate_functions.find(tag_name) ==
         result.tag_mutate_functions.end()) {
@@ -988,7 +989,8 @@ void DataBox<tmpl::list<Tags...>>::reset_compute_items(
 template <typename... Tags>
 template <typename MutatedTag>
 void DataBox<tmpl::list<Tags...>>::reset_compute_items_after_mutate() {
-  static const std::string mutated_tag = pretty_type::get_name<MutatedTag>();
+  using tag = detail::get_base<MutatedTag>;
+  static const std::string mutated_tag = pretty_type::get_name<tag>();
   if (tag_graphs_.tags_and_dependents.find(mutated_tag) !=
       tag_graphs_.tags_and_dependents.end()) {
     reset_compute_items(mutated_tag);
@@ -1069,7 +1071,9 @@ template <typename... Tags>
 template <typename Tag>
 void* DataBox<tmpl::list<Tags...>>::get_item_as_void_pointer_for_mutate() {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  return reinterpret_cast<void*>(&this->template get_item<Tag>());
+  return reinterpret_cast<void*>(
+      &this->template get_item<
+          detail::first_matching_tag<tmpl::list<Tags...>, Tag>>());
 }
 
 template <typename... Tags>

--- a/src/Domain/Creators/Tags/FunctionsOfTime.hpp
+++ b/src/Domain/Creators/Tags/FunctionsOfTime.hpp
@@ -21,9 +21,8 @@ struct FunctionOfTime;
 
 namespace domain::Tags {
 /// \brief The FunctionsOfTime initialized from a DomainCreator
-struct FunctionsOfTimeInitialize : FunctionsOfTime, db::SimpleTag {
-  using type = std::unordered_map<
-      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+struct FunctionsOfTimeInitialize : FunctionsOfTime {
+  using base = FunctionsOfTime;
 
   static constexpr bool pass_metavariables = true;
 

--- a/src/Domain/FunctionsOfTime/Tags.hpp
+++ b/src/Domain/FunctionsOfTime/Tags.hpp
@@ -3,9 +3,22 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+
 #include "DataStructures/DataBox/Tag.hpp"
+
+/// \cond
+namespace domain::FunctionsOfTime {
+struct FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+/// \endcond
 
 namespace domain::Tags {
 /// Tag to retrieve the FunctionsOfTime from the GlobalCache.
-struct FunctionsOfTime : db::BaseTag {};
+struct FunctionsOfTime : db::SimpleTag {
+  using type = std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+};
 }  // namespace domain::Tags

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionScri.hpp
@@ -82,7 +82,7 @@ struct InitializeCharacteristicEvolutionScri {
         db::get<InitializationTags::ScriInterpolationOrder>(*box);
     const size_t vector_size =
         Spectral::Swsh::number_of_swsh_collocation_points(
-            db::get<Spectral::Swsh::Tags::LMaxBase>(*box));
+            db::get<Spectral::Swsh::Tags::LMax>(*box));
     // silence compiler warnings when pack is empty
     (void)vector_size;
     if constexpr (sizeof...(TagPack) > 0) {

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionVariables.hpp
@@ -132,9 +132,9 @@ struct InitializeCharacteristicEvolutionVariables {
 
   template <typename TagList>
   static void initialize_impl(const gsl::not_null<db::DataBox<TagList>*> box) {
-    const size_t l_max = db::get<Spectral::Swsh::Tags::LMaxBase>(*box);
+    const size_t l_max = db::get<Spectral::Swsh::Tags::LMax>(*box);
     const size_t number_of_radial_points =
-        db::get<Spectral::Swsh::Tags::NumberOfRadialPointsBase>(*box);
+        db::get<Spectral::Swsh::Tags::NumberOfRadialPoints>(*box);
     const size_t boundary_size =
         Spectral::Swsh::number_of_swsh_collocation_points(l_max);
     const size_t volume_size = boundary_size * number_of_radial_points;

--- a/src/Evolution/Systems/Cce/Actions/InitializeKleinGordonVariables.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeKleinGordonVariables.hpp
@@ -70,9 +70,9 @@ struct InitializeKleinGordonVariables {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    const size_t l_max = db::get<Spectral::Swsh::Tags::LMaxBase>(box);
+    const size_t l_max = db::get<Spectral::Swsh::Tags::LMax>(box);
     const size_t number_of_radial_points =
-        db::get<Spectral::Swsh::Tags::NumberOfRadialPointsBase>(box);
+        db::get<Spectral::Swsh::Tags::NumberOfRadialPoints>(box);
     const size_t boundary_size =
         Spectral::Swsh::number_of_swsh_collocation_points(l_max);
     const size_t volume_size = boundary_size * number_of_radial_points;

--- a/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp
@@ -21,13 +21,6 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
-
-namespace Tags {
-/// \cond
-struct LMax;
-/// \endcond
-}  // namespace Tags
-
 /// The set of tags that should be calculated before the initial data is
 /// computed on the first hypersurface.
 using gauge_adjustments_setup_tags =

--- a/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
@@ -27,13 +27,6 @@ class ComplexDataVector;
 /// \endcond
 
 namespace Cce {
-namespace Tags {
-/// \cond
-struct LMax;
-struct NumberOfRadialPoints;
-/// \endcond
-}  // namespace Tags
-
 /// Contains utilities and \ref DataBoxGroup mutators for generating data for
 /// \f$J\f$ on the initial CCE hypersurface.
 namespace InitializeJ {

--- a/src/Evolution/Systems/Cce/LinearOperators.hpp
+++ b/src/Evolution/Systems/Cce/LinearOperators.hpp
@@ -29,10 +29,6 @@ void logical_partial_directional_derivative_of_complex(
     const Mesh<3>& mesh, size_t dimension_to_differentiate);
 
 namespace Tags {
-/// \cond
-struct LMax;
-/// \endcond
-
 /*!
  * \brief Compute tag for a manually-handled partial y derivative in the volume.
  *

--- a/src/Evolution/Systems/Cce/NewmanPenrose.hpp
+++ b/src/Evolution/Systems/Cce/NewmanPenrose.hpp
@@ -20,9 +20,6 @@ class ComplexDataVector;
 namespace Cce {
 
 /// \cond
-namespace Tags {
-struct LMax;
-}  // namespace Tags
 template <typename Tag>
 struct VolumeWeyl;
 /// \endcond

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -66,13 +66,6 @@ struct BondiSachsOutputFilePrefix {
   using group = Cce;
 };
 
-struct LMax {
-  using type = size_t;
-  static constexpr Options::String help{
-      "Maximum l value for spin-weighted spherical harmonics"};
-  using group = Cce;
-};
-
 struct FilterLMax {
   using type = size_t;
   static constexpr Options::String help{"l mode cutoff for angular filtering"};
@@ -96,13 +89,6 @@ struct RadialFilterHalfPower {
 struct ObservationLMax {
   using type = size_t;
   static constexpr Options::String help{"Maximum l value for swsh output"};
-  using group = Cce;
-};
-
-struct NumberOfRadialPoints {
-  using type = size_t;
-  static constexpr Options::String help{
-      "Number of radial grid points in the spherical domain"};
   using group = Cce;
 };
 
@@ -233,11 +219,12 @@ struct ScriOutputDensity : db::SimpleTag {
 }  // namespace InitializationTags
 
 namespace Tags {
-struct ExtractionRadius : db::BaseTag {};
-
-struct ExtractionRadiusSimple : ExtractionRadius, db::SimpleTag {
-  static std::string name() { return "ExtractionRadius"; }
+struct ExtractionRadius : db::SimpleTag {
   using type = double;
+};
+
+struct ExtractionRadiusSimple : ExtractionRadius {
+  using base = ExtractionRadius;
   using option_tags = tmpl::list<OptionTags::ExtractionRadius>;
 
   static constexpr bool pass_metavariables = false;
@@ -246,9 +233,8 @@ struct ExtractionRadiusSimple : ExtractionRadius, db::SimpleTag {
   }
 };
 
-struct ExtractionRadiusFromH5 : ExtractionRadius, db::SimpleTag {
-  static std::string name() { return "ExtractionRadius"; }
-  using type = double;
+struct ExtractionRadiusFromH5 : ExtractionRadius {
+  using base = ExtractionRadius;
   using option_tags = tmpl::list<OptionTags::BoundaryDataFilename,
                                  OptionTags::StandaloneExtractionRadius>;
 
@@ -296,8 +282,9 @@ struct H5WorldtubeBoundaryDataManager : db::SimpleTag {
   using type = std::unique_ptr<WorldtubeDataManager<
       Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>>;
   using option_tags =
-      tmpl::list<OptionTags::LMax, OptionTags::BoundaryDataFilename,
-                 OptionTags::H5LookaheadTimes, OptionTags::H5Interpolator,
+      tmpl::list<Spectral::Swsh::OptionTags::LMax,
+                 OptionTags::BoundaryDataFilename, OptionTags::H5LookaheadTimes,
+                 OptionTags::H5Interpolator,
                  OptionTags::StandaloneExtractionRadius>;
 
   static constexpr bool pass_metavariables = false;
@@ -335,7 +322,8 @@ struct KleinGordonH5WorldtubeBoundaryDataManager : db::SimpleTag {
   using type = std::unique_ptr<
       WorldtubeDataManager<Tags::klein_gordon_worldtube_boundary_tags>>;
   using option_tags =
-      tmpl::list<OptionTags::LMax, OptionTags::KleinGordonBoundaryDataFilename,
+      tmpl::list<Spectral::Swsh::OptionTags::LMax,
+                 OptionTags::KleinGordonBoundaryDataFilename,
                  OptionTags::H5LookaheadTimes, OptionTags::H5Interpolator,
                  OptionTags::StandaloneExtractionRadius>;
 
@@ -349,25 +337,6 @@ struct KleinGordonH5WorldtubeBoundaryDataManager : db::SimpleTag {
         std::make_unique<KleinGordonWorldtubeH5BufferUpdater>(
             filename, extraction_radius),
         l_max, number_of_lookahead_times, interpolator->get_clone());
-  }
-};
-
-struct LMax : db::SimpleTag, Spectral::Swsh::Tags::LMaxBase {
-  using type = size_t;
-  using option_tags = tmpl::list<OptionTags::LMax>;
-
-  static constexpr bool pass_metavariables = false;
-  static size_t create_from_options(const size_t l_max) { return l_max; }
-};
-
-struct NumberOfRadialPoints : db::SimpleTag,
-                              Spectral::Swsh::Tags::NumberOfRadialPointsBase {
-  using type = size_t;
-  using option_tags = tmpl::list<OptionTags::NumberOfRadialPoints>;
-
-  static constexpr bool pass_metavariables = false;
-  static size_t create_from_options(const size_t number_of_radial_points) {
-    return number_of_radial_points;
   }
 };
 
@@ -418,8 +387,8 @@ struct RadialFilterHalfPower : db::SimpleTag {
 /// `OptionTags::StartTime` is set to "Auto"), this will find the start time
 /// from the provided H5 file. If `OptionTags::StartTime` takes any other value,
 /// it will be used directly as the start time for the CCE evolution instead.
-struct StartTimeFromFile : Tags::StartTime, db::SimpleTag {
-  using type = double;
+struct StartTimeFromFile : Tags::StartTime {
+  using base = Tags::StartTime;
   using option_tags =
       tmpl::list<OptionTags::StartTime, OptionTags::BoundaryDataFilename,
                  OptionTags::StandaloneExtractionRadius>;
@@ -441,8 +410,8 @@ struct StartTimeFromFile : Tags::StartTime, db::SimpleTag {
 
 /// \brief Represents the start time of a bounded CCE evolution that must be
 /// supplied in the input file (for e.g. analytic tests).
-struct SpecifiedStartTime : Tags::StartTime, db::SimpleTag {
-  using type = double;
+struct SpecifiedStartTime : Tags::StartTime {
+  using base = Tags::StartTime;
   using option_tags = tmpl::list<OptionTags::StartTime>;
 
   static constexpr bool pass_metavariables = false;
@@ -463,8 +432,8 @@ struct SpecifiedStartTime : Tags::StartTime, db::SimpleTag {
 /// `OptionTags::EndTime` is set to "Auto"), this will find the end time
 /// from the provided H5 file. If `OptionTags::EndTime` takes any other value,
 /// it will be used directly as the final time for the CCE evolution instead.
-struct EndTimeFromFile : Tags::EndTime, db::SimpleTag {
-  using type = double;
+struct EndTimeFromFile : Tags::EndTime {
+  using base = Tags::EndTime;
   using option_tags =
       tmpl::list<OptionTags::EndTime, OptionTags::BoundaryDataFilename,
                  OptionTags::StandaloneExtractionRadius>;
@@ -485,8 +454,8 @@ struct EndTimeFromFile : Tags::EndTime, db::SimpleTag {
 
 /// \brief Represents the final time of a CCE evolution that should just proceed
 /// until it receives no more boundary data and becomes quiescent.
-struct NoEndTime : Tags::EndTime, db::SimpleTag {
-  using type = double;
+struct NoEndTime : Tags::EndTime {
+  using base = Tags::EndTime;
   using option_tags = tmpl::list<>;
 
   static constexpr bool pass_metavariables = false;
@@ -497,8 +466,8 @@ struct NoEndTime : Tags::EndTime, db::SimpleTag {
 
 /// \brief Represents the final time of a bounded CCE evolution that must be
 /// supplied in the input file (for e.g. analytic tests).
-struct SpecifiedEndTime : Tags::EndTime, db::SimpleTag {
-  using type = double;
+struct SpecifiedEndTime : Tags::EndTime {
+  using base = Tags::EndTime;
   using option_tags = tmpl::list<OptionTags::EndTime>;
 
   static constexpr bool pass_metavariables = false;
@@ -560,8 +529,9 @@ struct AnalyticInitializeJ : db::SimpleTag, InitializeJBase {
 /// A tag that constructs a `AnalyticBoundaryDataManager` from options
 struct AnalyticBoundaryDataManager : db::SimpleTag {
   using type = ::Cce::AnalyticBoundaryDataManager;
-  using option_tags = tmpl::list<OptionTags::ExtractionRadius, OptionTags::LMax,
-                                 OptionTags::AnalyticSolution>;
+  using option_tags =
+      tmpl::list<OptionTags::ExtractionRadius, Spectral::Swsh::OptionTags::LMax,
+                 OptionTags::AnalyticSolution>;
 
   static constexpr bool pass_metavariables = false;
   static Cce::AnalyticBoundaryDataManager create_from_options(

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -370,9 +370,16 @@ struct BondiR : db::SimpleTag {
   static std::string name() { return "R"; }
 };
 
-struct EndTime : db::BaseTag {};
+struct EndTime : db::SimpleTag {
+  using type = double;
+};
 
-struct StartTime : db::BaseTag {};
+struct StartTime : db::SimpleTag {
+  using type = double;
+};
+
+using LMax = Spectral::Swsh::Tags::LMax;
+using NumberOfRadialPoints = Spectral::Swsh::Tags::NumberOfRadialPoints;
 
 /// The (adapted) Newman-Penrose spin coefficient $\alpha^{SW}$. See
 /// documentation of `newman_penrose_alpha()` for definition.

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshDerivatives.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshDerivatives.hpp
@@ -187,9 +187,8 @@ struct AngularDerivativesImpl<tmpl::list<DerivativeTags...>,
   using return_tags =
       tmpl::list<DerivativeTags..., Tags::SwshTransform<DerivativeTags>...,
                  Tags::SwshTransform<UniqueDifferentiatedFromTags>...>;
-  using argument_tags =
-      tmpl::list<UniqueDifferentiatedFromTags..., Tags::LMaxBase,
-                 Tags::NumberOfRadialPointsBase>;
+  using argument_tags = tmpl::list<UniqueDifferentiatedFromTags..., Tags::LMax,
+                                   Tags::NumberOfRadialPoints>;
 
   static void apply(
       const gsl::not_null<typename DerivativeTags::type*>... derivative_scalars,

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp
@@ -12,14 +12,36 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace Cce::OptionTags {
+struct Cce;
+}  // namespace Cce::OptionTags
+/// \endcond
 
 namespace Spectral {
 namespace Swsh {
 /// \cond
 class SwshInterpolator;
 /// \endcond
+
+namespace OptionTags {
+struct LMax {
+  using type = size_t;
+  static constexpr Options::String help{
+      "Maximum l value for spin-weighted spherical harmonics"};
+  using group = Cce::OptionTags::Cce;
+};
+struct NumberOfRadialPoints {
+  using type = size_t;
+  static constexpr Options::String help{
+      "Number of radial grid points in the spherical domain"};
+  using group = Cce::OptionTags::Cce;
+};
+}  // namespace OptionTags
 
 namespace Tags {
 
@@ -189,27 +211,27 @@ struct SwshTransform : db::PrefixTag, db::SimpleTag {
 };
 
 /// \ingroup SwshGroup
-/// \brief Base Tag for the maximum spin-weighted spherical harmonic l; sets
-/// angular resolution.
-struct LMaxBase : db::BaseTag {};
-
-/// \ingroup SwshGroup
 /// \brief Tag for the maximum spin-weighted spherical harmonic l; sets angular
 /// resolution.
-struct LMax : db::SimpleTag, LMaxBase {
+struct LMax : db::SimpleTag {
   using type = size_t;
-};
+  using option_tags = tmpl::list<OptionTags::LMax>;
 
-/// \ingroup SwshGroup
-/// \brief Base Tag for the number of radial grid points in the
-/// three-dimensional representation of radially concentric spherical shells.
-struct NumberOfRadialPointsBase : db::BaseTag {};
+  static constexpr bool pass_metavariables = false;
+  static size_t create_from_options(const size_t l_max) { return l_max; }
+};
 
 /// \ingroup SwshGroup
 /// \brief Tag for the number of radial grid points in the three-dimensional
 /// representation of radially concentric spherical shells
-struct NumberOfRadialPoints : db::SimpleTag, NumberOfRadialPointsBase {
+struct NumberOfRadialPoints : db::SimpleTag {
   using type = size_t;
+  using option_tags = tmpl::list<OptionTags::NumberOfRadialPoints>;
+
+  static constexpr bool pass_metavariables = false;
+  static size_t create_from_options(const size_t number_of_radial_points) {
+    return number_of_radial_points;
+  }
 };
 
 /// \ingroup SwshGroup

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp
@@ -423,8 +423,8 @@ struct SwshTransform<tmpl::list<TransformTags...>, Representation> {
                 "same spin weight.");
 
   using return_tags = tmpl::list<Tags::SwshTransform<TransformTags>...>;
-  using argument_tags = tmpl::list<TransformTags..., Tags::LMaxBase,
-                                   Tags::NumberOfRadialPointsBase>;
+  using argument_tags =
+      tmpl::list<TransformTags..., Tags::LMax, Tags::NumberOfRadialPoints>;
 
   static void apply(
       const gsl::not_null<
@@ -507,9 +507,8 @@ struct InverseSwshTransform<tmpl::list<TransformTags...>, Representation> {
       "same spin weight.");
 
   using return_tags = tmpl::list<TransformTags...>;
-  using argument_tags =
-      tmpl::list<Tags::SwshTransform<TransformTags>..., Tags::LMaxBase,
-                 Tags::NumberOfRadialPointsBase>;
+  using argument_tags = tmpl::list<Tags::SwshTransform<TransformTags>...,
+                                   Tags::LMax, Tags::NumberOfRadialPoints>;
 
   static void apply(
       const gsl::not_null<typename TransformTags::type*>... collocations,

--- a/src/Parallel/Tags/Metavariables.hpp
+++ b/src/Parallel/Tags/Metavariables.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "DataStructures/DataBox/Tag.hpp"
 
 namespace Parallel::Tags {
@@ -13,7 +15,7 @@ struct Metavariables : db::BaseTag {};
 
 template <typename Metavars>
 struct MetavariablesImpl : Metavariables, db::SimpleTag {
-  using base = Metavariables;
   using type = Metavars;
+  static std::string name() { return "Metavariables"; }
 };
 }  // namespace Parallel::Tags

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp
@@ -88,7 +88,7 @@ struct ObserveCenters {
         "DataBox must contain ylm::Tags::EuclideanAreaElement<Frame>");
 
     // Only print the centers if we want to.
-    if (not Parallel::get<ah::Tags::ObserveCentersBase>(cache)) {
+    if (not Parallel::get<ah::Tags::ObserveCenters>(cache)) {
       return;
     }
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -14,8 +14,12 @@
 #include "IO/Logging/Verbosity.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace control_system::OptionTags {
+struct WriteDataToDisk;
+}  // namespace control_system::OptionTags
 class FastFlow;
 namespace ylm {
 template <typename Frame>
@@ -122,16 +126,12 @@ struct FailedInterpolationIterations : db::SimpleTag {
   using type = size_t;
 };
 
-/// Base tag for whether or not to write the centers of the horizons to disk.
-/// Most likely to be used in the `ObserveCenters` post horizon find callback
-///
-/// Other things can control whether the horizon centers are output by defining
-/// their own simple tag from this base tag.
-struct ObserveCentersBase : db::BaseTag {};
-
 /// Simple tag for whether to write the centers of the horizons to disk.
-/// Currently this tag is not creatable by options
-struct ObserveCenters : ObserveCentersBase, db::SimpleTag {
+struct ObserveCenters : db::SimpleTag {
   using type = bool;
+  using option_tags = tmpl::list<control_system::OptionTags::WriteDataToDisk>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
 };
 }  // namespace ah::Tags

--- a/tests/Unit/ControlSystem/Actions/Test_GridCenters.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_GridCenters.cpp
@@ -27,18 +27,14 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-struct FunctionsOfTimeTag : domain::Tags::FunctionsOfTime, db::SimpleTag {
-  using type = std::unordered_map<
-      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
-};
-
 template <typename Metavariables>
 struct Component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<3>;
   using mutable_global_cache_tags =
-      tmpl::list<FunctionsOfTimeTag, control_system::Tags::IsActiveMap>;
+      tmpl::list<domain::Tags::FunctionsOfTime,
+                 control_system::Tags::IsActiveMap>;
   using simple_tags = db::AddSimpleTags<::domain::Tags::Element<3>,
                                         Tags::TimeStepId, ::Tags::Time>;
   using compute_tags = tmpl::list<>;
@@ -180,7 +176,7 @@ void test_action() {
 
   // Remove things we need from FunctionsOfTime map to test ERRORs
   auto& cache = ActionTesting::cache<component>(runner, element_id_zero);
-  Parallel::mutate<FunctionsOfTimeTag, UpdateFot>(
+  Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFot>(
       cache, [&functions_of_time]() {
         auto local_fots = clone_unique_ptrs(functions_of_time);
         local_fots.erase("GridCenters");
@@ -190,7 +186,7 @@ void test_action() {
       make_not_null(&runner), element_id_zero,
       Catch::Matchers::ContainsSubstring("There is no function of time named "
                                          "'GridCenters', which is required ")));
-  Parallel::mutate<FunctionsOfTimeTag, UpdateFot>(
+  Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFot>(
       cache, [&functions_of_time]() {
         auto local_fots = clone_unique_ptrs(functions_of_time);
         local_fots.erase("Rotation");
@@ -200,7 +196,7 @@ void test_action() {
       make_not_null(&runner), element_id_zero,
       Catch::Matchers::ContainsSubstring("There is no function of time named "
                                          "'Rotation', which means that ")));
-  Parallel::mutate<FunctionsOfTimeTag, UpdateFot>(
+  Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFot>(
       cache, [&functions_of_time]() {
         auto local_fots = clone_unique_ptrs(functions_of_time);
         return local_fots;

--- a/tests/Unit/ControlSystem/Actions/Test_LimitTimeStep.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_LimitTimeStep.cpp
@@ -67,11 +67,6 @@ struct Var : db::SimpleTag {
   using type = double;
 };
 
-struct FunctionsOfTimeTag : domain::Tags::FunctionsOfTime, db::SimpleTag {
-  using type = std::unordered_map<
-      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
-};
-
 template <typename Metavariables>
 struct Component {
   using metavariables = Metavariables;
@@ -79,7 +74,7 @@ struct Component {
   using array_index = ElementId<3>;
   using mutable_global_cache_tags =
       tmpl::list<control_system::Tags::MeasurementTimescales,
-                 FunctionsOfTimeTag>;
+                 domain::Tags::FunctionsOfTime>;
   using simple_tags =
       db::AddSimpleTags<control_system::Tags::FutureMeasurements<systemsA>,
                         control_system::Tags::FutureMeasurements<systemsB>,
@@ -144,7 +139,7 @@ void test(const std::string& test_label, const double initial_time,
   control_system::Tags::MeasurementTimescales::type timescales{};
   timescales["LabelA"] = setup_fot(measurement_updatesA);
   timescales["LabelBLabelC"] = setup_fot(measurement_updatesBC);
-  FunctionsOfTimeTag::type functions_of_time{};
+  domain::Tags::FunctionsOfTime::type functions_of_time{};
   functions_of_time["LabelA"] = setup_fot(fot_updatesA);
   functions_of_time["LabelB"] = setup_fot(fot_updatesB);
   functions_of_time["LabelC"] = setup_fot(fot_updatesC);

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -66,6 +66,9 @@ struct Tag0 : db::SimpleTag {
   using type = double;
 };
 // [databox_tag_example]
+struct Tag0FromOption : Tag0 {
+  using base = Tag0;
+};
 struct Tag1 : db::SimpleTag {
   using type = std::vector<double>;
 };
@@ -204,8 +207,8 @@ void test_databox() {
   const auto create_original_box = []() {
     // [create_databox]
     auto original_box = db::create<
-        db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                          test_databox_tags::Tag2>,
+        db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                          test_databox_tags::Tag1, test_databox_tags::Tag2>,
         db::AddComputeTags<test_databox_tags::Tag4Compute,
                            test_databox_tags::Tag5Compute,
                            test_databox_tags::Lambda0Compute,
@@ -217,8 +220,9 @@ void test_databox() {
   {
     INFO("Default-construction");
     auto box = db::create<
-        db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                          test_databox_tags::Tag2, test_databox_tags::Tag3>,
+        db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                          test_databox_tags::Tag1, test_databox_tags::Tag2,
+                          test_databox_tags::Tag3>,
         db::AddComputeTags<test_databox_tags::Tag4Compute>>();
     CHECK(db::get<test_databox_tags::Tag0>(box) == 0.);
     CHECK(db::get<test_databox_tags::Tag1>(box).empty());
@@ -257,8 +261,8 @@ void test_databox() {
         std::is_same<
             decltype(original_box),
             const db::DataBox<db::detail::expand_subitems<tmpl::append<
-                tmpl::list<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                           test_databox_tags::Tag2>,
+                tmpl::list<test_databox_tags::Tag0FromOption,
+                           test_databox_tags::Tag1, test_databox_tags::Tag2>,
                 tmpl::list<test_databox_tags::Tag4Compute,
                            test_databox_tags::Tag5Compute,
                            test_databox_tags::Lambda0Compute,
@@ -387,8 +391,8 @@ void test_create_argument_types() {
 void test_get_databox() {
   INFO("test get databox");
   auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
+      db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                        test_databox_tags::Tag1, test_databox_tags::Tag2>,
       db::AddComputeTags<test_databox_tags::Tag4Compute,
                          test_databox_tags::Tag5Compute>>(
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
@@ -412,8 +416,8 @@ void test_get_databox() {
 
 void trigger_get_databox_error() {
   auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
+      db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                        test_databox_tags::Tag1, test_databox_tags::Tag2>,
       db::AddComputeTags<test_databox_tags::Tag4Compute,
                          test_databox_tags::Tag5Compute>>(
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
@@ -493,8 +497,9 @@ void test_mutate() {
   INFO("test mutate");
   const auto create_box = []() {
     return db::create<
-        db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                          test_databox_tags::Tag2, test_databox_tags::Pointer>,
+        db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                          test_databox_tags::Tag1, test_databox_tags::Tag2,
+                          test_databox_tags::Pointer>,
         db::AddComputeTags<test_databox_tags::Tag4Compute,
                            test_databox_tags::Tag5Compute>>(
         3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
@@ -514,8 +519,8 @@ void test_mutate() {
 
 void trigger_mutate_locked_get() {
   auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
+      db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                        test_databox_tags::Tag1, test_databox_tags::Tag2>,
       db::AddComputeTags<test_databox_tags::Tag4Compute,
                          test_databox_tags::Tag5Compute>>(
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
@@ -531,8 +536,8 @@ void trigger_mutate_locked_get() {
 
 void trigger_mutate_locked_mutate() {
   auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
+      db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                        test_databox_tags::Tag1, test_databox_tags::Tag2>,
       db::AddComputeTags<test_databox_tags::Tag4Compute,
                          test_databox_tags::Tag5Compute>>(
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
@@ -564,7 +569,8 @@ void test_mutate_locked() {
 
 void test_mutate_box() {
   INFO("test mutate entire box");
-  auto box = db::create<db::AddSimpleTags<test_databox_tags::Tag0>>(3.14);
+  auto box =
+      db::create<db::AddSimpleTags<test_databox_tags::Tag0FromOption>>(3.14);
   db::mutate<Tags::DataBox>(
       [&box](const gsl::not_null<decltype(box)*> mutate_box) {
         CHECK(&box == &*mutate_box);
@@ -593,15 +599,16 @@ struct NonCopyableFunctor {
 
 void test_apply() {
   INFO("test apply");
-  auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2, test_databox_tags::Pointer>,
-      db::AddComputeTags<test_databox_tags::Tag4Compute,
-                         test_databox_tags::Tag5Compute,
-                         test_databox_tags::PointerToCounterCompute,
-                         test_databox_tags::PointerToSumCompute>>(
-      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
-      std::make_unique<int>(3));
+  auto original_box =
+      db::create<db::AddSimpleTags<
+                     test_databox_tags::Tag0FromOption, test_databox_tags::Tag1,
+                     test_databox_tags::Tag2, test_databox_tags::Pointer>,
+                 db::AddComputeTags<test_databox_tags::Tag4Compute,
+                                    test_databox_tags::Tag5Compute,
+                                    test_databox_tags::PointerToCounterCompute,
+                                    test_databox_tags::PointerToSumCompute>>(
+          3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s,
+          std::make_unique<int>(3));
   auto check_result_no_args = [](const std::string& sample_string,
                                  const auto& computed_string) {
     CHECK(sample_string == "My Sample String"s);
@@ -1241,7 +1248,7 @@ void test_reset_compute_items() {
   const auto create_box = []() {
     return db::create<
         db::AddSimpleTags<
-            test_databox_tags::Tag0, test_databox_tags::Tag1,
+            test_databox_tags::Tag0FromOption, test_databox_tags::Tag1,
             test_databox_tags::Tag2,
             Tags::Variables<tmpl::list<test_databox_tags::ScalarTag,
                                        test_databox_tags::VectorTag>>>,
@@ -1604,7 +1611,7 @@ void test_mutate_apply() {
   const auto create_box = []() {
     return db::create<
         db::AddSimpleTags<
-            test_databox_tags::Tag0, test_databox_tags::Tag1,
+            test_databox_tags::Tag0FromOption, test_databox_tags::Tag1,
             test_databox_tags::Tag2,
             Tags::Variables<tmpl::list<test_databox_tags::ScalarTag,
                                        test_databox_tags::VectorTag>>,
@@ -1806,8 +1813,8 @@ void test_mutating_compute_item() {
   INFO("test mutating compute item");
   const auto create_box = []() {
     return db::create<
-        db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                          test_databox_tags::Tag2>,
+        db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                          test_databox_tags::Tag1, test_databox_tags::Tag2>,
         db::AddComputeTags<test_databox_tags::MutateTag0Compute,
                            test_databox_tags::MutateVariablesCompute,
                            test_databox_tags::Tag4Compute,
@@ -2493,8 +2500,8 @@ void test_with_tagged_tuple() {
 void serialization_non_subitem_simple_items() {
   INFO("serialization of a DataBox with non-Subitem simple items only");
   auto serialization_test_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>>(
+      db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                        test_databox_tags::Tag1, test_databox_tags::Tag2>>(
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
   const double* before_0 =
       &db::get<test_databox_tags::Tag0>(serialization_test_box);
@@ -2537,7 +2544,7 @@ void serialization_non_subitem_simple_items() {
 void serialization_subitems_simple_items() {
   INFO("serialization of a DataBox with Subitem and non-Subitem simple items");
   auto serialization_test_box =
-      db::create<db::AddSimpleTags<test_databox_tags::Tag0, Parent<0>,
+      db::create<db::AddSimpleTags<test_databox_tags::Tag0FromOption, Parent<0>,
                                    test_databox_tags::Tag1,
                                    test_databox_tags::Tag2, Parent<1>>>(
           3.14, std::make_pair(Boxed<int>(5), Boxed<double>(3.5)),
@@ -2657,7 +2664,7 @@ int CountingTagDoubleCompute<SecondId>::count = 0;
 void serialization_subitem_compute_items() {  // NOLINT
   INFO("serialization of a DataBox with Subitem compute items");
   auto serialization_test_box =
-      db::create<db::AddSimpleTags<test_databox_tags::Tag0, Parent<0>,
+      db::create<db::AddSimpleTags<test_databox_tags::Tag0FromOption, Parent<0>,
                                    test_databox_tags::Tag1,
                                    test_databox_tags::Tag2, Parent<1>>,
                  db::AddComputeTags<
@@ -3127,7 +3134,7 @@ void test_get_mutable_reference() {
   INFO("test get_mutable_reference");
   // Make sure the presence of tags that could not be extracted
   // doesn't prevent the function from working on other tags.
-  auto box = db::create<db::AddSimpleTags<test_databox_tags::Tag0,
+  auto box = db::create<db::AddSimpleTags<test_databox_tags::Tag0FromOption,
                                           test_databox_tags::Tag2, Parent<0>>,
                         db::AddComputeTags<test_databox_tags::Tag4Compute>>(
       3.14, "Original string"s,
@@ -3156,8 +3163,8 @@ void test_get_mutable_reference() {
 void test_output() {
   INFO("test output");
   auto box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
+      db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                        test_databox_tags::Tag1, test_databox_tags::Tag2>,
       db::AddComputeTags<test_databox_tags::Tag4Compute,
                          test_databox_tags::Tag5Compute,
                          test_databox_tags::Tag0Reference>>(
@@ -3165,7 +3172,8 @@ void test_output() {
   std::string output_types = db::as_access(box).print_types();
   std::string expected_types =
       "      DataBox type aliases:"
-      "      using tags_list = [(anonymous namespace)::test_databox_tags::Tag0,"
+      "      using tags_list = [(anonymous "
+      "namespace)::test_databox_tags::Tag0FromOption,"
       "(anonymous namespace)::test_databox_tags::Tag1,"
       "(anonymous namespace)::test_databox_tags::Tag2,"
       "(anonymous namespace)::test_databox_tags::Tag4Compute,"
@@ -3183,7 +3191,7 @@ void test_output() {
       "(anonymous namespace)::test_databox_tags::Tag0Reference,"
       "];"
       "      using mutable_item_tags = ["
-      "(anonymous namespace)::test_databox_tags::Tag0,"
+      "(anonymous namespace)::test_databox_tags::Tag0FromOption,"
       "(anonymous namespace)::test_databox_tags::Tag1,"
       "(anonymous namespace)::test_databox_tags::Tag2,"
       "];"
@@ -3196,7 +3204,7 @@ void test_output() {
       "(anonymous namespace)::test_databox_tags::Tag0Reference,"
       "];"
       "      using edge_list = brigand::list<brigand::edge<(anonymous "
-      "namespace)::test_databox_tags::Tag0, (anonymous "
+      "namespace)::test_databox_tags::Tag0FromOption, (anonymous "
       "namespace)::test_databox_tags::Tag4Compute, "
       "brigand::integral_constant<int, 1> >, brigand::edge<(anonymous "
       "namespace)::test_databox_tags::Tag2, (anonymous "
@@ -3205,7 +3213,7 @@ void test_output() {
       "namespace)::test_databox_tags::Tag4Compute, (anonymous "
       "namespace)::test_databox_tags::Tag5Compute, "
       "brigand::integral_constant<int, 1> >, brigand::edge<(anonymous "
-      "namespace)::test_databox_tags::Tag0, (anonymous "
+      "namespace)::test_databox_tags::Tag0FromOption, (anonymous "
       "namespace)::test_databox_tags::Tag0Reference, "
       "brigand::integral_constant<int, 1> > >;";
   // Remove whitespace since it may vary between compilers
@@ -3219,7 +3227,7 @@ void test_output() {
   std::string output_tags = db::as_access(box).print_tags();
   std::string expected_tags =
       "Simpletags(3)=["
-      "(anonymousnamespace)::test_databox_tags::Tag0,"
+      "(anonymousnamespace)::test_databox_tags::Tag0FromOption,"
       "(anonymousnamespace)::test_databox_tags::Tag1,"
       "(anonymousnamespace)::test_databox_tags::Tag2,"
       "];"
@@ -3239,7 +3247,7 @@ void test_output() {
   std::string expected_mutable_items =
       "Items:\n"
       "----------\n"
-      "Name:  (anonymous namespace)::test_databox_tags::Tag0\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag0FromOption\n"
       "Type:  double\n"
       "Value: 3.14\n"
       "----------\n"
@@ -3255,7 +3263,7 @@ void test_output() {
   std::string expected_items =
       "Items:\n"
       "----------\n"
-      "Name:  (anonymous namespace)::test_databox_tags::Tag0\n"
+      "Name:  (anonymous namespace)::test_databox_tags::Tag0FromOption\n"
       "Type:  double\n"
       "Value: 3.14\n"
       "----------\n"
@@ -3288,7 +3296,8 @@ void test_output() {
   CHECK(output_stream == expected_stream);
   const auto item_size = box.size_of_items();
   CHECK(item_size.size() == 5);
-  CHECK(item_size.at("(anonymous namespace)::test_databox_tags::Tag0") == 8);
+  CHECK(item_size.at(
+            "(anonymous namespace)::test_databox_tags::Tag0FromOption") == 8);
   CHECK(item_size.at("(anonymous namespace)::test_databox_tags::Tag1") == 32);
   CHECK(item_size.at("(anonymous namespace)::test_databox_tags::Tag2") == 24);
   CHECK(item_size.at("(anonymous namespace)::test_databox_tags::Tag4Compute") ==
@@ -3342,9 +3351,9 @@ void test_exception_safety() {
     return vars;
   };
 
-  auto box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, vars1_tag, vars2_tag>,
-      db::AddComputeTags<test_databox_tags::Tag4Compute>>(
+  auto box = db::create<db::AddSimpleTags<test_databox_tags::Tag0FromOption,
+                                          vars1_tag, vars2_tag>,
+                        db::AddComputeTags<test_databox_tags::Tag4Compute>>(
       1.0, make_vars1(1, 1.0), make_vars2(1, 1.0));
   // Make sure everything is evaluated
   CHECK(db::get<test_databox_tags::Tag4>(box) == 2.0);

--- a/tests/Unit/DataStructures/DataBox/Test_TestHelpers.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TestHelpers.cpp
@@ -19,9 +19,8 @@ struct NamedSimple : db::SimpleTag {
   using type = int;
 };
 
-struct SimpleWithForwardedBase : TestHelpers::db::Tags::Base, db::SimpleTag {
-  using base = TestHelpers::db::Tags::Base;
-  using type = int;
+struct SimpleFromOption : TestHelpers::db::Tags::Simple {
+  using base = TestHelpers::db::Tags::Simple;
 };
 }  // namespace
 
@@ -35,7 +34,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TestHelpers",
   TestHelpers::db::test_simple_tag<NamedSimple>("NamedSimpleName");
   TestHelpers::db::test_simple_tag<TestHelpers::db::Tags::SimpleWithBase>(
       "SimpleWithBase");
-  TestHelpers::db::test_simple_tag<SimpleWithForwardedBase>("Base");
+  TestHelpers::db::test_simple_tag<SimpleFromOption>("Simple");
   TestHelpers::db::test_compute_tag<TestHelpers::db::Tags::SimpleCompute>(
       "Simple");
 }

--- a/tests/Unit/Domain/FunctionsOfTime/Test_Tags.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_Tags.cpp
@@ -8,6 +8,6 @@
 
 namespace domain {
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.Tags", "[Domain][Unit]") {
-  TestHelpers::db::test_base_tag<Tags::FunctionsOfTime>("FunctionsOfTime");
+  TestHelpers::db::test_simple_tag<Tags::FunctionsOfTime>("FunctionsOfTime");
 }
 }  // namespace domain

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -50,16 +50,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   TestHelpers::db::test_simple_tag<
       Cce::Tags::KleinGordonH5WorldtubeBoundaryDataManager>(
       "KleinGordonH5WorldtubeBoundaryDataManager");
-  TestHelpers::db::test_base_tag<Cce::Tags::ExtractionRadius>(
+  TestHelpers::db::test_simple_tag<Cce::Tags::ExtractionRadius>(
       "ExtractionRadius");
   TestHelpers::db::test_simple_tag<Cce::Tags::ExtractionRadiusSimple>(
       "ExtractionRadius");
   TestHelpers::db::test_simple_tag<Cce::Tags::ExtractionRadiusFromH5>(
       "ExtractionRadius");
   TestHelpers::db::test_simple_tag<Cce::Tags::FilePrefix>("FilePrefix");
-  TestHelpers::db::test_simple_tag<Cce::Tags::LMax>("LMax");
-  TestHelpers::db::test_simple_tag<Cce::Tags::NumberOfRadialPoints>(
-      "NumberOfRadialPoints");
   TestHelpers::db::test_simple_tag<Cce::Tags::ObservationLMax>(
       "ObservationLMax");
   TestHelpers::db::test_simple_tag<Cce::Tags::FilterLMax>("FilterLMax");
@@ -67,15 +64,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "RadialFilterAlpha");
   TestHelpers::db::test_simple_tag<Cce::Tags::RadialFilterHalfPower>(
       "RadialFilterHalfPower");
-  TestHelpers::db::test_simple_tag<Cce::Tags::StartTimeFromFile>(
-      "StartTimeFromFile");
-  TestHelpers::db::test_simple_tag<Cce::Tags::EndTimeFromFile>(
-      "EndTimeFromFile");
-  TestHelpers::db::test_simple_tag<Cce::Tags::NoEndTime>("NoEndTime");
-  TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedStartTime>(
-      "SpecifiedStartTime");
-  TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedEndTime>(
-      "SpecifiedEndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::StartTimeFromFile>("StartTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EndTimeFromFile>("EndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::NoEndTime>("EndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedStartTime>("StartTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::SpecifiedEndTime>("EndTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::GhInterfaceManager>(
       "GhInterfaceManager");
   TestHelpers::db::test_simple_tag<Cce::Tags::AnalyticBoundaryDataManager>(
@@ -94,7 +87,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
   CHECK(
       TestHelpers::test_option_tag<Cce::OptionTags::BondiSachsOutputFilePrefix>(
           "Shrek") == "Shrek");
-  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::LMax>("8") == 8_st);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::FilterLMax>("7") == 7_st);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::RadialFilterAlpha>(
             "32.5") == 32.5);
@@ -102,8 +94,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
             "20") == 20_st);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::ObservationLMax>("6") ==
         6_st);
-  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::NumberOfRadialPoints>(
-            "3") == 3_st);
   CHECK(TestHelpers::test_option_tag<Cce::OptionTags::ExtractionRadius>(
             "100.0") == 100.0);
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_PrecomputeCceDependencies.cpp
@@ -137,17 +137,16 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.PrecomputeCceDependencies",
       Spectral::Swsh::number_of_swsh_collocation_points(l_max);
   const size_t number_of_volume_points =
       number_of_boundary_points * number_of_radial_grid_points;
-  auto precomputation_box =
-      db::create<db::AddSimpleTags<boundary_variables_tag,
-                                   independent_of_integration_variables_tag,
-                                   pre_swsh_derivatives_variables_tag,
-                                   Tags::LMax, Tags::NumberOfRadialPoints>>(
-          typename boundary_variables_tag::type{number_of_boundary_points},
-          typename independent_of_integration_variables_tag::type{
-              number_of_volume_points},
-          typename pre_swsh_derivatives_variables_tag::type{
-              number_of_volume_points},
-          l_max, number_of_radial_grid_points);
+  auto precomputation_box = db::create<db::AddSimpleTags<
+      boundary_variables_tag, independent_of_integration_variables_tag,
+      pre_swsh_derivatives_variables_tag, Spectral::Swsh::Tags::LMax,
+      Spectral::Swsh::Tags::NumberOfRadialPoints>>(
+      typename boundary_variables_tag::type{number_of_boundary_points},
+      typename independent_of_integration_variables_tag::type{
+          number_of_volume_points},
+      typename pre_swsh_derivatives_variables_tag::type{
+          number_of_volume_points},
+      l_max, number_of_radial_grid_points);
 
   auto expected_box =
       db::create<db::AddSimpleTags<boundary_variables_tag,

--- a/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_Tags.cpp
@@ -20,8 +20,8 @@ struct SomeTag {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Tags", "[Unit][Cce]") {
-  TestHelpers::db::test_base_tag<Cce::Tags::EndTime>("EndTime");
-  TestHelpers::db::test_base_tag<Cce::Tags::StartTime>("StartTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::EndTime>("EndTime");
+  TestHelpers::db::test_simple_tag<Cce::Tags::StartTime>("StartTime");
   TestHelpers::db::test_simple_tag<Cce::Tags::BondiBeta>("BondiBeta");
   TestHelpers::db::test_simple_tag<Cce::Tags::BondiH>("H");
   TestHelpers::db::test_simple_tag<Cce::Tags::BondiJ>("J");

--- a/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/DataBox/TestHelpers.hpp
@@ -100,8 +100,8 @@ void test_simple_tag(const std::string& expected_name) {
                 "db::ComputeTag");
   static_assert(detail::has_type_v<Tag>);
   if constexpr (detail::has_base_v<Tag>) {
-    static_assert(::db::is_base_tag_v<typename Tag::base>,
-                  "The base type alias of a simple tag must be a base tag.");
+    static_assert(::db::is_simple_tag_v<typename Tag::base>,
+                  "The base type alias of a simple tag must be a simple tag.");
   }
   static_assert(not std::is_same_v<Tag, typename Tag::type>,
                 "A type cannot be its own tag.");

--- a/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Test_SwshTags.cpp
@@ -9,6 +9,8 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -112,9 +114,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Tags",
   TestHelpers::db::test_simple_tag<LMax>("LMax");
   TestHelpers::db::test_simple_tag<NumberOfRadialPoints>(
       "NumberOfRadialPoints");
-  TestHelpers::db::test_base_tag<LMaxBase>("LMaxBase");
-  TestHelpers::db::test_base_tag<NumberOfRadialPointsBase>(
-      "NumberOfRadialPointsBase");
+  CHECK(TestHelpers::test_option_tag<OptionTags::LMax>("8") == 8_st);
+  CHECK(TestHelpers::test_option_tag<OptionTags::NumberOfRadialPoints>("3") ==
+        3_st);
 }
 }  // namespace
 }  // namespace Spectral::Swsh::Tags

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
@@ -40,12 +40,6 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-namespace LocalTags {
-struct FunctionsOfTime : domain::Tags::FunctionsOfTime, db::SimpleTag {
-  using type = domain::FunctionsOfTimeMap;
-};
-}  // namespace LocalTags
-
 struct Metavariables {
   static constexpr size_t volume_dim = 1;
   using component_list = tmpl::list<
@@ -119,7 +113,7 @@ void test() {
 
   auto box = db::create<
       db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
-                        Tags::Time, LocalTags::FunctionsOfTime,
+                        Tags::Time, domain::Tags::FunctionsOfTime,
                         domain::Tags::Domain<1>, domain::Tags::Mesh<1>,
                         amr::Criteria::Tags::Criteria, amr::Tags::Policies>>(
       Metavariables{}, time, std::move(functions_of_time), std::move(domain),

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
@@ -53,7 +53,5 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Tags",
       "PreviousIterationStrahlkorper");
   TestHelpers::db::test_simple_tag<ah::Tags::FailedInterpolationIterations>(
       "FailedInterpolationIterations");
-  TestHelpers::db::test_base_tag<ah::Tags::ObserveCentersBase>(
-      "ObserveCentersBase");
   TestHelpers::db::test_simple_tag<ah::Tags::ObserveCenters>("ObserveCenters");
 }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
@@ -54,11 +54,6 @@ struct Inertial;
 }  // namespace Frame
 
 namespace {
-namespace LocalTags {
-struct FunctionsOfTime : domain::Tags::FunctionsOfTime, db::SimpleTag {
-  using type = domain::FunctionsOfTimeMap;
-};
-}  // namespace LocalTags
 
 template <size_t VolumeDim>
 struct Metavariables {
@@ -127,7 +122,7 @@ void test() {
 
   auto box = db::create<db::AddSimpleTags<
       Parallel::Tags::MetavariablesImpl<metavars>, Tags::Time,
-      LocalTags::FunctionsOfTime, domain::Tags::Domain<VolumeDim>,
+      domain::Tags::FunctionsOfTime, domain::Tags::Domain<VolumeDim>,
       Tags::TimeStep,
       domain::Tags::MinimumGridSpacing<VolumeDim, Frame::Inertial>>>(
       metavars{}, time, std::move(functions_of_time), std::move(domain),


### PR DESCRIPTION
## Proposed changes

Eliminate several uses of base tags whose derived simple tags had the same `type` alias.
- Allow derived mutable tags.  This allows several tags to be derived from the same simple tag by adding a `base` type alias.  This allows choosing  at compile time one of the different methods that a simple tag can be created from options.
- Some base tags had one simple tag that could not be created from options, and one that could.  In this case the base and non-creatable simple tag can be removed, and replaced with the creatable simple tag.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
