### PR TITLE
AH rewrite: Switch AH execs to use new AH infrastructure

### DIFF
--- a/src/ControlSystem/Measurements/BothHorizons.hpp
+++ b/src/ControlSystem/Measurements/BothHorizons.hpp
@@ -17,6 +17,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
@@ -116,13 +117,13 @@ struct BothHorizons : tt::ConformsTo<protocols::Measurement> {
 
    public:
     template <typename ControlSystems>
-    using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+    using interpolation_target_tag = void;
     template <typename ControlSystems>
     using horizon_metavars = HorizonMetavars<ControlSystems>;
 
     template <typename ControlSystems>
-    using event = NonFactoryCreatableWrapper<intrp::Events::Interpolate<
-        3, InterpolationTarget<ControlSystems>, ::ah::source_vars<3>>>;
+    using event = NonFactoryCreatableWrapper<
+        ah::Events::FindApparentHorizon<HorizonMetavars<ControlSystems>>>;
   };
 
   using submeasurements = tmpl::list<FindHorizon<::domain::ObjectLabel::A>,

--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -20,6 +20,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
@@ -194,13 +195,13 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
 
    public:
     template <typename ControlSystems>
-    using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+    using interpolation_target_tag = void;
     template <typename ControlSystems>
     using horizon_metavars = HorizonMetavars<ControlSystems>;
 
     template <typename ControlSystems>
-    using event = NonFactoryCreatableWrapper<intrp::Events::Interpolate<
-        3, InterpolationTarget<ControlSystems>, ::ah::source_vars<3>>>;
+    using event = NonFactoryCreatableWrapper<
+        ah::Events::FindApparentHorizon<HorizonMetavars<ControlSystems>>>;
   };
 
   using submeasurements = tmpl::list<Horizon, Excision>;

--- a/src/ControlSystem/Measurements/SingleHorizon.hpp
+++ b/src/ControlSystem/Measurements/SingleHorizon.hpp
@@ -17,6 +17,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
@@ -115,13 +116,13 @@ struct SingleHorizon : tt::ConformsTo<protocols::Measurement> {
 
    public:
     template <typename ControlSystems>
-    using interpolation_target_tag = InterpolationTarget<ControlSystems>;
+    using interpolation_target_tag = void;
     template <typename ControlSystems>
     using horizon_metavars = HorizonMetavars<ControlSystems>;
 
     template <typename ControlSystems>
-    using event = NonFactoryCreatableWrapper<intrp::Events::Interpolate<
-        3, InterpolationTarget<ControlSystems>, ::ah::source_vars<3>>>;
+    using event = NonFactoryCreatableWrapper<
+        ah::Events::FindApparentHorizon<HorizonMetavars<ControlSystems>>>;
   };
 
   using submeasurements = tmpl::list<Submeasurement>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
@@ -22,9 +23,11 @@
 #include "ControlSystem/Trigger.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
 #include "Domain/Creators/BinaryCompactObject.hpp"
 #include "Domain/Creators/CylindricalBinaryCompactObject.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/TagsCharacteristicSpeeds.hpp"
 #include "Evolution/Actions/RunEventsAndDenseTriggers.hpp"
@@ -109,17 +112,25 @@
 #include "ParallelAlgorithms/Amr/Projectors/Variables.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveFieldsOnHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveTimeSeriesOnHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/SendDependencyToObserverWriter.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Events/Factory.hpp"
 #include "ParallelAlgorithms/Events/MonitorMemory.hpp"
 #include "ParallelAlgorithms/Events/ObserveTimeStepVolume.hpp"
@@ -144,9 +155,7 @@
 #include "ParallelAlgorithms/Interpolation/Events/Interpolate.hpp"
 #include "ParallelAlgorithms/Interpolation/Events/InterpolateWithoutInterpComponent.hpp"
 #include "ParallelAlgorithms/Interpolation/InterpolationTarget.hpp"
-#include "ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp"
 #include "ParallelAlgorithms/Interpolation/Interpolator.hpp"
-#include "ParallelAlgorithms/Interpolation/PointInfoTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/InterpolationTargetTag.hpp"
 #include "ParallelAlgorithms/Interpolation/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Targets/Sphere.hpp"
@@ -211,30 +220,6 @@ namespace Parallel {
 template <typename Metavariables>
 class CProxy_GlobalCache;
 }  // namespace Parallel
