### PR TITLE
AH rewrite: Prep control system for new AH infrastructure

### DIFF
--- a/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
+++ b/src/ControlSystem/Measurements/BNSCenterOfMass.hpp
@@ -229,9 +229,11 @@ struct SystemCenterOfMass : db::SimpleTag {
 struct BothNSCenters : tt::ConformsTo<protocols::Measurement> {
   struct FindTwoCenters : tt::ConformsTo<protocols::Submeasurement> {
     static std::string name() { return "BothNSCenters::FindTwoCenters"; }
-    /// Unused tag needed to conform to the submeasurement protocol.
+    /// Unused aliases needed to conform to the submeasurement protocol.
     template <typename ControlSystems>
     using interpolation_target_tag = void;
+    template <typename ControlSystems>
+    using horizon_metavars = void;
 
     template <typename ControlSystems>
     using event = BNSEvent<ControlSystems>;

--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -12,11 +12,14 @@
 #include "ControlSystem/RunCallbacks.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "Time/Tags/TimeAndPrevious.hpp"
@@ -88,9 +91,34 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
                                                         ::Frame::Distorted>>;
     };
 
+    template <typename ControlSystems>
+    struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+      static std::string name() {
+        return "ControlSystemAh" + ::domain::name(Horizon);
+      }
+
+      using time_tag = ::Tags::TimeAndPrevious<0>;
+
+      using frame = ::Frame::Distorted;
+
+      using horizon_find_callbacks =
+          tmpl::list<control_system::RunCallbacks<FindHorizon, ControlSystems>,
+                     ::ah::callbacks::ObserveCenters<HorizonMetavars>>;
+      using horizon_find_failure_callbacks =
+          tmpl::list<ah::callbacks::FailedHorizonFind<HorizonMetavars, false>>;
+
+      using compute_tags_on_element =
+          tmpl::list<::Tags::TimeAndPreviousCompute<0>>;
+
+      static constexpr ah::Destination destination =
+          ah::Destination::ControlSystem;
+    };
+
    public:
     template <typename ControlSystems>
     using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+    template <typename ControlSystems>
+    using horizon_metavars = HorizonMetavars<ControlSystems>;
 
     template <typename ControlSystems>
     using event = NonFactoryCreatableWrapper<intrp::Events::Interpolate<

--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -15,11 +15,14 @@
 #include "Domain/TagsTimeDependent.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
@@ -108,6 +111,8 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
    public:
     template <typename ControlSystems>
     using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+    template <typename ControlSystems>
+    using horizon_metavars = void;
 
     template <typename ControlSystems>
     using event = NonFactoryCreatableWrapper<
@@ -159,9 +164,39 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
           tmpl::list<control_system::RunCallbacks<Horizon, ControlSystems>>;
     };
 
+    template <typename ControlSystems>
+    struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+     private:
+      static constexpr size_t index =
+          Object == ::domain::ObjectLabel::A ? 1_st : 2_st;
+
+     public:
+      static std::string name() {
+        return "ControlSystemCharSpeedAh" + ::domain::name(Object);
+      }
+
+      // Separate time tags for each object
+      using time_tag = ::Tags::TimeAndPrevious<index>;
+
+      using frame = ::Frame::Distorted;
+
+      using horizon_find_callbacks =
+          tmpl::list<control_system::RunCallbacks<Horizon, ControlSystems>>;
+      using horizon_find_failure_callbacks =
+          tmpl::list<ah::callbacks::FailedHorizonFind<HorizonMetavars, false>>;
+
+      using compute_tags_on_element =
+          tmpl::list<::Tags::TimeAndPreviousCompute<index>>;
+
+      static constexpr ah::Destination destination =
+          ah::Destination::ControlSystem;
+    };
+
    public:
     template <typename ControlSystems>
     using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+    template <typename ControlSystems>
+    using horizon_metavars = HorizonMetavars<ControlSystems>;
 
     template <typename ControlSystems>
     using event = NonFactoryCreatableWrapper<intrp::Events::Interpolate<

--- a/src/ControlSystem/Measurements/SingleHorizon.hpp
+++ b/src/ControlSystem/Measurements/SingleHorizon.hpp
@@ -10,12 +10,16 @@
 #include "ControlSystem/Protocols/Measurement.hpp"
 #include "ControlSystem/Protocols/Submeasurement.hpp"
 #include "ControlSystem/RunCallbacks.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "Time/Tags/TimeAndPrevious.hpp"
