### PR TITLE
Finish variable-order time-stepper support

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -93,6 +93,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -229,7 +230,8 @@ struct EvolutionMetavars {
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -213,7 +213,7 @@ struct EvolutionMetavars {
                         volume_dim, SphericalSurface, interpolator_source_vars>,
                     tmpl::list<>>,
                 Events::time_events<system>,
-                dg::Events::ObserveTimeStepVolume<volume_dim>>>>,
+                dg::Events::ObserveTimeStepVolume<system>>>>,
         tmpl::pair<evolution::initial_data::InitialData, solutions_and_data>,
         tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -97,6 +97,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/ByBlock.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
@@ -250,7 +251,8 @@ struct EvolutionMetavars {
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -79,6 +79,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -191,7 +192,8 @@ struct EvolutionMetavars {
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -172,6 +172,7 @@
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
 #include "Time/ChangeSlabSize/Tags.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrors.hpp"
@@ -584,7 +585,8 @@ struct EvolutionMetavars {
                          evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -518,7 +518,7 @@ struct EvolutionMetavars {
                 control_system::metafunctions::control_system_events<
                     control_systems>,
                 Events::time_events<system>,
-                dg::Events::ObserveTimeStepVolume<3>>>>,
+                dg::Events::ObserveTimeStepVolume<system>>>>,
         tmpl::pair<control_system::size::State,
                    control_system::size::States::factory_creatable_states>,
         tmpl::pair<

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -297,7 +297,7 @@ struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
               Events::Completion, Events::MonitorMemory<volume_dim>,
               typename detail::ObserverTags<volume_dim>::field_observations,
               Events::time_events<system>,
-              dg::Events::ObserveTimeStepVolume<volume_dim>>>>,
+              dg::Events::ObserveTimeStepVolume<system>>>>,
       tmpl::pair<
           gh::BoundaryConditions::BoundaryCondition<volume_dim>,
           gh::BoundaryConditions::standard_boundary_conditions<volume_dim>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -134,6 +134,7 @@
 #include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/UpdateU.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -390,7 +391,8 @@ struct GeneralizedHarmonicTemplateBase {
                          evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -638,7 +638,7 @@ struct GhValenciaDivCleanTemplateBase<
                        Events::ObserveAtExtremum<observe_fields,
                                                  non_tensor_compute_tags>,
                        Events::time_events<system>,
-                       dg::Events::ObserveTimeStepVolume<volume_dim>,
+                       dg::Events::ObserveTimeStepVolume<system>,
                        control_system::metafunctions::control_system_events<
                            control_systems>,
                        intrp::Events::InterpolateWithoutInterpComponent<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -230,6 +230,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -755,7 +756,8 @@ struct GhValenciaDivCleanTemplateBase<
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-              system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -165,6 +165,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -415,7 +416,8 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                          system::primitive_from_conservative<
                              ordered_list_of_primitive_recovery_schemes>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -104,6 +104,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -291,7 +292,8 @@ struct EvolutionMetavars {
                              local_time_stepping, system, volume_dim, true>,
                          typename system::primitive_from_conservative>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -83,6 +83,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -197,7 +198,8 @@ struct EvolutionMetavars {
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -135,6 +135,7 @@
 #include "Time/Actions/RecordTimeStepperData.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/UpdateU.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
@@ -444,7 +445,8 @@ struct ScalarTensorTemplateBase {
                          evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -360,7 +360,7 @@ struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
                      Events::Completion, Events::MonitorMemory<volume_dim>,
                      typename detail::ObserverTags::field_observations,
                      Events::time_events<system>,
-                     dg::Events::ObserveTimeStepVolume<volume_dim>>>>,
+                     dg::Events::ObserveTimeStepVolume<system>>>>,
       tmpl::pair<
           ScalarTensor::BoundaryConditions::BoundaryCondition,
           ScalarTensor::BoundaryConditions::standard_boundary_conditions>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -98,6 +98,7 @@
 #include "Time/Actions/UpdateU.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
 #include "Time/ChangeSlabSize/Tags.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/StepChoosers/ByBlock.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
@@ -238,7 +239,8 @@ struct EvolutionMetavars {
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         system, volume_dim, false, use_dg_element_collection>>,
+                         system, volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
                   system, volume_dim, false, use_dg_element_collection>,

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -40,6 +40,7 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/TakeLtsStep.hpp"
 #include "Time/Actions/UpdateU.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -226,6 +227,7 @@ struct CharacteristicEvolution {
       compute_scri_quantities_and_observe,
       ::Actions::TakeLtsStep<cce_system,
                              typename Metavariables::cce_step_choosers>,
+      ::Actions::MutateApply<ChangeTimeStepperOrder<cce_system>>,
       ::Actions::CleanHistory<cce_system, false>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -17,6 +17,7 @@
 #include "Time/Actions/CleanHistory.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/Actions/TakeLtsStep.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -156,6 +157,7 @@ struct KleinGordonCharacteristicEvolution
       compute_scri_quantities_and_observe,
       ::Actions::TakeLtsStep<cce_system,
                              typename Metavariables::cce_step_choosers>,
+      ::Actions::MutateApply<ChangeTimeStepperOrder<cce_system>>,
       ::Actions::CleanHistory<cce_system, false>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.

--- a/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/CurvedScalarWave/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Characteristics.cpp
   Constraints.cpp
+  EventInstantiation.cpp
   TimeDerivative.cpp
   VolumeTermsInstantiation.cpp
   )
@@ -37,6 +38,7 @@ target_link_libraries(
   DataStructures
   Domain
   ErrorHandling
+  Events
   LinearOperators
   IO
   Importers

--- a/src/Evolution/Systems/CurvedScalarWave/EventInstantiation.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/EventInstantiation.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/CurvedScalarWave/System.hpp"
+#include "ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                      \
+  template class dg::Events::ObserveTimeStepVolume< \
+      CurvedScalarWave::System<DIM(data)>>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Characteristics.cpp
   Constraints.cpp
+  EventInstantiation.cpp
   Equations.cpp
   TimeDerivative.cpp
   VolumeTermsInstantiation.cpp
@@ -40,6 +41,7 @@ target_link_libraries(
   Domain
   DomainBoundaryConditions
   ErrorHandling
+  Events
   FunctionsOfTime
   GeneralRelativity
   GeneralRelativitySolutions
@@ -55,7 +57,6 @@ target_link_libraries(
   Spectral
   Utilities
   INTERFACE
-  Events # For observer tags
   Initialization
   Parallel
   )

--- a/src/Evolution/Systems/GeneralizedHarmonic/EventInstantiation.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/EventInstantiation.cpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data) \
+  template class dg::Events::ObserveTimeStepVolume<gh::System<DIM(data)>>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  EventInstantiation.cpp
   StressEnergy.cpp
   TimeDerivativeTerms.cpp
   VolumeTermsInstantiation.cpp

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/EventInstantiation.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/EventInstantiation.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
+#include "Evolution/Systems/RadiationTransport/NoNeutrinos/System.hpp"
+#include "ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+#define NEUTRINO(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                      \
+  template class dg::Events::ObserveTimeStepVolume< \
+      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION,
+                        (RadiationTransport::NoNeutrinos::System))
+
+#undef INSTANTIATION
+#undef NEUTRINO

--- a/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarTensor/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  EventInstantiation.cpp
   TimeDerivative.cpp
   VolumeTermsInstantiation.cpp
   )

--- a/src/Evolution/Systems/ScalarTensor/EventInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarTensor/EventInstantiation.cpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarTensor/System.hpp"
+#include "ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp"
+
+template class dg::Events::ObserveTimeStepVolume<ScalarTensor::System>;

--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -12,7 +12,6 @@ spectre_target_sources(
   ObserveConstantsPerElement.cpp
   ObserveDataBox.cpp
   ObserveNorms.cpp
-  ObserveTimeStepVolume.cpp
   )
 
 spectre_target_headers(
@@ -30,6 +29,7 @@ spectre_target_headers(
   ObserveNorms.hpp
   ObserveTimeStep.hpp
   ObserveTimeStepVolume.hpp
+  ObserveTimeStepVolume.tpp
   Tags.hpp
   )
 

--- a/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp
@@ -12,8 +12,10 @@
 #include "IO/H5/TensorData.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
 
 /// \cond
 enum class FloatingPointType;
@@ -34,17 +36,23 @@ template <size_t VolumeDim, typename Frame>
 struct MinimumGridSpacing;
 }  // namespace Tags
 }  // namespace domain
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
 namespace Parallel {
 template <typename Metavariables>
 class GlobalCache;
 }  // namespace Parallel
-namespace PUP {
-class er;
-}  // namespace PUP
 namespace Tags {
+template <typename Tag>
+struct HistoryEvolvedVariables;
 struct Time;
 struct TimeStep;
 }  // namespace Tags
+namespace TimeSteppers {
+template <typename Vars>
+class History;
+}  // namespace TimeSteppers
 /// \endcond
 
 namespace dg::Events {
@@ -60,10 +68,16 @@ namespace dg::Events {
  * - Time step
  * - Slab fraction
  * - Minimum grid spacing
+ * - Integration order
  */
-template <size_t VolumeDim>
-class ObserveTimeStepVolume : public ObserveConstantsPerElement<VolumeDim> {
+template <typename System>
+class ObserveTimeStepVolume
+    : public ObserveConstantsPerElement<System::volume_dim> {
  public:
+  static constexpr size_t volume_dim = System::volume_dim;
+  static_assert(not tt::is_a_v<tmpl::list, typename System::variables_tag>,
+                "Split variables systems not handled.");
+
   /// \cond
   explicit ObserveTimeStepVolume(CkMigrateMessage* m);
   using PUP::able::register_constructor;
@@ -71,9 +85,9 @@ class ObserveTimeStepVolume : public ObserveConstantsPerElement<VolumeDim> {
   /// \endcond
 
   static constexpr Options::String help =
-      "Observe the time step in the volume.";
+      "Observe the time step and integration order in the volume.";
 
-  ObserveTimeStepVolume() = default;
+  ObserveTimeStepVolume();
 
   ObserveTimeStepVolume(const std::string& subfile_name,
                         ::FloatingPointType coordinates_floating_point_type,
@@ -82,38 +96,46 @@ class ObserveTimeStepVolume : public ObserveConstantsPerElement<VolumeDim> {
   using compute_tags_for_observation_box = tmpl::list<>;
 
   using return_tags = tmpl::list<>;
-  using argument_tags =
-      tmpl::list<::Tags::Time, ::domain::Tags::FunctionsOfTime,
-                 ::domain::Tags::Domain<VolumeDim>, ::Tags::TimeStep,
-                 domain::Tags::MinimumGridSpacing<VolumeDim, Frame::Inertial>>;
+  using argument_tags = tmpl::list<
+      ::Tags::Time, ::domain::Tags::FunctionsOfTime,
+      ::domain::Tags::Domain<volume_dim>, ::Tags::TimeStep,
+      domain::Tags::MinimumGridSpacing<volume_dim, Frame::Inertial>,
+      ::Tags::HistoryEvolvedVariables<typename System::variables_tag>>;
 
   template <typename Metavariables, typename ParallelComponent>
-  void operator()(const double time,
-                  const std::unordered_map<
-                      std::string,
-                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-                      functions_of_time,
-                  const Domain<VolumeDim>& domain, const TimeDelta& time_step,
-                  const double minimum_grid_spacing,
-                  Parallel::GlobalCache<Metavariables>& cache,
-                  const ElementId<VolumeDim>& element_id,
-                  const ParallelComponent* const component,
-                  const Event::ObservationValue& observation_value) const {
+  void operator()(
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const Domain<volume_dim>& domain, const TimeDelta& time_step,
+      const double minimum_grid_spacing,
+      const TimeSteppers::History<typename System::variables_tag::type>&
+          history,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<volume_dim>& element_id,
+      const ParallelComponent* const component,
+      const Event::ObservationValue& observation_value) const {
     std::vector<TensorComponent> components =
         assemble_data(time, functions_of_time, domain, element_id, time_step,
-                      minimum_grid_spacing);
+                      minimum_grid_spacing, history);
 
     this->observe(components, cache, element_id, component, observation_value);
   }
 
   bool needs_evolved_variables() const override;
 
-  void pup(PUP::er& p) override;
-
  private:
   std::vector<TensorComponent> assemble_data(
-      double time, const domain::FunctionsOfTimeMap& functions_of_time,
-      const Domain<VolumeDim>& domain, const ElementId<VolumeDim>& element_id,
-      const TimeDelta& time_step, double minimum_grid_spacing) const;
+      double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const Domain<volume_dim>& domain, const ElementId<volume_dim>& element_id,
+      const TimeDelta& time_step, double minimum_grid_spacing,
+      const TimeSteppers::History<typename System::variables_tag::type>&
+          history) const;
 };
 }  // namespace dg::Events

--- a/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#pragma once
+
 #include "ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp"
 
 #include <cstddef>
@@ -13,11 +15,11 @@
 #include "DataStructures/FloatingPointType.hpp"
 #include "IO/H5/TensorData.hpp"
 #include "ParallelAlgorithms/Events/ObserveConstantsPerElement.hpp"
-#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Time/History.hpp"
 #include "Time/Time.hpp"
-#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
+/// \cond
 template <size_t VolumeDim>
 class Domain;
 template <size_t VolumeDim>
@@ -25,59 +27,54 @@ class ElementId;
 namespace domain::FunctionsOfTime {
 class FunctionOfTime;
 }  // namespace domain::FunctionsOfTime
+/// \endcond
 
 namespace dg::Events {
-template <size_t VolumeDim>
-ObserveTimeStepVolume<VolumeDim>::ObserveTimeStepVolume(
+template <typename System>
+ObserveTimeStepVolume<System>::ObserveTimeStepVolume(CkMigrateMessage* const m)
+    : ObserveConstantsPerElement<volume_dim>(m) {}
+
+template <typename System>
+ObserveTimeStepVolume<System>::ObserveTimeStepVolume() = default;
+
+template <typename System>
+ObserveTimeStepVolume<System>::ObserveTimeStepVolume(
     const std::string& subfile_name,
     const ::FloatingPointType coordinates_floating_point_type,
     const ::FloatingPointType floating_point_type)
-    : ObserveConstantsPerElement<VolumeDim>(
+    : ObserveConstantsPerElement<volume_dim>(
           subfile_name, coordinates_floating_point_type, floating_point_type) {}
 
-template <size_t VolumeDim>
-ObserveTimeStepVolume<VolumeDim>::ObserveTimeStepVolume(CkMigrateMessage* m)
-    : ObserveConstantsPerElement<VolumeDim>(m) {}
-
-template <size_t VolumeDim>
-bool ObserveTimeStepVolume<VolumeDim>::needs_evolved_variables() const {
+template <typename System>
+bool ObserveTimeStepVolume<System>::needs_evolved_variables() const {
   return false;
 }
 
-template <size_t VolumeDim>
-void ObserveTimeStepVolume<VolumeDim>::pup(PUP::er& p) {
-  ObserveConstantsPerElement<VolumeDim>::pup(p);
-}
-
-template <size_t VolumeDim>
-std::vector<TensorComponent> ObserveTimeStepVolume<VolumeDim>::assemble_data(
+template <typename System>
+std::vector<TensorComponent> ObserveTimeStepVolume<System>::assemble_data(
     const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time,
-    const Domain<VolumeDim>& domain, const ElementId<VolumeDim>& element_id,
-    const TimeDelta& time_step, const double minimum_grid_spacing) const {
+    const Domain<volume_dim>& domain, const ElementId<volume_dim>& element_id,
+    const TimeDelta& time_step, const double minimum_grid_spacing,
+    const TimeSteppers::History<typename System::variables_tag::type>& history)
+    const {
   std::vector<TensorComponent> components = this->allocate_and_insert_coords(
-      3, time, functions_of_time, domain, element_id);
+      4, time, functions_of_time, domain, element_id);
   this->add_constant(make_not_null(&components), "Time step",
                      time_step.value());
   this->add_constant(make_not_null(&components), "Slab fraction",
                      time_step.fraction().value());
   this->add_constant(make_not_null(&components), "Minimum grid spacing",
                      minimum_grid_spacing);
-
+  this->add_constant(make_not_null(&components), "Integration order",
+                     static_cast<double>(history.integration_order()));
   return components;
 }
 
-template <size_t VolumeDim>
-PUP::able::PUP_ID ObserveTimeStepVolume<VolumeDim>::my_PUP_ID = 0;  // NOLINT
-
-#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-
-#define INSTANTIATE(_, data) template class ObserveTimeStepVolume<DIM(data)>;
-
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
-
-#undef INSTANTIATE
-#undef DIM
+/// \cond
+template <typename System>
+PUP::able::PUP_ID ObserveTimeStepVolume<System>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
 }  // namespace dg::Events

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -23,6 +23,7 @@ spectre_target_sources(
   TimeStepRequest.cpp
   TimeStepRequestProcessor.cpp
   Utilities.cpp
+  VariableOrderAlgorithm.cpp
   )
 
 spectre_target_headers(
@@ -33,6 +34,7 @@ spectre_target_headers(
   ApproximateTime.hpp
   BoundaryHistory.hpp
   ChangeStepSize.hpp
+  ChangeTimeStepperOrder.hpp
   ChooseLtsStepSize.hpp
   EvolutionOrdering.hpp
   History.hpp
@@ -48,6 +50,7 @@ spectre_target_headers(
   TimeStepRequest.hpp
   TimeStepRequestProcessor.hpp
   Utilities.hpp
+  VariableOrderAlgorithm.hpp
   )
 
 target_link_libraries(

--- a/src/Time/ChangeTimeStepperOrder.hpp
+++ b/src/Time/ChangeTimeStepperOrder.hpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/TaggedVariant.hpp"
+#include "Time/History.hpp"
+#include "Time/StepperErrorEstimate.hpp"
+#include "Time/Tags/VariableOrderAlgorithm.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/VariableOrderAlgorithm.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct HistoryEvolvedVariables;
+template <typename Tag>
+struct Next;
+template <typename Tag>
+struct StepperErrors;
+struct TimeStepId;
+template <typename StepperInterface>
+struct TimeStepper;
+}  // namespace Tags
+/// \endcond
+
+namespace ChangeTimeStepperOrder_detail {
+// Doxygen is confused by the self-inheritance, even though this is in
+// a detail namespace.
+/// \cond
+template <typename VariablesTag>
+struct apply_impl : apply_impl<tmpl::list<VariablesTag>> {};
+
+template <typename... VariablesTags>
+struct apply_impl<tmpl::list<VariablesTags...>> {
+  static void apply(
+      const gsl::not_null<
+          TimeSteppers::History<typename VariablesTags::type>*>... histories,
+      const TimeStepper& time_stepper,
+      const VariableOrderAlgorithm& order_algorithm,
+      const TimeStepId& next_time_step_id,
+      const typename tmpl::has_type<
+          VariablesTags, std::array<std::optional<StepperErrorEstimate>,
+                                    2>>::type&... errors) {
+    if (next_time_step_id.substep() != 0) {
+      return;
+    }
+
+    const auto order_variant = time_stepper.order();
+    const auto* stepper_order =
+        variants::get_if<TimeSteppers::Tags::VariableOrder>(&order_variant);
+    if (stepper_order == nullptr) {
+      // Running at fixed order.
+      return;
+    }
+
+    const size_t new_order =
+        std::clamp(order_algorithm.template choose_order<VariablesTags...>(
+                       *histories..., errors...),
+                   stepper_order->minimum, stepper_order->maximum);
+
+    expand_pack((histories->integration_order(new_order), 0)...);
+  }
+};
+/// \endcond
+}  // namespace ChangeTimeStepperOrder_detail
+
+/*!
+ * \ingroup TimeGroup
+ * \brief Adjust the step order for local time-stepping
+ *
+ * \details See VariableOrderAlgorithm for descriptions of the
+ * algorithms.  This mutator wraps that class, checking that the order
+ * is not changed out of the valid range for the time stepper.
+ */
+template <typename System>
+struct ChangeTimeStepperOrder : ChangeTimeStepperOrder_detail::apply_impl<
+                                    typename System::variables_tag> {
+  using variables_tags = tmpl::conditional_t<
+      tt::is_a_v<tmpl::list, typename System::variables_tag>,
+      typename System::variables_tag,
+      tmpl::list<typename System::variables_tag>>;
+
+  using const_global_cache_tags = tmpl::list<Tags::VariableOrderAlgorithm>;
+  using return_tags =
+      tmpl::transform<variables_tags,
+                      tmpl::bind<Tags::HistoryEvolvedVariables, tmpl::_1>>;
+  using argument_tags = tmpl::append<
+      tmpl::list<Tags::TimeStepper<TimeStepper>, Tags::VariableOrderAlgorithm,
+                 Tags::Next<Tags::TimeStepId>>,
+      tmpl::transform<variables_tags,
+                      tmpl::bind<Tags::StepperErrors, tmpl::_1>>>;
+
+  // apply defined in apply_impl above
+};

--- a/src/Time/OptionTags/CMakeLists.txt
+++ b/src/Time/OptionTags/CMakeLists.txt
@@ -11,4 +11,5 @@ spectre_target_headers(
   MinimumTimeStep.hpp
   StepChoosers.hpp
   TimeStepper.hpp
+  VariableOrderAlgorithm.hpp
   )

--- a/src/Time/OptionTags/VariableOrderAlgorithm.hpp
+++ b/src/Time/OptionTags/VariableOrderAlgorithm.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Tags.hpp"
+#include "Options/String.hpp"
+#include "Time/VariableOrderAlgorithm.hpp"
+
+namespace OptionTags {
+/// \ingroup OptionTagsGroup
+/// \ingroup TimeGroup
+/// \brief Algorithm for changing the time-stepper order in a
+/// variable-order evolution.
+/// \see ChangeTimeStepperOrder
+struct VariableOrderAlgorithm {
+  using type = ::VariableOrderAlgorithm;
+  static constexpr Options::String help =
+      "Algorithm for changing the time-stepper order in a variable-order "
+      "evolution.";
+  using group = evolution::OptionTags::Group;
+};
+}  // namespace OptionTags

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/TaggedVariant.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
@@ -25,7 +26,10 @@
 #include "Time/Tags/StepperErrorTolerances.hpp"
 #include "Time/Tags/StepperErrors.hpp"
 #include "Time/TimeStepRequest.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/VariableOrderAlgorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -39,6 +43,9 @@ struct IsUsingTimeSteppingErrorControlCompute;
 struct StepChoosers;
 template <typename EvolvedVariableTag, bool LocalTimeStepping>
 struct StepperErrorTolerancesCompute;
+template <typename StepperInterface>
+struct TimeStepper;
+struct VariableOrderAlgorithm;
 }  // namespace Tags
 /// \endcond
 
@@ -343,7 +350,9 @@ struct StepperErrorTolerancesCompute
   using base = StepperErrorTolerances<EvolvedVariableTag>;
   using return_type = typename base::type;
   using argument_tags = tmpl::conditional_t<
-      LocalTimeStepping, tmpl::list<::Tags::StepChoosers>,
+      LocalTimeStepping,
+      tmpl::list<::Tags::StepChoosers, ::Tags::TimeStepper<::TimeStepper>,
+                 ::Tags::VariableOrderAlgorithm>,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 
   // local time stepping
@@ -351,10 +360,22 @@ struct StepperErrorTolerancesCompute
       const gsl::not_null<::StepperErrorTolerances*> tolerances,
       const std::vector<
           std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
-          step_choosers) {
+          step_choosers,
+      const ::TimeStepper& time_stepper,
+      const ::VariableOrderAlgorithm& variable_order_algorithm) {
     *tolerances = ::StepperErrorTolerances{};
     for (const auto& step_chooser : step_choosers) {
       set_tolerances_if_error_control(tolerances, *step_chooser);
+    }
+    // Error-based variable-order requires some variable to be
+    // controlled using error control, but in a split-variable system
+    // a different variable might be controlled, so no control on this
+    // variable is not an error.
+    if (tolerances->estimates != ::StepperErrorTolerances::Estimates::None and
+        variants::holds_alternative<TimeSteppers::Tags::VariableOrder>(
+            time_stepper.order())) {
+      tolerances->estimates = std::max(
+          tolerances->estimates, variable_order_algorithm.required_estimates());
     }
   }
 

--- a/src/Time/Tags/CMakeLists.txt
+++ b/src/Time/Tags/CMakeLists.txt
@@ -19,4 +19,5 @@ spectre_target_headers(
   TimeStep.hpp
   TimeStepId.hpp
   TimeStepper.hpp
+  VariableOrderAlgorithm.hpp
   )

--- a/src/Time/Tags/TimeStepper.hpp
+++ b/src/Time/Tags/TimeStepper.hpp
@@ -4,11 +4,19 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/TaggedVariant.hpp"
 #include "Time/OptionTags/TimeStepper.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
+
+/// \cond
+class LtsTimeStepper;
+/// \endcond
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
@@ -28,6 +36,13 @@ struct ConcreteTimeStepper : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   static std::unique_ptr<StepperType> create_from_options(
       const std::unique_ptr<StepperType>& time_stepper) {
+    if (not std::is_same_v<StepperType, LtsTimeStepper> and
+        variants::holds_alternative<TimeSteppers::Tags::VariableOrder>(
+            time_stepper->order())) {
+      ERROR_NO_TRACE(
+          "Variable-order TimeSteppers are only supported in evolutions with "
+          "local time-stepping.");
+    }
     return deserialize<type>(serialize<type>(time_stepper).data());
   }
 };

--- a/src/Time/Tags/VariableOrderAlgorithm.hpp
+++ b/src/Time/Tags/VariableOrderAlgorithm.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Time/OptionTags/VariableOrderAlgorithm.hpp"
+#include "Time/VariableOrderAlgorithm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup TimeGroup
+/// \brief Algorithm for changing the time-stepper order in a
+/// variable-order evolution.
+/// \see ChangeTimeStepperOrder
+struct VariableOrderAlgorithm : db::SimpleTag {
+  using type = ::VariableOrderAlgorithm;
+  using option_tags = tmpl::list<::OptionTags::VariableOrderAlgorithm>;
+  static constexpr bool is_overlayable = true;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& option) { return option; }
+};
+}  // namespace Tags

--- a/src/Time/TimeSteppers/AdamsBashforth.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "DataStructures/TaggedVariant.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "Time/StepperErrorEstimate.hpp"
@@ -202,10 +203,8 @@ class AdamsBashforth : public LtsTimeStepper {
   static constexpr const size_t maximum_order = 8;
 
   struct Order {
-    using type = size_t;
+    using type = Options::Auto<size_t>;
     static constexpr Options::String help = {"Convergence order"};
-    static type lower_bound() { return 1; }
-    static type upper_bound() { return maximum_order; }
   };
   using options = tmpl::list<Order>;
   static constexpr Options::String help = {

--- a/src/Time/TimeSteppers/AdamsMoultonPc.hpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "DataStructures/TaggedVariant.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "Time/StepperErrorEstimate.hpp"
@@ -104,10 +105,8 @@ class AdamsMoultonPc : public LtsTimeStepper {
   static constexpr size_t maximum_order = 8;
 
   struct Order {
-    using type = size_t;
+    using type = Options::Auto<size_t>;
     static constexpr Options::String help = {"Convergence order"};
-    static type lower_bound() { return minimum_order; }
-    static type upper_bound() { return maximum_order; }
   };
   using options = tmpl::list<Order>;
   static constexpr Options::String help =

--- a/src/Time/VariableOrderAlgorithm.cpp
+++ b/src/Time/VariableOrderAlgorithm.cpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Time/VariableOrderAlgorithm.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <pup.h>
+
+#include "Time/StepperErrorEstimate.hpp"
+#include "Time/StepperErrorTolerances.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+
+VariableOrderAlgorithm::VariableOrderAlgorithm() = default;
+
+VariableOrderAlgorithm::VariableOrderAlgorithm(const size_t goal_order)
+    : goal_order_(goal_order) {}
+
+VariableOrderAlgorithm::VariableOrderAlgorithm(const double order_falloff)
+    : order_falloff_(order_falloff) {}
+
+StepperErrorTolerances::Estimates VariableOrderAlgorithm::required_estimates()
+    const {
+  return order_falloff_.has_value()
+             ? StepperErrorTolerances::Estimates::AllOrders
+             : StepperErrorTolerances::Estimates::None;
+}
+
+void VariableOrderAlgorithm::pup(PUP::er& p) {
+  p | goal_order_;
+  p | order_falloff_;
+}
+
+size_t VariableOrderAlgorithm::choose_order_goal(
+    const size_t current_order) const {
+  if (current_order == goal_order_.value()) {
+    return current_order;
+  } else if (current_order < goal_order_.value()) {
+    return current_order + 1;
+  } else {
+    return current_order - 1;
+  }
+}
+
+namespace {
+template <size_t NVars>
+double largest_error(
+    const std::array<const std::optional<StepperErrorEstimate>*, NVars>& errors,
+    const size_t order) {
+  double order_error = -std::numeric_limits<double>::infinity();
+  for (const auto* error : errors) {
+    if (error->has_value()) {
+      order_error = std::max(order_error,
+                             gsl::at(error->value().errors, order - 1).value());
+    }
+  }
+
+  if (order_error == -std::numeric_limits<double>::infinity()) {
+    ERROR_NO_TRACE(
+        "OrderFalloff only implemented with error-based adaptive time "
+        "stepping.");
+  }
+
+  return order_error;
+}
+}  // namespace
+
+template <size_t NVars>
+size_t VariableOrderAlgorithm::choose_order_falloff(
+    const size_t current_order,
+    const std::array<const std::optional<StepperErrorEstimate>*, NVars>& errors)
+    const {
+  double prev_error = largest_error(errors, 1);
+  double best_convergence = 1.0;
+  for (size_t order = 2; order < current_order; ++order) {
+    const double error = largest_error(errors, order);
+    const double convergence = error / prev_error;
+    if (convergence > std::pow(best_convergence, order_falloff_.value())) {
+      return current_order - 1;
+    }
+    prev_error = error;
+    best_convergence = std::min(best_convergence, convergence);
+  }
+
+  const double current_error = largest_error(errors, current_order);
+
+  const double current_convergence = current_error / prev_error;
+  if (current_convergence >
+      std::pow(best_convergence, order_falloff_.value())) {
+    return current_order;
+  }
+
+  return current_order + 1;
+}
+
+bool operator==(const VariableOrderAlgorithm& a,
+                const VariableOrderAlgorithm& b) {
+  return a.goal_order_ == b.goal_order_ and
+         a.order_falloff_ == b.order_falloff_;
+}
+
+#define NVARS(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template size_t VariableOrderAlgorithm::choose_order_falloff(    \
+      size_t current_order,                                        \
+      const std::array<const std::optional<StepperErrorEstimate>*, \
+                       NVARS(data)>& errors) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2))
+
+#undef INSTATNTIATE
+#undef NVARS

--- a/src/Time/VariableOrderAlgorithm.hpp
+++ b/src/Time/VariableOrderAlgorithm.hpp
@@ -1,0 +1,126 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Tests for the VariableOrderAlgorithm class are performed in
+// Test_ChangeTimeStepperOrder.cpp.  The class is split into this file
+// to avoid include loops with the associated tags.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include "Options/String.hpp"
+#include "Time/History.hpp"
+#include "Time/StepperErrorEstimate.hpp"
+#include "Time/StepperErrorTolerances.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Options {
+template <typename... AlternativeLists>
+struct Alternatives;
+}  // namespace Options
+/// \endcond
+
+/*!
+ * \ingroup TimeGroup
+ * \brief Class encapsulating the time-stepper order changing algorithms
+ *
+ * \details Supports two modes: driving the order to a specified constant, and
+ * measuring the convergence of the error estimates.
+ *
+ * When driving to a constant, the order is changed by one towards the
+ * goal if it is not at the goal.
+ *
+ * When measuring convergence, let the relative error estimate from
+ * the time stepper for order-$k$ integration be $e_k$, and $\lambda
+ * \le 1$ be the falloff this class was constructed with.  Then, we
+ * decrease the order by one if, for any $k \ge 2$ and less than the
+ * current integration order,
+ *
+ * \f{equation}
+ *   \frac{e_k}{e_{k-1}} >
+ *   \left(\min_{2 \le j < k} \frac{e_j}{e_{j-1}}\right)^\lambda,
+ * \f}
+ *
+ * with the right-hand side taken to be $1$ for $k = 2$.  If the order
+ * is not decreased, it is kept the same if the above condition holds
+ * for $k$ equal to the current integration order, and is increased by
+ * one otherwise.  If the current integration order is $1$ (not
+ * possible for predictor-corrector methods), it is always increased.
+ * This algorithm will almost never prefer an integration order less
+ * than three.
+ *
+ * \note This is currently all implemented in one class for simplicity
+ * with dealing with templates.  If we add more algorithms splitting
+ * into a base class with implementations would be appropriate.
+ */
+class VariableOrderAlgorithm {
+ public:
+  struct GoalOrder {
+    using type = size_t;
+    static constexpr Options::String help = "Order to drive the integrator to.";
+  };
+
+  struct OrderFalloff {
+    using type = double;
+    static constexpr Options::String help =
+        "Threshold for changing time-stepper order, as a logarithmic "
+        "fraction of the best order-to-order improvement.";
+  };
+
+  using options = tmpl::list<
+      Options::Alternatives<tmpl::list<GoalOrder>, tmpl::list<OrderFalloff>>>;
+  static constexpr Options::String help =
+      "Algorithm for choosing the time-stepper order in a variable-order "
+      "evolution.";
+
+  VariableOrderAlgorithm();
+  explicit VariableOrderAlgorithm(size_t goal_order);
+  explicit VariableOrderAlgorithm(double order_falloff);
+
+  StepperErrorTolerances::Estimates required_estimates() const;
+
+  template <typename... VariablesTags>
+  size_t choose_order(
+      const TimeSteppers::History<typename VariablesTags::type>&... histories,
+      const typename tmpl::has_type<
+          VariablesTags,
+          std::array<std::optional<StepperErrorEstimate>, 2>>::type&... errors)
+      const {
+    const auto history_order =
+        get_first_argument(histories...).integration_order();
+    ASSERT((... and (history_order == histories.integration_order())),
+           "Multiple histories with different integration orders.");
+
+    if (goal_order_.has_value()) {
+      ASSERT(not order_falloff_.has_value(),
+             "Internal error: should not have multiple algorithms active");
+      return choose_order_goal(history_order);
+    } else {
+      ASSERT(order_falloff_.has_value(),
+             "VariableOrderAlgorithm not initialized");
+      return choose_order_falloff(history_order, std::array{&errors[1]...});
+    }
+  }
+
+  void pup(PUP::er& p);
+
+ private:
+  size_t choose_order_goal(size_t current_order) const;
+
+  template <size_t NVars>
+  size_t choose_order_falloff(
+      size_t current_order,
+      const std::array<const std::optional<StepperErrorEstimate>*, NVars>&
+          errors) const;
+
+  friend bool operator==(const VariableOrderAlgorithm& a,
+                         const VariableOrderAlgorithm& b);
+
+  std::optional<size_t> goal_order_{};
+  std::optional<double> order_falloff_{};
+};

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -204,6 +204,8 @@ Evolution:
   # you need it smaller you can edit it, but make sure to change the slab
   # intervals in the EventsAndTriggersAtSlabs
   InitialSlabSize: 0.1
+  VariableOrderAlgorithm:
+    GoalOrder: 4
   StepChoosers:
     - LimitIncrease:
         Factor: 2

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -89,6 +89,8 @@ Evolution:
   # This is the smallest interval we'd need to observe time step/constraints. If
   # you would like more frequent output, consider using dense output.
   InitialSlabSize: 0.1
+  VariableOrderAlgorithm:
+    GoalOrder: 4
   StepChoosers:
     - LimitIncrease:
         Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -21,6 +21,8 @@ Evolution:
   InitialTimeStep: 0.01
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -21,6 +21,8 @@ Evolution:
   InitialTimeStep: 0.1
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -21,6 +21,8 @@ Evolution:
   InitialTimeStep: 0.1
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -21,6 +21,8 @@ Evolution:
   InitialTimeStep: 0.1
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.6
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -21,6 +21,8 @@ Evolution:
   InitialTimeStep: 0.1
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -21,6 +21,8 @@ Evolution:
   InitialTimeStep: 0.1
   MinimumTimeStep: 1e-7
   InitialSlabSize: 1.0
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
@@ -66,6 +66,8 @@ Evolution:
   InitialTimeStep: 0.01
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -30,6 +30,8 @@ Evolution:
   InitialTimeStep: 0.01
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -18,6 +18,8 @@ Evolution:
   # The initial Slab size controls how often the EventsAndTriggers are run. They
   # are run once per Slab.
   InitialSlabSize: 10.0
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   # Can ignore this section since CCE performs best on a single core.

--- a/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
@@ -18,6 +18,8 @@ Evolution:
   # The initial Slab size controls how often the EventsAndTriggers are run. They
   # are run once per Slab.
   InitialSlabSize: 10.0
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 ResourceInfo:
   # Can ignore this section since CCE performs best on a single core.

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -33,6 +33,8 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.01
+  VariableOrderAlgorithm:
+    GoalOrder: 3
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -33,6 +33,8 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.01
+  VariableOrderAlgorithm:
+    GoalOrder: 3
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -48,6 +48,8 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.01
+  VariableOrderAlgorithm:
+    GoalOrder: 3
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -20,6 +20,8 @@ Evolution:
   InitialTimeStep: 0.0002
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.25
+  VariableOrderAlgorithm:
+    GoalOrder: 3
   StepChoosers:
     - LimitIncrease:
         Factor: 2

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -33,6 +33,8 @@ Evolution:
   # slab size for evolutions would be 0.1 to observe constraints. If you would
   # like more frequent output, consider using dense output.
   InitialSlabSize: 0.001
+  VariableOrderAlgorithm:
+    GoalOrder: 4
   StepChoosers:
     - LimitIncrease:
         Factor: 2

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -28,6 +28,8 @@ Evolution:
     AdamsBashforth:
       Order: 3
   InitialSlabSize: 0.001
+  VariableOrderAlgorithm:
+    GoalOrder: 3
   StepChoosers:
     - LimitIncrease:
         Factor: 2

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -114,7 +114,7 @@ struct Metavariables {
   using component_list = tmpl::list<ElementComponent<Metavariables>,
                                     MockObserverComponent<Metavariables>>;
   using const_global_cache_tags =
-      tmpl::list<Tags::AnalyticSolution<typename System::solution_for_test>>;
+      tmpl::list<::Tags::AnalyticSolution<typename System::solution_for_test>>;
   using initial_data =
       tmpl::conditional_t<HasAnalyticSolution,
                           typename System::solution_for_test, NoSuchType>;

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveTimeStepVolume.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
@@ -29,16 +30,19 @@
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/TestTags.hpp"
 #include "Helpers/ParallelAlgorithms/Events/ObserveFields.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/ArrayComponentId.hpp"
 #include "Parallel/Tags/Metavariables.hpp"
 #include "ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp"
+#include "ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Time/Slab.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStep.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -54,10 +58,17 @@ struct Inertial;
 }  // namespace Frame
 
 namespace {
+template <size_t VolumeDim>
+struct System {
+  constexpr static size_t volume_dim = VolumeDim;
+  using variables_tag =
+      Tags::Variables<tmpl::list<TestHelpers::Tags::Vector<>>>;
+};
 
 template <size_t VolumeDim>
 struct Metavariables {
   static constexpr size_t volume_dim = VolumeDim;
+  using system = System<volume_dim>;
   using component_list = tmpl::list<
       TestHelpers::dg::Events::ObserveFields::ElementComponent<Metavariables>,
       TestHelpers::dg::Events::ObserveFields::MockObserverComponent<
@@ -67,7 +78,7 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<Event,
-                   tmpl::list<dg::Events::ObserveTimeStepVolume<VolumeDim>>>,
+                   tmpl::list<dg::Events::ObserveTimeStepVolume<system>>>,
         tmpl::pair<Trigger, tmpl::list<Triggers::Always>>>;
   };
 };
@@ -102,6 +113,7 @@ void test() {
 
   const double time = 3.0;
   const auto time_step = Slab(4.0, 6.0).duration() / 4;
+  const size_t integration_order = 5;
 
   Domain domain(make_vector(
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
@@ -120,13 +132,17 @@ void test() {
           4.0));
   const double expected_offset = 2.0 + (time - 1.0) * 5.0;
 
+  using history_tag =
+      ::Tags::HistoryEvolvedVariables<typename metavars::system::variables_tag>;
+
   auto box = db::create<db::AddSimpleTags<
       Parallel::Tags::MetavariablesImpl<metavars>, Tags::Time,
       domain::Tags::FunctionsOfTime, domain::Tags::Domain<VolumeDim>,
       Tags::TimeStep,
-      domain::Tags::MinimumGridSpacing<VolumeDim, Frame::Inertial>>>(
-      metavars{}, time, std::move(functions_of_time), std::move(domain),
-      time_step, 0.23);
+      domain::Tags::MinimumGridSpacing<VolumeDim, Frame::Inertial>,
+      history_tag>>(metavars{}, time, std::move(functions_of_time),
+                    std::move(domain), time_step, 0.23,
+                    typename history_tag::type{integration_order});
 
   const double observation_value = 1.23;
 
@@ -148,7 +164,7 @@ void test() {
   CHECK(results.received_volume_data.extents ==
         std::vector<size_t>(VolumeDim, 2));
   const auto& components = results.received_volume_data.tensor_components;
-  REQUIRE(components.size() == VolumeDim + 3);
+  REQUIRE(components.size() == VolumeDim + 4);
   for (const auto& component : components) {
     std::visit(
         [](const auto& data) { CHECK(data.size() == two_to_the(VolumeDim)); },
@@ -211,6 +227,14 @@ void test() {
         }
       },
       components[VolumeDim + 2].data);
+  CHECK(components[VolumeDim + 3].name == "Integration order");
+  std::visit(
+      [&](const auto& data) {
+        for (size_t i = 0; i < data.size(); ++i) {
+          CHECK(data[i] == integration_order);
+        }
+      },
+      components[VolumeDim + 3].data);
 }
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Events.ObserveTimeStepVolume",

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ApproximateTime.cpp
   Test_BoundaryHistory.cpp
   Test_ChangeStepSize.cpp
+  Test_ChangeTimeStepperOrder.cpp
   Test_ChooseLtsStepSize.cpp
   Test_EvolutionOrdering.cpp
   Test_History.cpp
@@ -39,6 +40,7 @@ target_link_libraries(
   PRIVATE
   CoordinateMaps
   DataStructures
+  DataStructuresHelpers
   Domain
   DomainStructure
   Evolution

--- a/tests/Unit/Time/OptionTags/CMakeLists.txt
+++ b/tests/Unit/Time/OptionTags/CMakeLists.txt
@@ -9,4 +9,5 @@ set(LIBRARY_SOURCES
   OptionTags/Test_MinimumTimeStep.cpp
   OptionTags/Test_StepChoosers.cpp
   OptionTags/Test_TimeStepper.cpp
+  OptionTags/Test_VariableOrderAlgorithm.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Time/OptionTags/Test_VariableOrderAlgorithm.cpp
+++ b/tests/Unit/Time/OptionTags/Test_VariableOrderAlgorithm.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Framework/TestCreation.hpp"
+#include "Time/OptionTags/VariableOrderAlgorithm.hpp"
+#include "Time/VariableOrderAlgorithm.hpp"
+#include "Utilities/Literals.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.OptionTags.VariableOrderAlgorithm",
+                  "[Unit][Time]") {
+  CHECK(TestHelpers::test_option_tag<OptionTags::VariableOrderAlgorithm>(
+            "GoalOrder: 4") == VariableOrderAlgorithm(4_st));
+}

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -38,7 +38,12 @@
 #include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/StepperErrorTolerances.hpp"
 #include "Time/Tags/StepperErrors.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/Tags/VariableOrderAlgorithm.hpp"
 #include "Time/TimeStepRequest.hpp"
+#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/LtsTimeStepper.hpp"
+#include "Time/VariableOrderAlgorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -264,160 +269,198 @@ void test_tags() {
 
   {
     INFO("Compute tag LTS test");
+    const auto test_lts_tags = [](const auto box, const bool all_orders) {
+      const auto expected_estimates =
+          all_orders ? StepperErrorTolerances::Estimates::AllOrders
+                     : StepperErrorTolerances::Estimates::StepperOrder;
+
+      db::mutate<Tags::StepChoosers>(
+          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
+            *choosers =
+                TestHelpers::test_creation<typename Tags::StepChoosers::type,
+                                           Metavariables<true, true>>(
+                    "- ErrorControl:\n"
+                    "    SafetyFactor: 0.95\n"
+                    "    AbsoluteTolerance: 1.0e-5\n"
+                    "    RelativeTolerance: 1.0e-4\n"
+                    "    MaxFactor: 2.1\n"
+                    "    MinFactor: 0.5\n"
+                    "- LimitIncrease:\n"
+                    "    Factor: 2\n"
+                    "- Constant: 0.5");
+          },
+          box);
+      CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(*box));
+      CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(*box) ==
+            StepperErrorTolerances{.estimates = expected_estimates,
+                                   .absolute = 1.0e-5,
+                                   .relative = 1.0e-4});
+      CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
+                .estimates == StepperErrorTolerances::Estimates::None);
+
+      db::mutate<Tags::StepChoosers>(
+          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
+            *choosers =
+                TestHelpers::test_creation<typename Tags::StepChoosers::type,
+                                           Metavariables<true, true>>(
+                    "- LimitIncrease:\n"
+                    "    Factor: 2\n"
+                    "- Constant: 0.5");
+          },
+          box);
+      CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(*box));
+      CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(*box)
+                .estimates == StepperErrorTolerances::Estimates::None);
+      CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
+                .estimates == StepperErrorTolerances::Estimates::None);
+
+      db::mutate<Tags::StepChoosers>(
+          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
+            *choosers =
+                TestHelpers::test_creation<typename Tags::StepChoosers::type,
+                                           Metavariables<true, true>>("");
+          },
+          box);
+      CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(*box));
+      CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(*box)
+                .estimates == StepperErrorTolerances::Estimates::None);
+      CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
+                .estimates == StepperErrorTolerances::Estimates::None);
+
+      db::mutate<Tags::StepChoosers>(
+          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
+            *choosers =
+                TestHelpers::test_creation<typename Tags::StepChoosers::type,
+                                           Metavariables<true, true>>(
+                    "- ErrorControl:\n"
+                    "    SafetyFactor: 0.95\n"
+                    "    AbsoluteTolerance: 1.0e-5\n"
+                    "    RelativeTolerance: 1.0e-4\n"
+                    "    MaxFactor: 2.1\n"
+                    "    MinFactor: 0.5\n"
+                    "- ErrorControl:\n"
+                    "    SafetyFactor: 0.8\n"
+                    "    AbsoluteTolerance: 1.0e-5\n"
+                    "    RelativeTolerance: 1.0e-4\n"
+                    "    MaxFactor: 1.1\n"
+                    "    MinFactor: 0.1\n"
+                    "- LimitIncrease:\n"
+                    "    Factor: 2\n"
+                    "- Constant: 0.5");
+          },
+          box);
+      CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(*box));
+      CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(*box) ==
+            StepperErrorTolerances{.estimates = expected_estimates,
+                                   .absolute = 1.0e-5,
+                                   .relative = 1.0e-4});
+      CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
+                .estimates == StepperErrorTolerances::Estimates::None);
+
+      db::mutate<Tags::StepChoosers>(
+          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
+            *choosers =
+                TestHelpers::test_creation<typename Tags::StepChoosers::type,
+                                           Metavariables<true, true>>(
+                    "- ErrorControl:\n"
+                    "    SafetyFactor: 0.95\n"
+                    "    AbsoluteTolerance: 1.0e-5\n"
+                    "    RelativeTolerance: 1.0e-4\n"
+                    "    MaxFactor: 2.1\n"
+                    "    MinFactor: 0.5\n"
+                    "- ErrorControl(SelectorLabel):\n"
+                    "    SafetyFactor: 0.8\n"
+                    "    AbsoluteTolerance: 1.0e-5\n"
+                    "    RelativeTolerance: 1.0e-8\n"
+                    "    MaxFactor: 1.1\n"
+                    "    MinFactor: 0.1\n"
+                    "- LimitIncrease:\n"
+                    "    Factor: 2\n"
+                    "- Constant: 0.5");
+          },
+          box);
+      CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(*box));
+      CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(*box) ==
+            StepperErrorTolerances{.estimates = expected_estimates,
+                                   .absolute = 1.0e-5,
+                                   .relative = 1.0e-4});
+      CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(
+                *box) == StepperErrorTolerances{.estimates = expected_estimates,
+                                                .absolute = 1.0e-5,
+                                                .relative = 1.0e-8});
+
+      db::mutate<Tags::StepChoosers>(
+          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
+            *choosers =
+                TestHelpers::test_creation<typename Tags::StepChoosers::type,
+                                           Metavariables<true, true>>(
+                    "- ErrorControl:\n"
+                    "    SafetyFactor: 0.95\n"
+                    "    AbsoluteTolerance: 1.0e-5\n"
+                    "    RelativeTolerance: 1.0e-4\n"
+                    "    MaxFactor: 2.1\n"
+                    "    MinFactor: 0.5\n"
+                    "- ErrorControl:\n"
+                    "    SafetyFactor: 0.8\n"
+                    "    AbsoluteTolerance: 1.0e-5\n"
+                    "    RelativeTolerance: 1.0e-8\n"
+                    "    MaxFactor: 1.1\n"
+                    "    MinFactor: 0.1\n"
+                    "- LimitIncrease:\n"
+                    "    Factor: 2\n"
+                    "- Constant: 0.5");
+          },
+          box);
+      CHECK_THROWS_WITH(
+          db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(*box),
+          Catch::Matchers::ContainsSubstring("All ErrorControl events for ") and
+              Catch::Matchers::ContainsSubstring("EvolvedVar1") and
+              Catch::Matchers::ContainsSubstring(
+                  " must use the same tolerances."));
+    };
+
     auto box = db::create<
