### PR TITLE
Add Cartoon integral and interpolation

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/QuadratureWeights.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
@@ -78,6 +79,28 @@ double definite_integral<2>(const DataVector& integrand, const Mesh<2>& mesh) {
 
 template <>
 double definite_integral<3>(const DataVector& integrand, const Mesh<3>& mesh) {
+  if (mesh.basis(2) == Spectral::Basis::Cartoon) {
+    if (mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry) {
+      // spherical symmetry, integrand should have x^2 and logical to
+      // inertial jacobian determinant already multiplied
+      ASSERT(integrand.size() == mesh.slice_through(0).number_of_grid_points(),
+             "Mismatched input sizes: num_grid_points = "
+                 << mesh.slice_through(0).number_of_grid_points()
+                 << ", integrand size = " << integrand.size());
+      return 4.0 * M_PI *
+             definite_integral<1>(integrand, mesh.slice_through(0));
+    } else {
+      // axial symmetry, integrand should have x and logical to inertial
+      // jacobian already multiplied
+      ASSERT(
+          integrand.size() == mesh.slice_through(0, 1).number_of_grid_points(),
+          "Mismatched input sizes: num_grid_points = "
+              << mesh.slice_through(0, 1).number_of_grid_points()
+              << ", integrand size = " << integrand.size());
+      return 2 * M_PI *
+             definite_integral<2>(integrand, mesh.slice_through(0, 1));
+    }
+  }
   ASSERT(integrand.size() == mesh.number_of_grid_points(),
          "num_grid_points = " << mesh.number_of_grid_points()
                               << ", integrand size = " << integrand.size());

--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
@@ -33,6 +33,12 @@ class Mesh;
  * The integral is computed by quadrature, using the quadrature rule for the
  * basis associated with the collocation points.
  *
+ * If the mesh uses a Cartoon basis, the passed integrand must already be
+ * multiplied by the appropriate Jacobian determinants (i.e. both the
+ * \f$\boldsymbol{x}(\boldsymbol{\xi})\f$ and the cartesian to spherical/polar
+ * coordinates mappings, the latter being either
+ * \f$x^2\f$ or \f$x\f$, respectively).
+ *
  * \param integrand the function to integrate.
  * \param mesh the Mesh defining the grid points on the manifold.
  */

--- a/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.cpp
@@ -33,6 +33,11 @@ template <size_t Dim, typename VectorType>
 void indefinite_integral(const gsl::not_null<VectorType*> integral,
                          const VectorType& integrand, const Mesh<Dim>& mesh,
                          const size_t dim_to_integrate) {
+  if (mesh.basis(dim_to_integrate) == Spectral::Basis::Cartoon) {
+    ERROR("An indefinite integral cannot be preformed on a Cartoon basis. "
+          "dim_to_integrate: "
+          << dim_to_integrate << ", basis: " << mesh.basis());
+  }
   integral->destructive_resize(integrand.size());
   apply_matrices(integral,
                  make_integration_matrices<Dim>(

--- a/src/NumericalAlgorithms/Spectral/InterpolationMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/InterpolationMatrix.cpp
@@ -27,6 +27,15 @@ Matrix interpolation_matrix(const size_t num_points, const T& target_points) {
         "Cannot do barycentric interpolation with Basis::FiniteDifference.  "
         "Use an IrregularInterpolant");
   }
+  if constexpr (BasisType == Spectral::Basis::Cartoon) {
+    ASSERT(num_points == 1, "A Cartoon basis can only have one point.");
+    const size_t num_target_points = get_size(target_points);
+    Matrix interp_matrix(num_target_points, num_points);
+    for (size_t k = 0; k < num_target_points; ++k) {
+      interp_matrix(k, 0) = 1.0;
+    }
+    return interp_matrix;
+  }
   constexpr size_t max_num_points =
       Spectral::maximum_number_of_points<BasisType>;
   constexpr size_t min_num_points =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -545,6 +545,66 @@ void test_3d_spherical(const gsl::not_null<std::mt19937*> generator) {
     }
   }
 }
+
+void test_cartoon_spherical(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+
+  const size_t number_of_points = 6;
+  tnsr::I<DataVector, 3, Frame::ElementLogical> xi_target{number_of_points};
+  get<0>(xi_target) = make_with_random_values<DataVector>(
+      generator, make_not_null(&xi_distribution), xi_target);
+  get<1>(xi_target) = DataVector(number_of_points, 0.0);
+  get<2>(xi_target) = DataVector(number_of_points, 0.0);
+  for (size_t n_x = 4; n_x < 6; ++n_x) {
+    const Mesh<3> source_mesh{
+        {{n_x, 1, 1}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+          Spectral::Basis::Cartoon}},
+        {{Spectral::Quadrature::GaussLobatto,
+          Spectral::Quadrature::SphericalSymmetry,
+          Spectral::Quadrature::SphericalSymmetry}}};
+    const Polynomial f_r{n_x - 1, 1.5, 2.0};
+    const auto xi_source = logical_coordinates(source_mesh);
+    const DataVector f_source = f_r(get<0>(xi_source));
+    const DataVector f_expected = f_r(get<0>(xi_target));
+    const intrp::Irregular<3> interpolator(source_mesh, xi_target);
+    const DataVector f_interpolated = interpolator.interpolate(f_source);
+    CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+  }
+}
+
+void test_cartoon_axial(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+
+  const size_t number_of_points = 6;
+  tnsr::I<DataVector, 3, Frame::ElementLogical> xi_target{number_of_points};
+  get<0>(xi_target) = make_with_random_values<DataVector>(
+      generator, make_not_null(&xi_distribution), xi_target);
+  get<1>(xi_target) = make_with_random_values<DataVector>(
+      generator, make_not_null(&xi_distribution), xi_target);
+  get<2>(xi_target) = DataVector(number_of_points, 0.0);
+  for (size_t n_x = 4; n_x < 6; ++n_x) {
+    for (size_t n_y = 4; n_y < 6; ++n_y) {
+      const Mesh<3> source_mesh{
+          {{n_x, n_y, 1}},
+          {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+            Spectral::Basis::Cartoon}},
+          {{Spectral::Quadrature::GaussLobatto,
+            Spectral::Quadrature::GaussLobatto,
+            Spectral::Quadrature::AxialSymmetry}}};
+      const Polynomial f_x{n_x - 1, 1.5, 2.0};
+      const Polynomial f_y{n_y - 1, 2.5, 1.5};
+      const auto xi_source = logical_coordinates(source_mesh);
+      const DataVector f_source =
+          f_x(get<0>(xi_source)) * f_y(get<1>(xi_source));
+      const DataVector f_expected =
+          f_x(get<0>(xi_target)) * f_y(get<1>(xi_target));
+      const intrp::Irregular<3> interpolator(source_mesh, xi_target);
+      const DataVector f_interpolated = interpolator.interpolate(f_source);
+      CHECK_ITERABLE_APPROX(f_interpolated, f_expected);
+    }
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
@@ -566,4 +626,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
   MAKE_GENERATOR(generator);
   test_2d_spherical(make_not_null(&generator));
   test_3d_spherical(make_not_null(&generator));
+  test_cartoon_spherical(make_not_null(&generator));
+  test_cartoon_axial(make_not_null(&generator));
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -318,7 +318,25 @@ void test_3d_regular_interpolation() {
         test_regular_interpolation_override(mesh_lgl, mesh_lgl, coords);
         test_regular_interpolation_override(mesh_lgl, mesh_lg_high_res, coords);
       }
+      const auto mesh_cartoon_axial =
+          Mesh<3>{{{nx, ny, 1}},
+                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                    Spectral::Basis::Cartoon}},
+                  {{Spectral::Quadrature::GaussLobatto,
+                    Spectral::Quadrature::GaussLobatto,
+                    Spectral::Quadrature::AxialSymmetry}}};
+      test_regular_interpolation<3, DataVector>(mesh_cartoon_axial,
+                                                mesh_cartoon_axial);
     }
