### PR TITLE
AH rewrite: Add AH callback to observe center of horizon

### DIFF
--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -84,8 +84,8 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
           tmpl::list<intrp::callbacks::ErrorOnFailedApparentHorizon>;
       using post_horizon_find_callbacks =
           tmpl::list<control_system::RunCallbacks<FindHorizon, ControlSystems>,
-                     ::ah::callbacks::ObserveCenters<InterpolationTarget,
-                                                     ::Frame::Distorted>>;
+                     ::intrp::callbacks::ObserveCenters<InterpolationTarget,
+                                                        ::Frame::Distorted>>;
     };
 
    public:

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -100,7 +100,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
         intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Ah>,
         intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, Ah,
                                              Frame>,
-        ::ah::callbacks::ObserveCenters<Ah, Frame>>;
+        ::intrp::callbacks::ObserveCenters<Ah, Frame>>;
   };
 
   using ApparentHorizon = Ah<::Frame::Distorted>;

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp
@@ -31,8 +31,7 @@ struct Inertial;
 }  // namespace Frame
 /// \endcond
 
-namespace ah {
-namespace callbacks {
+namespace intrp::callbacks {
 /*!
  * \brief Writes the center of an apparent horizon to disk in both the
  * `Frame` template parameter frame and Frame::Inertial frame. Intended to be
@@ -63,11 +62,6 @@ namespace callbacks {
  */
 template <typename InterpolationTargetTag, typename Frame>
 struct ObserveCenters {
-  // Note that we don't add a const_global_cache_tags type alias here with
-  // ah::Tags::ObserveCenters because we want to use the base tag and so must be
-  // agnostic to how the tag was added to the cache. We do this so anything that
-  // uses ObserveCenters can control when it gets printed.
-
   template <typename DbTags, typename Metavariables, typename TemporalId>
   static void apply(const db::DataBox<DbTags>& box,
                     Parallel::GlobalCache<Metavariables>& cache,
@@ -139,5 +133,4 @@ struct ObserveCenters {
       {"Time", "GridCenter_x", "GridCenter_y", "GridCenter_z",
        "InertialCenter_x", "InertialCenter_y", "InertialCenter_z"}};
 };
-}  // namespace callbacks
-}  // namespace ah
+}  // namespace intrp::callbacks

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp
@@ -17,11 +17,14 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 
 /// \cond
 namespace Frame {
@@ -134,3 +137,108 @@ struct ObserveCenters {
        "InertialCenter_x", "InertialCenter_y", "InertialCenter_z"}};
 };
 }  // namespace intrp::callbacks