-        db::AddSimpleTags<Tags::StepChoosers>,
-        db::AddComputeTags<
+        db::AddSimpleTags<Tags::StepChoosers,
+                          Tags::ConcreteTimeStepper<LtsTimeStepper>,
+                          Tags::VariableOrderAlgorithm>,
+        tmpl::push_back<
+            time_stepper_ref_tags<LtsTimeStepper>,
             Tags::IsUsingTimeSteppingErrorControlCompute<true>,
             Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag, true>,
             Tags::StepperErrorTolerancesCompute<AltEvolvedVariablesTag,
                                                 true>>>();
-    db::mutate<Tags::StepChoosers>(
-        [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-          *choosers =
-              TestHelpers::test_creation<typename Tags::StepChoosers::type,
-                                         Metavariables<true, true>>(
-                  "- ErrorControl:\n"
-                  "    SafetyFactor: 0.95\n"
-                  "    AbsoluteTolerance: 1.0e-5\n"
-                  "    RelativeTolerance: 1.0e-4\n"
-                  "    MaxFactor: 2.1\n"
-                  "    MinFactor: 0.5\n"
-                  "- LimitIncrease:\n"
-                  "    Factor: 2\n"
-                  "- Constant: 0.5");
-        },
-        make_not_null(&box));
-    CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
-    CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(box) ==
-          StepperErrorTolerances{
-              .estimates = StepperErrorTolerances::Estimates::StepperOrder,
-              .absolute = 1.0e-5,
-              .relative = 1.0e-4});
-    CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box)
-              .estimates == StepperErrorTolerances::Estimates::None);
 
