### PR TITLE
AH rewrite: Add some AH callbacks

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_headers(
   HEADERS
   Callbacks.hpp
   ErrorOnFailedApparentHorizon.hpp
+  FailedHorizonFind.hpp
   FindApparentHorizon.hpp
   IgnoreFailedApparentHorizon.hpp
   InvokeCallbacks.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <set>
+#include <sstream>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace ah::callbacks {
+/*!
+ * \brief Callback when an apparent horizon find fails. The template \p Ignore
+ * says whether to ignore the failure or raise an ERROR.
+ */
+template <typename HorizonMetavars, bool Ignore>
+struct FailedHorizonFind : tt::ConformsTo<ah::protocols::Callback> {
+ private:
+  using Fr = typename HorizonMetavars::frame;
+
+ public:
+  template <typename DbTags, typename Metavariables>
+  static void apply(db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const FastFlow::Status failure_reason) {
+    std::ostringstream os{};
+
+    const auto& time = db::get<ah::Tags::CurrentTime>(box).value();
+    const auto& all_storage = db::get<ah::Tags::Storage<Fr>>(box);
+    const auto& current_time_storage = all_storage.at(time);
+    const auto& current_iteration = current_time_storage.current_iteration;
+
+    os << pretty_type::name<HorizonMetavars>()
+       << ": Horizon find failed at time " << time
+       << ". Reason = " << failure_reason
+       << ". Number of compute coords retries = "
+       << current_iteration.compute_coords_retries << ".";
+
+    if (failure_reason == FastFlow::Status::InterpolationFailure) {
+      const auto& block_coord_holders =
+          current_iteration.block_coord_holders.value();
+
+      std::vector<size_t> missing_indices{};
+      missing_indices.reserve(block_coord_holders.size());
+      for (size_t i = 0; i < block_coord_holders.size(); i++) {
+        if (not block_coord_holders[i].has_value()) {
+          missing_indices.push_back(i);
+        }
+      }
+
+      // Get the actual points
+      const auto& strahlkorper = current_iteration.strahlkorper;
+      const auto& fast_flow = db::get<ah::Tags::FastFlow>(box);
+      const size_t l_mesh = fast_flow.current_l_mesh(strahlkorper);
+      const auto prolonged_strahlkorper =
+          ylm::Strahlkorper<Fr>(l_mesh, l_mesh, strahlkorper);
+      const auto coords = ylm::cartesian_coords(prolonged_strahlkorper);
+
+      // Now output some information about them
+      os << "\n Invalid points (in " << pretty_type::name<Fr>()
+         << " frame) are:\n";
+      for (const size_t index : missing_indices) {
+        os << " (" << get<0>(coords)[index] << "," << get<1>(coords)[index]
+           << "," << get<2>(coords)[index] << ")\n";
+      }
+    }
+
+    if constexpr (Ignore) {
+      const ::Verbosity verbosity = db::get<ah::Tags::Verbosity>(box);
+      if (verbosity >= ::Verbosity::Quiet) {
+        Parallel::printf("%s\n", os.str());
+      }
+    } else {
+      ERROR(os.str());
+    }
+  }
+};
+}  // namespace ah::callbacks

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/VolumeActions.hpp"
@@ -14,10 +15,12 @@
 #include "Parallel/Printf/Printf.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 /// \cond
 namespace logging::Tags {
@@ -99,3 +102,46 @@ struct SendDependencyToObserverWriter {
   }
 };
 }  // namespace intrp::callbacks
+
+namespace ah::callbacks {
+/*!
+ * \brief A `ah::protocols::Callback` that will send a message to the
+ * ObserverWriter if we have a dependency using the
+ * `observers::ThreadedActions::ContributeDependency` action.
+ *
+ * \details If we have a dependency, the template bool \p WriteVolumeData
+ * determines if the message sent to the ObserverWriter says to write the volume
+ * data to disk or not.
+ */
+template <typename HorizonMetavars, bool WriteVolumeData>
+struct SendDependencyToObserverWriter
+    : tt::ConformsTo<ah::protocols::Callback> {
+  // Callback for when horizon find succeeds
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const FastFlow::Status /*status*/) {
+    const auto& time = db::get<ah::Tags::CurrentTime>(box).value();
+    const auto& dependency = db::get<ah::Tags::Dependency>(box);
+
+    if (dependency.has_value()) {
+      const auto& verbosity = db::get<ah::Tags::Verbosity>(box);
+
+      auto& observer_writer_proxy = Parallel::get_parallel_component<
+          observers::ObserverWriter<Metavariables>>(cache);
+
+      Parallel::threaded_action<
+          observers::ThreadedActions::ContributeDependency>(
+          observer_writer_proxy, time.id, pretty_type::name<HorizonMetavars>(),
+          dependency.value(), WriteVolumeData);
+
+      if (verbosity >= ::Verbosity::Verbose) {
+        Parallel::printf(
+            "Remark: We are%s writing volume data for horizon finder %s\n",
+            WriteVolumeData ? "" : " not",
+            pretty_type::name<HorizonMetavars>());
+      }
+    }
+  }
+};
+}  // namespace ah::callbacks

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -4,4 +4,5 @@
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Callbacks/Test_InvokeCallbacks.cpp
+  Callbacks/Test_FailedHorizonFind.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -5,4 +5,5 @@ set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Callbacks/Test_InvokeCallbacks.cpp
   Callbacks/Test_FailedHorizonFind.cpp