+
+namespace ah::callbacks {
+/*!
+ * \brief Writes the center of an apparent horizon to disk in both the
+ * `Frame` template parameter frame and Frame::Inertial frame. Intended to be
+ * used in the `horizon_find_callbacks` list of a
+ * `ah::protocols::HorizonMetavars`.
+ *
+ * The centers will be written to a subfile with the name
+ * `/ApparentHorizons/TargetName_Centers.dat` where `TargetName` is the
+ * pretty_type::name of the \p HorizonMetavars template parameter.
+ *
+ * The columns of the dat file are:
+ * - %Time
+ * - GridCenter_x
+ * - GridCenter_y
+ * - GridCenter_z
+ * - InertialCenter_x
+ * - InertialCenter_y
+ * - InertialCenter_z
+ *
+ * The `Frame` template parameter must be either `::Frame::Grid` or
+ * `::Frame::Distorted`. Even though the template parameter can be
+ * `::Frame::Distorted`, we still write `GridCenter_?` because the centers of
+ * the objects are the same in the Grid and Distorted frames.
+ *
+ * \note Requires `ylm::Tags::Strahlkorper<Frame>` and
+ * `ylm::Tags::CartesianCoords<Frame::Inertial>` and
+ * `ylm::Tags::EuclideanAreaElement<Frame>` to be in the DataBox of the horizon
+ * finder.
+ */
+template <typename HorizonMetavars>
+struct ObserveCenters : tt::ConformsTo<ah::protocols::Callback> {
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const FastFlow::Status /*status*/) {
+    using frame = typename HorizonMetavars::frame;
+    static_assert(std::is_same_v<frame, ::Frame::Grid> or
+                      std::is_same_v<frame, ::Frame::Distorted>,
+                  "Frame must be either Grid or Distorted.");
+    using HorizonTag = ylm::Tags::Strahlkorper<frame>;
+    using CoordsTag = ylm::Tags::CartesianCoords<::Frame::Inertial>;
+    using EuclideanAreaElementTag = ylm::Tags::EuclideanAreaElement<frame>;
+    static_assert(db::tag_is_retrievable_v<HorizonTag, db::DataBox<DbTags>>,
+                  "DataBox must contain ylm::Tags::Strahlkorper<Frame>");
+    static_assert(db::tag_is_retrievable_v<CoordsTag, db::DataBox<DbTags>>,
+                  "DataBox must contain "
+                  "ylm::Tags::CartesianCoords<Frame::Inertial>");
+    static_assert(
+        db::tag_is_retrievable_v<EuclideanAreaElementTag, db::DataBox<DbTags>>,
+        "DataBox must contain ylm::Tags::EuclideanAreaElement<Frame>");
+
+    // Only print the centers if we want to.
+    if (not Parallel::get<ah::Tags::ObserveCenters>(cache)) {
+      return;
+    }
+
+    const auto& grid_horizon = db::get<HorizonTag>(box);
+    const std::array<double, 3> grid_center = grid_horizon.physical_center();
+
+    // computes the inertial center to be the average value of the
+    // inertial coordinates over the Strahlkorper, where the average is
+    // computed by a surface integral.
+    // Note that we use the Euclidean area element here, since we are trying
+    // to find a geometric center of a surface without regard to GR.
+    const auto& inertial_coords = db::get<CoordsTag>(box);
+    const auto& area_element = db::get<EuclideanAreaElementTag>(box);
+    std::array<double, 3> inertial_center =
+        make_array<3>(std::numeric_limits<double>::signaling_NaN());
+    auto integrand = make_with_value<Scalar<DataVector>>(get(area_element), 0.);
+    const double denominator = grid_horizon.ylm_spherepack().definite_integral(
+        get(area_element).data());
+    for (size_t i = 0; i < 3; ++i) {
+      get(integrand) = get(area_element) * inertial_coords.get(i);
+      gsl::at(inertial_center, i) =
+          grid_horizon.ylm_spherepack().definite_integral(
+              get(integrand).data()) /
+          denominator;
+    }
+
+    // time, grid_x, grid_y, grid_z, inertial_x, inertial_y, inertial_z
+    const auto& current_time = db::get<ah::Tags::CurrentTime>(box).value();
+    const auto center_tuple = std::make_tuple(
+        current_time.id, grid_center[0], grid_center[1], grid_center[2],
+        inertial_center[0], inertial_center[1], inertial_center[2]);
+
+    auto& observer_writer_proxy = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+
+    const std::string subfile_path{"/ApparentHorizons/" +
+                                   HorizonMetavars::name() + "_Centers"};
+
+    Parallel::threaded_action<
+        observers::ThreadedActions::WriteReductionDataRow>(
+        // Node 0 is always the writer
+        observer_writer_proxy[0], subfile_path, legend_, center_tuple);
+  }
+
+ private:
+  const static inline std::vector<std::string> legend_{
+      {"Time", "GridCenter_x", "GridCenter_y", "GridCenter_z",
+       "InertialCenter_x", "InertialCenter_y", "InertialCenter_z"}};
+};
+}  // namespace ah::callbacks

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -5,5 +5,6 @@ set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   Callbacks/Test_InvokeCallbacks.cpp
   Callbacks/Test_FailedHorizonFind.cpp
+  Callbacks/Test_ObserveCenters.cpp
   Callbacks/Test_SendDependencyToObserverWriter.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_ObserveCenters.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_ObserveCenters.cpp
