### PR TITLE
AH rewrite: Add cleanup function and new tag

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  CleanUp.cpp
   Destination.cpp
   FastFlow.cpp
   InterpolationTarget.cpp
@@ -20,6 +21,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   ApparentHorizon.hpp
+  CleanUp.hpp
   Component.hpp
   ComputeExcisionBoundaryVolumeQuantities.hpp
   ComputeExcisionBoundaryVolumeQuantities.tpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CleanUp.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CleanUp.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/CleanUp.hpp"
+
+#include <optional>
+#include <set>
+#include <unordered_map>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ah {
+template <typename Fr>
+void clean_up_horizon_finder(
+    const gsl::not_null<std::optional<LinkedMessageId<double>>*>
+        current_time_optional,
+    const gsl::not_null<std::unordered_map<LinkedMessageId<double>,
+                                           ah::Storage::SingleTimeStorage<Fr>>*>
+        all_storage,
+    const gsl::not_null<std::set<LinkedMessageId<double>>*> completed_times,
+    const gsl::not_null<FastFlow*> fast_flow) {
+  ASSERT(current_time_optional->has_value(),
+         "Current time must be set in order to clean up the horizon finder.");
+
+  const auto& current_time = current_time_optional->value();
+
+  all_storage->erase(current_time);
+
+  // We want to keep track of all completed times to deal with the
+  // possibility of late arrivals of volume data. We could keep all
+  // completed times forever, but we probably don't want it to get too
+  // large, so we limit its size.  We assume that asynchronous calls to
+  // this action do not span more than 1000 temporal_ids.
+  completed_times->insert(current_time);
+  while (completed_times->size() > 1000) {
+    completed_times->erase(completed_times->begin());
+  }
+
+  // Reset time before we choose a new time
+  current_time_optional->reset();
+
+  fast_flow->reset_for_next_find();
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void clean_up_horizon_finder(                                       \
+      const gsl::not_null<std::optional<LinkedMessageId<double>>*>             \
+          current_time_optional,                                               \
+      const gsl::not_null<                                                     \
+          std::unordered_map<LinkedMessageId<double>,                          \
+                             ah::Storage::SingleTimeStorage<FRAME(data)>>*>    \
+          all_storage,                                                         \
+      const gsl::not_null<std::set<LinkedMessageId<double>>*> completed_times, \
+      const gsl::not_null<FastFlow*> fast_flow);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Inertial, Frame::Distorted, Frame::Grid))
+
+#undef INSTANTIATE
+#undef FRAME
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CleanUp.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CleanUp.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <set>
+#include <unordered_map>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ah {
+/*!
+ * \brief Cleans up the horizon finder after a horizon find has finished
+ *
+ * \details Removes the current time from the storage map, adds the current time
+ * to the completed times, and then resets the current time. If the completed
+ * times have more than 1000 entries, this will limit the size to 1000.
+ */
+template <typename Fr>
+void clean_up_horizon_finder(
+    gsl::not_null<std::optional<LinkedMessageId<double>>*>
+        current_time_optional,
+    gsl::not_null<std::unordered_map<LinkedMessageId<double>,
+                                     ah::Storage::SingleTimeStorage<Fr>>*>
+        all_storage,
+    gsl::not_null<std::set<LinkedMessageId<double>>*> completed_times,
+    gsl::not_null<FastFlow*> fast_flow);
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
@@ -60,7 +60,8 @@ struct Initialize {
 
   using const_global_cache_tags =
       tmpl::remove_duplicates<tmpl::flatten<tmpl::append<
-          tmpl::list<Tags::ApparentHorizonOptions<HorizonMetavars>>,
+          tmpl::list<Tags::ApparentHorizonOptions<HorizonMetavars>,
+                     Tags::BlocksForHorizonFind>,
           Parallel::get_const_global_cache_tags_from_actions<tmpl::flatten<
               tmpl::list<typename HorizonMetavars::horizon_find_callbacks,
                          typename HorizonMetavars::

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -11,10 +11,15 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/LinkedMessageId.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
+#include "Domain/Structure/ElementId.hpp"
 #include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
 
 /// \cond
 namespace control_system::OptionTags {
@@ -25,6 +30,10 @@ namespace ylm {
 template <typename Frame>
 class Strahlkorper;
 }  // namespace ylm
+namespace ah {
+template <class Metavariables, typename HorizonMetavars>
+struct Component;
+}  // namespace ah
 /// \endcond
 
 /*!
@@ -107,6 +116,95 @@ struct ApparentHorizonOptions : db::SimpleTag {
 
   static constexpr bool pass_metavariables = false;
   static type create_from_options(const type& option) { return option; }
+};
+
+namespace tags_detail {
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(component_being_mocked)
+
+template <typename HorizonComponent>
+struct get_horizon_metavars_from_component {
+  using type = typename HorizonComponent::horizon_metavars;
+};
+
+template <typename Metavariables>
+using get_horizon_metavars = tmpl::transform<
+    tmpl::filter<tmpl::transform<
+                     typename Metavariables::component_list,
+                     get_component_being_mocked_or_default<tmpl::_1, tmpl::_1>>,
+                 tt::is_a<ah::Component, tmpl::_1>>,
+    get_horizon_metavars_from_component<tmpl::_1>>;
+
+template <typename HorizonMetavars>
+struct get_horizon_options;
+
+template <typename... HorizonMetavars>
+struct get_horizon_options<tmpl::list<HorizonMetavars...>> {
+  using type =
+      tmpl::list<OptionTags::ApparentHorizonOptions<HorizonMetavars>...>;
+};
+
+}  // namespace tags_detail
+
+/*!
+ * \brief Holds a map between horizon name and a set of block names that should
+ * be used for interpolation for that horizon.
+ */
+struct BlocksForHorizonFind : db::SimpleTag {
+  using type = std::unordered_map<std::string, std::unordered_set<std::string>>;
+  template <typename Metavariables>
+  using option_tags = tmpl::push_front<
+      typename tags_detail::get_horizon_options<
+          tags_detail::get_horizon_metavars<Metavariables>>::type,
+      ::domain::OptionTags::DomainCreator<Metavariables::volume_dim>>;
+
+  static constexpr bool pass_metavariables = true;
+  template <typename Metavariables, typename... HorizonOptionClasses>
+  static type create_from_options(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const HorizonOptionClasses&... all_horizon_options) {
+    return create_from_options_impl<Metavariables>(
+        domain_creator, std::forward_as_tuple(all_horizon_options...),
+        std::make_index_sequence<sizeof...(HorizonOptionClasses)>{});
+  }
+
+ private:
+  // Need the names of the target tags which are in the option tags, but not the
+  // horizon options themselves. This just expands a tuple to be able to index
+  // the `option_tags` type alias so we can get the name of the target horizon
+  template <typename Metavariables, typename HorizonOptionsTuple, size_t... Is>
+  static type create_from_options_impl(
+      const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
+          domain_creator,
+      const HorizonOptionsTuple& all_horizon_options,
+      const std::index_sequence<Is...>& /*index_sequence*/
+  ) {
+    std::unordered_map<std::string, std::unordered_set<std::string>> result{};
+
+    const auto block_names = domain_creator->block_names();
+    const auto block_groups = domain_creator->block_groups();
+
+    const auto append_to_result = [&](const std::string& name,
+                                      const auto& horizon_options) {
+      if (horizon_options.blocks_for_horizon_find.has_value()) {
+        result[name] = domain::expand_block_groups_to_block_names(
+            horizon_options.blocks_for_horizon_find.value(), block_names,
+            block_groups);
+      } else {
+        // Insert all blocks
+        result[name].insert(block_names.begin(), block_names.end());
+      }
+
+      // Needed for the expand_pack below
+      return 0;
+    };
+
+    expand_pack(
+        append_to_result(tmpl::at_c<option_tags<Metavariables>, Is + 1>::name(),
+                         std::get<Is>(all_horizon_options))...);
+
+    return result;
+  }
 };
 
 /*!

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ApparentHorizonFinder")
 
 set(LIBRARY_SOURCES
   Test_ApparentHorizonFinder.cpp
+  Test_CleanUp.cpp
   Test_ComputeExcisionBoundaryVolumeQuantities.cpp
   Test_ComputeHorizonVolumeQuantities.cpp
   Test_Destination.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CleanUp.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CleanUp.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/CleanUp.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ah {
+namespace {
+template <typename Fr>
+void test_cleanup() {
+  LinkedMessageId<double> expected_current_time{3.0, {2.0}};
+  std::optional<LinkedMessageId<double>> current_time{expected_current_time};
+  std::unordered_map<LinkedMessageId<double>,
+                     ah::Storage::SingleTimeStorage<Fr>>
+      all_storage{};
+  all_storage[expected_current_time] = ah::Storage::SingleTimeStorage<Fr>{};
+  std::set<LinkedMessageId<double>> completed_times{
+      LinkedMessageId<double>{1.0, std::nullopt},
+      LinkedMessageId<double>{2.0, {1.0}}};
+  FastFlow fast_flow{
+      FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100};
+
+  clean_up_horizon_finder(
+      make_not_null(&current_time), make_not_null(&all_storage),
+      make_not_null(&completed_times), make_not_null(&fast_flow));
+
+  CHECK_FALSE(current_time.has_value());
+  CHECK_FALSE(all_storage.contains(expected_current_time));
+  CHECK(completed_times.contains(expected_current_time));
+  CHECK(fast_flow.current_iteration() == 0);
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      clean_up_horizon_finder(
+          make_not_null(&current_time), make_not_null(&all_storage),
+          make_not_null(&completed_times), make_not_null(&fast_flow)),
+      Catch::Matchers::ContainsSubstring(
+          "Current time must be set in order to clean up the horizon finder"));
+#endif
+
+  // Check that completed times is limited to 1000 entries
+  expected_current_time = LinkedMessageId<double>{2000.0, {1999.0}};
+  current_time = expected_current_time;
+  all_storage[expected_current_time] = ah::Storage::SingleTimeStorage<Fr>{};
+  for (size_t i = 4; i < 2000; i++) {
+    completed_times.insert(LinkedMessageId<double>{
+        static_cast<double>(i), {static_cast<double>(i - 1)}});
+  }
+
+  clean_up_horizon_finder(
+      make_not_null(&current_time), make_not_null(&all_storage),
+      make_not_null(&completed_times), make_not_null(&fast_flow));
+
+  CHECK(completed_times.size() == 1000);
+  CHECK(*std::prev(completed_times.end()) == expected_current_time);
+  CHECK(*completed_times.begin() == LinkedMessageId<double>{1001.0, {1000.0}});
+  CHECK(fast_flow.current_iteration() == 0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.CleanUp",
+                  "[ApparentHorizonFinder][Unit]") {
+  test_cleanup<::Frame::Grid>();
+  test_cleanup<::Frame::Distorted>();
+  test_cleanup<::Frame::Inertial>();
+}
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
@@ -5,17 +5,60 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <optional>
+#include <unordered_set>
+#include <vector>
 
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct MockHorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using time_tag = ::Tags::TimeAndPrevious<0>;
+
+  using frame = ::Frame::Grid;
+
+  // Don't need callbacks
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() { return "MockHorizonMetavars"; }
+};
+
+struct MockMetavariables {
+  static constexpr size_t volume_dim = 3;
+
+  using component_list =
+      tmpl::list<ah::Component<MockMetavariables, MockHorizonMetavars>>;
+};
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
                   "[ApparentHorizonFinder][Unit]") {
+  (void)MockHorizonMetavars::destination;
+  domain::creators::register_derived_with_charm();
+
   // Constants used in this test.
   const size_t l_max = 12;
   const double radius = 2.0;
@@ -46,4 +89,53 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
           "MaxInterpolationRetries: 3\n"
           "BlocksForHorizonFind: All");
   CHECK(created_opts == apparent_horizon_opts);
+
+  const auto domain_creator = domain::creators::Sphere(
+      1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
+
+  {
+    const auto blocks_for_horizon_find =
+        ah::Tags::BlocksForHorizonFind::create_from_options<MockMetavariables>(
+            std::make_unique<domain::creators::Sphere>(
+                1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st,
+                false),
+            created_opts);
+    REQUIRE(blocks_for_horizon_find.contains("MockHorizonMetavars"));
+    const auto block_names = domain_creator.block_names();
+    CHECK(blocks_for_horizon_find.at("MockHorizonMetavars") ==
+          std::unordered_set<std::string>{block_names.begin(),
+                                          block_names.end()});
+  }
+  {
+    const auto new_created_opts =
+        TestHelpers::test_creation<ah::HorizonOptions<Frame::Grid>>(
+            "FastFlow:\n"
+            "  Flow: Fast\n"
+            "  Alpha: 1.0\n"
+            "  Beta: 0.5\n"
+            "  AbsTol: 1e-12\n"
+            "  TruncationTol: 1e-2\n"
+            "  DivergenceTol: 1.2\n"
+            "  DivergenceIter: 5\n"
+            "  MaxIts: 100\n"
+            "Verbosity: Verbose\n"
+            "InitialGuess:\n"
+            "  Center: [0.05, 0.06, 0.07]\n"
+            "  Radius: 2.0\n"
+            "  LMax: 12\n"
+            "MaxInterpolationRetries: 3\n"
+            "BlocksForHorizonFind: [Shell0]");
+    const auto blocks_for_horizon_find =
+        ah::Tags::BlocksForHorizonFind::create_from_options<MockMetavariables>(
+            std::make_unique<domain::creators::Sphere>(
+                1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st,
+                false, std::nullopt, std::vector{2.0}),
+            new_created_opts);
+    REQUIRE(blocks_for_horizon_find.contains("MockHorizonMetavars"));
+    const auto block_names = domain_creator.block_names();
+    CHECK(blocks_for_horizon_find.at("MockHorizonMetavars") ==
+          std::unordered_set<std::string>{"Shell0UpperZ", "Shell0LowerZ",
+                                          "Shell0UpperY", "Shell0LowerY",
+                                          "Shell0UpperX", "Shell0LowerX"});
+  }
 }

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
@@ -48,6 +48,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Tags",
   TestHelpers::db::test_simple_tag<
       ah::Tags::ApparentHorizonOptions<MockHorizonMetavars>>(
       "ApparentHorizonOptions");
+  TestHelpers::db::test_simple_tag<ah::Tags::BlocksForHorizonFind>(
+      "BlocksForHorizonFind");
   TestHelpers::db::test_simple_tag<
       ah::Tags::PreviousIterationStrahlkorper<::Frame::Distorted>>(
       "PreviousIterationStrahlkorper");


### PR DESCRIPTION
## Proposed changes

Sixth PR of horizon finder changes. Adds a new tag that couldn't be added until #6752 was merged. Also adds a function to clean up the horizon finder.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
