### PR TITLE
Separate h and p refinement criteria so they can be applied separately in evolution executables

### DIFF
--- a/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
+++ b/src/Elliptic/Executables/Elasticity/SolveElasticity.hpp
@@ -184,6 +184,7 @@ struct Metavariables {
         typename solver::amr_projectors,
         Elasticity::Actions::InitializeConstitutiveRelation<Dim>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = false;
   };
 
   struct registration

--- a/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoisson.hpp
@@ -169,6 +169,7 @@ struct Metavariables {
     using element_array = dg_element_array;
     using projectors = typename solver::amr_projectors;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = false;
   };
 
   struct registration

--- a/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
+++ b/src/Elliptic/Executables/Punctures/SolvePunctures.hpp
@@ -147,6 +147,7 @@ struct Metavariables {
     using element_array = dg_element_array;
     using projectors = typename solver::amr_projectors;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = false;
   };
 
   struct registration

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -203,6 +203,7 @@ struct Metavariables {
     using element_array = dg_element_array;
     using projectors = typename solver::amr_projectors;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = false;
   };
 
   struct registration

--- a/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.hpp
+++ b/src/Elliptic/Systems/Punctures/AmrCriteria/RefineAtPunctures.hpp
@@ -16,6 +16,7 @@
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -42,6 +43,8 @@ class RefineAtPunctures : public amr::Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(RefineAtPunctures);  // NOLINT
   /// \endcond
+
+  amr::Criteria::Type type() override { return amr::Criteria::Type::h; }
 
   std::string observation_name() override { return "RefineAtPunctures"; }
 

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -706,6 +706,7 @@ struct EvolutionMetavars {
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = true;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -106,6 +106,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Tensors.hpp"
@@ -460,7 +461,10 @@ struct EvolutionMetavars {
         tmpl::pair<
             amr::Criterion,
             tmpl::list<
-                amr::Criteria::DriveToTarget<volume_dim>,
+                amr::Criteria::DriveToTarget<volume_dim,
+                                             amr::Criteria::Type::h>,
+                amr::Criteria::DriveToTarget<volume_dim,
+                                             amr::Criteria::Type::p>,
                 amr::Criteria::Constraints<
                     volume_dim,
                     tmpl::list<gh::Tags::ThreeIndexConstraintCompute<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -104,7 +104,6 @@
 #include "ParallelAlgorithms/Amr/Criteria/Constraints.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
-#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -107,6 +107,7 @@ struct EvolutionMetavars
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = true;
   };
 
   struct registration

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -302,6 +302,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = true;
   };
 
   struct registration

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -75,6 +75,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Tensors.hpp"
@@ -112,13 +113,13 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
-#include "PointwiseFunctions/GeneralRelativity/DerivativeSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
@@ -283,7 +284,8 @@ struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
       tmpl::pair<
           amr::Criterion,
           tmpl::list<
-              amr::Criteria::DriveToTarget<volume_dim>,
+              amr::Criteria::DriveToTarget<volume_dim, amr::Criteria::Type::h>,
+              amr::Criteria::DriveToTarget<volume_dim, amr::Criteria::Type::p>,
               amr::Criteria::Constraints<
                   volume_dim, tmpl::list<gh::Tags::ThreeIndexConstraintCompute<
                                   volume_dim, Frame::Inertial>>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -72,7 +72,6 @@
 #include "ParallelAlgorithms/Amr/Criteria/Constraints.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
