### PR TITLE
AH rewrite: Add function to interpolate AH volume vars

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   ComputeVarsToInterpolateToTarget.cpp
   Destination.cpp
   FastFlow.cpp
+  InterpolateVolumeVars.cpp
   InterpolationTarget.cpp
   OptionTags.cpp
   Storage.cpp
@@ -35,6 +36,7 @@ spectre_target_headers(
   FastFlow.hpp
   HorizonAliases.hpp
   Initialization.hpp
+  InterpolateVolumeVars.hpp
   InterpolationTarget.hpp
   OptionTags.hpp
   Storage.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/Variables.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+template <typename Fr>
+void interpolate_volume_data(
+    const gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration_storage,
+    const gsl::not_null<
+        std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>*>
+        all_volume_variables,
+    const LinkedMessageId<double>& time, const Domain<3>& domain,
+    const domain::FunctionsOfTimeMap& functions_of_time) {
+  std::vector<ElementId<3>> element_ids;
+  element_ids.reserve(all_volume_variables->size());
+  for (const auto& [element_id, volume_vars] : *all_volume_variables) {
+    (void)volume_vars;  // Avoid clang-tidy warning
+    if (not current_iteration_storage->interpolation_is_done_for_these_elements
+                .contains(element_id)) {
+      element_ids.push_back(element_id);
+      current_iteration_storage->interpolation_is_done_for_these_elements
+          .insert(element_id);
+    }
+  }
+
+  ASSERT(current_iteration_storage->block_coord_holders.has_value(),
+         "Block logical coordinates of horizon have not been set!");
+
+  const auto& block_coord_holders =
+      current_iteration_storage->block_coord_holders.value();
+  const auto element_coord_holders =
+      element_logical_coordinates(element_ids, block_coord_holders);
+
+  for (const auto& [element_id, element_coord_holder] : element_coord_holders) {
+    const auto& offsets = element_coord_holder.offsets;
+    auto& volume_vars_storage = all_volume_variables->at(element_id);
+    auto& interpolated_vars = current_iteration_storage->interpolated_vars;
+
+    // Only fill once
+    const size_t expected_num_points = block_coord_holders.size();
+    if (interpolated_vars.number_of_grid_points() != expected_num_points) {
+      interpolated_vars.initialize(expected_num_points);
+    }
+
+    // Take the ah::source_vars and convert to
+    // ah::vars_to_interpolate_to_target
+    ah::compute_vars_to_interpolate_to_target(
+        make_not_null(&volume_vars_storage), time, domain, element_id,
+        functions_of_time);
+
+    const intrp::Irregular<3> interpolator(
+        volume_vars_storage.mesh, element_coord_holder.element_logical_coords);
+
+    // Vars interpolated to points within this element
+    auto local_interpolated_vars = interpolator.interpolate(
+        volume_vars_storage.vars_to_interpolate_to_target);
+
+    // Loop over each tensor
+    tmpl::for_each<ah::vars_to_interpolate_to_target<3, Fr>>(
+        [&]<typename Tag>(tmpl::type_<Tag>) {
+          auto& individual_interpolated_var = get<Tag>(interpolated_vars);
+          auto& local_individual_interpolated_var =
+              get<Tag>(local_interpolated_vars);
+
+          // Loop over components of tensor
+          for (size_t i = 0; i < individual_interpolated_var.size(); i++) {
+            // Loop over number of points that were interpolated
+            for (size_t j = 0; j < offsets.size(); j++) {
+              // Copy the local interpolated value into the correct
+              // position in the overall tensor
+              individual_interpolated_var[i][offsets[j]] =
+                  local_individual_interpolated_var[i][j];
+            }
+          }
+        });
+
+    for (const size_t offset : offsets) {
+      current_iteration_storage->indicies_interpolated_to_thus_far.insert(
+          offset);
+    }
+  }
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                         \
+  template void interpolate_volume_data(                             \
+      const gsl::not_null<ah::Storage::Iteration<FRAME(data)>*>      \
+          current_iteration_storage,                                 \
+      const gsl::not_null<std::unordered_map<                        \
+          ElementId<3>, ah::Storage::VolumeVariables<FRAME(data)>>*> \
+          all_volume_variables,                                      \
+      const LinkedMessageId<double>& time, const Domain<3>& domain,  \
+      const domain::FunctionsOfTimeMap& functions_of_time);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Inertial, Frame::Distorted, Frame::Grid))
+
+#undef INSTANTIATE
+#undef FRAME
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class Domain;
+template <size_t VolumeDim>
+class ElementId;
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ah {
+/*!
+ * \brief Interpolate volume data from any new elements received by the horizon
+ * finder to the target points.
+ *
+ * \details For each new element, the `vars_to_interpolate_to_target` in
+ * \p all_volume_variables are computed using the
+ * `ah::compute_vars_to_interpolate_to_target()` function, and the results are
+ * interpolated to the target points and stored in \p current_iteration_storage.
+ */
+template <typename Fr>
+void interpolate_volume_data(
+    gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration_storage,
+    gsl::not_null<
+        std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>*>
+        all_volume_variables,
+    const LinkedMessageId<double>& time, const Domain<3>& domain,
+    const domain::FunctionsOfTimeMap& functions_of_time);
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Destination.cpp
   Test_FastFlow.cpp
   Test_Initialization.cpp
+  Test_InterpolateVolumeVars.cpp
   Test_InterpolationTargetApparentHorizon.cpp
   Test_ObserveCenters.cpp
   Test_OptionTags.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
@@ -1,0 +1,234 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <unordered_map>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/KerrHorizon.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+Variables<ah::source_vars<3>> compute_source_vars(
+    const gr::Solutions::KerrSchild& solution,
+    const LinkedMessageId<double>& time, const ElementId<3>& element_id,
+    const Block<3>& block, const Mesh<3>& mesh) {
+  const auto logical_coords = logical_coordinates(mesh);
+  const ElementMap<3, Frame::Inertial> map_logical_to_inertial{
+      element_id, block.stationary_map().get_clone()};
+  const auto inertial_coords = map_logical_to_inertial(logical_coords);
+
+  const InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      inv_jacobian_logical_to_inertial =
+          map_logical_to_inertial.inv_jacobian(logical_coords);
+
+  const auto solution_vars = solution.variables(
+      inertial_coords, time.id,
+      typename gr::Solutions::KerrSchild::tags<DataVector, Frame::Inertial>{});
+
+  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(solution_vars);
+  const auto& dt_lapse =
+      get<Tags::dt<gr::Tags::Lapse<DataVector>>>(solution_vars);
+  const auto& d_lapse =
+      get<typename gr::Solutions::KerrSchild::DerivLapse<DataVector>>(
+          solution_vars);
+  const auto& shift = get<gr::Tags::Shift<DataVector, 3>>(solution_vars);
+  const auto& d_shift =
+      get<typename gr::Solutions::KerrSchild::DerivShift<DataVector>>(
+          solution_vars);
+  const auto& dt_shift =
+      get<Tags::dt<gr::Tags::Shift<DataVector, 3>>>(solution_vars);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(solution_vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<DataVector, 3>>>(solution_vars);
+  const auto& d_spatial_metric =
+      get<typename gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector>>(
+          solution_vars);
+
+  Variables<ah::source_vars<3>> result{get(lapse).size()};
+  get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(result) =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  get<::gh::Tags::Phi<DataVector, 3>>(result) =
+      gh::phi(lapse, d_lapse, shift, d_shift, spatial_metric, d_spatial_metric);
+  get<::gh::Tags::Pi<DataVector, 3>>(result) =
+      gh::pi(lapse, dt_lapse, shift, dt_shift, spatial_metric,
+             dt_spatial_metric, get<::gh::Tags::Phi<DataVector, 3>>(result));
+
+  // Need to compute numerical deriv of Phi.
+  get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                  Frame::Inertial>>(result) =
+      partial_derivative(get<::gh::Tags::Phi<DataVector, 3>>(result), mesh,
+                         inv_jacobian_logical_to_inertial);
+
+  return result;
+}
+
+void test_interpolate_volume_vars() {
+  const size_t number_of_grid_points = 8;
+
+  const double mass = 1.0;
+  const std::array spin{0.1, 0.2, 0.3};
+  const std::array center{-0.01, -0.02, -0.03};
+  const LinkedMessageId<double> time{0.01, std::nullopt};
+  const domain::creators::Sphere domain_creator{
+      0.7,
+      6.0,
+      domain::creators::Sphere::Excision{nullptr},
+      0_st,
+      number_of_grid_points,
+      true};
+  const auto domain = domain_creator.create_domain();
+  const auto& functions_of_time = domain_creator.functions_of_time();
+
+  const auto& blocks = domain.blocks();
+  const auto element_ids = [&]() {
+    std::vector<ElementId<3>> result{};
+    for (const auto& block : blocks) {
+      const auto temp_element_ids = initial_element_ids(
+          block.id(), domain_creator.initial_refinement_levels()[block.id()]);
+      result.insert(result.end(), temp_element_ids.begin(),
+                    temp_element_ids.end());
+    }
+    return result;
+  }();
+
+  // For a quick test
+  const size_t l_max = 6;
+  const double radius = 2.0;
+
+  ah::Storage::Iteration<Frame::Inertial> current_iteration{};
+  current_iteration.strahlkorper =
+      ylm::Strahlkorper<Frame::Inertial>{l_max, radius, center};
+  const auto surface_coords =
+      ylm::cartesian_coords(current_iteration.strahlkorper);
+  current_iteration.block_coord_holders = ::block_logical_coordinates(
+      domain, surface_coords, time.id, functions_of_time);
+
+  const gr::Solutions::KerrSchild solution(mass, spin, {0.0, 0.0, 0.0});
+  const auto solution_vars = solution.variables(
+      surface_coords, time.id,
+      typename gr::Solutions::KerrSchild::tags<DataVector, Frame::Inertial>{});
+
+  std::unordered_map<ElementId<3>,
+                     ah::Storage::VolumeVariables<Frame::Inertial>>
+      all_volume_variables{};
+
+  // Check that if there aren't any volume variables, that nothing happens
+  ah::interpolate_volume_data(make_not_null(&current_iteration),
+                              make_not_null(&all_volume_variables), time,
+                              domain, functions_of_time);
+  CHECK(current_iteration.interpolation_is_done_for_these_elements.empty());
+  CHECK(current_iteration.indicies_interpolated_to_thus_far.empty());
+  CHECK(current_iteration.interpolated_vars.number_of_grid_points() == 0_st);
+
+  size_t num_previous_indices_interpolated_to = 0;
+  for (const auto& element_id : element_ids) {
+    const Mesh mesh{domain_creator.initial_extents()[element_id.block_id()],
+                    Spectral::Basis::Legendre,
+                    Spectral::Quadrature::GaussLobatto};
+
+    all_volume_variables[element_id].source_vars = compute_source_vars(
+        solution, time, element_id, blocks[element_id.block_id()], mesh);
+    all_volume_variables[element_id].mesh = mesh;
+
+    ah::interpolate_volume_data(make_not_null(&current_iteration),
+                                make_not_null(&all_volume_variables), time,
+                                domain, functions_of_time);
+
+    // Check that we finished interpolation and that the points we interpolated
+    // to aren't the default fill value
+    CHECK(current_iteration.interpolation_is_done_for_these_elements.contains(
+        element_id));
+    // We could in theory figure out which points are in which element for a
+    // given l_max, but that's quite tedious and we don't need such a stringent
+    // test
+    CHECK_FALSE(current_iteration.indicies_interpolated_to_thus_far.size() ==
+                num_previous_indices_interpolated_to);
+    num_previous_indices_interpolated_to =
+        current_iteration.indicies_interpolated_to_thus_far.size();
+    tmpl::for_each<ah::vars_to_interpolate_to_target<3, Frame::Inertial>>(
+        [&]<typename Tag>(tmpl::type_<Tag>) {
+          auto& interpolated_var =
+              get<Tag>(current_iteration.interpolated_vars);
+          for (size_t j = 0; j < interpolated_var.size(); j++) {
+            for (const size_t index :
+                 current_iteration.indicies_interpolated_to_thus_far) {
+              CHECK(interpolated_var[j][index] !=
+                    std::numeric_limits<double>::max());
+            }
+          }
+        });
+  }
+
+  const auto check_no_max = [&]() {
+    tmpl::for_each<ah::vars_to_interpolate_to_target<3, Frame::Inertial>>(
+        [&]<typename Tag>(tmpl::type_<Tag>) {
+          auto& interpolated_var =
+              get<Tag>(current_iteration.interpolated_vars);
+          for (size_t j = 0; j < interpolated_var.size(); j++) {
+            CHECK(alg::none_of(interpolated_var[j], [](const double value) {
+              return value == std::numeric_limits<double>::max();
+            }));
+          }
+        });
+  };
+
+  // Check all points have been interpolated to
+  check_no_max();
+
+  // Test sending volume data again that it doesn't do anything
+  const auto& element_id = element_ids[0];
+  const Mesh mesh{domain_creator.initial_extents()[element_id.block_id()],
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto};
+
+  ah::interpolate_volume_data(make_not_null(&current_iteration),
+                              make_not_null(&all_volume_variables), time,
+                              domain, functions_of_time);
+
+  // Check interpolation is still done
+  CHECK(current_iteration.interpolation_is_done_for_these_elements.contains(
+      element_id));
+  // This shouldn't have changed
+  CHECK(current_iteration.indicies_interpolated_to_thus_far.size() ==
+        num_previous_indices_interpolated_to);
+  // Again check that all points are interpolated to
+  check_no_max();
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.InterpolateVolumeVars",
+                  "[ApparentHorizonFinder][Unit]") {
+  // We don't need time dependent maps for this test. The actual time dependent
+  // parts are tested elsewhere
+  test_interpolate_volume_vars();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Ninth PR in horizon finder changes. This adds a function that runs every time a new element has sent and added its data to the horizon finder. It tries to interpolate the volume data from any new elements received to the trial surface points.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
