### PR TITLE
Add a Ccz4 wrapper class around gr solutions

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Ccz4WrappedGr.cpp
   GaugeWave.cpp
   GaugePlaneWave.cpp
   HarmonicSchwarzschild.cpp
@@ -22,6 +23,8 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Ccz4WrappedGr.hpp
+  Ccz4WrappedGr.tpp
   Factory.hpp
   GaugeWave.hpp
   GaugePlaneWave.hpp
@@ -39,6 +42,7 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   Boost::boost
+  Ccz4
   DataStructures
   ErrorHandling
   GeneralRelativity

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp"
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.tpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+GENERATE_INSTANTIATIONS(CCZ4_WRAPPED_GR_INSTANTIATE,
+                        (gr::Solutions::GaugeWave<3>,
+                         gr::Solutions::GaugePlaneWave<3>,
+                         gr::Solutions::Minkowski<3>,
+                         gr::Solutions::TrumpetSchwarzschild))

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp
@@ -1,0 +1,248 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Ccz4::Solutions {
+/*!
+ * \brief A wrapper for general-relativity analytic solutions that loads
+ * the analytic solution and then adds a function that returns
+ * any combination of the Ccz4 evolution variables.
+ * Specifically, see `Ccz4::fd::System`.
+ */
+template <typename SolutionType>
+class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
+                      public SolutionType {
+ public:
+  using SolutionType::SolutionType;
+
+  Ccz4WrappedGr() = default;
+  Ccz4WrappedGr(const Ccz4WrappedGr& /*rhs*/) = default;
+  Ccz4WrappedGr& operator=(const Ccz4WrappedGr& /*rhs*/) = default;
+  Ccz4WrappedGr(Ccz4WrappedGr&& /*rhs*/) = default;
+  Ccz4WrappedGr& operator=(Ccz4WrappedGr&& /*rhs*/) = default;
+  ~Ccz4WrappedGr() override = default;
+
+  explicit Ccz4WrappedGr(const SolutionType& wrapped_solution);
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
+  /// \cond
+  explicit Ccz4WrappedGr(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Ccz4WrappedGr);
+  /// \endcond
+
+  static constexpr size_t volume_dim = SolutionType::volume_dim;
+  static_assert(volume_dim == 3,
+                "Ccz4 evolution system has only been implemented in 3D!");
+  using options = typename SolutionType::options;
+  static constexpr Options::String help = SolutionType::help;
+  static std::string name() {
+    return "Ccz4(" + pretty_type::name<SolutionType>() + ")";
+  }
+
+  using DerivLapse = ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                                   tmpl::size_t<volume_dim>, Frame::Inertial>;
+  using DerivShift = ::Tags::deriv<gr::Tags::Shift<DataVector, volume_dim>,
+                                   tmpl::size_t<volume_dim>, Frame::Inertial>;
+  using DerivSpatialMetric =
+      ::Tags::deriv<gr::Tags::SpatialMetric<DataVector, volume_dim>,
+                    tmpl::size_t<volume_dim>, Frame::Inertial>;
+  using TimeDerivLapse = ::Tags::dt<gr::Tags::Lapse<DataVector>>;
+  using TimeDerivShift = ::Tags::dt<gr::Tags::Shift<DataVector, volume_dim>>;
+  using TimeDerivSpatialMetric =
+      ::Tags::dt<gr::Tags::SpatialMetric<DataVector, volume_dim>>;
+
+  using IntermediateVars = tuples::tagged_tuple_from_typelist<
+      typename SolutionType::template tags<DataVector>>;
+
+  template <typename DataType>
+  using tags =
+      tmpl::push_back<typename SolutionType::template tags<DataType>,
+                      Ccz4::Tags::ConformalMetric<DataType, volume_dim>,
+                      Ccz4::Tags::ConformalFactor<DataType>,
+                      Ccz4::Tags::ATilde<DataType, volume_dim>,
+                      gr::Tags::TraceExtrinsicCurvature<DataType>,
+                      Ccz4::Tags::Theta<DataType>,
+                      Ccz4::Tags::GammaHat<DataType, volume_dim>>;
+
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, volume_dim>& x, const double t,
+      tmpl::list<Tags...> /*meta*/) const {
+    // Get the underlying solution's variables using the solution's tags list,
+    // store in IntermediateVariables
+    const IntermediateVars& intermediate_vars = SolutionType::variables(
+        x, t, typename SolutionType::template tags<DataVector>{});
+
+    return {
+        get<Tags>(variables(x, t, tmpl::list<Tags>{}, intermediate_vars))...};
+  }
+
+  template <typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataVector, volume_dim>& x,
+                                     const double t,
+                                     tmpl::list<Tag> /*meta*/) const {
+    const IntermediateVars& intermediate_vars = SolutionType::variables(
+        x, t, typename SolutionType::template tags<DataVector>{});
+    return {get<Tag>(variables(x, t, tmpl::list<Tag>{}, intermediate_vars))};
+  }
+
+  // overloads for wrapping analytic data
+
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, volume_dim>& x,
+      tmpl::list<Tags...> /*meta*/) const {
+    // Get the underlying solution's variables using the solution's tags list,
+    // store in IntermediateVariables
+    const IntermediateVars intermediate_vars = SolutionType::variables(
+        x, typename SolutionType::template tags<DataVector>{});
+
+    return {get<Tags>(variables(x, tmpl::list<Tags>{}, intermediate_vars))...};
+  }
+
+  template <typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataVector, volume_dim>& x,
+                                     tmpl::list<Tag> /*meta*/) const {
+    const IntermediateVars intermediate_vars = SolutionType::variables(
+        x, typename SolutionType::template tags<DataVector>{});
+    return {get<Tag>(variables(x, tmpl::list<Tag>{}, intermediate_vars))};
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  // Preprocessor logic to avoid declaring variables() functions for
+  // tags other than the three the wrapper adds (i.e., other than
+  // Ccz4::Tags::ConformalMetric, Ccz4::Tags::ConformalFactor,
+  // Ccz4:Tags::ATilde, gr::Tags::TraceExtrinsicCurvature,
+  // Ccz4::Tags::Theta, Ccz4::Tags::GammaHat)
+  using TagShift = gr::Tags::Shift<DataVector, volume_dim>;
+  using TagSpatialMetric = gr::Tags::SpatialMetric<DataVector, volume_dim>;
+  using TagInverseSpatialMetric =
+      gr::Tags::InverseSpatialMetric<DataVector, volume_dim>;
+  using TagExCurvature = gr::Tags::ExtrinsicCurvature<DataVector, volume_dim>;
+
+  template <typename Tag>
+  tuples::TaggedTuple<Tag> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, double /*t*/,
+      tmpl::list<Tag> /*meta*/,
+      const IntermediateVars& intermediate_vars) const {
+    static_assert(
+        tmpl::list_contains_v<typename SolutionType::template tags<DataVector>,
+                              Tag>);
+    return {get<Tag>(intermediate_vars)};
+  }
+
+  template <typename Tag>
+  tuples::TaggedTuple<Tag> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/, tmpl::list<Tag> /*meta*/,
+      const IntermediateVars& intermediate_vars) const {
+    static_assert(
+        tmpl::list_contains_v<typename SolutionType::template tags<DataVector>,
+                              Tag>);
+    return {get<Tag>(intermediate_vars)};
+  }
+
+  tuples::TaggedTuple<Ccz4::Tags::ConformalMetric<DataVector, volume_dim>>
+  variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/,
+      tmpl::list<Ccz4::Tags::ConformalMetric<DataVector, volume_dim>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const;
+  tuples::TaggedTuple<Ccz4::Tags::ConformalFactor<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/,
+      tmpl::list<Ccz4::Tags::ConformalFactor<DataVector>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const;
+  tuples::TaggedTuple<Ccz4::Tags::ATilde<DataVector, volume_dim>> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/,
+      tmpl::list<Ccz4::Tags::ATilde<DataVector, volume_dim>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const;
+  tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/,
+      tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataVector>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const;
+  tuples::TaggedTuple<Ccz4::Tags::Theta<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/,
+      tmpl::list<Ccz4::Tags::Theta<DataVector>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const;
+  tuples::TaggedTuple<Ccz4::Tags::GammaHat<DataVector, volume_dim>> variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/,
+      tmpl::list<Ccz4::Tags::GammaHat<DataVector, volume_dim>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const;
+
+  tuples::TaggedTuple<Ccz4::Tags::ConformalMetric<DataVector, volume_dim>>
+  variables(
+      const tnsr::I<DataVector, volume_dim>& x, const double /*t*/,
+      tmpl::list<Ccz4::Tags::ConformalMetric<DataVector, volume_dim>> meta,
+      const IntermediateVars& intermediate_vars) const {
+    return variables(x, meta, intermediate_vars);
+  }
+  tuples::TaggedTuple<Ccz4::Tags::ConformalFactor<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& x, double /*t*/,
+      tmpl::list<Ccz4::Tags::ConformalFactor<DataVector>> meta,
+      const IntermediateVars& intermediate_vars) const {
+    return variables(x, meta, intermediate_vars);
+  }
+  tuples::TaggedTuple<Ccz4::Tags::ATilde<DataVector, volume_dim>> variables(
+      const tnsr::I<DataVector, volume_dim>& x, double /*t*/,
+      tmpl::list<Ccz4::Tags::ATilde<DataVector, volume_dim>> meta,
+      const IntermediateVars& intermediate_vars) const {
+    return variables(x, meta, intermediate_vars);
+  }
+  tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& x, const double /*t*/,
+      tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataVector>> meta,
+      const IntermediateVars& intermediate_vars) const {
+    return variables(x, meta, intermediate_vars);
+  }
+  tuples::TaggedTuple<Ccz4::Tags::Theta<DataVector>> variables(
+      const tnsr::I<DataVector, volume_dim>& x, double /*t*/,
+      tmpl::list<Ccz4::Tags::Theta<DataVector>> meta,
+      const IntermediateVars& intermediate_vars) const {
+    return variables(x, meta, intermediate_vars);
+  }
+  tuples::TaggedTuple<Ccz4::Tags::GammaHat<DataVector, volume_dim>> variables(
+      const tnsr::I<DataVector, volume_dim>& x, double /*t*/,
+      tmpl::list<Ccz4::Tags::GammaHat<DataVector, volume_dim>> meta,
+      const IntermediateVars& intermediate_vars) const {
+    return variables(x, meta, intermediate_vars);
+  }
+};
+
+template <typename SolutionType>
+bool operator==(const Ccz4WrappedGr<SolutionType>& lhs,
+                const Ccz4WrappedGr<SolutionType>& rhs);
+
+template <typename SolutionType>
+bool operator!=(const Ccz4WrappedGr<SolutionType>& lhs,
+                const Ccz4WrappedGr<SolutionType>& rhs);
+
+template <typename SolutionType>
+Ccz4WrappedGr(SolutionType solution) -> Ccz4WrappedGr<SolutionType>;
+}  // namespace Ccz4::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.tpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.tpp
@@ -1,0 +1,240 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp"
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/ATilde.hpp"
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace Ccz4::Solutions {
+template <typename SolutionType>
+Ccz4WrappedGr<SolutionType>::Ccz4WrappedGr(const SolutionType& wrapped_solution)
+    : SolutionType(wrapped_solution) {}
+
+template <typename SolutionType>
+Ccz4WrappedGr<SolutionType>::Ccz4WrappedGr(CkMigrateMessage* msg)
+    : InitialData(msg), SolutionType(msg) {}
+
+template <typename SolutionType>
+std::unique_ptr<evolution::initial_data::InitialData>
+Ccz4WrappedGr<SolutionType>::get_clone() const {
+  return std::make_unique<Ccz4WrappedGr<SolutionType>>(*this);
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<Ccz4::Tags::ConformalMetric<
+    DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>
+Ccz4WrappedGr<SolutionType>::variables(
+    const tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<
+                                  SolutionType>::volume_dim>& /*x*/,
+    tmpl::list<Ccz4::Tags::ConformalMetric<
+        DataVector,
+        Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const {
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  const auto& sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(intermediate_vars);
+  Scalar<DataVector> conformal_factor;
+  get(conformal_factor) = pow(get(sqrt_det_spatial_metric), -1. / 3.);
+  tnsr::ii<DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>
+      conformal_spatial_metric;
+  ::tenex::evaluate<ti::i, ti::j>(make_not_null(&conformal_spatial_metric),
+                                  (conformal_factor)() * (conformal_factor)() *
+                                      (spatial_metric)(ti::i, ti::j));
+  return {std::move(conformal_spatial_metric)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<Ccz4::Tags::ConformalFactor<DataVector>>
+Ccz4WrappedGr<SolutionType>::variables(
+    const tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<
+                                  SolutionType>::volume_dim>& /*x*/,
+    tmpl::list<Ccz4::Tags::ConformalFactor<DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const {
+  const auto& sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(intermediate_vars);
+  Scalar<DataVector> conformal_factor;
+  get(conformal_factor) = pow(get(sqrt_det_spatial_metric), -1. / 3.);
+
+  return {std::move(conformal_factor)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<Ccz4::Tags::ATilde<
+    DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>
+Ccz4WrappedGr<SolutionType>::variables(
+    const tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<
+                                  SolutionType>::volume_dim>& /*x*/,
+    tmpl::list<Ccz4::Tags::ATilde<
+        DataVector,
+        Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const {
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  const auto& sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(intermediate_vars);
+  Scalar<DataVector> conformal_factor_squared;
+  get(conformal_factor_squared) = pow(get(sqrt_det_spatial_metric), -2. / 3.);
+  const auto& extrinsic_curvature = get<gr::Tags::ExtrinsicCurvature<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  const auto& inverse_spatial_metric = get<gr::Tags::InverseSpatialMetric<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  const auto trace_extrinsic_curvature =
+      trace(extrinsic_curvature, inverse_spatial_metric);
+
+  return {::Ccz4::a_tilde(conformal_factor_squared, spatial_metric,
+                          extrinsic_curvature, trace_extrinsic_curvature)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<gr::Tags::TraceExtrinsicCurvature<DataVector>>
+Ccz4WrappedGr<SolutionType>::variables(
+    const tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<
+                                  SolutionType>::volume_dim>& /*x*/,
+    tmpl::list<gr::Tags::TraceExtrinsicCurvature<DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const {
+  const auto& extrinsic_curvature = get<gr::Tags::ExtrinsicCurvature<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  const auto& inverse_spatial_metric = get<gr::Tags::InverseSpatialMetric<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  const auto trace_extrinsic_curvature =
+      trace(extrinsic_curvature, inverse_spatial_metric);
+
+  return {std::move(trace_extrinsic_curvature)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<Ccz4::Tags::Theta<DataVector>>
+Ccz4WrappedGr<SolutionType>::variables(
+    const tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<
+                                  SolutionType>::volume_dim>& /*x*/,
+    tmpl::list<Ccz4::Tags::Theta<DataVector>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const {
+  const auto& sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(intermediate_vars);
+  // Theta won't be exactly zero due to numerical errors
+  // in the initial data leading to constraint violations.
+  // But in practice evolutions set this to zero; see e.g.
+  // Dumbser2017okk
+  const auto theta =
+      make_with_value<Scalar<DataVector>>(sqrt_det_spatial_metric, 0.0);
+
+  return {std::move(theta)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<Ccz4::Tags::GammaHat<
+    DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>
+Ccz4WrappedGr<SolutionType>::variables(
+    const tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<
+                                  SolutionType>::volume_dim>& /*x*/,
+    tmpl::list<Ccz4::Tags::GammaHat<
+        DataVector,
+        Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const {
+  const auto& sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(intermediate_vars);
+  Scalar<DataVector> inverse_conformal_factor_squared;
+  get(inverse_conformal_factor_squared) =
+      pow(get(sqrt_det_spatial_metric), 2. / 3.);
+  const auto& inverse_spatial_metric = get<gr::Tags::InverseSpatialMetric<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  tnsr::II<DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>
+      inverse_conformal_spatial_metric;
+  ::tenex::evaluate<ti::I, ti::J>(
+      make_not_null(&inverse_conformal_spatial_metric),
+      inverse_conformal_factor_squared() *
+          inverse_spatial_metric(ti::I, ti::J));
+
+  const auto& d_spatial_metric = get<DerivSpatialMetric>(intermediate_vars);
+  tnsr::i<DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>
+      d_det_spatial_metric;
+  ::tenex::evaluate<ti::i>(make_not_null(&d_det_spatial_metric),
+                           sqrt_det_spatial_metric() *
+                               sqrt_det_spatial_metric() *
+                               inverse_spatial_metric(ti::J, ti::K) *
+                               d_spatial_metric(ti::i, ti::j, ti::k));
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  tnsr::ijj<DataVector,
+            Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>
+      field_d(get(inverse_conformal_factor_squared));
+  for (size_t k = 0;
+       k < Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim; k++) {
+    for (size_t i = 0;
+         i < Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim; i++) {
+      for (size_t j = i;
+           j < Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim; j++) {
+        field_d.get(k, i, j) = d_spatial_metric.get(k, i, j) /
+                                   get(inverse_conformal_factor_squared) -
+                               pow(get(inverse_conformal_factor_squared), -4) *
+                                   d_det_spatial_metric.get(k) *
+                                   spatial_metric.get(i, j) / 3.;
+        field_d.get(k, i, j) *= 0.5;
+      }
+    }
+  }
+
+  const auto conformal_christoffel_second_kind =
+      ::Ccz4::conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d);
+  // \tilde{Gamma}^i in Ccz4
+  const auto contracted_conformal_christoffel_second_kind =
+      ::Ccz4::contracted_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, conformal_christoffel_second_kind);
+
+  // Similar to Theta, we assume the spatial Z4 constraints are zero,
+  // so \hat{Gamma}^i = \tilde{Gamma}^i
+  return {std::move(contracted_conformal_christoffel_second_kind)};
+}
+
+template <typename SolutionType>
+void Ccz4WrappedGr<SolutionType>::pup(PUP::er& p) {
+  InitialData::pup(p);
+  SolutionType::pup(p);
+}
+
+template <typename SolutionType>
+PUP::able::PUP_ID Ccz4WrappedGr<SolutionType>::my_PUP_ID = 0;
+
+template <typename SolutionType>
+bool operator==(const Ccz4WrappedGr<SolutionType>& lhs,
+                const Ccz4WrappedGr<SolutionType>& rhs) {
+  return static_cast<const SolutionType&>(lhs) ==
+         static_cast<const SolutionType&>(rhs);
+}
+
+template <typename SolutionType>
+bool operator!=(const Ccz4WrappedGr<SolutionType>& lhs,
+                const Ccz4WrappedGr<SolutionType>& rhs) {
+  return not(lhs == rhs);
+}
+
+#define CCZ4_WRAPPED_GR_SOLUTION_TYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define CCZ4_WRAPPED_GR_INSTANTIATE(_, data)                                   \
+  template class Ccz4::Solutions::Ccz4WrappedGr<CCZ4_WRAPPED_GR_SOLUTION_TYPE( \
+      data)>;                                                                  \
+  template bool Ccz4::Solutions::operator==(                                   \
+      const Ccz4WrappedGr<CCZ4_WRAPPED_GR_SOLUTION_TYPE(data)>& lhs,           \
+      const Ccz4WrappedGr<CCZ4_WRAPPED_GR_SOLUTION_TYPE(data)>& rhs);          \
+  template bool Ccz4::Solutions::operator!=(                                   \
+      const Ccz4WrappedGr<CCZ4_WRAPPED_GR_SOLUTION_TYPE(data)>& lhs,           \
+      const Ccz4WrappedGr<CCZ4_WRAPPED_GR_SOLUTION_TYPE(data)>& rhs);
+}  // namespace Ccz4::Solutions

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_GeneralRelativitySolutions")
 
 set(LIBRARY_SOURCES
+  Test_Ccz4WrappedGr.cpp
   Test_GaugeWave.cpp
   Test_GaugePlaneWave.cpp
   Test_HarmonicSchwarzschild.cpp
@@ -19,6 +20,7 @@ add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  Ccz4
   DataStructures
   Domain
   GeneralRelativity

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Ccz4WrappedGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Ccz4WrappedGr.cpp
@@ -1,0 +1,227 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <limits>
+#include <string>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/ATilde.hpp"
+#include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   tmpl::list<MathFunctions::PowX<1, Frame::Inertial>>>>;
+  };
+};
+
+template <typename SolutionType>
+void test_copy_and_move(const SolutionType& solution) {
+  test_copy_semantics(solution);
+  auto solution_copy2 = solution;
+  // clang-tidy: std::move of trivially copyable type
+  test_move_semantics(std::move(solution_copy2), solution);  // NOLINT
+}
+
+template <typename SolutionType>
+void test_ccz4_solution(
+    const SolutionType& solution,
+    const Ccz4::Solutions::Ccz4WrappedGr<SolutionType>& wrapped_solution) {
+  const DataVector data_vector{3.0, 4.0};
+  const tnsr::I<DataVector, SolutionType::volume_dim, Frame::Inertial> x{
+      data_vector};
+  // Don't set time to signaling NaN, since not all solutions tested here
+  // are static
+  const double t = 44.44;
+
+  // Check that the wrapped solution returns the same variables as
+  // the solution
+  const auto vars = solution.variables(
+      x, t, typename SolutionType::template tags<DataVector>{});
+  const auto wrapped_vars = wrapped_solution.variables(
+      x, t, typename SolutionType::template tags<DataVector>{});
+
+  tmpl::for_each<typename SolutionType::template tags<DataVector>>(
+      [&vars, &wrapped_vars](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        CHECK(get<tag>(vars) == get<tag>(wrapped_vars));
+      });
+
+  // Check that the wrapped solution returns the correct extra Ccz4 tags
+  const auto wrapped_Ccz4_vars = wrapped_solution.variables(
+      x, t,
+      tmpl::list<
+          Ccz4::Tags::ConformalMetric<DataVector, SolutionType::volume_dim>,
+          Ccz4::Tags::ConformalFactor<DataVector>,
+          Ccz4::Tags::ATilde<DataVector, SolutionType::volume_dim>,
+          gr::Tags::TraceExtrinsicCurvature<DataVector>,
+          Ccz4::Tags::Theta<DataVector>,
+          Ccz4::Tags::GammaHat<DataVector, SolutionType::volume_dim>>{});
+
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<DataVector, SolutionType::volume_dim>>(vars);
+  const auto& sqrt_det_spatial_metric =
+      get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(vars);
+  Scalar<DataVector> conformal_factor;
+  get(conformal_factor) = pow(get(sqrt_det_spatial_metric), -1. / 3.);
+  CHECK(conformal_factor ==
+        get<Ccz4::Tags::ConformalFactor<DataVector>>(wrapped_Ccz4_vars));
+
+  tnsr::ii<DataVector, SolutionType::volume_dim> conformal_spatial_metric;
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&conformal_spatial_metric),
+      conformal_factor() * conformal_factor() * spatial_metric(ti::i, ti::j));
+  CHECK(conformal_spatial_metric ==
+        get<Ccz4::Tags::ConformalMetric<DataVector, SolutionType::volume_dim>>(
+            wrapped_Ccz4_vars));
+
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<DataVector, SolutionType::volume_dim>>(
+          vars);
+  const auto& inverse_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataVector, SolutionType::volume_dim>>(
+          vars);
+  const auto trace_extrinsic_curvature =
+      trace(extrinsic_curvature, inverse_spatial_metric);
+  CHECK(trace_extrinsic_curvature ==
+        get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(wrapped_Ccz4_vars));
+
+  Scalar<DataVector> conformal_factor_squared;
+  get(conformal_factor_squared) = pow(get(sqrt_det_spatial_metric), -2. / 3.);
+  const auto a_tilde =
+      ::Ccz4::a_tilde(conformal_factor_squared, spatial_metric,
+                      extrinsic_curvature, trace_extrinsic_curvature);
+  CHECK(a_tilde ==
+        get<Ccz4::Tags::ATilde<DataVector, SolutionType::volume_dim>>(
+            wrapped_Ccz4_vars));
+
+  const auto theta =
+      make_with_value<Scalar<DataVector>>(conformal_factor_squared, 0.0);
+  CHECK(theta == get<Ccz4::Tags::Theta<DataVector>>(wrapped_Ccz4_vars));
+
+  tnsr::II<DataVector, SolutionType::volume_dim>
+      inverse_conformal_spatial_metric;
+  ::tenex::evaluate<ti::I, ti::J>(
+      make_not_null(&inverse_conformal_spatial_metric),
+      inverse_spatial_metric(ti::I, ti::J) / conformal_factor_squared());
+  const auto& d_spatial_metric = get<
+      Tags::deriv<gr::Tags::SpatialMetric<DataVector, SolutionType::volume_dim>,
+                  tmpl::size_t<SolutionType::volume_dim>, Frame::Inertial>>(
+      vars);
+  tnsr::i<DataVector, SolutionType::volume_dim> d_det_spatial_metric;
+  ::tenex::evaluate<ti::i>(make_not_null(&d_det_spatial_metric),
+                           sqrt_det_spatial_metric() *
+                               sqrt_det_spatial_metric() *
+                               inverse_spatial_metric(ti::J, ti::K) *
+                               d_spatial_metric(ti::i, ti::j, ti::k));
+  Scalar<DataVector> det_spatial_metric_to_minus_four_thirds;
+  get(det_spatial_metric_to_minus_four_thirds) =
+      pow(get(sqrt_det_spatial_metric), -8. / 3.);
+  tnsr::ijj<DataVector, SolutionType::volume_dim> field_d;
+  ::tenex::evaluate<ti::i, ti::j, ti::k>(
+      make_not_null(&field_d),
+      0.5 * conformal_factor_squared() * d_spatial_metric(ti::i, ti::j, ti::k) -
+          0.5 * spatial_metric(ti::j, ti::k) * d_det_spatial_metric(ti::i) *
+              det_spatial_metric_to_minus_four_thirds() / 3.);
+  const auto conformal_christoffel_second_kind =
+      ::Ccz4::conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, field_d);
+  const auto contracted_conformal_christoffel_second_kind =
+      ::Ccz4::contracted_conformal_christoffel_second_kind(
+          inverse_conformal_spatial_metric, conformal_christoffel_second_kind);
+  // we don't use CHECK here for we switch to tenex to evaluate field_d
+  // from the for loops in Ccz4WrappedGr.cpp
+  CHECK_ITERABLE_APPROX(
+      contracted_conformal_christoffel_second_kind,
+      (get<Ccz4::Tags::GammaHat<DataVector, SolutionType::volume_dim>>(
+          wrapped_Ccz4_vars)));
+
+  // Weak test of operators == and !=
+  CHECK(wrapped_solution == wrapped_solution);
+  CHECK_FALSE(wrapped_solution != wrapped_solution);
+
+  if constexpr (std::is_same_v<SolutionType,
+                               gr::Solutions::GaugePlaneWave<3>>) {
+    register_factory_classes_with_charm<Metavariables>();
+  }
+
+  test_serialization(wrapped_solution);
+  test_copy_and_move(wrapped_solution);
+}
+
+template <typename SolutionType>
+void test_construct_from_options(
+    const Ccz4::Solutions::Ccz4WrappedGr<SolutionType>& wrapped_solution) {
+  const auto created =
+      TestHelpers::test_creation<Ccz4::Solutions::Ccz4WrappedGr<SolutionType>>(
+          "Mass: 0.5\n"
+          "N: 2.5");
+
+  CHECK(created == wrapped_solution);
+}
+
+void test_gauge_plane_wave() {
+  const auto wave_vector = std::array<double, 3>{{0.1, 0.2, 0.3}};
+  const gr::Solutions::GaugePlaneWave<3> gauge_plane_wave_solution{
+      wave_vector,
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(2)};
+  const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::GaugePlaneWave<3>>
+      wrapped_gauge_plane_wave_solution{
+          wave_vector,
+          std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(2)};
+  test_ccz4_solution<gr::Solutions::GaugePlaneWave<3>>(
+      gauge_plane_wave_solution, wrapped_gauge_plane_wave_solution);
+}
+}  // namespace
+
+// [[TimeOut, 40]]
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.Ccz4WrappedGr",
+                  "[PointwiseFunctions][Unit]") {
+  const double amplitude = 0.24;
+  const double wavelength = 4.4;
+  const gr::Solutions::GaugeWave<3> gauge_wave_solution{amplitude, wavelength};
+  const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::GaugeWave<3>>
+      wrapped_gauge_wave_solution{amplitude, wavelength};
+  test_ccz4_solution<gr::Solutions::GaugeWave<3>>(gauge_wave_solution,
+                                                  wrapped_gauge_wave_solution);
+
+  test_gauge_plane_wave();
+
+  const gr::Solutions::Minkowski<3> minkowski_solution{};
+  const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::Minkowski<3>>
+      wrapped_minkowski_solution{};
+  test_ccz4_solution<gr::Solutions::Minkowski<3>>(minkowski_solution,
+                                                  wrapped_minkowski_solution);
+
+  const double mass = 0.5;
+  const double n = 2.5;
+  const gr::Solutions::TrumpetSchwarzschild trumpet_schwarzschild_solution{mass,
+                                                                           n};
+  const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::TrumpetSchwarzschild>
+      wrapped_trumpet_schwarzschild_solution{mass, n};
+  test_ccz4_solution<gr::Solutions::TrumpetSchwarzschild>(
+      trumpet_schwarzschild_solution, wrapped_trumpet_schwarzschild_solution);
+
+  test_construct_from_options<gr::Solutions::TrumpetSchwarzschild>(
+      wrapped_trumpet_schwarzschild_solution);
+}


### PR DESCRIPTION
## Proposed changes
Add a Ccz4 wrapper class around gr solutions to get Ccz4 evolution variables. This class is very similar to the `WrappedGr` class for the GH evolution variables.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