-    db::mutate<Tags::StepChoosers>(
-        [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-          *choosers =
-              TestHelpers::test_creation<typename Tags::StepChoosers::type,
-                                         Metavariables<true, true>>(
-                  "- LimitIncrease:\n"
-                  "    Factor: 2\n"
-                  "- Constant: 0.5");
+    db::mutate<Tags::ConcreteTimeStepper<LtsTimeStepper>,
+               Tags::VariableOrderAlgorithm>(
+        [](const gsl::not_null<std::unique_ptr<LtsTimeStepper>*> time_stepper,
+           const gsl::not_null<VariableOrderAlgorithm*> vo_algorithm) {
+          *time_stepper = std::make_unique<TimeSteppers::AdamsBashforth>(4);
+          *vo_algorithm = VariableOrderAlgorithm(0.1);
         },
         make_not_null(&box));
-    CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
-    CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(box)
-              .estimates == StepperErrorTolerances::Estimates::None);
-    CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box)
-              .estimates == StepperErrorTolerances::Estimates::None);
+    test_lts_tags(make_not_null(&box), false);
 
-    db::mutate<Tags::StepChoosers>(
-        [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-          *choosers =
-              TestHelpers::test_creation<typename Tags::StepChoosers::type,
-                                         Metavariables<true, true>>("");
+    db::mutate<Tags::VariableOrderAlgorithm>(
+        [](const gsl::not_null<VariableOrderAlgorithm*> vo_algorithm) {
+          *vo_algorithm = VariableOrderAlgorithm(4_st);
         },
         make_not_null(&box));
-    CHECK_FALSE(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
-    CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(box)
-              .estimates == StepperErrorTolerances::Estimates::None);
-    CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box)
-              .estimates == StepperErrorTolerances::Estimates::None);
+    test_lts_tags(make_not_null(&box), false);
 