@@ -1,0 +1,196 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <random>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/IO/Observers/MockWriteReductionDataRow.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+template <typename Fr>
+struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using temporal_id_tag = ::Tags::TimeAndPrevious<0>;
+  using frame = Fr;
+
+  using horizon_find_callbacks =
+      tmpl::list<ah::callbacks::ObserveCenters<HorizonMetavars>>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() {
+    return pretty_type::name<Fr>() + "TestingHorizonMetavars";
+  }
+};
+
+struct TestMetavars {
+  using const_global_cache_tags = tmpl::list<ah::Tags::ObserveCenters>;
+  using component_list =
+      tmpl::list<TestHelpers::observers::MockObserverWriter<TestMetavars>>;
+};
+
+using FoTPtr = std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>;
+
+template <typename LocalHorizonMetavars>
+void test() {
+  using frame = typename LocalHorizonMetavars::frame;
+  using observer_writer =
+      TestHelpers::observers::MockObserverWriter<TestMetavars>;
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> center_dist{-10.0, 10.0};
+
+  // set up runner and stuff
+  ActionTesting::MockRuntimeSystem<TestMetavars> runner{{true}};
+  runner.set_phase(Parallel::Phase::Initialization);
+  ActionTesting::emplace_nodegroup_component_and_initialize<observer_writer>(
+      make_not_null(&runner), {});
+  auto& cache = ActionTesting::cache<observer_writer>(runner, 0);
+
+  runner.set_phase(Parallel::Phase::Execute);
+
+  const auto make_center = [&gen, &center_dist]() -> std::array<double, 3> {
+    return make_with_random_values<std::array<double, 3>>(
+        make_not_null(&gen), center_dist, std::array<double, 3>{});
+  };
+
+  // Lists of centers so we can check that the correct centers were written
+  std::vector<std::array<double, 3>> grid_centers{};
+  std::vector<std::array<double, 3>> inertial_centers{};
+
+  db::DataBox<tmpl::list<ah::Tags::CurrentTime, ylm::Tags::Strahlkorper<frame>,
+                         ylm::Tags::CartesianCoords<::Frame::Inertial>,
+                         ylm::Tags::EuclideanAreaElement<frame>>>
+      box{};
+
+  const auto update_stored_centers = [&make_center, &grid_centers,
+                                      &inertial_centers,
+                                      &box](const LinkedMessageId<double>&
+                                                current_time) {
+    const auto grid_center = make_center();
+    const auto inertial_center = make_center();
+
+    grid_centers.push_back(grid_center);
+    inertial_centers.push_back(inertial_center);
+
+    db::mutate<ah::Tags::CurrentTime, ylm::Tags::Strahlkorper<frame>,
+               ylm::Tags::CartesianCoords<::Frame::Inertial>,
+               ylm::Tags::EuclideanAreaElement<frame>>(
+        [&](const gsl::not_null<std::optional<LinkedMessageId<double>>*>
+                box_current_time,
+            const gsl::not_null<ylm::Strahlkorper<frame>*> box_grid_horizon,
+            const gsl::not_null<tnsr::I<DataVector, 3, ::Frame::Inertial>*>
+                box_inertial_coords,
+            const gsl::not_null<Scalar<DataVector>*> box_area_element) {
+          *box_current_time = current_time;
+          *box_grid_horizon = ylm::Strahlkorper<frame>{10, 1.0, grid_center};
+          const auto theta_phi = ylm::theta_phi(*box_grid_horizon);
+          const auto radius = ylm::radius(*box_grid_horizon);
+          const auto rhat = ylm::rhat(theta_phi);
+
+          // Set area element to the Euclidean area element for the test.
+          *box_area_element = gr::surfaces::euclidean_area_element(
+              ylm::jacobian(theta_phi),
+              ylm::normal_one_form(ylm::cartesian_derivs_of_scalar(
+                                       radius, *box_grid_horizon, radius,
+                                       ylm::inv_jacobian(theta_phi)),
+                                   rhat),
+              radius, rhat);
+
+          // Simply offset the inertial coords from the grid coords.
+          const auto grid_coords =
+              ylm::cartesian_coords(*box_grid_horizon, radius, rhat);
+          for (size_t i = 0; i < 3; ++i) {
+            box_inertial_coords->get(i) = grid_coords.get(i) +
+                                          gsl::at(inertial_center, i) -
+                                          gsl::at(grid_center, i);
+          }
+        },
+        make_not_null(&box));
+  };
+
+  // times to write
+  const std::vector<double> times{0.0, 0.1, 0.2, 0.3, 0.4, 0.5};
+
+  // write some data
+  for (size_t i = 0; i < times.size(); i++) {
+    const LinkedMessageId<double> current_time{
+        times[i], i == 0 ? std::nullopt : std::optional{times[i - 1]}};
+    update_stored_centers(current_time);
+
+    ah::callbacks::ObserveCenters<LocalHorizonMetavars>::apply(
+        box, cache, FastFlow::Status::AbsTol);
+
+    const size_t num_threaded_actions =
+        ActionTesting::number_of_queued_threaded_actions<observer_writer>(
+            runner, 0);
+    CHECK(num_threaded_actions == 1);
+    ActionTesting::invoke_queued_threaded_action<observer_writer>(
+        make_not_null(&runner), 0);
+  }
+
+  // These must be the same as in ObserveCenters
+  const std::vector<std::string> compare_legend{
+      {"Time", "GridCenter_x", "GridCenter_y", "GridCenter_z",
+       "InertialCenter_x", "InertialCenter_y", "InertialCenter_z"}};
+  const std::string subfile_name =
+      "/ApparentHorizons/" + LocalHorizonMetavars::name() + "_Centers";
+
+  auto& h5_file = ActionTesting::get_databox_tag<
+      observer_writer, TestHelpers::observers::MockReductionFileTag>(runner, 0);
+  const auto& dataset = h5_file.get_dat(subfile_name);
+  const Matrix data = dataset.get_data();
+  const std::vector<std::string>& legend = dataset.get_legend();
+
+  // Check legend is correct
+  for (size_t i = 0; i < legend.size(); i++) {
+    CHECK(legend[i] == compare_legend[i]);
+  }
+
+  // Check proper number of times were written
+  CHECK(data.rows() == times.size());
+
+  // Check centers
+  for (size_t i = 0; i < times.size(); i++) {
+    CHECK(data(i, 0) == times[i]);
+
+    const std::array<double, 3>& grid_center = grid_centers[i];
+    const std::array<double, 3>& inertial_center = inertial_centers[i];
+    for (size_t j = 0; j < grid_center.size(); j++) {
+      // Grid center is columns 2-4
+      CHECK(data(i, j + 1) == approx(gsl::at(grid_center, j)));
+      // Inertial center is columns 5-7
+      CHECK(data(i, j + 4) == approx(gsl::at(inertial_center, j)));
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.ObserveCenters",
+                  "[Unit][ApparentHorizonFinder]") {
+  test<HorizonMetavars<::Frame::Grid>>();
+  test<HorizonMetavars<::Frame::Distorted>>();
+}
+}  // namespace

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ObserveCenters.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ObserveCenters.cpp
@@ -117,7 +117,7 @@ void test() {
   for (size_t i = 0; i < times.size(); i++) {
     update_stored_centers();
 
-    ah::callbacks::ObserveCenters<AhA, Frame>::apply(box, cache, times[i]);
+    intrp::callbacks::ObserveCenters<AhA, Frame>::apply(box, cache, times[i]);
 
     size_t num_threaded_actions =
         ActionTesting::number_of_queued_threaded_actions<observer_writer>(
@@ -163,8 +163,8 @@ void test() {
   }
 }
 
-SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.ObserveCenters",
-                  "[Unit][ApparentHorizonFinder]") {
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ObserveCenters",
+                  "[Unit]") {
   test<::Frame::Grid>();
   test<::Frame::Distorted>();
 }


### PR DESCRIPTION
## Proposed changes

Twelfth PR in horizon finder changes. The new ObserveCenters callback has the same logic as the existing one, just uses the new AH tags. In order to put the new callback in the proper place with the same name as the old one, I just moved the old one to the `intrp` namespace. It'll be deleted soon after anyways.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