+  Callbacks/Test_SendDependencyToObserverWriter.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_FailedHorizonFind.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_FailedHorizonFind.cpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Domain.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename Fr, bool Ignore>
+struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using temporal_id_tag = ::Tags::TimeAndPrevious<0>;
+  using frame = Fr;
+
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks =
+      tmpl::list<ah::callbacks::FailedHorizonFind<HorizonMetavars, Ignore>>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() { return "TestingHorizonMetavars"; }
+};
+
+struct EmptyMetavars {
+  using component_list = tmpl::list<>;
+};
+
+template <typename Fr>
+void run_test() {
+  const Parallel::GlobalCache<EmptyMetavars> cache{};
+
+  const domain::creators::Sphere sphere_creator{
+      0.9, 2.0, domain::creators::Sphere::Excision{nullptr}, 0_st, 4_st, true};
+  const Domain<3> domain = sphere_creator.create_domain();
+
+  const size_t l_max = 6;
+  const LinkedMessageId<double> time{2.0, {1.0}};
+
+  ah::Storage::Iteration<Fr> current_iteration{};
+  current_iteration.compute_coords_retries = 2;
+  current_iteration.strahlkorper =
+      ylm::Strahlkorper<Fr>{l_max, 1.34, std::array{0.0, 0.0, 0.0}};
+  current_iteration.block_coord_holders = ::block_logical_coordinates(
+      domain, ylm::cartesian_coords(current_iteration.strahlkorper));
+
+  // Manually set 4 points to be invalid
+  for (size_t i = 0; i < 4; i++) {
+    current_iteration.block_coord_holders.value()[i * 4].reset();
+  }
+
+  ah::Storage::SingleTimeStorage<Fr> current_time_storage{};
+  current_time_storage.current_iteration = current_iteration;
+
+  std::unordered_map<LinkedMessageId<double>,
+                     ah::Storage::SingleTimeStorage<Fr>>
+      all_storage{};
+  all_storage[time] = current_time_storage;
+
+  auto box = db::create<
+      db::AddSimpleTags<tmpl::list<ah::Tags::CurrentTime, ah::Tags::Storage<Fr>,
+                                   ah::Tags::FastFlow, ah::Tags::Verbosity>>>(
+      std::optional{time}, all_storage,
+      FastFlow{FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100},
+      ::Verbosity::Quiet);
+
+  static_assert(
+      tt::assert_conforms_to_v<
+          ah::callbacks::FailedHorizonFind<HorizonMetavars<Fr, true>, true>,
+          ah::protocols::Callback>);
+  static_assert(
+      tt::assert_conforms_to_v<
+          ah::callbacks::FailedHorizonFind<HorizonMetavars<Fr, false>, false>,
+          ah::protocols::Callback>);
+
+  // When we ignore the error, we just check that we can call things without an
+  // error since things are only printed using printf.
+  {
+    ah::callbacks::FailedHorizonFind<HorizonMetavars<Fr, true>, true>::apply(
+        box, cache, FastFlow::Status::MaxIts);
+    ah::callbacks::FailedHorizonFind<HorizonMetavars<Fr, true>, true>::apply(
+        box, cache, FastFlow::Status::InterpolationFailure);
+  }
+  // When erroring, check the message
+  {
+    CHECK_THROWS_WITH(
+        (ah::callbacks::FailedHorizonFind<HorizonMetavars<Fr, false>, false>::
+             apply(box, cache, FastFlow::Status::MaxIts)),
+        Catch::Matchers::ContainsSubstring("TestingHorizonMetavars") and
+            Catch::Matchers::ContainsSubstring("Too many iterations") and
+            Catch::Matchers::ContainsSubstring("retries = 2") and
+            not Catch::Matchers::ContainsSubstring("Invalid points"));
+    CHECK_THROWS_WITH(
+        (ah::callbacks::FailedHorizonFind<HorizonMetavars<Fr, false>, false>::
+             apply(box, cache, FastFlow::Status::InterpolationFailure)),
+        Catch::Matchers::ContainsSubstring("TestingHorizonMetavars") and
+            Catch::Matchers::ContainsSubstring(
+                "Cannot interpolate onto surface") and
+            Catch::Matchers::ContainsSubstring("retries = 2") and
+            Catch::Matchers::ContainsSubstring("Invalid points"));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FailedHorizonFind",
+                  "[ApparentHorizonFinder][Unit]") {
+  domain::creators::register_derived_with_charm();
+  run_test<Frame::Grid>();
+  run_test<Frame::Inertial>();
+}
+}  // namespace

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_SendDependencyToObserverWriter.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_SendDependencyToObserverWriter.cpp
@@ -1,0 +1,139 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <bool WriteVolData>
+struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using temporal_id_tag = ::Tags::TimeAndPrevious<0>;
+  using frame = Frame::Inertial;
+
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::Observation;
+
+  static std::string name() { return "TestingHorizonMetavars"; }
+};
+
+template <bool WriteVolData>
+struct MockContributeDependency {
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(db::DataBox<DbTagsList>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const gsl::not_null<Parallel::NodeLock*> /*node_lock*/,
+                    const double time, const std::string& dependency,
+                    std::string volume_subfile_name,
+                    const bool write_volume_data) {
+    CHECK(time == 2.0);
+    CHECK(volume_subfile_name == "FakeDependency");
+    CHECK(dependency == "TestingHorizonMetavars");
+    CHECK(write_volume_data == WriteVolData);
+  }
+};
+
+template <typename Metavariables, bool WriteVolData>
+struct MockObserverWriter {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = size_t;
+  using const_global_cache_tags = tmpl::list<observers::Tags::ReductionFileName,
+                                             observers::Tags::SurfaceFileName>;
+  using simple_tags =
+      typename observers::Actions::InitializeWriter<Metavariables>::simple_tags;
+  using compute_tags = typename observers::Actions::InitializeWriter<
+      Metavariables>::compute_tags;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<observers::Actions::InitializeWriter<Metavariables>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
+
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+
+  using replace_these_threaded_actions =
+      tmpl::list<observers::ThreadedActions::ContributeDependency>;
+  using with_these_threaded_actions =
+      tmpl::list<MockContributeDependency<WriteVolData>>;
+};
+
+template <bool WriteVolData>
+struct Metavariables {
+  using observed_reduction_data_tags = tmpl::list<>;
+  using component_list =
+      tmpl::list<MockObserverWriter<Metavariables, WriteVolData>>;
+};
+
+template <bool WriteVolData>
+void run_test() {
+  CAPTURE(WriteVolData);
+
+  using metavars = Metavariables<WriteVolData>;
+  using obs_writer = MockObserverWriter<metavars, WriteVolData>;
+  ActionTesting::MockRuntimeSystem<metavars> runner{{}};
+  ActionTesting::emplace_nodegroup_component<obs_writer>(
+      make_not_null(&runner));
+
+  auto& cache = ActionTesting::cache<obs_writer>(runner, 0_st);
+
+  const LinkedMessageId<double> time{2.0, {1.0}};
+
+  auto box =
+      db::create<db::AddSimpleTags<ah::Tags::CurrentTime, ah::Tags::Dependency,
+                                   ah::Tags::Verbosity>>(
+          std::optional{time},
+          WriteVolData ? std::optional{"FakeDependency"s} : std::nullopt,
+          ::Verbosity::Silent);
+
+  static_assert(
+      tt::assert_conforms_to_v<ah::callbacks::SendDependencyToObserverWriter<
+                                   HorizonMetavars<WriteVolData>, WriteVolData>,
+                               ah::protocols::Callback>);
+
+  ah::callbacks::SendDependencyToObserverWriter<
+      HorizonMetavars<WriteVolData>,
+      WriteVolData>::apply(box, cache, FastFlow::Status::TruncationTol);
+
+  REQUIRE(ActionTesting::number_of_queued_threaded_actions<obs_writer>(
+              runner, 0_st) == (WriteVolData ? 1 : 0));
+
+  if constexpr (WriteVolData) {
+    ActionTesting::invoke_queued_threaded_action<obs_writer>(
+        make_not_null(&runner), 0_st);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.SendDependencyToObserverWriter",
+                  "[ApparentHorizonFinder][Unit]") {
+  run_test<true>();
+  run_test<false>();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds AH callbacks `FailedHorizonFind` and `SendDependencyToObserverWriter`. These have the same logic as existing AH callbacks, but just use the new AH storage, tags, and callback function signature.

~Currently depends on and includes #6776.~

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
