### PR TITLE
AH rewrite: Add function to compute coords of new fast flow iteration

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   CleanUp.cpp
+  ComputeCoords.cpp
   ComputeVarsToInterpolateToTarget.cpp
   Destination.cpp
   FastFlow.cpp
@@ -24,6 +25,7 @@ spectre_target_headers(
   ApparentHorizon.hpp
   CleanUp.hpp
   Component.hpp
+  ComputeCoords.hpp
   ComputeExcisionBoundaryVolumeQuantities.hpp
   ComputeExcisionBoundaryVolumeQuantities.tpp
   ComputeHorizonVolumeQuantities.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.cpp
@@ -1,0 +1,152 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp"
+
+#include <cstddef>
+#include <deque>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ah {
+template <typename Fr>
+bool set_current_iteration_coords(
+    const gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration,
+    const LinkedMessageId<double>& time, const FastFlow& fast_flow,
+    const ylm::Strahlkorper<Fr>& initial_guess,
+    const ylm::Strahlkorper<Fr>& previous_iteration_surface,
+    const std::deque<ah::Storage::PreviousSurface<Fr>>& previous_surfaces,
+    const size_t max_compute_coords_retries, const Domain<3>& domain,
+    const domain::FunctionsOfTimeMap& functions_of_time) {
+  if (fast_flow.current_iteration() == 0) {
+    // Need to set the first surface. If this is the very first, set it to the
+    // initial guess. If not, use the previous horizon surface. The surface will
+    // potentially be extrapolated below
+    current_iteration->strahlkorper = UNLIKELY(previous_surfaces.empty())
+                                          ? initial_guess
+                                          : previous_surfaces.front().surface;
+
+    // If we have zero previous_surfaces, then the initial guess is already
+    // in strahlkorper, so do nothing.
+    //
+    // If we have one previous_surface, then we have had a successful
+    // horizon find, and the initial guess for the next horizon find is already
+    // in strahlkorper, so again we do nothing.
+    //
+    // If we have 2 valid previous_surfaces, then we set the initial guess
+    // by linear extrapolation in time using the last 2 previous_surfaces.
+    //
+    // If we have 3 valid previous_surfaces, then we set the initial guess
+    // by quadratic extrapolation in time using the last 3
+    // previous_surfaces.
+    //
+    // For extrapolation, we assume that
+    // * Expansion center of all the Strahlkorpers are equal.
+    // * Maximum L of all the Strahlkorpers are equal. It is easy to relax the
+    //   max L assumption once we start adaptively changing the L of the
+    //   strahlkorpers.
+    if (LIKELY(previous_surfaces.size() > 2)) {
+      // Quadratic extrapolation
+      const double dt_0 = previous_surfaces[0].time.id - time.id;
+      const double dt_1 = previous_surfaces[1].time.id - time.id;
+      const double dt_2 = previous_surfaces[2].time.id - time.id;
+      const double fac_0 = dt_1 * dt_2 / ((dt_1 - dt_0) * (dt_2 - dt_0));
+      const double fac_1 = dt_0 * dt_2 / ((dt_2 - dt_1) * (dt_0 - dt_1));
+      const double fac_2 = 1.0 - fac_0 - fac_1;
+      current_iteration->strahlkorper.coefficients() =
+          fac_0 * previous_surfaces[0].surface.coefficients() +
+          fac_1 * previous_surfaces[1].surface.coefficients() +
+          fac_2 * previous_surfaces[2].surface.coefficients();
+    } else if (previous_surfaces.size() > 1) {
+      // Linear extrapolation
+      const double dt_0 = previous_surfaces[0].time.id - time.id;
+      const double dt_1 = previous_surfaces[1].time.id - time.id;
+      const double fac_0 = dt_1 / (dt_1 - dt_0);
+      const double fac_1 = 1.0 - fac_0;
+      current_iteration->strahlkorper.coefficients() =
+          fac_0 * previous_surfaces[0].surface.coefficients() +
+          fac_1 * previous_surfaces[1].surface.coefficients();
+    }
+  }
+
+  const auto set_coords = [&]() {
+    const auto& strahlkorper = current_iteration->strahlkorper;
+
+    const size_t l_mesh = fast_flow.current_l_mesh(strahlkorper);
+
+    const auto prolonged_strahlkorper =
+        ylm::Strahlkorper<Fr>(l_mesh, l_mesh, strahlkorper);
+
+    // Frames are handled within block_logical_coordinates
+    current_iteration->block_coord_holders = ::block_logical_coordinates(
+        domain, ylm::cartesian_coords(prolonged_strahlkorper), time.id,
+        functions_of_time);
+  };
+
+  // Set the coordinates
+  set_coords();
+
+  // Check if any points were outside the domain
+  current_iteration->compute_coords_retries = 0;
+  while (alg::any_of(
+      current_iteration->block_coord_holders.value(),
+      [](const auto& coord_holder) { return not coord_holder.has_value(); })) {
+    // If so, try recomputation up to max_compute_coords_retries times
+    ++current_iteration->compute_coords_retries;
+
+    if (current_iteration->compute_coords_retries <=
+        max_compute_coords_retries) {
+      if (fast_flow.current_iteration() == 0) {
+        // If this is the zeroth iteration and we couldn't compute the coords,
+        // then just try increasing the size of the horizon by 50%
+        current_iteration->strahlkorper.coefficients()[0] *= 1.5;
+      } else {
+        // Otherwise move the new trial surface halfway between the current
+        // surface and the previous surface
+        current_iteration->strahlkorper.coefficients() +=
+            0.5 * (previous_iteration_surface.coefficients() -
+                   current_iteration->strahlkorper.coefficients());
+      }
+
+      // Set the coords using the new guess
+      set_coords();
+    } else {
+      // We didn't actually try computation here so we added one extra to the
+      // counter which we need to remove
+      --current_iteration->compute_coords_retries;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template bool set_current_iteration_coords(                           \
+      const gsl::not_null<ah::Storage::Iteration<FRAME(data)>*>         \
+          current_iteration,                                            \
+      const LinkedMessageId<double>& time, const FastFlow& fast_flow,   \
+      const ylm::Strahlkorper<FRAME(data)>& initial_guess,              \
+      const ylm::Strahlkorper<FRAME(data)>& previous_iteration_surface, \
+      const std::deque<ah::Storage::PreviousSurface<FRAME(data)>>&      \
+          previous_surfaces,                                            \
+      const size_t max_compute_coords_retries, const Domain<3>& domain, \
+      const domain::FunctionsOfTimeMap& functions_of_time);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Inertial, Frame::Distorted, Frame::Grid))
+
+#undef INSTANTIATE
+#undef FRAME
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <deque>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <size_t VolumeDim>
+class Domain;
+class FastFlow;
+namespace ylm {
+template <typename Frame>
+class Strahlkorper;
+}  // namespace ylm
+
+namespace ah {
+/*!
+ * \brief Compute the target points for the current iteration.
+ *
+ * \details Returns whether the computation of the target points was successful
+ * or if there are some points outside the domain. If computation fails, one of
+ * two attempts to recover will happen:
+ *
+ * - For the zeroth fast flow iteration, this will increase the $l=0,m=0$
+ *   coefficient (i.e. the size) by 50%.
+ * - For all other iterations, the coefficients become
+ * \begin{equation}
+ * S^{\mathrm{new}}_{lm} = \frac{1}{2}\left(S^{\mathrm{previous}}_{lm} +
+ * S^{\mathrm{failed}}_{lm}\right)
+ * \end{equation}
+ *   where $S^{\mathrm{failed}}_{lm}$ are the coefficients of the failed
+ *   computation and $S^{\mathrm{previous}}_{lm}$ are the coefficients from
+ *   the previous successful iteration.
+ *
+ * This function will try recomputing the coords using the above two rules
+ * \p max_compute_coords_retries times before returning false.
+ */
+template <typename Fr>
+bool set_current_iteration_coords(
+    gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration,
+    const LinkedMessageId<double>& time, const FastFlow& fast_flow,
+    const ylm::Strahlkorper<Fr>& initial_guess,
+    const ylm::Strahlkorper<Fr>& previous_iteration_surface,
+    const std::deque<ah::Storage::PreviousSurface<Fr>>& previous_surfaces,
+    size_t max_compute_coords_retries, const Domain<3>& domain,
+    const domain::FunctionsOfTimeMap& functions_of_time);
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.cpp
@@ -18,12 +18,12 @@ namespace ah {
 template <typename Fr>
 HorizonOptions<Fr>::HorizonOptions(
     ylm::Strahlkorper<Fr> initial_guess_in, ::FastFlow fast_flow_in,
-    ::Verbosity verbosity_in, const size_t max_interpolation_retries_in,
+    ::Verbosity verbosity_in, const size_t max_compute_coords_retries_in,
     std::optional<std::vector<std::string>> blocks_for_horizon_find_in)
     : initial_guess(std::move(initial_guess_in)),
       fast_flow(std::move(fast_flow_in)),  // NOLINT
       verbosity(std::move(verbosity_in)),  // NOLINT
-      max_interpolation_retries(max_interpolation_retries_in),
+      max_compute_coords_retries(max_compute_coords_retries_in),
       blocks_for_horizon_find(std::move(blocks_for_horizon_find_in)) {}
 
 template <typename Fr>
@@ -31,7 +31,7 @@ void HorizonOptions<Fr>::pup(PUP::er& p) {
   p | initial_guess;
   p | fast_flow;
   p | verbosity;
-  p | max_interpolation_retries;
+  p | max_compute_coords_retries;
   p | blocks_for_horizon_find;
 }
 
@@ -39,7 +39,7 @@ template <typename Fr>
 bool operator==(const HorizonOptions<Fr>& lhs, const HorizonOptions<Fr>& rhs) {
   return lhs.initial_guess == rhs.initial_guess and
          lhs.fast_flow == rhs.fast_flow and lhs.verbosity == rhs.verbosity and
-         lhs.max_interpolation_retries == rhs.max_interpolation_retries and
+         lhs.max_compute_coords_retries == rhs.max_compute_coords_retries and
          lhs.blocks_for_horizon_find == rhs.blocks_for_horizon_find;
 }
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp
@@ -39,10 +39,12 @@ struct HorizonOptions {
     static constexpr Options::String help = {"Verbosity"};
     using type = ::Verbosity;
   };
-  struct MaxInterpolationRetries {
+  struct MaxComputeCoordsRetries {
     static constexpr Options::String help = {
-        "Number of times to retry the interpolation where, with each retry, "
-        "the two previous surfaces are averaged and that new surface is used."};
+        "Number of times to retry computing the coordinates of the horizon for "
+        "each iteration. For the zeroth iteration, increases the 00 component "
+        "by 50%. For subsequent iterations, two previous surfaces are averaged "
+        "and that new surface is used."};
     using type = size_t;
   };
   struct BlocksForHorizonFind {
@@ -52,7 +54,7 @@ struct HorizonOptions {
     using type = Options::Auto<std::vector<std::string>, All>;
   };
   using options = tmpl::list<InitialGuess, FastFlow, Verbosity,
-                             MaxInterpolationRetries, BlocksForHorizonFind>;
+                             MaxComputeCoordsRetries, BlocksForHorizonFind>;
   static constexpr Options::String help = {
       "Provide an initial guess for the apparent horizon surface\n"
       "(Strahlkorper) and apparent-horizon-finding-algorithm (FastFlow)\n"
@@ -60,7 +62,7 @@ struct HorizonOptions {
 
   HorizonOptions(
       ylm::Strahlkorper<Fr> initial_guess_in, ::FastFlow fast_flow_in,
-      ::Verbosity verbosity_in, size_t max_interpolation_retries_in,
+      ::Verbosity verbosity_in, size_t max_compute_coords_retries_in,
       std::optional<std::vector<std::string>> blocks_for_horizon_find_in);
 
   HorizonOptions() = default;
@@ -76,7 +78,7 @@ struct HorizonOptions {
   ylm::Strahlkorper<Fr> initial_guess{};
   ::FastFlow fast_flow;
   ::Verbosity verbosity{::Verbosity::Quiet};
-  size_t max_interpolation_retries{};
+  size_t max_compute_coords_retries{};
   std::optional<std::vector<std::string>> blocks_for_horizon_find;
 };
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -5,6 +5,7 @@
 
 #include <pup.h>
 #include <pup_stl.h>
+#include <utility>
 
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -88,6 +89,11 @@ bool operator!=(const SingleTimeStorage<Fr>& lhs,
                 const SingleTimeStorage<Fr>& rhs) {
   return not(lhs == rhs);
 }
+
+template <typename Fr>
+PreviousSurface<Fr>::PreviousSurface(const LinkedMessageId<double>& time_in,
+                                     ylm::Strahlkorper<Fr> surface_in)
+    : time(time_in), surface(std::move(surface_in)) {}
 
 template <typename Fr>
 void PreviousSurface<Fr>::pup(PUP::er& p) {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -37,7 +37,7 @@ void Iteration<Fr>::reset_for_next_iteration() {
   this->block_coord_holders.reset();
   this->indicies_interpolated_to_thus_far.clear();
   this->interpolation_is_done_for_these_elements.clear();
-  this->interpolation_retries = 0;
+  this->compute_coords_retries = 0;
 }
 
 template <typename Fr>
@@ -47,7 +47,7 @@ void Iteration<Fr>::pup(PUP::er& p) {
   p | interpolated_vars;
   p | indicies_interpolated_to_thus_far;
   p | interpolation_is_done_for_these_elements;
-  p | interpolation_retries;
+  p | compute_coords_retries;
 }
 
 template <typename Fr>
@@ -59,7 +59,7 @@ bool operator==(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {
              rhs.indicies_interpolated_to_thus_far and
          lhs.interpolation_is_done_for_these_elements ==
              rhs.interpolation_is_done_for_these_elements and
-         lhs.interpolation_retries == rhs.interpolation_retries;
+         lhs.compute_coords_retries == rhs.compute_coords_retries;
 }
 template <typename Fr>
 bool operator!=(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -157,6 +157,10 @@ bool operator!=(const SingleTimeStorage<Fr>& lhs,
  */
 template <typename Fr>
 struct PreviousSurface {
+  PreviousSurface() = default;
+  PreviousSurface(const LinkedMessageId<double>& time_in,
+                  ylm::Strahlkorper<Fr> surface_in);
+
   LinkedMessageId<double> time;
   ylm::Strahlkorper<Fr> surface;
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -94,10 +94,10 @@ struct Iteration {
   std::unordered_set<ElementId<3>> interpolation_is_done_for_these_elements;
 
   /*!
-   * \brief How many times we've tried to reinterpolate the volume variables for
-   * this iteration.
+   * \brief How many times we've tried to compute the coordinates for this
+   * iteration.
    */
-  size_t interpolation_retries = 0;
+  size_t compute_coords_retries = 0;
 
   void reset_for_next_iteration();
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ApparentHorizonFinder")
 set(LIBRARY_SOURCES
   Test_ApparentHorizonFinder.cpp
   Test_CleanUp.cpp
+  Test_ComputeCoords.cpp
   Test_ComputeExcisionBoundaryVolumeQuantities.cpp
   Test_ComputeHorizonVolumeQuantities.cpp
   Test_ComputeVarsToInterpolateToTarget.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
@@ -1,0 +1,255 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <deque>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+namespace {
+void test_compute_points() {
+  // Only test grid frame because the only difference is a different code path
+  // is taken within block logical coordinates which we aren't testing here
+  using Fr = ::Frame::Grid;
+
+  const size_t l_max = 4;
+  ah::Storage::Iteration<Fr> current_iteration{};
+
+  const domain::creators::Sphere sphere{
+      1.0,          3.0,  domain::creators::Sphere::Excision{nullptr},
+      0_st,         2_st, true,
+      std::nullopt, {2.0}};
+  const Domain<3> domain = sphere.create_domain();
+  const domain::FunctionsOfTimeMap functions_of_time =
+      sphere.functions_of_time();
+
+  const size_t max_compute_coords_retries = 3;
+  const LinkedMessageId<double> time{4.0, {3.0}};
+  ylm::Strahlkorper<Fr> initial_guess{l_max, 2.5, std::array{0.0, 0.0, 0.0}};
+  ylm::Strahlkorper<Fr> previous_iteration_surface =
+      current_iteration.strahlkorper;
+  std::deque<ah::Storage::PreviousSurface<Fr>> previous_surfaces{};
+  FastFlow fast_flow{
+      FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100};
+
+  // We should find points
+  {
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time);
+
+    // We don't check the actual points because the function basically just
+    // wraps block_logical_coordinates and that's already tested. Here we check
+    // the wrapping logic
+    CHECK(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.compute_coords_retries == 0);
+  }
+
+  // This will succeed after failing once
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    const double initial_radius = 0.75;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, initial_radius, std::array{0.0, 0.0, 0.0}};
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time);
+
+    CHECK(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.strahlkorper.coefficients()[0] ==
+          1.5 * sqrt(8.0) * initial_radius);
+    CHECK(current_iteration.compute_coords_retries == 1);
+  }
+
+  // This will fail to find points and will increase the radius of the
+  // strahlkorper by 50% 3 times.
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    const double initial_radius = 1.e-6;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, initial_radius, std::array{0.0, 0.0, 0.0}};
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time);
+
+    CHECK_FALSE(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::none_of(current_iteration.block_coord_holders.value(),
+                       [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.strahlkorper.coefficients()[0] ==
+          approx(cube(1.5) * sqrt(8.0) * initial_radius));
+    CHECK(current_iteration.compute_coords_retries == 3);
+  }
+
+  // Force linear extrapolation of previous surfaces that will succeed
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}};
+
+    const LinkedMessageId<double> prev_time_1{3.0, {2.0}};
+    const LinkedMessageId<double> prev_time_2{2.0, {1.0}};
+    previous_surfaces.emplace_front(
+        prev_time_2,
+        ylm::Strahlkorper<Fr>{l_max, 1.1, std::array{0.0, 0.0, 0.0}});
+    previous_surfaces.emplace_front(
+        prev_time_1,
+        ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}});
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time);
+
+    CHECK(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.compute_coords_retries == 0);
+  }
+
+  // Force quadratic extrapolation of previous surfaces that will succeed
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+
+    const LinkedMessageId<double> prev_time{1.0, std::nullopt};
+    previous_surfaces.emplace_back(
+        prev_time,
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time);
+
+    CHECK(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.compute_coords_retries == 0);
+  }
+
+  // Succeed on second iteration of fast flow, but we had to recompute once
+  {
+    previous_surfaces.clear();
+    current_iteration.block_coord_holders.reset();
+    const double initial_radius = 1.0;
+    current_iteration.strahlkorper =
+        ylm::Strahlkorper<Fr>{l_max, initial_radius, std::array{0.0, 0.0, 0.0}};
+    current_iteration.compute_coords_retries = 0;
+
+    // Use Schwarzschild solution to get valid tensors for a fast flow iteration
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    const gr::Solutions::KerrSchild analytic_solution{
+        1.0, std::array{0.0, 0.0, 0.0}, std::array{0.0, 0.0, 0.0}};
+    Variables<
+        tmpl::list<gr::Tags::InverseSpatialMetric<DataVector, 3, Fr>,
+                   gr::Tags::ExtrinsicCurvature<DataVector, 3, Fr>,
+                   gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, Fr>>>
+        vars{ylm::Spherepack::physical_size(l_mesh, l_mesh)};
+    vars.assign_subset(analytic_solution.variables(
+        ylm::cartesian_coords(
+            ylm::Strahlkorper<Fr>{l_mesh, 1.0, std::array{0.0, 0.0, 0.0}}),
+        time.id, typename std::decay_t<decltype(vars)>::tags_list{}));
+
+    fast_flow.iterate_horizon_finder(
+        make_not_null(&current_iteration.strahlkorper),
+        get<gr::Tags::InverseSpatialMetric<DataVector, 3, Fr>>(vars),
+        get<gr::Tags::ExtrinsicCurvature<DataVector, 3, Fr>>(vars),
+        get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, Fr>>(vars));
+
+    // Reset strahlkorpers so that the average of these two coefficients are
+    // used
+    current_iteration.strahlkorper =
+        ylm::Strahlkorper<Fr>{l_max, 0.9, std::array{0.0, 0.0, 0.0}};
+    previous_iteration_surface =
+        ylm::Strahlkorper<Fr>{l_max, 2.0, std::array{0.0, 0.0, 0.0}};
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time);
+
+    CHECK(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.strahlkorper.coefficients()[0] ==
+          approx(sqrt(8.0) * (0.9 + 0.5 * 1.1)));
+    CHECK(current_iteration.compute_coords_retries == 1);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.ComputeCoords",
+                  "[ApparentHorizonFinder][Unit]") {
+  test_compute_points();
+}
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
@@ -86,7 +86,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
           "  Center: [0.05, 0.06, 0.07]\n"
           "  Radius: 2.0\n"
           "  LMax: 12\n"
-          "MaxInterpolationRetries: 3\n"
+          "MaxComputeCoordsRetries: 3\n"
           "BlocksForHorizonFind: All");
   CHECK(created_opts == apparent_horizon_opts);
 
@@ -123,7 +123,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
             "  Center: [0.05, 0.06, 0.07]\n"
             "  Radius: 2.0\n"
             "  LMax: 12\n"
-            "MaxInterpolationRetries: 3\n"
+            "MaxComputeCoordsRetries: 3\n"
             "BlocksForHorizonFind: [Shell0]");
     const auto blocks_for_horizon_find =
         ah::Tags::BlocksForHorizonFind::create_from_options<MockMetavariables>(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <deque>
 #include <optional>
 #include <set>
 #include <unordered_set>
@@ -55,6 +56,14 @@ void test_storage() {
   const ah::Storage::PreviousSurface<Fr> previous_surface{
       LinkedMessageId<double>{3.0, {2.0}}, iteration.strahlkorper};
   test_serialization(previous_surface);
+
+  // Check we can use PreviousSurface with `emplace`
+  std::deque<ah::Storage::PreviousSurface<Fr>> previous_surfaces{};
+  previous_surfaces.emplace_front(LinkedMessageId<double>{1.0, std::nullopt},
+                                  iteration.strahlkorper);
+  CHECK(previous_surfaces.front().time ==
+        LinkedMessageId<double>{1.0, std::nullopt});
+  CHECK(previous_surfaces.front().surface == iteration.strahlkorper);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Seventh PR in horizon finder changes. Adds a function that computes the block logical coordinates of the current iteration strahlkorper. Retries the computation with an adjusted strahlkorper if it fails. Also handles extrapolation for the zeroth fast-flow iteration surface.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
