### PR TITLE
Recommend charm version 8

### DIFF
--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -38,9 +38,9 @@ find_package(Charm ${SPECTRE_REQUIRED_CHARM_VERSION} REQUIRED
   EveryLB
   ${SCOTCHLB_COMPONENT}
   )
-if(CHARM_VERSION VERSION_GREATER 7.0.1)
-  message(WARNING "Builds with Charm++ versions greater than 7.0.1 are \
-considered experimental. Please file any issues you encounter.")
+if(CHARM_VERSION VERSION_LESS 8.0.0)
+  message(NOTICE "Charm++ versions less than 8.0.0 have known bugs with \
+element creation.  Dynamic h-refinement is disabled.")
 endif()
 
 if (USE_SCOTCH_LB)

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -113,9 +113,8 @@ The easiest way of installing SpECTRE natively on a new machine is this:
   ```sh
   git clone https://github.com/UIUC-PPL/charm
   cd charm
-  git checkout v7.0.0
-  git apply $SPECTRE_HOME/support/Charm/v7.0.0.patch
-  ./build charm++ <version> --with-production --build-shared
+  git checkout v8.0.0
+  ./build charm++ <version> --with-production --build-shared --disable-tls
   export CHARM_ROOT=$PWD/<version>
   ```
 
@@ -208,7 +207,7 @@ apt), or AppleClang 13.0.0 or later
 * [HDF5](https://support.hdfgroup.org/HDF5/) (non-mpi version on macOS)
   \cite Hdf5
 * [Python](https://www.python.org/) 3.8 or later.
-* [Charm++](http://charm.cs.illinois.edu/) 7.0.0, or later (experimental).
+* [Charm++](http://charm.cs.illinois.edu/) 7.0.0, or later (8 preferred).
   See also \ref building-charm. \cite Charmpp1 \cite Charmpp2 \cite Charmpp3
 
 The following dependencies will be fetched automatically if you set
@@ -496,7 +495,7 @@ and in their [documentation](https://charm.readthedocs.io/en/latest/quickstart.h
 Here are a few notes:
 
 - Once you cloned the [Charm++ repository](https://github.com/UIUC-PPL/charm),
-  run `git checkout v7.0.0` to switch to a supported, stable release of
+  run `git checkout v8.0.0` to switch to a supported, stable release of
   Charm++.
 - Apply the appropriate patch (if there is one) for the version from
   `${SPECTRE_ROOT}/support/Charm`. For example, if you have Charm++ v7.0.0
@@ -512,6 +511,8 @@ Here are a few notes:
   `--build-shared` to the `./build` command or pass `BUILD_SHARED=ON` to the
   CMake configuration (see the [Charm++ installation
   instructions](https://github.com/UIUC-PPL/charm#building-dynamic-libraries)).
+- Passing the `--disable-tls` option to `build` or `-D DISABLE_TLS=ON` to
+  cmake is required for SpECTRE's Python bindings to work.
 - When compiling Charm++ you can specify the compiler using, for example,
   ```
   ./build LIBS ARCH clang

--- a/docs/Installation/InstallationOnAppleSilicon.md
+++ b/docs/Installation/InstallationOnAppleSilicon.md
@@ -88,9 +88,9 @@ cd $SPECTRE_DEPS_ROOT
 # Install Charm++
 git clone https://github.com/UIUC-PPL/charm
 pushd charm
-git checkout v7.0.0
-git apply $SPECTRE_HOME/support/Charm/v7.0.0.patch
-./build charm++ multicore-darwin-arm8 --with-production -g3 -j --build-shared
+git checkout v8.0.0
+./build charm++ multicore-darwin-arm8 --with-production -g3 -j --build-shared \
+  --disable-tls
 popd
 
 # The following dependencies are optional! They will be installed in the build

--- a/src/ParallelAlgorithms/Amr/Actions/CreateParent.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/CreateParent.hpp
@@ -10,8 +10,10 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Parallel/Callback.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Amr/Actions/CollectDataFromChildren.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 
 /// \cond
 namespace db {
@@ -42,6 +44,12 @@ struct CreateParent {
       const ElementId<Metavariables::volume_dim>& child_id,
       std::deque<ElementId<Metavariables::volume_dim>> sibling_ids_to_collect,
       const std::unordered_map<Parallel::Phase, size_t> child_phase_bookmarks) {
+    if (CHARM_VERSION_MAJOR < 8 and
+        Parallel::number_of_procs<size_t>(cache) > 1) {
+      ERROR_NO_TRACE(
+          "Dynamically creating elements in parallel executables is broken "
+          "until charm 8.");
+    }
     auto child_proxy = element_proxy[child_id];
     element_proxy[parent_id].insert(
         cache.get_this_proxy(), Parallel::Phase::AdjustDomain,


### PR DESCRIPTION
This does not update containers, CI, or clusters, just the docs and cmake files.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Charm version 8 is now recommended over version 7, but 7 is still supported for applications not using dynamic h-refinement or similar post-startup element creation.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