-
-// We need separate time tags for all horizon finders because of complicated
-// Interpolator internal details. So we just make a simple compute tag that
-// takes the actual time out of the box since we still want the actual time to
-// be the same, just a different tag.
-namespace Tags {
-template <size_t Index>
-struct AhObservationTime {
-  static std::string name() { return "AhObservationTime" + get_output(Index); }
-  using type = double;
-};
-
-template <size_t Index>
-struct AhObservationTimeCompute : AhObservationTime<Index>, db::ComputeTag {
-  using argument_tags = tmpl::list<::Tags::Time>;
-  using base = AhObservationTime<Index>;
-  using return_type = double;
-
-  static void function(const gsl::not_null<double*> ah_time,
-                       const double time) {
-    *ah_time = time;
-  }
-};
-}  // namespace Tags
 /// \endcond
 
 // Note: this executable does not use GeneralizedHarmonicBase.hpp, because
@@ -264,38 +249,37 @@ struct EvolutionMetavars {
   void pup(PUP::er& /*p*/) {}
 
   template <::domain::ObjectLabel Horizon, typename Frame>
-  struct Ah : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    static constexpr size_t index = static_cast<size_t>(Horizon);
-    using temporal_id = ::Tags::AhObservationTime<index>;
-    using vars_to_interpolate_to_target =
-        ::ah::vars_to_interpolate_to_target<volume_dim, Frame>;
-    using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
-    using tags_to_observe = ::ah::tags_for_observing<Frame>;
-    using surface_tags_to_observe = ::ah::surface_tags_for_observing;
-    using compute_items_on_source =
-        tmpl::list<::Tags::AhObservationTimeCompute<index>>;
-    using compute_items_on_target =
-        ::ah::compute_items_on_target<volume_dim, Frame>;
-    using compute_target_points = ah::TargetPoints::ApparentHorizon<Ah, Frame>;
-    using post_interpolation_callbacks =
-        tmpl::list<intrp::callbacks::FindApparentHorizon<Ah, Frame>>;
-    using horizon_find_failure_callbacks = tmpl::append<
-        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>,
+  struct Ah : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+    static constexpr size_t index = 10 + static_cast<size_t>(Horizon);
+
+    using time_tag = ah::Tags::ObservationTime<index>;
+
+    using frame = Frame;
+
+    using horizon_find_callbacks = tmpl::append<
         tmpl::conditional_t<
             Horizon == ::domain::ObjectLabel::C,
-            tmpl::list<
-                intrp::callbacks::SendDependencyToObserverWriter<false, Ah>>,
-            tmpl::list<>>>;
-    using post_horizon_find_callbacks = tmpl::append<
-        tmpl::conditional_t<
-            Horizon == ::domain::ObjectLabel::C,
-            tmpl::list<
-                intrp::callbacks::SendDependencyToObserverWriter<true, Ah>>,
+            tmpl::list<ah::callbacks::SendDependencyToObserverWriter<Ah, true>>,
             tmpl::list<>>,
-        tmpl::list<
-            intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, Ah,
-                                                 Frame>,
-            intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Ah>>>;
+        tmpl::list<ah::callbacks::ObserveFieldsOnHorizon<
+                       ::ah::surface_tags_for_observing, Ah>,
+                   ah::callbacks::ObserveTimeSeriesOnHorizon<
+                       ::ah::tags_for_observing<Frame>, Ah>>>;
+    using horizon_find_failure_callbacks = tmpl::append<
+        // Only ignore errors for AhC
+        tmpl::list<ah::callbacks::FailedHorizonFind<
+            Ah, Horizon == ::domain::ObjectLabel::C>>,
+        tmpl::conditional_t<
+            Horizon == ::domain::ObjectLabel::C,
+            tmpl::list<
+                ah::callbacks::SendDependencyToObserverWriter<Ah, false>>,
+            tmpl::list<>>>;
+
+    using compute_tags_on_element =
+        tmpl::list<ah::Tags::ObservationTimeCompute<index>>;
+
+    static constexpr ah::Destination destination = ah::Destination::Observation;
+
     static std::string name() {
       return "ObservationAh" + ::domain::name(Horizon);
     }
@@ -348,7 +332,6 @@ struct EvolutionMetavars {
   static constexpr bool use_control_systems =
       tmpl::size<control_systems>::value > 0;
 
-  using interpolator_source_vars = ::ah::source_vars<volume_dim>;
   using source_vars_no_deriv =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,
                  gh::Tags::Pi<DataVector, volume_dim>,
@@ -369,7 +352,7 @@ struct EvolutionMetavars {
 
   using interpolation_target_tags = tmpl::push_back<
       control_system::metafunctions::interpolation_target_tags<control_systems>,
-      AhA, AhB, AhC, BondiSachs, ExcisionBoundaryA, ExcisionBoundaryB>;
+      BondiSachs, ExcisionBoundaryA, ExcisionBoundaryB>;
 
   using observe_fields = tmpl::append<
       tmpl::list<
@@ -498,27 +481,25 @@ struct EvolutionMetavars {
             DomainCreator<volume_dim>,
             tmpl::list<::domain::creators::BinaryCompactObject<false>,
                        ::domain::creators::CylindricalBinaryCompactObject>>,
-        tmpl::pair<
-            Event,
-            tmpl::flatten<tmpl::list<
-                intrp::Events::Interpolate<3, AhA, interpolator_source_vars>,
-                intrp::Events::Interpolate<3, AhB, interpolator_source_vars>,
-                intrp::Events::FindCommonHorizon<
-                    volume_dim, AhC, interpolator_source_vars, observe_fields,
-                    non_tensor_compute_tags>,
-                intrp::Events::InterpolateWithoutInterpComponent<
-                    3, BondiSachs, source_vars_no_deriv>,
-                intrp::Events::InterpolateWithoutInterpComponent<
-                    3, ExcisionBoundaryA, interpolator_source_vars>,
-                intrp::Events::InterpolateWithoutInterpComponent<
-                    3, ExcisionBoundaryB, interpolator_source_vars>,
-                Events::MonitorMemory<3>, Events::Completion,
-                dg::Events::field_observations<volume_dim, observe_fields,
-                                               non_tensor_compute_tags>,
-                control_system::metafunctions::control_system_events<
-                    control_systems>,
-                Events::time_events<system>,
-                dg::Events::ObserveTimeStepVolume<system>>>>,
+        tmpl::pair<Event,
+                   tmpl::flatten<tmpl::list<
+                       ah::Events::FindApparentHorizon<AhA>,
+                       ah::Events::FindApparentHorizon<AhB>,
+                       ah::Events::FindCommonHorizon<AhC, observe_fields,
+                                                     non_tensor_compute_tags>,
+                       intrp::Events::InterpolateWithoutInterpComponent<
+                           3, BondiSachs, source_vars_no_deriv>,
+                       intrp::Events::InterpolateWithoutInterpComponent<
+                           3, ExcisionBoundaryA, ah::source_vars<3>>,
+                       intrp::Events::InterpolateWithoutInterpComponent<
+                           3, ExcisionBoundaryB, ah::source_vars<3>>,
+                       Events::MonitorMemory<3>, Events::Completion,
+                       dg::Events::field_observations<
+                           volume_dim, observe_fields, non_tensor_compute_tags>,
+                       control_system::metafunctions::control_system_events<
+                           control_systems>,
+                       Events::time_events<system>,
+                       dg::Events::ObserveTimeStepVolume<system>>>>,
         tmpl::pair<control_system::size::State,
                    control_system::size::States::factory_creatable_states>,
         tmpl::pair<
@@ -559,8 +540,7 @@ struct EvolutionMetavars {
                  gh::Tags::DampingFunctionGamma2<volume_dim, Frame::Grid>>;
 
   using dg_registration_list =
-      tmpl::list<observers::Actions::RegisterEventsWithObservers,
-                 intrp::Actions::RegisterElementWithInterpolator>;
+      tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
   static constexpr auto default_phase_order =
       std::array{Parallel::Phase::Initialization,
@@ -677,6 +657,8 @@ struct EvolutionMetavars {
         tmpl::map<tmpl::pair<gh_dg_element_array, dg_registration_list>>;
   };
 
+  using control_system_horizon_metavars =
+      control_system::metafunctions::horizon_metavars<control_systems>;
   using control_components =
       control_system::control_components<EvolutionMetavars, control_systems>;
 
@@ -684,8 +666,8 @@ struct EvolutionMetavars {
       Parallel::GlobalCache<EvolutionMetavars>& cache,
       const std::vector<std::string>& deadlocked_components) {
     gh::deadlock::run_deadlock_analysis_simple_actions<
-        gh_dg_element_array, control_components, interpolation_target_tags>(
-        cache, deadlocked_components);
+        gh_dg_element_array, control_components, interpolation_target_tags,
+        false>(cache, deadlocked_components);
   }
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
@@ -729,7 +711,12 @@ struct EvolutionMetavars {
       observers::ObserverWriter<EvolutionMetavars>,
       importers::ElementDataReader<EvolutionMetavars>,
       mem_monitor::MemoryMonitor<EvolutionMetavars>,
-      intrp::Interpolator<EvolutionMetavars>,
+      ah::Component<EvolutionMetavars, AhA>,
+      ah::Component<EvolutionMetavars, AhB>,
+      ah::Component<EvolutionMetavars, AhC>,
+      tmpl::transform<
+          control_system_horizon_metavars,
+          tmpl::bind<ah::Component, tmpl::pin<EvolutionMetavars>, tmpl::_1>>,
       tmpl::transform<interpolation_target_tags,
                       tmpl::bind<intrp::InterpolationTarget,
                                  tmpl::pin<EvolutionMetavars>, tmpl::_1>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -17,6 +17,7 @@
 #include "ControlSystem/Systems/Size.hpp"
 #include "ControlSystem/Systems/Translation.hpp"
 #include "ControlSystem/Trigger.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Evolution/Actions/RunEventsAndTriggers.hpp"
 #include "Evolution/DiscontinuousGalerkin/InboxTags.hpp"
@@ -36,14 +37,20 @@
 #include "ParallelAlgorithms/Actions/FunctionsOfTimeAreReady.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveFieldsOnHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveTimeSeriesOnHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
@@ -70,6 +77,7 @@
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/Tags/StepperErrors.hpp"
 #include "Time/Tags/Time.hpp"
+#include "Time/Tags/TimeAndPrevious.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/PrettyType.hpp"
@@ -88,28 +96,25 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
       "formulation,\n"
       "on a domain with a single horizon and corresponding excised region"};
 
-  struct ApparentHorizon
-      : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::Time;
-    using tags_to_observe = ::ah::tags_for_observing<Frame::Inertial>;
-    using surface_tags_to_observe = ::ah::surface_tags_for_observing;
-    using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
-    using vars_to_interpolate_to_target =
-        ::ah::vars_to_interpolate_to_target<volume_dim, ::Frame::Inertial>;
-    using compute_items_on_target =
-        ::ah::compute_items_on_target<volume_dim, Frame::Inertial>;
-    using compute_target_points =
-        ah::TargetPoints::ApparentHorizon<ApparentHorizon, ::Frame::Inertial>;
-    using post_interpolation_callbacks =
-        tmpl::list<intrp::callbacks::FindApparentHorizon<ApparentHorizon,
-                                                         ::Frame::Inertial>>;
+  struct ApparentHorizon : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+    using time_tag = ah::Tags::ObservationTime<0>;
+
+    using frame = ::Frame::Inertial;
+
+    using horizon_find_callbacks = tmpl::list<
+        ah::callbacks::ObserveTimeSeriesOnHorizon<
+            ::ah::tags_for_observing<Frame::Inertial>, ApparentHorizon>,
+        ah::callbacks::ObserveFieldsOnHorizon<::ah::surface_tags_for_observing,
+                                              ApparentHorizon>>;
     using horizon_find_failure_callbacks =
-        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>;
-    using post_horizon_find_callbacks = tmpl::list<
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe,
-                                                     ApparentHorizon>,
-        intrp::callbacks::ObserveSurfaceData<
-            surface_tags_to_observe, ApparentHorizon, ::Frame::Inertial>>;
+        tmpl::list<ah::callbacks::FailedHorizonFind<ApparentHorizon, false>>;
+
+    using compute_tags_on_element =
+        tmpl::list<ah::Tags::ObservationTimeCompute<0>>;
+
+    static constexpr ah::Destination destination = ah::Destination::Observation;
+
+    static std::string name() { return "ApparentHorizon"; }
   };
 
   struct ExcisionBoundary
@@ -148,7 +153,11 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
   static constexpr bool use_control_systems =
       tmpl::size<control_systems>::value > 0;
 
-  using interpolator_source_vars = ::ah::source_vars<volume_dim>;
+  struct BondiSachs;
+
+  using interpolation_target_tags = tmpl::push_back<
+      control_system::metafunctions::interpolation_target_tags<control_systems>,
+      ExcisionBoundary, BondiSachs>;
   using source_vars_no_deriv =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, volume_dim>,
                  gh::Tags::Pi<DataVector, volume_dim>,
@@ -167,10 +176,6 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
     using interpolating_component = typename Metavariables::gh_dg_element_array;
   };
 
-  using interpolation_target_tags = tmpl::push_back<
-      control_system::metafunctions::interpolation_target_tags<control_systems>,
-      ApparentHorizon, ExcisionBoundary, BondiSachs>;
-
   // The interpolator_source_vars need to be the same in both the Interpolate
   // event and the InterpolateWithoutInterpComponent event.  The Interpolate
   // event interpolates to the horizon, and the
@@ -187,16 +192,16 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
                         LtsTimeStepper>,
             tmpl::pair<LtsTimeStepper,
                        TimeSteppers::monotonic_lts_time_steppers>>,
-        tmpl::pair<Event,
-                   tmpl::flatten<tmpl::list<
-                       intrp::Events::Interpolate<3, ApparentHorizon,
-                                                  interpolator_source_vars>,
-                       control_system::metafunctions::control_system_events<
-                           control_systems>,
-                       intrp::Events::InterpolateWithoutInterpComponent<
-                           3, BondiSachs, source_vars_no_deriv>,
-                       intrp::Events::InterpolateWithoutInterpComponent<
-                           3, ExcisionBoundary, interpolator_source_vars>>>>,
+        tmpl::pair<
+            Event,
+            tmpl::flatten<tmpl::list<
+                ah::Events::FindApparentHorizon<ApparentHorizon>,
+                control_system::metafunctions::control_system_events<
+                    control_systems>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    3, BondiSachs, source_vars_no_deriv>,
+                intrp::Events::InterpolateWithoutInterpComponent<
+                    3, ExcisionBoundary, ::ah::source_vars<volume_dim>>>>>,
         tmpl::pair<DenseTrigger,
                    control_system::control_system_triggers<control_systems>>,
         tmpl::pair<control_system::size::State,
@@ -208,12 +213,9 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::push_back<
           tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename ApparentHorizon::post_horizon_find_callbacks,
           typename ExcisionBoundary::post_interpolation_callbacks>>;
 
-  using dg_registration_list =
-      tmpl::push_back<typename gh_base::dg_registration_list,
-                      intrp::Actions::RegisterElementWithInterpolator>;
+  using dg_registration_list = typename gh_base::dg_registration_list;
 
   using step_actions = typename gh_base::template step_actions<control_systems>;
 
@@ -308,6 +310,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
         tmpl::map<tmpl::pair<gh_dg_element_array, dg_registration_list>>;
   };
 
+  using control_system_horizon_metavars =
+      control_system::metafunctions::horizon_metavars<control_systems>;
   using control_components =
       control_system::control_components<EvolutionMetavars, control_systems>;
 
@@ -315,8 +319,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
       Parallel::GlobalCache<EvolutionMetavars>& cache,
       const std::vector<std::string>& deadlocked_components) {
     gh::deadlock::run_deadlock_analysis_simple_actions<
-        gh_dg_element_array, control_components, interpolation_target_tags>(
-        cache, deadlocked_components);
+        gh_dg_element_array, control_components, interpolation_target_tags,
+        false>(cache, deadlocked_components);
   }
 
   using component_list = tmpl::flatten<tmpl::list<
@@ -325,7 +329,10 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
       observers::ObserverWriter<EvolutionMetavars>,
       mem_monitor::MemoryMonitor<EvolutionMetavars>,
       importers::ElementDataReader<EvolutionMetavars>, gh_dg_element_array,
-      intrp::Interpolator<EvolutionMetavars>, control_components,
+      ah::Component<EvolutionMetavars, ApparentHorizon>, control_components,
+      tmpl::transform<
+          control_system_horizon_metavars,
+          tmpl::bind<ah::Component, tmpl::pin<EvolutionMetavars>, tmpl::_1>>,
       tmpl::transform<interpolation_target_tags,
                       tmpl::bind<intrp::InterpolationTarget,
                                  tmpl::pin<EvolutionMetavars>, tmpl::_1>>>>;

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -28,15 +28,21 @@
 #include "Parallel/PhaseControl/ExecutePhaseChange.hpp"
 #include "ParallelAlgorithms/Actions/FunctionsOfTimeAreReady.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ErrorOnFailedApparentHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/IgnoreFailedApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveCenters.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveFieldsOnHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/ObserveTimeSeriesOnHorizon.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeExcisionBoundaryVolumeQuantities.tpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeHorizonVolumeQuantities.tpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/CleanUpInterpolator.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
@@ -80,30 +86,26 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
       "field \n"
       "on a domain with a single horizon and corresponding excised region"};
 
-  template <typename Frame>
-  struct Ah : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
-    using temporal_id = ::Tags::Time;
-    using tags_to_observe = ::ah::tags_for_observing<Frame>;
-    using surface_tags_to_observe = ::ah::surface_tags_for_observing;
-    using compute_vars_to_interpolate = ah::ComputeHorizonVolumeQuantities;
-    using vars_to_interpolate_to_target =
-        ::ah::vars_to_interpolate_to_target<volume_dim, Frame>;
-    using compute_items_on_target =
-        ::ah::compute_items_on_target<volume_dim, Frame>;
-    using compute_target_points =
-        ah::TargetPoints::ApparentHorizon<Ah, Frame>;
-    using post_interpolation_callbacks =
-        tmpl::list<intrp::callbacks::FindApparentHorizon<Ah, Frame>>;
-    using horizon_find_failure_callbacks =
-        tmpl::list<intrp::callbacks::IgnoreFailedApparentHorizon>;
-    using post_horizon_find_callbacks = tmpl::list<
-        intrp::callbacks::ObserveTimeSeriesOnSurface<tags_to_observe, Ah>,
-        intrp::callbacks::ObserveSurfaceData<surface_tags_to_observe, Ah,
-                                             Frame>,
-        ::intrp::callbacks::ObserveCenters<Ah, Frame>>;
-  };
+  struct ApparentHorizon : tt::ConformsTo<ah::protocols::HorizonMetavars> {
+    using time_tag = ah::Tags::ObservationTime<0>;
 
-  using ApparentHorizon = Ah<::Frame::Distorted>;
+    using frame = ::Frame::Distorted;
+
+    using horizon_find_callbacks = tmpl::list<
+        ah::callbacks::ObserveTimeSeriesOnHorizon<
+            ::ah::tags_for_observing<Frame::Distorted>, ApparentHorizon>,
+        ah::callbacks::ObserveFieldsOnHorizon<::ah::surface_tags_for_observing,
+                                              ApparentHorizon>>;
+    using horizon_find_failure_callbacks =
+        tmpl::list<ah::callbacks::FailedHorizonFind<ApparentHorizon, false>>;
+
+    using compute_tags_on_element =
+        tmpl::list<ah::Tags::ObservationTimeCompute<0>>;
+
+    static constexpr ah::Destination destination = ah::Destination::Observation;
+
+    static std::string name() { return "ApparentHorizon"; }
+  };
 
   struct ExcisionBoundaryA
       : tt::ConformsTo<intrp::protocols::InterpolationTargetTag> {
@@ -163,8 +165,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
 
   using interpolation_target_tags = tmpl::push_back<
       control_system::metafunctions::interpolation_target_tags<control_systems>,
-      ApparentHorizon, ExcisionBoundaryA, SphericalSurface, BondiSachs>;
-  using interpolator_source_vars = ::ah::source_vars<volume_dim>;
+      ExcisionBoundaryA, SphericalSurface, BondiSachs>;
 
   using scalar_charge_interpolator_source_vars =
       detail::ObserverTags::scalar_charge_vars_to_interpolate_to_target;
@@ -206,14 +207,13 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
         tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<
-                intrp::Events::Interpolate<volume_dim, ApparentHorizon,
-                                           interpolator_source_vars>,
+                ah::Events::FindApparentHorizon<ApparentHorizon>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     3, BondiSachs, source_vars_no_deriv>,
                 control_system::metafunctions::control_system_events<
                     control_systems>,
                 intrp::Events::InterpolateWithoutInterpComponent<
-                    volume_dim, ExcisionBoundaryA, interpolator_source_vars>,
+                    volume_dim, ExcisionBoundaryA, ah::source_vars<volume_dim>>,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     volume_dim, SphericalSurface,
                     scalar_charge_interpolator_source_vars>>>>,
@@ -225,14 +225,10 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
 
   using typename st_base::const_global_cache_tags;
 
-  using observed_reduction_data_tags =
-      observers::collect_reduction_data_tags<tmpl::push_back<
-          tmpl::at<typename factory_creation::factory_classes, Event>,
-          typename ApparentHorizon::post_horizon_find_callbacks>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::at<typename factory_creation::factory_classes, Event>>;
 
-  using dg_registration_list =
-      tmpl::push_back<typename st_base::dg_registration_list,
-                      intrp::Actions::RegisterElementWithInterpolator>;
+  using dg_registration_list = typename st_base::dg_registration_list;
 
   using step_actions = typename st_base::template step_actions<control_systems>;
 
@@ -293,12 +289,18 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
         dg_registration_list, tmpl::list<>>;
   };
 
