### PR TITLE
AH rewrite: Add function to compute volume vars

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   CleanUp.cpp
+  ComputeVarsToInterpolateToTarget.cpp
   Destination.cpp
   FastFlow.cpp
   InterpolationTarget.cpp
@@ -27,6 +28,7 @@ spectre_target_headers(
   ComputeExcisionBoundaryVolumeQuantities.tpp
   ComputeHorizonVolumeQuantities.hpp
   ComputeHorizonVolumeQuantities.tpp
+  ComputeVarsToInterpolateToTarget.hpp
   Destination.hpp
   FastFlow.hpp
   HorizonAliases.hpp
@@ -46,6 +48,7 @@ target_link_libraries(
   FiniteDifference
   GeneralRelativity
   LinearAlgebra
+  LinearOperators
   Logging
   Options
   Printf

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.cpp
@@ -1,0 +1,257 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp"
+
+#include <type_traits>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/TaggedContainers.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/FrameTransform.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Composition.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/ElementToBlockLogicalMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+namespace {
+// The jacobians can be omitted if the frame is truly the inertial one since
+// they won't be needed
+template <bool ForceInertialFrame = false, typename Fr>
+void compute_vars_to_interpolate_to_target_impl(
+    const gsl::not_null<ah::Storage::VolumeVariables<Fr>*> volume_vars_storage,
+    const Jacobian<DataVector, 3, Fr, Frame::Inertial>& jac_frame_to_inertial =
+        {},
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical, Fr>&
+        invjac_logical_to_frame = {}) {
+  // Handle the time-independent case where the frame could be anything, but we
+  // only need the inertial computation
+  using FrameToUse =
+      tmpl::conditional_t<ForceInertialFrame, ::Frame::Inertial, Fr>;
+  Variables<ah::vars_to_interpolate_to_target<3, FrameToUse>>
+      vars_to_interpolate_to_target;
+  vars_to_interpolate_to_target.set_data_ref(
+      volume_vars_storage->vars_to_interpolate_to_target.data(),
+      volume_vars_storage->vars_to_interpolate_to_target.size());
+
+  const auto& source_vars = volume_vars_storage->source_vars;
+  const auto& mesh = volume_vars_storage->mesh;
+
+  const auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars);
+  const auto& pi = get<gh::Tags::Pi<DataVector, 3>>(source_vars);
+  const auto& phi = get<gh::Tags::Phi<DataVector, 3>>(source_vars);
+  const auto& deriv_phi =
+      get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(source_vars);
+
+  // Inertial tags
+  using inertial_metric_tag = gr::Tags::SpatialMetric<DataVector, 3>;
+  using inertial_inv_metric_tag = gr::Tags::InverseSpatialMetric<DataVector, 3>;
+  using inertial_shift_tag = ::Tags::TempI<1, 3, Frame::Inertial, DataVector>;
+  using inertial_ex_curvature_tag = gr::Tags::ExtrinsicCurvature<DataVector, 3>;
+  using inertial_spatial_ricci_tag = gr::Tags::SpatialRicci<DataVector, 3>;
+  using inertial_spacetime_normal_vector_tag =
+      ::Tags::TempA<2, 3, Frame::Inertial, DataVector>;
+  using inertial_spatial_christoffel_tag =
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, 3>;
+  // Frame tags
+  using metric_tag = gr::Tags::SpatialMetric<DataVector, 3, FrameToUse>;
+  using inv_metric_tag =
+      gr::Tags::InverseSpatialMetric<DataVector, 3, FrameToUse>;
+  using lapse_tag = gr::Tags::Lapse<DataVector>;
+  using phi_tag = ::Tags::Tempijj<7, 3, FrameToUse, DataVector>;
+  using ex_curvature_tag =
+      gr::Tags::ExtrinsicCurvature<DataVector, 3, FrameToUse>;
+  using spatial_christoffel_tag =
+      gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, FrameToUse>;
+  using spatial_ricci_tag = gr::Tags::SpatialRicci<DataVector, 3, FrameToUse>;
+
+  TempBuffer<tmpl::list<
+      inertial_metric_tag, inertial_inv_metric_tag, lapse_tag,
+      inertial_shift_tag, inertial_spacetime_normal_vector_tag,
+      inertial_ex_curvature_tag, inertial_spatial_ricci_tag, phi_tag>>
+      buffer{get<0, 0>(spacetime_metric).size()};
+
+  auto& lapse = get<lapse_tag>(buffer);
+  auto& inertial_shift = get<inertial_shift_tag>(buffer);
+  auto& inertial_spacetime_normal_vector =
+      get<inertial_spacetime_normal_vector_tag>(buffer);
+
+  // As an optimization, get these from the vars to interpolate if they are in
+  // the inertial frame so we don't have to do copies below. Otherwise just
+  // grab them from the temporary buffer.
+  auto& inertial_metric = *(get<inertial_metric_tag>(
+      make_not_null(&vars_to_interpolate_to_target), make_not_null(&buffer)));
+  auto& inertial_inv_metric = *(get<inertial_inv_metric_tag>(
+      make_not_null(&vars_to_interpolate_to_target), make_not_null(&buffer)));
+  auto& inertial_ex_curvature = *(get<inertial_ex_curvature_tag>(
+      make_not_null(&vars_to_interpolate_to_target), make_not_null(&buffer)));
+  auto& inertial_spatial_ricci = *(get<inertial_spatial_ricci_tag>(
+      make_not_null(&vars_to_interpolate_to_target), make_not_null(&buffer)));
+
+  gr::spatial_metric(make_not_null(&inertial_metric), spacetime_metric);
+  // put determinant of 3-metric temporarily into lapse to save memory.
+  determinant_and_inverse(make_not_null(&lapse),
+                          make_not_null(&inertial_inv_metric), inertial_metric);
+
+  // Compute inertial extrinsic curvature
+  gr::shift(make_not_null(&inertial_shift), spacetime_metric,
+            inertial_inv_metric);
+  gr::lapse(make_not_null(&lapse), inertial_shift, spacetime_metric);
+  gr::spacetime_normal_vector(make_not_null(&inertial_spacetime_normal_vector),
+                              lapse, inertial_shift);
+  gh::extrinsic_curvature(make_not_null(&inertial_ex_curvature),
+                          inertial_spacetime_normal_vector, pi, phi);
+
+  // Compute inertial spatial ricci
+  gh::spatial_ricci_tensor(make_not_null(&inertial_spatial_ricci), phi,
+                           deriv_phi, inertial_inv_metric);
+
+  if constexpr (std::is_same_v<FrameToUse, ::Frame::Inertial>) {
+    (void)jac_frame_to_inertial;
+    (void)invjac_logical_to_frame;
+
+    auto& inertial_christoffel_second_kind =
+        get<inertial_spatial_christoffel_tag>(vars_to_interpolate_to_target);
+    gh::christoffel_second_kind(
+        make_not_null(&inertial_christoffel_second_kind), phi,
+        inertial_inv_metric);
+  } else {
+    auto& frame_metric = get<metric_tag>(vars_to_interpolate_to_target);
+    transform::to_different_frame(make_not_null(&frame_metric), inertial_metric,
+                                  jac_frame_to_inertial);
+
+    // Invert transformed 3-metric and put determinant of 3-metric temporarily
+    // into lapse to save memory (since we don't need the lapse anymore)
+    auto& frame_inv_metric = get<inv_metric_tag>(vars_to_interpolate_to_target);
+    determinant_and_inverse(make_not_null(&lapse),
+                            make_not_null(&frame_inv_metric), frame_metric);
+
+    // Transform extrinsic curvature
+    auto& frame_extrinsic_curvature =
+        get<ex_curvature_tag>(vars_to_interpolate_to_target);
+    transform::to_different_frame(make_not_null(&frame_extrinsic_curvature),
+                                  inertial_ex_curvature, jac_frame_to_inertial);
+
+    // Differentiate 3-metric to compute spatial christoffel
+    auto& frame_phi = get<phi_tag>(buffer);
+    auto& frame_christoffel_second_kind =
+        get<spatial_christoffel_tag>(vars_to_interpolate_to_target);
+    partial_derivative(make_not_null(&frame_phi), frame_metric, mesh,
+                       invjac_logical_to_frame);
+    gr::christoffel_second_kind(make_not_null(&frame_christoffel_second_kind),
+                                frame_phi, frame_inv_metric);
+
+    // Transform spatial ricci
+    auto& frame_spatial_ricci =
+        get<spatial_ricci_tag>(vars_to_interpolate_to_target);
+    transform::to_different_frame(make_not_null(&frame_spatial_ricci),
+                                  inertial_spatial_ricci,
+                                  jac_frame_to_inertial);
+  }
+}
+}  // namespace
+
+template <typename Fr>
+void compute_vars_to_interpolate_to_target(
+    const gsl::not_null<ah::Storage::VolumeVariables<Fr>*> volume_vars_storage,
+    const LinkedMessageId<double>& time, const Domain<3>& domain,
+    const ElementId<3>& element_id,
+    const domain::FunctionsOfTimeMap& functions_of_time) {
+  // This will only change the size if it isn't already the correct size
+  volume_vars_storage->vars_to_interpolate_to_target.initialize(
+      volume_vars_storage->source_vars.number_of_grid_points());
+
+  const auto& mesh = volume_vars_storage->mesh;
+  const auto& block = domain.blocks()[element_id.block_id()];
+  if (block.is_time_dependent()) {
+    if constexpr (std::is_same_v<Fr, ::Frame::Grid>) {
+      const ElementMap<3, Fr> map_logical_to_grid{
+          element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
+      const auto logical_coords = logical_coordinates(mesh);
+      const auto jac_grid_to_inertial =
+          block.moving_mesh_grid_to_inertial_map().jacobian(
+              map_logical_to_grid(logical_coords), time.id, functions_of_time);
+      const auto invjac_logical_to_grid =
+          map_logical_to_grid.inv_jacobian(logical_coords);
+
+      compute_vars_to_interpolate_to_target_impl(
+          volume_vars_storage, jac_grid_to_inertial, invjac_logical_to_grid);
+    } else if constexpr (std::is_same_v<Fr, ::Frame::Distorted>) {
+      ASSERT(block.has_distorted_frame(),
+             "Block doesn't have a distorted frame but this horizon is in the "
+             "distorted frame.");
+      const domain::CoordinateMaps::Composition
+          element_logical_to_distorted_map{
+              domain::element_to_block_logical_map(element_id),
+              block.moving_mesh_logical_to_grid_map().get_clone(),
+              block.moving_mesh_grid_to_distorted_map().get_clone()};
+      const domain::CoordinateMaps::Composition element_logical_to_grid_map{
+          domain::element_to_block_logical_map(element_id),
+          block.moving_mesh_logical_to_grid_map().get_clone()};
+      const auto logical_coords = logical_coordinates(mesh);
+      const auto jac_distorted_to_inertial =
+          block.moving_mesh_distorted_to_inertial_map().jacobian(
+              element_logical_to_distorted_map(logical_coords, time.id,
+                                               functions_of_time),
+              time.id, functions_of_time);
+      const auto invjac_logical_to_distorted =
+          element_logical_to_distorted_map.inv_jacobian(logical_coords, time.id,
+                                                        functions_of_time);
+
+      compute_vars_to_interpolate_to_target_impl(volume_vars_storage,
+                                                 jac_distorted_to_inertial,
+                                                 invjac_logical_to_distorted);
+    } else {
+      compute_vars_to_interpolate_to_target_impl(volume_vars_storage);
+    }
+  } else {
+    // No frame transformations needed, since the maps are time-independent
+    // and therefore all the frames are the same.
+    //
+    // The frame tags may be different, but the source vars should all be in the
+    // Inertial frame, so we force the inertial frame (True template).
+    compute_vars_to_interpolate_to_target_impl<true>(volume_vars_storage);
+  }
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                          \
+  template void compute_vars_to_interpolate_to_target(                \
+      const gsl::not_null<ah::Storage::VolumeVariables<FRAME(data)>*> \
+          volume_vars_storage,                                        \
+      const LinkedMessageId<double>& time, const Domain<3>& domain,   \
+      const ElementId<3>& element_id,                                 \
+      const domain::FunctionsOfTimeMap& functions_of_time);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Inertial, Frame::Distorted, Frame::Grid))
+
+#undef INSTANTIATE
+#undef FRAME
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ah {
+/*!
+ * \brief Compute the `ah::vars_to_interpolate_to_target` for a given
+ * \p element_id from the `ah::source_vars` in that element.
+ */
+template <typename Fr>
+void compute_vars_to_interpolate_to_target(
+    gsl::not_null<ah::Storage::VolumeVariables<Fr>*> volume_vars_storage,
+    const LinkedMessageId<double>& time, const Domain<3>& domain,
+    const ElementId<3>& element_id,
+    const domain::FunctionsOfTimeMap& functions_of_time);
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_CleanUp.cpp
   Test_ComputeExcisionBoundaryVolumeQuantities.cpp
   Test_ComputeHorizonVolumeQuantities.cpp
+  Test_ComputeVarsToInterpolateToTarget.cpp
   Test_Destination.cpp
   Test_FastFlow.cpp
   Test_Initialization.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
@@ -1,0 +1,278 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <typename Fr>
+void test_compute_horizon_volume_quantities(const bool is_time_dependent) {
+  CAPTURE(is_time_dependent);
+  CAPTURE(pretty_type::name<Fr>());
+  const size_t number_of_grid_points = 12;
+
+  const double mass = 1.0;
+  const std::array spin{0.1, 0.2, 0.3};
+  const LinkedMessageId<double> time{0.01, std::nullopt};
+  // We have time dependent maps so the code takes the correct paths, but we
+  // make them the identity so the vars that we interpolate are the same in each
+  // frame which makes checking them much easier. Also we have small grid
+  // spacing so derivatives are more accurate.
+  const domain::creators::Sphere domain_creator{
+      0.9,
+      1.0,
+      domain::creators::Sphere::Excision{nullptr},
+      1_st,
+      number_of_grid_points,
+      true,
+      std::nullopt,
+      {0.95},
+      domain::CoordinateMaps::Distribution::Linear,
+      ShellWedges::All,
+      is_time_dependent
+          ? std::optional{domain::creators::sphere::TimeDependentMapOptions{
+                0.0,
+                domain::creators::time_dependent_options::ShapeMapOptions<
+                    false, ::domain::ObjectLabel::None>{8_st, std::nullopt},
+                std::nullopt, std::nullopt,
+                domain::creators::time_dependent_options::TranslationMapOptions<
+                    3>{std::array{std::array{0.0, 0.0, 0.0},
+                                  std::array{0.0, 0.0, 0.0},
+                                  std::array{0.0, 0.0, 0.0}}},
+                true}}
+          : std::nullopt};
+  const auto domain = domain_creator.create_domain();
+  const auto& functions_of_time = domain_creator.functions_of_time();
+
+  // Just use the first block, it has all maps and all frames
+  const auto& block = domain.blocks()[0];
+  const auto element_ids = initial_element_ids(
+      block.id(), domain_creator.initial_refinement_levels()[block.id()]);
+
+  // Set up target coordinates, and jacobian.
+  const Mesh mesh{domain_creator.initial_extents()[block.id()],
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto};
+  const auto logical_coords = logical_coordinates(mesh);
+  tnsr::I<DataVector, 3, Fr> target_frame_coords{};
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{};
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      inv_jacobian_logical_to_inertial{mesh.number_of_grid_points(), 0.0};
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Fr>
+      inv_jacobian_logical_to_frame{mesh.number_of_grid_points(), 0.0};
+  if (is_time_dependent) {
+    const ElementMap<3, Frame::Grid> map_logical_to_grid{
+        element_ids[0], block.moving_mesh_logical_to_grid_map().get_clone()};
+
+    inertial_coords = block.moving_mesh_grid_to_inertial_map()(
+        map_logical_to_grid(logical_coords), time.id, functions_of_time);
+
+    const auto inv_jacobian_logical_to_grid =
+        map_logical_to_grid.inv_jacobian(logical_coords);
+    const auto inv_jacobian_grid_to_inertial =
+        block.moving_mesh_grid_to_inertial_map().inv_jacobian(
+            map_logical_to_grid(logical_coords), time.id, functions_of_time);
+
+    inv_jacobian_logical_to_inertial = tenex::evaluate<ti::I, ti::j>(
+        inv_jacobian_logical_to_grid(ti::I, ti::k) *
+        inv_jacobian_grid_to_inertial(ti::K, ti::j));
+
+    if constexpr (std::is_same_v<Fr, Frame::Grid>) {
+      inv_jacobian_logical_to_frame = inv_jacobian_logical_to_grid;
+    } else if constexpr (std::is_same_v<Fr, Frame::Inertial>) {
+      inv_jacobian_logical_to_frame = inv_jacobian_logical_to_inertial;
+    } else {
+      const auto inv_jacobian_grid_to_distorted =
+          block.moving_mesh_grid_to_distorted_map().inv_jacobian(
+              map_logical_to_grid(logical_coords), time.id, functions_of_time);
+
+      inv_jacobian_logical_to_frame = tenex::evaluate<ti::I, ti::j>(
+          inv_jacobian_logical_to_grid(ti::I, ti::k) *
+          inv_jacobian_grid_to_distorted(ti::K, ti::j));
+    }
+
+    if constexpr (std::is_same_v<Fr, Frame::Grid>) {
+      target_frame_coords = map_logical_to_grid(logical_coords);
+    } else if constexpr (std::is_same_v<Fr, Frame::Distorted>) {
+      target_frame_coords = block.moving_mesh_grid_to_distorted_map()(
+          map_logical_to_grid(logical_coords), time.id, functions_of_time);
+    } else {
+      static_assert(std::is_same_v<Fr, Frame::Inertial>,
+                    "Fr must be the Inertial frame");
+      target_frame_coords = block.moving_mesh_grid_to_inertial_map()(
+          map_logical_to_grid(logical_coords), time.id, functions_of_time);
+    }
+
+  } else {
+    // time-independent.
+    if (std::is_same_v<Fr, Frame::Distorted>) {
+      ERROR("Can't have a time independent distorted frame.");
+    }
+    // Grid == inertial so just get inertial and set the frame
+    const ElementMap<3, Frame::Inertial> map_logical_to_inertial{
+        element_ids[0], block.stationary_map().get_clone()};
+    inv_jacobian_logical_to_inertial =
+        map_logical_to_inertial.inv_jacobian(logical_coords);
+
+    inertial_coords = map_logical_to_inertial(logical_coords);
+    for (size_t i = 0; i < 3; i++) {
+      target_frame_coords[i] = inertial_coords[i];
+      for (size_t j = 0; j < 3; j++) {
+        inv_jacobian_logical_to_frame.get(i, j) =
+            inv_jacobian_logical_to_inertial.get(i, j);
+      }
+    }
+  }
+
+  // Set up analytic solution.
+  const gr::Solutions::KerrSchild solution(mass, spin, {0.0, 0.0, 0.0});
+  const auto solution_vars_inertial_frame = solution.variables(
+      inertial_coords, time.id,
+      typename gr::Solutions::KerrSchild::tags<DataVector, Frame::Inertial>{});
+
+  // Fill src vars with analytic solution.
+  ah::Storage::VolumeVariables<Fr> all_volume_vars{};
+  all_volume_vars.mesh = mesh;
+
+  // Set g, pi, and phi in the inertial frame
+  {
+    const auto& lapse =
+        get<gr::Tags::Lapse<DataVector>>(solution_vars_inertial_frame);
+    const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<DataVector>>>(
+        solution_vars_inertial_frame);
+    const auto& d_lapse =
+        get<typename gr::Solutions::KerrSchild::DerivLapse<DataVector>>(
+            solution_vars_inertial_frame);
+    const auto& shift =
+        get<gr::Tags::Shift<DataVector, 3>>(solution_vars_inertial_frame);
+    const auto& d_shift =
+        get<typename gr::Solutions::KerrSchild::DerivShift<DataVector>>(
+            solution_vars_inertial_frame);
+    const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<DataVector, 3>>>(
+        solution_vars_inertial_frame);
+    const auto& spatial_metric = get<gr::Tags::SpatialMetric<DataVector, 3>>(
+        solution_vars_inertial_frame);
+    const auto& dt_spatial_metric =
+        get<Tags::dt<gr::Tags::SpatialMetric<DataVector, 3>>>(
+            solution_vars_inertial_frame);
+    const auto& d_spatial_metric =
+        get<typename gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector>>(
+            solution_vars_inertial_frame);
+
+    auto& source_vars = all_volume_vars.source_vars;
+    source_vars.initialize(get(lapse).size(), 0.0);
+    get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars) =
+        gr::spacetime_metric(lapse, shift, spatial_metric);
+    get<::gh::Tags::Phi<DataVector, 3>>(source_vars) = gh::phi(
+        lapse, d_lapse, shift, d_shift, spatial_metric, d_spatial_metric);
+    get<::gh::Tags::Pi<DataVector, 3>>(source_vars) = gh::pi(
+        lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric,
+        get<::gh::Tags::Phi<DataVector, 3>>(source_vars));
+
+    // Need to compute numerical deriv of Phi.
+    get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                    Frame::Inertial>>(source_vars) =
+        partial_derivative(get<::gh::Tags::Phi<DataVector, 3>>(source_vars),
+                           mesh, inv_jacobian_logical_to_inertial);
+  }
+
+  // Compute other vars
+  ah::compute_vars_to_interpolate_to_target(make_not_null(&all_volume_vars),
+                                            time, domain, element_ids[0],
+                                            functions_of_time);
+
+  // Now make sure those computed vars are correct.
+  const auto solution_vars_target_frame = solution.variables(
+      target_frame_coords, 0.0,
+      tmpl::pop_back<ah::vars_to_interpolate_to_target<3, Fr>>{});
+  // Expected vars
+  const auto& expected_spatial_metric =
+      get<gr::Tags::SpatialMetric<DataVector, 3, Fr>>(
+          solution_vars_target_frame);
+  const auto& expected_inverse_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3, Fr>>(
+          solution_vars_target_frame);
+  const auto& expected_extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<DataVector, 3, Fr>>(
+          solution_vars_target_frame);
+  const auto& expected_christoffel =
+      get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, Fr>>(
+          solution_vars_target_frame);
+  const auto deriv_christoffel = partial_derivative(
+      expected_christoffel, mesh, inv_jacobian_logical_to_frame);
+  const auto expected_ricci =
+      gr::ricci_tensor(expected_christoffel, deriv_christoffel);
+
+  // Computed vars
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<DataVector, 3, Fr>>(
+      all_volume_vars.vars_to_interpolate_to_target);
+  const auto& inverse_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3, Fr>>(
+          all_volume_vars.vars_to_interpolate_to_target);
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<DataVector, 3, Fr>>(
+          all_volume_vars.vars_to_interpolate_to_target);
+  const auto& christoffel =
+      get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, Fr>>(
+          all_volume_vars.vars_to_interpolate_to_target);
+  const auto& ricci = get<gr::Tags::SpatialRicci<DataVector, 3, Fr>>(
+      all_volume_vars.vars_to_interpolate_to_target);
+
+  CHECK_ITERABLE_APPROX(expected_spatial_metric, spatial_metric);
+  CHECK_ITERABLE_APPROX(expected_inverse_spatial_metric,
+                        inverse_spatial_metric);
+  CHECK_ITERABLE_APPROX(expected_extrinsic_curvature, extrinsic_curvature);
+  // Larger tolerance because derivatives are inaccurate
+  const Approx custom_approx_1 = Approx::custom().epsilon(1.e-6).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_christoffel, christoffel,
+                               custom_approx_1);
+  const Approx custom_approx_2 = Approx::custom().epsilon(1.e-5).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_ricci, ricci, custom_approx_2);
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.ComputeVarsToInterpolateToTarget",
+                  "[ApparentHorizonFinder][Unit]") {
+  // time-independent.
+  test_compute_horizon_volume_quantities<Frame::Grid>(false);
+  test_compute_horizon_volume_quantities<Frame::Inertial>(false);
+
+  // time-dependent.
+  test_compute_horizon_volume_quantities<Frame::Grid>(true);
+  test_compute_horizon_volume_quantities<Frame::Distorted>(true);
+  test_compute_horizon_volume_quantities<Frame::Inertial>(true);
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Eighth PR in horizon finder changes. Adds a function that computes the `ah::vars_to_interpolate_to_target` variables from the volume `ah::source_vars`. 

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
