### PR TITLE
Add shape adaptive ah criterion

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   IncreaseResolution.cpp
   Residual.cpp
+  Shape.cpp
   )
 
 spectre_target_headers(
@@ -21,6 +22,7 @@ spectre_target_headers(
   Factory.hpp
   IncreaseResolution.hpp
   Residual.hpp
+  Shape.hpp
   )
 
 add_dependencies(

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp
@@ -5,8 +5,9 @@
 
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace ah::Criteria {
-using standard_criteria = tmpl::list<Residual>;
+using standard_criteria = tmpl::list<Residual, Shape>;
 }  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.cpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp"
+
+#include <cstddef>
+#include <pup.h>
+
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+
+namespace ah::Criteria {
+Shape::Shape(double min_truncation_error, double max_truncation_error,
+             size_t max_pile_up_modes, size_t min_resolution_l,
+             size_t max_resolution_l, const Options::Context& context)
+    : min_truncation_error_(min_truncation_error),
+      max_truncation_error_(max_truncation_error),
+      max_pile_up_modes_(max_pile_up_modes),
+      min_resolution_l_(min_resolution_l),
+      max_resolution_l_(max_resolution_l) {
+  if (min_truncation_error_ >= max_truncation_error_) {
+    PARSE_ERROR(context,
+                "MinTruncationError must be less than MaxTruncationError");
+  }
+  if (min_resolution_l_ < MinResolutionL::lower_bound()) {
+    PARSE_ERROR(context, "MinResolutionL must be at least "
+                             << MinResolutionL::lower_bound());
+  }
+  if (max_resolution_l_ < MinResolutionL::lower_bound()) {
+    PARSE_ERROR(context, "MaxResolutionL must be at least "
+                             << MinResolutionL::lower_bound());
+  }
+  if (min_resolution_l_ > max_resolution_l_) {
+    PARSE_ERROR(context, "MinResolutionL must be less than MaxResolutionL");
+  }
+}
+
+void Shape::pup(PUP::er& p) {
+  p | min_truncation_error_;
+  p | max_truncation_error_;
+  p | max_pile_up_modes_;
+  p | min_resolution_l_;
+  p | max_resolution_l_;
+}
+
+Shape::Shape(CkMigrateMessage* msg) : Criterion(msg) {}
+
+PUP::able::PUP_ID ah::Criteria::Shape::my_PUP_ID = 0;  // NOLINT
+}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <string>
+
+#include "NumericalAlgorithms/LinearOperators/PowerMonitors.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+/*!
+ * \brief Recommend an updated resolution $L_{\rm new}$ based on how well
+ * the shape of the apparent horizon is resolved in terms of its
+ * truncation error and pile up modes.
+ *
+ * \details The returned recommended resolution $L_{\rm new}$ depends on
+ * the following options:
+ * - MinTruncationError: a minimum truncation error $\mathcal{T}_{\rm min}$
+ * - MaxTruncationError: a maximum truncation error $\mathcal{T}_{\rm max}$
+ * - MaxPileUpModes: a maximum number of pile up modes $\mathcal{P}_{\rm max}$
+ * - MinResolutionL: a minimum resolution $L_{\rm min}$
+ * - MaxResolutionL: a maximum resolution $L_{\rm max}$
+ * The value returned for $L_{\rm new}$ is then determined as follows:
+ * - If $L > L_{\rm min}$ and $\mathcal{T} < \mathcal{T}_{\rm min}$, then
+ * $L_{\rm new} = L - 1$
+ * - If $L < L_{\rm max}$ and $\mathcal{T} > \mathcal{T}_{\rm max}$ and
+ * $\mathcal{P} \le \mathcal{P}_{\rm max}$, then
+ * $L_{\rm new} = L + 1$
+ * - Otherwise, $L_{\rm new} = L$
+ * Note that the truncation error is obtained via
+ * PowerMonitors::relative_truncation_error, and the number of pileup modes
+ * is given by PowerMonitors::convergence_rate_and_number_of_pile_up_modes
+ */
+class Shape : public Criterion {
+ public:
+  struct MinTruncationError {
+    using type = double;
+    static constexpr Options::String help = {"The minimum truncation error."};
+    static type lower_bound() { return 0.0; }
+  };
+  struct MaxTruncationError {
+    using type = double;
+    static constexpr Options::String help = {"The maximum truncation error."};
+    static type lower_bound() { return 0.0; }
+  };
+  struct MaxPileUpModes {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The maximum number of pile up modes."};
+    static type lower_bound() { return 0; }
+  };
+  struct MinResolutionL {
+    using type = size_t;
+    static constexpr Options::String help = {"The minimum resolution."};
+    // Power montior requires at least L=4, so don't allow L below that
+    static type lower_bound() { return 4; }
+  };
+  struct MaxResolutionL {
+    using type = size_t;
+    static constexpr Options::String help = {"The maximum resolution."};
+    // Power monitor requires at least L=4, so don't allow L below that
+    static type lower_bound() { return 4; }
+  };
+
+  using options = tmpl::list<MinTruncationError, MaxTruncationError,
+                             MaxPileUpModes, MinResolutionL, MaxResolutionL>;
+  static constexpr Options::String help = {
+      "Use Strahlkorper truncation error, number of pile up modes, and "
+      "resolution to suggest a new resolution."};
+
+  Shape() = default;
+  Shape(double min_truncation_error, double max_truncation_error,
+        size_t max_pile_up_modes, size_t min_resolution_l,
+        size_t max_resolution_l, const Options::Context& context = {});
+
+  /// \cond
+  explicit Shape(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Shape);  // NOLINT
+  /// \endcond
+
+  std::string observation_name() override { return "Shape"; }
+
+  using argument_tags = tmpl::list<>;
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  template <typename Metavariables, typename Frame>
+  size_t operator()(const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ylm::Strahlkorper<Frame>& strahlkorper,
+                    const FastFlow::IterInfo& /*info*/) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  double min_truncation_error_{std::numeric_limits<double>::signaling_NaN()};
+  double max_truncation_error_{std::numeric_limits<double>::signaling_NaN()};
+  size_t max_pile_up_modes_{};
+  size_t min_resolution_l_{};
+  size_t max_resolution_l_{};
+};
+
+// Out-of-line definition
+/// \cond
+template <typename Metavariables, typename Frame>
+size_t Shape::operator()(const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                         const ylm::Strahlkorper<Frame>& strahlkorper,
+                         const FastFlow::IterInfo& /*info*/) const {
+  if (UNLIKELY(min_resolution_l_ == max_resolution_l_)) {
+    ASSERT(min_resolution_l_ == strahlkorper.l_max(),
+           "If MinResolutionL == MaxResolutionL, strahlkorper resolution must "
+           "also equal MinResolution L, but here MinResolutionL is "
+               << min_resolution_l_ << ", MaxResolutionL is "
+               << max_resolution_l_ << ", and the current resolution is "
+               << strahlkorper.l_max());
+    return strahlkorper.l_max();
+  }
+
+  const DataVector& power_monitor = ylm::power_monitor(strahlkorper);
+  const double truncation_error = PowerMonitors::relative_truncation_error(
+      power_monitor, power_monitor.size());
+  const size_t pile_up_modes =
+      PowerMonitors::convergence_rate_and_number_of_pile_up_modes(power_monitor)
+          .number_of_pile_up_modes;
+  if (strahlkorper.l_max() > min_resolution_l_ and
+      truncation_error < min_truncation_error_ and strahlkorper.l_max() > 0) {
+    return strahlkorper.l_max() - 1;
+  }
+  if (strahlkorper.l_max() < max_resolution_l_ and
+      truncation_error > max_truncation_error_ and
+      pile_up_modes <= max_pile_up_modes_) {
+    return strahlkorper.l_max() + 1;
+  }
+  return strahlkorper.l_max();
+}
+/// \endcond
+}  // namespace ah::Criteria

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Criterion.cpp
   Test_IncreaseResolution.cpp
   Test_Residual.cpp
+  Test_Shape.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Shape.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Shape.cpp
@@ -1,0 +1,311 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "PointwiseFunctions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Criteria {
+namespace {
+template <typename Frame>
+struct Metavariables {
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<ah::Criterion, tmpl::list<Shape>>>;
+  };
+};
+
+template <typename Fr>
+ylm::Strahlkorper<Fr> make_strahlkorper(size_t l_max,
+                                        const std::array<double, 3>& spin) {
+  const ylm::Strahlkorper<Fr>& sphere =
+      ylm::Strahlkorper<Fr>(l_max, 4.5, {{0.4, 0.5, 0.6}});
+  const std::array<DataVector, 2> theta_phi =
+      sphere.ylm_spherepack().theta_phi_points();
+  const auto radius = gr::Solutions::kerr_horizon_radius(theta_phi, 1.0, spin);
+  return ylm::Strahlkorper<Fr>{l_max, l_max, get(radius), {{0.4, 0.5, 0.6}}};
+}
+
+template <typename Fr>
+void test_criterion_evaluation(
+    const std::unique_ptr<ah::Criterion>& criterion,
+    const ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>>& box,
+    Parallel::GlobalCache<Metavariables<Frame::Inertial>>& cache, size_t l_max,
+    const std::array<double, 3>& spin, size_t expected_new_l_max) {
+  const ylm::Strahlkorper<Fr> strahlkorper = make_strahlkorper<Fr>(l_max, spin);
+  const size_t new_l_max =
+      criterion->evaluate(box, cache, strahlkorper, FastFlow::IterInfo{});
+  CHECK(new_l_max == expected_new_l_max);
+}
+
+void test_shape() {
+  TestHelpers::db::test_simple_tag<ah::Criteria::Tags::Criteria>("Criteria");
+  const auto criterion{TestHelpers::test_factory_creation<ah::Criterion, Shape>(
+      "Shape:\n"
+      "  MinTruncationError: 1.0e-10\n"
+      "  MaxTruncationError: 1.0e-8\n"
+      "  MaxPileUpModes: 5\n"
+      "  MinResolutionL: 4\n"
+      "  MaxResolutionL: 12")};
+  // Test observation_name
+  CHECK(criterion->observation_name() == "Shape");
+
+  Parallel::GlobalCache<Metavariables<Frame::Inertial>> empty_cache{};
+  auto databox = db::create<tmpl::list<>>();
+  const ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<>>> box{
+      make_not_null(&databox)};
+
+  constexpr double min_truncation_error{1.0e-10};
+  constexpr double max_truncation_error{1.0e-8};
+  constexpr size_t max_pile_up_modes{5};
+  constexpr size_t min_resolution_l{4};
+  constexpr size_t max_resolution_l{12};
+  constexpr size_t mid_l{8};
+  const std::array<double, 3> zero_spin{{0.0, 0.0, 0.0}};
+  const std::array<double, 3> low_aligned_spin{{0.0, 0.0, 0.1}};
+  const std::array<double, 3> low_spin{{0.1, 0.2, 0.3}};
+  const std::array<double, 3> high_spin{{0.4, 0.5, 0.6}};
+  constexpr size_t min_l_allowed_by_power_monitor{4};
+  constexpr double eps{std::numeric_limits<double>::epsilon()};
+
+  // Normal case - decrease resolution when truncation error is low
+  // Make truncation error low by passing in a spherical Strahlkorper, i.e.
+  // a horizon of a black hole with zero spin
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             zero_spin, mid_l - 1);
+
+  // Normal case - increase resolution when truncation error is high
+  // Make truncation error high (~1e-7) by passing in a spinning Kerr Schild
+  // horizon for the strahlkorper
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             high_spin, mid_l + 1);
+
+  // Normal case - keep resolution the same when truncation error is in range
+  // Do this by using a Strahlkorper of a Kerr Schild black hole spinning
+  // but not quite as fast
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache, mid_l,
+                                             low_spin, mid_l);
+
+  // Normal case - keep resolution the same when you would have raised it
+  // except you have too many pile up modes. Here make lots of pile up modes by
+  // using high resolution for spin=0.1 Kerr-Schild black hole, and use
+  // very small truncation error ranges so that the criterion would otherwise
+  // want to increase resolution, if it weren't for the pileup modes
+  const std::unique_ptr<ah::Criterion> criterion_pile_up =
+      std::make_unique<ah::Criteria::Shape>(min_truncation_error * 1.e-10,
+                                            max_truncation_error * 1.e-10, 1,
+                                            min_resolution_l, mid_l * 4);
+  test_criterion_evaluation<Frame::Inertial>(criterion_pile_up, box,
+                                             empty_cache, mid_l * 4,
+                                             low_aligned_spin, mid_l * 4);
+
+  // Edge case - at minimum resolution, low truncation error
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache,
+                                             min_resolution_l, zero_spin,
+                                             min_resolution_l);
+
+  // Edge case - at max resolution, high truncation error
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache,
+                                             max_resolution_l, high_spin,
+                                             max_resolution_l);
+
+  // Edge case - at minimum resolution, high truncation error
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache,
+                                             min_resolution_l, high_spin,
+                                             min_resolution_l + 1);
+
+  // Edge case - at max resolution, low truncation error
+  test_criterion_evaluation<Frame::Inertial>(criterion, box, empty_cache,
+                                             max_resolution_l, zero_spin,
+                                             max_resolution_l - 1);
+
+  // Edge case - truncation error exactly at min_truncation_error
+  const ylm::Strahlkorper<Frame::Inertial>
+      strahlkorper_with_known_truncation_error =
+          make_strahlkorper<Frame::Inertial>(mid_l, high_spin);
+  const DataVector power_monitor_known_truncation_error =
+      ylm::power_monitor(strahlkorper_with_known_truncation_error);
+  const double known_truncation_error =
+      PowerMonitors::relative_truncation_error(
+          power_monitor_known_truncation_error,
+          power_monitor_known_truncation_error.size());
+  const std::unique_ptr<ah::Criterion> criterion_min_truncation_error =
+      std::make_unique<ah::Criteria::Shape>(
+          known_truncation_error, known_truncation_error * 100.0,
+          max_pile_up_modes, min_resolution_l, max_resolution_l);
+  test_criterion_evaluation<Frame::Inertial>(criterion_min_truncation_error,
+                                             box, empty_cache, mid_l, high_spin,
+                                             mid_l);
+
+  // Edge case - truncation error just above min_truncation_error
+  const std::unique_ptr<ah::Criterion>
+      criterion_min_truncation_error_just_above =
+          std::make_unique<ah::Criteria::Shape>(
+              known_truncation_error - eps, known_truncation_error * 100.0,
+              max_pile_up_modes, min_resolution_l, max_resolution_l);
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion_min_truncation_error_just_above, box, empty_cache, mid_l,
+      high_spin, mid_l);
+
+  // Edge case - truncation error just below min_truncation_error
+  const std::unique_ptr<ah::Criterion>
+      criterion_min_truncation_error_just_below =
+          std::make_unique<ah::Criteria::Shape>(
+              known_truncation_error + eps, known_truncation_error * 100.0,
+              max_pile_up_modes, min_resolution_l, max_resolution_l);
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion_min_truncation_error_just_below, box, empty_cache, mid_l,
+      high_spin, mid_l - 1);
+
+  // Edge case - truncation error exactly at max_truncation_error
+  const std::unique_ptr<ah::Criterion> criterion_max_truncation_error =
+      std::make_unique<ah::Criteria::Shape>(
+          known_truncation_error / 100.0, known_truncation_error,
+          max_pile_up_modes, min_resolution_l, max_resolution_l);
+  test_criterion_evaluation<Frame::Inertial>(criterion_max_truncation_error,
+                                             box, empty_cache, mid_l, high_spin,
+                                             mid_l);
+
+  // Edge case - truncation error just below max_truncation_error
+  const std::unique_ptr<ah::Criterion>
+      criterion_max_truncation_error_just_below =
+          std::make_unique<ah::Criteria::Shape>(
+              known_truncation_error / 100.0, known_truncation_error + eps,
+              max_pile_up_modes, min_resolution_l, max_resolution_l);
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion_max_truncation_error_just_below, box, empty_cache, mid_l,
+      high_spin, mid_l);
+
+  // Edge case - truncation error just above max_truncation_error
+  const std::unique_ptr<ah::Criterion>
+      criterion_max_truncation_error_just_above =
+          std::make_unique<ah::Criteria::Shape>(
+              known_truncation_error / 100.0, known_truncation_error - eps,
+              max_pile_up_modes, min_resolution_l, max_resolution_l);
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion_max_truncation_error_just_above, box, empty_cache, mid_l,
+      high_spin, mid_l + 1);
+
+  // Edge case - l_min = 4 (minimum allowed by power monitor)
+  const std::unique_ptr<ah::Criterion> criterion_l_min_4 =
+      std::make_unique<ah::Criteria::Shape>(
+          min_truncation_error, max_truncation_error, max_pile_up_modes,
+          min_l_allowed_by_power_monitor, max_resolution_l);
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion_l_min_4, box, empty_cache, min_l_allowed_by_power_monitor,
+      zero_spin, min_l_allowed_by_power_monitor);
+
+  // Edge case - l_min = 4 (minimum allowed by power monitor), high residual
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion_l_min_4, box, empty_cache, min_l_allowed_by_power_monitor,
+      high_spin, min_l_allowed_by_power_monitor + 1);
+
+  // Edge case - min_resolution_l == max_resolution_l
+  const std::unique_ptr<ah::Criterion>
+      criterion_min_resolution_l_eq_max_resolution_l =
+          std::make_unique<ah::Criteria::Shape>(
+              min_truncation_error, max_truncation_error, max_pile_up_modes,
+              mid_l, mid_l);
+  test_criterion_evaluation<Frame::Inertial>(
+      criterion_min_resolution_l_eq_max_resolution_l, box, empty_cache, mid_l,
+      high_spin, mid_l);
+
+  // Edge case - min_resolution_l == max_resolution_l but
+  // different from strahlkorper
+#ifdef SPECTRE_DEBUG
+  const ylm::Strahlkorper<Frame::Inertial> debug_strahlkorper{
+      make_strahlkorper<Frame::Inertial>(mid_l - 2, zero_spin)};
+  CHECK_THROWS_WITH(
+      criterion_min_resolution_l_eq_max_resolution_l->evaluate(
+          box, empty_cache, debug_strahlkorper, FastFlow::IterInfo{}),
+      Catch::Matchers::ContainsSubstring(
+          "If MinResolutionL == MaxResolutionL"));
+#endif
+}
+
+void test_shape_constructor_validation() {
+  // Define test constants
+  constexpr double min_truncation_error = 1.0e-6;
+  constexpr double max_truncation_error = 1.0e-4;
+  const double zero = 0.0;
+  constexpr size_t max_pile_up_modes = 5;
+  constexpr size_t min_resolution_l = 4;
+  constexpr size_t max_resolution_l = 12;
+  constexpr size_t min_allowed_resolution = 4;
+
+  // Test valid construction
+  CHECK_NOTHROW((Shape{min_truncation_error, max_truncation_error,
+                       max_pile_up_modes, min_resolution_l, max_resolution_l}));
+
+  // Test invalid construction - min_truncation_error >= max_truncation_error
+  CHECK_THROWS_WITH(
+      (Shape{max_truncation_error, min_truncation_error, max_pile_up_modes,
+             min_resolution_l, max_resolution_l}),
+      Catch::Matchers::ContainsSubstring(
+          "MinTruncationError must be less than MaxTruncationError"));
+
+  // Test invalid construction - min_truncation_error == max_truncation_error
+  CHECK_THROWS_WITH(
+      (Shape{min_truncation_error, min_truncation_error, max_pile_up_modes,
+             min_resolution_l, max_resolution_l}),
+      Catch::Matchers::ContainsSubstring(
+          "MinTruncationError must be less than MaxTruncationError"));
+
+  // Test invalid construction - min_resolution_l > max_resolution_l
+  CHECK_THROWS_WITH(
+      (Shape{min_truncation_error, max_truncation_error, max_pile_up_modes,
+             max_resolution_l, min_resolution_l}),
+      Catch::Matchers::ContainsSubstring(
+          "MinResolutionL must be less than MaxResolutionL"));
+
+  // Test edge case - zero max_truncation_error (should fail)
+  CHECK_THROWS_WITH(
+      (Shape{min_truncation_error, zero, max_pile_up_modes, min_resolution_l,
+             max_resolution_l}),
+      Catch::Matchers::ContainsSubstring(
+          "MinTruncationError must be less than MaxTruncationError"));
+
+  // Test edge case - min_resolution_l below minimum allowed value (4)
+  CHECK_THROWS_WITH(
+      (Shape{min_truncation_error, max_truncation_error, max_pile_up_modes,
+             min_allowed_resolution - 1, max_resolution_l}),
+      Catch::Matchers::ContainsSubstring("MinResolutionL must be at least 4"));
+
+  // Test edge case - max_resolution_l below minimum allowed value (4)
+  CHECK_THROWS_WITH(
+      (Shape{min_truncation_error, max_truncation_error, max_pile_up_modes,
+             min_allowed_resolution, min_allowed_resolution - 1}),
+      Catch::Matchers::ContainsSubstring("MaxResolutionL must be at least 4"));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Criteria.Shape",
+                  "[ApparentHorizonFinder][Unit]") {
+  test_shape();
+  test_shape_constructor_validation();
+}
+}  // namespace ah::Criteria


### PR DESCRIPTION
## Proposed changes

Adds an adaptive apparent horizon finder criterion based on the horizon shape. Specifically, the criterion increases or decreases resolution based on the apparent horizon truncation error and number of pile up modes.

Note: I used cursor AI tab completion when preparing this PR. I reviewed all suggested code, and to the best of my knowledge there are know issues with generated code reproducing unlicensed code.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
