### PR TITLE
AH rewrite: Add function to invoke AH callbacks

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_headers(
   ErrorOnFailedApparentHorizon.hpp
   FindApparentHorizon.hpp
   IgnoreFailedApparentHorizon.hpp
+  InvokeCallbacks.hpp
   ObserveCenters.hpp
   SendDependencyToObserverWriter.hpp
   )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/InvokeCallbacks.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/InvokeCallbacks.hpp
@@ -1,0 +1,152 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/StrahlkorperTransformations.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+/*!
+ * \brief Invoke the callbacks specified in the `horizon_find_callbacks` alias
+ * of the \p HorizonMetavars.
+ *
+ * \details Before invoking the callbacks, this function
+ *
+ * 1. Restricts the final interpolated variables from the $L_\mathrm{mesh}$ used
+ *    for the FastFlow algorithm, to the actual $L$ of the Strahlkorper.
+ * 2. Adds the current Strahlkorper to the `ah::Tags::PreviousSurfaces`.
+ * 3. Copies the Strahlkorper, its time derivative, and the \p dependency into
+ *    the box. Also possibly computes the Inertial coordinates of the final
+ *    Strahlkorper and stores them in the box if the `frame` of the
+ *    \p HorizonMetavars isn't the Inertial frame.
+ */
+template <typename HorizonMetavars, typename DbTags, typename Metavariables>
+void invoke_callbacks(const gsl::not_null<db::DataBox<DbTags>*> box,
+                      Parallel::GlobalCache<Metavariables>& cache,
+                      const std::optional<std::string>& dependency,
+                      const FastFlow::Status status) {
+  using Fr = typename HorizonMetavars::frame;
+
+  const auto& current_time = db::get<ah::Tags::CurrentTime>(*box).value();
+  const auto& all_storage = db::get<ah::Tags::Storage<Fr>>(*box);
+  const auto& current_time_storage = all_storage.at(current_time);
+  const auto& current_iteration = current_time_storage.current_iteration;
+  auto& previous_surfaces =
+      db::get_mutable_reference<ah::Tags::PreviousSurfaces<Fr>>(box);
+  const auto& fast_flow = db::get<ah::Tags::FastFlow>(*box);
+
+  // The interpolated variables have been interpolated from the volume to
+  // the points on the prolonged_strahlkorper, not to the points on the
+  // actual strahlkorper. So here we do a restriction of these quantities
+  // onto the actual strahlkorper.
+  const auto& current_strahlkorper = current_iteration.strahlkorper;
+  const auto& current_ylm = current_strahlkorper.ylm_spherepack();
+  const size_t L_mesh = fast_flow.current_l_mesh(current_strahlkorper);
+  const auto prolonged_strahlkorper =
+      ylm::Strahlkorper<Fr>(L_mesh, L_mesh, current_strahlkorper);
+  const auto& prolonged_ylm = prolonged_strahlkorper.ylm_spherepack();
+  const auto& prolonged_interpolated_vars = current_iteration.interpolated_vars;
+  db::mutate<::Tags::Variables<ah::vars_to_interpolate_to_target<3, Fr>>>(
+      [&](const gsl::not_null<
+          ::Variables<ah::vars_to_interpolate_to_target<3, Fr>>*>
+              new_interpolated_vars) {
+        new_interpolated_vars->initialize(current_ylm.physical_size());
+        tmpl::for_each<ah::vars_to_interpolate_to_target<3, Fr>>(
+            [&]<typename Tag>(tmpl::type_<Tag>) {
+              const auto& prolonged_var = get<Tag>(prolonged_interpolated_vars);
+              auto& new_var = get<Tag>(*new_interpolated_vars);
+              for (size_t i = 0; i < prolonged_var.size(); i++) {
+                new_var[i] =
+                    current_ylm.spec_to_phys(prolonged_ylm.prolong_or_restrict(
+                        prolonged_ylm.phys_to_spec(prolonged_var[i]),
+                        current_ylm));
+              }
+            });
+      },
+      box);
+
+  // This is the number of previous strahlkorpers that we
+  // keep around.
+  const size_t num_previous_strahlkorpers = 3;
+
+  // Update the previous strahlkorpers. We do this before the callbacks
+  // in case any of the callbacks need the previous strahlkorpers with the
+  // current strahlkorper already in it.
+  previous_surfaces.emplace_front(current_time, current_strahlkorper);
+
+  // Remove old previous_strahlkorpers that are no longer relevant.
+  while (previous_surfaces.size() > num_previous_strahlkorpers) {
+    previous_surfaces.pop_back();
+  }
+
+  db::mutate<ylm::Tags::Strahlkorper<Fr>, ylm::Tags::TimeDerivStrahlkorper<Fr>,
+             ah::Tags::Dependency>(
+      [&](const gsl::not_null<ylm::Strahlkorper<Fr>*> horizon,
+          const gsl::not_null<ylm::Strahlkorper<Fr>*> time_deriv_of_horizon,
+          const gsl::not_null<std::optional<std::string>*>
+              callback_dependency) {
+        *horizon = current_strahlkorper;
+
+        // This is a hack to use ylm::time_deriv_of_strahlkorper function below
+        std::deque<std::pair<double, ylm::Strahlkorper<Fr>>>
+            previous_horizons{};
+        for (const auto& previous_surface : previous_surfaces) {
+          previous_horizons.emplace_back(previous_surface.time.id,
+                                         previous_surface.surface);
+        }
+
+        *time_deriv_of_horizon = current_strahlkorper;
+        ylm::time_deriv_of_strahlkorper(time_deriv_of_horizon,
+                                        previous_horizons);
+
+        *callback_dependency = dependency;
+      },
+      box);
+
+  // Put inertial coords in the box if they aren't already there
+  if constexpr (not std::is_same_v<Fr, Frame::Inertial>) {
+    db::mutate<ylm::Tags::CartesianCoords<Frame::Inertial>>(
+        [&](const gsl::not_null<tnsr::I<DataVector, 3>*> inertial_coords) {
+          const auto& domain = Parallel::get<domain::Tags::Domain<3>>(cache);
+          const auto& functions_of_time =
+              Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+          strahlkorper_coords_in_different_frame(
+              inertial_coords, current_strahlkorper, domain, functions_of_time,
+              current_time.id);
+        },
+        box);
+  }
+
+  // Finally call callbacks
+  tmpl::for_each<typename HorizonMetavars::horizon_find_callbacks>(
+      [&]<typename Callback>(tmpl::type_<Callback>) {
+        Callback::apply(*box, cache, status);
+      });
+}
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
+add_subdirectory(Callbacks)
 add_subdirectory(Events)
 add_subdirectory(Protocols)
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY_SOURCES
+  ${LIBRARY_SOURCES}
+  Callbacks/Test_InvokeCallbacks.cpp
+  PARENT_SCOPE)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_InvokeCallbacks.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_InvokeCallbacks.cpp
@@ -1,0 +1,182 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Domain.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/InvokeCallbacks.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+constexpr size_t l_max = 6;
+constexpr double radius = 1.34;
+
+template <typename HorizonMetavars>
+struct TestCallback : tt::ConformsTo<ah::protocols::Callback> {
+ private:
+  using Fr = typename HorizonMetavars::frame;
+
+ public:
+  template <typename DbTags, typename Metavariables>
+  static void apply(db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const FastFlow::Status failure_reason) {
+    const auto& time = db::get<ah::Tags::CurrentTime>(box);
+    CHECK(time == std::optional{LinkedMessageId<double>{2.0, {1.0}}});
+    CHECK(failure_reason == FastFlow::Status::TruncationTol);
+    CHECK(db::get<ah::Tags::FastFlow>(box) == FastFlow{FastFlow::FlowType::Fast,
+                                                       1.0, 0.5, 1.e-12, 1.e-2,
+                                                       1.2, 5, 100});
+    CHECK(db::get<ah::Tags::Dependency>(box) ==
+          std::optional{"FakeDependency"});
+
+    const auto& strahlkorper = db::get<ylm::Tags::Strahlkorper<Fr>>(box);
+    CHECK(strahlkorper ==
+          ylm::Strahlkorper<Fr>{l_max, radius, std::array{0.0, 0.0, 0.0}});
+
+    // Check that we restricted properly
+    const size_t expected_size = ylm::Spherepack::physical_size(l_max, l_max);
+    tmpl::for_each<ah::vars_to_interpolate_to_target<3, Fr>>(
+        [&]<typename Tag>(tmpl::type_<Tag>) {
+          const auto& var = db::get<Tag>(box);
+          for (size_t i = 0; i < var.size(); i++) {
+            CHECK(var[i].size() == expected_size);
+          }
+        });
+
+    // Time deriv is zero because there weren't any previous horizons to compute
+    // the time deriv with
+    CHECK(db::get<ylm::Tags::TimeDerivStrahlkorper<Fr>>(box).coefficients() ==
+          DataVector{ylm::Spherepack::spectral_size(l_max, l_max), 0.0});
+  }
+};
+
+template <typename Fr>
+struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using temporal_id_tag = ::Tags::TimeAndPrevious<0>;
+  using frame = Fr;
+
+  using horizon_find_callbacks = tmpl::list<TestCallback<HorizonMetavars>>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() { return "TestingHorizonMetavars"; }
+};
+
+struct Metavariables {
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+  using component_list = tmpl::list<>;
+};
+
+template <typename Fr>
+void run_test() {
+  const domain::creators::Sphere sphere_creator{
+      0.9, 2.0, domain::creators::Sphere::Excision{nullptr}, 0_st, 4_st, true};
+
+  Parallel::GlobalCache<Metavariables> cache{
+      {sphere_creator.create_domain()}, {sphere_creator.functions_of_time()}};
+
+  const LinkedMessageId<double> time{2.0, {1.0}};
+  const FastFlow fast_flow{
+      FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100};
+  const std::optional<std::string> dependency{"FakeDependency"};
+
+  ah::Storage::Iteration<Fr> current_iteration{};
+  current_iteration.strahlkorper =
+      ylm::Strahlkorper<Fr>{l_max, radius, std::array{0.0, 0.0, 0.0}};
+  const size_t l_mesh =
+      fast_flow.current_l_mesh(current_iteration.strahlkorper);
+  // The actual values don't matter for this test
+  current_iteration.interpolated_vars =
+      Variables<ah::vars_to_interpolate_to_target<3, Fr>>{
+          ylm::Spherepack::physical_size(l_mesh, l_mesh), 3.21};
+
+  ah::Storage::SingleTimeStorage<Fr> current_time_storage{};
+  current_time_storage.current_iteration = current_iteration;
+
+  std::unordered_map<LinkedMessageId<double>,
+                     ah::Storage::SingleTimeStorage<Fr>>
+      all_storage{};
+  all_storage[time] = current_time_storage;
+
+  const FastFlow::Status status = FastFlow::Status::TruncationTol;
+
+  auto box = db::create<db::AddSimpleTags<tmpl::list<
+      ah::Tags::CurrentTime, ah::Tags::Storage<Fr>,
+      ah::Tags::PreviousSurfaces<Fr>, ah::Tags::FastFlow, ah::Tags::Verbosity,
+      ylm::Tags::Strahlkorper<Fr>, ylm::Tags::TimeDerivStrahlkorper<Fr>,
+      ah::Tags::Dependency, ylm::Tags::CartesianCoords<Frame::Inertial>,
+      ::Tags::Variables<ah::vars_to_interpolate_to_target<3, Fr>>>>>(
+      std::optional{time}, all_storage,
+      std::deque<ah::Storage::PreviousSurface<Fr>>{},
+      FastFlow{FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100},
+      ::Verbosity::Quiet, ylm::Strahlkorper<Fr>{}, ylm::Strahlkorper<Fr>{},
+      std::optional<std::string>{}, tnsr::I<DataVector, 3>{},
+      Variables<ah::vars_to_interpolate_to_target<3, Fr>>{});
+
+  ah::invoke_callbacks<HorizonMetavars<Fr>>(make_not_null(&box), cache,
+                                            dependency, status);
+
+  const auto& box_previous_surfaces =
+      db::get<ah::Tags::PreviousSurfaces<Fr>>(box);
+  REQUIRE_FALSE(box_previous_surfaces.empty());
+  CHECK(box_previous_surfaces.front().time == time);
+  CHECK(box_previous_surfaces.front().surface ==
+        current_iteration.strahlkorper);
+  CHECK(db::get<ylm::Tags::Strahlkorper<Fr>>(box) ==
+        current_iteration.strahlkorper);
+  CHECK(db::get<ylm::Tags::TimeDerivStrahlkorper<Fr>>(box).coefficients() ==
+        DataVector{current_iteration.strahlkorper.coefficients().size(), 0.0});
+  CHECK(db::get<ah::Tags::Dependency>(box) == dependency);
+  CHECK(
+      db::get<::Tags::Variables<ah::vars_to_interpolate_to_target<3, Fr>>>(box)
+          .number_of_grid_points() ==
+      ylm::Spherepack::physical_size(l_max, l_max));
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.InvokeCallbacks",
+                  "[ApparentHorizonFinder][Unit]") {
+  domain::creators::register_derived_with_charm();
+  run_test<Frame::Grid>();
+  run_test<Frame::Inertial>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Tenth PR in horizon finder changes. Adds a function that sets up the databox for callbacks to be run. Actual callbacks will be added in future PRs.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