-    db::mutate<Tags::StepChoosers>(
-        [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-          *choosers =
-              TestHelpers::test_creation<typename Tags::StepChoosers::type,
-                                         Metavariables<true, true>>(
-                  "- ErrorControl:\n"
-                  "    SafetyFactor: 0.95\n"
-                  "    AbsoluteTolerance: 1.0e-5\n"
-                  "    RelativeTolerance: 1.0e-4\n"
-                  "    MaxFactor: 2.1\n"
-                  "    MinFactor: 0.5\n"
-                  "- ErrorControl:\n"
-                  "    SafetyFactor: 0.8\n"
-                  "    AbsoluteTolerance: 1.0e-5\n"
-                  "    RelativeTolerance: 1.0e-4\n"
-                  "    MaxFactor: 1.1\n"
-                  "    MinFactor: 0.1\n"
-                  "- LimitIncrease:\n"
-                  "    Factor: 2\n"
-                  "- Constant: 0.5");
+    db::mutate<Tags::ConcreteTimeStepper<LtsTimeStepper>>(
+        [](const gsl::not_null<std::unique_ptr<LtsTimeStepper>*> time_stepper) {
+          *time_stepper =
+              std::make_unique<TimeSteppers::AdamsBashforth>(std::nullopt);
         },
         make_not_null(&box));
-    CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
-    CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(box) ==
-          StepperErrorTolerances{
-              .estimates = StepperErrorTolerances::Estimates::StepperOrder,
-              .absolute = 1.0e-5,
-              .relative = 1.0e-4});
-    CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box)
-              .estimates == StepperErrorTolerances::Estimates::None);
+    test_lts_tags(make_not_null(&box), false);
 
