### PR TITLE
AH rewrite: Add new events for the horizon finder

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -502,7 +502,7 @@ struct EvolutionMetavars {
             tmpl::flatten<tmpl::list<
                 intrp::Events::Interpolate<3, AhA, interpolator_source_vars>,
                 intrp::Events::Interpolate<3, AhB, interpolator_source_vars>,
-                ah::Events::FindCommonHorizon<
+                intrp::Events::FindCommonHorizon<
                     volume_dim, AhC, interpolator_source_vars, observe_fields,
                     non_tensor_compute_tags>,
                 intrp::Events::InterpolateWithoutInterpComponent<

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/CMakeLists.txt
@@ -5,5 +5,6 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  FindApparentHorizon.hpp
   FindCommonHorizon.hpp
   )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/String.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/Actions/GetItemFromDistributedObject.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Events {
+/*!
+ * \brief Starts a horizon find by sending volume data (`ah::source_vars`) to
+ * the horizon finder component (`ah::Component`) using the
+ * `ah::FindApparentHorizon` simple action.
+ *
+ * \details Only sends data if this Element is in the
+ * `ah::Tags::BlocksForHorizonFind` tag.
+ *
+ */
+template <typename HorizonMetavars>
+class FindApparentHorizon : public Event {
+ public:
+  /// \cond
+  explicit FindApparentHorizon(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(FindApparentHorizon);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr Options::String help = "Start a horizon find.";
+
+  static std::string name() { return pretty_type::name<HorizonMetavars>(); }
+
+  FindApparentHorizon() = default;
+
+  /// This constructor is not available through options
+  explicit FindApparentHorizon(std::optional<std::string> dependency)
+      : dependency_(std::move(dependency)) {}
+
+  using compute_tags_for_observation_box =
+      typename HorizonMetavars::compute_tags_on_element;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::append<tmpl::list<typename HorizonMetavars::time_tag,
+                              ::Events::Tags::ObserverMesh<3>>,
+                   ah::source_vars<3>>;
+
+  template <typename Metavariables, typename ParallelComponent>
+  void operator()(const LinkedMessageId<double>& time, const Mesh<3>& mesh,
+                  const tnsr::aa<DataVector, 3>& spacetime_metric,
+                  const tnsr::aa<DataVector, 3>& pi,
+                  const tnsr::iaa<DataVector, 3>& phi,
+                  const tnsr::ijaa<DataVector, 3>& deriv_phi,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<3>& array_index,
+                  const ParallelComponent* const /*meta*/,
+                  const ObservationValue& /*observation_value*/) const {
+    const auto& blocks_to_interpolate =
+        Parallel::get<ah::Tags::BlocksForHorizonFind>(cache);
+    ASSERT(blocks_to_interpolate.contains(name()),
+           "Blocks to interpolate doesn't contain target " << name());
+    const auto& blocks_to_interpolate_for_this_target =
+        blocks_to_interpolate.at(name());
+    const auto& blocks = Parallel::get<domain::Tags::Domain<3>>(cache).blocks();
+    const auto& block_name = blocks[array_index.block_id()].name();
+
+    // Only send data if this target needs this blocks data
+    if (not blocks_to_interpolate_for_this_target.contains(block_name)) {
+      return;
+    }
+
+    // Put everything into a single variables
+    Variables<ah::source_vars<3>> source_vars{mesh.number_of_grid_points()};
+    get<gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars) =
+        spacetime_metric;
+    get<gh::Tags::Pi<DataVector, 3>>(source_vars) = pi;
+    get<gh::Tags::Phi<DataVector, 3>>(source_vars) = phi;
+    get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                      Frame::Inertial>>(source_vars) = deriv_phi;
+
+    auto& horizon_finder_proxy = Parallel::get_parallel_component<
+        ah::Component<Metavariables, HorizonMetavars>>(cache);
+
+    Parallel::simple_action<ah::FindApparentHorizon<HorizonMetavars>>(
+        horizon_finder_proxy, time, array_index, mesh, std::move(source_vars),
+        dependency_);
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*component*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+  void pup(PUP::er& p) override {
+    Event::pup(p);
+    p | dependency_;
+  }
+
+ private:
+  std::optional<std::string> dependency_;
+};
+
+/// \cond
+// NOLINTBEGIN
+template <typename HorizonMetavars>
+PUP::able::PUP_ID FindApparentHorizon<HorizonMetavars>::my_PUP_ID = 0;
+// NOLINTEND
+/// \endcond
+}  // namespace ah::Events

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
@@ -41,7 +41,7 @@ struct ObserverMesh;
 }  // namespace Events::Tags
 /// \endcond
 