+  using control_system_horizon_metavars =
+      control_system::metafunctions::horizon_metavars<control_systems>;
+
   using component_list = tmpl::flatten<tmpl::list<
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
       mem_monitor::MemoryMonitor<EvolutionMetavars>,
       importers::ElementDataReader<EvolutionMetavars>, st_dg_element_array,
-      intrp::Interpolator<EvolutionMetavars>,
+      ah::Component<EvolutionMetavars, ApparentHorizon>,
+      tmpl::transform<
+          control_system_horizon_metavars,
+          tmpl::bind<ah::Component, tmpl::pin<EvolutionMetavars>, tmpl::_1>>,
       control_system::control_components<EvolutionMetavars, control_systems>,
       tmpl::transform<interpolation_target_tags,
                       tmpl::bind<intrp::InterpolationTarget,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -18,6 +18,8 @@
 #include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
 
@@ -34,6 +36,9 @@ namespace ah {
 template <class Metavariables, typename HorizonMetavars>
 struct Component;
 }  // namespace ah
+namespace Tags {
+struct Time;
+}  // namespace Tags
 /// \endcond
 
 /*!
@@ -206,6 +211,37 @@ struct BlocksForHorizonFind : db::SimpleTag {
     return result;
   }
 };
+
+/// @{
+/*!
+ * \brief Tag to be used for the `time_tag` alias of a `HorizonMetavars` for an
+ * observation horizon find.
+ *
+ * \details We need separate time tags for all horizon finders because of the
+ * current design of the horizon finder. So we just make a simple compute tag
+ * that takes the actual time out of the box since we still want the actual time
+ * to be the same, just a different tag.
+ *
+ */
+template <size_t Index>
+struct ObservationTime : db::SimpleTag {
+  static std::string name() { return "AhObservationTime" + get_output(Index); }
+  using type = LinkedMessageId<double>;
+};
+
+template <size_t Index>
+struct ObservationTimeCompute : ObservationTime<Index>, db::ComputeTag {
+  using argument_tags = tmpl::list<::Tags::Time>;
+  using base = ObservationTime<Index>;
+  using return_type = LinkedMessageId<double>;
+
+  static void function(const gsl::not_null<LinkedMessageId<double>*> ah_time,
+                       const double time) {
+    // The horizon finder knows how to handle the nullopt
+    *ah_time = LinkedMessageId<double>{time, std::nullopt};
+  }
+};
+/// @}
 
 /*!
  * \brief Tag that holds the strahlkorper of the previous FastFlow iteration

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -453,7 +453,6 @@ EventsRunAtCleanup:
         CoordinatesFloatingPointType: Float
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 ApparentHorizons:
@@ -472,8 +471,8 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Quiet
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: ["ObjectAShell", "ObjectACube"]
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: ["ObjectAShell", "ObjectACube"]
   ObservationAhB: &AhB
     InitialGuess:
       LMax: *ObsLMax
@@ -481,8 +480,8 @@ ApparentHorizons:
       Center: [*XCoordB, *YOffset, *ZOffset]
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: ["ObjectBShell", "ObjectBCube"]
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: ["ObjectBShell", "ObjectBCube"]
   ObservationAhC:
     InitialGuess:
       LMax: 33
@@ -490,8 +489,8 @@ ApparentHorizons:
       Center: [0.0, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation:
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind:
       - "ObjectAShell"
       - "ObjectACube"
       - "ObjectBShell"

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -289,7 +289,6 @@ EventsRunAtCleanup:
         CoordinatesFloatingPointType: Float
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 ApparentHorizons:
@@ -308,8 +307,8 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Quiet
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: ["Shell0"]
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: ["Shell0"]
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -268,7 +268,6 @@ Observers:
   SurfaceFileName: "GhBinaryBlackHoleSurfacesData"
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 ApparentHorizons:
@@ -287,8 +286,8 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: All
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: All
   ObservationAhB: &AhB
     InitialGuess:
       LMax: *LMax
@@ -296,8 +295,8 @@ ApparentHorizons:
       Center: [*XCoordB, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: All
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: All
   ObservationAhC:
     InitialGuess:
       LMax: 20
@@ -305,8 +304,8 @@ ApparentHorizons:
       Center: [0.0, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: All
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: All
   ControlSystemAhA: *AhA
   ControlSystemAhB: *AhB
   ControlSystemCharSpeedAhA: *AhA

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -233,7 +233,6 @@ Observers:
   SurfaceFileName: "GhKerrSchildSurfaces"
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 ApparentHorizons:
@@ -252,8 +251,8 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Verbose
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: All
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: All
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -11,7 +11,7 @@ ExpectedOutput:
   - KerrSchildSphericalHarmonicSurfaces.h5
 OutputFileChecks:
   - Label: "check_horizon_find"
-    Subfile: "/Ah.dat"
+    Subfile: "/ApparentHorizon.dat"
     FileGlob: "KerrSchildSphericalHarmonicReductions.h5"
     AbsoluteTolerance: 1e2
 
@@ -193,7 +193,7 @@ EventsAndTriggersAtSlabs:
           Interval: 2
           Offset: 2
     Events:
-      - Ah
+      - ApparentHorizon
   - Trigger:
       Slabs:
         EvenlySpaced:
@@ -227,11 +227,10 @@ Observers:
   SurfaceFileName: "KerrSchildSphericalHarmonicSurfaces"
 
 Interpolator:
-  DumpVolumeDataOnFailure: false
   Verbosity: Silent
 
 ApparentHorizons:
-  Ah: &Ah
+  ApparentHorizon: &Ah
     InitialGuess:
       LMax: &LMax 4
       Radius: 2.2
@@ -246,8 +245,8 @@ ApparentHorizons:
       DivergenceIter: 5
       MaxIts: 100
     Verbosity: Quiet
-    MaxInterpolationRetries: 3
-    BlocksForInterpolation: ["Shell0"]
+    MaxComputeCoordsRetries: 3
+    BlocksForHorizonFind: ["Shell0"]
   ControlSystemSingleAh: *Ah
   ControlSystemCharSpeedAh: *Ah
 

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -49,11 +49,6 @@ static_assert(
 static_assert(
     tt::assert_conforms_to_v<control_system::measurements::BothHorizons,
                              control_system::protocols::Measurement>);
-static_assert(
-    tt::assert_conforms_to_v<
-        control_system::measurements::BothHorizons::FindHorizon<
-            ::domain::ObjectLabel::A>::interpolation_target_tag<example_list>,
-        intrp::protocols::InterpolationTargetTag>);
 static_assert(tt::assert_conforms_to_v<
               control_system::measurements::BothHorizons::FindHorizon<
                   ::domain::ObjectLabel::A>::horizon_metavars<example_list>,
@@ -71,11 +66,6 @@ static_assert(
     tt::assert_conforms_to_v<
         control_system::measurements::SingleHorizon<::domain::ObjectLabel::B>,
         control_system::protocols::Measurement>);
-static_assert(
-    tt::assert_conforms_to_v<
-        control_system::measurements::SingleHorizon<::domain::ObjectLabel::B>::
-            Submeasurement::interpolation_target_tag<example_list>,
-        intrp::protocols::InterpolationTargetTag>);
 static_assert(
     tt::assert_conforms_to_v<
         control_system::measurements::SingleHorizon<::domain::ObjectLabel::B>::
@@ -111,10 +101,6 @@ static_assert(
 static_assert(tt::assert_conforms_to_v<
               control_system::measurements::CharSpeed<domain::ObjectLabel::A>::
                   Excision::interpolation_target_tag<example_list>,
-              intrp::protocols::InterpolationTargetTag>);
-static_assert(tt::assert_conforms_to_v<
-              control_system::measurements::CharSpeed<domain::ObjectLabel::A>::
-                  Horizon::interpolation_target_tag<example_list>,
               intrp::protocols::InterpolationTargetTag>);
 static_assert(tt::assert_conforms_to_v<
               control_system::measurements::CharSpeed<domain::ObjectLabel::A>::

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Tags.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "DataStructures/LinkedMessageId.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
@@ -12,6 +13,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "Time/Tags/TimeAndPrevious.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 
 namespace {
@@ -30,6 +32,12 @@ struct MockHorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
 
   static std::string name() { return "MockHorizonMetavars"; }
 };
+
+void test_observation_time() {
+  LinkedMessageId<double> result{};
+  ah::Tags::ObservationTimeCompute<0>::function(make_not_null(&result), 1.2);
+  CHECK(result == LinkedMessageId<double>{1.2, std::nullopt});
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Tags",
@@ -50,6 +58,11 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Tags",
       "ApparentHorizonOptions");
   TestHelpers::db::test_simple_tag<ah::Tags::BlocksForHorizonFind>(
       "BlocksForHorizonFind");
+  TestHelpers::db::test_simple_tag<ah::Tags::ObservationTime<0>>(
+      "AhObservationTime0");
+  TestHelpers::db::test_compute_tag<ah::Tags::ObservationTimeCompute<0>>(
+      "AhObservationTime0");
+  test_observation_time();
   TestHelpers::db::test_simple_tag<
       ah::Tags::PreviousIterationStrahlkorper<::Frame::Distorted>>(
       "PreviousIterationStrahlkorper");


### PR DESCRIPTION
## Proposed changes

Seventeenth PR in horizon finder changes. This PR switches out the old horizon finder infrastructure for the new infrastructure in the execs that have BHs in them. This PR doesn't remove any of the old infrastructure yet. That'll happen in a later PR.

~Currently this is a draft PR until I verify everything works on develop with this PR.~

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
In the `KerrSchildSphericalHarmonic.yaml` input file, rename instances of `Ah` to `ApparentHorizon`.

The following upgrades are for execs with horizon finders:
- Remove the `DumpVolumeDataOnFailure:` option under the `Interpolator:` group.
- Under the `ApparentHorizons:` block, rename `MaxInterpolationRetries:` to `MaxComputeCoordsRetries:` and `BlocksForInterpolation:` to `BlocksForHorizonFind`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
