### PR TITLE
Add helper function to fill fluxes from primitive data

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -22,6 +22,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Evolution/DgSubcell/SliceTensor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
@@ -199,9 +200,10 @@ void DemandOutgoingCharSpeeds::fd_demand_outgoing_char_speeds(
         tmpl::list<RestMassDensity, ElectronFraction, Pressure,
                    LorentzFactorTimesSpatialVelocity, MagneticField,
                    DivergenceCleaningField>;
-    using fluxes_tags = tmpl::list<SpecificInternalEnergy, SpatialMetric, Lapse,
-                                   Shift, SpatialVelocity, LorentzFactor,
-                                   SqrtDetSpatialMetric, InvSpatialMetric>;
+    using fluxes_tags =
+        tmpl::push_back<typename System::primitive_variables_tag::tags_list,
+                        LorentzFactorTimesSpatialVelocity, SpatialMetric, Lapse,
+                        Shift, SqrtDetSpatialMetric, InvSpatialMetric>;
 
     const bool need_tags_for_fluxes = cell_centered_ghost_fluxes->has_value();
     // Create a single large DV to reduce the number of Variables allocations
@@ -277,6 +279,13 @@ void DemandOutgoingCharSpeeds::fd_demand_outgoing_char_speeds(
                     static_cast<std::ptrdiff_t>(outermost_fluxes_vars.size())),
           num_face_pts * buffer_size_for_fluxes * ghost_zone_size};
 
+      get<RestMassDensity>(ghost_fluxes_vars) = *rest_mass_density;
+      get<ElectronFraction>(ghost_fluxes_vars) = *electron_fraction;
+      get<Pressure>(ghost_fluxes_vars) = *pressure;
+      get<MagneticField>(ghost_fluxes_vars) = *magnetic_field;
+      get<DivergenceCleaningField>(ghost_fluxes_vars) =
+          *divergence_cleaning_field;
+
       get<SpecificInternalEnergy>(outermost_fluxes_vars) =
           get_boundary_val(interior_specific_internal_energy);
       get<SpatialMetric>(outermost_fluxes_vars) =
@@ -309,47 +318,9 @@ void DemandOutgoingCharSpeeds::fd_demand_outgoing_char_speeds(
       Variables<typename System::variables_tag::tags_list> temp_vars(
           get(*rest_mass_density).size());
 
-      ConservativeFromPrimitive::apply(
-          make_not_null(&get<Tags::TildeD>(temp_vars)),
-          make_not_null(&get<Tags::TildeYe>(temp_vars)),
-          make_not_null(&get<Tags::TildeTau>(temp_vars)),
-          make_not_null(&get<Tags::TildeS<>>(temp_vars)),
-          make_not_null(&get<Tags::TildeB<>>(temp_vars)),
-          make_not_null(&get<Tags::TildePhi>(temp_vars)),
-
-          // Note: Only the spatial velocity changes.
-          *rest_mass_density, *electron_fraction,
-          get<SpecificInternalEnergy>(ghost_fluxes_vars), *pressure,
-          get<SpatialVelocity>(ghost_fluxes_vars),
-          get<LorentzFactor>(ghost_fluxes_vars), *magnetic_field,
-
-          get<SqrtDetSpatialMetric>(ghost_fluxes_vars),
-          get<SpatialMetric>(ghost_fluxes_vars), *divergence_cleaning_field);
-
-      ComputeFluxes::apply(
-          make_not_null(
-              &get<Flux<Tags::TildeD>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeYe>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeTau>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeS<>>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildeB<>>>(cell_centered_ghost_fluxes->value())),
-          make_not_null(
-              &get<Flux<Tags::TildePhi>>(cell_centered_ghost_fluxes->value())),
-
-          get<Tags::TildeD>(temp_vars), get<Tags::TildeYe>(temp_vars),
-          get<Tags::TildeTau>(temp_vars), get<Tags::TildeS<>>(temp_vars),
-          get<Tags::TildeB<>>(temp_vars), get<Tags::TildePhi>(temp_vars),
-
-          get<Lapse>(ghost_fluxes_vars), get<Shift>(ghost_fluxes_vars),
-          get<SqrtDetSpatialMetric>(ghost_fluxes_vars),
-          get<SpatialMetric>(ghost_fluxes_vars),
-          get<InvSpatialMetric>(ghost_fluxes_vars), *pressure,
-          get<SpatialVelocity>(ghost_fluxes_vars),
-          get<LorentzFactor>(ghost_fluxes_vars), *magnetic_field);
+      compute_fluxes_from_primitives(
+          make_not_null(&cell_centered_ghost_fluxes->value()),
+          ghost_fluxes_vars);
     }
   }
 }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -31,6 +31,7 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
@@ -43,6 +44,7 @@
 #include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Temperature.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -316,13 +318,18 @@ void DirichletAnalytic::fd_ghost(
     auto metric_boundary_values = call_with_dynamic_type<
         tuples::TaggedTuple<gr::Tags::Lapse<DataVector>,
                             gr::Tags::Shift<DataVector, 3>,
