### PR TITLE
Add support for clang+cuda

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -460,7 +460,7 @@ jobs:
           - compiler: clang-13
             build_type: Release
             BUILD_SHARED_LIBS: OFF
-            use_xsimd: OFF
+            USE_XSIMD: OFF
             MEMORY_ALLOCATOR: JEMALLOC
           # Add a test without PCH to the build matrix, which only builds core
           # libraries. Building all the tests without the PCH takes very long
@@ -499,6 +499,31 @@ jobs:
             # Test `install` target with clang in Release mode because it uses
             # little disk space
             install: ON
+          # Test compiling with clang and CUDA
+          - compiler: clang-18
+            CUDA: ON
+            KOKKOS: ON
+            # Compile for NVIDIA Ampere architecture. Can't run this on
+            # GitHub-hosted runners because they don't have the GPU hardware,
+            # but we can test the compilation.
+            KOKKOS_ARCH: "AMPERE80"
+            # Compile in Release mode to speed up the build
+            build_type: Release
+            # Disable PCH as clang+cuda seems to have a problem with that
+            USE_PCH: OFF
+            # Disable ccache as it isn't forwarded to the clang+cuda correctly
+            USE_CCACHE: OFF
+            # Build with static libs because Kokkos CUDA doesn't support shared
+            # libs
+            BUILD_SHARED_LIBS: OFF
+            # Build only a subset of the code because compiling the full code is
+            # too slow and exceeds the available memory. We should extend this
+            # to the full code once we have a better solution for the memory
+            # issue. See 'Test nvcc support' step below.
+            # unit_tests: OFF
+            test_executables: OFF
+            # Disable warnings as lots are emitted at the moment
+            ENABLE_WARNINGS: OFF
           # Test compiling with nvcc and CUDA
           - compiler: nvcc-12-6
             CUDA: ON
@@ -578,26 +603,45 @@ jobs:
           if [[ $COMPILER_ID = gcc ]]; then
             apt-get install -y $CC $CXX $FC
           elif [[ $COMPILER_ID = clang ]]; then
-            apt-get install -y $CC $FC
-          elif [[ $COMPILER_ID = nvcc ]]; then
-            # Install CUDA
-            wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-            dpkg -i cuda-keyring_1.1-1_all.deb
-            apt-get update -y
-            apt-get install -y cuda-nvcc-${COMPILER_VERSION} \
-              build-essential libc6-dev pkg-config
-            echo "/usr/local/cuda-${COMPILER_VERSION/-/.}/bin" >> $GITHUB_PATH
+            if [ "$COMPILER_VERSION" -le 16 ]; then
+              apt-get install -y $CC $FC
+            else
+              wget https://apt.llvm.org/llvm.sh
+              chmod +x llvm.sh
+              ./llvm.sh $COMPILER_VERSION
+              # Also install OMP development headers and clang-tools because
+              # they aren't included by default in the above llvm installation
+              # script but needed for Kokkos
+              apt-get install -y libomp-$COMPILER_VERSION-dev \
+                clang-tools-$COMPILER_VERSION
+            fi
           fi
+      - name: Install CUDA
+        if: matrix.CUDA == 'ON'
+        run: |
+          CUDA_VERSION=12.6
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+          dpkg -i cuda-keyring_1.1-1_all.deb
+          apt-get update -y
+          # Install minimal CUDA toolkit:
+          # - nvcc compiler
+          # - cuRAND because clang-18 includes a header from it
+          # - No cuBLAS for now because we don't currently use it and it takes
+          #   up ~270 MB of disk space
+          apt-get install -y cuda-nvcc-${CUDA_VERSION/\./-} \
+            libcurand-dev-${CUDA_VERSION/\./-}
+          echo "/usr/local/cuda-${CUDA_VERSION}/bin" >> $GITHUB_PATH
       - name: Install Kokkos
         if: matrix.KOKKOS == 'ON'
         working-directory: /work
         run: |
-          KOKKOS_VERSION=4.4.00
+          KOKKOS_VERSION=4.7.00
           wget -O kokkos.tar.gz "https://github.com/kokkos/kokkos/releases/download/${KOKKOS_VERSION}/kokkos-${KOKKOS_VERSION}.tar.gz"
           tar -xzf kokkos.tar.gz && mv kokkos-* kokkos && cd kokkos
           mkdir build && cd build
           cmake .. \
             -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -D CMAKE_CXX_STANDARD=20 \
             -D CMAKE_INSTALL_PREFIX=/usr/local \
             -D Kokkos_ENABLE_SERIAL=ON \
             -D Kokkos_ENABLE_OPENMP=ON \
@@ -715,8 +759,9 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
           UBSAN_UNDEFINED=${{ matrix.UBSAN_UNDEFINED }}
           UBSAN_INTEGER=${{ matrix.UBSAN_INTEGER }}
-          USE_PCH=${{ matrix.use_pch }}
-          USE_XSIMD=${{ matrix.use_xsimd }}
+          USE_PCH=${{ matrix.USE_PCH }}
+          USE_XSIMD=${{ matrix.USE_XSIMD }}
+          USE_CCACHE=${{ matrix.USE_CCACHE }}
           COVERAGE=${{ matrix.COVERAGE }}
           TEST_TIMEOUT_FACTOR=${{ matrix.TEST_TIMEOUT_FACTOR }}
           INPUT_FILE_MIN_PRIO=${{ matrix.input_file_tests_min_priority }}
@@ -743,7 +788,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D STUB_LIBRARY_OBJECT_FILES=ON
           -D USE_PCH=${USE_PCH:-'ON'}
           -D USE_XSIMD=${USE_XSIMD:-'ON'}
-          -D USE_CCACHE=ON
+          -D USE_CCACHE=${USE_CCACHE:-'ON'}
           -D ENABLE_OPENMP=ON
           -D SPECTRE_KOKKOS=${KOKKOS:-'OFF'}
           -D COVERAGE=${COVERAGE:-'OFF'}
@@ -933,9 +978,10 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           PYTHON_VERSION=${{ matrix.PYTHON_VERSION }}
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           MATRIX_CHARM_ROOT=${{ matrix.CHARM_ROOT }}
-          MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }};
-          USE_PCH=${{ matrix.use_pch }};
-          USE_XSIMD=${{ matrix.use_xsimd }}
+          MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }}
+          USE_PCH=${{ matrix.USE_PCH }}
+          USE_XSIMD=${{ matrix.USE_XSIMD }}
+          USE_CCACHE=${{ matrix.USE_CCACHE }}
 
           cmake
           -D CMAKE_C_COMPILER=${CC}
@@ -955,7 +1001,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D STUB_LIBRARY_OBJECT_FILES=ON
           -D USE_PCH=${USE_PCH:-'ON'}
           -D USE_XSIMD=${USE_XSIMD:-'ON'}
-          -D USE_CCACHE=ON
+          -D USE_CCACHE=${USE_CCACHE:-'ON'}
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
           -D MEMORY_ALLOCATOR=${MEMORY_ALLOCATOR:-'SYSTEM'}
           -D BUILD_DOCS=OFF

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -85,6 +85,16 @@ target_link_libraries(
   SpectreCudaWarnings
   )
 