-    db::mutate<Tags::StepChoosers>(
-        [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-          *choosers =
-              TestHelpers::test_creation<typename Tags::StepChoosers::type,
-                                         Metavariables<true, true>>(
-                  "- ErrorControl:\n"
-                  "    SafetyFactor: 0.95\n"
-                  "    AbsoluteTolerance: 1.0e-5\n"
-                  "    RelativeTolerance: 1.0e-4\n"
-                  "    MaxFactor: 2.1\n"
-                  "    MinFactor: 0.5\n"
-                  "- ErrorControl(SelectorLabel):\n"
-                  "    SafetyFactor: 0.8\n"
-                  "    AbsoluteTolerance: 1.0e-5\n"
-                  "    RelativeTolerance: 1.0e-8\n"
-                  "    MaxFactor: 1.1\n"
-                  "    MinFactor: 0.1\n"
-                  "- LimitIncrease:\n"
-                  "    Factor: 2\n"
-                  "- Constant: 0.5");
+    db::mutate<Tags::VariableOrderAlgorithm>(
+        [](const gsl::not_null<VariableOrderAlgorithm*> vo_algorithm) {
+          *vo_algorithm = VariableOrderAlgorithm(0.1);
         },
         make_not_null(&box));
-    CHECK(db::get<Tags::IsUsingTimeSteppingErrorControl>(box));
-    CHECK(db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(box) ==
-          StepperErrorTolerances{
-              .estimates = StepperErrorTolerances::Estimates::StepperOrder,
-              .absolute = 1.0e-5,
-              .relative = 1.0e-4});
-    CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(box) ==
-          StepperErrorTolerances{
-              .estimates = StepperErrorTolerances::Estimates::StepperOrder,
-              .absolute = 1.0e-5,
-              .relative = 1.0e-8});
-
-    db::mutate<Tags::StepChoosers>(
-        [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-          *choosers =
-              TestHelpers::test_creation<typename Tags::StepChoosers::type,
-                                         Metavariables<true, true>>(
-                  "- ErrorControl:\n"
-                  "    SafetyFactor: 0.95\n"
-                  "    AbsoluteTolerance: 1.0e-5\n"
-                  "    RelativeTolerance: 1.0e-4\n"
-                  "    MaxFactor: 2.1\n"
-                  "    MinFactor: 0.5\n"
-                  "- ErrorControl:\n"
-                  "    SafetyFactor: 0.8\n"
-                  "    AbsoluteTolerance: 1.0e-5\n"
-                  "    RelativeTolerance: 1.0e-8\n"
-                  "    MaxFactor: 1.1\n"
-                  "    MinFactor: 0.1\n"
-                  "- LimitIncrease:\n"
-                  "    Factor: 2\n"
-                  "- Constant: 0.5");
-        },
-        make_not_null(&box));
-    CHECK_THROWS_WITH(
-        db::get<Tags::StepperErrorTolerances<EvolvedVariablesTag>>(box),
-        Catch::Matchers::ContainsSubstring("All ErrorControl events for ") and
-            Catch::Matchers::ContainsSubstring("EvolvedVar1") and
-            Catch::Matchers::ContainsSubstring(
-                " must use the same tolerances."));
+    test_lts_tags(make_not_null(&box), true);
   }
 
   {

--- a/tests/Unit/Time/Tags/CMakeLists.txt
+++ b/tests/Unit/Time/Tags/CMakeLists.txt
@@ -16,4 +16,5 @@ set(LIBRARY_SOURCES
   Tags/Test_TimeAndPrevious.cpp
   Tags/Test_TimeStepId.cpp
   Tags/Test_TimeStepper.cpp
+  Tags/Test_VariableOrderAlgorithm.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Time/Tags/Test_TimeStepper.cpp
+++ b/tests/Unit/Time/Tags/Test_TimeStepper.cpp
@@ -3,10 +3,17 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <optional>
 #include <string>
+#include <type_traits>
 
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Time/Tags/TimeStepper.hpp"
+#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/LtsTimeStepper.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
 struct DummyType {};
@@ -40,4 +47,20 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.TimeStepper", "[Unit][Time]") {
   TestHelpers::db::test_simple_tag<Tags::TimeStepper<DummyType>>("TimeStepper");
   TestHelpers::db::test_reference_tag<
       Tags::TimeStepperRef<DummyType, DummyType>>("TimeStepper");
+
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
+  // Check that these are allowed...
+  Tags::ConcreteTimeStepper<TimeStepper>::create_from_options(
+      std::make_unique<TimeSteppers::AdamsBashforth>(3));
+  Tags::ConcreteTimeStepper<LtsTimeStepper>::create_from_options(
+      std::make_unique<TimeSteppers::AdamsBashforth>(3));
+  Tags::ConcreteTimeStepper<LtsTimeStepper>::create_from_options(
+      std::make_unique<TimeSteppers::AdamsBashforth>(std::nullopt));
+  // ...but this isn't.
+  CHECK_THROWS_WITH(
+      Tags::ConcreteTimeStepper<TimeStepper>::create_from_options(
+          std::make_unique<TimeSteppers::AdamsBashforth>(std::nullopt)),
+      Catch::Matchers::ContainsSubstring(
+          "Variable-order TimeSteppers are only supported in evolutions with "
+          "local time-stepping."));
 }

--- a/tests/Unit/Time/Tags/Test_VariableOrderAlgorithm.cpp
+++ b/tests/Unit/Time/Tags/Test_VariableOrderAlgorithm.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Time/Tags/VariableOrderAlgorithm.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.Tags.VariableOrderAlgorithm", "[Unit][Time]") {
+  TestHelpers::db::test_simple_tag<Tags::VariableOrderAlgorithm>(
+      "VariableOrderAlgorithm");
+}