@@ -87,9 +91,33 @@ struct SingleHorizon : tt::ConformsTo<protocols::Measurement> {
           control_system::RunCallbacks<Submeasurement, ControlSystems>>;
     };
 
+    template <typename ControlSystems>
+    struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+      static std::string name() {
+        return "ControlSystemSingleAh" + ::domain::name(Horizon);
+      }
+
+      using time_tag = ::Tags::TimeAndPrevious<0>;
+
+      using frame = ::Frame::Distorted;
+
+      using horizon_find_callbacks = tmpl::list<
+          control_system::RunCallbacks<Submeasurement, ControlSystems>>;
+      using horizon_find_failure_callbacks =
+          tmpl::list<ah::callbacks::FailedHorizonFind<HorizonMetavars, false>>;
+
+      using compute_tags_on_element =
+          tmpl::list<::Tags::TimeAndPreviousCompute<0>>;
+
+      static constexpr ah::Destination destination =
+          ah::Destination::ControlSystem;
+    };
+
    public:
     template <typename ControlSystems>
     using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+    template <typename ControlSystems>
+    using horizon_metavars = HorizonMetavars<ControlSystems>;
 
     template <typename ControlSystems>
     using event = NonFactoryCreatableWrapper<intrp::Events::Interpolate<

--- a/src/ControlSystem/Metafunctions.hpp
+++ b/src/ControlSystem/Metafunctions.hpp
@@ -76,6 +76,17 @@ struct interpolation_target_tags_for_submeasurement {
   using type = tmpl::conditional_t<std::is_same_v<declared_type, void>,
                                    tmpl::list<>, tmpl::list<declared_type>>;
 };
+
+template <typename Submeasurement, typename ControlSystems>
+struct horizon_metavars_for_submeasurement {
+ private:
+  using declared_type =
+      typename Submeasurement::template horizon_metavars<ControlSystems>;
+
+ public:
+  using type = tmpl::conditional_t<std::is_same_v<declared_type, void>,
+                                   tmpl::list<>, tmpl::list<declared_type>>;
+};
 }  // namespace detail
 
 /// Extract the `interpolation_target_tag` aliases from all
@@ -88,6 +99,16 @@ using interpolation_target_tags = tmpl::flatten<tmpl::transform<
     tmpl::lazy::transform<
         submeasurements<tmpl::_1>,
         tmpl::defer<detail::interpolation_target_tags_for_submeasurement<
+            tmpl::_1,
+            control_systems_with_measurement<tmpl::pin<ControlSystems>,
+                                             tmpl::parent<tmpl::_1>>>>>>>;
+
+template <typename ControlSystems>
+using horizon_metavars = tmpl::flatten<tmpl::transform<
+    measurements_t<ControlSystems>,
+    tmpl::lazy::transform<
+        submeasurements<tmpl::_1>,
+        tmpl::defer<detail::horizon_metavars_for_submeasurement<
             tmpl::_1,
             control_systems_with_measurement<tmpl::pin<ControlSystems>,
                                              tmpl::parent<tmpl::_1>>>>>>>;

