### PR TITLE
Add FlatOffsetWedge

### DIFF
--- a/docs/Images/Domain/CoordinateMaps/FlatOffsetWedge.svg
+++ b/docs/Images/Domain/CoordinateMaps/FlatOffsetWedge.svg
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="152.42502mm"
+   height="62.072186mm"
+   viewBox="0 0 152.42501 62.072186"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="FlatOffsetWedge.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7159"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7157"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7077"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7075"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6910"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6908"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6834"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart"
+       inkscape:collect="always">
+      <path
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6832"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5124"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path5122"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4546"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4972"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4970"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4882"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4880"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4836"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path4834"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4549"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.5974027"
+     inkscape:cx="222.51116"
+     inkscape:cy="70.074685"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1679"
+     inkscape:window-height="1072"
+     inkscape:window-x="241"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid815"
+       originx="-38.232083"
+       originy="-155.01866" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-38.232089,-79.909168)">
+    <circle
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path819"
+       cx="100.54166"
+       cy="138.25"
+       r="8.5265128e-14" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 100.54167,80.041667 V 117.08333 H 63.499999"
+       id="path823"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 63.499999,93.270833 V 117.08333"
+       id="path817"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.36500001;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path822"
+       sodipodi:type="arc"
+       sodipodi:cx="100.54166"
+       sodipodi:cy="138.25"
+       sodipodi:rx="2.6458333"
+       sodipodi:ry="2.6458333"
+       sodipodi:start="4.0243976"
+       sodipodi:end="4.0136086"
+       d="m 98.861587,136.20603 a 2.6458333,2.6458333 0 0 1 3.719493,0.35839 2.6458333,2.6458333 0 0 1 -0.34835,3.72045 2.6458333,2.6458333 0 0 1 -3.721379,-0.33832 2.6458333,2.6458333 0 0 1 0.328282,-3.72227"
+       sodipodi:open="true" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.58999992, 1.58999992;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 100.54167,138.25 71.4375,87.979167"
+       id="path3717"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="80.603905"
+       y="100.21983"
+       id="text4526"><tspan
+         sodipodi:role="line"
+         id="tspan4524"
+         x="80.603905"
+         y="100.21983"
+         style="stroke-width:0.26458332">R</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="103.53869"
+       y="129.35216"
+       id="text4534"><tspan
+         sodipodi:role="line"
+         id="tspan4532"
+         x="103.53869"
+         y="129.35216"
+         style="stroke-width:0.26458332">L</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="79.642273"
+       y="125.02083"
+       id="text4538"><tspan
+         sodipodi:role="line"
+         id="tspan4536"
+         x="79.642273"
+         y="125.02083"
+         style="stroke-width:0.26458332">D</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.52916663, 0.52916663;stroke-dashoffset:0;stroke-opacity:1;marker-mid:url(#marker4836);marker-end:url(#marker4836)"
+       d="m 105.83333,125.02083 v -7.9375"
+       id="path4542"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.52916663, 0.52916663;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4882)"
+       d="M 105.83333,130.3125 V 138.25"
+       id="path4544"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.52916663, 0.26458332;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#marker5124)"
+       d="m 63.5,119.72917 h 37.04167"
+       id="path5070"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="92.871437"
+       y="139.58635"
+       id="text6820"><tspan
+         sodipodi:role="line"
+         id="tspan6818"
+         x="92.871437"
+         y="139.58635"
+         style="stroke-width:0.26458332">C</tspan></text>
+    <circle
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6822"
+       cx="41.010422"
+       cy="125.02084"
+       r="2.6458333" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6834);marker-end:url(#marker6910)"
+       d="m 41.010421,106.5 v 18.52083 h 13.22917"
+       id="path6824"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="54.239594"
+       y="130.3125"
+       id="text6986"><tspan
+         sodipodi:role="line"
+         id="tspan6984"
+         x="54.239594"
+         y="130.3125"
+         style="stroke-width:0.26458332">x</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="43.656265"
+       y="106.50001"
+       id="text6990"><tspan
+         sodipodi:role="line"
+         id="tspan6988"
+         x="43.656265"
+         y="106.50001"
+         style="stroke-width:0.26458332">z</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="38.097321"
+       y="131.64885"
+       id="text6994"><tspan
+         sodipodi:role="line"
+         id="tspan6992"
+         x="38.097321"
+         y="131.64885"
+         style="stroke-width:0.26458332">y</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 39.166401,123.10999 3.68804,3.88851"
+       id="path6996"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 42.854441,123.04317 -3.62122,3.88851"
+       id="path6998"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 142.19483,93.27956 c 5.40553,-8.0429 14.45965,-12.86778 24.15026,-12.86953 9.69061,-0.002 18.74646,4.81986 24.1549,12.8608"
+       id="path7000"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 158.41286,109.51419 c 15.87499,0 15.87499,0 15.87499,0"
+       id="path7056"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 142.13696,93.23829 16.2759,16.2759"
+       id="path7058"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 174.28785,109.51419 190.56376,93.30511"
+       id="path7060"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="163.5843"
+       y="114.43182"
+       id="text7065"><tspan
+         sodipodi:role="line"
+         id="tspan7063"
+         x="163.5843"
+         y="114.43182"
+         style="stroke-width:0.26458332">2L</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker7159);marker-end:url(#marker7077)"
+       d="m 145.52083,117.08334 v 18.52083 h 15.875"
+       id="path7067"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="160.34091"
+       y="140.95403"
+       id="text8021"><tspan
+         sodipodi:role="line"
+         id="tspan8019"
+         x="160.34091"
+         y="140.95403"
+         style="stroke-width:0.26458332">y</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="140.40691"
+       y="119.19131"
+       id="text8025"><tspan
+         sodipodi:role="line"
+         id="tspan8023"
+         x="140.40691"
+         y="119.19131"
+         style="stroke-width:0.26458332">z</tspan></text>
+    <circle
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6822-3"
+       cx="145.4671"
+       cy="135.87076"
+       r="2.6458333" />
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path8048"
+       cx="145.42081"
+       cy="135.75859"
+       r="1.6036168" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="140.22916"
+       y="140.89584"
+       id="text8052"><tspan
+         sodipodi:role="line"
+         id="tspan8050"
+         x="140.22916"
+         y="140.89584"
+         style="stroke-width:0.26458332">x</tspan></text>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 63.451058,93.389133 C 73.891511,84.757052 87.015807,80.036796 100.56261,80.041672"
+       id="path8054"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.36500001;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path822-6"
+       sodipodi:type="arc"
+       sodipodi:cx="63.434597"
+       sodipodi:cy="138.33263"
+       sodipodi:rx="2.6458333"
+       sodipodi:ry="2.6458333"
+       sodipodi:start="4.0243976"
+       sodipodi:end="4.0136086"
+       d="m 61.754528,136.28866 a 2.6458333,2.6458333 0 0 1 3.719497,0.35839 2.6458333,2.6458333 0 0 1 -0.348357,3.72045 2.6458333,2.6458333 0 0 1 -3.721377,-0.33832 2.6458333,2.6458333 0 0 1 0.328283,-3.72228"
+       sodipodi:open="true" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.76388884px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="76.729172"
+       y="134.28125"
+       id="text970"><tspan
+         sodipodi:role="line"
+         id="tspan968"
+         x="76.729172"
+         y="135.84187"
+         style="stroke-width:0.26458332"></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:4.93888855px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="67.046936"
+       y="137.50517"
+       id="text6820-7"><tspan
+         sodipodi:role="line"
+         id="tspan6818-5"
+         x="67.046936"
+         y="137.50517"
+         style="stroke-width:0.26458332">O</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.76388884px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="76.729172"
+       y="130.3125"
+       id="text992"><tspan
+         sodipodi:role="line"
+         id="tspan990"
+         x="76.729172"
+         y="131.87312"
+         style="stroke-width:0.26458332"></tspan></text>
+  </g>
+</svg>

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_sources(
   Distribution.cpp
   EquatorialCompression.cpp
   Equiangular.cpp
+  FlatOffsetWedge.cpp
   FocallyLiftedEndcap.cpp
   FocallyLiftedFlatEndcap.cpp
   FocallyLiftedFlatSide.cpp
@@ -59,6 +60,7 @@ spectre_target_headers(
   Distribution.hpp
   EquatorialCompression.hpp
   Equiangular.hpp
+  FlatOffsetWedge.hpp
   FocallyLiftedEndcap.hpp
   FocallyLiftedFlatEndcap.hpp
   FocallyLiftedFlatSide.hpp

--- a/src/Domain/CoordinateMaps/FlatOffsetWedge.cpp
+++ b/src/Domain/CoordinateMaps/FlatOffsetWedge.cpp
@@ -1,0 +1,270 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/FlatOffsetWedge.hpp"
+
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <pup.h>
+#include <sstream>
+#include <utility>
+
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Serialization/PupStlCpp11.hpp"
+
+namespace domain::CoordinateMaps {
+
+FlatOffsetWedge::FlatOffsetWedge(double lower_face_y_half_width,
+                                 double lower_face_x_width, double outer_radius)
+    : lower_face_y_half_width_(lower_face_y_half_width),
+      lower_face_x_width_(lower_face_x_width),
+      outer_radius_(outer_radius) {
+  // The equal_within_roundoffs below have an implicit scale of 1,
+  // so the ASSERTs may trigger in the case where we really
+  // want an entire domain that is very small.
+  ASSERT(not equal_within_roundoff(lower_face_y_half_width, 0.0),
+         "Cannot have zero lower_face_y_half_width");
+  ASSERT(lower_face_y_half_width > 0.0,
+         "Cannot have negative lower_face_y_half_width");
+  ASSERT(not equal_within_roundoff(lower_face_x_width, 0.0),
+         "Cannot have zero lower_face_x_width");
+  ASSERT(lower_face_x_width > 0.0, "Cannot have negative lower_face_x_width");
+  ASSERT(not equal_within_roundoff(outer_radius, 0.0),
+         "Cannot have zero outer_radius");
+  ASSERT(outer_radius > 0.0, "Cannot have negative outer_radius");
+
+  // The following ASSERT (and the ones above) are the strict
+  // requirements for the map to be nonsingular.
+  // Below we will have further restrictions that prevent the
+  // map from going nearly singular and losing accuracy.
+  ASSERT(square(outer_radius) - square(lower_face_x_width) >
+             2.0 * square(lower_face_y_half_width),
+         "Must have R^2-D^2 > 2 L^2 or else map is singular.  "
+         "Here R = "
+             << outer_radius << ", D = " << lower_face_x_width
+             << ", L = " << lower_face_y_half_width);
+
+  // Here we arbitrarily restrict the parameters of the map to make
+  // our lives easier. The idea is that we don't want a map that is
+  // epsilon away from being singular, since then the map will have
+  // very large Jacobians (even though it is technically nonsingular)
+  // and this may cause numerical problems.  In the unit tests, we
+  // will stick to maps that have parameters that obey the
+  // restrictions below.
+  //
+  // The magic number epsilon here is chosen arbitrarily,
+  // but based on what we think a sensible user would want.
+  const double epsilon = 0.1;
+  // However, there is a restriction on epsilon.
+  // max(lower_face_y_half_width) - min(lower_face_y_half_with) must
+  // be positive, or else there are no possible values of
+  // lower_face_y_half_width.
+  // With the choices below, the smallest possible value of
+  // max(lower_face_y_half_width) - min(lower_face_y_half_with) turns out
+  // to be outer_radius*epsilon*(2-7*epsilon+O(epsilon)^2).  So we should
+  // choose epsilon < 2/7.
+  //
+  // Note that it is possible to choose multiple magic numbers,
+  // e.g. one value of epsilon for restrictions on lower_face_x_width
+  // and another value of epsilon for restrictions on
+  // lower_face_y_half_width, or even different magic numbers for the
+  // minimum and maximum values of each parameter. If we need to do
+  // such a thing later we can do so, but for now keep only one value
+  // of epsilon for simplicity.
+  ASSERT(lower_face_x_width >= epsilon * outer_radius and
+             lower_face_x_width <= (1 - epsilon) * outer_radius,
+         "The map is not tested if lower_face_x_width < epsilon*outer_radius "
+         "or if lower_face_x_width > (1-epsilon)*outer_radius. Here epsilon="
+             << epsilon << ",lower_face_x_width=" << lower_face_x_width
+             << ", outer_radius=" << outer_radius);
+  ASSERT(lower_face_y_half_width >= epsilon * outer_radius,
+         "The map is not tested if lower_face_y_half_width < "
+         "epsilon*outer_radius. Here epsilon = "
+             << epsilon << ",lower_face_y_half_width="
+             << lower_face_y_half_width << ", outer_radius=" << outer_radius);
+  ASSERT((square(outer_radius) - square(lower_face_x_width)) *
+                 square(1 - epsilon) >=
+             2.0 * square(lower_face_y_half_width),
+         "The map is not tested if 2L^2 > (1-epsilon)^2(R^2-D^2). Here R = "
+             << outer_radius << ", D = " << lower_face_x_width << ", L = "
+             << lower_face_y_half_width << ",epsilon = " << epsilon);
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> FlatOffsetWedge::operator()(
+    const std::array<T, 3>& source_coords) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xi = source_coords[0];
+  const ReturnType& eta = source_coords[1];
+  const ReturnType& zeta = source_coords[2];
+  std::array<ReturnType, 3> target_coords{};
+  ReturnType& x = target_coords[0];
+  ReturnType& y = target_coords[1];
+  ReturnType& z = target_coords[2];
+
+  const double q = 0.5 * lower_face_x_width_ / outer_radius_;
+
+  // Use x as temporary storage so we avoid memory allocations.
+  // x is set to P here (where P is the quantity in the dox).
+  x = outer_radius_ *
+      sqrt((1.0 - square(q * (xi - 1.0))) / (1.0 + square(eta)));
+
+  // Now fill the coordinates using x as temporary.
+  z = 0.5 *
+      (x + lower_face_y_half_width_ + zeta * (x - lower_face_y_half_width_));
+  y = eta * z;
+  x = (0.5 * lower_face_x_width_) * (xi + 1.0);
+
+  return target_coords;
+}
+
+std::optional<std::array<double, 3>> FlatOffsetWedge::inverse(
+    const std::array<double, 3>& target_coords) const {
+  const double& x = target_coords[0];
+  const double& y = target_coords[1];
+  const double& z = target_coords[2];
+
+  const double xi = 2.0 * x / lower_face_x_width_ - 1.0;
+
+  // Check for point out of range.
+  // Allow out of range by roundoff.
+  const double abs_xi = std::abs(xi);
+  if (abs_xi > 1.0 and not equal_within_roundoff(abs_xi, 1.0)) {
+    return std::nullopt;
+  }
+
+  // If z is zero, we are out of range (even if y is zero).
+  if (z == 0.0) {
+    return std::nullopt;
+  }
+  const double eta = y / z;
+
+  // Check for point out of range.
+  // Allow out of range by roundoff.
+  const double abs_eta = std::abs(eta);
+  if (abs_eta > 1.0 and not equal_within_roundoff(abs_eta, 1.0)) {
+    return std::nullopt;
+  }
+
+  // Since we know that xi and eta are in range, the following sqrts
+  // will always have positive arguments.
+  const double P =
+      outer_radius_ *
+      sqrt((1.0 - square((x - lower_face_x_width_) / outer_radius_)) /
+           (1.0 + square(eta)));
+  const double zeta =
+      (2.0 * z - P - lower_face_y_half_width_) / (P - lower_face_y_half_width_);
+
+  // Check for point out of range.
+  // Allow out of range by roundoff.
+  const double abs_zeta = std::abs(zeta);
+  if (abs_zeta > 1.0 and not equal_within_roundoff(abs_zeta, 1.0)) {
+    return std::nullopt;
+  }
+
+  return {{xi, eta, zeta}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+FlatOffsetWedge::jacobian(const std::array<T, 3>& source_coords) const {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xi = source_coords[0];
+  const ReturnType& eta = source_coords[1];
+  const ReturnType& zeta = source_coords[2];
+
+  auto jac =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  const double q = 0.5 * lower_face_x_width_ / outer_radius_;
+
+  // Use Jacobian components as temporary storage to avoid extra
+  // memory allocations.
+
+  // temporarily jac(0,0) = P (where P is the quantity in the dox)
+  get<0, 0>(jac) = outer_radius_ *
+                   sqrt((1.0 - square(q * (xi - 1.0))) / (1.0 + square(eta)));
+
+  // temporarily jac(1,1) = z
+  get<1, 1>(jac) = 0.5 * (get<0, 0>(jac) + lower_face_y_half_width_ +
+                          zeta * (get<0, 0>(jac) - lower_face_y_half_width_));
+
+  // Fill in correct jac(2,1)
+  get<2, 1>(jac) =
+      -get<0, 0>(jac) * 0.5 * eta * (1.0 + zeta) / (1.0 + square(eta));
+  // Now use that to get correct jac(1,1)
+  get<1, 1>(jac) += eta * get<2, 1>(jac);
+
+  // Fill in correct jac(2,0) and jac(1,0)
+  get<2, 0>(jac) = 0.5 * get<0, 0>(jac) * square(q) * (1.0 + zeta) *
+                   (1.0 - xi) / (1.0 - square(q * (xi - 1.0)));
+  get<1, 0>(jac) = eta * get<2, 0>(jac);
+
+  // Fill in correct jac(2,2) and jac(1,2)
+  get<2, 2>(jac) = 0.5 * (get<0, 0>(jac) - lower_face_y_half_width_);
+  get<1, 2>(jac) = eta * get<2, 2>(jac);
+
+  // Now set jac(0,0) to its real value instead of the temporary.
+  get<0, 0>(jac) = 0.5 * lower_face_x_width_;
+
+  return jac;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+FlatOffsetWedge::inv_jacobian(const std::array<T, 3>& source_coords) const {
+  return determinant_and_inverse(jacobian(source_coords)).second;
+}
+
+void FlatOffsetWedge::pup(PUP::er& p) {
+  size_t version = 0;
+  p | version;
+  // Remember to increment the version number when making changes to this
+  // function. Retain support for unpacking data written by previous versions
+  // whenever possible. See `Domain` docs for details.
+  if (version >= 0) {
+    p | lower_face_y_half_width_;
+    p | lower_face_x_width_;
+    p | outer_radius_;
+  }
+}
+
+bool operator==(const FlatOffsetWedge& lhs, const FlatOffsetWedge& rhs) {
+  return lhs.lower_face_y_half_width_ == rhs.lower_face_y_half_width_ and
+         lhs.lower_face_x_width_ == rhs.lower_face_x_width_ and
+         lhs.outer_radius_ == rhs.outer_radius_;
+}
+
+bool operator!=(const FlatOffsetWedge& lhs, const FlatOffsetWedge& rhs) {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>                 \
+  FlatOffsetWedge::operator()(const std::array<DTYPE(data), 3>& source_coords) \
+      const;                                                                   \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  FlatOffsetWedge::jacobian(const std::array<DTYPE(data), 3>& source_coords)   \
+      const;                                                                   \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>   \
+  FlatOffsetWedge::inv_jacobian(                                               \
+      const std::array<DTYPE(data), 3>& source_coords) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FlatOffsetWedge.hpp
+++ b/src/Domain/CoordinateMaps/FlatOffsetWedge.hpp
@@ -1,0 +1,284 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class FlattOffsetWedge.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from a cube to a volume that connects three planes and
+ * a portion of one spherical surface.
+ *
+ * \image html FlatOffsetWedge.svg "Two slices through a FlatOffsetWedge."
+ *
+ * \details A cube is mapped to the volume shown in the figure.
+ *
+ * A $y=0$ slice through the volume is shown in the left
+ * panel of the figure, and a $x=$const slice through the volume is shown
+ * in the right panel of the figure.
+ *
+ * The upper-$z$ face of the volume is a portion of a spherical surface
+ * of radius $R$ centered about point $C$ in the figure, which is along
+ * the $x$-axis a distance $D$ from the origin (point $O$ in the figure).
+ * The lower-$z$ face of the volume is a two-dimensional rectangle of
+ * constant $z$, located a distance $L$ above the origin.
+ * This rectangle extends from
+ * $0 \leq x \leq D$ in the $x$ direction, and from
+ * $-L \leq y \leq+L$ in the $y$ direction.
+ *
+ * The lower-$x$ face of the volume is a portion of the plane at constant
+ * $x=0$, and the upper-$x$ face of the volume is a portion of the plane
+ * at constant $x=D$. See the $x$ extents of the left panel of the
+ * figure.
+ *
+ * Every constant-$x$ cross section of the volume looks like the right panel
+ * of the figure: it is a two-dimensional wedge with 45 degree
+ * opening angle and a base of
+ * width $2L$.  The outer radius of this wedge varies with $x$ (this radius
+ * is $R$ at $x=D$ and $\sqrt{R^2-D^2}$ at $x=0$).
+ *
+ * ### Restrictions
+ *
+ * We require $D^2 + L^2 < R^2$ or else the lower-$x$ face of the mapped
+ * volume lies outside of the sphere of radius $R$.  This implies $L<R$
+ * and $D<R$.
+ * However, the condition that the upper-$z$ and lower-$z$ surface don't touch
+ * each other at the $\xi=-1$, $\eta=\pm 1$ corners is more stringent:
+ * $D^2 + 2L^2 < R^2$.  This implies that $L<R/\sqrt{2}$.
+ *
+ * ## Equations for the map
+ * Given our cube coordinates $\xi,\eta,\zeta$, each taking on values from
+ * $-1$ to $+1$, we can derive the formulas for the map.
+ *
+ * Define
+ * \begin{equation}
+ *    q \equiv \frac{D}{2R}.
+ * \end{equation}
+ *
+ * Notice that $q<1/2$, because of the restriction $D<R$.
+ *
+ * First, note that $x$ is a function of $\xi$ only, for all points in
+ * the cube:
+ * \begin{align}
+ *  x(\xi,\eta,\zeta) &= q R (\xi+1).
+ * \end{align}
+ *
+ * ### Surface map for bottom and top surfaces
+ * The $y$ and $z$ coordinates for the mapped $\zeta=-1$ surface are
+ * \begin{align}
+ *   \begin{bmatrix}
+ *      y(\xi,\eta,-1)\\
+ *      z(\xi,\eta,-1)
+ *   \end{bmatrix} = L
+ *   \begin{bmatrix}
+ *      \eta\\
+ *      1
+ *   \end{bmatrix}.
+ * \end{align}
+ *
+ * The $y$ and $z$ coordinates of the top surface,
+ * $\zeta=+1$, of the volume are given by
+ * \begin{align}
+ *   \begin{bmatrix}
+ *      y(\xi,\eta,+1)\\
+ *      z(\xi,\eta,+1)
+ *   \end{bmatrix} =
+ *     \frac{R}{\sqrt{1+\eta^2}}
+ *              \sqrt{1-q^2(\xi-1)^2}
+ *   \begin{bmatrix}
+ *      \eta \\
+ *      1
+ *   \end{bmatrix}.
+ * \end{align}
+ *
+ * ### Full volume map
+ * Adding the $\zeta$ dependence by linear interpolation gives us
+ * the full volume map for the $y$ and $z$ coordinates:
+ *
+ * \begin{align}
+ *   \begin{bmatrix}
+ *      y(\xi,\eta,\zeta)\\
+ *      z(\xi,\eta,\zeta)
+ *   \end{bmatrix} =
+ *      \left[L \frac{1-\zeta}{2}
+ *        + \frac{1+\zeta}{2}
+ *          \frac{R}{\sqrt{1+\eta^2}}
+ *           \sqrt{1-q^2(\xi-1)^2}\right]
+ *   \begin{bmatrix}
+ *      \eta \\
+ *      1
+ *   \end{bmatrix}.
+ * \end{align}
+ *
+ * ## Inverse
+ *
+ * The map can be inverted analytically:
+ *
+ * \begin{align}
+ *    \xi   &= \frac{x}{qR}-1\\
+ *    \eta  &= \frac{y}{z}\\
+ *    \zeta &= \frac{2z - L - P}{P-L},
+ *              \label{eq:zetaFromxyz}
+ * \end{align}
+ * where
+ * \begin{align}
+ *   P &\equiv R\frac{\sqrt{1-(x-D)^2/R^2}}{\sqrt{1+y^2/z^2}}\\
+ *     &= R\frac{\sqrt{1-q^2(\xi-1)^2}}{\sqrt{1+\eta^2}}.
+ *              \label{eq:Pdefinition}
+ * \end{align}
+ *
+ * It is easy to determine whether a point $(x,y,z)$ lies within the volume:
+ * First compute $\xi$ and $\eta$ and check that they are both in $[-1,1]$.
+ * If so, then the arguments of the square roots in
+ * Eq. ($\ref{eq:Pdefinition}$) are guaranteed positive, and the denominator
+ * of Eq. ($\ref{eq:zetaFromxyz}$) is guaranteed positive
+ * by our condition $R^2>2L^2+D^2$,
+ * so it is straightforward to
+ * compute $\zeta$ and then check if it is in $[-1,1]$.
+ *
+ * ## Jacobian
+ *
+ * Straightforward differentiation gives
+ *
+ * \begin{align}
+ *    \frac{\partial x}{\partial \xi}   &= qR\\
+ *    \frac{\partial x}{\partial \eta}   &= 0\\
+ *    \frac{\partial x}{\partial \zeta}   &= 0,
+ * \end{align}
+ *
+ * \begin{align}
+ *   \partial_\zeta \begin{bmatrix}
+ *      y\\
+ *      z
+ *   \end{bmatrix} &= \frac{1}{2}
+ *    \left[\frac{R}{\sqrt{1+\eta^2}}\sqrt{1-q^2(\xi-1)^2}
+ *    -L\right]
+ *   \begin{bmatrix}
+ *      \eta \\
+ *      1
+ *   \end{bmatrix}, \\
+ *   \partial_\xi \begin{bmatrix}
+ *      y\\
+ *      z
+ *   \end{bmatrix} &=
+ *    \left[\frac{Rq^2 (1+\zeta)(1-\xi)}{2\sqrt{1+\eta^2}}
+ *    \left(1-q^2(\xi-1)^2\right)^{-1/2}\right]
+ *   \begin{bmatrix}
+ *      \eta \\
+ *      1
+ *   \end{bmatrix}, \\
+ *   \partial_\eta \begin{bmatrix}
+ *      y\\
+ *      z
+ *   \end{bmatrix} &=
+ *       -\left[\frac{R\eta(1+\zeta)}{2(1+\eta^2)^{3/2}}
+ *        \sqrt{1-q^2(\xi-1)^2}\right]
+ *   \begin{bmatrix}
+ *      \eta \\
+ *      1
+ *   \end{bmatrix}+
+ *   \begin{bmatrix}
+ *      z \\
+ *      0
+ *   \end{bmatrix}.
+ * \end{align}
+ *
+ * ## Inverse Jacobian
+ *
+ * Let
+ * \begin{align}
+ *   \Xi &\equiv P\frac{1+\zeta}{P-L}.
+ * \end{align}
+ * Then
+ * \begin{align}
+ *    \frac{\partial \zeta}{\partial x}  &=
+ *        \Xi q\frac{\xi-1}{R\sqrt{1-q^2(\xi-1)^2}},\\
+ *    \frac{\partial \zeta}{\partial y}  &=
+ *        \Xi \frac{\eta}{z\sqrt{1+\eta^2}},\\
+ *    \frac{\partial \zeta}{\partial z}  &=
+ *        -\Xi \eta\frac{\eta}{z\sqrt{1+\eta^2}}
+ *     +\frac{2}{P-L},\\
+ *    \frac{\partial \xi}{\partial x}   &= \frac{1}{qR}\\
+ *    \frac{\partial \xi}{\partial y}   &= 0\\
+ *    \frac{\partial \xi}{\partial z}   &= 0\\
+ *    \frac{\partial \eta}{\partial x}  &= 0\\
+ *    \frac{\partial \eta}{\partial y}  &= \frac{1}{z}\\
+ *    \frac{\partial \eta}{\partial z}  &= -\frac{\eta}{z}.
+ * \end{align}
+ *
+ */
+class FlatOffsetWedge {
+ public:
+  static constexpr size_t dim = 3;
+  /*!
+   * \brief Constructs a FlatOffsetWedge.
+   *
+   * \param lower_face_y_half_width The half-width $L$ of the lower face in
+   * the $y$ direction.
+   * \param lower_face_x_width The width $D$ of the lower face in
+   * the $x$ direction.
+   * \param outer_radius The outer radius $R$.
+   */
+  FlatOffsetWedge(double lower_face_y_half_width, double lower_face_x_width,
+                  double outer_radius);
+
+  FlatOffsetWedge() = default;
+  ~FlatOffsetWedge() = default;
+  FlatOffsetWedge(FlatOffsetWedge&&) = default;
+  FlatOffsetWedge(const FlatOffsetWedge&) = default;
+  FlatOffsetWedge& operator=(const FlatOffsetWedge&) = default;
+  FlatOffsetWedge& operator=(FlatOffsetWedge&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const;
+
+  /// The inverse function is only callable with doubles because the inverse
+  /// might fail if called for a point out of range, and it is unclear
+  /// what should happen if the inverse were to succeed for some points in a
+  /// DataVector but fail for other points.
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p);  // NOLINT
+
+  static bool is_identity() { return false; }
+
+ private:
+  friend bool operator==(const FlatOffsetWedge& lhs,
+                         const FlatOffsetWedge& rhs);
+  double lower_face_y_half_width_{std::numeric_limits<double>::signaling_NaN()};
+  double lower_face_x_width_{std::numeric_limits<double>::signaling_NaN()};
+  double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator!=(const FlatOffsetWedge& lhs, const FlatOffsetWedge& rhs);
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -17,6 +17,7 @@
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
+#include "Domain/CoordinateMaps/FlatOffsetWedge.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_Distribution.cpp
   Test_EquatorialCompression.cpp
   Test_Equiangular.cpp
+  Test_FlatOffsetWedge.cpp
   Test_Frustum.cpp
   Test_Identity.cpp
   Test_Interval.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_FlatOffsetWedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_FlatOffsetWedge.cpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <optional>
+#include <random>
+
+#include "Domain/CoordinateMaps/FlatOffsetWedge.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+
+namespace domain {
+
+namespace {
+void test_flat_offset_wedge() {
+  INFO("FlatOffsetWedge");
+
+  // Set up random number generator
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+
+  // The value of outer_radius sets the scale.  Don't need to choose
+  // it to be random because we will scale all other variables in terms
+  // of outer_radius.
+  const double outer_radius = 10.0;
+
+  // The value of epsilon here must be the same as in the constructor
+  // of FlatOffsetWedge, so that the sanity checks in the constructor
+  // do not faile.  The sanity checks limit the values of the map
+  // parameters so that the map doesn't get too close to singular.
+  // With epsilon=0, the map might be singular for particularly
+  // unlucky choices of the random numbers; with epsilon>0 the map is
+  // always nonsingular (but might be close to singular depending on how
+  // small epsilon is and what random numbers are chosen).
+  const double epsilon = 0.1;
+
+  // To pass sanity checks in the constructor, we must have
+  // epsilon*outer_radius <= lower_face_x_width <= (1-epsilon)*outer_radius
+  const double lower_face_x_width =
+      outer_radius * (epsilon + (1.0 - 2.0 * epsilon) * unit_dis(gen));
+  CAPTURE(lower_face_x_width);
+
+  // To pass sanity checks in the constructor, we must have
+  // L > epsilon*R and 2L^2 < (1-epsilon)^2*(R^2-D^2)
+  // where L is lower_face_y_half_width and D is lower_face_x_width
+  const double lower_face_y_half_width_min = epsilon * outer_radius;
+  const double lower_face_y_half_width_max =
+      (1.0 - epsilon) *
+      sqrt((square(outer_radius) - square(lower_face_x_width)) / 2.0);
+  const double lower_face_y_half_width =
+      lower_face_y_half_width_min +
+      unit_dis(gen) *
+          (lower_face_y_half_width_max - lower_face_y_half_width_min);
+  CAPTURE(lower_face_y_half_width);
+
+  const CoordinateMaps::FlatOffsetWedge map(lower_face_y_half_width,
+                                            lower_face_x_width, outer_radius);
+  test_suite_for_map_on_unit_cube(map);
+
+  // The following are tests that the inverse function correctly
+  // returns an invalid std::optional when called for a point that is
+  // outside the range of the map.
+
+  // point with x < 0
+  CHECK_FALSE(map.inverse({{-1.0, 0.0, 0.0}}));
+
+  // point with x > lower_face_x_width
+  CHECK_FALSE(map.inverse({{1.1 * lower_face_x_width, 0.0, 0.0}}));
+
+  // point with z==0 but x is ok
+  CHECK_FALSE(map.inverse({{0.5 * lower_face_x_width, 0.0, 0.0}}));
+
+  // point outside of opening angle in y
+  CHECK_FALSE(
+      map.inverse({{0.5 * lower_face_x_width, 1.2 * lower_face_y_half_width,
+                    1.02 * lower_face_y_half_width}}));
+
+  // point with z < lower_face_y_half_width
+  CHECK_FALSE(map.inverse(
+      {{0.5 * lower_face_x_width, 0.0, 0.5 * lower_face_y_half_width}}));
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{0.0, lower_face_x_width,
+                                         outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot have zero lower_face_y_half_width"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{-lower_face_y_half_width,
+                                         lower_face_x_width, outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot have negative lower_face_y_half_width"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{lower_face_y_half_width,
+                                         -lower_face_x_width, outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot have negative lower_face_x_width"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{lower_face_y_half_width, 0.0,
+                                         outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot have zero lower_face_x_width"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{lower_face_y_half_width,
+                                         lower_face_x_width, -outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring("Cannot have negative outer_radius"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{lower_face_y_half_width,
+                                         lower_face_x_width, 0.0});
+      }(),
+      Catch::Matchers::ContainsSubstring("Cannot have zero outer_radius"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{
+            sqrt(square(outer_radius) - square(lower_face_x_width)),
+            lower_face_x_width, outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring("Must have R^2-D^2 > 2 L^2"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{lower_face_y_half_width,
+                                         0.99 * epsilon * outer_radius,
+                                         outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The map is not tested if lower_face_x_width"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{
+            outer_radius * sqrt(1.0 - square(1.001 * (1.0 - epsilon))) /
+                sqrt(2.01),
+            1.001 * (1 - epsilon) * outer_radius, outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The map is not tested if lower_face_x_width"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{0.99 * epsilon * outer_radius,
+                                         lower_face_x_width, outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The map is not tested if lower_face_y_half_width"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        (CoordinateMaps::FlatOffsetWedge{
+            sqrt(square(outer_radius) - square(lower_face_x_width)) *
+                (1 - epsilon) / sqrt(1.999),
+            lower_face_x_width, outer_radius});
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The map is not tested if 2L^2 > (1-epsilon)"));
+#endif
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.FlatOffsetWedge",
+                  "[Domain][Unit]") {
+  test_flat_offset_wedge();
+  CHECK(not CoordinateMaps::FlatOffsetWedge{}.is_identity());
+}
+}  // namespace domain


### PR DESCRIPTION
This is a new CoordinateMap that will be useful for making BNS domains.  Combining this map with rectangles, Wedges and half Wedges will build the inner part of a binary domain.


### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