+    const auto mesh_cartoon_spherical =
+        Mesh<3>{{{nx, 1, 1}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+                  Spectral::Basis::Cartoon}},
+                {{Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::SphericalSymmetry,
+                  Spectral::Quadrature::SphericalSymmetry}}};
+    test_regular_interpolation<3, DataVector>(mesh_cartoon_spherical,
+                                              mesh_cartoon_spherical);
   }
 }
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -138,6 +138,56 @@ void test_definite_integral_spherical_shell(const size_t n_r, const size_t L) {
   }
 }
 
+void test_definite_integral_cartoon_spherical(const size_t n_x) {
+  const Mesh mesh =
+      Mesh<3>{{{n_x, 1, 1}},
+              {{Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+                Spectral::Basis::Cartoon}},
+              {{Spectral::Quadrature::GaussLobatto,
+                Spectral::Quadrature::SphericalSymmetry,
+                Spectral::Quadrature::SphericalSymmetry}}};
+  const DataVector& x = Spectral::collocation_points(mesh.slice_through(0));
+  DataVector integrand(mesh.number_of_grid_points());
+  for (size_t a = 0; a < mesh.extents(0); ++a) {
+    for (size_t s = 0; s < integrand.size(); ++s) {
+      integrand[s] = pow(x[s], static_cast<double>(a));
+    }
+    if (0 == a % 2) {
+      CHECK(8.0 * M_PI / (a + 1.0) ==
+            approx(definite_integral(integrand, mesh)));
+    } else {
+      CHECK(0.0 == approx(definite_integral(integrand, mesh)));
+    }
+  }
+}
+void test_definite_inegral_cartoon_axial(const size_t n_x, const size_t n_y) {
+  const Mesh mesh = Mesh<3>{
+      {{n_x, n_y, 1}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+        Spectral::Basis::Cartoon}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+        Spectral::Quadrature::AxialSymmetry}}};
+  const DataVector& x = Spectral::collocation_points(mesh.slice_through(0));
+  const DataVector& y = Spectral::collocation_points(mesh.slice_through(1));
+  DataVector integrand(mesh.number_of_grid_points());
+  for (size_t a = 0; a < mesh.extents(0); ++a) {
+    for (size_t b = 0; b < mesh.extents(1); ++b) {
+      for (IndexIterator<2> index_it(mesh.slice_through(0, 1).extents());
+           index_it; ++index_it) {
+        integrand[index_it.collapsed_index()] =
+            pow(x[index_it()[0]], static_cast<double>(a)) *
+            pow(y[index_it()[1]], static_cast<double>(b));
+      }
+      if (0 == a % 2 and 0 == b % 2) {
+        CHECK(8.0 * M_PI / ((a + 1.0) * (b + 1.0)) ==
+              approx(definite_integral(integrand, mesh)));
+      } else {
+        CHECK(0.0 == approx(definite_integral(integrand, mesh)));
+      }
+    }
+  }
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.DefiniteIntegral",
@@ -173,6 +223,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.DefiniteIntegral",
   for (size_t n_r = 2; n_r < 5; ++n_r) {
     for (size_t L = 2; L < 9; ++L) {
       test_definite_integral_spherical_shell(n_r, L);
+    }
+  }
+
+  for (size_t n_x = min_extents; n_x <= max_extents; ++n_x) {
+    test_definite_integral_cartoon_spherical(n_x);
+    for (size_t n_y = min_extents; n_y <= max_extents - 1; ++n_y) {
+      test_definite_inegral_cartoon_axial(n_x, n_y);
     }
   }
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_IndefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_IndefiniteIntegral.cpp
@@ -112,6 +112,21 @@ void test_zero_bc() {
     }
   }
 }
+
+void test_cartoon() {
+  const Mesh<3> mesh_3d(
+      {{2, 2, 1}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+        Spectral::Basis::Cartoon}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+        Spectral::Quadrature::AxialSymmetry}});
+  const auto cords_3d = logical_coordinates((mesh_3d));
+  CHECK_THROWS_WITH(
+      (indefinite_integral(DataVector{mesh_3d.number_of_grid_points(), 1.0},
+                           mesh_3d, 2)),
+      Catch::Matchers::ContainsSubstring(
+          "An indefinite integral cannot be preformed on a Cartoon basis."));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.IndefiniteIntegral",
@@ -124,4 +139,5 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.IndefiniteIntegral",
                Spectral::Quadrature::GaussLobatto>();
   test_zero_bc<ComplexDataVector, Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto>();
+  test_cartoon();
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Making the code do what you would expect with Cartoon bases. 

For the definite integrals, the current set up is that the caller has to preemptively multiply by x or x^2, which follows the typical multiply-with-jacobian-before-calling pattern. Maybe a separate function that takes the coordinates will be more appropriate in the future
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