-                            gr::Tags::SpatialMetric<DataVector, 3>>,
+                            gr::Tags::SpatialMetric<DataVector, 3>,
+                            gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                            gr::Tags::InverseSpatialMetric<DataVector, 3>>,
         grmhd::ValenciaDivClean::InitialData::initial_data_list>(
         analytic_prescription_.get(),
         [&ghost_inertial_coords, &time](const auto* const initial_data) {
-          using gr_tags = tmpl::list<gr::Tags::Lapse<DataVector>,
-                                     gr::Tags::Shift<DataVector, 3>,
-                                     gr::Tags::SpatialMetric<DataVector, 3>>;
+          using gr_tags =
+              tmpl::list<gr::Tags::Lapse<DataVector>,
+                         gr::Tags::Shift<DataVector, 3>,
+                         gr::Tags::SpatialMetric<DataVector, 3>,
+                         gr::Tags::SqrtDetSpatialMetric<DataVector>,
+                         gr::Tags::InverseSpatialMetric<DataVector, 3>>;
           if constexpr (is_analytic_solution_v<
                             std::decay_t<decltype(*initial_data)>>) {
             return initial_data->variables(ghost_inertial_coords, time,
@@ -332,61 +339,11 @@ void DirichletAnalytic::fd_ghost(
             return initial_data->variables(ghost_inertial_coords, gr_tags{});
           }
         });
-    auto [sqrt_det_spatial_metric, inverse_spatial_metric] =
-        determinant_and_inverse(get<gr::Tags::SpatialMetric<DataVector, 3>>(
-            metric_boundary_values));
-    get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
 
-    Variables<typename System::variables_tag::tags_list> conserved_vars{
-        get(*rest_mass_density).size()};
-    ConservativeFromPrimitive::apply(
-        make_not_null(&get<Tags::TildeD>(conserved_vars)),
-        make_not_null(&get<Tags::TildeYe>(conserved_vars)),
-        make_not_null(&get<Tags::TildeTau>(conserved_vars)),
-        make_not_null(&get<Tags::TildeS<>>(conserved_vars)),
-        make_not_null(&get<Tags::TildeB<>>(conserved_vars)),
-        make_not_null(&get<Tags::TildePhi>(conserved_vars)),
-
-        get<hydro::Tags::RestMassDensity<DataVector>>(boundary_values),
-        get<hydro::Tags::ElectronFraction<DataVector>>(boundary_values),
-        get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_values),
-        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values),
-        sqrt_det_spatial_metric,
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(metric_boundary_values),
-        get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_values));
-
-    ComputeFluxes::apply(
-        make_not_null(
-            &get<Flux<Tags::TildeD>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeYe>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeTau>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeS<>>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeB<>>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildePhi>>(cell_centered_ghost_fluxes->value())),
-
-        get<Tags::TildeD>(conserved_vars), get<Tags::TildeYe>(conserved_vars),
-        get<Tags::TildeTau>(conserved_vars),
-        get<Tags::TildeS<>>(conserved_vars),
-        get<Tags::TildeB<>>(conserved_vars),
-        get<Tags::TildePhi>(conserved_vars),
-
-        get<gr::Tags::Lapse<DataVector>>(metric_boundary_values),
-        get<gr::Tags::Shift<DataVector, 3>>(metric_boundary_values),
-        sqrt_det_spatial_metric,
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(metric_boundary_values),
-        inverse_spatial_metric,
-        get<hydro::Tags::Pressure<DataVector>>(boundary_values),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_values),
-        get<hydro::Tags::LorentzFactor<DataVector>>(boundary_values),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_values));
+    compute_fluxes_from_primitives(
+        make_not_null(&cell_centered_ghost_fluxes->value()),
+        tagged_tuple_cat(std::move(boundary_values),
+                         std::move(metric_boundary_values)));
   }
 }
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.cpp
@@ -21,6 +21,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
@@ -222,18 +223,22 @@ void HydroFreeOutflow::fd_ghost(
 
     // fd_gridless_tags
     const fd::Reconstructor& reconstructor) {
-  Variables<tmpl::push_back<typename System::variables_tag::tags_list,
-                            SpatialVelocity, LorentzFactor, Pressure,
-                            SpecificInternalEnergy, SqrtDetSpatialMetric,
-                            SpatialMetric, InvSpatialMetric, Lapse, Shift>>
+  Variables<tmpl::push_back<
+      tmpl::append<typename System::variables_tag::tags_list,
+                   typename System::primitive_variables_tag::tags_list>,
+      SqrtDetSpatialMetric, SpatialMetric, InvSpatialMetric, Lapse, Shift>>
       temp_vars{get(*rest_mass_density).size()};
-  fd_ghost_impl(rest_mass_density, electron_fraction, temperature,
+
+  fd_ghost_impl(make_not_null(&get<RestMassDensity>(temp_vars)),
+                make_not_null(&get<ElectronFraction>(temp_vars)),
+                make_not_null(&get<Temperature>(temp_vars)),
                 make_not_null(&get<Pressure>(temp_vars)),
                 make_not_null(&get<SpecificInternalEnergy>(temp_vars)),
                 lorentz_factor_times_spatial_velocity,
                 make_not_null(&get<SpatialVelocity>(temp_vars)),
-                make_not_null(&get<LorentzFactor>(temp_vars)), magnetic_field,
-                divergence_cleaning_field,
+                make_not_null(&get<LorentzFactor>(temp_vars)),
+                make_not_null(&get<MagneticField>(temp_vars)),
+                make_not_null(&get<DivergenceCleaningField>(temp_vars)),
                 make_not_null(&get<SpatialMetric>(temp_vars)),
                 make_not_null(&get<InvSpatialMetric>(temp_vars)),
                 make_not_null(&get<SqrtDetSpatialMetric>(temp_vars)),
@@ -255,48 +260,19 @@ void HydroFreeOutflow::fd_ghost(
                 reconstructor.ghost_zone_size(),
 
                 cell_centered_ghost_fluxes->has_value());
+
   if (cell_centered_ghost_fluxes->has_value()) {
-    ConservativeFromPrimitive::apply(
-        make_not_null(&get<Tags::TildeD>(temp_vars)),
-        make_not_null(&get<Tags::TildeYe>(temp_vars)),
-        make_not_null(&get<Tags::TildeTau>(temp_vars)),
-        make_not_null(&get<Tags::TildeS<>>(temp_vars)),
-        make_not_null(&get<Tags::TildeB<>>(temp_vars)),
-        make_not_null(&get<Tags::TildePhi>(temp_vars)),
-
-        // Note: Only the spatial velocity changes.
-        *rest_mass_density, *electron_fraction,
-        get<SpecificInternalEnergy>(temp_vars), get<Pressure>(temp_vars),
-        get<SpatialVelocity>(temp_vars), get<LorentzFactor>(temp_vars),
-        *magnetic_field,
-
-        get<SqrtDetSpatialMetric>(temp_vars), get<SpatialMetric>(temp_vars),
-        *divergence_cleaning_field);
-
-    ComputeFluxes::apply(
-        make_not_null(
-            &get<Flux<Tags::TildeD>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeYe>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeTau>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeS<>>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeB<>>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildePhi>>(cell_centered_ghost_fluxes->value())),
-
-        get<Tags::TildeD>(temp_vars), get<Tags::TildeYe>(temp_vars),
-        get<Tags::TildeTau>(temp_vars), get<Tags::TildeS<>>(temp_vars),
-        get<Tags::TildeB<>>(temp_vars), get<Tags::TildePhi>(temp_vars),
-
-        get<Lapse>(temp_vars), get<Shift>(temp_vars),
-        get<SqrtDetSpatialMetric>(temp_vars), get<SpatialMetric>(temp_vars),
-        get<InvSpatialMetric>(temp_vars), get<Pressure>(temp_vars),
-        get<SpatialVelocity>(temp_vars), get<LorentzFactor>(temp_vars),
-        *magnetic_field);
+    compute_fluxes_from_primitives(
+        make_not_null(&cell_centered_ghost_fluxes->value()), temp_vars);
   }
+
+  *rest_mass_density = get<hydro::Tags::RestMassDensity<DataVector>>(temp_vars);
+  *electron_fraction =
+      get<hydro::Tags::ElectronFraction<DataVector>>(temp_vars);
+  *temperature = get<hydro::Tags::Temperature<DataVector>>(temp_vars);
+  *magnetic_field = get<hydro::Tags::MagneticField<DataVector, 3>>(temp_vars);
+  *divergence_cleaning_field =
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(temp_vars);
 }
 
 void HydroFreeOutflow::fd_ghost_impl(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Reflective.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Reflective.cpp
@@ -21,6 +21,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Evolution/DgSubcell/SliceTensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
@@ -283,18 +284,22 @@ void Reflective::fd_ghost(
 
     // fd_gridless_tags
     const fd::Reconstructor& reconstructor) const {
-  Variables<tmpl::push_back<typename System::variables_tag::tags_list,
-                            SpatialVelocity, LorentzFactor, Pressure,
-                            SpecificInternalEnergy, SqrtDetSpatialMetric,
-                            SpatialMetric, InvSpatialMetric, Lapse, Shift>>
+  Variables<tmpl::push_back<
+      tmpl::append<typename System::variables_tag::tags_list,
+                   typename System::primitive_variables_tag::tags_list>,
+      SqrtDetSpatialMetric, SpatialMetric, InvSpatialMetric, Lapse, Shift>>
       temp_vars{get(*rest_mass_density).size()};
-  fd_ghost_impl(rest_mass_density, electron_fraction, temperature,
+
+  fd_ghost_impl(make_not_null(&get<RestMassDensity>(temp_vars)),
+                make_not_null(&get<ElectronFraction>(temp_vars)),
+                make_not_null(&get<Temperature>(temp_vars)),
                 make_not_null(&get<Pressure>(temp_vars)),
                 make_not_null(&get<SpecificInternalEnergy>(temp_vars)),
                 lorentz_factor_times_spatial_velocity,
                 make_not_null(&get<SpatialVelocity>(temp_vars)),
-                make_not_null(&get<LorentzFactor>(temp_vars)), magnetic_field,
-                divergence_cleaning_field,
+                make_not_null(&get<LorentzFactor>(temp_vars)),
+                make_not_null(&get<MagneticField>(temp_vars)),
+                make_not_null(&get<DivergenceCleaningField>(temp_vars)),
                 make_not_null(&get<SpatialMetric>(temp_vars)),
                 make_not_null(&get<InvSpatialMetric>(temp_vars)),
                 make_not_null(&get<SqrtDetSpatialMetric>(temp_vars)),
@@ -316,48 +321,19 @@ void Reflective::fd_ghost(
                 reconstructor.ghost_zone_size(),
 
                 cell_centered_ghost_fluxes->has_value());
+
   if (cell_centered_ghost_fluxes->has_value()) {
-    ConservativeFromPrimitive::apply(
-        make_not_null(&get<Tags::TildeD>(temp_vars)),
-        make_not_null(&get<Tags::TildeYe>(temp_vars)),
-        make_not_null(&get<Tags::TildeTau>(temp_vars)),
-        make_not_null(&get<Tags::TildeS<>>(temp_vars)),
-        make_not_null(&get<Tags::TildeB<>>(temp_vars)),
-        make_not_null(&get<Tags::TildePhi>(temp_vars)),
-
-        // Note: Only the spatial velocity changes.
-        *rest_mass_density, *electron_fraction,
-        get<SpecificInternalEnergy>(temp_vars), get<Pressure>(temp_vars),
-        get<SpatialVelocity>(temp_vars), get<LorentzFactor>(temp_vars),
-        *magnetic_field,
-
-        get<SqrtDetSpatialMetric>(temp_vars), get<SpatialMetric>(temp_vars),
-        *divergence_cleaning_field);
-
-    ComputeFluxes::apply(
-        make_not_null(
-            &get<Flux<Tags::TildeD>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeYe>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeTau>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeS<>>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildeB<>>>(cell_centered_ghost_fluxes->value())),
-        make_not_null(
-            &get<Flux<Tags::TildePhi>>(cell_centered_ghost_fluxes->value())),
-
-        get<Tags::TildeD>(temp_vars), get<Tags::TildeYe>(temp_vars),
-        get<Tags::TildeTau>(temp_vars), get<Tags::TildeS<>>(temp_vars),
-        get<Tags::TildeB<>>(temp_vars), get<Tags::TildePhi>(temp_vars),
-
-        get<Lapse>(temp_vars), get<Shift>(temp_vars),
-        get<SqrtDetSpatialMetric>(temp_vars), get<SpatialMetric>(temp_vars),
-        get<InvSpatialMetric>(temp_vars), get<Pressure>(temp_vars),
-        get<SpatialVelocity>(temp_vars), get<LorentzFactor>(temp_vars),
-        *magnetic_field);
+    compute_fluxes_from_primitives(
+        make_not_null(&cell_centered_ghost_fluxes->value()), temp_vars);
   }
+
+  *rest_mass_density = get<hydro::Tags::RestMassDensity<DataVector>>(temp_vars);
+  *electron_fraction =
+      get<hydro::Tags::ElectronFraction<DataVector>>(temp_vars);
+  *temperature = get<hydro::Tags::Temperature<DataVector>>(temp_vars);
+  *magnetic_field = get<hydro::Tags::MagneticField<DataVector, 3>>(temp_vars);
+  *divergence_cleaning_field =
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(temp_vars);
 }
 
 void Reflective::fd_ghost_impl(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -30,6 +30,7 @@ spectre_target_headers(
   AllSolutions.hpp
   Characteristics.hpp
   ComovingMagneticFieldMagnitude.hpp
+  ComputeFluxesFromPrimitives.hpp
   ConservativeFromPrimitive.hpp
   FixConservatives.hpp
   Flattener.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::ValenciaDivClean {
+namespace detail {
+template <typename FluxTags, typename BoundaryVarsType, typename... ReturnTags,
+          typename... ConservativeTags, typename... ArgumentTags,
+          typename... FluxArgumentTags>
+void compute_fluxes_from_primitives_impl(
+    const gsl::not_null<Variables<FluxTags>*> flux_vars,
+    const BoundaryVarsType& boundary_vars, tmpl::list<ReturnTags...> /*meta*/,
+    tmpl::list<ConservativeTags...> /*meta*/,
+    tmpl::list<ArgumentTags...> /*meta*/,
+    tmpl::list<FluxArgumentTags...> /*meta*/) {
+  Variables<typename tmpl::list<ConservativeTags...>> conserved_vars{
+      flux_vars->number_of_grid_points()};
+  grmhd::ValenciaDivClean::ConservativeFromPrimitive::apply(
+      make_not_null(&get<ConservativeTags>(conserved_vars))...,
+      get<ArgumentTags>(boundary_vars)...);
+  grmhd::ValenciaDivClean::ComputeFluxes::apply(
+      make_not_null(&get<ReturnTags>(*flux_vars))...,
+      get<ConservativeTags>(conserved_vars)...,
+      get<FluxArgumentTags>(boundary_vars)...);
+}
+}  // namespace detail
+
+/*!
+ * \brief Helper function that computes fluxes from a given set of primitive
+ * variables. Primarily used for filling neighbor data when flux information is
+ * needed for boundaries.
+ *
+ * \warning This computes the conservative variables internally. If you also
+ * need those, you shouldn't call this function.
+ */
+template <typename FluxTags, typename BoundaryVarsType>
+void compute_fluxes_from_primitives(
+    const gsl::not_null<Variables<FluxTags>*> flux_vars,
+    const BoundaryVarsType& boundary_vars) {
+  using ConservativeTags =
+      typename grmhd::ValenciaDivClean::ConservativeFromPrimitive::return_tags;
+  using FluxArgumentTags =
+      typename grmhd::ValenciaDivClean::ComputeFluxes::argument_tags;
+  using flux_arg_tags = tmpl::back<tmpl::split_at<
+      FluxArgumentTags, tmpl::next<tmpl::index_of<
+                            FluxArgumentTags, tmpl::back<ConservativeTags>>>>>;
+  detail::compute_fluxes_from_primitives_impl(
+      flux_vars, boundary_vars,
+      typename grmhd::ValenciaDivClean::ComputeFluxes::return_tags{},
+      ConservativeTags{},
+      typename grmhd::ValenciaDivClean::ConservativeFromPrimitive::
+          argument_tags{},
+      flux_arg_tags{});
+}
+}  // namespace grmhd::ValenciaDivClean

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIBRARY_SOURCES
   Subcell/Test_TimeDerivative.cpp
   Test_Characteristics.cpp
   Test_ComovingMagneticFieldMagnitude.cpp
+  Test_ComputeFluxesFromPrimitives.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_FixConservatives.cpp
   Test_Flattener.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -43,6 +43,7 @@
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/BoundaryConditionGhostData.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
@@ -54,9 +55,11 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -172,32 +175,31 @@ void test(const BoundaryConditionType& boundary_condition,
   // be satisfied at the first place. Later we will change shift vector to its
   // original value (0.0) and check that the DemandOutgoingCharSpeeds condition
   // is violated as expected.
-  Variables<typename System::spacetime_variables_tag::tags_list>
-      volume_spacetime_vars{subcell_mesh.number_of_grid_points()};
-  volume_spacetime_vars.assign_subset(solution.variables(
+  Variables<tmpl::append<typename System::spacetime_variables_tag::tags_list,
+                         typename System::primitive_variables_tag::tags_list>>
+      volume_vars{subcell_mesh.number_of_grid_points()};
+  volume_vars.assign_subset(solution.variables(
       subcell_inertial_coords, time,
       typename System::spacetime_variables_tag::tags_list{}));
   for (size_t i = 0; i < 3; ++i) {
-    get<gr::Tags::Shift<DataVector, 3>>(volume_spacetime_vars).get(i) = -2.0;
+    get<gr::Tags::Shift<DataVector, 3>>(volume_vars).get(i) = -2.0;
   }
 
-  Variables<typename System::primitive_variables_tag::tags_list>
-      volume_prim_vars{subcell_mesh.number_of_grid_points()};
-  get(get<RestMassDensity>(volume_prim_vars)) = 1.0;
-  get(get<ElectronFraction>(volume_prim_vars)) = 0.1;
-  get(get<Pressure>(volume_prim_vars)) = 1.0;
-  get(get<LorentzFactor>(volume_prim_vars)) = 2.0;
+  get(get<RestMassDensity>(volume_vars)) = 1.0;
+  get(get<ElectronFraction>(volume_vars)) = 0.1;
+  get(get<Pressure>(volume_vars)) = 1.0;
+  get(get<LorentzFactor>(volume_vars)) = 2.0;
   // This quantity is fixed by the equation of state given P and rho
-  get(get<SpecificInternalEnergy>(volume_prim_vars)) = 1.0 / (1.4 - 1.0);
-  get<Temperature>(volume_prim_vars) =
+  get(get<SpecificInternalEnergy>(volume_vars)) = 1.0 / (1.4 - 1.0);
+  get<Temperature>(volume_vars) =
       solution.equation_of_state().temperature_from_density_and_energy(
-          get<RestMassDensity>(volume_prim_vars),
-          get<SpecificInternalEnergy>(volume_prim_vars));
+          get<RestMassDensity>(volume_vars),
+          get<SpecificInternalEnergy>(volume_vars));
   for (size_t i = 0; i < 3; ++i) {
-    get<SpatialVelocity>(volume_prim_vars).get(i) = 0.1;
-    get<MagneticField>(volume_prim_vars).get(i) = 0.5;
+    get<SpatialVelocity>(volume_vars).get(i) = 0.1;
+    get<MagneticField>(volume_vars).get(i) = 0.5;
   }
-  get(get<DivergenceCleaningField>(volume_prim_vars)) = 1e-2;
+  get(get<DivergenceCleaningField>(volume_vars)) = 1e-2;
 
   std::optional<tnsr::I<DataVector, 3>> volume_mesh_velocity{};
 
@@ -249,56 +251,8 @@ void test(const BoundaryConditionType& boundary_condition,
   if (set_fluxes) {
     cell_centered_fluxes = typename decltype(cell_centered_fluxes)::value_type{
         subcell_mesh.number_of_grid_points()};
-    ConservativeFromPrimitive::apply(
-        get<tmpl::at_c<cons_tags, 0>>(make_not_null(&volume_cons_vars)),
-        get<tmpl::at_c<cons_tags, 1>>(make_not_null(&volume_cons_vars)),
-        get<tmpl::at_c<cons_tags, 2>>(make_not_null(&volume_cons_vars)),
-        get<tmpl::at_c<cons_tags, 3>>(make_not_null(&volume_cons_vars)),
-        get<tmpl::at_c<cons_tags, 4>>(make_not_null(&volume_cons_vars)),
-        get<tmpl::at_c<cons_tags, 5>>(make_not_null(&volume_cons_vars)),
-        get<hydro::Tags::RestMassDensity<DataVector>>(volume_prim_vars),
-        get<hydro::Tags::ElectronFraction<DataVector>>(volume_prim_vars),
-        get<hydro::Tags::SpecificInternalEnergy<DataVector>>(volume_prim_vars),
-        get<hydro::Tags::Pressure<DataVector>>(volume_prim_vars),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(volume_prim_vars),
-        get<hydro::Tags::LorentzFactor<DataVector>>(volume_prim_vars),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(volume_prim_vars),
-        get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(volume_spacetime_vars),
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(volume_spacetime_vars),
-        get<hydro::Tags::DivergenceCleaningField<DataVector>>(
-            volume_prim_vars));
-
-    ComputeFluxes::apply(
-        get<Flux<tmpl::at_c<cons_tags, 0>>>(
-            make_not_null(&cell_centered_fluxes.value())),
-        get<Flux<tmpl::at_c<cons_tags, 1>>>(
-            make_not_null(&cell_centered_fluxes.value())),
-        get<Flux<tmpl::at_c<cons_tags, 2>>>(
-            make_not_null(&cell_centered_fluxes.value())),
-        get<Flux<tmpl::at_c<cons_tags, 3>>>(
-            make_not_null(&cell_centered_fluxes.value())),
-        get<Flux<tmpl::at_c<cons_tags, 4>>>(
-            make_not_null(&cell_centered_fluxes.value())),
-        get<Flux<tmpl::at_c<cons_tags, 5>>>(
-            make_not_null(&cell_centered_fluxes.value())),
-
-        get<tmpl::at_c<cons_tags, 0>>(volume_cons_vars),
-        get<tmpl::at_c<cons_tags, 1>>(volume_cons_vars),
-        get<tmpl::at_c<cons_tags, 2>>(volume_cons_vars),
-        get<tmpl::at_c<cons_tags, 3>>(volume_cons_vars),
-        get<tmpl::at_c<cons_tags, 4>>(volume_cons_vars),
-        get<tmpl::at_c<cons_tags, 5>>(volume_cons_vars),
-
-        get<gr::Tags::Lapse<DataVector>>(volume_spacetime_vars),
-        get<gr::Tags::Shift<DataVector, 3>>(volume_spacetime_vars),
-        get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(volume_spacetime_vars),
-        get<gr::Tags::SpatialMetric<DataVector, 3>>(volume_spacetime_vars),
-        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
-            volume_spacetime_vars),
-        get<hydro::Tags::Pressure<DataVector>>(volume_prim_vars),
-        get<hydro::Tags::SpatialVelocity<DataVector, 3>>(volume_prim_vars),
-        get<hydro::Tags::LorentzFactor<DataVector>>(volume_prim_vars),
-        get<hydro::Tags::MagneticField<DataVector, 3>>(volume_prim_vars));
+    compute_fluxes_from_primitives(make_not_null(&cell_centered_fluxes.value()),
+                                   volume_vars);
   }
 
   using Vlo =
@@ -319,8 +273,9 @@ void test(const BoundaryConditionType& boundary_condition,
       domain::Tags::ElementMap<3, Frame::Grid>,
       domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
                                                   Frame::Inertial>,
-      typename System::spacetime_variables_tag,
-      typename System::primitive_variables_tag,
+      ::Tags::Variables<
+          tmpl::append<typename System::spacetime_variables_tag::tags_list,
+                       typename System::primitive_variables_tag::tags_list>>,
       evolution::dg::subcell::Tags::CellCenteredFlux<
           typename System::flux_variables, 3>,
       ::Tags::VariableFixer<::VariableFixing::FixToAtmosphere<3>>,
@@ -337,8 +292,8 @@ void test(const BoundaryConditionType& boundary_condition,
               domain::CoordinateMaps::Identity<3>{})},
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{}),
-      volume_spacetime_vars, volume_prim_vars, cell_centered_fluxes,
-      variable_fixer, solution.equation_of_state().promote_to_3d_eos());
+      volume_vars, cell_centered_fluxes, variable_fixer,
+      solution.equation_of_state().promote_to_3d_eos());
 
   {
     // compute FD ghost data and retrieve the result
@@ -390,8 +345,30 @@ void test(const BoundaryConditionType& boundary_condition,
             const auto& spatial_velocity, const auto& lorentz_factor,
             const auto& magnetic_field, const auto& div_cleaning_field,
             const double shift_value) {
-          typename System::variables_tag::type expected_cons_vars{
-              get(rest_mass_density).size()};
+          using fluxes_tags = tmpl::push_back<
+              typename System::primitive_variables_tag::tags_list,
+              gr::Tags::SpatialMetric<DataVector, 3>,
+              gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+              gr::Tags::SqrtDetSpatialMetric<DataVector>,
+              gr::Tags::InverseSpatialMetric<DataVector, 3>>;
+          Variables<fluxes_tags> boundary_data{get(rest_mass_density).size()};
+
+          get<RestMassDensity>(boundary_data) = rest_mass_density;
+          get<ElectronFraction>(boundary_data) = electron_fraction;
+          get<SpecificInternalEnergy>(boundary_data) = specific_internal_energy;
+          get<Temperature>(boundary_data) = local_temperature;
+          get<SpatialVelocity>(boundary_data) = spatial_velocity;
+          get<LorentzFactor>(boundary_data) = lorentz_factor;
+          get<MagneticField>(boundary_data) = magnetic_field;
+          get<DivergenceCleaningField>(boundary_data) = div_cleaning_field;
+
+          get<Pressure>(boundary_data) =
+              solution.equation_of_state().pressure_from_density_and_energy(
+                  rest_mass_density,
+                  solution.equation_of_state()
+                      .specific_internal_energy_from_density_and_temperature(
+                          rest_mass_density, local_temperature));
+
           tnsr::ii<DataVector, 3> spatial_metric(get(rest_mass_density).size(),
                                                  0.0);
           tnsr::II<DataVector, 3> inverse_spatial_metric(
@@ -400,55 +377,22 @@ void test(const BoundaryConditionType& boundary_condition,
             spatial_metric.get(i, i) = 1.0;
             inverse_spatial_metric.get(i, i) = 1.0;
           }
-          const auto local_pressure =
-              solution.equation_of_state().pressure_from_density_and_energy(
-                  rest_mass_density,
-                  solution.equation_of_state()
-                      .specific_internal_energy_from_density_and_temperature(
-                          rest_mass_density, local_temperature));
-          const Scalar<DataVector> sqrt_det_spatial_metric(
-              get(rest_mass_density).size(), 1.0);
-          const Scalar<DataVector> lapse(get(rest_mass_density).size(), 1.0);
-          const tnsr::I<DataVector, 3> shift(get(rest_mass_density).size(),
-                                             shift_value);
+          get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_data) =
+              spatial_metric;
+          get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_data) =
+              inverse_spatial_metric;
+          get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_data) =
+              Scalar<DataVector>(get(rest_mass_density).size(), 1.0);
+          get<gr::Tags::Lapse<DataVector>>(boundary_data) =
+              Scalar<DataVector>(get(rest_mass_density).size(), 1.0);
+          get<gr::Tags::Shift<DataVector, 3>>(boundary_data) =
+              tnsr::I<DataVector, 3>(get(rest_mass_density).size(),
+                                     shift_value);
           typename evolution::dg::subcell::Tags::CellCenteredFlux<
               typename System::flux_variables, 3>::type::value_type
               expected_neighbor_fluxes{get(rest_mass_density).size()};
-          ConservativeFromPrimitive::apply(
-              get<tmpl::at_c<cons_tags, 0>>(make_not_null(&expected_cons_vars)),
-              get<tmpl::at_c<cons_tags, 1>>(make_not_null(&expected_cons_vars)),
-              get<tmpl::at_c<cons_tags, 2>>(make_not_null(&expected_cons_vars)),
-              get<tmpl::at_c<cons_tags, 3>>(make_not_null(&expected_cons_vars)),
-              get<tmpl::at_c<cons_tags, 4>>(make_not_null(&expected_cons_vars)),
-              get<tmpl::at_c<cons_tags, 5>>(make_not_null(&expected_cons_vars)),
-              rest_mass_density, electron_fraction, specific_internal_energy,
-              local_pressure, spatial_velocity, lorentz_factor, magnetic_field,
-              sqrt_det_spatial_metric, spatial_metric, div_cleaning_field);
-
-          ComputeFluxes::apply(
-              get<Flux<tmpl::at_c<cons_tags, 0>>>(
-                  make_not_null(&expected_neighbor_fluxes)),
-              get<Flux<tmpl::at_c<cons_tags, 1>>>(
-                  make_not_null(&expected_neighbor_fluxes)),
-              get<Flux<tmpl::at_c<cons_tags, 2>>>(
-                  make_not_null(&expected_neighbor_fluxes)),
-              get<Flux<tmpl::at_c<cons_tags, 3>>>(
-                  make_not_null(&expected_neighbor_fluxes)),
-              get<Flux<tmpl::at_c<cons_tags, 4>>>(
-                  make_not_null(&expected_neighbor_fluxes)),
-              get<Flux<tmpl::at_c<cons_tags, 5>>>(
-                  make_not_null(&expected_neighbor_fluxes)),
-
-              get<tmpl::at_c<cons_tags, 0>>(expected_cons_vars),
-              get<tmpl::at_c<cons_tags, 1>>(expected_cons_vars),
-              get<tmpl::at_c<cons_tags, 2>>(expected_cons_vars),
-              get<tmpl::at_c<cons_tags, 3>>(expected_cons_vars),
-              get<tmpl::at_c<cons_tags, 4>>(expected_cons_vars),
-              get<tmpl::at_c<cons_tags, 5>>(expected_cons_vars),
-
-              lapse, shift, sqrt_det_spatial_metric, spatial_metric,
-              inverse_spatial_metric, local_pressure, spatial_velocity,
-              lorentz_factor, magnetic_field);
+          compute_fluxes_from_primitives(
+              make_not_null(&expected_neighbor_fluxes), boundary_data);
           tmpl::for_each<tmpl::list<tmpl::at_c<cons_tags, 0>>>(
               [&fd_ghost_fluxes, &expected_neighbor_fluxes](auto cons_tag_v) {
                 using tag =

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ComputeFluxesFromPrimitives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ComputeFluxesFromPrimitives.cpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::ValenciaDivClean {
+namespace {
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.ValenciaDivClean.ComputeFluxesFromPrimitives",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  const size_t num_pts = 5;
+
+  using ConservativeTags =
+      typename grmhd::ValenciaDivClean::ConservativeFromPrimitive::return_tags;
+  using ArgumentTags = typename grmhd::ValenciaDivClean::
+      ConservativeFromPrimitive::argument_tags;
+
+  auto flux_vars =
+      make_with_random_values<Variables<ComputeFluxes::return_tags>>(
+          make_not_null(&gen), make_not_null(&dist), num_pts);
+
+  auto conservative_vars = make_with_random_values<Variables<ConservativeTags>>(
+      make_not_null(&gen), make_not_null(&dist), num_pts);
+
+  auto boundary_vars = make_with_random_values<Variables<tmpl::push_back<
+      ArgumentTags, gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3>>>>(
+      make_not_null(&gen), make_not_null(&dist), num_pts);
+
+  Variables<ConservativeFromPrimitive::return_tags> expected_conservative{
+      num_pts};
+  Variables<ComputeFluxes::return_tags> expected_fluxes{num_pts};
+  ConservativeFromPrimitive::apply(
+      make_not_null(
+          &get<grmhd::ValenciaDivClean::Tags::TildeD>(expected_conservative)),
+      make_not_null(
+          &get<grmhd::ValenciaDivClean::Tags::TildeYe>(expected_conservative)),
+      make_not_null(
+          &get<grmhd::ValenciaDivClean::Tags::TildeTau>(expected_conservative)),
+      make_not_null(
+          &get<grmhd::ValenciaDivClean::Tags::TildeS<>>(expected_conservative)),
+      make_not_null(
+          &get<grmhd::ValenciaDivClean::Tags::TildeB<>>(expected_conservative)),
+      make_not_null(
+          &get<grmhd::ValenciaDivClean::Tags::TildePhi>(expected_conservative)),
+      get<hydro::Tags::RestMassDensity<DataVector>>(boundary_vars),
+      get<hydro::Tags::ElectronFraction<DataVector>>(boundary_vars),
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(boundary_vars),
+      get<hydro::Tags::Pressure<DataVector>>(boundary_vars),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_vars),
+      get<hydro::Tags::LorentzFactor<DataVector>>(boundary_vars),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_vars),
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_vars),
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_vars),
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(boundary_vars));
+  ComputeFluxes::apply(
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeD,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeYe,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeTau,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeS<>,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeB<>,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      make_not_null(&get<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildePhi,
+                                      tmpl::size_t<3>, Frame::Inertial>>(
+          expected_fluxes)),
+      get<grmhd::ValenciaDivClean::Tags::TildeD>(expected_conservative),
+      get<grmhd::ValenciaDivClean::Tags::TildeYe>(expected_conservative),
+      get<grmhd::ValenciaDivClean::Tags::TildeTau>(expected_conservative),
+      get<grmhd::ValenciaDivClean::Tags::TildeS<>>(expected_conservative),
+      get<grmhd::ValenciaDivClean::Tags::TildeB<>>(expected_conservative),
+      get<grmhd::ValenciaDivClean::Tags::TildePhi>(expected_conservative),
+      get<gr::Tags::Lapse<DataVector>>(boundary_vars),
+      get<gr::Tags::Shift<DataVector, 3>>(boundary_vars),
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(boundary_vars),
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(boundary_vars),
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(boundary_vars),
+      get<hydro::Tags::Pressure<DataVector>>(boundary_vars),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(boundary_vars),
+      get<hydro::Tags::LorentzFactor<DataVector>>(boundary_vars),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(boundary_vars));
+
+  compute_fluxes_from_primitives(make_not_null(&flux_vars), boundary_vars);
+
+  tmpl::for_each<ComputeFluxes::return_tags>(
+      [&expected_fluxes, &flux_vars](auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CHECK_ITERABLE_APPROX(get<tag>(flux_vars), get<tag>(expected_fluxes));
+      });
+}
+}  // namespace
+}  // namespace grmhd::ValenciaDivClean


### PR DESCRIPTION
## Proposed changes

Adds a helper function to `ValenciaDivClean` which takes primitive variable data, feeds it through `ConservativeFromPrimitive`, then runs `ComputeFluxes`.

When using higher order finite difference, it is necessary to compute cell centered flux information from the ghost data when handling boundary conditions. Because of this, there are several occasions when these two functions are run in sequence (_e.g._ in the `fd_ghost` functions in the boundary condition files). This helper function is purely meant to improve readability and reduce the number of lines of code in the boundary condition files. This will result in a notable reduction in the number of lines added when higher order finite difference is implemented for `GhValenciaDivClean` as well.

_N.B._ there are some instances when `ConservativeFromPrimitive` is immediately followed by `ComputeFluxes` which were not converted to the helper function (_e.g._ in the `dg_ghost` functions in the boundary condition files). These are instances when the conservative data is also saved for other purposes, so it makes sense to keep these functions separate.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