-namespace ah::Events {
+namespace intrp::Events {
 /*!
  * \brief Event that combines the `intrp::Events::interpolate` event with
  * `dg::Events::ObserveFields` specifically for common horizon finding.
@@ -169,4 +169,4 @@ PUP::able::PUP_ID FindCommonHorizon<
     tmpl::list<Tensors...>, tmpl::list<NonTensorComputeTags...>>::my_PUP_ID = 0;
 // NOLINTEND
 /// \endcond
-}  // namespace ah::Events
+}  // namespace intrp::Events

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
@@ -8,17 +8,20 @@
 #include <string>
 #include <type_traits>
 
+#include "DataStructures/DataVector.hpp"
 #include "Options/String.hpp"
 #include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
 #include "Parallel/ArrayCollection/PerformAlgorithmOnElement.hpp"
 #include "Parallel/ArrayCollection/Tags/ElementLocations.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Actions/GetItemFromDistributedObject.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/Events/ObserveFields.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/GetComputeItemsOnSource.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolate.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -170,3 +173,129 @@ PUP::able::PUP_ID FindCommonHorizon<
 // NOLINTEND
 /// \endcond
 }  // namespace intrp::Events
+
+namespace ah::Events {
+/*!
+ * \brief Event that combines the `ah::Events::FindApparentHorizon` event with
+ * `dg::Events::ObserveFields` specifically for common horizon finding.
+ *
+ * \details This is just a thin wrapper around each event and doesn't do
+ * anything extra.
+ */
+template <typename HorizonMetavars, typename Tensors,
+          typename NonTensorComputeTagsList = tmpl::list<>>
+class FindCommonHorizon;
+
+template <typename HorizonMetavars, typename... Tensors,
+          typename... NonTensorComputeTags>
+class FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
+                        tmpl::list<NonTensorComputeTags...>> : public Event {
+  using ObserveFieldsEvent =
+      dg::Events::ObserveFields<3, tmpl::list<Tensors...>,
+                                tmpl::list<NonTensorComputeTags...>>;
+  using HorizonFindEvent = ah::Events::FindApparentHorizon<HorizonMetavars>;
+
+ public:
+  /// \cond
+  explicit FindCommonHorizon(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(FindCommonHorizon);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::append<typename ObserveFieldsEvent::options,
+                               typename HorizonFindEvent::options>;
+  static constexpr Options::String help =
+      "Starts a common horizon find and sends the evolved variables to be "
+      "written to disk.";
+
+  static std::string name() { return pretty_type::name<HorizonMetavars>(); }
+
+  FindCommonHorizon() = default;
+
+  FindCommonHorizon(
+      const std::string& subfile_name,
+      FloatingPointType coordinates_floating_point_type,
+      const std::vector<FloatingPointType>& floating_point_types,
+      const std::vector<std::string>& variables_to_observe,
+      std::optional<std::vector<std::string>> active_block_or_block_groups = {},
+      std::optional<Mesh<3>> interpolation_mesh = {},
+      const Options::Context& context = {})
+      : observe_fields_event_(subfile_name, coordinates_floating_point_type,
+                              floating_point_types, variables_to_observe,
+                              active_block_or_block_groups, interpolation_mesh,
+                              {name()}, context),
+        horizon_find_event_(subfile_name) {}
+
+  using compute_tags_for_observation_box = tmpl::remove_duplicates<tmpl::append<
+      typename ObserveFieldsEvent::compute_tags_for_observation_box,
+      typename HorizonFindEvent::compute_tags_for_observation_box>>;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<::Tags::ObservationBox, ::Events::Tags::ObserverMesh<3>>;
+
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename Metavariables, typename ParallelComponent>
+  void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
+                  const Mesh<3>& mesh,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<3>& array_index,
+                  const ParallelComponent* const component,
+                  const ObservationValue& observation_value) const {
+    observe_fields_event_(box, mesh, cache, array_index, component,
+                          observation_value);
+
+    horizon_find_event_(
+        get<typename HorizonMetavars::time_tag>(box), mesh,
+        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(box),
+        get<gh::Tags::Pi<DataVector, 3>>(box),
+        get<gh::Tags::Phi<DataVector, 3>>(box),
+        get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                          Frame::Inertial>>(box),
+        cache, array_index, component, observation_value);
+  }
+
+  using observation_registration_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList>
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration(
+      const db::DataBox<DbTagsList>& box) const {
+    return observe_fields_event_.get_observation_type_and_key_for_registration(
+        box);
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override {
+    Event::pup(p);
+    p | observe_fields_event_;
+    p | horizon_find_event_;
+  }
+
+ private:
+  ObserveFieldsEvent observe_fields_event_;
+  HorizonFindEvent horizon_find_event_;
+};
+
+/// \cond
+// NOLINTBEGIN
+template <typename HorizonMetavars, typename... Tensors,
+          typename... NonTensorComputeTags>
+PUP::able::PUP_ID
+    FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
+                      tmpl::list<NonTensorComputeTags...>>::my_PUP_ID = 0;
+// NOLINTEND
+/// \endcond
+}  // namespace ah::Events

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/CMakeLists.txt
@@ -3,5 +3,6 @@
 
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
+  Events/Test_FindApparentHorizon.cpp
   Events/Test_FindCommonHorizon.cpp
   PARENT_SCOPE)

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
@@ -1,0 +1,231 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "ControlSystem/UpdateFunctionOfTime.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Tags/Metavariables.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct MockFindApparentHorizon {
+  struct Results {
+    LinkedMessageId<double> time{};
+    ElementId<3> element_id{};
+    Mesh<3> mesh;
+    Variables<ah::source_vars<3>> vars;
+    std::optional<std::string> dependency;
+  };
+  static Results results;  // NOLINT
+
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(
+      db::DataBox<DbTags>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const LinkedMessageId<double>& incoming_time,
+      const ElementId<3>& incoming_element_id, const ::Mesh<3>& incoming_mesh,
+      Variables<ah::source_vars<3>>&& incoming_source_vars,
+      const std::optional<std::string>& dependency,
+      const bool /*source_vars_have_already_been_received*/ = false) {
+    results.time = incoming_time;
+    results.element_id = incoming_element_id;
+    results.mesh = incoming_mesh;
+    results.vars = incoming_source_vars;
+    results.dependency = dependency;
+  }
+};
+
+MockFindApparentHorizon::Results MockFindApparentHorizon::results{};  // NOLINT
+
+struct MockHorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using time_tag = ::Tags::TimeAndPrevious<0>;
+
+  using frame = ::Frame::Grid;
+
+  // Don't need callbacks
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() { return "MockHorizonMetavars"; }
+};
+
+template <typename Metavariables>
+struct MockComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      ah::Component<Metavariables, MockHorizonMetavars>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<3>, ah::Tags::BlocksForHorizonFind>;
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<ah::FindApparentHorizon<MockHorizonMetavars>>;
+  using with_these_simple_actions = tmpl::list<MockFindApparentHorizon>;
+};
+
+template <typename Metavariables>
+struct MockElement {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<3>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+};
+
+struct MockMetavariables {
+  using component_list = tmpl::list<MockComponent<MockMetavariables>,
+                                    MockElement<MockMetavariables>>;
+
+  using event = ah::Events::FindApparentHorizon<MockHorizonMetavars>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<Event, tmpl::list<event>>>;
+  };
+};
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
+                  "[ApparentHorizonFinder][Unit]") {
+  (void)MockHorizonMetavars::destination;
+  ::domain::FunctionsOfTime::register_derived_with_charm();
+  ::domain::creators::register_derived_with_charm();
+  using metavars = MockMetavariables;
+  const ElementId<3> element_id(2);
+  const ElementId<3> array_index(element_id);
+
+  using component = MockComponent<metavars>;
+  using elem_component = MockElement<metavars>;
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  const double initial_expr_time = 0.1;
+  const std::string name{"FunctionToCheck"};
+  functions_of_time[name] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
+          0.0, std::array<DataVector, 1>{{DataVector{1, 0.0}}},
+          initial_expr_time);
+  const auto domain_creator = domain::creators::Sphere(
+      1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
+  const auto block_names = domain_creator.block_names();
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {domain_creator.create_domain(),
+       std::unordered_map<std::string, std::unordered_set<std::string>>{
+           {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}},
+      {std::move(functions_of_time)}};
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+  ActionTesting::emplace_array_component<component>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
+  ActionTesting::emplace_array_component<elem_component>(
+      &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
+      array_index);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  const Mesh<3> mesh(5, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const LinkedMessageId<double> observation_time{2.0, {1.0}};
+  Variables<ah::source_vars<3>> vars(mesh.number_of_grid_points(), 9.876);
+  std::optional<std::string> dependency{"FakeDependency"};
+  auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
+
+  // Test the event version
+  auto box =
+      db::create<db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<metavars>,
+                                   typename MockHorizonMetavars::time_tag,
+                                   ::Events::Tags::ObserverMesh<3>,
+                                   ::Tags::Variables<ah::source_vars<3>>>>(
+          metavars{}, observation_time, mesh, vars);
+
+  const metavars::event event{dependency};
+  const metavars::event serialized_event = serialize_and_deserialize(event);
+
+  CHECK(serialized_event.needs_evolved_variables());
+
+  auto obs_box = make_observation_box<
+      typename metavars::event::compute_tags_for_observation_box>(
+      make_not_null(&box));
+  serialized_event.run(make_not_null(&obs_box), cache, array_index,
+                       std::add_pointer_t<elem_component>{}, {});
+
+  const auto check_results = [&]() {
+    // Invoke all actions
+    runner.invoke_queued_simple_action<component>(0);
+
+    // No more queued simple actions.
+    CHECK(runner.is_simple_action_queue_empty<component>(0));
+    CHECK(runner.is_simple_action_queue_empty<elem_component>(array_index));
+
+    const auto& results = MockFindApparentHorizon::results;
+    CHECK(results.time == observation_time);
+    CHECK(results.element_id == element_id);
+    CHECK(results.mesh == mesh);
+    CHECK(results.vars == vars);
+    CHECK(results.dependency == dependency);
+  };
+
+  check_results();
+
+  MockFindApparentHorizon::results = MockFindApparentHorizon::Results{};
+  dependency.reset();
+
+  const auto option_event =
+      TestHelpers::test_creation<typename metavars::event>("");
+  const metavars::event serialized_option_event =
+      serialize_and_deserialize(option_event);
+
+  serialized_option_event.run(make_not_null(&obs_box), cache, array_index,
+                              std::add_pointer_t<elem_component>{}, {});
+
+  check_results();
+}
+}  // namespace

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
@@ -275,7 +275,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindCommonHorizon",
           std::array{logical_coords[0], logical_coords[1], logical_coords[2]}},
       vars);
 