--- a/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
+++ b/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
@@ -1,0 +1,252 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <iomanip>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/DataStructures/TestTags.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
+#include "Time/Slab.hpp"
+#include "Time/StepperErrorEstimate.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/StepperErrors.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/Tags/VariableOrderAlgorithm.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Time/VariableOrderAlgorithm.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using Vars1 = Tags::Variables<tmpl::list<TestHelpers::Tags::Vector<>>>;
+using Vars2 = Tags::Variables<tmpl::list<TestHelpers::Tags::Scalar<>>>;
+
+struct System1 {
+  using variables_tag = Vars1;
+  static constexpr bool two_vars = false;
+};
+
+struct System2 {
+  using variables_tag = tmpl::list<Vars1, Vars2>;
+  static constexpr bool two_vars = true;
+};
+
+template <typename System>
+size_t test_system(VariableOrderAlgorithm algorithm, const size_t initial_order,
+                   std::optional<StepperErrorEstimate> errors1,
+                   std::optional<StepperErrorEstimate> errors2) {
+  const Slab slab(0.0, 1.0);
+
+  // First entry is for the previous step, which is only used for step
+  // size control, not order.
+  std::array<std::optional<StepperErrorEstimate>, 2> stepper_errors1{};
+  std::array<std::optional<StepperErrorEstimate>, 2> stepper_errors2{};
+  stepper_errors1[1] = std::move(errors1);
+  stepper_errors2[1] = std::move(errors2);
+
+  using history_tag1 = Tags::HistoryEvolvedVariables<Vars1>;
+  using history_tag2 = Tags::HistoryEvolvedVariables<Vars2>;
+
+  const TimeStepId next_time_step_id(true, 0, slab.end());
+
+  auto box = db::create<
+      db::AddSimpleTags<
+          Tags::ConcreteTimeStepper<TimeStepper>, Tags::VariableOrderAlgorithm,
+          history_tag1, history_tag2, Tags::StepperErrors<Vars1>,
+          Tags::StepperErrors<Vars2>, Tags::Next<Tags::TimeStepId>>,
+      time_stepper_ref_tags<TimeStepper>>(
+      static_cast<std::unique_ptr<TimeStepper>>(
+          std::make_unique<TimeSteppers::AdamsBashforth>(initial_order)),
+      std::move(algorithm), history_tag1::type{initial_order},
+      history_tag2::type{initial_order}, stepper_errors1, stepper_errors2,
+      next_time_step_id);
+
+  // Does nothing for fixed-order
+  db::mutate_apply<ChangeTimeStepperOrder<System>>(make_not_null(&box));
+  CHECK(db::get<history_tag1>(box).integration_order() == initial_order);
+  CHECK(db::get<history_tag2>(box).integration_order() == initial_order);
+
+  db::mutate<Tags::ConcreteTimeStepper<TimeStepper>,
+             Tags::Next<Tags::TimeStepId>>(
+      [&](const gsl::not_null<std::unique_ptr<TimeStepper>*> stepper,
+          const gsl::not_null<TimeStepId*> id) {
+        *stepper = make_unique<TimeSteppers::AdamsBashforth>(std::nullopt);
+        *id = TimeStepId(true, 0, slab.start(), 1, slab.duration(), 1.0);
+      },
+      make_not_null(&box));
+
+  // Does nothing on a substep
+  db::mutate_apply<ChangeTimeStepperOrder<System>>(make_not_null(&box));
+  CHECK(db::get<history_tag1>(box).integration_order() == initial_order);
+  CHECK(db::get<history_tag2>(box).integration_order() == initial_order);
+
+  db::mutate<Tags::Next<Tags::TimeStepId>>(
+      [&](const gsl::not_null<TimeStepId*> id) {
+        *id = TimeStepId(true, 0, slab.end());
+      },
+      make_not_null(&box));
+  db::mutate_apply<ChangeTimeStepperOrder<System>>(make_not_null(&box));
+
+  if constexpr (System::two_vars) {
+    CHECK(db::get<history_tag2>(box).integration_order() ==
+          db::get<history_tag1>(box).integration_order());
+  } else {
+    CHECK(db::get<history_tag2>(box).integration_order() == initial_order);
+  }
+  return db::get<history_tag1>(box).integration_order();
+}
+
+size_t goal_order(const size_t goal, const size_t initial_order) {
+  const VariableOrderAlgorithm goal_algorithm{goal};
+  const auto algorithm_from_options =
+      TestHelpers::test_creation<VariableOrderAlgorithm>(
+          MakeString{} << "GoalOrder: " << goal);
+  CHECK(algorithm_from_options == goal_algorithm);
+  CHECK(goal_algorithm.required_estimates() ==
+        StepperErrorTolerances::Estimates::None);
+
+  const size_t result = test_system<System1>(goal_algorithm, initial_order,
+                                             std::nullopt, std::nullopt);
+  CHECK(test_system<System2>(goal_algorithm, initial_order, std::nullopt,
+                             std::nullopt) == result);
+  CHECK(test_system<System1>(algorithm_from_options, initial_order,
+                             std::nullopt, std::nullopt) == result);
+  CHECK(test_system<System2>(algorithm_from_options, initial_order,
+                             std::nullopt, std::nullopt) == result);
+  return result;
+}
+
+void test_goal() {
+  CHECK(goal_order(4, 1) == 2);
+  CHECK(goal_order(4, 2) == 3);
+  CHECK(goal_order(4, 3) == 4);
+  CHECK(goal_order(4, 4) == 4);
+  CHECK(goal_order(4, 5) == 4);
+  CHECK(goal_order(4, 6) == 5);
+  CHECK(goal_order(1, 1) == 1);
+}
+
+size_t falloff_order(const double falloff, const std::vector<double>& errors) {
+  const VariableOrderAlgorithm falloff_algorithm{falloff};
+  const auto algorithm_from_options =
+      TestHelpers::test_creation<VariableOrderAlgorithm>(
+          MakeString{} << std::setprecision(18) << "OrderFalloff: " << falloff);
+  CHECK(algorithm_from_options == falloff_algorithm);
+  CHECK(falloff_algorithm.required_estimates() ==
+        StepperErrorTolerances::Estimates::AllOrders);
+
+  const Slab slab(0.0, 1.0);
+  // Time and step size are unused.
+  StepperErrorEstimate falloff_errors(slab.start(), slab.duration(),
+                                      errors.size() - 1, errors.back());
+  for (size_t i = 0; i < errors.size() - 1; ++i) {
+    gsl::at(falloff_errors.errors, i).emplace(errors[i]);
+  }
+
+  const double min_error = *alg::min_element(errors);
+  StepperErrorEstimate constant_errors(slab.start(), slab.duration(),
+                                       errors.size() - 1, min_error);
+  for (size_t i = 0; i < errors.size() - 1; ++i) {
+    gsl::at(constant_errors.errors, i).emplace(min_error);
+  }
+
+  const size_t result = test_system<System1>(falloff_algorithm, errors.size(),
+                                             falloff_errors, std::nullopt);
+  CHECK(test_system<System2>(falloff_algorithm, errors.size(), falloff_errors,
+                             falloff_errors) == result);
+  CHECK(test_system<System2>(falloff_algorithm, errors.size(), falloff_errors,
+                             constant_errors) == result);
+  CHECK(test_system<System2>(falloff_algorithm, errors.size(), constant_errors,
+                             falloff_errors) == result);
+  CHECK(test_system<System2>(falloff_algorithm, errors.size(), falloff_errors,
+                             std::nullopt) == result);
+  CHECK(test_system<System2>(falloff_algorithm, errors.size(), std::nullopt,
+                             falloff_errors) == result);
+  return result;
+}
+
+void test_falloff_without_errors() {
+  const size_t initial_order = 4;
+  const Slab slab(0.0, 1.0);
+
+  std::array<std::optional<StepperErrorEstimate>, 2> stepper_errors{};
+
+  using history_tag = Tags::HistoryEvolvedVariables<Vars1>;
+
+  const TimeStepId next_time_step_id(true, 0, slab.end());
+
+  auto box =
+      db::create<db::AddSimpleTags<Tags::ConcreteTimeStepper<TimeStepper>,
+                                   Tags::VariableOrderAlgorithm, history_tag,
+                                   Tags::StepperErrors<Vars1>,
+                                   Tags::Next<Tags::TimeStepId>>,
+                 time_stepper_ref_tags<TimeStepper>>(
+          static_cast<std::unique_ptr<TimeStepper>>(
+              std::make_unique<TimeSteppers::AdamsBashforth>(initial_order)),
+          VariableOrderAlgorithm{0.1}, history_tag::type{initial_order},
+          stepper_errors, next_time_step_id);
+
+  // Does nothing for fixed-order
+  db::mutate_apply<ChangeTimeStepperOrder<System1>>(make_not_null(&box));
+  CHECK(db::get<history_tag>(box).integration_order() == initial_order);
+
+  db::mutate<Tags::ConcreteTimeStepper<TimeStepper>>(
+      [&](const gsl::not_null<std::unique_ptr<TimeStepper>*> stepper) {
+        *stepper = make_unique<TimeSteppers::AdamsBashforth>(std::nullopt);
+      },
+      make_not_null(&box));
+
+  CHECK_THROWS_WITH(
+      db::mutate_apply<ChangeTimeStepperOrder<System1>>(make_not_null(&box)),
+      Catch::Matchers::ContainsSubstring(
+          "OrderFalloff only implemented with error-based adaptive time "
+          "stepping."));
+}
+
+void test_falloff() {
+  // Euler's method should always increase to second order
+  CHECK(falloff_order(0.1, {3.0}) == 2);
+
+  // The algorithm can't decrease from second to first order, and will
+  // only stay the same if second is actually worse.
+  CHECK(falloff_order(0.1, {0.9, 0.899}) == 3);
+  CHECK(falloff_order(0.1, {0.9, 0.901}) == 2);
+
+  // Max order can't increase
+  CHECK(falloff_order(0.1, {1.0e-1, 1.0e-2, 1.0e-3, 1.0e-4, 1.0e-5, 1.0e-6,
+                            1.0e-7, 1.0e-8}) == 8);
+
+  // Typical cases
+  // Make the largest drop a factor of 4, falloff 0.5 then requires
+  // factor of 2 decrease.
+  CHECK(falloff_order(0.5, {0.9, 0.8, 0.2, 0.15, 1.0e-5}) == 4);
+  CHECK(falloff_order(0.5, {0.9, 0.8, 0.2, 0.08, 0.041}) == 5);
+  CHECK(falloff_order(0.5, {0.9, 0.8, 0.2, 0.08, 0.039}) == 6);
+  CHECK(falloff_order(0.51, {0.9, 0.8, 0.2, 0.08, 0.04}) == 5);
+  CHECK(falloff_order(0.49, {0.9, 0.8, 0.2, 0.08, 0.04}) == 6);
+
+  test_falloff_without_errors();
+}
+
+SPECTRE_TEST_CASE("Unit.Time.ChangeTimeStepperOrder", "[Unit][Time]") {
+  test_goal();
+  test_falloff();
+}
+}  // namespace

