### PR TITLE
AH rewrite: Add AH callbacks to observe surface and time series data on a horizon

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -12,5 +12,7 @@ spectre_target_headers(
   IgnoreFailedApparentHorizon.hpp
   InvokeCallbacks.hpp
   ObserveCenters.hpp
+  ObserveFieldsOnHorizon.hpp
+  ObserveTimeSeriesOnHorizon.hpp
   SendDependencyToObserverWriter.hpp
   )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveFieldsOnHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveFieldsOnHorizon.hpp
@@ -1,0 +1,153 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Tests for this file are combined with the ones for
+// ObserveTimeSeriesOnHorizon.hpp in
+// Test_ObserveFieldsAndTimeSeriesOnHorizon.cpp since they are so similar.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah ::callbacks {
+/*!
+ * \brief A `ah::protocols::Callback` that outputs 2D "volume" data on a
+ * surface and the surface's spherical harmonic data.
+ *
+ * \details The columns of spherical harmonic data written take the form
+ *
+ * \code
+ * [Time, {Frame}ExpansionCenter_x, {Frame}ExpansionCenter_y,
+ * {Frame}ExpansionCenter_z, Lmax, coef(0,0), ... coef(Lmax,Lmax)]
+ * \endcode
+ *
+ * where `coef(l,m)` refers to the strahlkorper coefficients stored and defined
+ * by `ylm::Strahlkorper::coefficients() const`, and `Frame` is
+ * `HorizonMetavars::frame`. It is assumed that $l_{\mathrm{max}} =
+ * m_{\mathrm{max}}$.
+ *
+ * \note Currently, $l_{\mathrm{max}}$ for a given surface does not change over
+ * the course of the simulation, which means that the total number of columns of
+ * coefficients that we need to write is also constant. The current
+ * implementation of writing the coefficients at one time assumes
+ * $l_{\mathrm{max}}$ of a surface remains constant. If and when in the future
+ * functionality for an adaptive $l_{\mathrm{max}}$ is added, the implementation
+ * for writing the coefficients will need to be updated to account for this. One
+ * possible way to address this is to have a known maximum $l_{\mathrm{max}}$
+ * for a given surface and write all coefficients up to that maximum
+ * $l_{\mathrm{max}}$.
+ */
+template <typename TagsToObserve, typename HorizonMetavars>
+struct ObserveFieldsOnHorizon : tt::ConformsTo<ah::protocols::Callback> {
+  using Fr = typename HorizonMetavars::frame;
+
+  using const_global_cache_tags = tmpl::list<observers::Tags::SurfaceFileName>;
+
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const FastFlow::Status /*status*/) {
+    const auto& current_time = db::get<ah::Tags::CurrentTime>(box).value();
+    const auto& strahlkorper = get<ylm::Tags::Strahlkorper<Fr>>(box);
+    const ylm::Spherepack& ylm = strahlkorper.ylm_spherepack();
+
+    // Output the inertial-frame coordinates of the Strahlkorper.
+    // Note that these coordinates are not Spherepack-evenly-distributed over
+    // the inertial-frame sphere (they are Spherepack-evenly-distributed over
+    // the frame sphere).
+    std::vector<TensorComponent> tensor_components;
+    const auto& inertial_strahlkorper_coords =
+        get<ylm::Tags::CartesianCoords<::Frame::Inertial>>(box);
+    tensor_components.push_back(
+        {"InertialCoordinates_x"s, get<0>(inertial_strahlkorper_coords)});
+    tensor_components.push_back(
+        {"InertialCoordinates_y"s, get<1>(inertial_strahlkorper_coords)});
+    tensor_components.push_back(
+        {"InertialCoordinates_z"s, get<2>(inertial_strahlkorper_coords)});
+
+    tmpl::for_each<TagsToObserve>([&box, &tensor_components](auto tag_v) {
+      using Tag = tmpl::type_from<decltype(tag_v)>;
+      const auto tag_name = db::tag_name<Tag>();
+      const auto& tensor = get<Tag>(box);
+      for (size_t i = 0; i < tensor.size(); ++i) {
+        tensor_components.emplace_back(tag_name + tensor.component_suffix(i),
+                                       tensor[i]);
+      }
+    });
+
+    const std::string& surface_name = pretty_type::name<HorizonMetavars>();
+    const std::string subfile_path{std::string{"/"} + surface_name};
+    const std::vector<size_t> extents_vector{
+        {ylm.physical_extents()[0], ylm.physical_extents()[1]}};
+    const std::vector<Spectral::Basis> bases_vector{
+        2, Spectral::Basis::SphericalHarmonic};
+    const std::vector<Spectral::Quadrature> quadratures_vector{
+        {Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}};
+    const observers::ObservationId observation_id{current_time.id,
+                                                  subfile_path + ".vol"};
+
+    auto& proxy = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+
+    // We call this on proxy[0] because the 0th element of a NodeGroup is
+    // always guaranteed to be present.
+    Parallel::threaded_action<observers::ThreadedActions::WriteVolumeData>(
+        proxy[0], Parallel::get<observers::Tags::SurfaceFileName>(cache),
+        subfile_path, observation_id,
+        std::vector<ElementVolumeData>{{surface_name, tensor_components,
+                                        extents_vector, bases_vector,
+                                        quadratures_vector}});
+
+    std::vector<std::string> ylm_legend{};
+    std::vector<double> ylm_data{};
+    // The number of coefficients written will be (l_max + 1)^2 where l_max is
+    // the current value of l_max for this surface's strahlkorper. Because l_max
+    // remains constant, the number of coefficient columns written does, too. In
+    // the future when l_max is adaptive, instead of passing in the current
+    // l_max of the strahlkorper, we could pass in the maximum value that l_max
+    // could be to ensure that we (a) have enough columns to write all the
+    // coefficients regardless of the current value of l_max and (b) write a
+    // constant number of columns for each row of data regardless of the current
+    // l_max.
+    ylm::fill_ylm_legend_and_data(make_not_null(&ylm_legend),
+                                  make_not_null(&ylm_data), strahlkorper,
+                                  current_time.id, strahlkorper.l_max());
+
+    const std::string ylm_subfile_name{std::string{"/"} + surface_name +
+                                       "_Ylm"};
+
+    Parallel::threaded_action<
+        observers::ThreadedActions::WriteReductionDataRow>(
+        proxy[0], ylm_subfile_name, std::move(ylm_legend),
+        std::make_tuple(std::move(ylm_data)));
+  }
+};
+}  // namespace ah::callbacks

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveTimeSeriesOnHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveTimeSeriesOnHorizon.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Tests for this file are combined with the ones for
+// ObserveFieldsOnHorizon.hpp in
+// Test_ObserveFieldsAndTimeSeriesOnHorizon.cpp since they are so similar.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
+#include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::callbacks {
+namespace detail {
+template <typename T>
+struct is_array_of_double : std::false_type {};
+
+template <std::size_t N>
+struct is_array_of_double<std::array<double, N>> : std::true_type {};
+
+template <typename... Ts>
+auto make_legend(tmpl::list<Ts...> /* meta */) {
+  std::vector<std::string> legend = {"Time"};
+
+  [[maybe_unused]] auto append_tags = [&legend](auto tag) {
+    using TagType = decltype(tag);
+    using ReturnType = typename TagType::type;
+
+    if constexpr (is_array_of_double<ReturnType>::value) {
+      constexpr std::array<const char*, 3> suffix = {"_x", "_y", "_z"};
+      for (size_t i = 0; i < std::tuple_size<ReturnType>::value; ++i) {
+        legend.push_back(db::tag_name<TagType>() + gsl::at(suffix, i));
+      }
+    } else {
+      legend.push_back(db::tag_name<TagType>());
+    }
+  };
+
+  (append_tags(Ts{}), ...);
+
+  return legend;
+}
+
+template <typename DbTags, typename... Ts>
+auto make_reduction_data(const db::DataBox<DbTags>& box, double time,
+                         tmpl::list<Ts...> /* meta */) {
+  return std::make_tuple(time, get<Ts>(box)...);
+}
+
+}  // namespace detail
+
+/*!
+ * \brief A `ah::protocol::Callback` that outputs a `double` or
+ * `std::array<double, N>` quantity on a surface as a time series in the
+ * reductions file.
+ */
+template <typename TagsToObserve, typename HorizonMetavars>
+struct ObserveTimeSeriesOnHorizon : tt::ConformsTo<ah::protocols::Callback> {
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const FastFlow::Status /*status*/) {
+    const auto& time = db::get<ah::Tags::CurrentTime>(box).value();
+    auto& proxy = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+
+    // We call this on proxy[0] because the 0th element of a NodeGroup is
+    // always guaranteed to be present.
+    Parallel::threaded_action<
+        observers::ThreadedActions::WriteReductionDataRow>(
+        proxy[0], std::string{"/" + pretty_type::name<HorizonMetavars>()},
+        detail::make_legend(TagsToObserve{}),
+        detail::make_reduction_data(box, time.id, TagsToObserve{}));
+  }
+};
+}  // namespace ah::callbacks

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -34,7 +34,9 @@ target_link_libraries(
   FiniteDifference
   GeneralRelativity
   GeneralRelativitySolutions
+  GrSurfacesHelpers
   InterpolationHelpers
+  IoTestHelpers
   LinearOperators
   Logging
   ObserverHelpers

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/CMakeLists.txt
@@ -6,5 +6,6 @@ set(LIBRARY_SOURCES
   Callbacks/Test_InvokeCallbacks.cpp
   Callbacks/Test_FailedHorizonFind.cpp
   Callbacks/Test_ObserveCenters.cpp
+  Callbacks/Test_ObserveFieldsAndTimeSeriesOnHorizon.cpp
   Callbacks/Test_SendDependencyToObserverWriter.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_ObserveFieldsAndTimeSeriesOnHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_ObserveFieldsAndTimeSeriesOnHorizon.cpp
@@ -1,0 +1,486 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/IO/VolumeData.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/Surfaces/TestHelpers.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/AngularOrdering.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveFieldsOnHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveTimeSeriesOnHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/GeneralRelativity/KerrHorizon.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+constexpr size_t low_l_max = 3;
+constexpr size_t high_l_max = 16;
+
+template <typename Fr>
+Variables<ah::vars_to_interpolate_to_target<3, Fr>> make_vars(
+    const ylm::Strahlkorper<Fr>& horizon, const LinkedMessageId<double>& time,
+    const double mass) {
+  const gr::Solutions::KerrSchild solution{mass, std::array{0.0, 0.0, 0.0},
+                                           std::array{0.0, 0.0, 0.0}};
+  const auto coords = ylm::cartesian_coords(horizon);
+  const auto vars = solution.variables(
+      coords, time.id,
+      tmpl::pop_back<ah::vars_to_interpolate_to_target<3, Fr>>{});
+  const size_t size =
+      get<0, 0>(get<gr::Tags::SpatialMetric<DataVector, 3, Fr>>(vars)).size();
+  Variables<ah::vars_to_interpolate_to_target<3, Fr>> result{size, 0.0};
+  result.assign_subset(vars);
+  get<gr::Tags::SpatialRicci<DataVector, 3, Fr>>(result) =
+      TestHelpers::Schwarzschild::spatial_ricci(coords, mass);
+
+  return result;
+}
+
+void check_ylm_data(
+    const std::string& h5_file_name,
+    const ylm::Strahlkorper<Frame::Inertial>& expected_surface) {
+  const std::vector<std::string> ylm_expected_legend{
+      "Time",
+      "InertialExpansionCenter_x",
+      "InertialExpansionCenter_y",
+      "InertialExpansionCenter_z",
+      "Lmax",
+      "coef(0,0)",
+      "coef(1,-1)",
+      "coef(1,0)",
+      "coef(1,1)",
+      "coef(2,-2)",
+      "coef(2,-1)",
+      "coef(2,0)",
+      "coef(2,1)",
+      "coef(2,2)",
+      "coef(3,-3)",
+      "coef(3,-2)",
+      "coef(3,-1)",
+      "coef(3,0)",
+      "coef(3,1)",
+      "coef(3,2)",
+      "coef(3,3)"};
+  const size_t expected_num_columns = ylm_expected_legend.size();
+
+  // Check that the H5 file was written correctly.
+  const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
+  const auto& ylm_dat_file = file.get<h5::Dat>("/HorizonD_Ylm");
+  const Matrix ylm_written_data = ylm_dat_file.get_data();
+  const auto& ylm_written_legend = ylm_dat_file.get_legend();
+
+  CHECK(ylm_written_legend.size() == expected_num_columns);
+  CHECK(ylm_written_data.columns() == expected_num_columns);
+  CHECK(ylm_written_legend == ylm_expected_legend);
+
+  // Center is origin
+  std::vector<double> ylm_expected_data{2.0, 0.0, 0.0, 0.0, low_l_max};
+
+  ylm::SpherepackIterator iter(low_l_max, low_l_max);
+  for (size_t l = 0; l <= low_l_max; l++) {
+    for (int m = -static_cast<int>(l); m <= static_cast<int>(l); m++) {
+      iter.set(l, m);
+      ylm_expected_data.push_back(expected_surface.coefficients()[iter()]);
+    }
+  }
+
+  ASSERT(ylm_expected_data.size() == expected_num_columns,
+         "The size of the constructed test Ylm legend ("
+             << expected_num_columns
+             << ") and the number of columns in the constructed test Ylm data ("
+             << ylm_expected_data.size() << ") do not match.");
+
+  for (size_t i = 0; i < expected_num_columns; i++) {
+    CHECK(ylm_written_data(0, i) == ylm_expected_data[i]);
+  }
+}
+
+void check_surface_volume_data(
+    const std::string& surfaces_file_name,
+    const ylm::Strahlkorper<Frame::Inertial>& strahlkorper,
+    const LinkedMessageId<double>& time, const double mass) {
+  const ylm::Spherepack& ylm = strahlkorper.ylm_spherepack();
+  const std::vector<size_t> extents{
+      {ylm.physical_extents()[0], ylm.physical_extents()[1]}};
+  const std::string grid_name{"HorizonD"};
+
+  const auto coords = ylm::cartesian_coords(strahlkorper);
+  const auto all_vars = make_vars(strahlkorper, time, mass);
+  const std::vector<DataVector> tensor_and_coord_data{
+      get<0>(coords), get<1>(coords), get<2>(coords),
+      DataVector{get<0>(coords).size(), 0.5 / square(mass)}};
+  const std::vector<TensorComponent> tensor_components{
+      {grid_name + "/InertialCoordinates_x", tensor_and_coord_data[0]},
+      {grid_name + "/InertialCoordinates_y", tensor_and_coord_data[1]},
+      {grid_name + "/InertialCoordinates_z", tensor_and_coord_data[2]},
+      {grid_name + "/RicciScalar", tensor_and_coord_data[3]}};
+
+  const std::vector<Spectral::Basis> bases{2,
+                                           Spectral::Basis::SphericalHarmonic};
+  const std::vector<Spectral::Quadrature> quadratures{
+      {Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}};
+  const observers::ObservationId observation_id{2., "/HorizonD.vol"};
+  TestHelpers::io::VolumeData::check_volume_data(
+      surfaces_file_name, 0, grid_name, observation_id.hash(),
+      observation_id.value(), std::nullopt, tensor_and_coord_data, {grid_name},
+      {bases}, {quadratures}, {extents},
+      {"InertialCoordinates_x"s, "InertialCoordinates_y"s,
+       "InertialCoordinates_z"s, "RicciScalar"s},
+      {{0, 1, 2, 3}}, std::optional{1.0e-10});
+}
+
+template <typename Metavariables>
+struct MockObserverWriter {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = size_t;
+  using const_global_cache_tags = tmpl::list<observers::Tags::ReductionFileName,
+                                             observers::Tags::SurfaceFileName>;
+  using simple_tags =
+      typename observers::Actions::InitializeWriter<Metavariables>::simple_tags;
+  using compute_tags = typename observers::Actions::InitializeWriter<
+      Metavariables>::compute_tags;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<observers::Actions::InitializeWriter<Metavariables>>>,
+      Parallel::PhaseActions<Parallel::Phase::Testing, tmpl::list<>>>;
+
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+};
+
+template <typename Metavariables, typename HorizonMetavars>
+struct MockComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked = ah::Component<Metavariables, HorizonMetavars>;
+
+  using frame = typename HorizonMetavars::frame;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<
+          typename ah::Initialize<HorizonMetavars>::simple_tags,
+          typename ah::Initialize<HorizonMetavars>::compute_tags>>>>;
+};
+
+struct MockMetavariables {
+  template <typename Fr>
+  struct HorizonAB : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+    using temporal_id_tag = ::Tags::TimeAndPrevious<0>;
+    using frame = Fr;
+
+    using horizon_find_callbacks =
+        tmpl::list<ah::callbacks::ObserveTimeSeriesOnHorizon<
+            tmpl::list<gr::surfaces::Tags::AreaCompute<frame>>, HorizonAB>>;
+    using horizon_find_failure_callbacks = tmpl::list<>;
+
+    using compute_tags_on_element = tmpl::list<>;
+
+    static constexpr ah::Destination destination =
+        ah::Destination::ControlSystem;
+
+    static std::string name() {
+      return "Horizon"s + (std::is_same_v<Fr, Frame::Inertial> ? "A"s : "B"s);
+    }
+  };
+
+  using HorizonA = HorizonAB<Frame::Inertial>;
+  using HorizonB = HorizonAB<Frame::Grid>;
+
+  struct HorizonC : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+    using temporal_id_tag = ::Tags::TimeAndPrevious<0>;
+    using frame = Frame::Inertial;
+
+    using horizon_find_callbacks =
+        tmpl::list<ah::callbacks::ObserveTimeSeriesOnHorizon<
+            tmpl::list<ylm::Tags::MaxRicciScalarCompute>, HorizonC>>;
+    using horizon_find_failure_callbacks = tmpl::list<>;
+
+    using compute_tags_on_element = tmpl::list<>;
+
+    static constexpr ah::Destination destination =
+        ah::Destination::ControlSystem;
+
+    static std::string name() { return "HorizonC"; }
+  };
+
+  struct HorizonD : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+    using temporal_id_tag = ::Tags::TimeAndPrevious<0>;
+    using frame = Frame::Inertial;
+
+    using horizon_find_callbacks =
+        tmpl::list<ah::callbacks::ObserveFieldsOnHorizon<
+            tmpl::list<ylm::Tags::RicciScalar>, HorizonD>>;
+    using horizon_find_failure_callbacks = tmpl::list<>;
+
+    using compute_tags_on_element = tmpl::list<>;
+
+    static constexpr ah::Destination destination = ah::Destination::Observation;
+
+    static std::string name() { return "HorizonD"; }
+  };
+
+  using observed_reduction_data_tags = tmpl::list<>;
+
+  using component_list = tmpl::list<MockObserverWriter<MockMetavariables>,
+                                    MockComponent<MockMetavariables, HorizonA>,
+                                    MockComponent<MockMetavariables, HorizonB>,
+                                    MockComponent<MockMetavariables, HorizonC>,
+                                    MockComponent<MockMetavariables, HorizonD>>;
+};
+
+void run_test() {
+  // Check if either file generated by this test exists and remove them
+  // if so. Check for both files existing before the test runs, since
+  // both files get written when evaluating the list of post interpolation
+  // callbacks below.
+  const std::string h5_file_prefix = "Test_ObserveFieldsAndTimeSeriesOnHorizon";
+  const auto h5_file_name = h5_file_prefix + ".h5";
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+  const std::string surfaces_file_prefix = "Surfaces";
+  const auto surfaces_file_name = surfaces_file_prefix + ".h5";
+  if (file_system::check_if_file_exists(surfaces_file_name)) {
+    file_system::rm(surfaces_file_name, true);
+  }
+
+  // Test That ObserveTimeSeriesOnSurface indeed does conform to its protocol
+  using metavars = MockMetavariables;
+  (void)metavars::HorizonA::destination;
+  (void)metavars::HorizonB::destination;
+  (void)metavars::HorizonC::destination;
+  (void)metavars::HorizonD::destination;
+  using horizon_a_callback =
+      tmpl::front<typename metavars::HorizonA::horizon_find_callbacks>;
+  using horizon_b_callback =
+      tmpl::front<typename metavars::HorizonB::horizon_find_callbacks>;
+  using horizon_c_callback =
+      tmpl::front<typename metavars::HorizonC::horizon_find_callbacks>;
+  using horizon_d_callback =
+      tmpl::front<typename metavars::HorizonD::horizon_find_callbacks>;
+  using protocol = ah::protocols::Callback;
+  static_assert(tt::assert_conforms_to_v<horizon_a_callback, protocol>);
+  static_assert(tt::assert_conforms_to_v<horizon_b_callback, protocol>);
+  static_assert(tt::assert_conforms_to_v<horizon_c_callback, protocol>);
+  static_assert(tt::assert_conforms_to_v<horizon_d_callback, protocol>);
+
+  using horizon_a_component = MockComponent<metavars, metavars::HorizonA>;
+  using horizon_b_component = MockComponent<metavars, metavars::HorizonB>;
+  using horizon_c_component = MockComponent<metavars, metavars::HorizonC>;
+  using horizon_d_component = MockComponent<metavars, metavars::HorizonD>;
+  using obs_writer = MockObserverWriter<metavars>;
+
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {h5_file_prefix, surfaces_file_prefix}};
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+
+  const LinkedMessageId<double> time{2.0, {1.0}};
+  const double mass = 0.5;
+  const double radius = 2.0 * mass;
+  const std::array center{0.0, 0.0, 0.0};
+
+  const auto initialize_component =
+      [&]<typename Component>(Component /*component_v*/, const size_t l_max) {
+        using Fr = typename Component::frame;
+
+        const ylm::Strahlkorper<Fr> horizon{l_max, radius, center};
+
+        ActionTesting::emplace_array_component<Component>(
+            make_not_null(&runner), ActionTesting::NodeId{0},
+            ActionTesting::LocalCoreId{0}, 0);
+
+        auto& box =
+            ActionTesting::get_databox<Component>(make_not_null(&runner), 0);
+
+        db::mutate<ylm::Tags::Strahlkorper<Fr>, ah::Tags::CurrentTime,
+                   ::Tags::Variables<ah::vars_to_interpolate_to_target<3, Fr>>>(
+            [&](const gsl::not_null<ylm::Strahlkorper<Fr>*> strahlkorper,
+                const gsl::not_null<std::optional<LinkedMessageId<double>>*>
+                    current_time,
+                const gsl::not_null<
+                    ::Variables<ah::vars_to_interpolate_to_target<3, Fr>>*>
+                    vars) {
+              (*strahlkorper) = horizon;
+              (*current_time) = time;
+              (*vars) = make_vars(horizon, time, mass);
+            },
+            make_not_null(&box));
+      };
+
+  const ylm::Strahlkorper<Frame::Inertial> low_l_horizon{low_l_max, radius,
+                                                         center};
+  const ylm::Strahlkorper<Frame::Inertial> high_l_horizon{high_l_max, radius,
+                                                          center};
+
+  initialize_component(horizon_a_component{}, low_l_max);
+  initialize_component(horizon_b_component{}, low_l_max);
+  initialize_component(horizon_c_component{}, high_l_max);
+  initialize_component(horizon_d_component{}, low_l_max);
+
+  ActionTesting::emplace_nodegroup_component<obs_writer>(&runner);
+  for (size_t i = 0; i < 2; ++i) {
+    ActionTesting::next_action<obs_writer>(make_not_null(&runner), 0);
+  }
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  const FastFlow::Status status = FastFlow::Status::AbsTol;
+  auto& cache = ActionTesting::cache<obs_writer>(runner, 0_st);
+
+  const auto& horizon_a_box =
+      ActionTesting::get_databox<horizon_a_component>(runner, 0);
+  const auto& horizon_b_box =
+      ActionTesting::get_databox<horizon_b_component>(runner, 0);
+  const auto& horizon_c_box =
+      ActionTesting::get_databox<horizon_c_component>(runner, 0);
+  const auto& horizon_d_box =
+      ActionTesting::get_databox<horizon_d_component>(runner, 0);
+
+  // Call callbacks
+  horizon_a_callback::apply(horizon_a_box, cache, status);
+  horizon_b_callback::apply(horizon_b_box, cache, status);
+  horizon_c_callback::apply(horizon_c_box, cache, status);
+  horizon_d_callback::apply(horizon_d_box, cache, status);
+
+  // One for each ObserveTimeSeries and two for the ObserveFields
+  REQUIRE(ActionTesting::number_of_queued_threaded_actions<obs_writer>(runner,
+                                                                       0) == 5);
+
+  for (size_t i = 0; i < 5; i++) {
+    ActionTesting::invoke_queued_threaded_action<obs_writer>(
+        make_not_null(&runner), 0);
+  }
+
+  const std::vector<double> expected_integral_ab{4.0 * M_PI};
+  const std::vector<double> expected_integral_c{2.0 / square(radius)};
+  const std::vector<std::string> expected_legend_ab{"Time", "Area"};
+  const std::vector<std::string> expected_legend_c{"Time", "MaxRicciScalar"};
+
+  // Check that the H5 file was written correctly.
+  const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
+  auto check_file_contents =
+      [&file](const std::vector<double>& expected_integral,
+              const std::vector<std::string>& expected_legend,
+              const std::string& group_name) {
+        CAPTURE(group_name);
+        CAPTURE(expected_legend);
+        file.close_current_object();
+        const auto& dat_file = file.get<h5::Dat>(group_name);
+        const Matrix written_data = dat_file.get_data();
+        const auto& written_legend = dat_file.get_legend();
+        CHECK(written_legend == expected_legend);
+        CHECK(2.0 == written_data(0, 0));
+        // The interpolation is not perfect because we use too few grid points.
+        const Approx custom_approx = Approx::custom().epsilon(1.e-4).scale(1.0);
+        for (size_t i = 0; i < expected_integral.size(); ++i) {
+          CAPTURE(i);
+          CHECK(expected_integral[i] == custom_approx(written_data(0, i + 1)));
+        }
+      };
+  check_file_contents(expected_integral_ab, expected_legend_ab, "/HorizonA");
+  check_file_contents(expected_integral_ab, expected_legend_ab, "/HorizonB");
+  check_file_contents(expected_integral_c, expected_legend_c, "/HorizonC");
+
+  // Check that the Ylm data were written correctly
+  // As this data depends only on the known target (a KerrHorizon) it
+  // uses no interpolated data
+  check_ylm_data(h5_file_name, low_l_horizon);
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  // Check that the Surfaces file contains the correct surface data
+  check_surface_volume_data(surfaces_file_name, low_l_horizon, time, mass);
+
+  if (file_system::check_if_file_exists(surfaces_file_name)) {
+    file_system::rm(surfaces_file_name, true);
+  }
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.ApparentHorizonFinder.ObserveFieldsAndTimeSeriesOnHorizon",
+    "[ApparentHorizonFinder][Unit]") {
+  run_test();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Thirteenth PR in horizon finder changes. Same logic as existing AH callbacks, but uses the new AH tags and storage. These two callbacks are added in the same commit because there's only one test that checks both of them.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