-  using FindCommonHorizon = ah::Events::FindCommonHorizon<
+  using FindCommonHorizon = intrp::Events::FindCommonHorizon<
       metavars::volume_dim, typename metavars::InterpolationTargetA,
       typename metavars::interpolator_source_vars,
       tmpl::push_back<typename metavars::interpolator_source_vars,

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
@@ -74,6 +74,22 @@ struct MockContributeVolumeData {
   }
 };
 
+template <typename Metavariables>
+struct MockObserver {
+  using component_being_mocked = observers::Observer<Metavariables>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeVolumeData>;
+  using with_these_simple_actions = tmpl::list<MockContributeVolumeData>;
+};
+
+namespace test_intrp {
 struct MockInterpolatorReceiveVolumeData {
   template <typename ParallelComponent, typename DbTags, typename Metavariables,
             typename ArrayIndex, size_t VolumeDim>
@@ -99,21 +115,6 @@ struct MockAddTemporalIdsToInterpolationTarget {
                     std::optional<std::string> dependency) {  // NOLINT
     CHECK(dependency == std::optional{"SubfileName"});
   }
-};
-
-template <typename Metavariables>
-struct MockObserver {
-  using component_being_mocked = observers::Observer<Metavariables>;
-
-  using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockGroupChare;
-  using array_index = int;
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
-
-  using replace_these_simple_actions =
-      tmpl::list<observers::Actions::ContributeVolumeData>;
-  using with_these_simple_actions = tmpl::list<MockContributeVolumeData>;
 };
 
 template <typename Metavariables>
@@ -201,8 +202,7 @@ struct MockMetavariables {
       MockElement<MockMetavariables>>;
 };
 
-SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindCommonHorizon",
-                  "[ApparentHorizonFinder][Unit]") {
+void common_horizon_event() {
   ::domain::creators::register_derived_with_charm();
   using metavars = MockMetavariables;
   const ElementId<metavars::volume_dim> element_id(0);
@@ -304,4 +304,174 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindCommonHorizon",
   // queued actions on each component.
   check_results(1);
 }
+}  // namespace test_intrp
+
+namespace test_ah {
+struct MockFindApparentHorizon {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(
+      db::DataBox<DbTags>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const LinkedMessageId<double>& /*incoming_time*/,
+      const ElementId<3>& /*incoming_element_id*/,
+      const ::Mesh<3>& /*incoming_mesh*/,
+      Variables<ah::source_vars<3>>&& /*incoming_source_vars*/,
+      const std::optional<std::string>& /*dependency*/,
+      const bool /*source_vars_have_already_been_received*/ = false) {}
+};
+
+struct MockHorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+  using time_tag = ::Tags::TimeAndPrevious<0>;
+
+  using frame = ::Frame::Grid;
+
+  // Don't need callbacks
+  using horizon_find_callbacks = tmpl::list<>;
+  using horizon_find_failure_callbacks = tmpl::list<>;
+
+  using compute_tags_on_element = tmpl::list<>;
+
+  static constexpr ah::Destination destination = ah::Destination::ControlSystem;
+
+  static std::string name() { return "MockHorizonMetavars"; }
+};
+
+template <typename Metavariables>
+struct MockHorizonComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      ah::Component<Metavariables, MockHorizonMetavars>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<3>, ah::Tags::BlocksForHorizonFind>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<ah::FindApparentHorizon<MockHorizonMetavars>>;
+  using with_these_simple_actions = tmpl::list<MockFindApparentHorizon>;
+};
+
+template <typename Metavariables>
+struct MockElement {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<3>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+  using initial_databox = db::compute_databox_type<
+      db::AddSimpleTags<::ah::source_vars<Metavariables::volume_dim>>>;
+};
+
+struct MockMetavariables {
+  static constexpr size_t volume_dim = 3;
+  using component_list = tmpl::list<MockObserver<MockMetavariables>,
+                                    MockHorizonComponent<MockMetavariables>,
+                                    MockElement<MockMetavariables>>;
+};
+
+void common_horizon_event() {
+  (void)MockHorizonMetavars::destination;
+  ::domain::creators::register_derived_with_charm();
+  using metavars = MockMetavariables;
+  const ElementId<metavars::volume_dim> element_id(0);
+  const ElementId<metavars::volume_dim> array_index(element_id);
+
+  using obs_component = MockObserver<metavars>;
+  using horizon_component = MockHorizonComponent<metavars>;
+  using elem_component = MockElement<metavars>;
+
+  const ::domain::creators::Brick brick{
+      {0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}, {0, 0, 0}, {5, 5, 5}};
+  const auto block_names = brick.block_names();
+  ActionTesting::MockRuntimeSystem<metavars> runner{
+      {brick.create_domain(),
+       std::unordered_map<std::string, std::unordered_set<std::string>>{
+           {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}}};
+  ActionTesting::set_phase(make_not_null(&runner),
+                           Parallel::Phase::Initialization);
+  ActionTesting::emplace_group_component<obs_component>(make_not_null(&runner));
+  ActionTesting::emplace_array_component<horizon_component>(
+      make_not_null(&runner), ActionTesting::NodeId{0},
+      ActionTesting::LocalCoreId{0}, 0);
+  ActionTesting::emplace_component<elem_component>(make_not_null(&runner),
+                                                   array_index);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+
+  const auto check_results = [&runner,
+                              &element_id](const size_t num_queued_actions) {
+    CHECK(ActionTesting::is_simple_action_queue_empty<elem_component>(
+        runner, element_id));
+    CHECK(ActionTesting::number_of_queued_simple_actions<obs_component>(
+              runner, 0) == num_queued_actions);
+    CHECK(ActionTesting::number_of_queued_simple_actions<horizon_component>(
+              runner, 0) == num_queued_actions);
+  };
+
+  // No events queued yet
+  check_results(0);
+
+  const Mesh<metavars::volume_dim> mesh(5, Spectral::Basis::Legendre,
+                                        Spectral::Quadrature::GaussLobatto);
+  const double observation_time = 2.0;
+  const Variables<ah::source_vars<metavars::volume_dim>> vars(
+      mesh.number_of_grid_points(), 1.0);
+  auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
+
+  const LinkedMessageId<double> temporal_id{observation_time, std::nullopt};
+  const ::Event::ObservationValue observation_value{"FindCommonHorizon",
+                                                    observation_time};
+
+  // Actual coords don't matter
+  const auto logical_coords = logical_coordinates(mesh);
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<metavars>,
+      Parallel::Tags::GlobalCache<metavars>, MockHorizonMetavars::time_tag,
+      Tags::Time, ::Events::Tags::ObserverMesh<metavars::volume_dim>,
+      ::domain::Tags::Coordinates<3, ::Frame::Inertial>,
+      ::Tags::Variables<typename decltype(vars)::tags_list>>>(
+      metavars{}, &cache, temporal_id, observation_time, mesh,
+      tnsr::I<DataVector, 3, ::Frame::Inertial>{
+          std::array{logical_coords[0], logical_coords[1], logical_coords[2]}},
+      vars);
+
+  using FindCommonHorizon = ah::Events::FindCommonHorizon<
+      MockHorizonMetavars,
+      tmpl::push_back<ah::source_vars<metavars::volume_dim>,
+                      ::domain::Tags::Coordinates<3, ::Frame::Inertial>>>;
+
+  const FindCommonHorizon find_common_horizon{"SubfileName",
+                                              FloatingPointType::Double,
+                                              {FloatingPointType::Double},
+                                              {"Pi"}};
+
+  CHECK(find_common_horizon.needs_evolved_variables());
+  CHECK(find_common_horizon.is_ready(cache, 0,
+                                     std::add_pointer_t<elem_component>{}));
+
+  // Only compute tags for cache items necessary for observation box since this
+  // test just puts the tags in the regular box
+  auto obs_box =
+      make_observation_box<tmpl::list<Parallel::Tags::FromGlobalCache<
+          ::domain::Tags::Domain<metavars::volume_dim>, metavars>>>(
+          make_not_null(&box));
+  find_common_horizon(obs_box, mesh, cache, array_index,
+                      std::add_pointer_t<elem_component>{}, observation_value);
+
+  // Since this event is a combination of two events, and those two events are
+  // individually tested, here we only check we have the correct number of
+  // queued actions on each component.
+  check_results(1);
+}
+}  // namespace test_ah
 }  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindCommonHorizon",
+                  "[ApparentHorizonFinder][Unit]") {
+  test_intrp::common_horizon_event();
+  test_ah::common_horizon_event();
+}


### PR DESCRIPTION
## Proposed changes

Fifteenth PR in horizon finder changes. This PR adds two new events to find apparent horizons, and to specifically find the common horizon. The logic of these events is the same as the existing events, but the new ones just use the new Tags/infrastructure.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