--- a/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
+++ b/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
@@ -8,30 +8,55 @@
 #include <iomanip>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedVariant.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Helpers/DataStructures/TestTags.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "Time/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/ChangeTimeStepperOrder.hpp"
+#include "Time/ChooseLtsStepSize.hpp"
 #include "Time/Slab.hpp"
+#include "Time/StepChoosers/ErrorControl.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepperErrorEstimate.hpp"
+#include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/MinimumTimeStep.hpp"
+#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/StepperErrors.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Time/Tags/TimeStep.hpp"
 #include "Time/Tags/TimeStepId.hpp"
 #include "Time/Tags/TimeStepper.hpp"
 #include "Time/Tags/VariableOrderAlgorithm.hpp"
+#include "Time/TakeStep.hpp"
+#include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/AdamsMoultonPc.hpp"
+#include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Time/VariableOrderAlgorithm.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
@@ -245,8 +270,183 @@ void test_falloff() {
   test_falloff_without_errors();
 }
 
+// See Hairer II.4
+//
+// Evolves the system
+// y1' = 1 + y1^2 y2 - 4 y1
+// y2' = 3 y1 - y1^2 y2
+//
+// This is a popular test for various sorts of adaptive stepping
+// because the solution has a sawtooth-like shape, with gradual
+// changes alternating with rapid ones.
+namespace brusselator {
+struct Var1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct Var2 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct System {
+  using variables_tag = ::Tags::Variables<tmpl::list<Var1, Var2>>;
+
+  struct compute_time_derivative {
+    using return_tags = tmpl::list<::Tags::dt<Var1>, ::Tags::dt<Var2>>;
+    using argument_tags = tmpl::list<Var1, Var2>;
+    static void apply(const gsl::not_null<Scalar<DataVector>*> dt_var1,
+                      const gsl::not_null<Scalar<DataVector>*> dt_var2,
+                      const Scalar<DataVector>& var1,
+                      const Scalar<DataVector>& var2) {
+      tenex::evaluate(dt_var1, 1.0 + square(var1()) * var2() - 4.0 * var1());
+      tenex::evaluate(dt_var2, 3.0 * var1() - square(var1()) * var2());
+    }
+  };
+};
+
+using ErrorControl =
+    StepChoosers::ErrorControl<StepChooserUse::LtsStep, System::variables_tag>;
+
+struct Metavariables {
+  using system = System;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                             tmpl::list<ErrorControl>>>;
+  };
+};
+
+double run(std::unique_ptr<LtsTimeStepper> time_stepper, const double tolerance,
+           const double initial_step_size,
+           const std::optional<std::string>& output_file = {}) {
+  // Prevent people from forgetting to turn this off after testing.
+  CHECK(not output_file.has_value());
+
+  const Slab slab(0.0, 20.0);
+
+  const TimeStepId initial_time_step_id(true, 0, slab.start());
+  const TimeDelta initial_time_step =
+      choose_lts_step_size(slab.start(), initial_step_size);
+
+  std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>
+      step_choosers{};
+  step_choosers.push_back(
+      std::make_unique<ErrorControl>(tolerance, tolerance, 2.0, 0.25, 0.95));
+
+  const double minimum_time_step = 1.0e-7;
+
+  System::variables_tag::type initial_vars{1};
+  get(get<Var1>(initial_vars)) = 1.5;
+  get(get<Var2>(initial_vars)) = 3.0;
+
+  const auto stepper_order = time_stepper->order();
+  REQUIRE(holds_alternative<TimeSteppers::Tags::VariableOrder>(stepper_order));
+  const size_t initial_order =
+      get<TimeSteppers::Tags::VariableOrder>(stepper_order).minimum;
+
+  using dt_variables_tag =
+      db::add_tag_prefix<::Tags::dt, System::variables_tag>;
+  using history_tag = ::Tags::HistoryEvolvedVariables<System::variables_tag>;
+
+  auto box = db::create<
+      db::AddSimpleTags<::Parallel::Tags::MetavariablesImpl<Metavariables>,
+                        ::Tags::ConcreteTimeStepper<LtsTimeStepper>,
+                        Tags::VariableOrderAlgorithm, ::Tags::TimeStepId,
+                        ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
+                        ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics,
+                        ::Tags::StepChoosers, ::Tags::MinimumTimeStep,
+                        System::variables_tag, dt_variables_tag, history_tag,
+                        ::Tags::StepperErrors<System::variables_tag>>,
+      tmpl::push_back<
+          time_stepper_ref_tags<LtsTimeStepper>,
+          ::Tags::IsUsingTimeSteppingErrorControlCompute<true>,
+          ::Tags::StepperErrorTolerancesCompute<System::variables_tag, true>>>(
+      Metavariables{}, std::move(time_stepper), VariableOrderAlgorithm(0.1),
+      initial_time_step_id,
+      time_stepper->next_time_id(initial_time_step_id, initial_time_step),
+      initial_time_step, slab.start().value(), ::AdaptiveSteppingDiagnostics{},
+      std::move(step_choosers), minimum_time_step, std::move(initial_vars),
+      dt_variables_tag::type{1}, history_tag::type{initial_order},
+      ::Tags::StepperErrors<System::variables_tag>::type{});
+
+  if (output_file.has_value()) {
+    ::file_system::rm(*output_file, false);
+  }
+
+  size_t order_sum = 0;
+  size_t num_steps = 0;
+
+  for (;;) {
+    if (output_file.has_value() and
+        db::get<::Tags::TimeStepId>(box).substep() == 0) {
+      Parallel::fprintf(
+          *output_file, "%zu\t%.16g\t%.16g\t%.16g\t%.16g\t%zu\n",
+          static_cast<size_t>(db::get<::Tags::AdaptiveSteppingDiagnostics>(box)
+                                  .number_of_steps),
+          db::get<::Tags::Time>(box), get(db::get<Var1>(box))[0],
+          get(db::get<Var2>(box))[0], db::get<::Tags::TimeStep>(box).value(),
+          static_cast<size_t>(db::get<history_tag>(box).integration_order()));
+    }
+    if (db::get<::Tags::TimeStepId>(box).slab_number() != 0) {
+      break;
+    }
+
+    order_sum += db::get<history_tag>(box).integration_order();
+    ++num_steps;
+
+    db::mutate_apply<System::compute_time_derivative>(make_not_null(&box));
+    take_step<System, true>(make_not_null(&box));
+    db::mutate_apply<ChangeTimeStepperOrder<System>>(make_not_null(&box));
+
+    db::mutate<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+               ::Tags::Time, ::Tags::AdaptiveSteppingDiagnostics, history_tag>(
+        [](const gsl::not_null<TimeStepId*> time_step_id,
+           const gsl::not_null<TimeStepId*> next_time_step_id,
+           const gsl::not_null<double*> time,
+           const gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
+           const gsl::not_null<history_tag::type*> history,
+           const TimeStepper& local_time_stepper, const TimeDelta& time_step) {
+          if (next_time_step_id->substep() == 0) {
+            ++diags->number_of_steps;
+          }
+          *time_step_id = *next_time_step_id;
+          *next_time_step_id = local_time_stepper.next_time_id(
+              *next_time_step_id,
+              time_step.with_slab(time_step_id->step_time().slab()));
+          *time = time_step_id->substep_time();
+          local_time_stepper.clean_history(history);
+        },
+        make_not_null(&box), db::get<::Tags::TimeStepper<TimeStepper>>(box),
+        db::get<::Tags::TimeStep>(box));
+  }
+
+  return static_cast<double>(order_sum) / static_cast<double>(num_steps);
+}
+
+void test() {
+  const auto average_order_ab_3 =
+      run(std::make_unique<TimeSteppers::AdamsBashforth>(std::nullopt), 1.0e-3,
+          1.0e-3);
+  const auto average_order_ab_8 =
+      run(std::make_unique<TimeSteppers::AdamsBashforth>(std::nullopt), 1.0e-8,
+          1.0e-6);
+  const auto average_order_am_3 =
+      run(std::make_unique<TimeSteppers::AdamsMoultonPc<true>>(std::nullopt),
+          1.0e-3, 1.0e-3);
+  const auto average_order_am_8 =
+      run(std::make_unique<TimeSteppers::AdamsMoultonPc<true>>(std::nullopt),
+          1.0e-8, 1.0e-6);
+
+  CHECK(average_order_ab_3 < average_order_ab_8);
+  CHECK(average_order_am_3 < average_order_am_8);
+}
+}  // namespace brusselator
+
 SPECTRE_TEST_CASE("Unit.Time.ChangeTimeStepperOrder", "[Unit][Time]") {
   test_goal();
   test_falloff();
+  brusselator::test();
 }
 }  // namespace


### PR DESCRIPTION
This is the final PR enabling variable-order LTS.  There will be one more follow-up to enable h-refinement.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
* Input files using local time-stepping can now specify `Auto` for the order of the TimeStepper to enable variable-order time-stepping.  They must also specify the new `VariableOrderAlgorithm` option, for example as shown below.  See the option help for possible values.  The choice has no effect if the time-stepper order is not `Auto`.
```yaml
Evolution:
  VariableOrderAlgorithm:
    GoalOrder: 4
```

* Executables using local time-stepping must now include the `ChangeTimeStepperOrder` mutator in their action lists.  See the existing executables for details.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
