### PR TITLE
AH rewrite: Add AH action that actually finds the horizon

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   CleanUp.cpp
   ComputeCoords.cpp
   ComputeVarsToInterpolateToTarget.cpp
+  CurrentTime.cpp
   Destination.cpp
   FastFlow.cpp
   InterpolateVolumeVars.cpp
@@ -32,8 +33,10 @@ spectre_target_headers(
   ComputeHorizonVolumeQuantities.hpp
   ComputeHorizonVolumeQuantities.tpp
   ComputeVarsToInterpolateToTarget.hpp
+  CurrentTime.hpp
   Destination.hpp
   FastFlow.hpp
+  FindApparentHorizon.hpp
   HorizonAliases.hpp
   Initialization.hpp
   InterpolateVolumeVars.hpp

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.cpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp"
+
+#include <optional>
+#include <set>
+#include <sstream>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ah {
+template <typename Fr>
+void set_current_time(
+    const gsl::not_null<std::optional<LinkedMessageId<double>>*> current_time,
+    const gsl::not_null<std::set<LinkedMessageId<double>>*> pending_times,
+    const std::set<LinkedMessageId<double>>& completed_times,
+    const std::unordered_map<LinkedMessageId<double>,
+                             ah::Storage::SingleTimeStorage<Fr>>& all_storage,
+    const ::Verbosity& verbosity, const std::string& name) {
+  std::stringstream ss{};
+  const bool verbose_print = verbosity >= ::Verbosity::Verbose;
+  const bool debug_print = verbosity >= ::Verbosity::Debug;
+  if (debug_print) {
+    ss << name << ": ";
+  }
+
+  // If there's already a horizon find in progress, end here
+  if (current_time->has_value() or pending_times->empty()) {
+    if (debug_print) {
+      if (current_time->has_value()) {
+        ss << "Interpolation already in progress at time "
+           << current_time->value();
+      } else {
+        ss << "No pending times.";
+      }
+      Parallel::printf("%s\n", ss.str());
+    }
+
+    return;
+  }
+
+  // To determine if we are going to use the next pending time, we need to check
+  // if we have any completed times so we can check if this is the very first
+  // time or not. If this horizon find is used for observation, we don't have a
+  // previous time, so we just use the next pending time regardless. Though this
+  // is technically prone to async issues where times arrive out of order, we
+  // shouldn't be observing so often that this should matter.
+  const auto& next_pending_time = *pending_times->begin();
+  const Destination destination = all_storage.at(next_pending_time).destination;
+  const bool use_next_pending_time =
+      (destination == Destination::Observation) or
+      (UNLIKELY(completed_times.empty())
+           ? not next_pending_time.previous.has_value()
+           : next_pending_time.previous.value() ==
+                 std::prev(completed_times.end())->id);
+
+  // If we are using the next pending time:
+  // 1. Set the current time to this next pending time
+  // 2. Remove this time from pending
+  if (use_next_pending_time) {
+    (*current_time) = next_pending_time;
+    pending_times->erase(pending_times->begin());
+
+    if (verbose_print) {
+      ss << "Setting current time to " << *current_time;
+    }
+  } else if (verbose_print) {
+    ss << "Not setting current time.";
+  }
+
+  if (verbose_print) {
+    Parallel::printf("%s\n", ss.str());
+  }
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template void set_current_time(                                            \
+      const gsl::not_null<std::optional<LinkedMessageId<double>>*>           \
+          current_time,                                                      \
+      const gsl::not_null<std::set<LinkedMessageId<double>>*> pending_times, \
+      const std::set<LinkedMessageId<double>>& completed_times,              \
+      const std::unordered_map<LinkedMessageId<double>,                      \
+                               ah::Storage::SingleTimeStorage<FRAME(data)>>& \
+          all_storage,                                                       \
+      const ::Verbosity& verbosity, const std::string& name);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Frame::Inertial, Frame::Distorted, Frame::Grid))
+
+#undef INSTANTIATE
+#undef FRAME
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/Callback.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace ah {
+template <class Metavariables, typename HorizonMetavars>
+struct Component;
+template <typename HorizonMetavars>
+struct FindApparentHorizon;
+}  // namespace ah
+/// \endcond
+
+namespace ah {
+/*!
+ * \brief Determines what the current time should be.
+ *
+ * \details If there's already a current time, or there are no pending times
+ * available, then there's nothing to do. Otherwise, checks if the first pending
+ * time is the next to use. If so, sets it as the current time and removes it
+ * from pending.
+ */
+template <typename Fr>
+void set_current_time(
+    gsl::not_null<std::optional<LinkedMessageId<double>>*> current_time,
+    gsl::not_null<std::set<LinkedMessageId<double>>*> pending_times,
+    const std::set<LinkedMessageId<double>>& completed_times,
+    const std::unordered_map<LinkedMessageId<double>,
+                             ah::Storage::SingleTimeStorage<Fr>>& all_storage,
+    const ::Verbosity& verbosity, const std::string& name);
+
+/*!
+ * \brief Checks if the current time is ready.
+ *
+ * \details If the current time is after any expiration time, registers a
+ * callback for the `ah::FindApparentHorizon` action (but doesn't send the
+ * volume variables again because we already did that). Returns if the current
+ * time is ready or not.
+ */
+template <typename HorizonMetavars, typename Metavariables>
+bool check_if_current_time_is_ready(
+    const LinkedMessageId<double>& current_time,
+    Parallel::GlobalCache<Metavariables>& cache,
+    const LinkedMessageId<double>& incoming_time,
+    const ElementId<3>& incoming_element_id, const ::Mesh<3>& incoming_mesh,
+    const std::optional<std::string>& dependency) {
+  const auto& domain = get<domain::Tags::Domain<3>>(cache);
+
+  // Now we need to check the functions of time for the current time
+  if constexpr (Parallel::is_in_global_cache<Metavariables,
+                                             domain::Tags::FunctionsOfTime>) {
+    if (domain.is_time_dependent()) {
+      auto& this_proxy = Parallel::get_parallel_component<
+          Component<Metavariables, HorizonMetavars>>(cache);
+      double min_expiration_time = std::numeric_limits<double>::max();
+      const Parallel::ArrayComponentId array_component_id =
+          Parallel::make_array_component_id<
+              Component<Metavariables, HorizonMetavars>>(0);
+      // If the functions of time aren't ready, this will set a callback to
+      // FindApparentHorizon that will be called by the GlobalCache when
+      // domain::Tags::FunctionsOfTime is updated.
+      return ::Parallel::mutable_cache_item_is_ready<
+          domain::Tags::FunctionsOfTime>(
+          cache, array_component_id,
+          [&](const std::unordered_map<
+              std::string,
+              std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+                  functions_of_time) -> std::unique_ptr<Parallel::Callback> {
+            min_expiration_time =
+                std::min_element(functions_of_time.begin(),
+                                 functions_of_time.end(),
+                                 [](const auto& a, const auto& b) {
+                                   return a.second->time_bounds()[1] <
+                                          b.second->time_bounds()[1];
+                                 })
+                    ->second->time_bounds()[1];
+
+            // Success: the current time is ok.
+            // Failure: the current time is not ok.
+            return current_time.id <= min_expiration_time
+                       ? std::unique_ptr<Parallel::Callback>{}
+                       : std::unique_ptr<Parallel::Callback>(
+                             new Parallel::SimpleActionCallback<
+                                 FindApparentHorizon<HorizonMetavars>,
+                                 decltype(this_proxy), LinkedMessageId<double>,
+                                 ElementId<3>, Mesh<3>,
+                                 Variables<ah::source_vars<3>>,
+                                 std::optional<std::string>, bool>(
+                                 this_proxy, incoming_time, incoming_element_id,
+                                 incoming_mesh, Variables<ah::source_vars<3>>{},
+                                 dependency, true));
+          });
+    }  // if (domain.is_time_dependent())
+  } else {
+    if (domain.is_time_dependent()) {
+      // We error here because the maps are time-dependent, yet
+      // the cache does not contain FunctionsOfTime.  It would be
+      // nice to make this a compile-time error; however, we want
+      // the code to compile for the completely time-independent
+      // case where there are no FunctionsOfTime in the cache at
+      // all.  Unfortunately, checking whether the maps are
+      // time-dependent is currently not constexpr.
+      ERROR(
+          "There is a time-dependent CoordinateMap in at least one "
+          "of the Blocks, but FunctionsOfTime are not in the "
+          "GlobalCache.  If you intend to use a time-dependent "
+          "CoordinateMap, please add FunctionsOfTime to the GlobalCache.");
+    }
+  }
+
+  // The current time is ready
+  return true;
+}
+}  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -1,0 +1,351 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Actions/FunctionsOfTimeAreReady.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/InvokeCallbacks.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/CleanUp.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ah {
+/*!
+ * \brief Simple action run on the horizon finder by the Elements which receives
+ * volume data, finds the apparent horizon, and calls the callbacks after the
+ * horizon is found.
+ *
+ * \details First, the volume source variables `ah::source_vars` are put into
+ * the `ah::Tags::Storage`. Then, we try to set the `ah::Tags::CurrentTime` with
+ * the `ah::set_current_time` function. Once we have a current time, we ensure
+ * the functions of time are up-to-date at this current time with
+ * `ah::check_if_current_time_is_ready`.
+ *
+ * Once we ensure the functions of time are ready, we compute the cartesian
+ * coordinates for the current fast-flow iteration surface with
+ * `ah::set_current_iteration_coords`. Once we have the coords, we interpolate
+ * the volume date onto these coordinates. After that, we do one iteration of
+ * the `FastFlow` algorithm to get a new surface. If we haven't converged yet,
+ * we compute new cartesian and start another iteration. Once we have converged,
+ * we call the callbacks with `ah::invoke_callbacks` and then clean up the
+ * horizon finer with `ah::clean_up_horizon_finder`. Then we try to set a new
+ * current time and the process starts over again. If `FastFlow` never
+ * converges, we call the `horizon_find_failure_callbacks` from the
+ * \p HorizonMetavars.
+ */
+template <typename HorizonMetavars>
+struct FindApparentHorizon {
+  using frame = typename HorizonMetavars::frame;
+
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const LinkedMessageId<double>& incoming_time,
+                    const ElementId<3>& incoming_element_id,
+                    const ::Mesh<3>& incoming_mesh,
+                    Variables<ah::source_vars<3>>&& incoming_source_vars,
+                    const std::optional<std::string>& dependency,
+                    const bool source_vars_have_already_been_received = false) {
+    const auto& verbosity = db::get<ah::Tags::Verbosity>(box);
+    const bool quiet_print = verbosity >= ::Verbosity::Quiet;
+    const bool verbose_print = verbosity >= ::Verbosity::Verbose;
+    const bool debug_print = verbosity >= ::Verbosity::Debug;
+    const std::string& name = pretty_type::name<HorizonMetavars>();
+
+    // If we've already completed this horizon find, ignore the volume data and
+    // just return
+    auto& completed_times = db::get_mutable_reference<ah::Tags::CompletedTimes>(
+        make_not_null(&box));
+    if (completed_times.contains(incoming_time)) {
+      if (debug_print) {
+        Parallel::printf(
+            "%s: Received volume data at finished time %s from Element %s. "
+            "Ignoring.\n",
+            name, incoming_time, incoming_element_id);
+      }
+      return;
+    }
+
+    auto& current_time_optional =
+        db::get_mutable_reference<ah::Tags::CurrentTime>(make_not_null(&box));
+    auto& pending_times =
+        db::get_mutable_reference<ah::Tags::PendingTimes>(make_not_null(&box));
+
+    // Only add to pending if it isn't the current time.
+    if (not(current_time_optional.has_value() and
+            current_time_optional.value() == incoming_time)) {
+      pending_times.insert(incoming_time);
+    }
+
+    auto& all_storage = db::get_mutable_reference<ah::Tags::Storage<frame>>(
+        make_not_null(&box));
+
+    // Add volume variables and destination to the box if they haven't already
+    // been received
+    if (not source_vars_have_already_been_received) {
+      all_storage[incoming_time].all_volume_variables.emplace(
+          incoming_element_id,
+          ah::Storage::VolumeVariables<frame>{incoming_mesh,
+                                              std::move(incoming_source_vars)});
+      all_storage.at(incoming_time).destination = HorizonMetavars::destination;
+    }
+
+    // ========================================================================
+    // The incoming source vars are moved and used in the above code. Below, we
+    // only use quantities at the current time, except for forwarding the
+    // incoming quantities to a callback for checking if the functions of time
+    // are ready.
+    // ========================================================================
+
+    // Keep trying to find horizons for as long as we can
+    while (true) {
+      // Set current time using the pending times if it isn't already set
+      set_current_time(make_not_null(&current_time_optional),
+                       make_not_null(&pending_times), completed_times,
+                       all_storage, verbosity, name);
+
+      // At this point, if we don't have a current id we can't do anything so
+      // just exit.
+      if (not current_time_optional.has_value()) {
+        if (verbose_print) {
+          Parallel::printf(
+              "%s: No current time set. Stopping here. Incoming time: %s\n",
+              name, incoming_time);
+        }
+        return;
+      }
+
+      const LinkedMessageId<double>& current_time =
+          current_time_optional.value();
+      ASSERT(all_storage.contains(current_time),
+             "Current time doesn't have any data.");
+
+      auto& current_time_storage = all_storage.at(current_time);
+
+      // Only check if the current time is ready once
+      if (UNLIKELY(not current_time_storage.time_is_ready)) {
+        if (check_if_current_time_is_ready<HorizonMetavars>(
+                current_time, cache, incoming_time, incoming_element_id,
+                incoming_mesh, dependency)) {
+          // Set this so we don't check it again
+          current_time_storage.time_is_ready = true;
+
+          if (verbose_print) {
+            Parallel::printf("%s: Current time %s is ready.\n", name,
+                             current_time);
+          }
+        } else {
+          if (verbose_print) {
+            Parallel::printf("%s: Current time %s is NOT ready.\n", name,
+                             current_time);
+          }
+          // We need to wait for the functions of time to be updated so we can't
+          // do anything yet.
+          return;
+        }
+      }
+
+      const auto& domain = Parallel::get<domain::Tags::Domain<3>>(cache);
+      const auto& functions_of_time =
+          Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+      const auto& options =
+          Parallel::get<ah::Tags::ApparentHorizonOptions<HorizonMetavars>>(
+              cache);
+      auto& fast_flow =
+          db::get_mutable_reference<ah::Tags::FastFlow>(make_not_null(&box));
+
+      auto& all_volume_variables = current_time_storage.all_volume_variables;
+      auto& previous_surfaces =
+          db::get_mutable_reference<ah::Tags::PreviousSurfaces<frame>>(
+              make_not_null(&box));
+
+      // Keep doing fast flow iterations for as long as we can until we find a
+      // horizon
+      while (true) {
+        auto& current_iteration_storage =
+            current_time_storage.current_iteration;
+        auto& previous_iteration_surface =
+            current_time_storage.previous_iteration_surface;
+
+        // Points haven't been set for this iteration so need to do so now
+        if (not current_iteration_storage.block_coord_holders.has_value()) {
+          const bool coords_set_successfully = set_current_iteration_coords(
+              make_not_null(&current_iteration_storage), current_time,
+              fast_flow, options.initial_guess, previous_iteration_surface,
+              previous_surfaces, options.max_compute_coords_retries, domain,
+              functions_of_time);
+
+          // Some points are outside the domain and we cannot recover
+          if (not coords_set_successfully) {
+            // This will possibly throw an error
+            tmpl::for_each<
+                typename HorizonMetavars::horizon_find_failure_callbacks>(
+                [&](auto callback_v) {
+                  using callback = tmpl::type_from<decltype(callback_v)>;
+                  callback::apply(box, cache,
+                                  FastFlow::Status::InterpolationFailure);
+                });
+
+            // Still clean up in case we didn't error so we don't keep accepting
+            // volume data for this time
+            clean_up_horizon_finder(make_not_null(&current_time_optional),
+                                    make_not_null(&all_storage),
+                                    make_not_null(&completed_times),
+                                    make_not_null(&fast_flow));
+
+            // If we didn't error, move on to the next horizon find
+            break;
+          }
+
+          if (debug_print) {
+            Parallel::printf(
+                "%s: For current time %s, at iteration %zu, coords have been "
+                "set.\n",
+                name, current_time, fast_flow.current_iteration());
+          }
+        }
+
+        // Interpolate new elements to points
+        interpolate_volume_data(make_not_null(&current_iteration_storage),
+                                make_not_null(&all_volume_variables),
+                                current_time, domain, functions_of_time);
+
+        // Sanity check
+        ASSERT(
+            current_iteration_storage.indicies_interpolated_to_thus_far
+                    .size() <=
+                current_iteration_storage.block_coord_holders.value().size(),
+            "The number indices interpolated to is larger than the number of "
+            "coordinates. This is an internal error. Please file an issue.");
+
+        if (current_iteration_storage.indicies_interpolated_to_thus_far
+                .size() !=
+            current_iteration_storage.block_coord_holders.value().size()) {
+          if (debug_print) {
+            Parallel::printf(
+                "%s: For current time %s, at iteration %zu, need more volume "
+                "data. Missing %zu points.\n",
+                name, current_time, fast_flow.current_iteration(),
+                current_iteration_storage.block_coord_holders.value().size() -
+                    current_iteration_storage.indicies_interpolated_to_thus_far
+                        .size());
+          }
+          return;
+        }
+
+        // Set this before we iterate the fast flow. Note that this will have to
+        // be updated once we have adaptive horizon finding
+        previous_iteration_surface = current_iteration_storage.strahlkorper;
+
+        // Do a single fast flow iteration.
+        std::pair<FastFlow::Status, FastFlow::IterInfo> status_and_info;
+        {
+          using InverseSpatialMetric =
+              gr::Tags::InverseSpatialMetric<DataVector, 3, frame>;
+          using ExtrinsicCurvature =
+              gr::Tags::ExtrinsicCurvature<DataVector, 3, frame>;
+          using SpatialChristoffel =
+              gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, frame>;
+
+          auto& interpolated_vars = current_iteration_storage.interpolated_vars;
+          status_and_info = fast_flow.iterate_horizon_finder(
+              make_not_null(&current_iteration_storage.strahlkorper),
+              get<InverseSpatialMetric>(interpolated_vars),
+              get<ExtrinsicCurvature>(interpolated_vars),
+              get<SpatialChristoffel>(interpolated_vars));
+        }
+
+        const auto& status = status_and_info.first;
+        const auto& info = status_and_info.second;
+        const auto has_converged = converged(status);
+
+        if (verbose_print or (quiet_print and has_converged)) {
+          Parallel::printf(
+              "%s: t=%.6g: its=%zu: %.1e<R<%.0e, |R|=%.1g, "
+              "|R_grid|=%.1g, %.4g<r<%.4g\n",
+              pretty_type::name<HorizonMetavars>(), current_time.id,
+              info.iteration, info.min_residual, info.max_residual,
+              info.residual_ylm, info.residual_mesh, info.r_min, info.r_max);
+        }
+
+        if (status == FastFlow::Status::SuccessfulIteration) {
+          // Reset so we compute and interpolate to new points
+          current_iteration_storage.reset_for_next_iteration();
+
+          // Continue in the iteration while loop
+          continue;
+        } else if (not has_converged) {
+          // This will possibly throw an error
+          tmpl::for_each<
+              typename HorizonMetavars::horizon_find_failure_callbacks>(
+              [&](auto callback_v) {
+                using callback = tmpl::type_from<decltype(callback_v)>;
+                callback::apply(box, cache, status);
+              });
+
+          // Still clean up in case we didn't error so we don't keep accepting
+          // volume data for this time
+          clean_up_horizon_finder(make_not_null(&current_time_optional),
+                                  make_not_null(&all_storage),
+                                  make_not_null(&completed_times),
+                                  make_not_null(&fast_flow));
+
+          // If we didn't error, move on to the next horizon find
+          break;
+        }
+
+        // We have converged to the apparent horizon. Invoke the callbacks and
+        // clean up for the next horizon find
+        invoke_callbacks<HorizonMetavars>(make_not_null(&box), cache,
+                                          dependency, status);
+
+        if (debug_print) {
+          Parallel::printf(
+              "%s: Horizon find finished at current time %s. Cleaning up and "
+              "moving to next time\n",
+              name, current_time);
+        }
+
+        clean_up_horizon_finder(
+            make_not_null(&current_time_optional), make_not_null(&all_storage),
+            make_not_null(&completed_times), make_not_null(&fast_flow));
+
+        // Break out of the iteration while loop. Go back into the overall while
+        // loop for time
+        break;
+      }  // while (true)
+    }    // while (true)
+  }
+};
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -10,8 +10,10 @@ set(LIBRARY_SOURCES
   Test_ComputeExcisionBoundaryVolumeQuantities.cpp
   Test_ComputeHorizonVolumeQuantities.cpp
   Test_ComputeVarsToInterpolateToTarget.cpp
+  Test_CurrentTime.cpp
   Test_Destination.cpp
   Test_FastFlow.cpp
+  Test_FindApparentHorizon.cpp
   Test_Initialization.cpp
   Test_InterpolateVolumeVars.cpp
   Test_InterpolationTargetApparentHorizon.cpp

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
@@ -1,0 +1,311 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <optional>
+#include <set>
+#include <unordered_map>
+
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/RotationAboutZAxis.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/MockRuntimeSystemFreeFunctions.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+
+namespace ah {
+namespace {
+void test_set_current_time() {
+  std::optional<LinkedMessageId<double>> current_time =
+      LinkedMessageId<double>{1.0, std::nullopt};
+  std::set<LinkedMessageId<double>> pending_times{};
+  std::set<LinkedMessageId<double>> completed_times{};
+  std::unordered_map<LinkedMessageId<double>,
+                     ah::Storage::SingleTimeStorage<Frame::Grid>>
+      all_storage{};
+  const std::unordered_map<ElementId<3>, Storage::VolumeVariables<Frame::Grid>>
+      unused_volume_vars{};
+  const Storage::Iteration<Frame::Grid> unused_interation{};
+  const ylm::Strahlkorper<Frame::Grid> unused_prev_strahlkorper{};
+  const ::Verbosity verbosity = ::Verbosity::Silent;
+  const std::string name{"HorizonMetavars"};
+
+  const auto add_to_all_storage = [&](const LinkedMessageId<double>& time,
+                                      const Destination destination) {
+    all_storage.emplace(time, ah::Storage::SingleTimeStorage<Frame::Grid>{
+                                  unused_volume_vars, unused_interation,
+                                  unused_prev_strahlkorper, destination});
+  };
+
+  // Current time has value, so do nothing
+  {
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK(current_time ==
+          std::optional{LinkedMessageId<double>{1.0, std::nullopt}});
+    CHECK(pending_times.empty());
+  }
+
+  // Current time doesn't have a value, but pending times is empty, so do
+  // nothing
+  {
+    current_time.reset();
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK_FALSE(current_time.has_value());
+    CHECK(pending_times.empty());
+  }
+
+  // No completed ids, the pending id isn't the first, and this is a control
+  // system, so do nothing
+  {
+    const LinkedMessageId<double> pending_time{2.0, {1.0}};
+    pending_times.insert(pending_time);
+    add_to_all_storage(pending_time, Destination::ControlSystem);
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK_FALSE(current_time.has_value());
+    CHECK(pending_times.contains(pending_time));
+  }
+
+  // No completed ids, the pending id isn't the first, and this is a
+  // observation, so make it the current time
+  {
+    all_storage.clear();
+    const LinkedMessageId<double> pending_time{2.0, {1.0}};
+    pending_times.insert(pending_time);
+    add_to_all_storage(pending_time, Destination::Observation);
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK(current_time == std::optional{pending_time});
+    CHECK(pending_times.empty());
+  }
+
+  // No completed ids and the pending id is the first, so make it the current
+  // time
+  {
+    all_storage.clear();
+    current_time.reset();
+    const LinkedMessageId<double> pending_time{1.0, std::nullopt};
+    pending_times.insert(pending_time);
+    add_to_all_storage(pending_time, Destination::ControlSystem);
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK(current_time == std::optional{pending_time});
+    CHECK(pending_times.empty());
+  }
+
+  // One completed id, this is a control system, but the pending id isn't next
+  // so do nothing
+  {
+    all_storage.clear();
+    current_time.reset();
+    pending_times.clear();
+    completed_times.insert(LinkedMessageId<double>{1.0, std::nullopt});
+    const LinkedMessageId<double> pending_time{3.0, {2.0}};
+    pending_times.insert(pending_time);
+    add_to_all_storage(pending_time, Destination::ControlSystem);
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK_FALSE(current_time.has_value());
+    CHECK(pending_times.contains(pending_time));
+  }
+
+  // One completed id and this is an observation, so use the next pending id
+  {
+    all_storage.clear();
+    current_time.reset();
+    pending_times.clear();
+    completed_times.insert(LinkedMessageId<double>{1.0, std::nullopt});
+    const LinkedMessageId<double> pending_time{3.0, {2.0}};
+    pending_times.insert(pending_time);
+    add_to_all_storage(pending_time, Destination::Observation);
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK(current_time == std::optional{pending_time});
+    CHECK(pending_times.empty());
+  }
+
+  // One completed id, and the pending id is next so make it the current time
+  {
+    all_storage.clear();
+    current_time.reset();
+    pending_times.clear();
+    completed_times.insert(LinkedMessageId<double>{1.0, std::nullopt});
+    const LinkedMessageId<double> pending_time{2.0, {1.0}};
+    pending_times.insert(pending_time);
+    add_to_all_storage(pending_time, Destination::ControlSystem);
+    set_current_time(make_not_null(&current_time),
+                     make_not_null(&pending_times), completed_times,
+                     all_storage, verbosity, name);
+    CHECK(current_time == std::optional{pending_time});
+    CHECK_FALSE(pending_times.contains(pending_time));
+  }
+}
+
+struct UpdateFoT {
+  static void apply(
+      const gsl::not_null<std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+          f_of_t_list,
+      const std::string& f_of_t_name, const double update_time,
+      DataVector update_deriv, const double new_expiration_time) {
+    (*f_of_t_list)
+        .at(f_of_t_name)
+        ->update(update_time, std::move(update_deriv), new_expiration_time);
+  }
+};
+
+struct MockHorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using time_tag = ::Tags::TimeAndPrevious<0>;
+
+  using frame = ::Frame::Grid;
+
+  // Don't need callbacks
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr Destination destination = Destination::ControlSystem;
+
+  static std::string name() { return "MockHorizonMetavars"; }
+};
+
+size_t call_count = 0;  // NOLINT
+struct MockFindApparentHorizon {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const LinkedMessageId<double>& /*incoming_time*/,
+                    const ElementId<3>& /*incoming_element_id*/,
+                    const ::Mesh<3>& /*incoming_mesh*/,
+                    Variables<ah::source_vars<3>>&& /*incoming_source_vars*/,
+                    const std::optional<std::string>& /*dependency*/,
+                    const bool source_vars_have_already_been_received = false) {
+    ++call_count;
+    CHECK(source_vars_have_already_been_received);
+  }
+};
+
+template <typename Metavariables>
+struct MockComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      ah::Component<Metavariables, MockHorizonMetavars>;
+  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<ah::FindApparentHorizon<MockHorizonMetavars>>;
+  using with_these_simple_actions = tmpl::list<MockFindApparentHorizon>;
+};
+
+struct MockMetavariables {
+  using component_list = tmpl::list<MockComponent<MockMetavariables>>;
+};
+
+void test_check_current_time() {
+  (void)MockHorizonMetavars::destination;
+
+  const auto domain_creator = domain::creators::Sphere(
+      1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st, false,
+      std::nullopt, std::vector<double>{},
+      domain::CoordinateMaps::Distribution::Linear, ShellWedges::All,
+      {std::make_unique<
+          domain::creators::time_dependence::RotationAboutZAxis<3>>(0.0, 0.0,
+                                                                    0.1, 0.0)});
+
+  using component = MockComponent<MockMetavariables>;
+
+  ActionTesting::MockRuntimeSystem<MockMetavariables> runner{
+      {domain_creator.create_domain()},
+      {domain_creator.functions_of_time({{"Rotation", 2.0}})}};
+
+  ActionTesting::emplace_array_component<component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, 0);
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  auto& cache = ActionTesting::cache<component>(runner, 0_st);
+
+  const LinkedMessageId<double> incoming_time{100.0, {99.0}};
+  const ElementId<3> incoming_element_id{1};
+  const Mesh<3> incoming_mesh{2, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto};
+  const std::optional<std::string> dependency{"FakeDependency"};
+  LinkedMessageId<double> current_time{0.0, {std::nullopt}};
+
+  // Current time is ready so no callback is registered
+  CHECK(check_if_current_time_is_ready<MockHorizonMetavars>(
+      current_time, cache, incoming_time, incoming_element_id, incoming_mesh,
+      dependency));
+
+  // Current time isn't ready so a callback should be registered
+  current_time = LinkedMessageId<double>{2.5, {1.5}};
+  CHECK_FALSE(check_if_current_time_is_ready<MockHorizonMetavars>(
+      current_time, cache, incoming_time, incoming_element_id, incoming_mesh,
+      dependency));
+
+  // Mutate the function of time which will call (queue) the simple action
+  Parallel::mutate<domain::Tags::FunctionsOfTime, UpdateFoT>(
+      cache, "Rotation"s, 2.0, DataVector{0.0}, 3.0);
+  REQUIRE(ActionTesting::number_of_queued_simple_actions<component>(runner,
+                                                                    0) == 1);
+  ActionTesting::invoke_queued_simple_action<component>(make_not_null(&runner),
+                                                        0);
+  CHECK(call_count == 1);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.CurrentTime",
+                  "[ApparentHorizonFinder][Unit]") {
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  test_set_current_time();
+  test_check_current_time();
+}
+}  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
@@ -1,0 +1,440 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Actions/InitializeItems.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+size_t callback_failure_count = 0;                                  // NOLINT
+FastFlow::Status callback_failure_mode = FastFlow::Status::AbsTol;  // NOLINT
+template <typename HorizonMetavars, size_t Index>
+struct TestHorizonFindFailureCallback
+    : tt::ConformsTo<ah::protocols::Callback> {
+ private:
+  using Fr = typename HorizonMetavars::frame;
+
+ public:
+  template <typename DbTags, typename Metavariables>
+  static void apply(db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& cache,
+                    const FastFlow::Status failure_reason) {
+    // Ignore error so we just increment the counter
+    ah::callbacks::FailedHorizonFind<HorizonMetavars, true>::apply(
+        box, cache, failure_reason);
+    ++callback_failure_count;
+    callback_failure_mode = failure_reason;
+  }
+};
+
+size_t callback_count = 0;  // NOLINT
+template <typename HorizonMetavars, size_t Index>
+struct TestHorizonFindCallback : tt::ConformsTo<ah::protocols::Callback> {
+ private:
+  using Fr = typename HorizonMetavars::frame;
+
+ public:
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const FastFlow::Status /*status*/) {
+    ++callback_count;
+
+    const auto& strahlkorper = get<ylm::Tags::Strahlkorper<Fr>>(box);
+    // Test that InverseSpatialMetric can be retrieved from the
+    // DataBox and that its number of grid points is the same
+    // as that of the strahlkorper.
+    const auto& inv_metric =
+        get<gr::Tags::InverseSpatialMetric<DataVector, 3, Fr>>(box);
+    CHECK(strahlkorper.ylm_spherepack().physical_size() ==
+          get<0, 0>(inv_metric).size());
+  }
+};
+
+template <typename Fr, ah::Destination Dest>
+struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using time_tag = ::Tags::TimeAndPrevious<0>;
+  using frame = Fr;
+
+  using horizon_find_callbacks =
+      tmpl::list<TestHorizonFindCallback<HorizonMetavars, 0>,
+                 TestHorizonFindCallback<HorizonMetavars, 1>>;
+  using horizon_find_failure_callbacks =
+      tmpl::list<TestHorizonFindFailureCallback<HorizonMetavars, 0>,
+                 TestHorizonFindFailureCallback<HorizonMetavars, 1>>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = Dest;
+
+  static std::string name() { return "TestingHorizonMetavars"; }
+};
+
+template <typename Metavariables, typename HorizonMetavars>
+struct MockComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked = ah::Component<Metavariables, HorizonMetavars>;
+
+  using frame = typename HorizonMetavars::frame;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<Initialization::Actions::InitializeItems<
+          ah::Initialize<HorizonMetavars>>>>>;
+};
+
+template <typename Fr, ah::Destination Dest>
+struct MockMetavariables {
+  using component_list =
+      tmpl::list<MockComponent<MockMetavariables, HorizonMetavars<Fr, Dest>>>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<3>,
+                 ah::Tags::ApparentHorizonOptions<HorizonMetavars<Fr, Dest>>>;
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+};
+
+template <typename Callbacks>
+struct check_callbacks;
+
+template <typename... Callbacks>
+struct check_callbacks<tmpl::list<Callbacks...>>
+    : std::integral_constant<bool,
+                             tmpl2::flat_all_v<tt::assert_conforms_to_v<
+                                 Callbacks, ah::protocols::Callback>...>> {};
+
+template <typename Callbacks>
+constexpr bool check_callbacks_v = check_callbacks<Callbacks>::value;
+
+template <typename Fr, ah::Destination Dest = ah::Destination::ControlSystem,
+          bool MakeHorizonFinderFailOnPurpose = false>
+void test_apparent_horizon(
+    const size_t l_max, const size_t grid_points_each_dimension,
+    const double mass, const std::array<double, 3>& dimensionless_spin,
+    const bool is_time_dependent,
+    const std::optional<std::string>& dependency = std::nullopt,
+    const size_t max_its = 100_st) {
+  using metavars = MockMetavariables<Fr, Dest>;
+  using horizon_metavars = HorizonMetavars<Fr, Dest>;
+  using component = MockComponent<metavars, horizon_metavars>;
+
+  // Assert the protocols
+  static_assert(tt::assert_conforms_to_v<horizon_metavars,
+                                         ah::protocols::HorizonMetavars>);
+  static_assert(
+      check_callbacks_v<typename horizon_metavars::horizon_find_callbacks>);
+  static_assert(check_callbacks_v<
+                typename horizon_metavars::horizon_find_failure_callbacks>);
+
+  // The initial guess for the horizon search is a sphere of radius 2.8M unless
+  // we are in the Distorted frame, then we pick 2.2 so it's within the blocks
+  // that actually have a distorted frame
+  ah::HorizonOptions<Fr> apparent_horizon_opts(
+      ylm::Strahlkorper<Fr>{l_max,
+                            std::is_same_v<Fr, ::Frame::Distorted> ? 2.2 : 2.8,
+                            {{0.0, 0.0, 0.0}}},
+      FastFlow{FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5,
+               max_its},
+      Verbosity::Silent, 3_st, std::nullopt);
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      blocks_for_interpolation{};
+
+  // The test finds an apparent horizon for a Schwarzschild or Kerr metric with
+  // M=1.  We choose a spherical shell domain extending from radius 1.9M to
+  // 2.9M; this ensures the horizon is inside the domain, and it gives a narrow
+  // domain so that we don't need a large number of grid points to resolve the
+  // horizon (which would make the test slower).
+  std::unique_ptr<DomainCreator<3>> domain_creator = std::make_unique<
+      domain::creators::Sphere>(
+      1.9, 2.9, domain::creators::Sphere::Excision{nullptr}, 1_st,
+      grid_points_each_dimension, true, std::nullopt, std::vector<double>{2.4},
+      domain::CoordinateMaps::Distribution::Linear, ShellWedges::All,
+      is_time_dependent
+          ? std::optional{domain::creators::sphere::TimeDependentMapOptions{
+                0.0,
+                domain::creators::time_dependent_options::ShapeMapOptions<
+                    false, ::domain::ObjectLabel::None>{
+                    l_max,
+                    domain::creators::time_dependent_options::
+                        KerrSchildFromBoyerLindquist{mass, dimensionless_spin}},
+                std::nullopt, std::nullopt,
+                domain::creators::time_dependent_options::TranslationMapOptions<
+                    3>{std::array{std::array{0.0, 0.0, 0.0},
+                                  std::array{0.0, 0.01, 0.0},
+                                  std::array{0.0, 0.0, 0.0}}},
+                true}}
+          : std::nullopt);
+
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {domain_creator->create_domain(), apparent_horizon_opts,
+       blocks_for_interpolation},
+      {domain_creator->functions_of_time()}};
+
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+  ActionTesting::emplace_array_component<component>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0_st);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Register);
+
+  // Find horizon at three times.  The horizon find at the second time will use
+  // the result from the first time as an initial guess.  The horizon find at
+  // the third time will use an initial guess that was linearly extrapolated
+  // from the first two horizon finds. For the time-independent case, the volume
+  // data will not change between horizon finds, so the second and third horizon
+  // finds will take zero iterations.  Having three times tests some logic in
+  // the interpolator.
+  const std::vector<LinkedMessageId<double>> times{
+      {12.0 / 15.0, std::nullopt},
+      {13.0 / 15.0, {12.0 / 15.0}},
+      {14.0 / 15.0, {13.0 / 15.0}}};
+
+  // Create element_ids.
+  std::vector<ElementId<3>> element_ids{};
+  const Domain<3> domain = domain_creator->create_domain();
+  const domain::FunctionsOfTimeMap functions_of_time =
+      domain_creator->functions_of_time();
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs =
+        domain_creator->initial_refinement_levels()[block.id()];
+    auto elem_ids = initial_element_ids(block.id(), initial_ref_levs);
+    element_ids.insert(element_ids.end(), elem_ids.begin(), elem_ids.end());
+  }
+
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  // Center of the analytic solution.
+  const auto analytic_solution_center = []() -> std::array<double, 3> {
+    if constexpr (MakeHorizonFinderFailOnPurpose) {
+      // Make the analytic solution off-center on purpose, so that the domain
+      // only partially contains the horizon and therefore the interpolation
+      // fails.
+      return {0.5, 0.0, 0.0};
+    }
+    return {0.0, 0.0, 0.0};
+  }();
+
+  // Create volume data and send it to the interpolator, for each time.
+  for (const auto& time : times) {
+    for (const auto& element_id : element_ids) {
+      const auto& block = domain.blocks()[element_id.block_id()];
+      const ::Mesh<3> mesh{
+          domain_creator->initial_extents()[element_id.block_id()],
+          Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+
+      tnsr::I<DataVector, 3, ::Frame::Inertial> inertial_mesh_coords{};
+      InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+          inv_jacobian_logical_to_inertial{mesh.number_of_grid_points(), 0.0};
+      const auto logical_coords = logical_coordinates(mesh);
+      if (domain.is_time_dependent()) {
+        const ElementMap<3, Frame::Grid> map_logical_to_grid{
+            element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
+
+        inertial_mesh_coords = block.moving_mesh_grid_to_inertial_map()(
+            map_logical_to_grid(logical_coords), time.id, functions_of_time);
+
+        const auto inv_jacobian_logical_to_grid =
+            map_logical_to_grid.inv_jacobian(logical_coords);
+        const auto inv_jacobian_grid_to_inertial =
+            block.moving_mesh_grid_to_inertial_map().inv_jacobian(
+                map_logical_to_grid(logical_coords), time.id,
+                functions_of_time);
+
+        inv_jacobian_logical_to_inertial = tenex::evaluate<ti::I, ti::j>(
+            inv_jacobian_logical_to_grid(ti::I, ti::k) *
+            inv_jacobian_grid_to_inertial(ti::K, ti::j));
+      } else {
+        // Accounts for Grid vs Inertial
+        const ElementMap<3, ::Frame::Inertial> map{
+            element_id, block.stationary_map().get_clone()};
+        inertial_mesh_coords = map(logical_coords);
+
+        inv_jacobian_logical_to_inertial = map.inv_jacobian(logical_coords);
+      }
+
+      // Compute g, pi, phi for KerrSchild.
+      // Horizon is always at 0,0,0 in analytic_solution_coordinates.
+      const gr::Solutions::KerrSchild solution(mass, dimensionless_spin,
+                                               analytic_solution_center);
+      const auto solution_vars = solution.variables(
+          inertial_mesh_coords, 0.0,
+          typename gr::Solutions::KerrSchild::tags<DataVector,
+                                                   ::Frame::Inertial>{});
+
+      // Fill output variables with solution.
+      Variables<ah::source_vars<3>> output_vars(mesh.number_of_grid_points());
+
+      const auto& lapse = get<gr::Tags::Lapse<DataVector>>(solution_vars);
+      const auto& dt_lapse =
+          get<Tags::dt<gr::Tags::Lapse<DataVector>>>(solution_vars);
+      const auto& d_lapse = get<typename gr::Solutions::KerrSchild ::DerivLapse<
+          DataVector, ::Frame::Inertial>>(solution_vars);
+      const auto& shift = get<gr::Tags::Shift<DataVector, 3>>(solution_vars);
+      const auto& d_shift = get<typename gr::Solutions::KerrSchild ::DerivShift<
+          DataVector, ::Frame::Inertial>>(solution_vars);
+      const auto& dt_shift =
+          get<Tags::dt<gr::Tags::Shift<DataVector, 3>>>(solution_vars);
+      const auto& g =
+          get<gr::Tags::SpatialMetric<DataVector, 3>>(solution_vars);
+      const auto& dt_g =
+          get<Tags::dt<gr::Tags::SpatialMetric<DataVector, 3>>>(solution_vars);
+      const auto& d_g =
+          get<typename gr::Solutions::KerrSchild ::DerivSpatialMetric<
+              DataVector, ::Frame::Inertial>>(solution_vars);
+
+      get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(output_vars) =
+          gr::spacetime_metric(lapse, shift, g);
+      get<::gh::Tags::Phi<DataVector, 3>>(output_vars) =
+          gh::phi(lapse, d_lapse, shift, d_shift, g, d_g);
+      get<::gh::Tags::Pi<DataVector, 3>>(output_vars) =
+          gh::pi(lapse, dt_lapse, shift, dt_shift, g, dt_g,
+                 get<::gh::Tags::Phi<DataVector, 3>>(output_vars));
+
+      // Need to compute numerical deriv of Phi.
+      get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                      Frame::Inertial>>(output_vars) =
+          partial_derivative(get<::gh::Tags::Phi<DataVector, 3>>(output_vars),
+                             mesh, inv_jacobian_logical_to_inertial);
+
+      // Queue the action so we can invoke in a random order below
+      ActionTesting::queue_simple_action<
+          component, ah::FindApparentHorizon<horizon_metavars>>(
+          make_not_null(&runner), 0, time, element_id, mesh, output_vars,
+          dependency);
+    }
+  }
+
+  // Invoke remaining actions in random order.
+  MAKE_GENERATOR(generator);
+  auto array_indices_with_queued_simple_actions =
+      ActionTesting::array_indices_with_queued_simple_actions<
+          typename metavars::component_list>(make_not_null(&runner));
+  while (ActionTesting::number_of_elements_with_queued_simple_actions<
+             typename metavars::component_list>(
+             array_indices_with_queued_simple_actions) > 0) {
+    ActionTesting::invoke_random_queued_simple_action<
+        typename metavars::component_list>(
+        make_not_null(&runner), make_not_null(&generator),
+        array_indices_with_queued_simple_actions);
+    array_indices_with_queued_simple_actions =
+        ActionTesting::array_indices_with_queued_simple_actions<
+            typename metavars::component_list>(make_not_null(&runner));
+  }
+}
+
+// [[TimeOut, 60]]
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizon",
+                  "[ApparentHorizonFinder][Unit]") {
+  domain::creators::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  const std::optional<std::string> dependency{"FakeDependency"};
+
+  // Time-independent tests.
+  callback_failure_count = 0;
+  callback_count = 0;
+  test_apparent_horizon<Frame::Inertial>(3, 3, 1.0, {{0.0, 0.0, 0.0}}, false,
+                                         dependency);
+  test_apparent_horizon<Frame::Grid>(3, 4, 1.1, {{0.2, 0.1, -0.4}}, false);
+  test_apparent_horizon<Frame::Inertial, ah::Destination::Observation>(
+      3, 4, 1.1, {{0.2, 0.1, -0.4}}, false);
+  CHECK(callback_count == 18);
+  CHECK(callback_failure_count == 0);
+  callback_count = 0;
+
+  // Time-dependent tests.
+  test_apparent_horizon<Frame::Inertial>(3, 5, 1.1, {{0.2, 0.1, -0.4}}, true);
+  test_apparent_horizon<Frame::Distorted>(3, 4, 1.1, {{0.2, 0.1, -0.4}}, true,
+                                          dependency);
+  test_apparent_horizon<Frame::Distorted, ah::Destination::Observation>(
+      3, 4, 1.1, {{0.2, 0.1, -0.4}}, true);
+  test_apparent_horizon<Frame::Grid>(3, 3, 1.0, {{0.0, 0.0, 0.0}}, true);
+  CHECK(callback_count == 24);
+  CHECK(callback_failure_count == 0);
+  callback_count = 0;
+
+  // Failure tests
+  test_apparent_horizon<Frame::Inertial, ah::Destination::ControlSystem, true>(
+      3, 3, 1.0, {{0.0, 0.0, 0.0}}, true);
+  CHECK(callback_count == 0);
+  CHECK(callback_failure_count == 6);
+  CHECK(callback_failure_mode == FastFlow::Status::InterpolationFailure);
+  callback_failure_count = 0;
+
+  test_apparent_horizon<Frame::Grid, ah::Destination::ControlSystem, true>(
+      3, 3, 10.0, {{0.0, 0.0, 0.0}}, false);
+  CHECK(callback_count == 0);
+  CHECK(callback_failure_count == 6);
+  CHECK(callback_failure_mode == FastFlow::Status::InterpolationFailure);
+  callback_failure_count = 0;
+
+  test_apparent_horizon<Frame::Inertial, ah::Destination::ControlSystem, true>(
+      3, 3, 1.0, {{0.0, 0.0, 0.0}}, true, dependency, 1);
+  CHECK(callback_count == 0);
+  CHECK(callback_failure_count == 6);
+  CHECK(callback_failure_mode == FastFlow::Status::MaxIts);
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Fourteenth PR in horizon finder changes. Finally adds the actual simple action `FindApparentHorizon` that will find the apparent horizon. Additionally adds a function that computes what the current time should be and a function to check if the FunctionsOfTime are up-to-date at this current time.

This second function registers a callback to the `FindApparentHorizon` action and thus has to be added in the same commit. However, initially I split these into two commits for easier reviewing and I'll squash them together at the end.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