--- a/src/ControlSystem/Protocols/Submeasurement.hpp
+++ b/src/ControlSystem/Protocols/Submeasurement.hpp
@@ -25,12 +25,17 @@ namespace control_system::protocols {
  *   alias may be `void` if the submeasurement does not use an interpolation
  *   target tag.  This is only used to collect the tags that must be registered
  *   in the metavariables.
- * - An `event` type alias also templated on the
- *   \ref ControlSystem "control systems" using this submeasurement which is an
- *   `::Event`. It is templated on the control systems because the event usually
- *   takes the `interpolation_target_tag` as a template parameter. Currently,
- *   this event must be fully functional when it is default constructed. It will
- *   not be constructed with any arguments.
+ * - A `horizon_metavars` type alias templated on the \ref ControlSystem
+ *   "control systems" using this submeasurement.  (This template parameter must
+ *   be used in the call to `RunCallbacks` discussed below.) This alias may be
+ *   `void` if the submeasurement does not find a horizon. This is only used to
+ *   collect the tags that must be registered in the metavariables.
+ * - An `event` type alias also templated on the \ref ControlSystem "control
+ *   systems" using this submeasurement which is an `::Event`. It is templated
+ *   on the control systems because the event usually takes the
+ *   `interpolation_target_tag` or `horizon_metavars` as a template parameter.
+ *   Currently, this event must be fully functional when it is default
+ *   constructed. It will not be constructed with any arguments.
  *
  * The `event` will be run on every element, and they must collectively
  * result in a single call on one chare (which need not be one of the element
@@ -38,8 +43,9 @@ namespace control_system::protocols {
  * ControlSystems>::apply`. This will almost always require performing a
  * reduction. The `ControlSystems` template parameter passed to `RunCallbacks`
  * here must be the same type that was passed to the `interpolation_target_tag`
- * and `event` type aliases. The `ControlSystems` template parameter will be
- * a list of all control systems that use the same Submeasurement.
+ * (or `horizon_metavars`) and `event` type aliases. The `ControlSystems`
+ * template parameter will be a list of all control systems that use the same
+ * Submeasurement.
  *
  * Here's an example for a class conforming to this protocol:
  *
@@ -53,6 +59,9 @@ struct Submeasurement {
     using interpolation_target_tag =
         typename ConformingType::template interpolation_target_tag<
             tmpl::list<DummyControlSystem>>;
+
+    using horizon_metavars = typename ConformingType::template horizon_metavars<
+        tmpl::list<DummyControlSystem>>;
 
     using event =
         typename ConformingType::template event<tmpl::list<DummyControlSystem>>;

--- a/src/ControlSystem/RunCallbacks.hpp
+++ b/src/ControlSystem/RunCallbacks.hpp
@@ -11,6 +11,9 @@
 #include "DataStructures/LinkedMessageId.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/PostInterpolationCallback.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -27,20 +30,23 @@ struct Verbosity;
 /// \endcond
 
 namespace control_system {
-/// \ingroup ControlSystemGroup
-/// Apply the `process_measurement` struct of each of the \p
-/// ControlSystems to the result of the \p Submeasurement.
-///
-/// The submeasurement results are supplied as a `db::DataBox` in
-/// order to allow individual control systems to select the portions
-/// of the submeasurement that they are interested in.
-///
-/// In addition to being manually called, this struct is designed to
-/// be usable as a `post_horizon_find_callback` or a
-/// `post_interpolation_callback`.
+/*!
+ * \ingroup ControlSystemGroup
+ * \details Apply the `process_measurement` struct of each of the \p
+ * ControlSystems to the result of the \p Submeasurement.
+ *
+ * The submeasurement results are supplied as a `db::DataBox` in
+ * order to allow individual control systems to select the portions
+ * of the submeasurement that they are interested in.
+ *
+ * In addition to being manually called, struct can be called as a callback and
+ * conform to the `intrp::protocols::PostInterpolationCallback` and
+ * `ah::protocols::Callback` protocols.
+ */
 template <typename Submeasurement, typename ControlSystems>
 struct RunCallbacks
-    : tt::ConformsTo<intrp::protocols::PostInterpolationCallback> {
+    : tt::ConformsTo<intrp::protocols::PostInterpolationCallback>,
+      tt::ConformsTo<ah::protocols::Callback> {
  private:
   static_assert(
       tt::assert_conforms_to_v<Submeasurement, protocols::Submeasurement>);
@@ -57,6 +63,32 @@ struct RunCallbacks
     static_assert(
         std::is_same_v<TemporalId, LinkedMessageId<double>>,
         "RunCallbacks expects a LinkedMessageId<double> as its temporal id");
+    tmpl::for_each<ControlSystems>(
+        [&box, &cache, &measurement_id](auto control_system_v) {
+          using ControlSystem = tmpl::type_from<decltype(control_system_v)>;
+          db::apply<typename ControlSystem::process_measurement::
+                        template argument_tags<Submeasurement>>(
+              [&cache, &measurement_id](const auto&... args) {
+                ControlSystem::process_measurement::apply(
+                    Submeasurement{}, args..., cache, measurement_id);
+              },
+              box);
+        });
+
+    if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
+      Parallel::printf(
+          "time = %.16f: For the '%s' measurement, calling process_measurement "
+          "for the following control systems: (%s).\n",
+          measurement_id.id, pretty_type::name<Submeasurement>(),
+          pretty_type::list_of_names<ControlSystems>());
+    }
+  }
+
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const FastFlow::Status /*status*/) {
+    const auto& measurement_id = db::get<ah::Tags::CurrentTime>(box).value();
     tmpl::for_each<ControlSystems>(
         [&box, &cache, &measurement_id](auto control_system_v) {
           using ControlSystem = tmpl::type_from<decltype(control_system_v)>;

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -65,6 +65,8 @@ struct Submeasurement
     : tt::ConformsTo<control_system::protocols::Submeasurement> {
   template <typename ControlSystems>
   using interpolation_target_tag = void;
+  template <typename ControlSystems>
+  using horizon_metavars = void;
 
   template <typename ControlSystems>
   using event = control_system::TestHelpers::TestEvent<ExpectedSystems,

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "Time/Tags/Time.hpp"
@@ -53,6 +54,10 @@ static_assert(
         control_system::measurements::BothHorizons::FindHorizon<
             ::domain::ObjectLabel::A>::interpolation_target_tag<example_list>,
         intrp::protocols::InterpolationTargetTag>);
+static_assert(tt::assert_conforms_to_v<
+              control_system::measurements::BothHorizons::FindHorizon<
+                  ::domain::ObjectLabel::A>::horizon_metavars<example_list>,
+              ah::protocols::HorizonMetavars>);
 static_assert(
     not control_system::measurements::BothHorizons::FindHorizon<
         ::domain::ObjectLabel::A>::event<example_list>::factory_creatable);
@@ -71,6 +76,11 @@ static_assert(
         control_system::measurements::SingleHorizon<::domain::ObjectLabel::B>::
             Submeasurement::interpolation_target_tag<example_list>,
         intrp::protocols::InterpolationTargetTag>);
+static_assert(
+    tt::assert_conforms_to_v<
+        control_system::measurements::SingleHorizon<::domain::ObjectLabel::B>::
+            Submeasurement::horizon_metavars<example_list>,
+        ah::protocols::HorizonMetavars>);
 static_assert(
     not control_system::measurements::SingleHorizon<::domain::ObjectLabel::B>::
         Submeasurement::event<example_list>::factory_creatable);
@@ -106,6 +116,10 @@ static_assert(tt::assert_conforms_to_v<
               control_system::measurements::CharSpeed<domain::ObjectLabel::A>::
                   Horizon::interpolation_target_tag<example_list>,
               intrp::protocols::InterpolationTargetTag>);
+static_assert(tt::assert_conforms_to_v<
+              control_system::measurements::CharSpeed<domain::ObjectLabel::A>::
+                  Horizon::horizon_metavars<example_list>,
+              ah::protocols::HorizonMetavars>);
 static_assert(
     not control_system::measurements::CharSpeed<domain::ObjectLabel::A>::
         Excision::event<example_list>::factory_creatable);

--- a/tests/Unit/ControlSystem/Test_Metafunctions.cpp
+++ b/tests/Unit/ControlSystem/Test_Metafunctions.cpp
@@ -116,11 +116,15 @@ static_assert(
 namespace InterpolationTargetTags {
 template <typename Systems>
 struct Target;
+template <typename Systems>
+struct HorizonMetavars;
 
-struct SubmeasurementTarget
+struct SubmeasurementNoVoid
     : tt::ConformsTo<control_system::protocols::Submeasurement> {
   template <typename ControlSystems>
   using interpolation_target_tag = Target<ControlSystems>;
+  template <typename ControlSystems>
+  using horizon_metavars = HorizonMetavars<ControlSystems>;
 
   template <typename ControlSystems>
   using event = SomeEvent<LabelA, ControlSystems>;
@@ -130,13 +134,15 @@ struct SubmeasurementVoid
     : tt::ConformsTo<control_system::protocols::Submeasurement> {
   template <typename ControlSystems>
   using interpolation_target_tag = void;
+  template <typename ControlSystems>
+  using horizon_metavars = void;
 
   template <typename ControlSystems>
   using event = SomeEvent<LabelA, ControlSystems>;
 };
 
 struct Measurement : tt::ConformsTo<control_system::protocols::Measurement> {
-  using submeasurements = tmpl::list<SubmeasurementTarget, SubmeasurementVoid>;
+  using submeasurements = tmpl::list<SubmeasurementNoVoid, SubmeasurementVoid>;
 };
 
 struct MeasurementEmpty
@@ -178,6 +184,12 @@ static_assert(
             ControlSystem<LabelA>, ControlSystem<LabelB>, ControlSystemEmpty>>,
         tmpl::list<
             Target<tmpl::list<ControlSystem<LabelA>, ControlSystem<LabelB>>>>>);
+static_assert(
+    std::is_same_v<
+        horizon_metavars<tmpl::list<ControlSystem<LabelA>,
+                                    ControlSystem<LabelB>, ControlSystemEmpty>>,
+        tmpl::list<HorizonMetavars<
+            tmpl::list<ControlSystem<LabelA>, ControlSystem<LabelB>>>>>);
 }  // namespace InterpolationTargetTags
 
 namespace Events {
@@ -186,6 +198,8 @@ struct Submeasurement
     : tt::ConformsTo<control_system::protocols::Submeasurement> {
   template <typename ControlSystems>
   using interpolation_target_tag = void;
+  template <typename ControlSystems>
+  using horizon_metavars = void;
   template <typename ControlSystems>
   using event = SomeEvent<Label, ControlSystems>;
 };

--- a/tests/Unit/ControlSystem/Test_RunCallbacks.cpp
+++ b/tests/Unit/ControlSystem/Test_RunCallbacks.cpp
@@ -148,8 +148,13 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.RunCallbacks", "[ControlSystem][Unit]") {
       make_not_null(&box));
   event.run(make_not_null(&obs_box), cache, 0, element_component_p, {});
 
-  ActionTesting::invoke_queued_simple_action<control_system_component>(
-      make_not_null(&runner), 0);
+  CHECK(
+      ActionTesting::number_of_queued_simple_actions<control_system_component>(
+          runner, 0) == 2);
+  for (size_t i = 0; i < 2; i++) {
+    ActionTesting::invoke_queued_simple_action<control_system_component>(
+        make_not_null(&runner), 0);
+  }
   CHECK(ActionTesting::is_simple_action_queue_empty<control_system_component>(
       runner, 0));
 

--- a/tests/Unit/Helpers/ControlSystem/Examples.hpp
+++ b/tests/Unit/Helpers/ControlSystem/Examples.hpp
@@ -81,6 +81,9 @@ struct ExampleSubmeasurement
   // This submeasurement does not use an interpolation component.
   template <typename ControlSystems>
   using interpolation_target_tag = void;
+  // This submeasurement does not find a horizon.
+  template <typename ControlSystems>
+  using horizon_metavars = void;
 
   template <typename ControlSystems>
   using event = SomeEvent<ControlSystems>;

--- a/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
+++ b/tests/Unit/Helpers/ControlSystem/TestStructs.hpp
@@ -13,10 +13,13 @@
 #include "ControlSystem/Protocols/Measurement.hpp"
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Helpers/ControlSystem/Examples.hpp"
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/GetOutput.hpp"
@@ -43,6 +46,8 @@ struct Submeasurement
     : tt::ConformsTo<control_system::protocols::Submeasurement> {
   template <typename ControlSystems>
   using interpolation_target_tag = void;
+  template <typename ControlSystems>
+  using horizon_metavars = void;
   template <typename ControlSystems>
   using event = TestEvent<Label, ControlSystems, CallRunCallbacks>;
 };
@@ -80,11 +85,16 @@ class TestEvent : public ::Event {
     const LinkedMessageId<double> measurement_id{time, previous_time};
     // Just a hack so we don't have to add a whole other component
     const auto box = db::create<
-        db::AddSimpleTags<control_system::TestHelpers::MeasurementResultTag>>(
-        data_from_element);
+        db::AddSimpleTags<control_system::TestHelpers::MeasurementResultTag,
+                          ah::Tags::CurrentTime>>(
+        data_from_element, std::optional{measurement_id});
     control_system::RunCallbacks<Submeasurement<Label, CallRunCallbacks>,
                                  ControlSystems>::apply(box, cache,
                                                         measurement_id);
+    ++call_count;
+    control_system::RunCallbacks<
+        Submeasurement<Label, CallRunCallbacks>,
+        ControlSystems>::apply(box, cache, FastFlow::Status::AbsTol);
     ++call_count;
   }
 


### PR DESCRIPTION
## Proposed changes

Sixteenth PR in horizon finder changes. Includes editing RunCallbacks to conform to the new ah::protocols::Callback protocol and editing the submeasurement protocol to accept horizon metavars.

Note that none of the new AH infrastructure is used in any executables yet. This is that last PR before changing the executables to use the new infrastructure.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
