### PR TITLE
Change ringdown gauge parameters to match inspiral

### DIFF
--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -109,7 +109,7 @@ EvolutionSystem:
     GaugeCondition:
       DampedHarmonic:
         SpatialDecayWidth: 17.0152695482514
-        Amplitudes: [1.0, 1.0, 1.0]
+        Amplitudes: [1.0, 0.0, 1.0]
         Exponents: [2, 2, 2]
     # The parameter choices here come from our experience with the Spectral
     # Einstein Code (SpEC). They should be suitable for evolutions of a


### PR DESCRIPTION
## Proposed changes

The Damped Harmonic gauge parameters do not match the ones used for the inspiral. I am seeing that this leads to gauge effects at the very start of the ringdown. 

For instance, the time derivative of the 00-coeficient of the horizon Strahlkorper seems to be discontinuous at the inspiral-ringdown match time (the horizon grows more rapidly at about 10x larger rate on the ringdown side than on the inspiral side). This might make the control systems struggle more.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
