### PR TITLE
Implement DG cartoon divergence

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -91,6 +91,32 @@ void divergence(gsl::not_null<Scalar<DataType>*> div_input,
 
 /// @{
 /*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Compute the divergence of fluxes where a Cartoon basis is being
+ * utilized.
+ *
+ * The additional parameter `inertial_coords` is used for division by the
+ * \f$x\f$ coordinates. If \f$x=0\f$ is included in the domain, it is assumed to
+ * be present only at the first index and is handled by L'H&ocirc;pital's rule.
+ *
+ * The mesh is required to have the Cartoon basis in the last and potentially
+ * second-to-last coordinates and the inverse jacobian is accordingly used only
+ * in the first and potentially second dimensions.
+ *
+ * \see cartoon_partial_derivatives for details on Cartoon derivatives.
+ */
+template <typename... DivTags, typename... FluxTags, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3> = nullptr>
+void cartoon_divergence(
+    gsl::not_null<Variables<tmpl::list<DivTags...>>*> divergence_of_F,
+    const Variables<tmpl::list<FluxTags...>>& F, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian_3d,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+/// @}
+
+/// @{
+/*!
  * \brief Compute the divergence of fluxes in logical coordinates
  *
  * Applies the logical differentiation matrix to the fluxes in each dimension

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -5,10 +5,12 @@
 
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
@@ -58,20 +60,19 @@ void divergence(
         LogicalImpl<Dim, tmpl::list<FluxTags...>, DerivativeTags>::apply(
             make_not_null(&logical_derivs), &temp0, &temp1, F, mesh);
   } else {
-    Variables<DerivativeTags> *temp = nullptr;
+    Variables<DerivativeTags>* temp = nullptr;
     partial_derivatives_detail::
         LogicalImpl<Dim, tmpl::list<FluxTags...>, DerivativeTags>::apply(
             make_not_null(&logical_derivs), temp, temp, F, mesh);
   }
 
-  const auto apply_div = [
-    &divergence_of_F, &inverse_jacobian, &logical_partial_derivatives_of_F
-  ](auto flux_tag_v, auto div_tag_v) {
+  const auto apply_div = [&divergence_of_F, &inverse_jacobian,
+                          &logical_partial_derivatives_of_F](auto flux_tag_v,
+                                                             auto div_tag_v) {
     using FluxTag = std::decay_t<decltype(flux_tag_v)>;
     using DivFluxTag = std::decay_t<decltype(div_tag_v)>;
 
-    using first_index =
-        tmpl::front<typename FluxTag::type::index_list>;
+    using first_index = tmpl::front<typename FluxTag::type::index_list>;
     static_assert(
         std::is_same_v<typename first_index::Frame, DerivativeFrame> and
             first_index::ul == UpLo::Up,
@@ -95,6 +96,280 @@ void divergence(
     }
   };
   EXPAND_PACK_LEFT_TO_RIGHT(apply_div(FluxTags{}, DivTags{}));
+}
+
+template <size_t CompDim, typename DivTags, typename FluxTags, size_t Dim,
+          typename DerivativeFrame>
+void cartoon_divergence_apply(
+    const gsl::not_null<Variables<DivTags>*> divergence_of_F,
+    const Variables<FluxTags>& F, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian_3d,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  static_assert(Dim == 3);
+  ASSERT((CompDim == 2 and
+          mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry) or
+             (CompDim == 1 and
+              (mesh.quadrature(1) == Spectral::Quadrature::SphericalSymmetry and
+               mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry)),
+         "Invalid Quadrature combinations: axial symmetry requires 2 "
+         "non-Cartoon dimensions, spherical symmetry requires 1 non-Cartoon "
+         "dimension. Got: "
+             << mesh.quadrature());
+
+  if (UNLIKELY(divergence_of_F->number_of_grid_points() !=
+               mesh.number_of_grid_points())) {
+    divergence_of_F->initialize(mesh.number_of_grid_points());
+  }
+
+  using DerivativeTags = FluxTags;
+  using ValueType = typename Variables<DerivativeTags>::value_type;
+  const size_t vars_size =
+      Variables<DerivativeTags>::number_of_independent_components *
+      F.number_of_grid_points();
+  const auto logical_derivs_data =
+      cpp20::make_unique_for_overwrite<ValueType[]>(
+          (CompDim > 1 ? (CompDim + 2) : CompDim) * vars_size);
+  std::array<ValueType*, CompDim> logical_derivs{};
+  std::array<Variables<DerivativeTags>, CompDim>
+      logical_partial_derivatives_of_F{};
+  for (size_t i = 0; i < CompDim; ++i) {
+    gsl::at(logical_derivs, i) = &(logical_derivs_data[i * vars_size]);
+    gsl::at(logical_partial_derivatives_of_F, i)
+        .set_data_ref(gsl::at(logical_derivs, i), vars_size);
+  }
+
+  if constexpr (CompDim == 1) {
+    Variables<DerivativeTags>* temp = nullptr;
+    partial_derivatives_detail::LogicalImpl<CompDim, FluxTags, DerivativeTags>::
+        apply(make_not_null(&logical_derivs), temp, temp, F,
+              mesh.slice_through(0));
+  } else {
+    Variables<DerivativeTags> temp0{&logical_derivs_data[CompDim * vars_size],
+                                    vars_size};
+    Variables<DerivativeTags> temp1{
+        &logical_derivs_data[(CompDim + 1) * vars_size], vars_size};
+    partial_derivatives_detail::LogicalImpl<CompDim, FluxTags, DerivativeTags>::
+        apply(make_not_null(&logical_derivs), &temp0, &temp1, F,
+              mesh.slice_through(0, 1));
+  }
+
+  const Spectral::Quadrature quad_type = mesh.quadrature(2);
+  const auto numerical_deriv_in_this_direction = [](const size_t deriv_num) {
+    if constexpr (CompDim == 2) {
+      return deriv_num == 0 or deriv_num == 1;
+    } else {
+      return deriv_num == 0;
+    }
+  };
+
+  DataVector safe_x_coords = get<0>(inertial_coords);
+  const bool element_contains_zero_of_symmetry_axis = equal_within_roundoff(
+      0.0, safe_x_coords[0], std::numeric_limits<double>::epsilon() * 100.0,
+      max(safe_x_coords));
+  // Having x=0 requires both not dividing by zero (done here by setting to
+  // arbitrary non-zero value) and remembering to then do L'Hopital
+  if (element_contains_zero_of_symmetry_axis) {
+    safe_x_coords[0] = 1.0;
+    if constexpr (CompDim == 2) {
+      const size_t x_extents = mesh.extents(0);
+      const size_t y_extents = mesh.extents(1);
+      for (size_t i = 1; i < y_extents; ++i) {
+        ASSERT(
+            equal_within_roundoff(
+                0.0, safe_x_coords[i * x_extents],
+                std::numeric_limits<double>::epsilon() * 100.0,
+                max(safe_x_coords)),
+            "The passed inertial coordinates do not follow the required format "
+            "of a rectangular mesh with x=0 being located at the first index "
+            "of each constant-y subdomain of the x DataVector. x="
+                << safe_x_coords);
+        safe_x_coords[i * x_extents] = 1.0;
+      }
+    }
+  }
+  // If doing L'Hopital's rule, we need to store temporary forms of the data
+  // in two different tensors (hence the 0 & 1 labels) for each tensor type
+  // They only have to hold the x=0 positions, so of size y_extents
+  using FluxTypes = tmpl::remove_duplicates<
+      tmpl::transform<FluxTags, tmpl::bind<tmpl::type_from, tmpl::_1>>>;
+
+  using TempTags0 = ::Tags::convert_to_temp_tensors<FluxTypes, 0>;
+  using TempTags1 = ::Tags::convert_to_temp_tensors<FluxTypes, 1>;
+  using VarTags = tmpl::append<TempTags0, TempTags1>;
+
+  Variables<VarTags> temp_vars{};
+  if (element_contains_zero_of_symmetry_axis) {
+    const size_t y_extents = mesh.extents(1);
+    temp_vars.initialize(y_extents);
+  }
+
+  tmpl::for_each<
+      FluxTags>([&divergence_of_F, &F, &inverse_jacobian_3d, &mesh,
+                 &safe_x_coords, &logical_partial_derivatives_of_F,
+                 &numerical_deriv_in_this_direction, &quad_type, &temp_vars,
+                 &element_contains_zero_of_symmetry_axis]<typename FluxTag>(
+                    tmpl::type_<FluxTag> /*meta*/) {
+    using DivFluxTag = tmpl::at<DivTags, tmpl::index_of<FluxTags, FluxTag>>;
+
+    using first_index = tmpl::front<typename FluxTag::type::index_list>;
+    static_assert(
+        std::is_same_v<typename first_index::Frame, DerivativeFrame> and
+            first_index::ul == UpLo::Up,
+        "First index of tensor cannot be contracted with derivative "
+        "because either it is in the wrong frame or it has the wrong "
+        "valence");
+    static_assert(first_index::index_type == IndexType::Spatial);
+
+    auto& divergence_of_flux = get<DivFluxTag>(*divergence_of_F);
+    auto& flux = get<FluxTag>(F);
+    TensorMetafunctions::prepend_spatial_index<typename FluxTag::type, Dim,
+                                               UpLo::Lo, Frame::Inertial>
+        cart_deriv_tensor;
+    cartoon_derivative<typename FluxTag::type, 3, Frame::Inertial>(
+        cart_deriv_tensor, flux, safe_x_coords, quad_type);
+
+    if (not element_contains_zero_of_symmetry_axis) {
+      for (auto it = divergence_of_flux.begin(); it != divergence_of_flux.end();
+           ++it) {
+        *it = 0.0;
+        const auto div_flux_indices = divergence_of_flux.get_tensor_index(it);
+        for (size_t i0 = 0; i0 < Dim; ++i0) {
+          const auto flux_indices = prepend(div_flux_indices, i0);
+          if (numerical_deriv_in_this_direction(i0)) {
+            // only accessing relevenat entries of inverse_jacobian_3d
+            for (size_t d = 0; d < CompDim; ++d) {
+              *it += inverse_jacobian_3d.get(d, i0) *
+                     get<FluxTag>(gsl::at(logical_partial_derivatives_of_F, d))
+                         .get(flux_indices);
+            }
+          } else {
+            const auto d_flux_indices = prepend(flux_indices, i0);
+            *it += cart_deriv_tensor.get(d_flux_indices);
+          }
+        }
+      }
+    } else {
+      const size_t x_extents = mesh.extents(0);
+      const size_t y_extents = mesh.extents(1);
+      const auto insert_with_stride =
+          [x_extents, y_extents](gsl::not_null<DataVector*> to_insert_into,
+                                 const DataVector& take_from,
+                                 const bool accumulate = false) {
+            auto& insert_into = *to_insert_into;
+            if (accumulate) {
+              for (size_t i = 0; i < y_extents; ++i) {
+                insert_into[i] += take_from[i * x_extents];
+              }
+            } else {
+              for (size_t i = 0; i < y_extents; ++i) {
+                insert_into[i] = take_from[i * x_extents];
+              }
+            }
+          };
+      // for storing intermediate x-derivatives
+      auto& dx_flux =
+          get<::Tags::TempTensor<0, typename FluxTag::type>>(temp_vars);
+      auto& contracted_dx_flux =
+          get<::Tags::TempTensor<1, typename FluxTag::type>>(temp_vars);
+
+      for (auto it = divergence_of_flux.begin(); it != divergence_of_flux.end();
+           ++it) {
+        *it = 0.0;
+        const auto div_flux_indices = divergence_of_flux.get_tensor_index(it);
+        for (size_t first_flux_index = 0; first_flux_index < index_dim<0>(flux);
+             ++first_flux_index) {
+          auto flux_indices = prepend(div_flux_indices, first_flux_index);
+          for (size_t d_i = 0; d_i < Dim; ++d_i) {
+            if (numerical_deriv_in_this_direction(d_i)) {
+              if (d_i == first_flux_index) {
+                const auto d_indices = prepend(div_flux_indices, d_i);
+                for (size_t d_contract = 0; d_contract < CompDim;
+                     ++d_contract) {
+                  *it += inverse_jacobian_3d.get(d_contract, d_i) *
+                         get<FluxTag>(gsl::at(logical_partial_derivatives_of_F,
+                                              d_contract))
+                             .get(d_indices);
+                }
+              }
+              if (d_i == 0) {
+                // storing all \partial_x derivatives for L'Hopital
+                if (first_flux_index == d_i) {
+                  insert_with_stride(make_not_null(&dx_flux.get(flux_indices)),
+                                     *it);
+                } else {
+                  insert_with_stride(
+                      make_not_null(&dx_flux.get(flux_indices)),
+                      inverse_jacobian_3d.get(0, d_i) *
+                          get<FluxTag>(
+                              gsl::at(logical_partial_derivatives_of_F, 0))
+                              .get(flux_indices));
+                  if constexpr (CompDim == 2) {
+                    insert_with_stride(
+                        make_not_null(&dx_flux.get(flux_indices)),
+                        inverse_jacobian_3d.get(1, d_i) *
+                            get<FluxTag>(
+                                gsl::at(logical_partial_derivatives_of_F, 1))
+                                .get(flux_indices),
+                        true);
+                  }
+                }
+              }
+            } else if (first_flux_index == d_i) {
+              const auto d_flux_indices = prepend(flux_indices, d_i);
+              *it += cart_deriv_tensor.get(d_flux_indices);
+            }
+          }
+        }
+      }
+      const size_t start_index =
+          quad_type == Spectral::Quadrature::SphericalSymmetry ? 1 : 2;
+      for (size_t deriv_index = start_index; deriv_index < Dim; ++deriv_index) {
+        cartoon_contraction(make_not_null(&contracted_dx_flux), dx_flux,
+                            deriv_index, quad_type);
+        for (size_t component_index = 0;
+             component_index < contracted_dx_flux.size(); ++component_index) {
+          const auto input_index =
+              contracted_dx_flux.get_tensor_index(component_index);
+          if (gsl::at(input_index, 0) == deriv_index) {
+            std::array<size_t, input_index.size() - 1> output_indices{};
+            std::copy(input_index.begin() + 1, input_index.end(),
+                      output_indices.begin());
+            const size_t output_index =
+                divergence_of_flux.get_storage_index(output_indices);
+            for (size_t i = 0; i < y_extents; ++i) {
+              divergence_of_flux[output_index][i * x_extents] +=
+                  contracted_dx_flux[component_index][i];
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
+template <typename... DivTags, typename... FluxTags, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3>>
+void cartoon_divergence(
+    const gsl::not_null<Variables<tmpl::list<DivTags...>>*> divergence_of_F,
+    const Variables<tmpl::list<FluxTags...>>& F, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian_3d,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  if (mesh.basis(0) != Spectral::Basis::Cartoon and
+      mesh.basis(2) == Spectral::Basis::Cartoon) {
+    if (mesh.basis(1) == Spectral::Basis::Cartoon) {
+      cartoon_divergence_apply<1, tmpl::list<DivTags...>,
+                               tmpl::list<FluxTags...>, Dim, DerivativeFrame>(
+          divergence_of_F, F, mesh, inverse_jacobian_3d, inertial_coords);
+    } else {
+      cartoon_divergence_apply<2, tmpl::list<DivTags...>,
+                               tmpl::list<FluxTags...>, Dim, DerivativeFrame>(
+          divergence_of_F, F, mesh, inverse_jacobian_3d, inertial_coords);
+    }
+  } else {
+    ERROR("Bases do not match valid Cartoon pattern. Got mesh " << mesh);
+  }
 }
 
 template <typename FluxTags, size_t Dim>

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -25,6 +26,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Tags.hpp"
@@ -44,6 +46,7 @@
 
 namespace {
 using Affine = domain::CoordinateMaps::Affine;
+using Identity1D = domain::CoordinateMaps::Identity<1>;
 using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
 using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
@@ -330,6 +333,295 @@ void test_divergence_compute() {
     }
   }
 }
+
+template <bool Spherical>
+DataVector cartoon_func(const tnsr::I<DataVector, 3, Frame::Inertial>& coords) {
+  if constexpr (Spherical) {
+    // a radial function, f(r) = f(x) because the computational domain is the x
+    // axis
+    return 0.01 * pow(get<0>(coords), 4) + 0.3 * pow(get<0>(coords), 3) -
+           0.1 * pow(get<0>(coords), 2) - 2.0 * get<0>(coords) - 1.5;
+  } else {
+    // an axially symmetric function about the y axis,
+    // f(\sqrt{x^2 + z^2}, y) = f(x, y) because the computational domain is the
+    // x-y plane
+    return square(get<1>(coords)) + square(get<0>(coords)) * get<1>(coords);
+  }
+}
+
+template <bool Spherical>
+DataVector cartoon_dfunc(
+    size_t deriv_index, const tnsr::I<DataVector, 3, Frame::Inertial>& coords) {
+  if constexpr (Spherical) {
+    if (deriv_index == 0) {
+      return 0.04 * pow(get<0>(coords), 3) + 0.9 * pow(get<0>(coords), 2) -
+             0.2 * get<0>(coords) - 2.0;
+    } else {
+      return {get<0>(coords).size(), 0.0};
+    }
+  } else {
+    if (deriv_index == 0) {
+      return 2.0 * get<0>(coords) * get<1>(coords);
+    } else if (deriv_index == 1) {
+      return 2.0 * get<1>(coords) + square(get<0>(coords));
+    } else {
+      return {get<0>(coords).size(), 0.0};
+    }
+  }
+}
+
+template <bool Spherical>
+void test_cartoon(const double x_start) {
+  Mesh<3> mesh;
+  tnsr::I<DataVector, 3, Frame::Inertial> coords;
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      inv_jacobian;
+
+  const Identity1D identity_cartoon_map;
+
+  if constexpr (Spherical) {
+    // spherical symmetry
+    const size_t num_grid_pts = 8;
+    const double x_end = 4.0;
+
+    mesh = Mesh<3>{{{num_grid_pts, 1, 1}},
+                   {{Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+                     Spectral::Basis::Cartoon}},
+                   {{Spectral::Quadrature::GaussLobatto,
+                     Spectral::Quadrature::SphericalSymmetry,
+                     Spectral::Quadrature::SphericalSymmetry}}};
+
+    const Affine affine_x_map(-1.0, 1.0, x_start, x_end);
+
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                                Cartoon_map_combination>
+        map{{affine_x_map, identity_cartoon_map, identity_cartoon_map}};
+    inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+    coords = map(logical_coordinates(mesh));
+  } else {
+    // axial symmetry
+    const size_t num_x_grid_pts = 6;
+    const double x_end = 3.25;
+    const size_t num_y_grid_pts = 7;
+    const double y_start = -2.5;
+    const double y_end = 4.0;
+
+    mesh = Mesh<3>{{{num_x_grid_pts, num_y_grid_pts, 1}},
+                   {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                     Spectral::Basis::Cartoon}},
+                   {{Spectral::Quadrature::GaussLobatto,
+                     Spectral::Quadrature::GaussLobatto,
+                     Spectral::Quadrature::AxialSymmetry}}};
+
+    const Affine affine_x_map(-1.0, 1.0, x_start, x_end);
+    const Affine affine_y_map(-1.0, 1.0, y_start, y_end);
+
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                                Cartoon_map_combination>
+        map{{affine_x_map, affine_y_map, identity_cartoon_map}};
+    inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+    coords = map(logical_coordinates(mesh));
+  }
+
+  using TempIjk =
+      ::Tags::TempTensor<0, tnsr::Ijk<DataVector, 3, Frame::Inertial>>;
+
+  using VarTags = tmpl::list<::Tags::TempI<0, 3, Frame::Inertial>,
+                             ::Tags::TempIj<0, 3, Frame::Inertial>, TempIjk>;
+
+  Variables<VarTags> vars{mesh.number_of_grid_points()};
+
+  using div_VarTags =
+      tmpl::transform<VarTags, tmpl::bind<::Tags::div, tmpl::_1>>;
+
+  Variables<div_VarTags> expected_div_vars{mesh.number_of_grid_points()};
+
+  // Here we create "prefactors", which serve to fill out our tensors by being
+  // mulitplied by our cartoon_func(), which themselves make our tensors have
+  // some nontrivial spatial derivative
+  // The point of these prefactors is to ensure the tensors respect the
+  // symmetry of the spacetime: it is not sufficient that each component
+  // follows the symmetry, rather the entire tensor must satisfy
+  // \mathcal{L}_\xi (tensor) = 0. Each rank has it's own form of prefactor
+  Variables<VarTags> prefactor_vars{mesh.number_of_grid_points()};
+
+  using TempiJkl =
+      ::Tags::TempTensor<0, TensorMetafunctions::prepend_spatial_index<
+                                tnsr::Ijk<DataVector, 3, Frame::Inertial>, 3,
+                                UpLo::Lo, Frame::Inertial>>;
+
+  // prepending a spatial index to VarTags (= PrefactorVarTags if it existed)
+  using d_PrefactorVarTags =
+      tmpl::list<::Tags::TempiJ<0, 3, Frame::Inertial>,
+                 ::Tags::TempiJk<0, 3, Frame::Inertial>, TempiJkl>;
+  Variables<d_PrefactorVarTags> d_prefactor_vars{mesh.number_of_grid_points()};
+
+  const size_t dv_size = get<0>(coords).size();
+
+  auto& vector = get<::Tags::TempI<0, 3>>(prefactor_vars);
+  auto& d_vector = get<::Tags::TempiJ<0, 3>>(d_prefactor_vars);
+  if constexpr (Spherical) {
+    // spherical case, vector/one form, using x^i
+    for (size_t i = 0; i < index_dim<0>(vector); ++i) {
+      vector.get(i) = coords.get(i);
+    }
+    // partial_i of x_j is \delta_ij
+    for (size_t i = 0; i < index_dim<0>(d_vector); ++i) {
+      for (size_t j = 0; j < index_dim<1>(d_vector); ++j) {
+        if (i == j) {
+          d_vector.get(i, j) = DataVector(dv_size, 1.0);
+        } else {
+          d_vector.get(i, j) = DataVector(dv_size, 0.0);
+        }
+      }
+    }
+  } else {
+    // axial case, vector/one form, using x^i = (-z, 0, x) (pure rotation)
+    get<0>(vector) = -1.0 * coords.get(2);
+    get<1>(vector) = DataVector(dv_size, 0.0);
+    get<2>(vector) = get<0>(coords);
+
+    // \partial_i of x_j is (\delta_i2, 0, \delta_i0)
+    for (size_t i = 0; i < index_dim<0>(d_vector); ++i) {
+      for (size_t j = 0; j < index_dim<1>(d_vector); ++j) {
+        if (i == 2 and j == 0) {
+          d_vector.get(i, j) = DataVector(dv_size, -1.0);
+        } else if (i == 0 and j == 2) {
+          d_vector.get(i, j) = DataVector(dv_size, 1.0);
+        } else {
+          d_vector.get(i, j) = DataVector(dv_size, 0.0);
+        }
+      }
+    }
+  }
+
+  auto& rank2 = get<::Tags::TempIj<0, 3>>(prefactor_vars);
+  auto& d_rank2 = get<::Tags::TempiJk<0, 3>>(d_prefactor_vars);
+  // Filling with (essenially) projector to tangent space of sphere
+  // P_ij = \delta_ij + x_i x_j
+  // can have arbitrary function in from of each term, not doing here
+  // (the real projector is \delta_ij - x_i x_j / r^2)
+  for (size_t i = 0; i < index_dim<0>(rank2); ++i) {
+    for (size_t j = 0; j < index_dim<1>(rank2); ++j) {
+      if (i == j) {
+        rank2.get(i, j) =
+            DataVector(dv_size, 1.0) + coords.get(i) * coords.get(j);
+      } else {
+        rank2.get(i, j) = coords.get(i) * coords.get(j);
+      }
+    }
+  }
+  // \partial_i of (\delta_jk + x_j x_k) is (x_j \delta_ik + x_k \delta_ij)
+  for (size_t i = 0; i < index_dim<0>(d_rank2); ++i) {
+    for (size_t j = 0; j < index_dim<1>(d_rank2); ++j) {
+      for (size_t k = 0; k < index_dim<2>(d_rank2); ++k) {
+        d_rank2.get(i, j, k) = DataVector(dv_size, 0.0);
+        if (i == k) {
+          d_rank2.get(i, j, k) += coords.get(j);
+        }
+        if (i == j) {
+          d_rank2.get(i, j, k) += coords.get(k);
+        }
+      }
+    }
+  }
+
+  auto& rank3 = get<TempIjk>(prefactor_vars);
+  auto& d_rank3 = get<TempiJkl>(d_prefactor_vars);
+  // x_i x_j x_k + \delta_ij x_k \delta_ik x_j \delta_jk x_i
+  for (size_t i = 0; i < index_dim<0>(rank3); ++i) {
+    for (size_t j = 0; j < index_dim<1>(rank3); ++j) {
+      for (size_t k = 0; k < index_dim<2>(rank3); ++k) {
+        rank3.get(i, j, k) = coords.get(i) * coords.get(j) * coords.get(k);
+        if (i == j) {
+          rank3.get(i, j, k) += coords.get(k);
+        }
+        if (i == k) {
+          rank3.get(i, j, k) += coords.get(j);
+        }
+        if (j == k) {
+          rank3.get(i, j, k) += coords.get(i);
+        }
+      }
+    }
+  }
+  // \partial_i of (x_j x_k x_l + \delta_jk x_l \delta_jl x_k \delta_kl x_j) is
+  // \delta_ij x_k x_l + \delta_ik x_j x_l + \delta_il x_j x_k +
+  //   \delta_jk \delta_il + \delta_jl \delta_ik + \delta_kl \delta_ij
+  for (size_t i = 0; i < index_dim<0>(d_rank3); ++i) {
+    for (size_t j = 0; j < index_dim<1>(d_rank3); ++j) {
+      for (size_t k = 0; k < index_dim<2>(d_rank3); ++k) {
+        for (size_t l = 0; l < index_dim<3>(d_rank3); ++l) {
+          d_rank3.get(i, j, k, l) = DataVector(dv_size, 0.0);
+          if (i == j) {
+            d_rank3.get(i, j, k, l) += coords.get(k) * coords.get(l);
+          }
+          if (i == k) {
+            d_rank3.get(i, j, k, l) += coords.get(j) * coords.get(l);
+          }
+          if (i == l) {
+            d_rank3.get(i, j, k, l) += coords.get(j) * coords.get(k);
+          }
+          if (j == k and i == l) {
+            d_rank3.get(i, j, k, l) += 1.0;
+          }
+          if (j == l and i == k) {
+            d_rank3.get(i, j, k, l) += 1.0;
+          }
+          if (k == l and i == j) {
+            d_rank3.get(i, j, k, l) += 1.0;
+          }
+        }
+      }
+    }
+  }
+
+  tmpl::for_each<VarTags>([&vars, &prefactor_vars, &expected_div_vars,
+                           &d_prefactor_vars, &coords]<typename tensor_tag>(
+                              tmpl::type_<tensor_tag> /*meta*/) {
+    auto& tensor = get<tensor_tag>(vars);
+    auto& prefactor_tensor = get<tensor_tag>(prefactor_vars);
+    using div_tensor_tag = ::Tags::div<tensor_tag>;
+    auto& div_tensor = get<div_tensor_tag>(expected_div_vars);
+    auto& d_prefactor_tensor =
+        get<tmpl::at<d_PrefactorVarTags, tmpl::index_of<VarTags, tensor_tag>>>(
+            d_prefactor_vars);
+
+    for (size_t storage_index = 0; storage_index < tensor.size();
+         ++storage_index) {
+      tensor[storage_index] =
+          prefactor_tensor[storage_index] * cartoon_func<Spherical>(coords);
+
+      const auto input_index = tensor.get_tensor_index(storage_index);
+      std::array<size_t, tensor_tag::type::rank() - 1> output_index{};
+      std::copy(input_index.begin() + 1, input_index.end(),
+                output_index.begin());
+
+      const size_t deriv_index = input_index[0];
+      if (deriv_index == 0) {
+        div_tensor.get(output_index) = 0.0 * tensor.get(input_index);
+      }
+      const auto d_input_index = prepend(input_index, deriv_index);
+
+      div_tensor.get(output_index) +=
+          prefactor_tensor.get(input_index) *
+              cartoon_dfunc<Spherical>(deriv_index, coords) +
+          cartoon_func<Spherical>(coords) *
+              d_prefactor_tensor.get(d_input_index);
+    }
+  });
+
+  Variables<div_VarTags> div_vars{mesh.number_of_grid_points()};
+  cartoon_divergence(make_not_null(&div_vars), vars, mesh, inv_jacobian,
+                     coords);
+
+  const Approx local_approx = Approx::custom().epsilon(1.0e-10).scale(1.0);
+  CHECK_VARIABLES_CUSTOM_APPROX(div_vars, expected_div_vars, local_approx);
+}
 }  // namespace
 
 // [[Timeout, 20]]
@@ -338,6 +630,11 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence",
   test_divergence<DataVector>();
   test_divergence<ComplexDataVector>();
   test_divergence_compute();
+
+  test_cartoon<true>(0.0);
+  test_cartoon<true>(1.0);
+  test_cartoon<false>(0.0);
+  test_cartoon<false>(1.0);
 
   BENCHMARK_ADVANCED("Divergence of vector")
   (Catch::Benchmark::Chronometer meter) {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Very similar to `cartoon_partial_derivatives()` with a near-identical test, this does divergence using the cartoon contraction functions found in `PartialDerivatives.tpp`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

The logic in the function when we need to do L'Hopital's rule is more complicated than for partials because we need all \partial_x derivatives, but as we are doing divergence, we will not already have most of these calculated so extra steps are required.