+# Have Clang warn about unsupported CUDA versions but don't error
+create_cxx_flags_target(
+  "-Wno-error=unknown-cuda-version"
+  SpectreCudaClangWarnings)
+target_link_libraries(
+  SpectreWarnings
+  INTERFACE
+  SpectreCudaClangWarnings
+  )
+
 target_link_libraries(
   SpectreFlags
   INTERFACE

--- a/docs/DevGuide/GpuSupport.md
+++ b/docs/DevGuide/GpuSupport.md
@@ -17,6 +17,11 @@ library.
 
 ## Build configuration
 
+You can use either NVIDIA's NVCC compiler (which comes with the CUDA toolkit) or
+Clang (which supports CUDA compilation and also requires the CUDA toolkit to be
+installed) to compile for GPUs. We haven't tested backends other than CUDA very
+much so far.
+
 To enable GPU support, set the CMake option `-D SPECTRE_KOKKOS=ON` when
 configuring the build. Either point CMake to a Kokkos installation with
 `-D Kokkos_ROOT=path/to/kokkos` or set `-D SPECTRE_FETCH_MISSING_DEPS=ON` to
@@ -39,7 +44,7 @@ Here's an example for using an existing Kokkos installation:
 ```sh
 cmake -D SPECTRE_KOKKOS=ON \
       -D Kokkos_ROOT=path/to/kokkos/build \
-      -D CMAKE_CXX_COMPILER=path/to/kokkos/bin/nvcc_wrapper \
+      -D CMAKE_CXX_COMPILER={path/to/kokkos/bin/nvcc_wrapper or clang++} \
       ...
 ```
 
@@ -47,4 +52,4 @@ When building Kokkos separately with the CUDA backend, you have to set the
 following configuration options:
 
 - `Kokkos_ENABLE_CUDA_CONSTEXPR=ON`
-- `Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE`
+- `Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON`

--- a/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
+++ b/src/ControlSystem/ControlErrors/Size/AhSpeed.cpp
@@ -215,5 +215,7 @@ double AhSpeed::control_error(
          (Y00 * control_error_args.avg_distorted_normal_dot_unit_coord_vector);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID AhSpeed::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
@@ -155,5 +155,7 @@ double DeltaR::control_error(const Info& /*info*/,
   return control_error_args.control_error_delta_r;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID DeltaR::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftInward.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftInward.cpp
@@ -157,8 +157,10 @@ double DeltaRDriftInward::control_error(
   return control_error_args.control_error_delta_r + info.target_char_speed;
 }
 
+#ifndef __CUDA_ARCH__
 // cppcoreguidelines-avoid-non-const-global-variables
 PUP::able::PUP_ID DeltaRDriftInward::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 
 double target_speed_for_inward_drift(
     const double avg_distorted_normal_dot_unit_coord_vector,

--- a/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRDriftOutward.cpp
@@ -92,5 +92,7 @@ double DeltaRDriftOutward::control_error(
       std::numeric_limits<double>::signaling_NaN());
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID DeltaRDriftOutward::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/DeltaRNoDrift.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaRNoDrift.cpp
@@ -120,6 +120,8 @@ double DeltaRNoDrift::control_error(
   return control_error_args.control_error_delta_r;
 }
 
+#ifndef __CUDA_ARCH__
 // cppcoreguidelines-avoid-non-const-global-variables
 PUP::able::PUP_ID DeltaRNoDrift::my_PUP_ID = 0; // NOLINT
+#endif                                          // __CUDA_ARCH__
 }  // namespace control_system::size::States

--- a/src/ControlSystem/ControlErrors/Size/Initial.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Initial.cpp
@@ -108,5 +108,7 @@ double Initial::control_error(
          control_error_args.time_deriv_of_lambda_00;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Initial::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace control_system::size::States

--- a/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
+++ b/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
@@ -193,8 +193,10 @@ class BNSEvent : public ::Event {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename ControlSystems>
 PUP::able::PUP_ID BNSEvent<ControlSystems>::my_PUP_ID = 0;  // NOLINT
+#endif                                                      // __CUDA_ARCH__
 /// \endcond
 
 namespace measurements {

--- a/src/ControlSystem/Measurements/NonFactoryCreatable.hpp
+++ b/src/ControlSystem/Measurements/NonFactoryCreatable.hpp
@@ -32,8 +32,10 @@ struct NonFactoryCreatableWrapper : public FactoryCreatableClass {
 
 /// \cond
 // NOLINTBEGIN
+#ifndef __CUDA_ARCH__
 template <typename FactoryCreatableClass>
 PUP::able::PUP_ID NonFactoryCreatableWrapper<FactoryCreatableClass>::my_PUP_ID =
     0;
+#endif  // __CUDA_ARCH__
 // NOLINTEND
 /// \endcond

--- a/src/ControlSystem/Trigger.hpp
+++ b/src/ControlSystem/Trigger.hpp
@@ -194,8 +194,10 @@ class Trigger : public DenseTrigger {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename ControlSystems>
 PUP::able::PUP_ID Trigger<ControlSystems>::my_PUP_ID = 0;  // NOLINT
+#endif                                                     // __CUDA_ARCH__
 /// \endcond
 
 // This metafunction is tested in Test_EventTriggerMetafunctions.cpp

--- a/src/Domain/BoundaryConditions/None.hpp
+++ b/src/Domain/BoundaryConditions/None.hpp
@@ -87,9 +87,11 @@ void None<SystemBoundaryConditionBaseClass>::pup(PUP::er& p) {
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename SystemBoundaryConditionBaseClass>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID None<SystemBoundaryConditionBaseClass>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 /// Check if a boundary condition inherits from `MarkAsNone`, which

--- a/src/Domain/BoundaryConditions/Periodic.hpp
+++ b/src/Domain/BoundaryConditions/Periodic.hpp
@@ -89,9 +89,11 @@ void Periodic<SystemBoundaryConditionBaseClass>::pup(PUP::er& p) {
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename SystemBoundaryConditionBaseClass>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Periodic<SystemBoundaryConditionBaseClass>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 /// Check if a boundary condition inherits from `MarkAsPeriodic`, which

--- a/src/Domain/CoordinateMaps/Composition.hpp
+++ b/src/Domain/CoordinateMaps/Composition.hpp
@@ -226,9 +226,11 @@ Composition(std::unique_ptr<FirstMap>, std::unique_ptr<Maps>... maps)
                    FirstMap::dim>;
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Frames, size_t Dim, size_t... Is>
 PUP::able::PUP_ID
     Composition<Frames, Dim, std::index_sequence<Is...>>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -534,9 +534,11 @@ CoordinateMap<SourceFrame, TargetFrame, NewMap, Maps...> push_front(
     CoordinateMap<SourceFrame, TargetFrame, Maps...> old_map, NewMap new_map);
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 PUP::able::PUP_ID
     CoordinateMap<SourceFrame, TargetFrame, Maps...>::my_PUP_ID =  // NOLINT
     0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace domain

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/SphereTransition.cpp
@@ -311,6 +311,8 @@ void SphereTransition::pup(PUP::er& p) {
 SphereTransition::SphereTransition(CkMigrateMessage* const msg)
     : ShapeMapTransitionFunction(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SphereTransition::my_PUP_ID = 0;  // NOLINT
+#endif                                              // __CUDA_ARCH__
 
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Wedge.cpp
@@ -828,6 +828,8 @@ void Wedge::pup(PUP::er& p) {
 
 Wedge::Wedge(CkMigrateMessage* const msg) : ShapeMapTransitionFunction(msg) {}
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID Wedge::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace domain::CoordinateMaps::ShapeMapTransitionFunctions

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -246,7 +246,7 @@ class Rectilinear : public DomainCreator<Dim> {
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
-  std::vector<std::string> block_names() const override { return block_names_; }
+  std::vector<std::string> block_names() const override { return {name()}; }
 
   std::unordered_map<std::string, std::unordered_set<std::string>>
   block_groups() const override {
@@ -283,7 +283,6 @@ class Rectilinear : public DomainCreator<Dim> {
                  2>,
       Dim>
       boundary_conditions_{};
-  inline static const std::vector<std::string> block_names_{name()};
 };
 
 template <size_t Dim>

--- a/src/Domain/Creators/TimeDependence/RotationAboutZAxis.hpp
+++ b/src/Domain/Creators/TimeDependence/RotationAboutZAxis.hpp
@@ -160,7 +160,7 @@ class RotationAboutZAxis final : public TimeDependence<MeshDim> {
       std::numeric_limits<double>::signaling_NaN()};
   double initial_angular_acceleration_{
       std::numeric_limits<double>::signaling_NaN()};
-  inline static const std::string function_of_time_name_{"Rotation"};
+  static constexpr const char* function_of_time_name_{"Rotation"};
 };
 
 template <size_t Dim>

--- a/src/Domain/Creators/TimeDependence/Shape.cpp
+++ b/src/Domain/Creators/TimeDependence/Shape.cpp
@@ -144,8 +144,8 @@ Shape<Label>::functions_of_time(const std::unordered_map<std::string, double>&
 
   // If we have control systems, overwrite the expiration time with the one
   // supplied by the control system
-  if (initial_expiration_times.count(function_of_time_name_) == 1) {
-    expiration_time = initial_expiration_times.at(function_of_time_name_);
+  if (initial_expiration_times.count(function_of_time_name()) == 1) {
+    expiration_time = initial_expiration_times.at(function_of_time_name());
   }
 
   const ylm::Spherepack ylm{l_max_, l_max_};
@@ -157,7 +157,7 @@ Shape<Label>::functions_of_time(const std::unordered_map<std::string, double>&
   const auto radial_distortion_coefs = ylm.phys_to_spec(radial_distortion);
   const DataVector zeros =
       make_with_value<DataVector>(radial_distortion_coefs, 0.0);
-  result[function_of_time_name_] =
+  result[function_of_time_name()] =
       std::make_unique<FunctionsOfTime::PiecewisePolynomial<3>>(
           initial_time_,
           std::array<DataVector, 4>{
@@ -191,14 +191,14 @@ template <domain::ObjectLabel Label>
 auto Shape<Label>::grid_to_inertial_map() const -> GridToInertialMap {
   return GridToInertialMap{ShapeMap{center_, l_max_, l_max_,
                                     transition_func_->get_clone(),
-                                    function_of_time_name_}};
+                                    function_of_time_name()}};
 }
 
 template <domain::ObjectLabel Label>
 auto Shape<Label>::grid_to_distorted_map() const -> GridToDistortedMap {
   return GridToDistortedMap{ShapeMap{center_, l_max_, l_max_,
                                      transition_func_->get_clone(),
-                                     function_of_time_name_}};
+                                     function_of_time_name()}};
 }
 
 template <domain::ObjectLabel Label>

--- a/src/Domain/Creators/TimeDependence/Shape.hpp
+++ b/src/Domain/Creators/TimeDependence/Shape.hpp
@@ -209,8 +209,9 @@ class Shape final : public TimeDependence<3> {
       make_array<3>(std::numeric_limits<double>::signaling_NaN())};
   std::array<double, 3> center_{
       make_array<3>(std::numeric_limits<double>::signaling_NaN())};
-  inline static const std::string function_of_time_name_{"Shape" +
-                                                         get_output(Label)};
+  static std::string function_of_time_name() {
+    return "Shape" + get_output(Label);
+  }
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   std::unique_ptr<TransitionFunction> transition_func_;

--- a/src/Domain/Creators/TimeDependence/SphericalCompression.hpp
+++ b/src/Domain/Creators/TimeDependence/SphericalCompression.hpp
@@ -179,7 +179,7 @@ class SphericalCompression final : public TimeDependence<3> {
   double initial_value_{std::numeric_limits<double>::signaling_NaN()};
   double initial_velocity_{std::numeric_limits<double>::signaling_NaN()};
   double initial_acceleration_{std::numeric_limits<double>::signaling_NaN()};
-  inline static const std::string function_of_time_name_{"Size"};
+  static constexpr const char* function_of_time_name_{"Size"};
 };
 
 bool operator!=(const SphericalCompression& lhs,

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.cpp
@@ -139,12 +139,12 @@ UniformTranslation<MeshDim, Index>::functions_of_time(
   // If we have control systems, overwrite the expiration time with the one
   // supplied by the control system
   if (initial_expiration_times.count(
-          function_of_time_name_grid_to_distorted_) == 1) {
+          function_of_time_name_grid_to_distorted()) == 1) {
     expiration_time_grid_to_distorted =
-        initial_expiration_times.at(function_of_time_name_grid_to_distorted_);
+        initial_expiration_times.at(function_of_time_name_grid_to_distorted());
   }
 
-  result[function_of_time_name_grid_to_distorted_] =
+  result[function_of_time_name_grid_to_distorted()] =
       std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
           initial_time_,
           std::array<DataVector, 3>{
@@ -160,12 +160,12 @@ UniformTranslation<MeshDim, Index>::functions_of_time(
     double expiration_time_distorted_to_inertial =
         std::numeric_limits<double>::infinity();
     if (initial_expiration_times.count(
-            function_of_time_name_distorted_to_inertial_) == 1) {
+            function_of_time_name_distorted_to_inertial()) == 1) {
       expiration_time_distorted_to_inertial = initial_expiration_times.at(
-          function_of_time_name_distorted_to_inertial_);
+          function_of_time_name_distorted_to_inertial());
     }
 
-    result[function_of_time_name_distorted_to_inertial_] =
+    result[function_of_time_name_distorted_to_inertial()] =
         std::make_unique<FunctionsOfTime::PiecewisePolynomial<2>>(
             initial_time_,
             std::array<DataVector, 3>{{{MeshDim, 0.0},
@@ -181,7 +181,7 @@ auto UniformTranslation<MeshDim, Index>::grid_to_inertial_map_simple() const
     -> GridToInertialMapSimple {
   return GridToInertialMapSimple{
       domain::CoordinateMaps::TimeDependent::Translation<MeshDim>{
-          function_of_time_name_grid_to_distorted_}};
+          function_of_time_name_grid_to_distorted()}};
 }
 
 template <size_t MeshDim, size_t Index>
@@ -189,7 +189,7 @@ auto UniformTranslation<MeshDim, Index>::grid_to_distorted_map() const
     -> GridToDistortedMap {
   return GridToDistortedMap{
       domain::CoordinateMaps::TimeDependent::Translation<MeshDim>{
-          function_of_time_name_grid_to_distorted_}};
+          function_of_time_name_grid_to_distorted()}};
 }
 
 template <size_t MeshDim, size_t Index>
@@ -197,7 +197,7 @@ auto UniformTranslation<MeshDim, Index>::distorted_to_inertial_map() const
     -> DistortedToInertialMap {
   return DistortedToInertialMap{
       domain::CoordinateMaps::TimeDependent::Translation<MeshDim>{
-          function_of_time_name_distorted_to_inertial_}};
+          function_of_time_name_distorted_to_inertial()}};
 }
 
 template <size_t MeshDim, size_t Index>
@@ -205,9 +205,9 @@ auto UniformTranslation<MeshDim, Index>::grid_to_inertial_map_combined() const
     -> GridToInertialMapCombined {
   return GridToInertialMapCombined{
       domain::CoordinateMaps::TimeDependent::Translation<MeshDim>{
-          function_of_time_name_grid_to_distorted_},
+          function_of_time_name_grid_to_distorted()},
       domain::CoordinateMaps::TimeDependent::Translation<MeshDim>{
-          function_of_time_name_distorted_to_inertial_}};
+          function_of_time_name_distorted_to_inertial()}};
 }
 
 template <size_t Dim, size_t Index>

--- a/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
+++ b/src/Domain/Creators/TimeDependence/UniformTranslation.hpp
@@ -180,10 +180,14 @@ class UniformTranslation final : public TimeDependence<MeshDim> {
   std::array<double, MeshDim> velocity_grid_to_distorted_{};
   std::array<double, MeshDim> velocity_distorted_to_inertial_{};
   bool distorted_and_inertial_frames_are_equal_{true};
-  inline static const std::string function_of_time_name_grid_to_distorted_{
-      "Translation" + (Index == 0 ? "" : get_output(Index))};
-  inline static const std::string function_of_time_name_distorted_to_inertial_{
-      "TranslationDistortedToInertial" + (Index == 0 ? "" : get_output(Index))};
+
+  static std::string function_of_time_name_grid_to_distorted() {
+    return "Translation" + (Index == 0 ? "" : get_output(Index));
+  }
+  static std::string function_of_time_name_distorted_to_inertial() {
+    return "TranslationDistortedToInertial" +
+           (Index == 0 ? "" : get_output(Index));
+  }
 };
 
 template <size_t Dim, size_t Index>

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp
@@ -354,16 +354,15 @@ struct TimeDependentMapOptions {
 
   // Names are public because they need to be used when constructing maps in the
   // BCO domain creators themselves
-  inline static const std::string expansion_name{"Expansion"};
-  inline static const std::string expansion_outer_boundary_name{
+  static constexpr const char* expansion_name{"Expansion"};
+  static constexpr const char* expansion_outer_boundary_name{
       "ExpansionOuterBoundary"};
-  inline static const std::string rotation_name{"Rotation"};
-  inline static const std::string translation_name{"Translation"};
-  inline static const std::string skew_name{"Skew"};
-  inline static const std::array<std::string, 2> size_names{{"SizeA", "SizeB"}};
-  inline static const std::array<std::string, 2> shape_names{
-      {"ShapeA", "ShapeB"}};
-  inline static const std::string grid_centers_name{"GridCenters"};
+  static constexpr const char* rotation_name{"Rotation"};
+  static constexpr const char* translation_name{"Translation"};
+  static constexpr const char* skew_name{"Skew"};
+  static constexpr std::array<const char*, 2> size_names{{"SizeA", "SizeB"}};
+  static constexpr std::array<const char*, 2> shape_names{{"ShapeA", "ShapeB"}};
+  static constexpr const char* grid_centers_name{"GridCenters"};
 
  private:
   static size_t get_index(domain::ObjectLabel object);

--- a/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
@@ -194,13 +194,13 @@ struct TimeDependentMapOptions {
    */
   bool using_distorted_frame() const;
 
-  inline static const std::string size_name{"Size"};
-  inline static const std::string shape_name{"Shape"};
-  inline static const std::string rotation_name{"Rotation"};
-  inline static const std::string expansion_name{"Expansion"};
-  inline static const std::string expansion_outer_boundary_name{
+  static constexpr const char* size_name{"Size"};
+  static constexpr const char* shape_name{"Shape"};
+  static constexpr const char* rotation_name{"Rotation"};
+  static constexpr const char* expansion_name{"Expansion"};
+  static constexpr const char* expansion_outer_boundary_name{
       "ExpansionOuterBoundary"};
-  inline static const std::string translation_name{"Translation"};
+  static constexpr const char* translation_name{"Translation"};
 
  private:
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -197,7 +197,3 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef DIM
 #undef FRAME
 #undef INSTANTIATE
-
-// Some compilers (clang 3.9.1) don't instantiate the default argument
-// to the second Domain constructor.
-template class std::vector<PairOfFaces>;

--- a/src/Domain/FunctionsOfTime/FixedSpeedCubic.cpp
+++ b/src/Domain/FunctionsOfTime/FixedSpeedCubic.cpp
@@ -92,7 +92,9 @@ bool operator!=(const FixedSpeedCubic& lhs, const FixedSpeedCubic& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID FixedSpeedCubic::my_PUP_ID = 0;  // NOLINT
+#endif                                             // __CUDA_ARCH__
 
 #define DERIV(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Domain/FunctionsOfTime/IntegratedFunctionOfTime.cpp
+++ b/src/Domain/FunctionsOfTime/IntegratedFunctionOfTime.cpp
@@ -150,7 +150,9 @@ bool operator!=(const IntegratedFunctionOfTime& lhs,
                 const IntegratedFunctionOfTime& rhs) {
   return not(lhs == rhs);
 }
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID IntegratedFunctionOfTime::my_PUP_ID = 0;  // NOLINT
+#endif                                                      // __CUDA_ARCH__
 
 #define DIMRETURNED(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
+++ b/src/Domain/FunctionsOfTime/PiecewisePolynomial.hpp
@@ -126,8 +126,10 @@ bool operator!=(const PiecewisePolynomial<MaxDeriv>& lhs,
                 const PiecewisePolynomial<MaxDeriv>& rhs);
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t MaxDeriv>
 PUP::able::PUP_ID PiecewisePolynomial<MaxDeriv>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace FunctionsOfTime
 }  // namespace domain

--- a/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
+++ b/src/Domain/FunctionsOfTime/QuaternionFunctionOfTime.hpp
@@ -199,7 +199,9 @@ bool operator!=(const QuaternionFunctionOfTime<MaxDeriv>& lhs,
                 const QuaternionFunctionOfTime<MaxDeriv>& rhs);
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t MaxDeriv>
 PUP::able::PUP_ID QuaternionFunctionOfTime<MaxDeriv>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace domain::FunctionsOfTime

--- a/src/Domain/FunctionsOfTime/SettleToConstant.cpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstant.cpp
@@ -82,7 +82,9 @@ bool operator!=(const SettleToConstant& lhs, const SettleToConstant& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SettleToConstant::my_PUP_ID = 0;  // NOLINT
+#endif                                              // __CUDA_ARCH__
 
 #define DERIV(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Domain/FunctionsOfTime/SettleToConstantQuaternion.cpp
+++ b/src/Domain/FunctionsOfTime/SettleToConstantQuaternion.cpp
@@ -124,7 +124,9 @@ bool operator!=(const SettleToConstantQuaternion& lhs,
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SettleToConstantQuaternion::my_PUP_ID = 0;  // NOLINT
+#endif                                                        // __CUDA_ARCH__
 
 #define DERIV(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Domain/Structure/Hypercube.hpp
+++ b/src/Domain/Structure/Hypercube.hpp
@@ -133,8 +133,8 @@ struct HypercubeElementsIterator {
   /// The number of `ElementDim`-dimensional elements on the boundary of a
   /// `HypercubeDim`-dimensional hypercube.
   static constexpr size_t size() {
-    return two_to_the(num_indices) * factorial(HypercubeDim) /
-           factorial(ElementDim) / factorial(num_indices);
+    return two_to_the(num_indices) *
+           falling_factorial(HypercubeDim, ElementDim) / factorial(ElementDim);
   }
 
   HypercubeElementsIterator();

--- a/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
+++ b/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
@@ -230,11 +230,13 @@ void AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename System, size_t Dim, typename... FieldTags,
           typename... FluxTags>
 PUP::able::PUP_ID AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
                                    tmpl::list<FluxTags...>>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace elliptic::BoundaryConditions

--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -485,11 +485,13 @@ MinusLaplacian<Dim, OptionsGroup, Solver, LinearSolverRegistrars>::solve(
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename OptionsGroup, typename Solver,
           typename LinearSolverRegistrars>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MinusLaplacian<Dim, OptionsGroup, Solver,
                                  LinearSolverRegistrars>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace elliptic::subdomain_preconditioners

--- a/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.cpp
+++ b/src/Elliptic/Systems/BnsInitialData/BoundaryConditions/StarSurface.cpp
@@ -47,6 +47,8 @@ bool operator!=(const StarSurface& lhs, const StarSurface& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID StarSurface::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 
 }  // namespace BnsInitialData::BoundaryConditions

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/LaserBeam.cpp
@@ -47,6 +47,8 @@ bool operator!=(const LaserBeam& lhs, const LaserBeam& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID LaserBeam::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 
 }  // namespace Elasticity::BoundaryConditions

--- a/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp
+++ b/src/Elliptic/Systems/Elasticity/BoundaryConditions/Zero.hpp
@@ -112,8 +112,10 @@ bool operator!=(const Zero<Dim, BoundaryConditionType>& lhs,
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim, elliptic::BoundaryConditionType BoundaryConditionType>
 PUP::able::PUP_ID Zero<Dim, BoundaryConditionType>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace Elasticity::BoundaryConditions

--- a/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.cpp
+++ b/src/Elliptic/Systems/Poisson/BoundaryConditions/Robin.cpp
@@ -82,8 +82,10 @@ bool operator!=(const Robin<Dim>& lhs, const Robin<Dim>& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID Robin<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                        // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.cpp
+++ b/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.cpp
@@ -43,5 +43,7 @@ std::array<amr::Flag, 3> RefineAtPunctures::impl(
   return make_array<3>(amr::Flag::DoNothing);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RefineAtPunctures::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 }  // namespace Punctures::AmrCriteria

--- a/src/Elliptic/Systems/Punctures/BoundaryConditions/Flatness.cpp
+++ b/src/Elliptic/Systems/Punctures/BoundaryConditions/Flatness.cpp
@@ -35,6 +35,8 @@ bool operator!=(const Flatness& lhs, const Flatness& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Flatness::my_PUP_ID = 0;  // NOLINT
+#endif                                      // __CUDA_ARCH__
 
 }  // namespace Punctures::BoundaryConditions

--- a/src/Elliptic/Systems/ScalarGaussBonnet/BoundaryConditions/DoNothing.hpp
+++ b/src/Elliptic/Systems/ScalarGaussBonnet/BoundaryConditions/DoNothing.hpp
@@ -86,7 +86,9 @@ inline bool operator!=(const DoNothing& /*lhs*/, const DoNothing& /*rhs*/) {
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID DoNothing::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace sgb::BoundaryConditions

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Angular.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Angular.cpp
@@ -47,6 +47,8 @@ bool operator!=(const Angular& lhs, const Angular& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Angular::my_PUP_ID = 0;  // NOLINT
+#endif                                     // __CUDA_ARCH__
 
 }  // namespace ScalarSelfForce::BoundaryConditions

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
@@ -68,6 +68,8 @@ bool operator!=(const Sommerfeld& lhs, const Sommerfeld& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Sommerfeld::my_PUP_ID = 0;  // NOLINT
+#endif                                        // __CUDA_ARCH__
 
 }  // namespace ScalarSelfForce::BoundaryConditions

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/ApparentHorizon.cpp
@@ -646,8 +646,10 @@ void ApparentHorizon<ConformalGeometry>::pup(PUP::er& p) {
   p | solution_for_negative_expansion_;
 }
 
+#ifndef __CUDA_ARCH__
 template <Xcts::Geometry ConformalGeometry>
 PUP::able::PUP_ID ApparentHorizon<ConformalGeometry>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 
 template class ApparentHorizon<Xcts::Geometry::FlatCartesian>;
 template class ApparentHorizon<Xcts::Geometry::Curved>;

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Flatness.cpp
@@ -116,8 +116,10 @@ bool operator!=(const Flatness<EnabledEquations>& lhs,
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 template <Xcts::Equations EnabledEquations>
 PUP::able::PUP_ID Flatness<EnabledEquations>::my_PUP_ID = 0;  // NOLINT
+#endif                                                        // __CUDA_ARCH__
 
 #define EQNS(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Robin.cpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Robin.cpp
@@ -189,8 +189,10 @@ bool operator!=(const Robin<EnabledEquations>& lhs,
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 template <Xcts::Equations EnabledEquations>
 PUP::able::PUP_ID Robin<EnabledEquations>::my_PUP_ID = 0;  // NOLINT
+#endif                                                     // __CUDA_ARCH__
 
 #define EQNS(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp
+++ b/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp
@@ -277,9 +277,11 @@ class ObserveAdmIntegrals : public Event {
 /// @}
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename ArraySectionIdTag>
 PUP::able::PUP_ID ObserveAdmIntegrals<ArraySectionIdTag>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace Events

--- a/src/Elliptic/Triggers/EveryNIterations.hpp
+++ b/src/Elliptic/Triggers/EveryNIterations.hpp
@@ -62,7 +62,9 @@ class EveryNIterations : public Trigger {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Label>
 PUP::able::PUP_ID EveryNIterations<Label>::my_PUP_ID = 0;  // NOLINT
+#endif                                                     // __CUDA_ARCH__
 /// \endcond
 }  // namespace elliptic::Triggers

--- a/src/Elliptic/Triggers/HasConverged.hpp
+++ b/src/Elliptic/Triggers/HasConverged.hpp
@@ -37,7 +37,9 @@ class HasConverged : public Trigger {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Label>
 PUP::able::PUP_ID HasConverged<Label>::my_PUP_ID = 0;  // NOLINT
+#endif                                                 // __CUDA_ARCH__
 /// \endcond
 }  // namespace elliptic::Triggers

--- a/src/Evolution/Particles/MonteCarlo/MonteCarloOptions.cpp
+++ b/src/Evolution/Particles/MonteCarlo/MonteCarloOptions.cpp
@@ -9,8 +9,10 @@
 
 namespace Particles::MonteCarlo {
 
+#ifndef __CUDA_ARCH__
 template <size_t NeutrinoSpecies>
 PUP::able::PUP_ID MonteCarloOptions<NeutrinoSpecies>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 
 template <size_t NeutrinoSpecies>
 void MonteCarloOptions<NeutrinoSpecies>::pup(PUP::er& p) {

--- a/src/Evolution/Particles/MonteCarlo/NeutrinoInteractionTable.cpp
+++ b/src/Evolution/Particles/MonteCarlo/NeutrinoInteractionTable.cpp
@@ -258,9 +258,13 @@ void NeutrinoInteractionTable<EnergyBins, NeutrinoSpecies>::pup(PUP::er& p) {
   }
 }
 
+// NOLINTBEGIN
+#ifndef __CUDA_ARCH__
 template <size_t EnergyBins, size_t NeutrinoSpecies>
-PUP::able::PUP_ID NeutrinoInteractionTable<EnergyBins,
-  NeutrinoSpecies>::my_PUP_ID = 0;  // NOLINT
+PUP::able::PUP_ID
+    NeutrinoInteractionTable<EnergyBins, NeutrinoSpecies>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
+// NOLINTEND
 
 template <size_t EnergyBins, size_t NeutrinoSpecies>
 void NeutrinoInteractionTable<EnergyBins,

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -94,6 +94,8 @@ void DemandOutgoingCharSpeeds::fd_demand_outgoing_char_speeds(
   }
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DemandOutgoingCharSpeeds::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.cpp
@@ -44,6 +44,8 @@ void Dirichlet::fd_ghost(const gsl::not_null<Scalar<DataVector>*> u,
   get(*u) = u_value_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Dirichlet::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/DirichletAnalytic.cpp
@@ -112,6 +112,8 @@ void DirichletAnalytic::flux_impl(
   Burgers::Fluxes::apply(flux, u_analytic);
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Burgers::BoundaryConditions

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Hll.cpp
@@ -71,5 +71,7 @@ void Hll::dg_boundary_terms(
 }
 }  // namespace Burgers::BoundaryCorrections
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Burgers::BoundaryCorrections::Hll::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__

--- a/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/Burgers/BoundaryCorrections/Rusanov.cpp
@@ -66,5 +66,7 @@ void Rusanov::dg_boundary_terms(
 }
 }  // namespace Burgers::BoundaryCorrections
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Burgers::BoundaryCorrections::Rusanov::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__

--- a/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.cpp
@@ -40,7 +40,9 @@ std::unique_ptr<Reconstructor> MonotonisedCentral::get_clone() const {
 
 void MonotonisedCentral::pup(PUP::er& p) { Reconstructor::pup(p); }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MonotonisedCentral::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 void MonotonisedCentral::reconstruct(
     const gsl::not_null<std::array<Variables<face_vars_tags>, 1>*>

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/BouncingBlackHole.cpp
@@ -307,5 +307,7 @@ void BouncingBlackHole::pup(PUP::er& p) {
   p | frequency_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID BouncingBlackHole::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/GaugeWave.cpp
@@ -205,5 +205,7 @@ void GaugeWave::pup(PUP::er& p) {
   p | duration_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID GaugeWave::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
@@ -111,7 +111,9 @@ LinearizedBondiSachs::get_clone() const {
   return std::make_unique<LinearizedBondiSachs>(*this);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID LinearizedBondiSachs::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace InitializeJ
 
 namespace {
@@ -609,5 +611,7 @@ void LinearizedBondiSachs::pup(PUP::er& p) {
   p | frequency_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID LinearizedBondiSachs::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RobinsonTrautman.cpp
@@ -461,5 +461,7 @@ void RobinsonTrautman::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RobinsonTrautman::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/RotatingSchwarzschild.cpp
@@ -117,5 +117,7 @@ void RotatingSchwarzschild::pup(PUP::er& p) {
   p | frequency_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RotatingSchwarzschild::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/TeukolskyWave.cpp
@@ -309,5 +309,7 @@ void TeukolskyWave::pup(PUP::er& p) {
   p | duration_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TeukolskyWave::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::Solutions

--- a/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
+++ b/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
@@ -557,6 +557,8 @@ ObserveFields::ObserveFields(
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ObserveFields::my_PUP_ID = 0;  // NOLINT
+#endif                                           // __CUDA_ARCH__
 /// \endcond
 }  // namespace Cce::Events

--- a/src/Evolution/Systems/Cce/Events/ObserveTimeStep.hpp
+++ b/src/Evolution/Systems/Cce/Events/ObserveTimeStep.hpp
@@ -141,6 +141,8 @@ ObserveTimeStep::ObserveTimeStep(const std::string& subfile_name,
       legend_(std::vector<std::string>{"Time", "Time Step"}) {}
 
 /// \cond
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ObserveTimeStep::my_PUP_ID = 0;  // NOLINT
+#endif                                             // __CUDA_ARCH__
 /// \endcond
 }  // namespace Cce::Events

--- a/src/Evolution/Systems/Cce/Initialize/ConformalFactor.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/ConformalFactor.cpp
@@ -417,7 +417,9 @@ void ConformalFactor::pup(PUP::er& p) {
   p | input_mode_filename_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ConformalFactor::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 std::ostream& operator<<(
     std::ostream& os,
     const Cce::InitializeJ::ConformalFactorIterationHeuristic& heuristic_type) {

--- a/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/InverseCubic.cpp
@@ -114,6 +114,8 @@ void InverseCubic<false>::operator()(
 void InverseCubic<true>::pup(PUP::er& /*p*/) {}
 void InverseCubic<false>::pup(PUP::er& /*p*/) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID InverseCubic<true>::my_PUP_ID = 0;
 PUP::able::PUP_ID InverseCubic<false>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.cpp
@@ -225,5 +225,7 @@ void NoIncomingRadiation::pup(PUP::er& p) {
   p | max_iterations_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NoIncomingRadiation::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.cpp
@@ -127,5 +127,7 @@ void ZeroNonSmooth::pup(PUP::er& p) {
   p | max_iterations_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ZeroNonSmooth::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLocalTimeStepping.cpp
@@ -181,5 +181,7 @@ void GhLocalTimeStepping::pup(PUP::er& p) {
   p | latest_removed_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID GhLocalTimeStepping::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::InterfaceManagers

--- a/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
+++ b/src/Evolution/Systems/Cce/InterfaceManagers/GhLockstep.cpp
@@ -58,5 +58,7 @@ void GhLockstep::pup(PUP::er& p) {
   p | requests_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID GhLockstep::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Cce::InterfaceManagers

--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
@@ -982,11 +982,13 @@ void KleinGordonWorldtubeH5BufferUpdater::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <typename T>
 PUP::able::PUP_ID MetricWorldtubeH5BufferUpdater<T>::my_PUP_ID = 0;  // NOLINT
 template <typename T>
 PUP::able::PUP_ID BondiWorldtubeH5BufferUpdater<T>::my_PUP_ID = 0;     // NOLINT
 PUP::able::PUP_ID KleinGordonWorldtubeH5BufferUpdater::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 
 template class MetricWorldtubeH5BufferUpdater<ComplexModalVector>;
 template class MetricWorldtubeH5BufferUpdater<DataVector>;

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -528,7 +528,9 @@ void KleinGordonWorldtubeDataManager::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MetricWorldtubeDataManager::my_PUP_ID = 0;       // NOLINT
 PUP::able::PUP_ID BondiWorldtubeDataManager::my_PUP_ID = 0;        // NOLINT
 PUP::able::PUP_ID KleinGordonWorldtubeDataManager::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 }  // namespace Cce

--- a/src/Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Actions/NumericInitialData.cpp
@@ -30,8 +30,10 @@ const importers::ImporterOptions& NumericInitialData::importer_options() const {
   return importer_options_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID NumericInitialData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 size_t NumericInitialData::volume_data_id() const {
   size_t hash = 0;

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/AnalyticConstant.cpp
@@ -71,9 +71,11 @@ std::optional<std::string> AnalyticConstant<Dim>::dg_ghost(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID AnalyticConstant<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
@@ -156,9 +156,11 @@ ConstraintPreservingSphericalRadiation<Dim>::dg_time_derivative(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID ConstraintPreservingSphericalRadiation<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -67,9 +67,11 @@ DemandOutgoingCharSpeeds<Dim>::dg_demand_outgoing_char_speeds(
   return std::nullopt;  // LCOV_EXCL_LINE
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DemandOutgoingCharSpeeds<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryConditions/Worldtube.cpp
@@ -32,9 +32,11 @@ void Worldtube<Dim>::pup(PUP::er& p) {
   BoundaryCondition<Dim>::pup(p);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Worldtube<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 std::optional<std::string> Worldtube<Dim>::dg_time_derivative(

--- a/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -147,9 +147,11 @@ bool operator!=(const UpwindPenalty<Dim>& lhs, const UpwindPenalty<Dim>& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID UpwindPenalty<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/InitialData/ZerothOrderPuncture.cpp
@@ -92,8 +92,10 @@ void ZerothOrderPuncture::pup(PUP::er& p) {
   p | kerr_schild_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID ZerothOrderPuncture::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const ZerothOrderPuncture& lhs,
                 const ZerothOrderPuncture& rhs) {

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/InsideHorizon.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/InsideHorizon.cpp
@@ -27,5 +27,7 @@ bool InsideHorizon::operator()(
   return orbit_radius + wt_radius_inertial < 1.99;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID InsideHorizon::my_PUP_ID = 0;  // NOLINT
+#endif                                           // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Triggers/OrbitRadius.cpp
@@ -43,5 +43,7 @@ bool OrbitRadius::operator()(
 // NOLINTNEXTLINE(google-runtime-references)
 void OrbitRadius::pup(PUP::er& p) { p | radii_; }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID OrbitRadius::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Evolution/Systems/ForceFree/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/ForceFree/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -30,8 +30,10 @@ DemandOutgoingCharSpeeds::get_clone() const {
 
 void DemandOutgoingCharSpeeds::pup(PUP::er& p) { BoundaryCondition::pup(p); }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DemandOutgoingCharSpeeds::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 std::optional<std::string>
 DemandOutgoingCharSpeeds::dg_demand_outgoing_char_speeds(

--- a/src/Evolution/Systems/ForceFree/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/ForceFree/BoundaryConditions/DirichletAnalytic.cpp
@@ -52,8 +52,10 @@ void DirichletAnalytic::pup(PUP::er& p) {
   p | analytic_prescription_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 std::optional<std::string> DirichletAnalytic::dg_ghost(
     const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_e,

--- a/src/Evolution/Systems/ForceFree/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/ForceFree/BoundaryCorrections/Rusanov.cpp
@@ -25,8 +25,10 @@ std::unique_ptr<BoundaryCorrection> Rusanov::get_clone() const {
 
 void Rusanov::pup(PUP::er& p) { BoundaryCorrection::pup(p); }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Rusanov::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 double Rusanov::dg_package_data(
     const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.cpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.cpp
@@ -73,8 +73,10 @@ void AdaptiveOrder::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID AdaptiveOrder::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 void AdaptiveOrder::reconstruct(
     const gsl::not_null<std::array<Variables<recons_tags>, dim>*>

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.cpp
@@ -36,8 +36,10 @@ std::unique_ptr<Reconstructor> MonotonisedCentral::get_clone() const {
 
 void MonotonisedCentral::pup(PUP::er& p) { Reconstructor::pup(p); }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MonotonisedCentral::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 void MonotonisedCentral::reconstruct(
     const gsl::not_null<std::array<Variables<recons_tags>, dim>*>

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.cpp
@@ -54,8 +54,10 @@ void Wcns5z::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Wcns5z::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 void Wcns5z::reconstruct(
     const gsl::not_null<std::array<Variables<recons_tags>, dim>*>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
@@ -65,7 +65,9 @@ NumericInitialData::NumericInitialData(
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
     : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NumericInitialData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 size_t NumericInitialData::volume_data_id() const {
   size_t hash = 0;

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -544,9 +544,11 @@ void ConstraintPreservingBjorhus<Dim>::compute_intermediate_vars(
                         face_mesh_velocity);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID ConstraintPreservingBjorhus<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -79,9 +79,11 @@ DemandOutgoingCharSpeeds<Dim>::dg_demand_outgoing_char_speeds(
   return std::nullopt;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 template <size_t Dim>
 PUP::able::PUP_ID DemandOutgoingCharSpeeds<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.cpp
@@ -119,9 +119,11 @@ void DirichletAnalytic<Dim>::lapse_shift_and_inv_spatial_metric(
   gr::lapse(lapse, *shift, spacetime_metric);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.cpp
@@ -76,9 +76,11 @@ std::optional<std::string> DirichletMinkowski<Dim>::dg_ghost(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletMinkowski<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.cpp
@@ -285,9 +285,11 @@ bool operator!=(const UpwindPenalty<Dim>& lhs, const UpwindPenalty<Dim>& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID UpwindPenalty<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/AnalyticChristoffel.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/AnalyticChristoffel.cpp
@@ -119,8 +119,10 @@ void AnalyticChristoffel::gauge_and_spacetime_derivative_impl(
   }
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID AnalyticChristoffel::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -541,8 +541,10 @@ void DampedHarmonic::gauge_and_spacetime_derivative(
                   spatial_decay_width_);
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DampedHarmonic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Harmonic.cpp
@@ -40,8 +40,10 @@ void Harmonic::gauge_and_spacetime_derivative(
 
 bool Harmonic::is_harmonic() const { return true; }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Harmonic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.cpp
@@ -30,7 +30,9 @@ NumericInitialData::NumericInitialData(
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
     : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NumericInitialData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 size_t NumericInitialData::volume_data_id() const {
   size_t hash = 0;

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ConstraintPreservingFreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ConstraintPreservingFreeOutflow.cpp
@@ -202,6 +202,8 @@ std::optional<std::string> ConstraintPreservingFreeOutflow::dg_time_derivative(
       logical_dt_phi, d_spacetime_metric, d_pi, d_phi);
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID ConstraintPreservingFreeOutflow::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace grmhd::GhValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -90,9 +90,11 @@ void DirichletAnalytic<System>::pup(PUP::er& p) {
   BoundaryCondition::pup(p);
   p | analytic_prescription_;
 }
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 std::optional<std::string> DirichletAnalytic<System>::dg_ghost(

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/DirichletFreeOutflow.cpp
@@ -90,9 +90,11 @@ void DirichletFreeOutflow<System>::pup(PUP::er& p) {
   BoundaryCondition::pup(p);
   p | analytic_prescription_;
 }
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletFreeOutflow<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 std::optional<std::string> DirichletFreeOutflow<System>::dg_ghost(

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryCorrections/ProductOfCorrections.hpp
@@ -261,9 +261,11 @@ class ProductOfCorrections final : public BoundaryCorrection {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename DerivedGhCorrection, typename DerivedValenciaCorrection>
 PUP::able::PUP_ID ProductOfCorrections<DerivedGhCorrection,
                                        DerivedValenciaCorrection>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace grmhd::GhValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -72,9 +72,11 @@ void MonotonisedCentralPrim<System>::pup(PUP::er& p) {
   p | reconstruct_rho_times_temperature_;
 }
 
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MonotonisedCentralPrim<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 template <size_t ThermodynamicDim, typename TagsList>

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -119,9 +119,11 @@ void PositivityPreservingAdaptiveOrderPrim<System>::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID PositivityPreservingAdaptiveOrderPrim<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 template <size_t ThermodynamicDim, typename TagsList>

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -90,9 +90,11 @@ void Wcns5zPrim<System>::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Wcns5zPrim<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 template <size_t ThermodynamicDim, typename TagsList>

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.cpp
@@ -28,7 +28,9 @@ NumericInitialData::NumericInitialData(
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
     : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NumericInitialData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 size_t NumericInitialData::volume_data_id() const {
   size_t hash = 0;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -354,7 +354,9 @@ void DemandOutgoingCharSpeeds::fd_demand_outgoing_char_speeds(
   }
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DemandOutgoingCharSpeeds::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.cpp
@@ -80,8 +80,10 @@ void DirichletAnalytic::pup(PUP::er& p) {
   BoundaryCondition::pup(p);
   p | analytic_prescription_;
 }
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 std::optional<std::string> DirichletAnalytic::dg_ghost(
     const gsl::not_null<Scalar<DataVector>*> tilde_d,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.cpp
@@ -40,8 +40,10 @@ HydroFreeOutflow::get_clone() const {
 
 void HydroFreeOutflow::pup(PUP::er& p) { BoundaryCondition::pup(p); }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID HydroFreeOutflow::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 std::optional<std::string> HydroFreeOutflow::dg_ghost(
     const gsl::not_null<Scalar<DataVector>*> tilde_d,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Reflective.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Reflective.cpp
@@ -45,8 +45,10 @@ void Reflective::pup(PUP::er& p) {
   p | reflect_both_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Reflective::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 std::optional<std::string> Reflective::dg_ghost(
     const gsl::not_null<Scalar<DataVector>*> tilde_d,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Hll.cpp
@@ -355,6 +355,8 @@ bool operator==(const Hll& lhs, const Hll& rhs) {
 }
 bool operator!=(const Hll& lhs, const Hll& rhs) { return not(lhs == rhs); }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Hll::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace grmhd::ValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Rusanov.cpp
@@ -227,6 +227,8 @@ bool operator!=(const Rusanov& lhs, const Rusanov& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Rusanov::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace grmhd::ValenciaDivClean::BoundaryCorrections

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
@@ -52,8 +52,10 @@ void MonotonicityPreserving5Prim::pup(PUP::er& p) {
   p | reconstruct_rho_times_temperature_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MonotonicityPreserving5Prim::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t ThermodynamicDim>
 void MonotonicityPreserving5Prim::reconstruct(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -45,8 +45,10 @@ void MonotonisedCentralPrim::pup(PUP::er& p) {
   p | reconstruct_rho_times_temperature_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MonotonisedCentralPrim::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t ThermodynamicDim>
 void MonotonisedCentralPrim::reconstruct(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -94,8 +94,10 @@ void PositivityPreservingAdaptiveOrderPrim::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID PositivityPreservingAdaptiveOrderPrim::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t ThermodynamicDim>
 void PositivityPreservingAdaptiveOrderPrim::reconstruct(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -74,8 +74,10 @@ void Wcns5zPrim::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Wcns5zPrim::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t ThermodynamicDim>
 void Wcns5zPrim::reconstruct(

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -39,9 +39,11 @@ void DemandOutgoingCharSpeeds<Dim>::pup(PUP::er& p) {
   BoundaryCondition<Dim>::pup(p);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DemandOutgoingCharSpeeds<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 template <size_t ThermodynamicDim>

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/DirichletAnalytic.cpp
@@ -117,9 +117,11 @@ std::optional<std::string> DirichletAnalytic<Dim>::dg_ghost(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Reflection.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryConditions/Reflection.cpp
@@ -95,9 +95,11 @@ std::optional<std::string> Reflection<Dim>::dg_ghost(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Reflection<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hll.cpp
@@ -200,9 +200,11 @@ void Hll<Dim>::dg_boundary_terms(
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Hll<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Hllc.cpp
@@ -296,9 +296,11 @@ void Hllc<Dim>::dg_boundary_terms(
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Hllc<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/BoundaryCorrections/Rusanov.cpp
@@ -158,9 +158,11 @@ void Rusanov<Dim>::dg_boundary_terms(
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Rusanov<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/AoWeno.cpp
@@ -64,9 +64,11 @@ void AoWeno53Prim<Dim>::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID AoWeno53Prim<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 template <typename TagsList>

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.cpp
@@ -40,9 +40,11 @@ void MonotonisedCentralPrim<Dim>::pup(PUP::er& p) {
   Reconstructor<Dim>::pup(p);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MonotonisedCentralPrim<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 template <typename TagsList>

--- a/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/LaneEmdenGravitationalField.cpp
@@ -77,6 +77,8 @@ tnsr::I<DataVector, 3> LaneEmdenGravitationalField::gravitational_field(
   return gravitational_field_result;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID LaneEmdenGravitationalField::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace NewtonianEuler::Sources

--- a/src/Evolution/Systems/NewtonianEuler/Sources/NoSource.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/NoSource.cpp
@@ -39,9 +39,11 @@ void NoSource<Dim>::operator()(
     const EquationsOfState::EquationOfState<false, 2>& /*eos*/,
     const tnsr::I<DataVector, Dim>& /*coords*/, const double /*time*/) const {}
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID NoSource<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/NewtonianEuler/Sources/UniformAcceleration.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/UniformAcceleration.cpp
@@ -55,9 +55,11 @@ void UniformAcceleration<Dim>::operator()(
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID UniformAcceleration<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 bool operator==(const UniformAcceleration<Dim>& lhs,

--- a/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Sources/VortexPerturbation.cpp
@@ -56,6 +56,8 @@ void VortexPerturbation::operator()(
                                  get(dvz_by_dz);
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID VortexPerturbation::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace NewtonianEuler::Sources

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryConditions/DirichletAnalytic.cpp
@@ -190,10 +190,12 @@ DirichletAnalytic<tmpl::list<NeutrinoSpecies...>>::dg_ghost(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <typename... NeutrinoSpecies>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic<tmpl::list<NeutrinoSpecies...>>::my_PUP_ID =
     0;
+#endif  // __CUDA_ARCH__
 
 template class DirichletAnalytic<tmpl::list<neutrinos::ElectronNeutrinos<1>>>;
 

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/BoundaryCorrections/Rusanov.hpp
@@ -205,9 +205,11 @@ class Rusanov<tmpl::list<NeutrinoSpecies...>> final
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename... NeutrinoSpecies>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Rusanov<tmpl::list<NeutrinoSpecies...>>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace RadiationTransport::M1Grey::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/BoundaryCorrections/Rusanov.cpp
@@ -78,10 +78,12 @@ void Rusanov<Dim>::dg_boundary_terms(
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID
     ScalarAdvection::BoundaryCorrections::Rusanov<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.cpp
@@ -68,8 +68,10 @@ void AoWeno53<Dim>::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID AoWeno53<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 template <typename TagsList>

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.cpp
@@ -43,8 +43,10 @@ void MonotonisedCentral<Dim>::pup(PUP::er& p) {
   Reconstructor<Dim>::pup(p);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID MonotonisedCentral<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 template <typename TagsList>

--- a/src/Evolution/Systems/ScalarTensor/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/ScalarTensor/Actions/SetInitialData.cpp
@@ -41,8 +41,10 @@ NumericInitialData::NumericInitialData(
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
     : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID NumericInitialData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 size_t NumericInitialData::volume_data_id() const {
   size_t hash = 0;

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.cpp
@@ -204,6 +204,8 @@ std::optional<std::string> ConstraintPreserving::dg_time_derivative(
   return gh_string.value() + ";" + scalar_string.value();
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID ConstraintPreserving::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -80,6 +80,8 @@ DemandOutgoingCharSpeeds::dg_demand_outgoing_char_speeds(
   return std::nullopt;  // LCOV_EXCL_LINE
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DemandOutgoingCharSpeeds::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/DirichletAnalytic.cpp
@@ -133,6 +133,8 @@ std::optional<std::string> DirichletAnalytic::dg_ghost(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace ScalarTensor::BoundaryConditions

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp
@@ -306,9 +306,11 @@ class ProductOfCorrections final : public BoundaryCorrection {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename DerivedGhCorrection, typename DerivedScalarCorrection>
 PUP::able::PUP_ID ProductOfCorrections<DerivedGhCorrection,
                                        DerivedScalarCorrection>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace ScalarTensor::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.cpp
@@ -185,9 +185,11 @@ ConstraintPreservingSphericalRadiation<Dim>::dg_time_derivative(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID ConstraintPreservingSphericalRadiation<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
@@ -88,9 +88,11 @@ std::optional<std::string> DirichletAnalytic<Dim>::dg_ghost(
   return std::nullopt;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DirichletAnalytic<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/SphericalRadiation.cpp
@@ -106,9 +106,11 @@ std::optional<std::string> SphericalRadiation<Dim>::dg_ghost(
   return {};
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID SphericalRadiation<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.cpp
@@ -204,9 +204,11 @@ void UpwindPenalty<Dim>::dg_boundary_terms(
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID UpwindPenalty<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Evolution/Triggers/SeparationLessThan.cpp
+++ b/src/Evolution/Triggers/SeparationLessThan.cpp
@@ -103,10 +103,12 @@ void SeparationLessThan<UseGridCentersFunctionOfTime>::pup(PUP::er& p) {
   p | separation_;
 }
 
+#ifndef __CUDA_ARCH__
 template <bool UseGridCentersFunctionOfTime>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID SeparationLessThan<UseGridCentersFunctionOfTime>::my_PUP_ID =
     0;
+#endif  // __CUDA_ARCH__
 
 template class SeparationLessThan<true>;
 template class SeparationLessThan<false>;

--- a/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
@@ -41,5 +41,7 @@ double BarycentricRationalSpanInterpolator::interpolate(
   return interpolant(target_point);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID intrp::BarycentricRationalSpanInterpolator::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
@@ -50,5 +50,7 @@ std::complex<double> CubicSpanInterpolator::interpolate(
   return interpolate_impl(source_points, values, target_point);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID intrp::CubicSpanInterpolator::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
@@ -35,5 +35,7 @@ std::complex<double> LinearSpanInterpolator::interpolate(
   return interpolate_impl(source_points, values, target_point);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID intrp::LinearSpanInterpolator::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace intrp

--- a/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ExplicitInverse.hpp
@@ -255,9 +255,11 @@ ExplicitInverse<ValueType, LinearSolverRegistrars>::solve(
 
 /// \cond
 // NOLINTBEGIN
+#ifndef __CUDA_ARCH__
 template <typename ValueType, typename LinearSolverRegistrars>
 PUP::able::PUP_ID
     ExplicitInverse<ValueType, LinearSolverRegistrars>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 // NOLINTEND
 /// \endcond
 

--- a/src/NumericalAlgorithms/LinearSolver/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres.hpp
@@ -484,11 +484,13 @@ Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::solve(
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename VarsType, typename Preconditioner,
           typename LinearSolverRegistrars>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID
     Gmres<VarsType, Preconditioner, LinearSolverRegistrars>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace Serial

--- a/src/Parallel/ArrayCollection/DgElementArrayMember.hpp
+++ b/src/Parallel/ArrayCollection/DgElementArrayMember.hpp
@@ -566,11 +566,13 @@ void DgElementArrayMember<Dim, Metavariables,
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename Metavariables,
           typename... PhaseDepActionListsPack, typename SimpleTagsFromOptions>
 PUP::able::PUP_ID DgElementArrayMember<
     Dim, Metavariables, tmpl::list<PhaseDepActionListsPack...>,
     SimpleTagsFromOptions>::my_PUP_ID =  // NOLINT
     0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace Parallel

--- a/src/Parallel/Callback.hpp
+++ b/src/Parallel/Callback.hpp
@@ -320,6 +320,7 @@ class PerformAlgorithmCallback : public Callback {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Proxy>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID PerformAlgorithmCallback<Proxy>::my_PUP_ID = 0;
@@ -341,6 +342,7 @@ template <typename ThreadedAction, typename Proxy>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID ThreadedActionCallback<ThreadedAction, Proxy>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace Parallel

--- a/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.cpp
+++ b/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.cpp
@@ -43,4 +43,6 @@ void CheckpointAndExitAfterWallclock::pup(PUP::er& p) {
 }
 }  // namespace PhaseControl
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID PhaseControl::CheckpointAndExitAfterWallclock::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__

--- a/src/Parallel/PhaseControl/VisitAndReturn.hpp
+++ b/src/Parallel/PhaseControl/VisitAndReturn.hpp
@@ -172,6 +172,8 @@ struct VisitAndReturn : public PhaseChange {
 }  // namespace PhaseControl
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <Parallel::Phase TargetPhase>
 PUP::able::PUP_ID PhaseControl::VisitAndReturn<TargetPhase>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond

--- a/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
@@ -254,8 +254,10 @@ void Constraints<Dim, TensorTags>::pup(PUP::er& p) {
   p | coarsening_factor_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename TensorTags>
 PUP::able::PUP_ID Constraints<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+#endif                                                          // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.cpp
@@ -84,8 +84,10 @@ std::array<Flag, Dim> DriveToTarget<Dim, CriteriaType>::impl(
   return result;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, Type CriteriaType>
 PUP::able::PUP_ID DriveToTarget<Dim, CriteriaType>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 
 template class DriveToTarget<1, Type::h>;
 template class DriveToTarget<2, Type::h>;

--- a/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
@@ -52,8 +52,10 @@ class IncreaseResolution : public Criterion {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID IncreaseResolution<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                                     // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
@@ -270,8 +270,10 @@ void Loehner<Dim, TensorTags>::pup(PUP::er& p) {
   p | coarsening_factor_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename TensorTags>
 PUP::able::PUP_ID Loehner<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+#endif                                                      // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
@@ -233,8 +233,10 @@ void Persson<Dim, TensorTags>::pup(PUP::er& p) {
   p | coarsening_factor_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename TensorTags>
 PUP::able::PUP_ID Persson<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+#endif                                                      // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
@@ -73,8 +73,10 @@ amr::Flag random_flag(
 }
 }  // namespace detail
 
+#ifndef __CUDA_ARCH__
 template <Type CriteriaType>
 PUP::able::PUP_ID Random<CriteriaType>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 
 template class Random<Type::h>;
 template class Random<Type::p>;

--- a/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
@@ -186,8 +186,10 @@ void TruncationError<Dim, TensorTags>::pup(PUP::er& p) {
   p | target_rel_truncation_error_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename TensorTags>
 PUP::able::PUP_ID TruncationError<Dim, TensorTags>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp
@@ -143,7 +143,9 @@ class ObserveAmrCriteria
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Metavariables>
 PUP::able::PUP_ID ObserveAmrCriteria<Metavariables>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace amr::Events

--- a/src/ParallelAlgorithms/Amr/Events/RefineMesh.cpp
+++ b/src/ParallelAlgorithms/Amr/Events/RefineMesh.cpp
@@ -14,5 +14,7 @@ RefineMesh::RefineMesh(CkMigrateMessage* m) : Event(m) {}
 
 void RefineMesh::pup(PUP::er& p) { Event::pup(p); }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RefineMesh::my_PUP_ID = 0;  // NOLINT
+#endif                                        // __CUDA_ARCH__
 }  // namespace amr::Events

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.cpp
@@ -7,5 +7,7 @@ namespace ah::Criteria {
 IncreaseResolution::IncreaseResolution(CkMigrateMessage* msg)
     : Criterion(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID IncreaseResolution::my_PUP_ID = 0;  // NOLINT
+#endif                                                // __CUDA_ARCH__
 }  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.cpp
@@ -43,5 +43,7 @@ void Residual::pup(PUP::er& p) {
 }
 Residual::Residual(CkMigrateMessage* msg) : Criterion(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ah::Criteria::Residual::my_PUP_ID = 0;  // NOLINT
+#endif                                                    // __CUDA_ARCH__
 }  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
@@ -164,12 +164,14 @@ class FindCommonHorizon<
 
 /// \cond
 // NOLINTBEGIN
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim, typename InterpolationTargetTag,
           typename... InterpolatorSourceVarTags, typename... Tensors,
           typename... NonTensorComputeTags>
 PUP::able::PUP_ID FindCommonHorizon<
     VolumeDim, InterpolationTargetTag, tmpl::list<InterpolatorSourceVarTags...>,
     tmpl::list<Tensors...>, tmpl::list<NonTensorComputeTags...>>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 // NOLINTEND
 /// \endcond
 }  // namespace intrp::Events

--- a/src/ParallelAlgorithms/Events/ErrorIfDataTooBig.hpp
+++ b/src/ParallelAlgorithms/Events/ErrorIfDataTooBig.hpp
@@ -167,9 +167,12 @@ class ErrorIfDataTooBig : public Event {
 };
 
 /// \cond
+// NOLINTBEGIN
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename Tensors, typename NonTensorComputeTags>
 PUP::able::PUP_ID
-    ErrorIfDataTooBig<Dim, Tensors,
-                      NonTensorComputeTags>::my_PUP_ID = 0;  // NOLINT
+    ErrorIfDataTooBig<Dim, Tensors, NonTensorComputeTags>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
+// NOLINTEND
 /// \endcond
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/MonitorMemory.hpp
+++ b/src/ParallelAlgorithms/Events/MonitorMemory.hpp
@@ -326,8 +326,10 @@ void MonitorMemory<Dim>::pup(PUP::er& p) {
   p | components_to_monitor_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID MonitorMemory<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                                // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/ObserveAdaptiveSteppingDiagnostics.cpp
+++ b/src/ParallelAlgorithms/Events/ObserveAdaptiveSteppingDiagnostics.cpp
@@ -4,5 +4,7 @@
 #include "ParallelAlgorithms/Events/ObserveAdaptiveSteppingDiagnostics.hpp"
 
 namespace Events {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ObserveAdaptiveSteppingDiagnostics::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/ObserveAtExtremum.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveAtExtremum.hpp
@@ -406,11 +406,13 @@ void ObserveAtExtremum<tmpl::list<ObservableTensorTags...>,
   p | additional_tensor_names_;
 }
 
+#ifndef __CUDA_ARCH__
 template <typename... ObservableTensorTags, typename... NonTensorComputeTags,
           typename ArraySectionIdTag>
 PUP::able::PUP_ID ObserveAtExtremum<tmpl::list<ObservableTensorTags...>,
                                     tmpl::list<NonTensorComputeTags...>,
                                     ArraySectionIdTag>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/ObserveDataBox.cpp
+++ b/src/ParallelAlgorithms/Events/ObserveDataBox.cpp
@@ -34,7 +34,9 @@ void ObserveDataBox::impl(const db::Access& box_access,
   }
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ObserveDataBox::my_PUP_ID = 0;  // NOLINT
+#endif                                            // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -488,11 +488,13 @@ ObserveFields<VolumeDim, tmpl::list<Tensors...>,
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim, typename... Tensors,
           typename... NonTensorComputeTags, typename ArraySectionIdTag>
 PUP::able::PUP_ID ObserveFields<VolumeDim, tmpl::list<Tensors...>,
                                 tmpl::list<NonTensorComputeTags...>,
                                 ArraySectionIdTag>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace Events
 }  // namespace dg

--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -509,11 +509,13 @@ void ObserveNorms<tmpl::list<ObservableTensorTags...>,
 }
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+#ifndef __CUDA_ARCH__
 template <typename... ObservableTensorTags, typename... NonTensorComputeTags,
           typename ArraySectionIdTag, typename OptionName>
 PUP::able::PUP_ID ObserveNorms<tmpl::list<ObservableTensorTags...>,
                                tmpl::list<NonTensorComputeTags...>,
                                ArraySectionIdTag, OptionName>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 /// \endcond
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/ObserveTimeStep.tpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStep.tpp
@@ -102,7 +102,9 @@ auto ObserveTimeStep<System>::assemble_data(
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename System>
 PUP::able::PUP_ID ObserveTimeStep<System>::my_PUP_ID = 0;  // NOLINT
+#endif                                                     // __CUDA_ARCH__
 /// \endcond
 }  // namespace Events

--- a/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp
+++ b/src/ParallelAlgorithms/Events/ObserveTimeStepVolume.tpp
@@ -74,7 +74,9 @@ std::vector<TensorComponent> ObserveTimeStepVolume<System>::assemble_data(
 }
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename System>
 PUP::able::PUP_ID ObserveTimeStepVolume<System>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace dg::Events

--- a/src/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Filter.cpp
+++ b/src/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Filter.cpp
@@ -17,5 +17,7 @@ void Filter::pup(PUP::er& p) {
   p | filter_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Filter::my_PUP_ID = 0;  // NOLINT
+#endif                                    // __CUDA_ARCH__
 }  // namespace DenseTriggers

--- a/src/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Or.cpp
+++ b/src/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Or.cpp
@@ -15,5 +15,7 @@ void Or::pup(PUP::er& p) {
   p | triggers_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Or::my_PUP_ID = 0;  // NOLINT
+#endif                                // __CUDA_ARCH__
 }  // namespace DenseTriggers

--- a/src/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Times.cpp
+++ b/src/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Times.cpp
@@ -41,5 +41,7 @@ std::optional<double> Times::next_check_time_impl(
   return next_time;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Times::my_PUP_ID = 0;  // NOLINT
+#endif                                   // __CUDA_ARCH__
 }  // namespace DenseTriggers

--- a/src/ParallelAlgorithms/EventsAndTriggers/Completion.cpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/Completion.cpp
@@ -4,5 +4,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Completion.hpp"
 
 namespace Events {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Completion::my_PUP_ID = 0;  // NOLINT
+#endif                                        // __CUDA_ARCH__
 }  // namespace Events

--- a/src/ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.cpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.cpp
@@ -4,8 +4,10 @@
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 
 namespace Triggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Always::my_PUP_ID = 0;  // NOLINT
 PUP::able::PUP_ID Not::my_PUP_ID = 0;  // NOLINT
 PUP::able::PUP_ID And::my_PUP_ID = 0;  // NOLINT
 PUP::able::PUP_ID Or::my_PUP_ID = 0;  // NOLINT
+#endif                                // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/Interpolate.hpp
@@ -153,12 +153,14 @@ class Interpolate<VolumeDim, InterpolationTargetTag,
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim, typename InterpolationTargetTag,
           typename... InterpolatorSourceVarTags>
 PUP::able::PUP_ID
     Interpolate<VolumeDim, InterpolationTargetTag,
                 tmpl::list<InterpolatorSourceVarTags...>>::my_PUP_ID =
         0;  // NOLINT
+#endif      // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace Events

--- a/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
+++ b/src/ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp
@@ -419,12 +419,14 @@ class InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim, typename InterpolationTargetTag,
           typename... SourceVarTags>
 PUP::able::PUP_ID
     InterpolateWithoutInterpComponent<VolumeDim, InterpolationTargetTag,
                                       tmpl::list<SourceVarTags...>>::my_PUP_ID =
         0;  // NOLINT
+#endif      // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace intrp::Events

--- a/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Burgers/Sinusoid.cpp
@@ -32,7 +32,9 @@ tuples::TaggedTuple<Tags::U> Sinusoid::variables(
 
 void Sinusoid::pup(PUP::er& p) { InitialData::pup(p); }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Sinusoid::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const Sinusoid& /*lhs*/, const Sinusoid& /*rhs*/) {
   return true;

--- a/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
+++ b/src/PointwiseFunctions/AnalyticData/CurvedWaveEquation/PureSphericalHarmonic.cpp
@@ -73,8 +73,10 @@ void PureSphericalHarmonic::pup(PUP::er& p) {
   p | mode_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID PureSphericalHarmonic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const PureSphericalHarmonic& lhs,
                 const PureSphericalHarmonic& rhs) {

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/FfeBreakdown.cpp
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/FfeBreakdown.cpp
@@ -27,7 +27,9 @@ void FfeBreakdown::pup(PUP::er& p) {
   p | background_spacetime_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID FfeBreakdown::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 tuples::TaggedTuple<Tags::TildeE> FfeBreakdown::variables(
     const tnsr::I<DataVector, 3>& coords, tmpl::list<Tags::TildeE> /*meta*/) {

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/MagnetosphericWald.cpp
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/MagnetosphericWald.cpp
@@ -40,8 +40,10 @@ void MagnetosphericWald::pup(PUP::er& p) {
   p | background_spacetime_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID MagnetosphericWald::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 tuples::TaggedTuple<Tags::TildeE> MagnetosphericWald::variables(
     const tnsr::I<DataVector, 3>& x, tmpl::list<Tags::TildeE> /*meta*/) {

--- a/src/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.cpp
+++ b/src/PointwiseFunctions/AnalyticData/ForceFree/RotatingDipole.cpp
@@ -64,7 +64,9 @@ void RotatingDipole::pup(PUP::er& p) {
   p | background_spacetime_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RotatingDipole::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 tuples::TaggedTuple<Tags::TildeE> RotatingDipole::variables(
     const tnsr::I<DataVector, 3>& coords, tmpl::list<Tags::TildeE> /*meta*/) {

--- a/src/PointwiseFunctions/AnalyticData/GeneralRelativity/SpecInitialData.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GeneralRelativity/SpecInitialData.cpp
@@ -51,7 +51,9 @@ void SpecInitialData::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SpecInitialData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename DataType>
 tuples::tagged_tuple_from_typelist<

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BlastWave.cpp
@@ -190,7 +190,9 @@ BlastWave::variables(
       get<density_tag>(data), get<energy_tag>(data), get<pressure_tag>(data));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID BlastWave::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const BlastWave& lhs, const BlastWave& rhs) {
   return lhs.inner_radius_ == rhs.inner_radius_ and

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.cpp
@@ -215,7 +215,9 @@ BondiHoyleAccretion::variables(
       get<density_tag>(data), get<energy_tag>(data), get<pressure_tag>(data));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID BondiHoyleAccretion::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const BondiHoyleAccretion& lhs,
                 const BondiHoyleAccretion& rhs) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CcsnCollapse.cpp
@@ -850,7 +850,9 @@ auto CcsnCollapse::variables(
   return {make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(x, 0.0)};
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID CcsnCollapse::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const CcsnCollapse& lhs, const CcsnCollapse& rhs) {
   // The equation of state and progenitor solution aren't explicitly checked.

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/FukaInitialData.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/FukaInitialData.cpp
@@ -48,7 +48,9 @@ void FukaInitialData::pup(PUP::er& p) {
   p | electron_fraction_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID FukaInitialData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 }  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Poloidal.cpp
@@ -28,8 +28,10 @@ void Poloidal::pup(PUP::er& p) {
   p | max_distance_from_center_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Poloidal::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 Poloidal::Poloidal(const size_t pressure_exponent, const double cutoff_pressure,
                    const double vector_potential_amplitude,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Toroidal.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/InitialMagneticFields/Toroidal.cpp
@@ -29,8 +29,10 @@ void Toroidal::pup(PUP::er& p) {
   p | max_distance_from_center_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Toroidal::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 Toroidal::Toroidal(const size_t pressure_exponent, const double cutoff_pressure,
                    const double vector_potential_amplitude,

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/KhInstability.cpp
@@ -199,7 +199,9 @@ KhInstability::variables(
           variables(x, tmpl::list<hydro::Tags::Pressure<DataType>>{})));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID KhInstability::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const KhInstability& lhs, const KhInstability& rhs) {
   // No comparison for equation_of_state_. Comparing adiabatic_index_ should

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticFieldLoop.cpp
@@ -184,7 +184,9 @@ MagneticFieldLoop::variables(
           variables(x, tmpl::list<hydro::Tags::Pressure<DataType>>{})));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MagneticFieldLoop::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const MagneticFieldLoop& lhs, const MagneticFieldLoop& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagneticRotor.cpp
@@ -174,7 +174,9 @@ MagneticRotor::variables(
       get<density_tag>(data), get<energy_tag>(data), get<pressure_tag>(data));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MagneticRotor::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const MagneticRotor& lhs, const MagneticRotor& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
@@ -267,7 +267,9 @@ MagnetizedFmDisk::variables(
   return result;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MagnetizedFmDisk::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const MagnetizedFmDisk& lhs, const MagnetizedFmDisk& rhs) {
   return lhs.fm_disk_ == rhs.fm_disk_ and

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.cpp
@@ -96,7 +96,9 @@ void MagnetizedTovVariables<DataType, Region>::operator()(
 }
 }  // namespace magnetized_tov_detail
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MagnetizedTovStar::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const MagnetizedTovStar& lhs, const MagnetizedTovStar& rhs) {
   bool equal =

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.cpp
@@ -121,7 +121,9 @@ OrszagTangVortex::variables(
       get<density_tag>(data), get<energy_tag>(data), get<pressure_tag>(data));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID OrszagTangVortex::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const OrszagTangVortex& /*lhs*/,
                 const OrszagTangVortex& /*rhs*/) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/PolarMagnetizedFmDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/PolarMagnetizedFmDisk.cpp
@@ -26,7 +26,9 @@ void PolarMagnetizedFmDisk::pup(PUP::er& p) {
   p | torus_map_;
 }
 
-PUP::able::PUP_ID PolarMagnetizedFmDisk::my_PUP_ID = 0; // NOLINT
+#ifndef __CUDA_ARCH__
+PUP::able::PUP_ID PolarMagnetizedFmDisk::my_PUP_ID = 0;  // NOLINT
+#endif                                                   // __CUDA_ARCH__
 
 bool operator==(const PolarMagnetizedFmDisk& lhs,
                 const PolarMagnetizedFmDisk& rhs) {

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.cpp
@@ -207,7 +207,9 @@ tuples::TaggedTuple<gr::Tags::Shift<DataType, 3>> RiemannProblem::variables(
   return {std::move(shift)};
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RiemannProblem::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const RiemannProblem& lhs, const RiemannProblem& rhs) {
   return lhs.adiabatic_index_ == rhs.adiabatic_index_ and

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.cpp
@@ -185,7 +185,9 @@ tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>> SlabJet::variables(
       get<density_tag>(data), get<energy_tag>(data), get<pressure_tag>(data));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SlabJet::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const SlabJet& lhs, const SlabJet& rhs) {
   return lhs.equation_of_state_ == rhs.equation_of_state_ and

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/SpecInitialData.cpp
@@ -88,8 +88,10 @@ void SpecInitialData<ThermodynamicDim>::pup(PUP::er& p) {
   }
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t ThermodynamicDim>
 PUP::able::PUP_ID SpecInitialData<ThermodynamicDim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t ThermodynamicDim>
 template <typename DataType>

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/KhInstability.cpp
@@ -62,9 +62,11 @@ template <size_t Dim>
 KhInstability<Dim>::KhInstability(CkMigrateMessage* msg)
     : evolution::initial_data::InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID KhInstability<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 void KhInstability<Dim>::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/ShuOsherTube.cpp
@@ -51,8 +51,10 @@ std::unique_ptr<evolution::initial_data::InitialData> ShuOsherTube::get_clone()
 ShuOsherTube::ShuOsherTube(CkMigrateMessage* msg)
     : evolution::initial_data::InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID ShuOsherTube::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 void ShuOsherTube::pup(PUP::er& p) {
   evolution::initial_data::InitialData::pup(p);

--- a/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.cpp
+++ b/src/PointwiseFunctions/AnalyticData/NewtonianEuler/SodExplosion.cpp
@@ -69,9 +69,11 @@ template <size_t Dim>
 SodExplosion<Dim>::SodExplosion(CkMigrateMessage* msg)
     : evolution::initial_data::InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID SodExplosion<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 void SodExplosion<Dim>::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticData/Punctures/MultiplePunctures.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Punctures/MultiplePunctures.cpp
@@ -161,6 +161,8 @@ void MultiplePuncturesVariables::operator()(
 
 }  // namespace detail
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MultiplePunctures::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 
 }  // namespace Punctures::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/RadiationTransport/M1Grey/HomogeneousSphere.cpp
+++ b/src/PointwiseFunctions/AnalyticData/RadiationTransport/M1Grey/HomogeneousSphere.cpp
@@ -140,8 +140,10 @@ void HomogeneousSphere::pup(PUP::er& p) {
   p | outer_opacity_;
   p | boundary_roundness_;
 }
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID HomogeneousSphere::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator!=(const HomogeneousSphere& lhs, const HomogeneousSphere& rhs) {
   return not(lhs == rhs);

--- a/src/PointwiseFunctions/AnalyticData/ScalarTensor/KerrSphericalHarmonic.cpp
+++ b/src/PointwiseFunctions/AnalyticData/ScalarTensor/KerrSphericalHarmonic.cpp
@@ -91,7 +91,9 @@ KerrSphericalHarmonic::variables(
   return pi;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID KerrSphericalHarmonic::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const KerrSphericalHarmonic& lhs,
                 const KerrSphericalHarmonic& rhs) {

--- a/src/PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.cpp
+++ b/src/PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.cpp
@@ -216,6 +216,8 @@ bool operator!=(const CircularOrbit& lhs, const CircularOrbit& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID CircularOrbit::my_PUP_ID = 0;  // NOLINT
+#endif                                           // __CUDA_ARCH__
 
 }  // namespace ScalarSelfForce::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
@@ -520,9 +520,11 @@ class Binary : public elliptic::analytic_data::Background,
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename IsolatedObjectBase, typename IsolatedObjectClasses>
 PUP::able::PUP_ID Binary<IsolatedObjectBase, IsolatedObjectClasses>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace Xcts::AnalyticData

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.cpp
@@ -73,7 +73,9 @@ void Bump::pup(PUP::er& p) {
   p | center_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Bump::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.cpp
@@ -52,7 +52,9 @@ void Linear::pup(PUP::er& p) {
   p | shock_time_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Linear::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
@@ -63,7 +63,9 @@ void Step::pup(PUP::er& p) {
   p | initial_shock_position_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Step::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace Burgers::Solutions
 
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.cpp
@@ -92,7 +92,9 @@ void BentBeamVariables<DataType>::operator()(
 
 }  // namespace detail
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID BentBeam::my_PUP_ID = 0;  // NOLINT
+#endif                                      // __CUDA_ARCH__
 
 bool operator==(const BentBeam& lhs, const BentBeam& rhs) {
   return lhs.length() == rhs.length() and lhs.height() == rhs.height() and

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.cpp
@@ -237,7 +237,9 @@ void HalfSpaceMirrorVariables<DataType>::operator()(
 
 }  // namespace detail
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID HalfSpaceMirror::my_PUP_ID = 0;  // NOLINT
+#endif                                             // __CUDA_ARCH__
 
 bool operator==(const HalfSpaceMirror& lhs, const HalfSpaceMirror& rhs) {
   return lhs.beam_width() == rhs.beam_width() and

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/Zero.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/Zero.hpp
@@ -68,8 +68,10 @@ class Zero : public elliptic::analytic_data::AnalyticSolution {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID Zero<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 /// \endcond
 
 template <size_t Dim>

--- a/src/PointwiseFunctions/AnalyticSolutions/ForceFree/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ForceFree/AlfvenWave.cpp
@@ -43,7 +43,9 @@ void AlfvenWave::pup(PUP::er& p) {
   p | background_spacetime_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID AlfvenWave::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 DataVector AlfvenWave::wave_profile(const DataVector& x_prime) {
   // Compute the B_z'(=-E_x') at the rest frame of the wave

--- a/src/PointwiseFunctions/AnalyticSolutions/ForceFree/ExactWald.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ForceFree/ExactWald.cpp
@@ -36,8 +36,10 @@ void ExactWald::pup(PUP::er& p) {
   p | magnetic_field_amplitude_;
 }
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID ExactWald::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 tuples::TaggedTuple<Tags::TildeE> ExactWald::variables(
     const tnsr::I<DataVector, 3>& x, double /*t*/,

--- a/src/PointwiseFunctions/AnalyticSolutions/ForceFree/FastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ForceFree/FastWave.cpp
@@ -27,7 +27,9 @@ void FastWave::pup(PUP::er& p) {
   p | background_spacetime_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID FastWave::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 DataVector FastWave::initial_profile(const DataVector& coords) {
   // Compute the initial functional form of B_y(=E_z)

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.tpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.tpp
@@ -125,8 +125,10 @@ void WrappedGr<SolutionType>::pup(PUP::er& p) {
   SolutionType::pup(p);
 }
 
+#ifndef __CUDA_ARCH__
 template <typename SolutionType>
 PUP::able::PUP_ID WrappedGr<SolutionType>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename SolutionType>
 bool operator==(const WrappedGr<SolutionType>& lhs,

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
@@ -205,7 +205,9 @@ AlfvenWave::variables(
   return {std::move(specific_internal_energy)};
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID AlfvenWave::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const AlfvenWave& lhs, const AlfvenWave& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -321,7 +321,9 @@ BondiMichel::variables(
   return result;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID BondiMichel::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const BondiMichel& lhs, const BondiMichel& rhs) {
   // there is no comparison operator for the EoS, but should be okay as

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
@@ -181,7 +181,9 @@ KomissarovShock::variables(
       get<density_tag>(data), get<energy_tag>(data), get<pressure_tag>(data));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID KomissarovShock::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const KomissarovShock& lhs, const KomissarovShock& rhs) {
   return lhs.adiabatic_index_ == rhs.adiabatic_index_ and

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
@@ -47,7 +47,9 @@ SmoothFlow::variables(
   return {make_with_value<Scalar<DataType>>(x, 0.0)};
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SmoothFlow::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const SmoothFlow& lhs, const SmoothFlow& rhs) {
   using smooth_flow = RelativisticEuler::Solutions::SmoothFlow<3>;

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
@@ -56,9 +56,11 @@ template <size_t Dim>
 IsentropicVortex<Dim>::IsentropicVortex(CkMigrateMessage* msg)
     : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID IsentropicVortex<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 void IsentropicVortex<Dim>::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/LaneEmdenStar.cpp
@@ -35,8 +35,10 @@ std::unique_ptr<evolution::initial_data::InitialData> LaneEmdenStar::get_clone()
 
 LaneEmdenStar::LaneEmdenStar(CkMigrateMessage* msg) : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID LaneEmdenStar::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 void LaneEmdenStar::pup(PUP::er& p) {
   InitialData::pup(p);

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/RiemannProblem.cpp
@@ -168,9 +168,11 @@ template <size_t Dim>
 RiemannProblem<Dim>::RiemannProblem(CkMigrateMessage* msg)
     : evolution::initial_data::InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID RiemannProblem<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 void RiemannProblem<Dim>::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/SmoothFlow.cpp
@@ -43,9 +43,11 @@ void SmoothFlow<Dim>::pup(PUP::er& p) {
   smooth_flow::pup(p);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID SmoothFlow<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 bool operator==(const SmoothFlow<Dim>& lhs, const SmoothFlow<Dim>& rhs) {

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
@@ -145,8 +145,10 @@ class Lorentzian : public elliptic::analytic_data::AnalyticSolution {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename DataType>
 PUP::able::PUP_ID Lorentzian<Dim, DataType>::my_PUP_ID = 0;  // NOLINT
+#endif                                                       // __CUDA_ARCH__
 /// \endcond
 
 template <size_t Dim, typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/MathFunction.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/MathFunction.cpp
@@ -64,8 +64,10 @@ void MathFunctionVariables<DataType, Dim>::operator()(
 
 }  // namespace detail
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID MathFunction<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 
 template <size_t Dim>
 std::unique_ptr<elliptic::analytic_data::AnalyticSolution>

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
@@ -108,8 +108,10 @@ class Moustache : public elliptic::analytic_data::AnalyticSolution {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID Moustache<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                            // __CUDA_ARCH__
 /// \endcond
 
 template <size_t Dim>

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
@@ -140,8 +140,10 @@ class ProductOfSinusoids : public elliptic::analytic_data::AnalyticSolution {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename DataType>
 PUP::able::PUP_ID ProductOfSinusoids<Dim, DataType>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 template <size_t Dim, typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Zero.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Zero.hpp
@@ -65,8 +65,10 @@ class Zero : public elliptic::analytic_data::AnalyticSolution {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename DataType>
 PUP::able::PUP_ID Zero<Dim, DataType>::my_PUP_ID = 0;  // NOLINT
+#endif                                                 // __CUDA_ARCH__
 /// \endcond
 
 template <size_t Dim, typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/Punctures/Flatness.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Punctures/Flatness.cpp
@@ -12,5 +12,7 @@ bool operator!=(const Flatness& lhs, const Flatness& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Flatness::my_PUP_ID = 0;  // NOLINT
+#endif                                      // __CUDA_ARCH__
 }  // namespace Punctures::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/M1Grey/ConstantM1.cpp
@@ -38,8 +38,10 @@ void ConstantM1::pup(PUP::er& p) {
   p | comoving_energy_density_;
   p | background_spacetime_;
 }
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE
 PUP::able::PUP_ID ConstantM1::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 // Variables templated on neutrino species.
 template <typename NeutrinoSpecies>

--- a/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/HomogeneousSphere.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RadiationTransport/MonteCarlo/HomogeneousSphere.cpp
@@ -186,7 +186,9 @@ HomogeneousSphere::variables(
   return {make_with_value<Scalar<DataType>>(x, 0.0)};
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID HomogeneousSphere::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 
 bool operator==(const HomogeneousSphere& lhs, const HomogeneousSphere& rhs) {
   return (lhs.radius_ == rhs.radius_ && lhs.densities_ == rhs.densities_ &&

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -386,7 +386,9 @@ void FishboneMoncriefDisk::variables_impl(
   }
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID FishboneMoncriefDisk::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const FishboneMoncriefDisk& lhs,
                 const FishboneMoncriefDisk& rhs) {

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/RotatingStar.cpp
@@ -996,7 +996,9 @@ auto RotatingStar::variables(
           variables(vars, x, tmpl::list<DerivSpatialMetric<DataType>>{})));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RotatingStar::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const RotatingStar& lhs, const RotatingStar& rhs) {
   return lhs.rot_ns_filename_ == rhs.rot_ns_filename_ and

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/SmoothFlow.cpp
@@ -71,8 +71,10 @@ void SmoothFlow<Dim>::pup(PUP::er& p) {
   p | background_spacetime_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID SmoothFlow<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 bool operator==(const SmoothFlow<Dim>& lhs, const SmoothFlow<Dim>& rhs) {

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TovStar.cpp
@@ -760,7 +760,9 @@ void TovVariables<DataType, Region>::operator()(
 #endif  // defined(__GNUC__) && !defined(__clang__)
 }  // namespace tov_detail
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TovStar::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const TovStar& lhs, const TovStar& rhs) {
   return lhs.central_rest_mass_density_ == rhs.central_rest_mass_density_ and

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Krivodonova.cpp
@@ -87,7 +87,9 @@ void Krivodonova::pup(PUP::er& p) { InitialData::pup(p); }
 
 Krivodonova::Krivodonova(CkMigrateMessage* msg) : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Krivodonova::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const Krivodonova& /*lhs*/, const Krivodonova& /*rhs*/) {
   return true;

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Kuzmin.cpp
@@ -84,7 +84,9 @@ void Kuzmin::pup(PUP::er& p) { InitialData::pup(p); }
 
 Kuzmin::Kuzmin(CkMigrateMessage* msg) : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Kuzmin::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const Kuzmin& /*lhs*/, const Kuzmin& /*rhs*/) { return true; }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/ScalarAdvection/Sinusoid.cpp
@@ -31,7 +31,9 @@ void Sinusoid::pup(PUP::er& p) { InitialData::pup(p); }
 
 Sinusoid::Sinusoid(CkMigrateMessage* msg) : InitialData(msg) {}
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Sinusoid::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 bool operator==(const Sinusoid& /*lhs*/, const Sinusoid& /*rhs*/) {
   return true;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -165,8 +165,10 @@ T PlaneWave<Dim>::u(const tnsr::I<T, Dim>& x, const double t) const {
   return result;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID PlaneWave<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace ScalarWave::Solutions
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -135,5 +135,7 @@ void RegularSphericalWave::pup(PUP::er& p) {
   p | profile_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RegularSphericalWave::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace ScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.cpp
@@ -163,5 +163,7 @@ void SemidiscretizedDg::pup(PUP::er& p) {
   p | amplitudes_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SemidiscretizedDg::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace ScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.cpp
@@ -147,7 +147,9 @@ ConstantDensityStar::variables(
   return {compute_piecewise(magnitude(x), radius_, density_, 0.)};
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ConstantDensityStar::my_PUP_ID = 0;  // NOLINT
+#endif                                                 // __CUDA_ARCH__
 
 bool operator==(const ConstantDensityStar& lhs,
                 const ConstantDensityStar& rhs) {

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.cpp
@@ -12,5 +12,7 @@ bool operator!=(const Flatness& lhs, const Flatness& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Flatness::my_PUP_ID = 0;  // NOLINT
+#endif                                      // __CUDA_ARCH__
 }  // namespace Xcts::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.cpp
@@ -1035,7 +1035,9 @@ template class SchwarzschildVariables<DataVector>;
 
 }  // namespace detail
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Schwarzschild::my_PUP_ID = 0;  // NOLINT
+#endif                                           // __CUDA_ARCH__
 
 }  // namespace Xcts::Solutions
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.cpp
@@ -333,7 +333,9 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 
 }  // namespace Xcts::Solutions::tov_detail
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Xcts::Solutions::TovStar::my_PUP_ID = 0;  // NOLINT
+#endif                                                      // __CUDA_ARCH__
 
 // Instantiate implementations for common variables
 template class Xcts::Solutions::CommonVariables<

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.cpp
@@ -441,8 +441,10 @@ template class WrappedGrVariables<DataVector, true>;
 
 }  // namespace detail
 
+#ifndef __CUDA_ARCH__
 template <typename GrSolution, bool HasMhd>
 PUP::able::PUP_ID WrappedGr<GrSolution, HasMhd>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 
 }  // namespace Xcts::Solutions
 

--- a/src/PointwiseFunctions/ConstraintDamping/Constant.hpp
+++ b/src/PointwiseFunctions/ConstraintDamping/Constant.hpp
@@ -102,8 +102,10 @@ bool operator!=(const Constant<VolumeDim, Fr>& lhs,
 }  // namespace ConstraintDamping
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim, typename Fr>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID ConstraintDamping::Constant<VolumeDim, Fr>::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond

--- a/src/PointwiseFunctions/ConstraintDamping/GaussianPlusConstant.hpp
+++ b/src/PointwiseFunctions/ConstraintDamping/GaussianPlusConstant.hpp
@@ -132,9 +132,11 @@ bool operator!=(const GaussianPlusConstant<VolumeDim, Fr>& lhs,
 }  // namespace ConstraintDamping
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim, typename Fr>
 PUP::able::PUP_ID
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     ConstraintDamping::GaussianPlusConstant<VolumeDim, Fr>::my_PUP_ID =
         0;  // NOLINT
+#endif      // __CUDA_ARCH__
 /// \endcond

--- a/src/PointwiseFunctions/ConstraintDamping/TimeDependentTripleGaussian.cpp
+++ b/src/PointwiseFunctions/ConstraintDamping/TimeDependentTripleGaussian.cpp
@@ -210,6 +210,8 @@ bool operator!=(const TimeDependentTripleGaussian& lhs,
   return not(lhs == rhs);
 }
 }  // namespace ConstraintDamping
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID ConstraintDamping::TimeDependentTripleGaussian::my_PUP_ID =
     0;  // NOLINT
+#endif  // __CUDA_ARCH__

--- a/src/PointwiseFunctions/ConstraintDamping/TimeDependentTripleGaussian.hpp
+++ b/src/PointwiseFunctions/ConstraintDamping/TimeDependentTripleGaussian.hpp
@@ -181,8 +181,8 @@ class TimeDependentTripleGaussian : public DampingFunction<3, Frame::Grid> {
   double inverse_width_3_ = std::numeric_limits<double>::signaling_NaN();
   std::array<double, 3> center_3_{};
   MovementMethods movement_method_{MovementMethods::ExpansionFactor};
-  inline static const std::string function_of_time_for_scaling_{"Expansion"};
-  inline static const std::string function_of_time_for_centers_{"GridCenters"};
+  static constexpr const char* function_of_time_for_scaling_{"Expansion"};
+  static constexpr const char* function_of_time_for_centers_{"GridCenters"};
 
   template <typename T>
   void apply_call_operator(

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/CubicCrystal.cpp
@@ -62,7 +62,9 @@ double CubicCrystal::poisson_ratio() const {
   return 1. / (1. + (c_11_ / c_12_));
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID CubicCrystal::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 void CubicCrystal::pup(PUP::er& p) {
   p | c_11_;

--- a/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
+++ b/src/PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp
@@ -168,8 +168,10 @@ bool operator!=(const IsotropicHomogeneous<Dim>& lhs,
                 const IsotropicHomogeneous<Dim>& rhs);
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID IsotropicHomogeneous<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace ConstitutiveRelations

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.hpp
@@ -166,8 +166,10 @@ class Barotropic2D : public EquationOfState<ColdEos::is_relativistic, 2> {
   ColdEos underlying_eos_;
 };
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename ColdEos>
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID EquationsOfState::Barotropic2D<ColdEos>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.hpp
@@ -173,7 +173,9 @@ class Barotropic3D : public EquationOfState<ColdEquilEos::is_relativistic, 3> {
   ColdEquilEos underlying_eos_;
 };
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename ColdEquilEos>
 PUP::able::PUP_ID EquationsOfState::Barotropic3D<ColdEquilEos>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
@@ -132,8 +132,10 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <bool IsRelativistic>
 PUP::able::PUP_ID EquationsOfState::DarkEnergyFluid<IsRelativistic>::my_PUP_ID =
     0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Enthalpy.cpp
@@ -540,8 +540,10 @@ double Enthalpy<LowDensityEoS>::rest_mass_density_from_enthalpy(
                                1.0e-15);
   }
 }
+#ifndef __CUDA_ARCH__
 template <typename LowDensityEoS>
 PUP::able::PUP_ID EquationsOfState::Enthalpy<LowDensityEoS>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template class EquationsOfState::Enthalpy<Spectral>;
 template class EquationsOfState::Enthalpy<PolytropicFluid<true>>;

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp
@@ -175,7 +175,9 @@ class Equilibrium3D : public EquationOfState<EquilEos::is_relativistic, 3> {
   EquilEos underlying_eos_;
 };
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename EquilEos>
 PUP::able::PUP_ID EquationsOfState::Equilibrium3D<EquilEos>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -169,8 +169,10 @@ class HybridEos
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename ColdEquationOfState>
 PUP::able::PUP_ID EquationsOfState::HybridEos<ColdEquationOfState>::my_PUP_ID =
     0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -152,7 +152,9 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <bool IsRelativistic>
 PUP::able::PUP_ID EquationsOfState::IdealFluid<IsRelativistic>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PiecewisePolytropicFluid.hpp
@@ -174,8 +174,10 @@ class PiecewisePolytropicFluid : public EquationOfState<IsRelativistic, 1> {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <bool IsRelativistic>
 PUP::able::PUP_ID
     EquationsOfState::PiecewisePolytropicFluid<IsRelativistic>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp
@@ -131,8 +131,10 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <bool IsRelativistic>
 PUP::able::PUP_ID EquationsOfState::PolytropicFluid<IsRelativistic>::my_PUP_ID =
     0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Spectral.cpp
@@ -311,6 +311,8 @@ double Spectral::rest_mass_density_from_enthalpy(
   }
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID EquationsOfState::Spectral::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
@@ -253,8 +253,10 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <bool IsRelativistic>
 PUP::able::PUP_ID EquationsOfState::Tabulated3D<IsRelativistic>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 
 }  // namespace EquationsOfState

--- a/src/PointwiseFunctions/InitialDataUtilities/NumericData.cpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/NumericData.cpp
@@ -55,7 +55,9 @@ bool operator!=(const NumericData& lhs, const NumericData& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NumericData::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 
 }  // namespace elliptic::analytic_data
 
@@ -83,6 +85,8 @@ bool operator!=(const NumericData& lhs, const NumericData& rhs) {
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NumericData::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 
 }  // namespace evolution::initial_data

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
@@ -212,10 +212,12 @@ bool operator!=(const Gaussian<VolumeDim, Fr>& lhs,
 }  // namespace MathFunctions
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim, typename Fr>
 PUP::able::PUP_ID MathFunctions::Gaussian<VolumeDim, Fr>::my_PUP_ID =
     0;  // NOLINT
 
 template <typename Fr>
 PUP::able::PUP_ID MathFunctions::Gaussian<1, Fr>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond

--- a/src/PointwiseFunctions/MathFunctions/PowX.hpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.hpp
@@ -85,6 +85,8 @@ class PowX<1, Fr> : public MathFunction<1, Fr> {
 }  // namespace MathFunctions
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Fr>
 PUP::able::PUP_ID MathFunctions::PowX<1, Fr>::my_PUP_ID = 0;  // NOLINT
+#endif                                                        // __CUDA_ARCH__
 /// \endcond

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
@@ -97,6 +97,8 @@ class Sinusoid<1, Fr> : public MathFunction<1, Fr> {
 }  // namespace MathFunctions
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Fr>
 PUP::able::PUP_ID MathFunctions::Sinusoid<1, Fr>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond

--- a/src/Time/ChangeSlabSize/Event.cpp
+++ b/src/Time/ChangeSlabSize/Event.cpp
@@ -4,5 +4,7 @@
 #include "Time/ChangeSlabSize/Event.hpp"
 
 namespace Events {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ChangeSlabSize::my_PUP_ID = 0;  // NOLINT
+#endif                                            // __CUDA_ARCH__
 }  // namespace Events

--- a/src/Time/StepChoosers/ByBlock.cpp
+++ b/src/Time/StepChoosers/ByBlock.cpp
@@ -47,8 +47,10 @@ void ByBlock<Dim>::pup(PUP::er& p) {
   p | sizes_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID ByBlock<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -90,7 +90,9 @@ class Cfl : public StepChooser<StepChooserUse::Slab>,
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Frame, typename System>
 PUP::able::PUP_ID Cfl<Frame, System>::my_PUP_ID = 0;  // NOLINT
+#endif                                                // __CUDA_ARCH__
 /// \endcond
 }  // namespace StepChoosers

--- a/src/Time/StepChoosers/Constant.cpp
+++ b/src/Time/StepChoosers/Constant.cpp
@@ -28,7 +28,9 @@ void Constant::pup(PUP::er& p) {
   p | value_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Constant::my_PUP_ID = 0;  // NOLINT
+#endif                                      // __CUDA_ARCH__
 }  // namespace StepChoosers
 
 template <>

--- a/src/Time/StepChoosers/ElementSizeCfl.hpp
+++ b/src/Time/StepChoosers/ElementSizeCfl.hpp
@@ -103,7 +103,9 @@ class ElementSizeCfl : public StepChooser<StepChooserUse::Slab>,
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename System>
 PUP::able::PUP_ID ElementSizeCfl<Dim, System>::my_PUP_ID = 0;  // NOLINT
+#endif                                                         // __CUDA_ARCH__
 /// \endcond
 }  // namespace StepChoosers

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -238,9 +238,11 @@ class ErrorControl : public StepChooser<StepChooserUse>,
   double safety_factor_ = std::numeric_limits<double>::signaling_NaN();
 };
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename StepChooserUse, typename EvolvedVariableTag,
           typename ErrorControlSelector>
 PUP::able::PUP_ID ErrorControl<StepChooserUse, EvolvedVariableTag,
                                ErrorControlSelector>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace StepChoosers

--- a/src/Time/StepChoosers/FixedLtsRatio.cpp
+++ b/src/Time/StepChoosers/FixedLtsRatio.cpp
@@ -25,5 +25,7 @@ void FixedLtsRatio::pup(PUP::er& p) {
   p | step_choosers_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID FixedLtsRatio::my_PUP_ID = 0;  // NOLINT
+#endif                                           // __CUDA_ARCH__
 }  // namespace StepChoosers

--- a/src/Time/StepChoosers/LimitIncrease.cpp
+++ b/src/Time/StepChoosers/LimitIncrease.cpp
@@ -26,5 +26,7 @@ void LimitIncrease::pup(PUP::er& p) {
   p | factor_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID LimitIncrease::my_PUP_ID = 0;  // NOLINT
+#endif                                           // __CUDA_ARCH__
 }  // namespace StepChoosers

--- a/src/Time/StepChoosers/Maximum.cpp
+++ b/src/Time/StepChoosers/Maximum.cpp
@@ -28,7 +28,9 @@ void Maximum::pup(PUP::er& p) {
   p | value_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Maximum::my_PUP_ID = 0;  // NOLINT
+#endif                                     // __CUDA_ARCH__
 }  // namespace StepChoosers
 
 template <>

--- a/src/Time/StepChoosers/PreventRapidIncrease.hpp
+++ b/src/Time/StepChoosers/PreventRapidIncrease.hpp
@@ -79,7 +79,9 @@ class PreventRapidIncrease : public StepChooser<StepChooserUse::Slab>,
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename VariablesTag>
 PUP::able::PUP_ID PreventRapidIncrease<VariablesTag>::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__
 /// \endcond
 }  // namespace StepChoosers

--- a/src/Time/StepChoosers/Random.cpp
+++ b/src/Time/StepChoosers/Random.cpp
@@ -71,8 +71,10 @@ void Random<VolumeDim>::pup(PUP::er& p) {
   p | seed_;
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t VolumeDim>
 PUP::able::PUP_ID Random<VolumeDim>::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Time/StepChoosers/StepToTimes.cpp
+++ b/src/Time/StepChoosers/StepToTimes.cpp
@@ -55,5 +55,7 @@ void StepToTimes::pup(PUP::er& p) {
   p | times_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID StepToTimes::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 }  // namespace StepChoosers

--- a/src/Time/TimeSequence.cpp
+++ b/src/Time/TimeSequence.cpp
@@ -51,8 +51,10 @@ void EvenlySpaced<T>::pup(PUP::er& p) {
   p | offset_;
 }
 
+#ifndef __CUDA_ARCH__
 template <typename T>
 PUP::able::PUP_ID EvenlySpaced<T>::my_PUP_ID = 0;  // NOLINT
+#endif                                             // __CUDA_ARCH__
 
 template <typename T>
 Specified<T>::Specified(std::vector<T> values) : values_(std::move(values)) {
@@ -87,8 +89,10 @@ void Specified<T>::pup(PUP::er& p) {
   p | values_;
 }
 
+#ifndef __CUDA_ARCH__
 template <typename T>
 PUP::able::PUP_ID Specified<T>::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 
 // For time values
 template class EvenlySpaced<double>;

--- a/src/Time/TimeSteppers/AdamsBashforth.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforth.cpp
@@ -377,4 +377,6 @@ TIME_STEPPER_DEFINE_OVERLOADS(AdamsBashforth)
 LTS_TIME_STEPPER_DEFINE_OVERLOADS(AdamsBashforth)
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::AdamsBashforth::my_PUP_ID = 0;  // NOLINT
+#endif                                                          // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/AdamsLts.cpp
+++ b/src/Time/TimeSteppers/AdamsLts.cpp
@@ -402,10 +402,11 @@ LtsCoefficients lts_coefficients(const ConstBoundaryHistoryTimes& local_times,
             continue;
           }
           step_coefficients.emplace_back(
-              local_ids[local_step_index], remote_ids[remote_step_index],
-              small_step_coefficients[contributing_small_step] *
-                  local_interpolation_coefficients[local_step_index] *
-                  remote_interpolation_coefficients[remote_step_index]);
+              std::tuple<TimeStepId, TimeStepId, double>{
+                  local_ids[local_step_index], remote_ids[remote_step_index],
+                  small_step_coefficients[contributing_small_step] *
+                      local_interpolation_coefficients[local_step_index] *
+                      remote_interpolation_coefficients[remote_step_index]});
         }
       }
     }

--- a/src/Time/TimeSteppers/AdamsMoultonPc.cpp
+++ b/src/Time/TimeSteppers/AdamsMoultonPc.cpp
@@ -604,8 +604,10 @@ TIME_STEPPER_DEFINE_OVERLOADS_TEMPLATED(AdamsMoultonPc<Monotonic>,
 LTS_TIME_STEPPER_DEFINE_OVERLOADS_TEMPLATED(AdamsMoultonPc<Monotonic>,
                                             bool Monotonic)
 
+#ifndef __CUDA_ARCH__
 template <bool Monotonic>
 PUP::able::PUP_ID AdamsMoultonPc<Monotonic>::my_PUP_ID = 0;  // NOLINT
+#endif                                                       // __CUDA_ARCH__
 
 #define MONOTONIC(data) BOOST_PP_TUPLE_ELEM(0, data)
 

--- a/src/Time/TimeSteppers/ClassicalRungeKutta4.cpp
+++ b/src/Time/TimeSteppers/ClassicalRungeKutta4.cpp
@@ -54,4 +54,6 @@ const RungeKutta::ButcherTableau& ClassicalRungeKutta4::butcher_tableau()
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::ClassicalRungeKutta4::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/DormandPrince5.cpp
+++ b/src/Time/TimeSteppers/DormandPrince5.cpp
@@ -63,4 +63,6 @@ const RungeKutta::ButcherTableau& DormandPrince5::butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::DormandPrince5::my_PUP_ID = 0;  // NOLINT
+#endif                                                          // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Heun2.cpp
+++ b/src/Time/TimeSteppers/Heun2.cpp
@@ -46,4 +46,6 @@ Heun2::implicit_butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Heun2::my_PUP_ID = 0;  // NOLINT
+#endif                                                 // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
+++ b/src/Time/TimeSteppers/Rk3HesthavenSsp.cpp
@@ -157,4 +157,6 @@ bool Rk3HesthavenSsp::can_change_step_size_impl(
 TIME_STEPPER_DEFINE_OVERLOADS(Rk3HesthavenSsp)
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk3HesthavenSsp::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk3Kennedy.cpp
+++ b/src/Time/TimeSteppers/Rk3Kennedy.cpp
@@ -60,4 +60,6 @@ Rk3Kennedy::implicit_butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk3Kennedy::my_PUP_ID = 0;  // NOLINT
+#endif                                                      // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk3Owren.cpp
+++ b/src/Time/TimeSteppers/Rk3Owren.cpp
@@ -39,4 +39,6 @@ const RungeKutta::ButcherTableau& Rk3Owren::butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk3Owren::my_PUP_ID = 0;  // NOLINT
+#endif                                                    // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk3Pareschi.cpp
+++ b/src/Time/TimeSteppers/Rk3Pareschi.cpp
@@ -60,4 +60,6 @@ Rk3Pareschi::implicit_butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk3Pareschi::my_PUP_ID = 0;  // NOLINT
+#endif                                                       // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk4Kennedy.cpp
+++ b/src/Time/TimeSteppers/Rk4Kennedy.cpp
@@ -71,4 +71,6 @@ Rk4Kennedy::implicit_butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk4Kennedy::my_PUP_ID = 0;  // NOLINT
+#endif                                                      // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk4Owren.cpp
+++ b/src/Time/TimeSteppers/Rk4Owren.cpp
@@ -53,4 +53,6 @@ const RungeKutta::ButcherTableau& Rk4Owren::butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk4Owren::my_PUP_ID = 0;  // NOLINT
+#endif                                                    // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk5Owren.cpp
+++ b/src/Time/TimeSteppers/Rk5Owren.cpp
@@ -62,4 +62,6 @@ const RungeKutta::ButcherTableau& Rk5Owren::butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk5Owren::my_PUP_ID = 0;  // NOLINT
+#endif                                                    // __CUDA_ARCH__

--- a/src/Time/TimeSteppers/Rk5Tsitouras.cpp
+++ b/src/Time/TimeSteppers/Rk5Tsitouras.cpp
@@ -52,4 +52,6 @@ const RungeKutta::ButcherTableau& Rk5Tsitouras::butcher_tableau() const {
 }
 }  // namespace TimeSteppers
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeSteppers::Rk5Tsitouras::my_PUP_ID = 0;  // NOLINT
+#endif                                                        // __CUDA_ARCH__

--- a/src/Time/Triggers/NearTimes.cpp
+++ b/src/Time/Triggers/NearTimes.cpp
@@ -46,5 +46,7 @@ void NearTimes::pup(PUP::er& p) {
   p | direction_;
 }
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NearTimes::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Time/Triggers/OnSubsteps.cpp
+++ b/src/Time/Triggers/OnSubsteps.cpp
@@ -4,5 +4,7 @@
 #include "Time/Triggers/OnSubsteps.hpp"
 
 namespace Triggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID OnSubsteps::my_PUP_ID = 0;  // NOLINT
+#endif                                        // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Time/Triggers/SlabCompares.cpp
+++ b/src/Time/Triggers/SlabCompares.cpp
@@ -4,5 +4,7 @@
 #include "Time/Triggers/SlabCompares.hpp"
 
 namespace Triggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SlabCompares::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Time/Triggers/Slabs.cpp
+++ b/src/Time/Triggers/Slabs.cpp
@@ -4,5 +4,7 @@
 #include "Time/Triggers/Slabs.hpp"
 
 namespace Triggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Slabs::my_PUP_ID = 0;  // NOLINT
+#endif                                   // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Time/Triggers/StepsWithinSlab.cpp
+++ b/src/Time/Triggers/StepsWithinSlab.cpp
@@ -4,5 +4,7 @@
 #include "Time/Triggers/StepsWithinSlab.hpp"
 
 namespace Triggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID StepsWithinSlab::my_PUP_ID = 0;  // NOLINT
+#endif                                             // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Time/Triggers/TimeCompares.cpp
+++ b/src/Time/Triggers/TimeCompares.cpp
@@ -4,5 +4,7 @@
 #include "Time/Triggers/TimeCompares.hpp"
 
 namespace Triggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TimeCompares::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Time/Triggers/Times.cpp
+++ b/src/Time/Triggers/Times.cpp
@@ -4,5 +4,7 @@
 #include "Time/Triggers/Times.hpp"
 
 namespace Triggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Times::my_PUP_ID = 0;  // NOLINT
+#endif                                   // __CUDA_ARCH__
 }  // namespace Triggers

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -72,10 +72,12 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) cube(const T& x) {
  * \note The largest representable factorial is 20!. It is
  * up to the user to ensure this is satisfied
  */
-KOKKOS_FUNCTION constexpr uint64_t falling_factorial(const uint64_t x,
-                                                     const uint64_t n) {
+constexpr uint64_t falling_factorial(const uint64_t x, const uint64_t n) {
+  // Clang 18 compiling for CUDA 12.6 has issues with assert()
+#ifndef __CUDA_ARCH__
   // clang-tidy: don't warn about STL internals, I can't fix them
   assert(n <= x);  // NOLINT
+#endif
   uint64_t r = 1;
   for (uint64_t k = 0; k < n; ++k) {
     r *= (x - k);
@@ -87,8 +89,11 @@ KOKKOS_FUNCTION constexpr uint64_t falling_factorial(const uint64_t x,
  * \ingroup ConstantExpressionsGroup
  * \brief Compute the factorial of \f$n!\f$
  */
-KOKKOS_FUNCTION constexpr uint64_t factorial(const uint64_t n) {
+constexpr uint64_t factorial(const uint64_t n) {
+  // Clang 18 compiling for CUDA 12.6 has issues with assert()
+#ifndef __CUDA_ARCH__
   assert(n <= 20);  // NOLINT
+#endif
   return falling_factorial(n, n);
 }
 
@@ -169,29 +174,29 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) pow(const T& t) {
 /// The argument must be comparable to an int and must be negatable.
 template <typename T, Requires<tt::is_integer_v<T> or
                                std::is_floating_point_v<T>> = nullptr>
-KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr T ce_abs(const T& x) {
+SPECTRE_ALWAYS_INLINE constexpr T ce_abs(const T& x) {
   return x < 0 ? -x : x;
 }
 
 /// \cond
 template <>
-KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr double ce_abs(const double& x) {
+SPECTRE_ALWAYS_INLINE constexpr double ce_abs(const double& x) {
   return __builtin_fabs(x);
 }
 
 template <>
-KOKKOS_FUNCTION SPECTRE_ALWAYS_INLINE constexpr float ce_abs(const float& x) {
+SPECTRE_ALWAYS_INLINE constexpr float ce_abs(const float& x) {
   return __builtin_fabsf(x);
 }
 /// \endcond
 
 /// \ingroup ConstantExpressionsGroup
 /// \brief Compute the absolute value of its argument
-KOKKOS_FUNCTION constexpr SPECTRE_ALWAYS_INLINE double ce_fabs(const double x) {
+constexpr SPECTRE_ALWAYS_INLINE double ce_fabs(const double x) {
   return ce_abs(x);
 }
 
-KOKKOS_FUNCTION constexpr SPECTRE_ALWAYS_INLINE float ce_fabs(const float x) {
+constexpr SPECTRE_ALWAYS_INLINE float ce_fabs(const float x) {
   return ce_abs(x);
 }
 

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
@@ -655,25 +655,6 @@ void test(const bool include_expansion, const bool include_rotation,
 }
 
 template <bool IsCylindrical>
-void check_names() {
-  INFO("Check names");
-  // These are hard-coded so this is just a regression test
-  CHECK(TimeDependentMapOptions<IsCylindrical>::expansion_name == "Expansion"s);
-  CHECK(TimeDependentMapOptions<IsCylindrical>::expansion_outer_boundary_name ==
-        "ExpansionOuterBoundary"s);
-  CHECK(TimeDependentMapOptions<IsCylindrical>::rotation_name == "Rotation"s);
-  CHECK(TimeDependentMapOptions<IsCylindrical>::translation_name ==
-        "Translation"s);
-  CHECK(TimeDependentMapOptions<IsCylindrical>::skew_name == "Skew"s);
-  CHECK(TimeDependentMapOptions<IsCylindrical>::size_names ==
-        std::array{"SizeA"s, "SizeB"s});
-  CHECK(TimeDependentMapOptions<IsCylindrical>::shape_names ==
-        std::array{"ShapeA"s, "ShapeB"s});
-  CHECK(TimeDependentMapOptions<IsCylindrical>::grid_centers_name ==
-        "GridCenters"s);
-}
-
-template <bool IsCylindrical>
 void test_errors() {
   INFO("Test errors");
   CAPTURE(IsCylindrical);
@@ -867,8 +848,6 @@ SPECTRE_TEST_CASE(
                transition_ends_at_cube_A, transition_ends_at_cube_B,
                include_grid_centers);
   }
-  check_names<true>();
-  check_names<false>();
   test_errors<true>();
   test_errors<false>();
   test_worldtube_fots();

--- a/tests/Unit/Domain/FunctionsOfTime/Test_OutputTimeBounds.cpp
+++ b/tests/Unit/Domain/FunctionsOfTime/Test_OutputTimeBounds.cpp
@@ -66,7 +66,9 @@ class TestFoT : public domain::FunctionsOfTime::FunctionOfTime {
   double upper_bound_{};
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestFoT::my_PUP_ID = 0;  // NOLINT
+#endif                                     // __CUDA_ARCH__
 
 SPECTRE_TEST_CASE("Unit.Domain.FunctionsOfTime.OutputTimeBounds",
                   "[Unit][Domain]") {

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -660,13 +660,12 @@ struct TestTimeDependentMapOptions {
 
   // Names are public because they need to be used when constructing maps in the
   // BCO domain creators themselves
-  inline static const std::string expansion_name{"Expansion"};
-  inline static const std::string expansion_outer_boundary_name{
+  static constexpr const char* expansion_name{"Expansion"};
+  static constexpr const char* expansion_outer_boundary_name{
       "ExpansionOuterBoundary"};
-  inline static const std::string rotation_name{"Rotation"};
-  inline static const std::array<std::string, 2> size_names{{"SizeA", "SizeB"}};
-  inline static const std::array<std::string, 2> shape_names{
-      {"ShapeA", "ShapeB"}};
+  static constexpr const char* rotation_name{"Rotation"};
+  static constexpr std::array<const char*, 2> size_names{{"SizeA", "SizeB"}};
+  static constexpr std::array<const char*, 2> shape_names{{"ShapeA", "ShapeB"}};
 
  private:
   static size_t get_index(const ObjectLabel object) {

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -46,7 +46,9 @@ struct NoAnalyticSolution : elliptic::analytic_data::Background {
   // Does _not_ provide variables for all system fields
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID NoAnalyticSolution::my_PUP_ID = 0;  // NOLINT
+#endif                                                // __CUDA_ARCH__
 
 struct AnalyticSolution : elliptic::analytic_data::AnalyticSolution {
   AnalyticSolution() = default;
@@ -65,7 +67,9 @@ struct AnalyticSolution : elliptic::analytic_data::AnalyticSolution {
   }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID AnalyticSolution::my_PUP_ID = 0;  // NOLINT
+#endif                                              // __CUDA_ARCH__
 #pragma GCC diagnostic pop
 
 template <typename Metavariables>

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
@@ -68,7 +68,9 @@ struct InitialGuess : elliptic::analytic_data::InitialGuess {
   // NOLINTEND(readability-convert-member-functions-to-static)
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID InitialGuess::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 
 template <typename Metavariables>
 struct ElementArray {

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
@@ -67,7 +67,9 @@ struct Background : elliptic::analytic_data::Background {
   // NOLINTEND(readability-convert-member-functions-to-static)
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID Background::my_PUP_ID = 0;  // NOLINT
+#endif                                        // __CUDA_ARCH__
 
 template <typename Metavariables>
 struct ElementArray {

--- a/tests/Unit/Elliptic/Actions/Test_RunEventsAndTriggers.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_RunEventsAndTriggers.cpp
@@ -65,7 +65,9 @@ struct TestEvent : public Event {
   bool needs_evolved_variables() const override { return false; }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestEvent::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 
 struct Label {};
 

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
@@ -94,8 +94,10 @@ struct TestSolution : elliptic::analytic_data::AnalyticSolution {
   }
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID TestSolution<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 
 template <size_t Dim>
 struct Metavariables {

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_BoundaryCondition.cpp
@@ -103,7 +103,9 @@ class TestBoundaryCondition : public BoundaryCondition<1> {
   }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestBoundaryCondition::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 }  // namespace
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -294,8 +294,10 @@ struct RandomBackground : elliptic::analytic_data::Background {
   }
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID RandomBackground<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                                   // __CUDA_ARCH__
 
 template <typename SubdomainOperator, typename Fields>
 struct ApplySubdomainOperator {

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -340,8 +340,10 @@ struct ModifiedPoissonSolution : Poisson::Solutions::ProductOfSinusoids<Dim> {
   }
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID ModifiedPoissonSolution<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                                          // __CUDA_ARCH__
 
 template <
     typename System, bool Linearized, typename AnalyticSolution,

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -75,8 +75,10 @@ struct BoundaryCondition
   std::vector<elliptic::BoundaryConditionType> bc_types_;
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID BoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                                    // __CUDA_ARCH__
 
 // We don't actually solve the subdomain operator in this test, because it is
 // implemented and tested elsewhere. Instead, we test the solver is invoked

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndDenseTriggers.cpp
@@ -165,7 +165,9 @@ class TestTrigger : public DenseTrigger {
   std::optional<double> next_trigger_{};
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestTrigger::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 
 struct TestEvent : public Event {
   TestEvent() = default;
@@ -258,7 +260,9 @@ struct TestEvent : public Event {
 
 std::vector<DataTuple> TestEvent::calls{};
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestEvent::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 
 struct System {
   using variables_tag = Tags::Variables<tmpl::list<EvolvedVar>>;

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndTriggers.cpp
@@ -78,7 +78,9 @@ struct TestEvent : public Event {
 };
 
 std::optional<double> TestEvent::last_value{};
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestEvent::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 
 template <typename Metavariables>
 struct Component {

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -104,8 +104,10 @@ struct SystemAnalyticSolution : public MarkAsAnalyticSolution,
   void pup(PUP::er& /*p*/) override {}  // NOLINT
 };
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID SystemAnalyticSolution::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 struct System {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -162,8 +162,10 @@ struct BoundaryTerms final : public BoundaryCorrection<Dim> {
   }
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID BoundaryTerms<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                                // __CUDA_ARCH__
 
 template <bool LocalTimeStepping>
 struct SetLocalMortarData {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -733,12 +733,14 @@ struct BoundaryTerms final
   double sign_of_normal_{0.0};
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, bool HasPrims, SystemType SysType,
           bool HasInverseSpatialMetric>
 PUP::able::PUP_ID
     // NOLINTNEXTLINE
     BoundaryTerms<Dim, HasPrims, SysType, HasInverseSpatialMetric>::my_PUP_ID =
         0;
+#endif  // __CUDA_ARCH__
 
 // Forward declare different boundary conditions.
 //
@@ -930,9 +932,11 @@ class DemandOutgoingCharSpeeds : public BoundaryCondition<System> {
   bool mesh_is_moving_{false};
 };
 
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID DemandOutgoingCharSpeeds<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 class Ghost : public BoundaryCondition<System> {
@@ -1366,9 +1370,11 @@ class Ghost : public BoundaryCondition<System> {
   bool mesh_is_moving_{false};
 };
 
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID Ghost<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 class TimeDerivative : public BoundaryCondition<System> {
@@ -1676,9 +1682,11 @@ class TimeDerivative : public BoundaryCondition<System> {
   double expected_dt_var1_{std::numeric_limits<double>::signaling_NaN()};
 };
 
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID TimeDerivative<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename System>
 class GhostAndTimeDerivative : public BoundaryCondition<System> {
@@ -2061,9 +2069,11 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
   TimeDerivative<System> time_derivative_;
 };
 
+#ifndef __CUDA_ARCH__
 template <typename System>
 // NOLINTNEXTLINE
 PUP::able::PUP_ID GhostAndTimeDerivative<System>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <bool AddTypeAlias, size_t Dim>
 struct InverseSpatialMetricTagImpl {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -273,8 +273,10 @@ struct Correction final : public CorrectionBase {
   }
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, typename VolumeDoubleType>
 PUP::able::PUP_ID Correction<Dim, VolumeDoubleType>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim, bool CurvedBackground, typename VolumeDoubleType>
 void test_impl(const gsl::not_null<std::mt19937*> gen) {

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -144,8 +144,10 @@ struct SystemAnalyticSolution : public MarkAsAnalyticSolution,
   }
 };
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID SystemAnalyticSolution::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 struct SystemAnalyticData : public MarkAsAnalyticData,
                             public evolution::initial_data::InitialData {
@@ -215,8 +217,10 @@ struct SystemAnalyticData : public MarkAsAnalyticData,
   void pup(PUP::er& p) override { InitialData::pup(p); }
 };
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID SystemAnalyticData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim, bool HasPrimitiveAndConservativeVars>
 struct System {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -76,7 +76,9 @@ struct RotatingSchwarzschildWithNoninertialNews
   }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID RotatingSchwarzschildWithNoninertialNews::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 struct SetRandomBoundaryValues {
   template <typename DbTags, typename... InboxTags, typename Metavariables,

--- a/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_KleinGordonWorldtubeData.cpp
@@ -132,8 +132,10 @@ class KleinGordonDummyBufferUpdater
   size_t l_max_ = 0;
 };
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID Cce::KleinGordonDummyBufferUpdater::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 namespace {
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -410,10 +410,12 @@ class BondiBufferUpdater
   size_t l_max_ = 0;
 };
 
+#ifndef __CUDA_ARCH__
 template <typename T>
 PUP::able::PUP_ID Cce::DummyBufferUpdater<T>::my_PUP_ID = 0;  // NOLINT
 template <typename T>
 PUP::able::PUP_ID Cce::BondiBufferUpdater<T>::my_PUP_ID = 0;  // NOLINT
+#endif                                                        // __CUDA_ARCH__
 
 template class Cce::DummyBufferUpdater<ComplexModalVector>;
 template class Cce::DummyBufferUpdater<DataVector>;

--- a/tests/Unit/Evolution/Test_ComputeTags.cpp
+++ b/tests/Unit/Evolution/Test_ComputeTags.cpp
@@ -58,7 +58,9 @@ struct TestAnalyticSolution : public MarkAsAnalyticSolution,
   void pup(PUP::er& p) override { InitialData::pup(p); }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestAnalyticSolution::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 struct TestAnalyticData : public MarkAsAnalyticData,
                           public evolution::initial_data::InitialData {
@@ -86,8 +88,10 @@ struct TestAnalyticData : public MarkAsAnalyticData,
   void pup(PUP::er& p) override { InitialData::pup(p); }
 };
 
+#ifndef __CUDA_ARCH__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PUP::able::PUP_ID TestAnalyticData::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeTags", "[Unit][Evolution]") {

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -126,9 +126,11 @@ template <typename Label, typename ControlSystems, bool CallRunCallbacks>
 size_t TestEvent<Label, ControlSystems, CallRunCallbacks>::call_count = 0;
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Label, typename ControlSystems, bool CallRunCallbacks>
 PUP::able::PUP_ID
     TestEvent<Label, ControlSystems, CallRunCallbacks>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 /// \endcond
 // NOLINTEND
 

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.cpp
@@ -91,8 +91,10 @@ bool operator!=(const TestBoundaryCondition<Dim>& lhs,
   return not(lhs == rhs);
 }
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID TestBoundaryCondition<Dim>::my_PUP_ID = 0;  // NOLINT
+#endif                                                        // __CUDA_ARCH__
 
 template <size_t Dim>
 void test_boundary_conditions(

--- a/tests/Unit/Helpers/Domain/CMakeLists.txt
+++ b/tests/Unit/Helpers/Domain/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(
   DomainCreators
   ErrorHandling
   Framework
+  H5
   Spectral
 
   PUBLIC

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -790,8 +790,10 @@ struct BoundaryTerms final : public BoundaryCorrection<Dim, HasPrims> {
   /// [bt_mp]
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim, bool HasPrims>
 PUP::able::PUP_ID BoundaryTerms<Dim, HasPrims>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 // We only use an DemandOutgoingCharSpeeds boundary condition with a static
 // member variable that we set to verify the call went through. The actual
@@ -860,8 +862,10 @@ class DemandOutgoingCharSpeeds : public BoundaryCondition<Dim> {
   static size_t number_of_times_called;
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Dim>
 PUP::able::PUP_ID DemandOutgoingCharSpeeds<Dim>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <size_t Dim>
 size_t DemandOutgoingCharSpeeds<Dim>::number_of_times_called = 0;

--- a/tests/Unit/Helpers/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/TestTrigger.cpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/TestTrigger.cpp
@@ -4,5 +4,7 @@
 #include "Helpers/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp"
 
 namespace TestHelpers::DenseTriggers {
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestTrigger::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 }  // namespace TestHelpers::DenseTriggers

--- a/tests/Unit/Helpers/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/TestTrigger.hpp
@@ -143,7 +143,9 @@ class BoxTrigger : public DenseTrigger {
 };
 
 /// \cond
+#ifndef __CUDA_ARCH__
 template <typename Label>
 PUP::able::PUP_ID BoxTrigger<Label>::my_PUP_ID = 0;  // NOLINT
+#endif                                               // __CUDA_ARCH__
 /// \endcond
 }  // namespace TestHelpers::DenseTriggers

--- a/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterEvents.cpp
@@ -80,7 +80,9 @@ class SomeEvent : public Event {
   std::string subfile_path_;
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SomeEvent::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 
 template <typename Metavariables>
 struct Component {

--- a/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_ExecutePhaseChange.cpp
@@ -107,8 +107,10 @@ struct TestPhaseChange : public PhaseChange {
   void pup(PUP::er& /*p*/) override {}  // NOLINT
 };
 
+#ifndef __CUDA_ARCH__
 template <PhaseControl::ArbitrationStrategy Strategy, size_t Index>
 PUP::able::PUP_ID TestPhaseChange<Strategy, Index>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 struct Metavariables {
   using component_list = tmpl::list<>;

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseChange.cpp
@@ -133,7 +133,9 @@ struct TestPhaseChange : public PhaseChange {
   int stored_multiplier_ = 0;
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestPhaseChange::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 struct Metavariables {
   using component_list = tmpl::list<TestComponentAlpha, TestComponentBeta>;

--- a/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_PhaseControlTags.cpp
@@ -80,8 +80,10 @@ struct TestCreatable : public PhaseChange {
   int option_value_ = 0;
 };
 
+#ifndef __CUDA_ARCH__
 template <size_t Val>
 PUP::able::PUP_ID TestCreatable<Val>::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 struct Metavariables {
   struct factory_creation

--- a/tests/Unit/Parallel/Test_AlgorithmPhaseControl.hpp
+++ b/tests/Unit/Parallel/Test_AlgorithmPhaseControl.hpp
@@ -101,8 +101,10 @@ struct SolveTrigger : public Trigger {
   bool operator()(const size_t step) const { return step % 3 == 0; }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID SolveTrigger::my_PUP_ID = 0;
 PUP::able::PUP_ID RegisterTrigger::my_PUP_ID = 0;
+#endif  // __CUDA_ARCH__
 
 template <typename Metavariables>
 struct ComponentAlpha {

--- a/tests/Unit/Parallel/Test_GlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_GlobalCache.cpp
@@ -621,12 +621,14 @@ void Test_GlobalCache<Metavariables>::exit() {
 // --------- registration stuff below -------
 
 // clang-format off
+#ifndef __CUDA_ARCH__
 PUPable_def(UseCkCallbackAsCallback)
 // clang-tidy: possibly throwing constructor static storage
 // clang-tidy: false positive: redundant declaration
 PUP::able::PUP_ID Triangle::my_PUP_ID = 0;  // NOLINT
 PUP::able::PUP_ID Square::my_PUP_ID = 0;        // NOLINT
 PUP::able::PUP_ID Arthropod::my_PUP_ID = 0;     // NOLINT
+#endif  // __CUDA_ARCH__
 // clang-format on
 
 extern "C" void CkRegisterMainModule() {

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
@@ -90,7 +90,9 @@ class CriterionOne : public amr::Criterion {
   double critical_value_{0.0};
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID CriterionOne::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 
 class CriterionTwo : public amr::Criterion {
  public:
@@ -139,7 +141,9 @@ class CriterionTwo : public amr::Criterion {
   double target_value_{0.0};
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID CriterionTwo::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 #pragma GCC diagnostic pop
 
 struct Metavariables {

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Criterion.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Criterion.cpp
@@ -89,7 +89,9 @@ class CriterionOne : public ah::Criterion {
   double target_value_{std::numeric_limits<double>::signaling_NaN()};
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID CriterionOne::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 
 class CriterionTwo : public ah::Criterion {
  public:
@@ -135,7 +137,9 @@ class CriterionTwo : public ah::Criterion {
   double target_value_{std::numeric_limits<double>::signaling_NaN()};
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID CriterionTwo::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 #pragma GCC diagnostic pop
 
 struct Metavariables {

--- a/tests/Unit/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Test_Filter.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndDenseTriggers/DenseTriggers/Test_Filter.cpp
@@ -64,7 +64,9 @@ class TestTrigger : public Trigger {
   bool result_{};
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestTrigger::my_PUP_ID = 0;  // NOLINT
+#endif                                         // __CUDA_ARCH__
 
 struct Metavariables {
   using component_list = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndDenseTriggers/Test_EventsAndDenseTriggers.cpp
@@ -123,8 +123,10 @@ template <typename Label>
 std::optional<double> TestEvent<Label>::previous_time_during_event =
     std::nullopt;
 
+#ifndef __CUDA_ARCH__
 template <typename Label>
 PUP::able::PUP_ID TestEvent<Label>::my_PUP_ID = 0;  // NOLINT
+#endif                                              // __CUDA_ARCH__
 
 namespace EventLabels {
 struct A {
@@ -375,7 +377,9 @@ class MutatingTrigger : public DenseTrigger {
   }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID MutatingTrigger::my_PUP_ID = 0;  // NOLINT
+#endif                                             // __CUDA_ARCH__
 
 struct MutatingMetavariables {
   using component_list = tmpl::list<>;

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -96,7 +96,9 @@ struct TestEvent : public Event {
   bool needs_evolved_variables() const override { return false; }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID TestEvent::my_PUP_ID = 0;  // NOLINT
+#endif                                       // __CUDA_ARCH__
 
 struct Component {};
 

--- a/tests/Unit/Time/StepChoosers/Test_FixedLtsRatio.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_FixedLtsRatio.cpp
@@ -53,7 +53,9 @@ class ErrorChooser : public StepChooser<StepChooserUse::LtsStep> {
   bool can_be_delayed() const override { return true; }
 };
 
+#ifndef __CUDA_ARCH__
 PUP::able::PUP_ID ErrorChooser::my_PUP_ID = 0;  // NOLINT
+#endif                                          // __CUDA_ARCH__
 
 struct Metavariables {
   struct factory_creation

--- a/tests/Unit/Utilities/Serialization/Test_PupStlCpp11.cpp
+++ b/tests/Unit/Utilities/Serialization/Test_PupStlCpp11.cpp
@@ -127,6 +127,8 @@ SPECTRE_TEST_CASE("Unit.Serialization.PupStlCpp11", "[Serialization][Unit]") {
   }
 }
 
+#ifndef __CUDA_ARCH__
 // clang-tidy: possibly throwing constructor static storage
 // clang-tidy: false positive: redundant declaration
 PUP::able::PUP_ID Test_Classes::DerivedInPupStlCpp11::my_PUP_ID = 0;  // NOLINT
+#endif  // __CUDA_ARCH__


### PR DESCRIPTION
## Proposed changes

Make the code compile with Clang's CUDA support (https://llvm.org/docs/CompileCudaWithLLVM.html). It lags a few versions behind NVCC, so we still have to support compiling with NVCC to use the latest CUDA, but it could be a useful alternative (probably needs less memory and is faster than NVCC, which currently can't actually compile the whole code on CI).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