-#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Type.hpp"

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -337,6 +337,7 @@ struct EvolutionMetavars {
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = true;
   };
 
   struct registration

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -66,6 +66,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Events/RefineMesh.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
@@ -179,7 +180,10 @@ struct EvolutionMetavars {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<amr::Criterion,
-                   tmpl::list<amr::Criteria::DriveToTarget<volume_dim>,
+                   tmpl::list<amr::Criteria::DriveToTarget<
+                                  volume_dim, amr::Criteria::Type::h>,
+                              amr::Criteria::DriveToTarget<
+                                  volume_dim, amr::Criteria::Type::p>,
                               amr::Criteria::TruncationError<
                                   volume_dim,
                                   typename system::variables_tag::tags_list>>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -63,7 +63,6 @@
 #include "ParallelAlgorithms/Amr/Actions/SendAmrDiagnostics.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
-#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Type.hpp"

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -71,7 +71,8 @@ struct RandomAmrMetavars {
                                   volume_dim, amr::Criteria::Type::h>,
                               amr::Criteria::DriveToTarget<
                                   volume_dim, amr::Criteria::Type::p>,
-                              amr::Criteria::Random>>,
+                              amr::Criteria::Random<amr::Criteria::Type::h>,
+                              amr::Criteria::Random<amr::Criteria::Type::p>>>,
         tmpl::pair<
             PhaseChange,
             tmpl::list<

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -35,6 +35,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
@@ -66,7 +67,10 @@ struct RandomAmrMetavars {
     using factory_classes = tmpl::map<
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<amr::Criterion,
-                   tmpl::list<amr::Criteria::DriveToTarget<volume_dim>,
+                   tmpl::list<amr::Criteria::DriveToTarget<
+                                  volume_dim, amr::Criteria::Type::h>,
+                              amr::Criteria::DriveToTarget<
+                                  volume_dim, amr::Criteria::Type::p>,
                               amr::Criteria::Random>>,
         tmpl::pair<
             PhaseChange,

--- a/src/Executables/Examples/RandomAmr/RandomAmr.hpp
+++ b/src/Executables/Examples/RandomAmr/RandomAmr.hpp
@@ -130,5 +130,6 @@ struct RandomAmrMetavars {
         domain::Tags::InitialRefinementLevels<Dim>,
         evolution::dg::Tags::Quadrature>>;
     static constexpr bool keep_coarse_grids = KeepCoarseGrids;
+    static constexpr bool p_refine_only_in_event = false;
   };
 };

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -63,6 +63,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/Events/MonitorMemory.hpp"
@@ -304,7 +305,10 @@ struct Metavariables {
         tmpl::pair<DomainCreator<volume_dim>, domain_creators<volume_dim>>,
         tmpl::pair<
             amr::Criterion,
-            tmpl::list<amr::Criteria::DriveToTarget<volume_dim>,
+            tmpl::list<amr::Criteria::DriveToTarget<volume_dim,
+                                                    amr::Criteria::Type::h>,
+                       amr::Criteria::DriveToTarget<volume_dim,
+                                                    amr::Criteria::Type::p>,
                        amr::Criteria::Random,
                        amr::Criteria::TruncationError<
                            volume_dim, tmpl::list<::domain::Tags::Coordinates<

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -309,7 +309,8 @@ struct Metavariables {
                                                     amr::Criteria::Type::h>,
                        amr::Criteria::DriveToTarget<volume_dim,
                                                     amr::Criteria::Type::p>,
-                       amr::Criteria::Random,
+                       amr::Criteria::Random<amr::Criteria::Type::h>,
+                       amr::Criteria::Random<amr::Criteria::Type::p>,
                        amr::Criteria::TruncationError<
                            volume_dim, tmpl::list<::domain::Tags::Coordinates<
                                            volume_dim, Frame::Inertial>>>>>,

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -379,6 +379,7 @@ struct Metavariables {
             ::domain::Tags::InitialRefinementLevels<Dim>,
             evolution::dg::Tags::Quadrature>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = false;
   };
 
   struct registration

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -33,6 +33,7 @@
 #include "ParallelAlgorithms/Amr/Policies/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
 #include "ParallelAlgorithms/Amr/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -74,7 +75,9 @@ namespace amr::Actions {
 /// \details
 /// - Evaluates each refinement criteria held by amr::Criteria::Tags::Criteria,
 ///   and in each dimension selects the amr::Flag with the highest
-///   priority (i.e the highest integral value).
+///   priority (i.e the highest integral value).  If
+///   Metavariables::amr::p_refine_only_in_event is true, only h-refinement
+///   criteria will be evaluated
 /// - If necessary, changes the refinement decision in order to satisfy the
 ///   amr::Policies
 /// - An Element that is splitting in one dimension is not allowed to join
@@ -113,9 +116,31 @@ struct EvaluateRefinementCriteria {
     const auto& refinement_criteria =
         db::get<amr::Criteria::Tags::Criteria>(box);
     for (const auto& criterion : refinement_criteria) {
+      if (Metavariables::amr::p_refine_only_in_event and
+          criterion->type() == amr::Criteria::Type::p) {
+        continue;
+      }
       auto decision = criterion->evaluate(observation_box, cache, element_id);
+      if constexpr (Metavariables::amr::p_refine_only_in_event) {
+        ASSERT(alg::none_of(decision,
+                            [](amr::Flag flag) {
+                              return flag == amr::Flag::IncreaseResolution or
+                                     flag == amr::Flag::DecreaseResolution;
+                            }),
+               "The criterion '"
+                   << typeid(*criterion).name()
+                   << "' requested p-refinement, but claims to be "
+                      "for h-refinement.");
+      }
       for (size_t d = 0; d < volume_dim; ++d) {
         overall_decision[d] = std::max(overall_decision[d], decision[d]);
+      }
+    }
+
+    // If no refinement criteria were called, then set flag to do nothing
+    for (size_t d = 0; d < volume_dim; ++d) {
+      if (overall_decision[d] == amr::Flag::Undefined) {
+        overall_decision[d] = amr::Flag::DoNothing;
       }
     }
 

--- a/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/Criteria/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   Persson.cpp
   Random.cpp
   TruncationError.cpp
+  Type.cpp
   )
 
 spectre_target_headers(
@@ -31,6 +32,7 @@ spectre_target_headers(
   Persson.hpp
   Random.hpp
   TruncationError.hpp
+  Type.hpp
   )
 
 add_dependencies(

--- a/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Constraints.hpp
@@ -23,6 +23,7 @@
 #include "Options/ParseError.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Events/Tags.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -158,6 +159,8 @@ class Constraints : public Criterion {
                                  Dim, Frame::ElementLogical, Frame::Inertial>,
                              Events::Tags::ObserverJacobianCompute<
                                  Dim, Frame::ElementLogical, Frame::Inertial>>>;
+
+  Type type() override { return Type::p; }
 
   std::string observation_name() override { return "Constraints"; }
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Criterion.hpp
@@ -12,6 +12,7 @@
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -53,6 +54,8 @@ class Criterion : public PUP::able {
   explicit Criterion(CkMigrateMessage* msg) : PUP::able(msg) {}
 
   WRAPPED_PUPable_abstract(Criterion);  // NOLINT
+
+  virtual Criteria::Type type() = 0;
 
   virtual std::string observation_name() = 0;
 

--- a/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.cpp
@@ -11,51 +11,70 @@
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace amr::Criteria {
-template <size_t Dim>
-DriveToTarget<Dim>::DriveToTarget(
-    const std::array<size_t, Dim>& target_number_of_grid_points,
-    const std::array<size_t, Dim>& target_refinement_levels,
+template <size_t Dim, Type CriteriaType>
+DriveToTarget<Dim, CriteriaType>::DriveToTarget(
+    const std::array<size_t, Dim>& target,
     const std::array<Flag, Dim>& flags_at_target)
-    : target_number_of_grid_points_(target_number_of_grid_points),
-      target_refinement_levels_(target_refinement_levels),
-      flags_at_target_(flags_at_target) {}
+    : target_(target), flags_at_target_(flags_at_target) {
+  if constexpr (CriteriaType == Type::h) {
+    if (alg::any_of(flags_at_target_, [](Flag flag) {
+          return flag == Flag::IncreaseResolution or
+                 flag == Flag::DecreaseResolution;
+        })) {
+      ERROR("Cannot use p-refinement flag in OscillationAtTarget "
+            << flags_at_target);
+    }
+  } else {
+    if (alg::any_of(flags_at_target_, [](Flag flag) {
+          return flag == Flag::Join or flag == Flag::Split;
+        })) {
+      ERROR("Cannot use h-refinement flag in OscillationAtTarget "
+            << flags_at_target);
+    }
+  }
+}
 
-template <size_t Dim>
-DriveToTarget<Dim>::DriveToTarget(CkMigrateMessage* msg) : Criterion(msg) {}
+template <size_t Dim, Type CriteriaType>
+DriveToTarget<Dim, CriteriaType>::DriveToTarget(CkMigrateMessage* msg)
+    : Criterion(msg) {}
 
 // NOLINTNEXTLINE(google-runtime-references)
-template <size_t Dim>
-void DriveToTarget<Dim>::pup(PUP::er& p) {
+template <size_t Dim, Type CriteriaType>
+void DriveToTarget<Dim, CriteriaType>::pup(PUP::er& p) {
   Criterion::pup(p);
-  p | target_number_of_grid_points_;
-  p | target_refinement_levels_;
+  p | target_;
   p | flags_at_target_;
 }
 
-template <size_t Dim>
-std::array<Flag, Dim> DriveToTarget<Dim>::impl(
+template <size_t Dim, Type CriteriaType>
+std::array<Flag, Dim> DriveToTarget<Dim, CriteriaType>::impl(
     const Mesh<Dim>& current_mesh, const ElementId<Dim>& element_id) const {
   auto result = make_array<Dim>(Flag::DoNothing);
-  const std::array<size_t, Dim> levels = element_id.refinement_levels();
+  [[maybe_unused]] const std::array<size_t, Dim> levels =
+      element_id.refinement_levels();
   bool is_at_target = true;
   for (size_t d = 0; d < Dim; ++d) {
-    if (gsl::at(levels, d) < gsl::at(target_refinement_levels_, d)) {
-      gsl::at(result, d) = Flag::Split;
-      is_at_target = false;
-    } else if (current_mesh.extents(d) <
-               gsl::at(target_number_of_grid_points_, d)) {
-      gsl::at(result, d) = Flag::IncreaseResolution;
-      is_at_target = false;
-    } else if (current_mesh.extents(d) >
-               gsl::at(target_number_of_grid_points_, d)) {
-      gsl::at(result, d) = Flag::DecreaseResolution;
-      is_at_target = false;
-    } else if (gsl::at(levels, d) > gsl::at(target_refinement_levels_, d)) {
-      gsl::at(result, d) = Flag::Join;
-      is_at_target = false;
+    if constexpr (CriteriaType == Type::h) {
+      if (gsl::at(levels, d) < gsl::at(target_, d)) {
+        gsl::at(result, d) = Flag::Split;
+        is_at_target = false;
+      } else if (gsl::at(levels, d) > gsl::at(target_, d)) {
+        gsl::at(result, d) = Flag::Join;
+        is_at_target = false;
+      }
+    } else {
+      if (current_mesh.extents(d) < gsl::at(target_, d)) {
+        gsl::at(result, d) = Flag::IncreaseResolution;
+        is_at_target = false;
+      } else if (current_mesh.extents(d) > gsl::at(target_, d)) {
+        gsl::at(result, d) = Flag::DecreaseResolution;
+        is_at_target = false;
+      }
     }
   }
   if (is_at_target) {
@@ -65,10 +84,13 @@ std::array<Flag, Dim> DriveToTarget<Dim>::impl(
   return result;
 }
 
-template <size_t Dim>
-PUP::able::PUP_ID DriveToTarget<Dim>::my_PUP_ID = 0;  // NOLINT
+template <size_t Dim, Type CriteriaType>
+PUP::able::PUP_ID DriveToTarget<Dim, CriteriaType>::my_PUP_ID = 0;  // NOLINT
 
-template class DriveToTarget<1>;
-template class DriveToTarget<2>;
-template class DriveToTarget<3>;
+template class DriveToTarget<1, Type::h>;
+template class DriveToTarget<2, Type::h>;
+template class DriveToTarget<3, Type::h>;
+template class DriveToTarget<1, Type::p>;
+template class DriveToTarget<2, Type::p>;
+template class DriveToTarget<3, Type::p>;
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
@@ -75,6 +75,8 @@ class DriveToTarget : public Criterion {
                                    : "DriveToTargetRefinementLevels";
   }
 
+  Type type() override { return CriteriaType; }
+
   std::string observation_name() override { return "DriveToTarget"; }
 
   using compute_tags_for_observation_box = tmpl::list<>;

--- a/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp
@@ -10,6 +10,7 @@
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Tags.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -33,43 +34,34 @@ namespace amr::Criteria {
  *
  * \note This criterion is primarily for testing the mechanics of refinement.
  */
-template <size_t Dim>
+template <size_t Dim, Type CriteriaType>
 class DriveToTarget : public Criterion {
  public:
-  /// The target number of grid point in each dimension
-  struct TargetNumberOfGridPoints {
+  /// The target (number of grid points or refinement level) in each dimension
+  struct Target {
     using type = std::array<size_t, Dim>;
     static constexpr Options::String help = {
-        "The target number of grid points in each dimension."};
+        CriteriaType == Type::p
+            ? "The target number of grid points in each dimension."
+            : "The target refinement level in each dimension."};
   };
 
-  /// The target refinement level in each dimension
-  struct TargetRefinementLevels {
-    using type = std::array<size_t, Dim>;
-    static constexpr Options::String help = {
-        "The target refinement level in each dimension."};
-  };
-
-  /// The AMR flags chosen when the target number of grid points and refinement
-  /// levels are reached
+  /// The AMR flags chosen when the target in each dimension is reached
   struct OscillationAtTarget {
     using type = std::array<Flag, Dim>;
     static constexpr Options::String help = {
         "The flags returned when at the target."};
   };
 
-  using options = tmpl::list<TargetNumberOfGridPoints, TargetRefinementLevels,
-                             OscillationAtTarget>;
+  using options = tmpl::list<Target, OscillationAtTarget>;
 
   static constexpr Options::String help = {
-      "Refine the grid towards the TargetNumberOfGridPoints and "
-      "TargetRefinementLevels, and then oscillate about them by applying "
-      "OscillationAtTarget."};
+      "Refine the grid towards the Target, and then oscillate about them by "
+      "applying OscillationAtTarget."};
 
   DriveToTarget() = default;
 
-  DriveToTarget(const std::array<size_t, Dim>& target_number_of_grid_points,
-                const std::array<size_t, Dim>& target_refinement_levels,
+  DriveToTarget(const std::array<size_t, Dim>& target,
                 const std::array<Flag, Dim>& flags_at_target);
 
   /// \cond
@@ -77,6 +69,11 @@ class DriveToTarget : public Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(DriveToTarget);  // NOLINT
   /// \endcond
+
+  static std::string name() {
+    return CriteriaType == Type::p ? "DriveToTargetNumberOfGridPoints"
+                                   : "DriveToTargetRefinementLevels";
+  }
 
   std::string observation_name() override { return "DriveToTarget"; }
 
@@ -95,14 +92,13 @@ class DriveToTarget : public Criterion {
   std::array<Flag, Dim> impl(const Mesh<Dim>& current_mesh,
                              const ElementId<Dim>& element_id) const;
 
-  std::array<size_t, Dim> target_number_of_grid_points_{};
-  std::array<size_t, Dim> target_refinement_levels_{};
+  std::array<size_t, Dim> target_{};
   std::array<Flag, Dim> flags_at_target_{};
 };
 
-template <size_t Dim>
+template <size_t Dim, Type CriteriaType>
 template <typename Metavariables>
-auto DriveToTarget<Dim>::operator()(
+auto DriveToTarget<Dim, CriteriaType>::operator()(
     const Mesh<Dim>& current_mesh,
     Parallel::GlobalCache<Metavariables>& /*cache*/,
     const ElementId<Dim>& element_id) const {

--- a/src/ParallelAlgorithms/Amr/Criteria/Factory.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Factory.hpp
@@ -30,6 +30,7 @@ using standard_criteria = tmpl::list<
     ::amr::Criteria::Loehner<Dim, TensorTags>,
     ::amr::Criteria::Persson<Dim, TensorTags>,
     // Criteria for testing or experimenting
-    ::amr::Criteria::DriveToTarget<Dim>, ::amr::Criteria::Random>;
+    ::amr::Criteria::DriveToTarget<Dim, Type::h>,
+    ::amr::Criteria::DriveToTarget<Dim, Type::p>, ::amr::Criteria::Random>;
 
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Factory.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Factory.hpp
@@ -31,6 +31,7 @@ using standard_criteria = tmpl::list<
     ::amr::Criteria::Persson<Dim, TensorTags>,
     // Criteria for testing or experimenting
     ::amr::Criteria::DriveToTarget<Dim, Type::h>,
-    ::amr::Criteria::DriveToTarget<Dim, Type::p>, ::amr::Criteria::Random>;
+    ::amr::Criteria::DriveToTarget<Dim, Type::p>,
+    ::amr::Criteria::Random<Type::h>, ::amr::Criteria::Random<Type::p>>;
 
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp
@@ -9,6 +9,7 @@
 
 #include "Domain/Amr/Flag.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -34,6 +35,8 @@ class IncreaseResolution : public Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(IncreaseResolution);  // NOLINT
   /// \endcond
+
+  Type type() override { return Type::p; }
 
   std::string observation_name() override { return "IncreaseResolution"; }
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Loehner.hpp
@@ -22,6 +22,7 @@
 #include "Options/ParseError.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -176,6 +177,8 @@ class Loehner : public Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(Loehner);  // NOLINT
   /// \endcond
+
+  Type type() override { return Type::h; }
 
   std::string observation_name() override { return "Loehner"; }
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Persson.hpp
@@ -22,6 +22,7 @@
 #include "Options/ParseError.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -140,6 +141,8 @@ class Persson : public Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(Persson);  // NOLINT
   /// \endcond
+
+  Type type() override { return Type::h; }
 
   std::string observation_name() override { return "Persson"; }
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.cpp
@@ -12,13 +12,31 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 
 namespace amr::Criteria {
-Random::Random(std::unordered_map<amr::Flag, size_t> probability_weights)
-    : probability_weights_(std::move(probability_weights)) {}
+template <Type CriteriaType>
+Random<CriteriaType>::Random(
+    std::unordered_map<amr::Flag, size_t> probability_weights)
+    : probability_weights_(std::move(probability_weights)) {
+  if constexpr (CriteriaType == Type::h) {
+    if (probability_weights_.contains(amr::Flag::IncreaseResolution) or
+        probability_weights_.contains(amr::Flag::DecreaseResolution)) {
+      ERROR("Cannot use p-refinement flag in ProbabilityWeights "
+            << probability_weights_);
+    }
+  } else {
+    if (probability_weights_.contains(amr::Flag::Split) or
+        probability_weights_.contains(amr::Flag::Join)) {
+      ERROR("Cannot use h-refinement flag in ProbabilityWeights "
+            << probability_weights_);
+    }
+  }
+}
 
-Random::Random(CkMigrateMessage* msg) : Criterion(msg) {}
+template <Type CriteriaType>
+Random<CriteriaType>::Random(CkMigrateMessage* msg) : Criterion(msg) {}
 
 // NOLINTNEXTLINE(google-runtime-references)
-void Random::pup(PUP::er& p) {
+template <Type CriteriaType>
+void Random<CriteriaType>::pup(PUP::er& p) {
   Criterion::pup(p);
   p | probability_weights_;
 }
@@ -55,5 +73,9 @@ amr::Flag random_flag(
 }
 }  // namespace detail
 
-PUP::able::PUP_ID Random::my_PUP_ID = 0;  // NOLINT
+template <Type CriteriaType>
+PUP::able::PUP_ID Random<CriteriaType>::my_PUP_ID = 0;  // NOLINT
+
+template class Random<Type::h>;
+template class Random<Type::p>;
 }  // namespace amr::Criteria

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
@@ -67,6 +67,8 @@ class Random : public Criterion {
     return CriteriaType == Type::p ? "RandomP" : "RandomH";
   }
 
+  Type type() override { return CriteriaType; }
+
   std::string observation_name() override { return "Random"; }
 
   using compute_tags_for_observation_box = tmpl::list<>;

--- a/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Random.hpp
@@ -13,6 +13,7 @@
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -34,6 +35,7 @@ amr::Flag random_flag(
  * - Flags with weight zero do not need to be specified.
  * - If all weights are zero, `amr::Flag::DoNothing` is always chosen.
  */
+template <Type CriteriaType>
 class Random : public Criterion {
  public:
   struct ProbabilityWeights {
@@ -61,6 +63,10 @@ class Random : public Criterion {
   WRAPPED_PUPable_decl_template(Random);  // NOLINT
   /// \endcond
 
+  static std::string name() {
+    return CriteriaType == Type::p ? "RandomP" : "RandomH";
+  }
+
   std::string observation_name() override { return "Random"; }
 
   using compute_tags_for_observation_box = tmpl::list<>;
@@ -77,9 +83,11 @@ class Random : public Criterion {
   std::unordered_map<amr::Flag, size_t> probability_weights_{};
 };
 
+template <Type CriteriaType>
 template <size_t Dim, typename Metavariables>
-auto Random::operator()(Parallel::GlobalCache<Metavariables>& /*cache*/,
-                        const ElementId<Dim>& /*element_id*/) const {
+auto Random<CriteriaType>::operator()(
+    Parallel::GlobalCache<Metavariables>& /*cache*/,
+    const ElementId<Dim>& /*element_id*/) const {
   auto result = make_array<Dim>(amr::Flag::Undefined);
   for (size_t d = 0; d < Dim; ++d) {
     result[d] = detail::random_flag(probability_weights_);

--- a/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/TruncationError.hpp
@@ -21,6 +21,7 @@
 #include "Options/ParseError.hpp"
 #include "Options/String.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -105,6 +106,8 @@ class TruncationError : public Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(TruncationError);  // NOLINT
   /// \endcond
+
+  Type type() override { return Type::p; }
 
   std::string observation_name() override { return "TruncationError"; }
 

--- a/src/ParallelAlgorithms/Amr/Criteria/Type.cpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Type.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
+
+#include <ostream>
+#include <vector>
+
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+namespace {
+std::vector<amr::Criteria::Type> known_amr_criteria_types() {
+  return std::vector{amr::Criteria::Type::h, amr::Criteria::Type::p};
+}
+}  // namespace
+
+namespace amr::Criteria {
+
+std::ostream& operator<<(std::ostream& os, const Type& type) {
+  switch (type) {
+    case Type::h:
+      os << "h";
+      break;
+    case Type::p:
+      os << "p";
+      break;
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("An unknown AMR criteria type was passed to the stream operator.");
+      // LCOV_EXCL_STOP
+  }
+  return os;
+}
+}  // namespace amr::Criteria
+
+template <>
+amr::Criteria::Type
+Options::create_from_yaml<amr::Criteria::Type>::create<void>(
+    const Options::Option& options) {
+  const auto type_read = options.parse_as<std::string>();
+  for (const auto type : known_amr_criteria_types()) {
+    if (type_read == get_output(type)) {
+      return type;
+    }
+  }
+  using ::operator<<;
+  PARSE_ERROR(options.context(),
+              "Failed to convert \""
+                  << type_read << "\" to amr::Criteria::Type.\nMust be one of "
+                  << known_amr_criteria_types() << ".");
+}

--- a/src/ParallelAlgorithms/Amr/Criteria/Type.hpp
+++ b/src/ParallelAlgorithms/Amr/Criteria/Type.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdint>
+#include <iosfwd>
+
+/// \cond
+namespace Options {
+class Option;
+template <typename T>
+struct create_from_yaml;
+}  // namespace Options
+/// \endcond
+
+namespace amr::Criteria {
+
+/// \ingroup AmrGroup
+/// \brief Type of mesh refinement
+enum class Type : uint8_t {
+  h, /**< Used to split or join elements */
+  p  /**< used to change the extents of a Mesh in an Element */
+};
+
+/// Output operator for a Type.
+std::ostream& operator<<(std::ostream& os, const Type& type);
+}  // namespace amr::Criteria
+
+template <>
+struct Options::create_from_yaml<amr::Criteria::Type> {
+  template <typename Metavariables>
+  static amr::Criteria::Type create(const Options::Option& options) {
+    return create<void>(options);
+  }
+};
+
+template <>
+amr::Criteria::Type
+Options::create_from_yaml<amr::Criteria::Type>::create<void>(
+    const Options::Option& options);

--- a/src/ParallelAlgorithms/Amr/Events/RefineMesh.hpp
+++ b/src/ParallelAlgorithms/Amr/Events/RefineMesh.hpp
@@ -27,6 +27,7 @@
 #include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -45,12 +46,12 @@ struct get_tags {
 };
 
 }  // namespace detail
+
 /// \ingroup AmrGroup
 /// \brief Performs p-refinement on the domain
 ///
 /// \details
-/// - Loops over all refinement criteria specified in the
-///   input file, ignoring any requests to join or split the Element.
+/// - Loops over all p-refinement criteria specified in the input file.
 ///   If no valid p-refinement decision is requested, no change is
 ///   made to the Element.
 /// - Updates the Mesh and all return tags of Metavariables::amr::projectors
@@ -80,11 +81,7 @@ class RefineMesh : public Event {
                   const ElementId<Metavariables::volume_dim>& element_id,
                   const Component* const /*meta*/,
                   const ObservationValue& /*observation_value*/) const {
-    // Evaluate AMR refinement criteria
-    // NOTE: This evaluates all criteria.  In the future this could be
-    // restricted to evaluate only those criteria that do p-refinement that can
-    // be evaluated locally (i.e. do not need neighbor information that is
-    // already in the DataBox)
+    // Evaluate AMR p-refinement criteria
     constexpr size_t volume_dim = Metavariables::volume_dim;
     auto overall_decision = make_array<volume_dim>(amr::Flag::Undefined);
 
@@ -97,16 +94,20 @@ class RefineMesh : public Event {
     const auto& refinement_criteria =
         db::get<amr::Criteria::Tags::Criteria>(*box);
     for (const auto& criterion : refinement_criteria) {
+      if (criterion->type() == amr::Criteria::Type::h) {
+        continue;
+      }
       auto decision = criterion->evaluate(observation_box, cache, element_id);
+      ASSERT(alg::none_of(decision,
+                          [](amr::Flag flag) {
+                            return flag == amr::Flag::Split or
+                                   flag == amr::Flag::Join;
+                          }),
+             "The criterion '" << typeid(*criterion).name()
+                               << "' requested h-refinement, but claims to be "
+                                  "for p-refinement.");
       for (size_t d = 0; d < volume_dim; ++d) {
-        // Ignore h-refinement decisions
-        if (decision[d] == amr::Flag::Split or decision[d] == amr::Flag::Join) {
-          ERROR("The criterion '" << typeid(*criterion).name()
-                                  << "' requested h-refinement, but RefineMesh "
-                                     "only works for p-refinement.");
-        } else {
-          overall_decision[d] = std::max(overall_decision[d], decision[d]);
-        }
+        overall_decision[d] = std::max(overall_decision[d], decision[d]);
       }
     }
     // If no refinement criteria requested p-refinement, then set flag to

--- a/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
+++ b/src/ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp
@@ -26,6 +26,11 @@ namespace amr::protocols {
 ///   (e.g. `domain::Tags::Element`, `domain::Tags::Mesh`, and
 ///   `domain::Tags::NeighborMesh` are handled by AMR). See
 ///   `amr::protocols::Projector` for details.
+/// - `p_refine_only_in_event`: A boolean indicating that only h-refinement
+///   criteria should be evaluated in
+///   `::amr::Actions::EvaluateRefinementCriteria`.  Only h-refinement will be
+///   done in `Phase::AdjustDomain`; p-refinement will only be done via
+///   `::amr::Events::RefineMesh`.
 /// - `keep_coarse_grids`: A boolean indicating that AMR should create a
 ///   completely new grid at each AMR step with an incremented grid index, and
 ///   keep the old grid around. This is useful for multigrid solvers.
@@ -52,6 +57,8 @@ struct AmrMetavariables {
         tmpl::all<projectors,
                   tt::assert_conforms_to<tmpl::_1, Projector>>::value);
     static constexpr bool keep_coarse_grids = ConformingType::keep_coarse_grids;
+    static constexpr bool p_refine_only_in_event =
+        ConformingType::p_refine_only_in_event;
   };
 };
 }  // namespace amr::protocols

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -17,7 +17,7 @@ Parallelization:
 
 Amr:
   Criteria:
-    - Random:
+    - RandomH:
         ProbabilityWeights:
           Split: 2
           Join: 1

--- a/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
@@ -17,7 +17,7 @@ Parallelization:
 
 Amr:
   Criteria:
-    - Random:
+    - RandomH:
         ProbabilityWeights:
           Split: 2
           Join: 1

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -16,7 +16,7 @@ Parallelization:
 
 Amr:
   Criteria:
-    - Random:
+    - RandomH:
         ProbabilityWeights:
           Split: 2
           Join: 1

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -81,11 +81,13 @@ DomainCreator:
 Amr:
   Verbosity: Debug
   Criteria:
-    - DriveToTarget:
+    - DriveToTargetRefinementLevels:
         # First AMR iteration will split the 2 elements in 4
-        TargetRefinementLevels: [2]
+        Target: [2]
+        OscillationAtTarget: [DoNothing]
+    - DriveToTargetNumberOfGridPoints:
         # Second AMR iteration will increase num points from 4 to 5
-        TargetNumberOfGridPoints: [5]
+        Target: [5]
         OscillationAtTarget: [DoNothing]
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -27,10 +27,13 @@ InitialData: &InitialData
 
 Amr:
   Criteria:
+    - DriveToTargetRefinementLevels:
+        Target: [4]
+        OscillationAtTarget: [Split]
     - TruncationError:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
-        RelativeTarget: 1.0
+        RelativeTarget: 1.e-6
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
@@ -45,7 +48,7 @@ PhaseChangeAndTriggers:
   - Trigger:
       Slabs:
         EvenlySpaced:
-          Interval: 1
+          Interval: 2
           Offset: 0
     PhaseChanges:
       - VisitAndReturn(EvaluateAmrCriteria)
@@ -92,6 +95,13 @@ SpatialDiscretization:
 #     BlocksToFilter: All
 
 EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    Events:
+      - RefineMesh
   - Trigger:
       Slabs:
         Specified:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -29,10 +29,13 @@ InitialData:
 
 Amr:
   Criteria:
+    - DriveToTargetRefinementLevels:
+        Target: [2]
+        OscillationAtTarget: [Split]
     - TruncationError:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
-        RelativeTarget: 1.0
+        RelativeTarget: 1.e-6
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -30,10 +30,13 @@ InitialData:
 
 Amr:
   Criteria:
+    - DriveToTargetRefinementLevels:
+        Target: [2]
+        OscillationAtTarget: [Split]
     - TruncationError:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
-        RelativeTarget: 1.0
+        RelativeTarget: 1.e-6
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
@@ -113,6 +116,13 @@ EventsAndDenseTriggers:
               Components: Sum
 
 EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    Events:
+      - RefineMesh
   - Trigger:
       Slabs:
         Specified:

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -68,6 +68,7 @@
 #include "ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
@@ -512,7 +513,8 @@ struct Metavariables {
             tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>>>,
         tmpl::pair<elliptic::analytic_data::Background,
                    tmpl::list<RandomBackground<volume_dim>>>,
-        tmpl::pair<::amr::Criterion, tmpl::list<::amr::Criteria::Random>>>;
+        tmpl::pair<::amr::Criterion, tmpl::list<::amr::Criteria::Random<
+                                         amr::Criteria::Type::p>>>>;
   };
   template <typename Tag>
   using overlaps_tag =
@@ -607,11 +609,13 @@ void test_subdomain_operator(
 
     // Configure AMR criteria
     std::vector<std::unique_ptr<::amr::Criterion>> amr_criteria{};
-    amr_criteria.push_back(std::make_unique<::amr::Criteria::Random>(
-        std::unordered_map<::amr::Flag, size_t>{
-            // h-refinement is not supported yet in the action testing framework
-            {::amr::Flag::IncreaseResolution, 1},
-            {::amr::Flag::DoNothing, 1}}));
+    amr_criteria.push_back(
+        std::make_unique<::amr::Criteria::Random<amr::Criteria::Type::p>>(
+            std::unordered_map<::amr::Flag, size_t>{
+                // h-refinement is not supported yet in the action testing
+                // framework
+                {::amr::Flag::IncreaseResolution, 1},
+                {::amr::Flag::DoNothing, 1}}));
 
     ActionTesting::MockRuntimeSystem<metavariables> runner{tuples::TaggedTuple<
         domain::Tags::Domain<Dim>, domain::Tags::FunctionsOfTimeInitialize,

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -549,6 +549,7 @@ struct Metavariables {
             System, typename element_array::background_tag>,
         typename element_array::dg_operator::amr_projectors, ExtraInitActions>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = false;
   };
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -251,6 +251,7 @@ struct Metavariables {
             System, typename element_array::analytic_solution_tag>,
         typename element_array::dg_operator::amr_projectors>>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = false;
   };
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -53,6 +53,7 @@
 #include "ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Actions/Initialize.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
@@ -227,7 +228,8 @@ struct Metavariables {
         tmpl::pair<elliptic::analytic_data::AnalyticSolution,
                    tmpl::list<AnalyticSolution>>,
         tmpl::pair<AnalyticSolution, tmpl::list<AnalyticSolution>>,
-        tmpl::pair<::amr::Criterion, tmpl::list<::amr::Criteria::Random>>>;
+        tmpl::pair<::amr::Criterion, tmpl::list<::amr::Criteria::Random<
+                                         amr::Criteria::Type::p>>>>;
   };
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = ElementArray<System, Linearized, Metavariables>;
@@ -395,12 +397,13 @@ void test_dg_operator(
 
   // Configure AMR criteria so we _increase_ (never decrease) resolution
   std::vector<std::unique_ptr<::amr::Criterion>> amr_criteria{};
-  amr_criteria.push_back(std::make_unique<::amr::Criteria::Random>(
-      std::unordered_map<::amr::Flag, size_t>{
-          // h-refinement is not supported yet in the action testing framework
-          {::amr::Flag::Split, 0},
-          {::amr::Flag::IncreaseResolution, 1},
-          {::amr::Flag::DoNothing, 1}}));
+  amr_criteria.push_back(
+      std::make_unique<::amr::Criteria::Random<amr::Criteria::Type::p>>(
+          std::unordered_map<::amr::Flag, size_t>{
+              // h-refinement is not supported yet in the
+              // action testing framework
+              {::amr::Flag::IncreaseResolution, 1},
+              {::amr::Flag::DoNothing, 1}}));
 
   ActionTesting::MockRuntimeSystem<Metavars> runner{tuples::TaggedTuple<
       domain::Tags::Domain<Dim>, domain::Tags::FunctionsOfTimeInitialize,

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -156,6 +156,7 @@ struct Metavariables {
         Parallel::Tags::GlobalCache<Metavariables>,
         domain::Tags::NeighborMesh<1>>>;
     static constexpr bool keep_coarse_grids = KeepCoarseGrids;
+    static constexpr bool p_refine_only_in_event = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -45,14 +45,14 @@ namespace {
 // when called on the specified refinement level, this criteria
 // always will choose to join
 auto create_always_join() {
-  return std::make_unique<amr::Criteria::Random>(
+  return std::make_unique<amr::Criteria::Random<amr::Criteria::Type::h>>(
       std::unordered_map<amr::Flag, size_t>{{amr::Flag::Join, 1}});
 }
 
 // when called on any refinement level, this criteria always will choose to do
 // nothing
 auto create_always_do_nothing() {
-  return std::make_unique<amr::Criteria::Random>(
+  return std::make_unique<amr::Criteria::Random<amr::Criteria::Type::h>>(
       std::unordered_map<amr::Flag, size_t>{{amr::Flag::DoNothing, 1}});
 }
 
@@ -80,10 +80,11 @@ struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<tmpl::pair<
-        amr::Criterion, tmpl::list<amr::Criteria::Random,
-                                   amr::Criteria::DriveToTarget<
-                                       volume_dim, amr::Criteria::Type::h>>>>;
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion,
+                   tmpl::list<amr::Criteria::Random<amr::Criteria::Type::h>,
+                              amr::Criteria::DriveToTarget<
+                                  volume_dim, amr::Criteria::Type::h>>>>;
   };
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -25,7 +25,7 @@
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
-#include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
@@ -41,20 +41,59 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace {
-
-// when called on the specified refinement level, this criteria
-// always will choose to join
-auto create_always_join() {
-  return std::make_unique<amr::Criteria::Random<amr::Criteria::Type::h>>(
-      std::unordered_map<amr::Flag, size_t>{{amr::Flag::Join, 1}});
+auto wants_to_join() {
+  return std::make_unique<
+      amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
+      std::array{0_st}, std::array{amr::Flag::DoNothing});
 }
 
-// when called on any refinement level, this criteria always will choose to do
-// nothing
-auto create_always_do_nothing() {
-  return std::make_unique<amr::Criteria::Random<amr::Criteria::Type::h>>(
-      std::unordered_map<amr::Flag, size_t>{{amr::Flag::DoNothing, 1}});
+auto wants_to_split() {
+  return std::make_unique<
+      amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
+      std::array{8_st}, std::array{amr::Flag::DoNothing});
 }
+
+auto wants_to_increase_resolution() {
+  return std::make_unique<amr::Criteria::IncreaseResolution<1>>();
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+template <size_t Dim>
+class BadCriterion : public amr::Criterion {
+ public:
+  using options = tmpl::list<>;
+
+  BadCriterion() = default;
+  explicit BadCriterion(CkMigrateMessage* msg) : Criterion(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(BadCriterion);  // NOLINT
+
+  amr::Criteria::Type type() override { return amr::Criteria::Type::h; }
+
+  std::string observation_name() override { return "BadCriterion"; }
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+  using argument_tags = tmpl::list<>;
+
+  template <typename Metavariables>
+  auto operator()(
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Metavariables::volume_dim>& /*element_id*/) const {
+    if constexpr (Dim == 1) {
+      return std::array{amr::Flag::DecreaseResolution};
+    } else {
+      return std::array{amr::Flag::DecreaseResolution,
+                        amr::Flag::IncreaseResolution};
+    }
+  }
+
+  void pup(PUP::er& p) override { Criterion::pup(p); }
+};
+
+template <size_t Dim>
+PUP::able::PUP_ID BadCriterion<Dim>::my_PUP_ID = 0;  // NOLINT
+#pragma GCC diagnostic pop
 
 template <typename Metavariables>
 struct Component {
@@ -73,7 +112,7 @@ struct Component {
       tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
 };
 
-template <size_t VolumeDim>
+template <size_t VolumeDim, bool IgnoreP>
 struct Metavariables {
   static constexpr size_t volume_dim = VolumeDim;
 
@@ -82,7 +121,8 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<amr::Criterion,
-                   tmpl::list<amr::Criteria::Random<amr::Criteria::Type::h>,
+                   tmpl::list<BadCriterion<volume_dim>,
+                              amr::Criteria::IncreaseResolution<volume_dim>,
                               amr::Criteria::DriveToTarget<
                                   volume_dim, amr::Criteria::Type::h>>>>;
   };
@@ -91,6 +131,7 @@ struct Metavariables {
     using element_array = Component<Metavariables>;
     using projectors = tmpl::list<>;
     static constexpr bool keep_coarse_grids = false;
+    static constexpr bool p_refine_only_in_event = IgnoreP;
   };
 };
 
@@ -108,10 +149,16 @@ struct Metavariables {
 // parallel environment, it is possible for an Element to execute
 // UpdateAmrDecision (triggered by a neighboring Element) prior to executing
 // EvaluateAmrCriteria
+//
+// If IgnoreP is true, only h-refinement criteria are evaluated
+template <bool IgnoreP>
 void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
                        const std::array<amr::Flag, 1> expected_flags) {
-  using my_component = Component<Metavariables<1>>;
+  using metavariables = Metavariables<1, IgnoreP>;
+  using my_component = Component<metavariables>;
   CAPTURE(expected_flags);
+  const bool p_refined =
+      (expected_flags == std::array{amr::Flag::IncreaseResolution});
   const ElementId<1> self_id(0, {{{1, 1}}});
   const ElementId<1> lo_id(0, {{{1, 0}}});
   const ElementId<1> up_id(1, {{{1, 0}}});
@@ -124,11 +171,17 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
                         Spectral::Quadrature::GaussLobatto};
   const Mesh<1> up_sibling_mesh{5_st, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> p_self_mesh{3_st, Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> p_lo_mesh{4_st, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<1> p_up_mesh{5_st, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
 
   amr::Info<1> initial_info{std::array{amr::Flag::Undefined}, Mesh<1>{}};
   std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info;
 
-  ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
       {std::move(criteria),
        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
 
@@ -178,7 +231,8 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
                                amr::Actions::EvaluateRefinementCriteria>(
       make_not_null(&runner), self_id);
 
-  const amr::Info<1> self_info{expected_flags, self_mesh};
+  const amr::Info<1> self_info{expected_flags,
+                               p_refined ? p_self_mesh : self_mesh};
   for (const auto& id : {self_id, lo_id, up_id}) {
     CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Info<1>>(
               runner, id) == (id == self_id ? self_info : initial_info));
@@ -194,7 +248,7 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
                                amr::Actions::EvaluateRefinementCriteria>(
       make_not_null(&runner), lo_id);
 
-  const amr::Info<1> lo_info{expected_flags, lo_mesh};
+  const amr::Info<1> lo_info{expected_flags, p_refined ? p_lo_mesh : lo_mesh};
   for (const auto& id : {self_id, lo_id, up_id}) {
     CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Info<1>>(
               runner, id) ==
@@ -228,7 +282,7 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
   ActionTesting::simple_action<my_component,
                                amr::Actions::EvaluateRefinementCriteria>(
       make_not_null(&runner), up_id);
-  const amr::Info<1> up_info{expected_flags, up_mesh};
+  const amr::Info<1> up_info{expected_flags, p_refined ? p_up_mesh : up_mesh};
   for (const auto& id : {self_id, lo_id, up_id}) {
     CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Info<1>>(
               runner, id) ==
@@ -246,7 +300,8 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
 }
 
 void check_split_while_join_is_avoided() {
-  using my_component = Component<Metavariables<2>>;
+  using metavariables = Metavariables<2, true>;
+  using my_component = Component<metavariables>;
 
   // The part of action we are testing does not depend upon information
   // from neighbors, so we just use a single Element setup on refinement
@@ -266,7 +321,7 @@ void check_split_while_join_is_avoided() {
           std::array{1_st, 0_st},
           std::array{amr::Flag::DoNothing, amr::Flag::DoNothing}));
 
-  Parallel::GlobalCache<Metavariables<2>> empty_cache{};
+  Parallel::GlobalCache<metavariables> empty_cache{};
   auto databox = db::create<tmpl::list<::domain::Tags::Mesh<2>>>(mesh);
   ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<::domain::Tags::Mesh<2>>>>
       box{make_not_null(&databox)};
@@ -276,7 +331,7 @@ void check_split_while_join_is_avoided() {
 
   // But we do not allow an Element to simultaneously split and join so the
   // action should change the flags to (DoNothing, Split)
-  ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
       {std::move(criteria),
        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
 
@@ -309,27 +364,74 @@ void check_split_while_join_is_avoided() {
   CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
             runner, self_id) == 0);
 }
-}  // namespace
+}  //  namespace
 
 SPECTRE_TEST_CASE("Unit.Amr.Actions.EvaluateRefinementCriteria",
                   "[Unit][ParallelAlgorithms]") {
-  register_factory_classes_with_charm<Metavariables<2>>();
-  std::vector<std::unique_ptr<amr::Criterion>> criteria;
-  // Run the test 3 times, twice with a single criterion that give known
-  // decisions, and then once with two criteria, one of which always produces
-  // flags of a higher priority than the other
-  criteria.emplace_back(create_always_join());
-  evaluate_criteria(std::move(criteria), std::array{amr::Flag::Join});
-  criteria.clear();
-  criteria.emplace_back(create_always_do_nothing());
-  evaluate_criteria(std::move(criteria), std::array{amr::Flag::DoNothing});
-  criteria.clear();
-  criteria.emplace_back(create_always_do_nothing());
-  criteria.emplace_back(create_always_join());
-  evaluate_criteria(std::move(criteria), std::array{amr::Flag::DoNothing});
-  criteria.clear();
-  criteria.emplace_back(create_always_join());
-  criteria.emplace_back(create_always_do_nothing());
-  evaluate_criteria(std::move(criteria), std::array{amr::Flag::DoNothing});
+  register_factory_classes_with_charm<Metavariables<2, true>>();
+  register_factory_classes_with_charm<Metavariables<1, true>>();
+  register_factory_classes_with_charm<Metavariables<1, false>>();
+  {
+    INFO("No criteria");
+    evaluate_criteria<true>(std::vector<std::unique_ptr<amr::Criterion>>{},
+                            std::array{amr::Flag::DoNothing});
+    evaluate_criteria<false>(std::vector<std::unique_ptr<amr::Criterion>>{},
+                             std::array{amr::Flag::DoNothing});
+  }
+  {
+    INFO("Only one p-criteria");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria;
+    criteria.emplace_back(wants_to_increase_resolution());
+    evaluate_criteria<false>(std::move(criteria),
+                             std::array{amr::Flag::IncreaseResolution});
+  }
+  {
+    INFO("Only one p-criteria, ignored");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria;
+    criteria.emplace_back(wants_to_increase_resolution());
+    evaluate_criteria<true>(std::move(criteria),
+                            std::array{amr::Flag::DoNothing});
+  }
+  {
+    INFO("Should join");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria;
+    criteria.emplace_back(wants_to_join());
+    evaluate_criteria<false>(std::move(criteria), std::array{amr::Flag::Join});
+  }
+  {
+    INFO("Should join, p-ignored");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria;
+    criteria.emplace_back(wants_to_join());
+    criteria.emplace_back(wants_to_increase_resolution());
+    evaluate_criteria<true>(std::move(criteria), std::array{amr::Flag::Join});
+  }
+  {
+    INFO("Should split");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria;
+    criteria.emplace_back(wants_to_split());
+    criteria.emplace_back(wants_to_join());
+    evaluate_criteria<false>(std::move(criteria), std::array{amr::Flag::Split});
+  }
+  {
+    INFO("Should split, p-ignored");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria;
+    criteria.emplace_back(wants_to_join());
+    criteria.emplace_back(wants_to_increase_resolution());
+    criteria.emplace_back(wants_to_split());
+    evaluate_criteria<true>(std::move(criteria), std::array{amr::Flag::Split});
+  }
+#ifdef SPECTRE_DEBUG
+  {
+    INFO("Check ASSERT triggers");
+    std::vector<std::unique_ptr<amr::Criterion>> criteria;
+    criteria.emplace_back(std::make_unique<BadCriterion<1>>());
+
+    CHECK_THROWS_WITH(
+        (evaluate_criteria<true>(std::move(criteria),
+                                 std::array{amr::Flag::DoNothing})),
+        Catch::Matchers::ContainsSubstring(
+            "requested p-refinement, but claims to be for h-refinement"));
+  }
+#endif
   check_split_while_join_is_avoided();
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -27,6 +27,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
@@ -81,7 +82,8 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<tmpl::pair<
         amr::Criterion, tmpl::list<amr::Criteria::Random,
-                                   amr::Criteria::DriveToTarget<volume_dim>>>>;
+                                   amr::Criteria::DriveToTarget<
+                                       volume_dim, amr::Criteria::Type::h>>>>;
   };
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
@@ -258,9 +260,10 @@ void check_split_while_join_is_avoided() {
   // the refinement criteria wants to drive self to levels (1, 0) so
   // it will return flags (Split, Join).
   std::vector<std::unique_ptr<amr::Criterion>> criteria;
-  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<2>>(
-      std::array{2_st, 2_st}, std::array{1_st, 0_st},
-      std::array{amr::Flag::DoNothing, amr::Flag::DoNothing}));
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<2, amr::Criteria::Type::h>>(
+          std::array{1_st, 0_st},
+          std::array{amr::Flag::DoNothing, amr::Flag::DoNothing}));
 
   Parallel::GlobalCache<Metavariables<2>> empty_cache{};
   auto databox = db::create<tmpl::list<::domain::Tags::Mesh<2>>>(mesh);

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_Initialize.cpp
@@ -24,6 +24,7 @@ struct Metavariables {
     using element_array = void;
     using projectors = tmpl::list<>;
     static constexpr bool keep_coarse_grids = false;
+    [[maybe_unused]] static constexpr bool p_refine_only_in_event = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeChild.cpp
@@ -70,6 +70,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using projectors = tmpl::list<>;
     static constexpr bool keep_coarse_grids = false;
+    [[maybe_unused]] static constexpr bool p_refine_only_in_event = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_InitializeParent.cpp
@@ -70,6 +70,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using projectors = tmpl::list<>;
     [[maybe_unused]] static constexpr bool keep_coarse_grids = false;
+    [[maybe_unused]] static constexpr bool p_refine_only_in_event = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_SendDataToChildren.cpp
@@ -125,6 +125,7 @@ struct Metavariables {
     using element_array = Component<Metavariables>;
     using projectors = tmpl::list<>;
     static constexpr bool keep_coarse_grids = false;
+    [[maybe_unused]] static constexpr bool p_refine_only_in_event = false;
   };
 };
 

--- a/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Criteria/Test_Persson.cpp
   Criteria/Test_Random.cpp
   Criteria/Test_TruncationError.cpp
+  Criteria/Test_Type.cpp
   Events/Test_ObserveAmrCriteria.cpp
   Events/Test_RefineMesh.cpp
   Policies/Test_EnforcePolicies.cpp

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
@@ -66,6 +66,8 @@ class CriterionOne : public amr::Criterion {
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(CriterionOne);  // NOLINT
 
+  amr::Criteria::Type type() override { return amr::Criteria::Type::h; }
+
   std::string observation_name() override { return "CriterionOne"; }
 
   using compute_tags_for_observartion_box = tmpl::list<>;
@@ -109,6 +111,8 @@ class CriterionTwo : public amr::Criterion {
   explicit CriterionTwo(CkMigrateMessage* /*msg*/) {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(CriterionTwo);  // NOLINT
+
+  amr::Criteria::Type type() override { return amr::Criteria::Type::h; }
 
   std::string observation_name() override { return "CriterionTwo"; }
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_DriveToTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_DriveToTarget.cpp
@@ -19,6 +19,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -33,7 +34,10 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<tmpl::pair<
-        amr::Criterion, tmpl::list<amr::Criteria::DriveToTarget<VolumeDim>>>>;
+        amr::Criterion,
+        tmpl::list<
+            amr::Criteria::DriveToTarget<VolumeDim, amr::Criteria::Type::h>,
+            amr::Criteria::DriveToTarget<VolumeDim, amr::Criteria::Type::p>>>>;
   };
 };
 struct TestComponent {};
@@ -62,10 +66,9 @@ void test_criterion(
   CHECK(flags == expected_flags);
 }
 
-template <size_t VolumeDim>
+template <amr::Criteria::Type CriteriaType, size_t VolumeDim>
 void test(
-    const std::array<size_t, VolumeDim>& target_extents,
-    const std::array<size_t, VolumeDim>& target_levels,
+    const std::array<size_t, VolumeDim>& target,
     const std::array<amr::Flag, VolumeDim>& flags_at_target,
     const std::vector<
         std::tuple<std::array<size_t, VolumeDim>, std::array<size_t, VolumeDim>,
@@ -73,8 +76,8 @@ void test(
     const std::string& option_string) {
   register_factory_classes_with_charm<Metavariables<VolumeDim>>();
 
-  const amr::Criteria::DriveToTarget criterion{target_extents, target_levels,
-                                               flags_at_target};
+  const amr::Criteria::DriveToTarget<VolumeDim, CriteriaType> criterion{
+      target, flags_at_target};
   const auto criterion_from_option_string =
       TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
                                  Metavariables<VolumeDim>>(option_string);
@@ -91,17 +94,16 @@ void test(
 SPECTRE_TEST_CASE("Unit.Amr.Criteria.DriveToTarget",
                   "[Unit][ParallelAlgorithms]") {
   {
-    INFO("1D");
-    const std::array target_extents{4_st};
+    INFO("1D h");
     const std::array target_levels{3_st};
     const std::array flags_at_target{amr::Flag::Join};
     const auto test_cases =
         std::vector{std::tuple{std::array{4_st}, std::array{3_st},
                                std::array{amr::Flag::Join}},
                     std::tuple{std::array{3_st}, std::array{3_st},
-                               std::array{amr::Flag::IncreaseResolution}},
+                               std::array{amr::Flag::Join}},
                     std::tuple{std::array{5_st}, std::array{3_st},
-                               std::array{amr::Flag::DecreaseResolution}},
+                               std::array{amr::Flag::Join}},
                     std::tuple{std::array{4_st}, std::array{2_st},
                                std::array{amr::Flag::Split}},
                     std::tuple{std::array{3_st}, std::array{2_st},
@@ -111,60 +113,178 @@ SPECTRE_TEST_CASE("Unit.Amr.Criteria.DriveToTarget",
                     std::tuple{std::array{4_st}, std::array{4_st},
                                std::array{amr::Flag::Join}},
                     std::tuple{std::array{3_st}, std::array{4_st},
+                               std::array{amr::Flag::Join}},
+                    std::tuple{std::array{5_st}, std::array{4_st},
+                               std::array{amr::Flag::Join}}};
+    const std::string option =
+        "DriveToTargetRefinementLevels:\n"
+        "  Target: [3]\n"
+        "  OscillationAtTarget: [Join]\n";
+    test<amr::Criteria::Type::h>(target_levels, flags_at_target, test_cases,
+                                 option);
+    CHECK_THROWS_WITH(
+        (test<amr::Criteria::Type::h>(target_levels,
+                                      std::array{amr::Flag::IncreaseResolution},
+                                      test_cases, option)),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot use p-refinement flag in OscillationAtTarget"));
+  }
+  {
+    INFO("1D p");
+    const std::array target_extents{4_st};
+    const std::array flags_at_target{amr::Flag::DecreaseResolution};
+    const auto test_cases =
+        std::vector{std::tuple{std::array{4_st}, std::array{3_st},
+                               std::array{amr::Flag::DecreaseResolution}},
+                    std::tuple{std::array{3_st}, std::array{3_st},
+                               std::array{amr::Flag::IncreaseResolution}},
+                    std::tuple{std::array{5_st}, std::array{3_st},
+                               std::array{amr::Flag::DecreaseResolution}},
+                    std::tuple{std::array{4_st}, std::array{2_st},
+                               std::array{amr::Flag::DecreaseResolution}},
+                    std::tuple{std::array{3_st}, std::array{2_st},
+                               std::array{amr::Flag::IncreaseResolution}},
+                    std::tuple{std::array{5_st}, std::array{2_st},
+                               std::array{amr::Flag::DecreaseResolution}},
+                    std::tuple{std::array{4_st}, std::array{4_st},
+                               std::array{amr::Flag::DecreaseResolution}},
+                    std::tuple{std::array{3_st}, std::array{4_st},
                                std::array{amr::Flag::IncreaseResolution}},
                     std::tuple{std::array{5_st}, std::array{4_st},
                                std::array{amr::Flag::DecreaseResolution}}};
     const std::string option =
-        "DriveToTarget:\n"
-        "  TargetNumberOfGridPoints: [4]\n"
-        "  TargetRefinementLevels: [3]\n"
-        "  OscillationAtTarget: [Join]\n";
-    test(target_extents, target_levels, flags_at_target, test_cases, option);
+        "DriveToTargetNumberOfGridPoints:\n"
+        "  Target: [4]\n"
+        "  OscillationAtTarget: [DecreaseResolution]\n";
+    test<amr::Criteria::Type::p>(target_extents, flags_at_target, test_cases,
+                                 option);
+    CHECK_THROWS_WITH(
+        (test<amr::Criteria::Type::p>(
+            target_extents, std::array{amr::Flag::Join}, test_cases, option)),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot use h-refinement flag in OscillationAtTarget"));
   }
   {
-    INFO("2D");
-    const std::array target_extents{4_st, 6_st};
+    INFO("2D h");
     const std::array target_levels{8_st, 3_st};
-    const std::array flags_at_target{amr::Flag::IncreaseResolution,
-                                     amr::Flag::Split};
+    const std::array flags_at_target{amr::Flag::Join, amr::Flag::Split};
     const auto test_cases = std::vector{
         std::tuple{std::array{4_st, 6_st}, std::array{8_st, 3_st},
-                   std::array{amr::Flag::IncreaseResolution, amr::Flag::Split}},
-        std::tuple{
-            std::array{5_st, 6_st}, std::array{8_st, 3_st},
-            std::array{amr::Flag::DecreaseResolution, amr::Flag::DoNothing}},
+                   std::array{amr::Flag::Join, amr::Flag::Split}},
+        std::tuple{std::array{5_st, 6_st}, std::array{8_st, 3_st},
+                   std::array{amr::Flag::Join, amr::Flag::Split}},
         std::tuple{std::array{3_st, 6_st}, std::array{7_st, 4_st},
                    std::array{amr::Flag::Split, amr::Flag::Join}},
         std::tuple{std::array{4_st, 6_st}, std::array{8_st, 2_st},
                    std::array{amr::Flag::DoNothing, amr::Flag::Split}}};
     const std::string option =
-        "DriveToTarget:\n"
-        "  TargetNumberOfGridPoints: [4, 6]\n"
-        "  TargetRefinementLevels: [8, 3]\n"
-        "  OscillationAtTarget: [IncreaseResolution, Split]\n";
-    test(target_extents, target_levels, flags_at_target, test_cases, option);
+        "DriveToTargetRefinementLevels:\n"
+        "  Target: [8, 3]\n"
+        "  OscillationAtTarget: [Join, Split]\n";
+    test<amr::Criteria::Type::h>(target_levels, flags_at_target, test_cases,
+                                 option);
+    CHECK_THROWS_WITH(
+        (test<amr::Criteria::Type::h>(
+            target_levels,
+            std::array{amr::Flag::Split, amr::Flag::IncreaseResolution},
+            test_cases, option)),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot use p-refinement flag in OscillationAtTarget"));
   }
   {
-    INFO("3D");
-    const std::array target_extents{3_st, 9_st, 5_st};
+    INFO("2D p");
+    const std::array target_extents{4_st, 6_st};
+    const std::array flags_at_target{amr::Flag::IncreaseResolution,
+                                     amr::Flag::DecreaseResolution};
+    const auto test_cases = std::vector{
+        std::tuple{std::array{4_st, 6_st}, std::array{8_st, 3_st},
+                   std::array{amr::Flag::IncreaseResolution,
+                              amr::Flag::DecreaseResolution}},
+        std::tuple{
+            std::array{5_st, 6_st}, std::array{8_st, 3_st},
+            std::array{amr::Flag::DecreaseResolution, amr::Flag::DoNothing}},
+        std::tuple{
+            std::array{3_st, 6_st}, std::array{7_st, 4_st},
+            std::array{amr::Flag::IncreaseResolution, amr::Flag::DoNothing}},
+        std::tuple{
+            std::array{4_st, 5_st}, std::array{8_st, 2_st},
+            std::array{amr::Flag::DoNothing, amr::Flag::IncreaseResolution}}};
+    const std::string option =
+        "DriveToTargetNumberOfGridPoints:\n"
+        "  Target: [4, 6]\n"
+        "  OscillationAtTarget: [IncreaseResolution, DecreaseResolution]\n";
+    test<amr::Criteria::Type::p>(target_extents, flags_at_target, test_cases,
+                                 option);
+    CHECK_THROWS_WITH(
+        (test<amr::Criteria::Type::p>(
+            target_extents,
+            std::array{amr::Flag::Join, amr::Flag::DecreaseResolution},
+            test_cases, option)),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot use h-refinement flag in OscillationAtTarget"));
+  }
+  {
+    INFO("3D h");
     const std::array target_levels{5_st, 2_st, 4_st};
-    const std::array flags_at_target{
-        amr::Flag::Split, amr::Flag::DecreaseResolution, amr::Flag::DoNothing};
+    const std::array flags_at_target{amr::Flag::Split, amr::Flag::Join,
+                                     amr::Flag::DoNothing};
     const auto test_cases = std::vector{
         std::tuple{std::array{3_st, 9_st, 5_st}, std::array{5_st, 2_st, 4_st},
-                   std::array{amr::Flag::Split, amr::Flag::DecreaseResolution,
+                   std::array{amr::Flag::Split, amr::Flag::Join,
                               amr::Flag::DoNothing}},
         std::tuple{std::array{3_st, 9_st, 5_st}, std::array{5_st, 5_st, 4_st},
                    std::array{amr::Flag::DoNothing, amr::Flag::Join,
                               amr::Flag::DoNothing}},
+        std::tuple{std::array{3_st, 9_st, 3_st}, std::array{5_st, 2_st, 5_st},
+                   std::array{amr::Flag::DoNothing, amr::Flag::DoNothing,
+                              amr::Flag::Join}}};
+    const std::string option =
+        "DriveToTargetRefinementLevels:\n"
+        "  Target: [5, 2, 4]\n"
+        "  OscillationAtTarget: [Split, Join, DoNothing]\n";
+    test<amr::Criteria::Type::h>(target_levels, flags_at_target, test_cases,
+                                 option);
+    CHECK_THROWS_WITH(
+        (test<amr::Criteria::Type::h>(
+            target_levels,
+            std::array{amr::Flag::Split, amr::Flag::IncreaseResolution,
+                       amr::Flag::DecreaseResolution},
+            test_cases, option)),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot use p-refinement flag in OscillationAtTarget"));
+  }
+  {
+    INFO("3D p");
+    const std::array target_extents{3_st, 9_st, 5_st};
+    const std::array flags_at_target{amr::Flag::IncreaseResolution,
+                                     amr::Flag::DecreaseResolution,
+                                     amr::Flag::DoNothing};
+    const auto test_cases = std::vector{
+        std::tuple{
+            std::array{3_st, 9_st, 5_st}, std::array{5_st, 2_st, 4_st},
+            std::array{amr::Flag::IncreaseResolution,
+                       amr::Flag::DecreaseResolution, amr::Flag::DoNothing}},
+        std::tuple{std::array{4_st, 8_st, 2_st}, std::array{5_st, 5_st, 4_st},
+                   std::array{amr::Flag::DecreaseResolution,
+                              amr::Flag::IncreaseResolution,
+                              amr::Flag::IncreaseResolution}},
         std::tuple{std::array{3_st, 9_st, 3_st}, std::array{5_st, 2_st, 4_st},
                    std::array{amr::Flag::DoNothing, amr::Flag::DoNothing,
                               amr::Flag::IncreaseResolution}}};
     const std::string option =
-        "DriveToTarget:\n"
-        "  TargetNumberOfGridPoints: [3, 9, 5]\n"
-        "  TargetRefinementLevels: [5, 2, 4]\n"
-        "  OscillationAtTarget: [Split, DecreaseResolution, DoNothing]\n";
-    test(target_extents, target_levels, flags_at_target, test_cases, option);
+        "DriveToTargetNumberOfGridPoints:\n"
+        "  Target: [3, 9, 5]\n"
+        "  OscillationAtTarget: [IncreaseResolution, DecreaseResolution, "
+        "DoNothing]\n";
+    test<amr::Criteria::Type::p>(target_extents, flags_at_target, test_cases,
+                                 option);
+    CHECK_THROWS_WITH(
+        (test<amr::Criteria::Type::p>(
+            target_extents,
+            std::array{amr::Flag::Split, amr::Flag::Join,
+                       amr::Flag::DecreaseResolution},
+            test_cases, option)),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot use h-refinement flag in OscillationAtTarget"));
   }
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Random.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Random.cpp
@@ -21,6 +21,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Random.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -35,44 +36,53 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
-        tmpl::pair<amr::Criterion, tmpl::list<amr::Criteria::Random>>>;
+        tmpl::pair<amr::Criterion,
+                   tmpl::list<amr::Criteria::Random<amr::Criteria::Type::h>,
+                              amr::Criteria::Random<amr::Criteria::Type::p>>>>;
   };
 };
 struct TestComponent {};
 
-template <size_t VolumeDim>
+template <size_t VolumeDim, amr::Criteria::Type CriteriaType>
 void test_criterion(const amr::Criterion& criterion) {
   Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
   auto databox = db::create<db::AddSimpleTags<>>();
   auto empty_box =
       make_observation_box<db::AddComputeTags<>>(make_not_null(&databox));
 
-  ElementId<VolumeDim> root_id{0};
+  const ElementId<VolumeDim> root_id{0};
   auto flags = criterion.evaluate(empty_box, empty_cache, root_id);
   for (size_t d = 0; d < VolumeDim; ++d) {
-    CHECK((gsl::at(flags, d) == amr::Flag::Split or
-           gsl::at(flags, d) == amr::Flag::DoNothing));
+    if constexpr (amr::Criteria::Type::h == CriteriaType) {
+      CHECK((gsl::at(flags, d) == amr::Flag::Split or
+             gsl::at(flags, d) == amr::Flag::DoNothing));
+    } else {
+      CHECK((gsl::at(flags, d) == amr::Flag::IncreaseResolution or
+             gsl::at(flags, d) == amr::Flag::DoNothing));
+    }
   }
 }
 
 template <size_t VolumeDim>
 void test_always_split() {
-  const amr::Criteria::Random criterion{{{amr::Flag::Split, 1}}};
+  const amr::Criteria::Random<amr::Criteria::Type::h> criterion{
+      {{amr::Flag::Split, 1}}};
   Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
   auto databox = db::create<db::AddSimpleTags<>>();
   auto empty_box =
       make_observation_box<db::AddComputeTags<>>(make_not_null(&databox));
 
-  ElementId<VolumeDim> root_id{0};
+  const ElementId<VolumeDim> root_id{0};
   auto flags = criterion.evaluate(empty_box, empty_cache, root_id);
   for (size_t d = 0; d < VolumeDim; ++d) {
     CHECK(gsl::at(flags, d) == amr::Flag::Split);
   }
 }
 
-template <size_t VolumeDim>
+template <size_t VolumeDim, amr::Criteria::Type CriteriaType>
 void test_always_do_nothing() {
-  const amr::Criteria::Random criterion{{{amr::Flag::DoNothing, 1}}};
+  const amr::Criteria::Random<CriteriaType> criterion{
+      {{amr::Flag::DoNothing, 1}}};
 
   Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
   auto databox = db::create<db::AddSimpleTags<>>();
@@ -89,17 +99,32 @@ void test_always_do_nothing() {
 }
 
 template <size_t VolumeDim>
-void test_h_or_p() {
-  const amr::Criteria::Random criterion{{{amr::Flag::Split, 1},
-                                         {amr::Flag::IncreaseResolution, 1},
-                                         {amr::Flag::DecreaseResolution, 1},
-                                         {amr::Flag::Join, 1}}};
+void test_h() {
+  const amr::Criteria::Random<amr::Criteria::Type::h> criterion{
+      {{amr::Flag::Split, 1}, {amr::Flag::Join, 1}}};
   Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
   auto databox = db::create<db::AddSimpleTags<>>();
   auto empty_box =
       make_observation_box<db::AddComputeTags<>>(make_not_null(&databox));
 
-  ElementId<VolumeDim> root_id{0};
+  const ElementId<VolumeDim> root_id{0};
+  auto flags = criterion.evaluate(empty_box, empty_cache, root_id);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    CHECK((gsl::at(flags, d) != amr::Flag::DoNothing and
+           gsl::at(flags, d) != amr::Flag::Undefined));
+  }
+}
+
+template <size_t VolumeDim>
+void test_p() {
+  const amr::Criteria::Random<amr::Criteria::Type::p> criterion{
+      {{amr::Flag::IncreaseResolution, 1}, {amr::Flag::DecreaseResolution, 1}}};
+  Parallel::GlobalCache<Metavariables<VolumeDim>> empty_cache{};
+  auto databox = db::create<db::AddSimpleTags<>>();
+  auto empty_box =
+      make_observation_box<db::AddComputeTags<>>(make_not_null(&databox));
+
+  const ElementId<VolumeDim> root_id{0};
   auto flags = criterion.evaluate(empty_box, empty_cache, root_id);
   for (size_t d = 0; d < VolumeDim; ++d) {
     CHECK((gsl::at(flags, d) != amr::Flag::DoNothing and
@@ -111,22 +136,54 @@ template <size_t VolumeDim>
 void test() {
   register_factory_classes_with_charm<Metavariables<VolumeDim>>();
   test_always_split<VolumeDim>();
-  test_always_do_nothing<VolumeDim>();
-  test_h_or_p<VolumeDim>();
-  const amr::Criteria::Random random_criterion{
-      {{amr::Flag::Split, 4}, {amr::Flag::DoNothing, 1}}};
-  test_criterion<VolumeDim>(random_criterion);
-  test_criterion<VolumeDim>(serialize_and_deserialize(random_criterion));
+  test_always_do_nothing<VolumeDim, amr::Criteria::Type::h>();
+  test_always_do_nothing<VolumeDim, amr::Criteria::Type::p>();
+  test_h<VolumeDim>();
+  test_p<VolumeDim>();
+  CHECK_THROWS_WITH(
+      (amr::Criteria::Random<amr::Criteria::Type::h>{
+          {{amr::Flag::Split, 1}, {amr::Flag::IncreaseResolution, 1}}}),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot use p-refinement flag in ProbabilityWeights"));
+  CHECK_THROWS_WITH(
+      (amr::Criteria::Random<amr::Criteria::Type::p>{
+          {{amr::Flag::IncreaseResolution, 1}, {amr::Flag::Join, 1}}}),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot use h-refinement flag in ProbabilityWeights"));
 
-  const auto criterion =
+  const amr::Criteria::Random<amr::Criteria::Type::h> random_h_criterion{
+      {{amr::Flag::Split, 4}, {amr::Flag::DoNothing, 1}}};
+  test_criterion<VolumeDim, amr::Criteria::Type::h>(random_h_criterion);
+  test_criterion<VolumeDim, amr::Criteria::Type::h>(
+      serialize_and_deserialize(random_h_criterion));
+
+  const auto h_criterion =
       TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
                                  Metavariables<VolumeDim>>(
-          "Random:\n"
+          "RandomH:\n"
           "  ProbabilityWeights:\n"
           "    Split: 4\n"
           "    DoNothing: 1\n");
-  test_criterion<VolumeDim>(*criterion);
-  test_criterion<VolumeDim>(*serialize_and_deserialize(criterion));
+  test_criterion<VolumeDim, amr::Criteria::Type::h>(*h_criterion);
+  test_criterion<VolumeDim, amr::Criteria::Type::h>(
+      *serialize_and_deserialize(h_criterion));
+
+  const amr::Criteria::Random<amr::Criteria::Type::p> random_p_criterion{
+      {{amr::Flag::IncreaseResolution, 4}, {amr::Flag::DoNothing, 1}}};
+  test_criterion<VolumeDim, amr::Criteria::Type::p>(random_p_criterion);
+  test_criterion<VolumeDim, amr::Criteria::Type::p>(
+      serialize_and_deserialize(random_p_criterion));
+
+  const auto p_criterion =
+      TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
+                                 Metavariables<VolumeDim>>(
+          "RandomP:\n"
+          "  ProbabilityWeights:\n"
+          "    IncreaseResolution: 4\n"
+          "    DoNothing: 1\n");
+  test_criterion<VolumeDim, amr::Criteria::Type::p>(*p_criterion);
+  test_criterion<VolumeDim, amr::Criteria::Type::p>(
+      *serialize_and_deserialize(p_criterion));
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Type.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Type.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <vector>
+
+#include "Framework/TestCreation.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
+
+SPECTRE_TEST_CASE("Unit.Amr.Criteria.Type", "[Unit][ParallelAlgorithms]") {
+  CHECK(get_output(amr::Criteria::Type::h) == "h");
+  CHECK(get_output(amr::Criteria::Type::p) == "p");
+
+  const std::vector known_amr_types{amr::Criteria::Type::h,
+                                    amr::Criteria::Type::p};
+
+  for (const auto type : known_amr_types) {
+    CHECK(type ==
+          TestHelpers::test_creation<amr::Criteria::Type>(get_output(type)));
+  }
+
+  CHECK_THROWS_WITH(
+      ([]() {
+        TestHelpers::test_creation<amr::Criteria::Type>("Bad type name");
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          MakeString{} << "Failed to convert \"Bad type name\" to "
+                          "amr::Criteria::Type.\nMust be one of "
+                       << known_amr_types << "."));
+}

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_ObserveAmrCriteria.cpp
@@ -23,6 +23,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Events/ObserveAmrCriteria.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
@@ -50,7 +51,11 @@ struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
-        tmpl::pair<amr::Criterion, tmpl::list<amr::Criteria::DriveToTarget<1>>>,
+        tmpl::pair<
+            amr::Criterion,
+            tmpl::list<
+                amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>,
+                amr::Criteria::DriveToTarget<1, amr::Criteria::Type::p>>>,
         tmpl::pair<Event,
                    tmpl::list<amr::Events::ObserveAmrCriteria<Metavariables>>>>;
   };
@@ -58,16 +63,21 @@ struct Metavariables {
 
 void test() {
   std::vector<std::unique_ptr<amr::Criterion>> criteria;
-  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
-      std::array{4_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
-  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
-      std::array{3_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
-  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
-      std::array{5_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
-  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
-      std::array{4_st}, std::array{0_st}, std::array{amr::Flag::DoNothing}));
-  criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
-      std::array{4_st}, std::array{2_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
+          std::array{1_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<1, amr::Criteria::Type::p>>(
+          std::array{3_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<1, amr::Criteria::Type::p>>(
+          std::array{5_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
+          std::array{0_st}, std::array{amr::Flag::DoNothing}));
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
+          std::array{2_st}, std::array{amr::Flag::DoNothing}));
   const size_t number_of_criteria = criteria.size();
   const std::vector<double> expected_values{0.0, -1.0, 1.0, -2.0, 2.0};
   register_factory_classes_with_charm<Metavariables>();

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <memory>
+#include <pup.h>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -31,9 +32,41 @@
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+class BadCriterion : public amr::Criterion {
+ public:
+  using options = tmpl::list<>;
+
+  BadCriterion() = default;
+  explicit BadCriterion(CkMigrateMessage* msg) : Criterion(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(BadCriterion);  // NOLINT
+
+  amr::Criteria::Type type() override { return amr::Criteria::Type::p; }
+
+  std::string observation_name() override { return "BadCriterion"; }
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+  using argument_tags = tmpl::list<>;
+
+  template <typename Metavariables>
+  auto operator()(
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<Metavariables::volume_dim>& /*element_id*/) const {
+    return std::array{amr::Flag::Split};
+  }
+
+  void pup(PUP::er& p) override { Criterion::pup(p); }
+};
+
+PUP::able::PUP_ID BadCriterion::my_PUP_ID = 0;  // NOLINT
+#pragma GCC diagnostic pop
 
 template <typename Metavariables>
 struct ElementComponent {
@@ -60,7 +93,7 @@ struct Metavariables {
         tmpl::pair<
             amr::Criterion,
             tmpl::list<
-                amr::Criteria::IncreaseResolution<1>,
+                BadCriterion, amr::Criteria::IncreaseResolution<1>,
                 amr::Criteria::DriveToTarget<1, amr::Criteria::Type::p>,
                 amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>>>;
   };
@@ -91,6 +124,11 @@ void test(const Event& event) {
     std::vector<std::unique_ptr<amr::Criterion>> criteria{};
     criteria.emplace_back(
         std::make_unique<amr::Criteria::IncreaseResolution<1>>());
+    // this should be ignored...
+    criteria.emplace_back(
+        std::make_unique<
+            amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
+            std::array{1_st}, std::array{amr::Flag::DoNothing}));
     ActionTesting::MockRuntimeSystem<Metavariables> runner{
         {std::move(criteria), ::Verbosity::Debug}};
 
@@ -163,14 +201,12 @@ void test(const Event& event) {
             "Tried refining beyond the AMR limits in element"));
   }
 
+#ifdef SPECTRE_DEBUG
   {
     INFO("Test h-refinement error");
-    // Try to drive to larger refinement which isn't allowed for this event
+    // Try to use a bad criterion
     std::vector<std::unique_ptr<amr::Criterion>> criteria{};
-    criteria.emplace_back(
-        std::make_unique<
-            amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
-            std::array{1_st}, std::array{amr::Flag::DoNothing}));
+    criteria.emplace_back(std::make_unique<BadCriterion>());
     ActionTesting::MockRuntimeSystem<Metavariables> runner{
         {std::move(criteria), ::Verbosity::Debug}};
 
@@ -186,9 +222,9 @@ void test(const Event& event) {
                    element_id, std::add_pointer_t<element_component>{},
                    {"Unused", -1.0})),
         Catch::Matchers::ContainsSubstring(
-            "requested h-refinement, but RefineMesh only works for "
-            "p-refinement"));
+            "requested h-refinement, but claims to be for p-refinement"));
   }
+#endif
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
@@ -19,6 +19,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/DriveToTarget.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/IncreaseResolution.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
 #include "ParallelAlgorithms/Amr/Events/RefineMesh.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
@@ -54,11 +55,14 @@ struct Metavariables {
   using component_list = tmpl::list<ElementComponent<Metavariables>>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes =
-        tmpl::map<tmpl::pair<Event, tmpl::list<amr::Events::RefineMesh>>,
-                  tmpl::pair<amr::Criterion,
-                             tmpl::list<amr::Criteria::IncreaseResolution<1>,
-                                        amr::Criteria::DriveToTarget<1>>>>;
+    using factory_classes = tmpl::map<
+        tmpl::pair<Event, tmpl::list<amr::Events::RefineMesh>>,
+        tmpl::pair<
+            amr::Criterion,
+            tmpl::list<
+                amr::Criteria::IncreaseResolution<1>,
+                amr::Criteria::DriveToTarget<1, amr::Criteria::Type::p>,
+                amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>>>;
   };
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
@@ -115,8 +119,10 @@ void test(const Event& event) {
     INFO("Obey policies");
     // Try to drive to smaller number of grid points than we allow
     std::vector<std::unique_ptr<amr::Criterion>> criteria{};
-    criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
-        std::array{1_st}, std::array{0_st}, std::array{amr::Flag::DoNothing}));
+    criteria.emplace_back(
+        std::make_unique<
+            amr::Criteria::DriveToTarget<1, amr::Criteria::Type::p>>(
+            std::array{1_st}, std::array{amr::Flag::DoNothing}));
     ActionTesting::MockRuntimeSystem<Metavariables> runner{
         {std::move(criteria), ::Verbosity::Debug}};
 
@@ -161,8 +167,10 @@ void test(const Event& event) {
     INFO("Test h-refinement error");
     // Try to drive to larger refinement which isn't allowed for this event
     std::vector<std::unique_ptr<amr::Criterion>> criteria{};
-    criteria.emplace_back(std::make_unique<amr::Criteria::DriveToTarget<1>>(
-        std::array{3_st}, std::array{1_st}, std::array{amr::Flag::DoNothing}));
+    criteria.emplace_back(
+        std::make_unique<
+            amr::Criteria::DriveToTarget<1, amr::Criteria::Type::h>>(
+            std::array{1_st}, std::array{amr::Flag::DoNothing}));
     ActionTesting::MockRuntimeSystem<Metavariables> runner{
         {std::move(criteria), ::Verbosity::Debug}};
 

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.cpp
@@ -116,6 +116,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
     [[maybe_unused]] static constexpr bool keep_coarse_grids = false;
+    [[maybe_unused]] static constexpr bool p_refine_only_in_event = false;
   };
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.cpp
@@ -150,6 +150,7 @@ struct Metavariables {
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
     [[maybe_unused]] static constexpr bool keep_coarse_grids = false;
+    [[maybe_unused]] static constexpr bool p_refine_only_in_event = false;
   };
 
   using component_list = tmpl::flatten<tmpl::list<


### PR DESCRIPTION
## Proposed changes

- introduce enum amr::Criteria::Type to designate each amr::Criterion as being h or p
- only evaluate p criteria during the event RefineMesh
- add bool p_refine_only_in_event to amr struct in metavariables that allows one to choose whether or not to evaluate p criteria during AMR phase changes

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- New amr::Criterion have to overload the function `type` based on whether it returns h or p refinement flags
- The amr struct in the metavariables must define a static constexpr bool p_refine_in_events_only; the recommendation is to set it to true for evolution executables and false for elliptic executables.
- If you were previously doing p-refinement via phase changes, you will need to add something like the following to the list of EventsAndTriggers in the input file:
```
 - Trigger:
       Slabs:
       EvenlySpaced:
           Interval: 1
           Offset: 0
    Events:
        RefineMesh
```
 where you should change the trigger to what you desire.   If you only want to do p-refinement, then you should omit PhaseChanges related to AMR in the list of PhaseChangeAndTriggers.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
