### PR TITLE
Introduce higher-order FD for ValenciaDivClean

### DIFF
--- a/src/Evolution/DgSubcell/GhostZoneInverseJacobian.hpp
+++ b/src/Evolution/DgSubcell/GhostZoneInverseJacobian.hpp
@@ -10,6 +10,7 @@
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -72,7 +73,11 @@ struct GhostZoneInverseJacobian {
         evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>,
         evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>;
 
+    const size_t comp_dim = fd::get_computational_dim(subcell_mesh);
     for (const auto& direction : Direction<Dim>::all_directions()) {
+      if (direction.dimension() >= comp_dim) {
+        continue;
+      }
       const auto logical_coords = fd::ghost_zone_logical_coordinates(
           subcell_mesh, reconstructor.ghost_zone_size(), direction);
       const auto inv_jacobian = element_map.inv_jacobian(logical_coords);

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -27,6 +27,7 @@
 #include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
 #include "Evolution/DgSubcell/GetTciDecision.hpp"
+#include "Evolution/DgSubcell/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/NeighborTciDecision.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
@@ -534,6 +535,8 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
                                        false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
+          evolution::dg::subcell::GhostZoneInverseJacobian<
+              volume_dim, grmhd::ValenciaDivClean::fd::Tags::Reconstructor>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<
           evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -33,6 +33,7 @@
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/CellCenteredFlux.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
@@ -55,6 +56,7 @@
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace grmhd::ValenciaDivClean::subcell {
@@ -85,6 +87,17 @@ struct TimeDerivative {
         "need this look at the complete implementation in GhValenciaDivClean. "
         "You will at least need to update the high-order boundary correction "
         "code to include the right normal vectors/Jacobians.");
+
+    // Arrays representing the conormals used for
+    // `cartesian_high_order_flux_corrections`. These are not normalized
+    // by the magnitude of the conormals, but they do include a factor of the
+    // determinant of the Jacobian, i.e. \tilde{n}_\hat{i} = J n_\hat{i}
+    std::array<tnsr::i<DataVector, 3, Frame::Inertial>, 3> conormal;
+    const auto& ghost_zone_inv_jac =
+        db::get<evolution::dg::subcell::Tags::GhostZoneInverseJacobian<3>>(
+            *box);
+    std::array<DirectionMap<3, tnsr::i<DataVector, 3, Frame::Inertial>>, 3>
+        ghost_cells_conormal;
 
     const Mesh<3>& subcell_mesh =
         db::get<evolution::dg::subcell::Tags::Mesh<3>>(*box);
@@ -326,33 +339,82 @@ struct TimeDerivative {
             // The unnormalized normal vector is
             // n_j = d \xi^{\hat i}/dx^j
             // with "i" the current face.
-            tnsr::i<DataVector, 3, Frame::Inertial> lower_outward_conormal{
+            tnsr::i<DataVector, 3, Frame::Inertial> lower_outward_conormal_face{
                 reconstructed_num_pts, 0.0};
+            tnsr::i<DataVector, 3, Frame::Inertial> conormal_in_dir{
+                subcell_mesh.extents().product(), 0.0};
             for (size_t j = 0; j < 3; j++) {
-              lower_outward_conormal.get(j) =
+              conormal_in_dir.get(j) = evolution::dg::subcell::fd::project(
+                  inv_jacobian_dg.get(i, j), dg_mesh, subcell_mesh.extents());
+              lower_outward_conormal_face.get(j) =
                   evolution::dg::subcell::fd::project_to_faces(
                       inv_jacobian_dg.get(i, j), dg_mesh, face_mesh_extents, i,
                       (i == 0) != (j == 0) ? Spectral::Parity::Odd
                                            : Spectral::Parity::Even);
             }
+            const auto det_inv_jacobian = evolution::dg::subcell::fd::project(
+                get(det_inv_jacobian_dg), dg_mesh, subcell_mesh.extents());
             const auto det_inv_jacobian_face =
                 evolution::dg::subcell::fd::project_to_faces(
                     get(det_inv_jacobian_dg), dg_mesh, face_mesh_extents, i,
                     Spectral::Parity::Even);
 
-            const Scalar<DataVector> normalization{sqrt(get(
-                dot_product(lower_outward_conormal, lower_outward_conormal,
-                            get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
-                                vars_upper_face))))};
+            const Scalar<DataVector> normalization{sqrt(get(dot_product(
+                lower_outward_conormal_face, lower_outward_conormal_face,
+                get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                    vars_upper_face))))};
             for (size_t j = 0; j < 3; j++) {
-              lower_outward_conormal.get(j) =
-                  lower_outward_conormal.get(j) / get(normalization);
+              lower_outward_conormal_face.get(j) =
+                  lower_outward_conormal_face.get(j) / get(normalization);
             }
 
-            tnsr::i<DataVector, 3, Frame::Inertial> upper_outward_conormal{
+            tnsr::i<DataVector, 3, Frame::Inertial> upper_outward_conormal_face{
                 reconstructed_num_pts, 0.0};
             for (size_t j = 0; j < 3; j++) {
-              upper_outward_conormal.get(j) = -lower_outward_conormal.get(j);
+              upper_outward_conormal_face.get(j) =
+                  -lower_outward_conormal_face.get(j);
+              gsl::at(conormal, i).get(j) =
+                  conormal_in_dir.get(j) / det_inv_jacobian;
+            }
+
+            for (const auto side : {Side::Lower, Side::Upper}) {
+              const Direction<3> direction{i, side};
+              const auto& ghost_cells_grid_coords = get<
+                  evolution::dg::subcell::Tags::Coordinates<3, Frame::Grid>>(
+                  ghost_zone_inv_jac.at(direction));
+              const auto& ghost_cells_grid_inv_jacobian =
+                  get<evolution::dg::subcell::fd::Tags::
+                          InverseJacobianLogicalToGrid<3>>(
+                      ghost_zone_inv_jac.at(direction));
+              const auto& ghost_cells_inertial_inv_jacobian =
+                  db::get<domain::CoordinateMaps::Tags::CoordinateMap<
+                      3, Frame::Grid, Frame::Inertial>>(*box)
+                      .inv_jacobian(
+                          ghost_cells_grid_coords, db::get<::Tags::Time>(*box),
+                          db::get<::domain::Tags::FunctionsOfTime>(*box));
+              auto total_inv_jacobian =
+                  make_with_value<tnsr::Ij<DataVector, 3>>(
+                      ghost_cells_inertial_inv_jacobian, 0.0);
+              for (size_t m = 0; m < 3; m++) {
+                for (size_t n = 0; n < 3; n++) {
+                  for (size_t j = 0; j < 3; j++) {
+                    total_inv_jacobian.get(m, n) +=
+                        ghost_cells_grid_inv_jacobian.get(m, j) *
+                        ghost_cells_inertial_inv_jacobian.get(j, n);
+                  }
+                }
+              }
+              const auto ghost_cells_det_inv_jacobian =
+                  determinant(total_inv_jacobian);
+              tnsr::i<DataVector, 3, Frame::Inertial> tmp_ghost_cells_conormal{
+                  ghost_cells_grid_coords.size()};
+              for (size_t j = 0; j < 3; j++) {
+                tmp_ghost_cells_conormal.get(j) =
+                    total_inv_jacobian.get(i, j) /
+                    get(ghost_cells_det_inv_jacobian);
+              }
+              gsl::at(ghost_cells_conormal, i)
+                  .insert_or_assign(direction, tmp_ghost_cells_conormal);
             }
             // Note: we probably should compute the normal vector in addition to
             // the co-vector. Not a huge issue since we'll get an FPE right now
@@ -364,14 +426,16 @@ struct TimeDerivative {
                 typename DerivedCorrection::dg_package_data_primitive_tags>;
             evolution::dg::Actions::detail::dg_package_data<System>(
                 make_not_null(&upper_packaged_data), *derived_correction,
-                vars_upper_face, upper_outward_conormal, mesh_velocity_on_face,
-                *box, typename DerivedCorrection::dg_package_data_volume_tags{},
+                vars_upper_face, upper_outward_conormal_face,
+                mesh_velocity_on_face, *box,
+                typename DerivedCorrection::dg_package_data_volume_tags{},
                 dg_package_data_projected_tags{});
 
             evolution::dg::Actions::detail::dg_package_data<System>(
                 make_not_null(&lower_packaged_data), *derived_correction,
-                vars_lower_face, lower_outward_conormal, mesh_velocity_on_face,
-                *box, typename DerivedCorrection::dg_package_data_volume_tags{},
+                vars_lower_face, lower_outward_conormal_face,
+                mesh_velocity_on_face, *box,
+                typename DerivedCorrection::dg_package_data_volume_tags{},
                 dg_package_data_projected_tags{});
 
             // Now need to check if any of our neighbors are doing DG,
@@ -455,17 +519,6 @@ struct TimeDerivative {
           });
     }
 
-    if (UNLIKELY(fd_derivative_order != ::fd::DerivativeOrder::Two)) {
-      ERROR(
-          "We don't yet have high-order flux corrections for curved/moving "
-          "meshes and the implementation assumes curved/moving meshes. We need "
-          "to dot the Cartesian fluxes into the cell-centered "
-          "J inv(J)^{hat{i}}_j to get JF^{hat{i}} = J inv(J)^{hat{i}}_j F^j."
-          " Some care needs to be taken since we also get F^j from our "
-          "neighbors, which leaves the question as to whether to interpolate "
-          "the _inertial fluxes_ and then transform or whether to transform "
-          "and then interpolate the _densitized logical fluxes_.");
-    }
     std::optional<std::array<Variables<evolved_vars_tags>, 3>>
         high_order_corrections{};
     ::fd::cartesian_high_order_flux_corrections(
@@ -477,8 +530,8 @@ struct TimeDerivative {
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
             *box),
         subcell_mesh, recons.ghost_zone_size(),
-        reconstruction_order.value_or(
-            std::array<gsl::span<std::uint8_t>, 3>{}));
+        reconstruction_order.value_or(std::array<gsl::span<std::uint8_t>, 3>{}),
+        false, conormal, ghost_cells_conormal);
 
     const auto& cell_centered_det_inv_jacobian = db::get<
         evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToInertial>(

--- a/src/NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp
@@ -96,9 +96,15 @@ void cartesian_high_order_fluxes_using_nodes(
                  EvolvedVarsTags, tmpl::size_t<Dim>, Frame::Inertial>...>>>&
         ghost_cell_inertial_flux,
     const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_cells,
-    [[maybe_unused]] const std::array<gsl::span<std::uint8_t>, Dim>&
-        reconstruction_order = {}) {
+    const std::array<gsl::span<std::uint8_t>, Dim>& reconstruction_order = {},
+    const bool aligned_coordinates = true,
+    const std::array<tnsr::i<DataVector, Dim, Frame::Inertial>, Dim>& normal =
+        {},
+    const std::array<
+        DirectionMap<Dim, tnsr::i<DataVector, Dim, Frame::Inertial>>, Dim>&
+        ghost_cell_normal = {}) {
   using std::min;
+  static_assert(Dim > 0 and Dim <= 3, "Dim must be 1, 2, or 3");
   constexpr int max_correction_order = 10;
   static_assert(static_cast<int>(DerivOrder) <= max_correction_order);
   constexpr size_t stencil_size = static_cast<int>(DerivOrder) < 0
@@ -116,6 +122,9 @@ void cartesian_high_order_fluxes_using_nodes(
                      [](const auto& t) { return not t.empty(); }) or
              static_cast<int>(DerivOrder) > 0,
          "For adaptive derivative orders the reconstruction_order must be set");
+  ASSERT(normal[0][0].size() != 0 or aligned_coordinates,
+         "Normal vectors must be specified when coordinate systems are not "
+         "aligned");
   for (size_t dim = 0; dim < Dim; ++dim) {
     gsl::at(*high_order_boundary_corrections_in_logical_direction, dim)
         .initialize(
@@ -133,10 +142,14 @@ void cartesian_high_order_fluxes_using_nodes(
                      number_of_ghost_cells,
                      &second_order_boundary_corrections_in_logical_direction,
                      &subcell_mesh, &correction_width, &reconstruction_order,
-                     &reconstruction_extents](auto tag_v, auto dim_v) {
+                     &reconstruction_extents, &normal,
+                     &ghost_cell_normal]<typename tag, size_t dim,
+                                         bool AlignedCoordinates>(
+                        tmpl::type_<tag> /*meta*/,
+                        std::integral_constant<size_t, dim> /*meta*/,
+                        std::integral_constant<bool,
+                                               AlignedCoordinates> /*meta*/) {
     (void)reconstruction_extents;
-    using tag = decltype(tag_v);
-    constexpr size_t dim = decltype(dim_v)::value;
 
     auto& high_order_var_correction =
         get<tag>((*high_order_boundary_corrections_in_logical_direction)[dim]);
@@ -161,11 +174,13 @@ void cartesian_high_order_fluxes_using_nodes(
     const size_t number_of_components = second_order_var_correction.size();
     for (size_t storage_index = 0; storage_index < number_of_components;
          ++storage_index) {
-      const auto flux_multi_index = prepend(
-          second_order_var_correction.get_tensor_index(storage_index), dim);
-      const size_t flux_storage_index =
-          FluxTensor::get_storage_index(flux_multi_index);
-      // Loop over each face
+      std::array<size_t, Dim> flux_storage_indices;
+      for (size_t n = 0; n < Dim; ++n) {
+        const auto temp_multi_index = prepend(
+            second_order_var_correction.get_tensor_index(storage_index), n);
+        flux_storage_indices[n] =
+            FluxTensor::get_storage_index(temp_multi_index);
+      }
       for (size_t k = 0; k < (Dim == 3 ? subcell_face_extents[2] : 1); ++k) {
         for (size_t j = 0; j < (Dim >= 2 ? subcell_face_extents[1] : 1); ++j) {
           for (size_t i = 0; i < subcell_face_extents[0]; ++i) {
@@ -194,7 +209,9 @@ void cartesian_high_order_fluxes_using_nodes(
                     0.0;
 
             std::array<double, stencil_size> cell_centered_fluxes_for_stencil{};
-            // fill if we have to retrieve from lower neighbor
+            // fill if we have to retrieve from lower neighbor; compute a
+            // dot-product with normal components when coordinates are not
+            // aligned
             size_t stencil_index = 0;
             for (int grid_index = static_cast<int>(face_index[dim]) -
                                   static_cast<int>(correction_width);
@@ -202,27 +219,61 @@ void cartesian_high_order_fluxes_using_nodes(
                                   static_cast<int>(correction_width);
                  ++grid_index, ++stencil_index) {
               if (grid_index < 0) {
-                neighbor_index[dim] = static_cast<size_t>(
-                    static_cast<int>(number_of_ghost_cells) + grid_index);
+                neighbor_index[dim] =
+                    number_of_ghost_cells + static_cast<size_t>(grid_index);
+                const size_t idx_flat =
+                    collapsed_index(neighbor_index, neighbor_extents);
+                double normal_flux = 0.0;
+                for (size_t n = 0; n < Dim; ++n) {
+                  const double normal_in_direction =
+                      AlignedCoordinates
+                          ? (n == dim ? 1.0 : 0.0)
+                          : ghost_cell_normal[dim]
+                                .at(Direction<Dim>{dim, Side::Lower})
+                                .get(n)[idx_flat];
+                  normal_flux +=
+                      lower_neighbor_cell_centered_flux[flux_storage_indices[n]]
+                                                       [idx_flat] *
+                      normal_in_direction;
+                }
                 gsl::at(cell_centered_fluxes_for_stencil, stencil_index) =
-                    lower_neighbor_cell_centered_flux[flux_storage_index]
-                                                     [collapsed_index(
-                                                         neighbor_index,
-                                                         neighbor_extents)];
+                    normal_flux;
               } else if (grid_index >= static_cast<int>(subcell_extents[dim])) {
                 neighbor_index[dim] = static_cast<size_t>(
                     grid_index - static_cast<int>(subcell_extents[dim]));
+                const size_t idx_flat =
+                    collapsed_index(neighbor_index, neighbor_extents);
+                double normal_flux = 0.0;
+                for (size_t n = 0; n < Dim; ++n) {
+                  const double normal_in_direction =
+                      AlignedCoordinates
+                          ? (n == dim ? 1.0 : 0.0)
+                          : ghost_cell_normal[dim]
+                                .at(Direction<Dim>{dim, Side::Upper})
+                                .get(n)[idx_flat];
+                  normal_flux +=
+                      upper_neighbor_cell_centered_flux[flux_storage_indices[n]]
+                                                       [idx_flat] *
+                      normal_in_direction;
+                }
                 gsl::at(cell_centered_fluxes_for_stencil, stencil_index) =
-                    upper_neighbor_cell_centered_flux[flux_storage_index]
-                                                     [collapsed_index(
-                                                         neighbor_index,
-                                                         neighbor_extents)];
+                    normal_flux;
               } else {
                 Index<Dim> volume_index = face_index;
                 volume_index[dim] = static_cast<size_t>(grid_index);
+                const size_t idx_flat =
+                    collapsed_index(volume_index, subcell_extents);
+                double normal_flux = 0.0;
+                for (size_t n = 0; n < Dim; ++n) {
+                  const double normal_in_direction =
+                      AlignedCoordinates ? (n == dim ? 1.0 : 0.0)
+                                         : normal[dim].get(n)[idx_flat];
+                  normal_flux +=
+                      cell_centered_flux[flux_storage_indices[n]][idx_flat] *
+                      normal_in_direction;
+                }
                 gsl::at(cell_centered_fluxes_for_stencil, stencil_index) =
-                    cell_centered_flux[flux_storage_index][collapsed_index(
-                        volume_index, subcell_extents)];
+                    normal_flux;
               }
             }
 
@@ -353,14 +404,33 @@ void cartesian_high_order_fluxes_using_nodes(
     }
   };
 
-  EXPAND_PACK_LEFT_TO_RIGHT(
-      impl(EvolvedVarsTags{}, std::integral_constant<size_t, 0>{}));
-  if constexpr (Dim > 1) {
-    EXPAND_PACK_LEFT_TO_RIGHT(
-        impl(EvolvedVarsTags{}, std::integral_constant<size_t, 1>{}));
-    if constexpr (Dim > 2) {
-      EXPAND_PACK_LEFT_TO_RIGHT(
-          impl(EvolvedVarsTags{}, std::integral_constant<size_t, 2>{}));
+  if (aligned_coordinates) {
+    EXPAND_PACK_LEFT_TO_RIGHT(impl(tmpl::type_<EvolvedVarsTags>{},
+                                   std::integral_constant<size_t, 0>{},
+                                   std::true_type{}));
+    if constexpr (Dim > 1) {
+      EXPAND_PACK_LEFT_TO_RIGHT(impl(tmpl::type_<EvolvedVarsTags>{},
+                                     std::integral_constant<size_t, 1>{},
+                                     std::true_type{}));
+      if constexpr (Dim > 2) {
+        EXPAND_PACK_LEFT_TO_RIGHT(impl(tmpl::type_<EvolvedVarsTags>{},
+                                       std::integral_constant<size_t, 2>{},
+                                       std::true_type{}));
+      }
+    }
+  } else {
+    EXPAND_PACK_LEFT_TO_RIGHT(impl(tmpl::type_<EvolvedVarsTags>{},
+                                   std::integral_constant<size_t, 0>{},
+                                   std::false_type{}));
+    if constexpr (Dim > 1) {
+      EXPAND_PACK_LEFT_TO_RIGHT(impl(tmpl::type_<EvolvedVarsTags>{},
+                                     std::integral_constant<size_t, 1>{},
+                                     std::false_type{}));
+      if constexpr (Dim > 2) {
+        EXPAND_PACK_LEFT_TO_RIGHT(impl(tmpl::type_<EvolvedVarsTags>{},
+                                       std::integral_constant<size_t, 2>{},
+                                       std::false_type{}));
+      }
     }
   }
 }
@@ -382,8 +452,13 @@ void cartesian_high_order_fluxes_using_nodes(
         ghost_cell_inertial_flux,
     const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_cells,
     const DerivativeOrder derivative_order,
-    [[maybe_unused]] const std::array<gsl::span<std::uint8_t>, Dim>&
-        reconstruction_order = {}) {
+    const std::array<gsl::span<std::uint8_t>, Dim>& reconstruction_order = {},
+    const bool aligned_coordinates = true,
+    const std::array<tnsr::i<DataVector, Dim, Frame::Inertial>, Dim>& normal =
+        {},
+    const std::array<
+        DirectionMap<Dim, tnsr::i<DataVector, Dim, Frame::Inertial>>, Dim>&
+        ghost_cell_normal = {}) {
   switch (derivative_order) {
     case DerivativeOrder::OneHigherThanRecons:
       cartesian_high_order_fluxes_using_nodes<
@@ -391,7 +466,8 @@ void cartesian_high_order_fluxes_using_nodes(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
-          number_of_ghost_cells, reconstruction_order);
+          number_of_ghost_cells, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
       break;
     case DerivativeOrder::OneHigherThanReconsButFiveToFour:
       cartesian_high_order_fluxes_using_nodes<
@@ -399,42 +475,48 @@ void cartesian_high_order_fluxes_using_nodes(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
-          number_of_ghost_cells, reconstruction_order);
+          number_of_ghost_cells, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
       break;
     case DerivativeOrder::Two:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Two>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
-          number_of_ghost_cells, reconstruction_order);
+          number_of_ghost_cells, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
       break;
     case DerivativeOrder::Four:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Four>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
-          number_of_ghost_cells, reconstruction_order);
+          number_of_ghost_cells, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
       break;
     case DerivativeOrder::Six:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Six>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
-          number_of_ghost_cells, reconstruction_order);
+          number_of_ghost_cells, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
       break;
     case DerivativeOrder::Eight:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Eight>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
-          number_of_ghost_cells, reconstruction_order);
+          number_of_ghost_cells, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
       break;
     case DerivativeOrder::Ten:
       cartesian_high_order_fluxes_using_nodes<DerivativeOrder::Ten>(
           high_order_boundary_corrections_in_logical_direction,
           second_order_boundary_corrections_in_logical_direction,
           cell_centered_inertial_flux, ghost_cell_inertial_flux, subcell_mesh,
-          number_of_ghost_cells, reconstruction_order);
+          number_of_ghost_cells, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
       break;
     default:
       ERROR("Unsupported correction order " << derivative_order);
@@ -513,8 +595,13 @@ void cartesian_high_order_flux_corrections(
     const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>&
         all_ghost_data,
     const Mesh<Dim>& subcell_mesh, const size_t ghost_zone_size,
-    [[maybe_unused]] const std::array<gsl::span<std::uint8_t>, Dim>&
-        reconstruction_order = {},
+    const std::array<gsl::span<std::uint8_t>, Dim>& reconstruction_order = {},
+    const bool aligned_coordinates = true,
+    const std::array<tnsr::i<DataVector, Dim, Frame::Inertial>, Dim>& normal =
+        {},
+    const std::array<
+        DirectionMap<Dim, tnsr::i<DataVector, Dim, Frame::Inertial>>, Dim>&
+        ghost_cell_normal = {},
     const size_t number_of_rdmp_values_in_ghost_data = 0) {
   if (cell_centered_fluxes.has_value()) {
     ASSERT(alg::all_of(
@@ -550,7 +637,8 @@ void cartesian_high_order_flux_corrections(
           make_not_null(&(high_order_corrections->value())),
           second_order_boundary_corrections, cell_centered_fluxes.value(),
           flux_neighbor_data, subcell_mesh, ghost_zone_size,
-          fd_derivative_order, reconstruction_order);
+          fd_derivative_order, reconstruction_order, aligned_coordinates,
+          normal, ghost_cell_normal);
     }
   }
 }

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
@@ -1,0 +1,259 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveValenciaDivClean
+Testing:
+  Check: parse;execute
+  Timeout: 30
+  Priority: High
+ExpectedOutput:
+  - TovStarVolume0.h5
+  - TovStarReductions.h5
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: False
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.0001
+  MinimumTimeStep: 1e-7
+  TimeStepper:
+    # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers
+    # for spectre for hydro right now.
+    Rk3HesthavenSsp:
+    # AdamsMoultonPc:
+    #   Order: 3
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1000
+          Offset: 5
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
+
+InitialData: &InitialData
+  TovStar:
+    CentralDensity: 1.28e-3
+    EquationOfState:
+        PolytropicFluid:
+            PolytropicConstant: 100.0
+            PolytropicExponent: 2.0
+    Coordinates: Isotropic
+
+EquationOfState:
+  FromInitialData
+# Note: these domains are chosen so that we only need to simulate the interior
+# of the star, avoiding the surface discontinuity. A few pre-made options are
+# provided to test out more or less complicated domains. The least trivial, a
+# Sphere domain with filled interior, is enabled by default.
+# A simpler domain would be a Brick. If the boundaries are set to [-3.5, 3.5]^3,
+# it will remain within the star.
+DomainCreator:
+  Sphere:
+    InnerRadius: 3.
+    OuterRadius: 7.
+    Interior:
+      FillWithSphericity: 0.0
+      # To test only the wedges, which would be a less complicated domain,
+      # comment out the above line and uncomment the below ones
+      #ExciseWithBoundaryCondition:
+      #  DirichletAnalytic:
+      #      AnalyticPrescription: *InitialData
+    InitialRefinement: [1,1,1]
+    InitialGridPoints: [5,5,5]
+    EquatorialCompression: None
+    WhichWedges: All
+    RadialPartitioning: []
+    RadialDistribution: [Linear]
+    UseEquiangularMap: False
+    TimeDependentMaps: None
+    OuterBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+
+VariableFixing:
+  FixConservatives:
+    Enable: False # Only needed when not using Kastaun for recovery
+    CutoffD: &CutoffD 1.1e-15
+    MinimumValueOfD: &MinimumD 1.0e-15
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
+    SafetyFactorForB: &BSafetyFactor 1.0e-12
+    SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-8
+    SafetyFactorForSSlope: 0.0001
+    MagneticField: AssumeZero
+  FixToAtmosphere:
+    DensityOfAtmosphere: 1.0e-15
+    DensityCutoff: &AtmosphereDensityCutoff 1.1e-15
+    VelocityLimiting:
+      AtmosphereMaxVelocity: 0.0
+      NearAtmosphereMaxVelocity: 1.0e-4
+      AtmosphereDensityCutoff: 3.0e-15
+      TransitionDensityBound: 3.0e-14
+    KappaLimiting:
+      DensityLowerBound: 2.0e-14
+      EplisonKappaMinus: 1.0e-3
+      DensityUpperBound: 2.0e-13
+      EpsilonKappaMax: 0.01
+      LimitAboveDensityUpperBound: False
+      MinTemperature: FromEos
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
+
+EvolutionSystem:
+  ValenciaDivClean:
+    DampingParameter: 0.0
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    Hll:
+      MagneticFieldMagnitudeForHydro: 1.0e-30
+      LightSpeedDensityCutoff: 1.0e-8
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+    Filtering:
+      - None:
+          BlocksToFilter: All
+    Subcell:
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: False # Enable to test FD convergence
+        EnableExtensionDirections: False
+        UseHalo: False
+        OnlyDgBlocksAndGroups: None
+      SubcellToDgReconstructionMethod: DimByDim
+      FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 3 # Can be reduced for simpler domains
+    TciOptions:
+      MinimumValueOfD: 1.0e-20
+      MinimumValueOfYe: 1.0e-20
+      MinimumValueOfTildeTau: 1.0e-50
+      AtmosphereDensity: *AtmosphereDensityCutoff
+      SafetyFactorForB: *BSafetyFactor
+      MagneticFieldCutoff: DoNotCheckMagneticField
+  SubcellSolver:
+    Reconstructor:
+      PositivityPreservingAdaptiveOrderPrim:
+        Alpha5: 3.8
+        Alpha7: None
+        Alpha9: None
+        LowOrderReconstructor: MonotonisedCentral
+        ReconstructRhoTimesTemperature: True
+
+EventsAndTriggersAtCheckpoints:
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    Events:
+      - ChangeSlabSize:
+          DelayChange: 5
+          StepChoosers:
+            - Cfl:
+                SafetyFactor: 0.5
+            - LimitIncrease:
+                Factor: 1.5
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    Events:
+      - ObserveTimeStep:
+          SubfileName: Time
+          PrintTimeToTerminal: True
+          ObservePerCore: False
+      - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+            - Name: RestMassDensity
+              NormType: Max
+              Components: Individual
+            - Name: Error(RestMassDensity)
+              NormType: L2Norm
+              Components: Individual
+            - Name: Error(SpecificInternalEnergy)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(SpatialVelocity)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pressure)
+              NormType: L2Norm
+              Components: Sum
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    Events:
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - RestMassDensity
+            - Error(RestMassDensity)
+            - SpatialVelocity
+            - SpecificInternalEnergy
+            - TciStatus
+          InterpolateToMesh: None
+          ProjectToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          BlocksToObserve: All
+  - Trigger:
+      Slabs:
+        Specified:
+          Values: [3]
+    Events:
+      - Completion
+
+Observers:
+  VolumeFileName: "TovStarVolume"
+  ReductionFileName: "TovStarReductions"
+
+EventsAndDenseTriggers:
+
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:
+    - ObserveFields:
+        SubfileName: VolumeDataOnFailure
+        VariablesToObserve:
+          - RestMassDensity
+          - Error(RestMassDensity)
+          - TildeD
+          - SpatialVelocity
+          - SpecificInternalEnergy
+          - TildeTau
+          - Pressure
+          - TciStatus
+        InterpolateToMesh: None
+        ProjectToMesh: None
+        CoordinatesFloatingPointType: Double
+        FloatingPointTypes: [Double]
+        BlocksToObserve: All
+

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -23,6 +23,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
@@ -30,17 +31,21 @@
 #include "Domain/Creators/Tags/Domain.hpp"
 #include "Domain/Creators/Tags/FunctionsOfTime.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/BoundaryCorrection.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DgSubcell/CellCenteredFlux.hpp"
+#include "Evolution/DgSubcell/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/DgSubcell/Tags/CellCenteredFlux.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
 #include "Evolution/DgSubcell/Tags/ReconstructionOrder.hpp"
@@ -98,6 +103,14 @@ struct DummyEvolutionMetaVars {
   };
 };
 
+template <bool aligned>
+using CoordinateMap = tmpl::conditional_t<
+    aligned,
+    domain::CoordinateMaps::ProductOf3Maps<domain::CoordinateMaps::Affine,
+                                           domain::CoordinateMaps::Affine,
+                                           domain::CoordinateMaps::Affine>,
+    domain::CoordinateMaps::Frustum>;
+
 template <size_t Dim, typename... Maps, typename Solution>
 auto face_centered_gr_tags(
     const Mesh<Dim>& subcell_mesh, const double time,
@@ -130,29 +143,41 @@ auto face_centered_gr_tags(
   return face_centered_gr_vars;
 }
 
+template <bool AlignedCoordinates>
 std::array<double, 5> test(const size_t num_dg_pts,
                            const ::fd::DerivativeOrder fd_derivative_order,
                            std::optional<double> expansion_velocity) {
   using flux_tags =
       db::wrap_tags_in<::Tags::Flux, typename System::flux_variables,
                        tmpl::size_t<3>, Frame::Inertial>;
-  using Affine = domain::CoordinateMaps::Affine;
-  using Affine3D =
-      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-  const Affine affine_map{-1.0, 1.0, 1.0, 15.0};
+
+  CoordinateMap<AlignedCoordinates> coordinate_map;
+  if constexpr (AlignedCoordinates) {
+    using Affine = domain::CoordinateMaps::Affine;
+    using Affine3D =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+    const Affine affine_map{-1.0, 1.0, 1.0, 15.0};
+    coordinate_map = Affine3D{affine_map, affine_map, affine_map};
+  } else {
+    const std::array<std::array<double, 2>, 4> face_vertices{
+        {{{-5., -5.}}, {{5., 5.}}, {{-3., -3.}}, {{3., 3.}}}};
+    coordinate_map = domain::CoordinateMaps::Frustum(
+        face_vertices, -2., 4., OrientationMap<3>::create_aligned());
+  }
+
   std::vector<Block<3>> blocks;
   blocks.emplace_back(Block<3>(
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Affine3D{affine_map, affine_map, affine_map}),
+          coordinate_map),
       0, {}));
   const auto element = domain::create_initial_element(
-      ElementId<3>{0, {SegmentId{2, 2}, SegmentId{2, 2}, SegmentId{2, 2}}},
+      ElementId<3>{0, {SegmentId{3, 2}, SegmentId{3, 2}, SegmentId{3, 2}}},
       blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
   const ElementMap<3, Frame::Grid> element_map{
       element.id(),
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
-          Affine3D{affine_map, affine_map, affine_map})};
+          coordinate_map)};
   const auto grid_to_inertial_map =
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{});
@@ -168,7 +193,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
 
   const grmhd::Solutions::BondiMichel soln{1.0, 5.0, 0.05, 1.4, 2.0};
 
-  const double time = 0.0;
+  const double time = 0.5;
   const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
@@ -177,6 +202,14 @@ std::array<double, 5> test(const size_t num_dg_pts,
       (*grid_to_inertial_map)(element_map(logical_coordinates(subcell_mesh)));
   const auto dg_coords =
       (*grid_to_inertial_map)(element_map(logical_coordinates(dg_mesh)));
+
+  typename evolution::dg::subcell::Tags::GhostZoneInverseJacobian<3>::type
+      ghost_zone_inv_jac{};
+
+  evolution::dg::subcell::GhostZoneInverseJacobian<
+      3, grmhd::ValenciaDivClean::fd::PositivityPreservingAdaptiveOrderPrim>::
+      apply(make_not_null(&ghost_zone_inv_jac), subcell_mesh, element_map,
+            recons);
 
   Variables<typename System::spacetime_variables_tag::tags_list>
       cell_centered_spacetime_vars{subcell_mesh.number_of_grid_points()};
@@ -336,10 +369,16 @@ std::array<double, 5> test(const size_t num_dg_pts,
   Domain<3> dummy_domain{};
   typename evolution::dg::Tags::NormalCovectorAndMagnitude<3>::type
       dummy_normal_covector_and_magnitude{};
-  const double dummy_time{0.0};
+
+  // Test arbitrary function of time to ensure that the grid to inertial
+  // inverse Jacobian is applied properly to the ghost zone.
   std::unordered_map<std::string,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-      dummy_functions_of_time{};
+      functions_of_time{};
+  functions_of_time["translation"] =
+      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+          0.0, std::array<DataVector, 3>{{{3, 0.0}, {3, -4.3}, {3, 0.0}}},
+          100.0);
 
   using CellCenteredFluxesTag = evolution::dg::subcell::Tags::CellCenteredFlux<
       typename System::flux_variables, 3>;
@@ -403,7 +442,8 @@ std::array<double, 5> test(const size_t num_dg_pts,
           Parallel::Tags::MetavariablesImpl<DummyEvolutionMetaVars>,
           CellCenteredFluxesTag,
           evolution::dg::subcell::Tags::SubcellOptions<3>,
-          evolution::dg::subcell::Tags::ReconstructionOrder<3>>,
+          evolution::dg::subcell::Tags::ReconstructionOrder<3>,
+          evolution::dg::subcell::Tags::GhostZoneInverseJacobian<3>>,
       db::AddComputeTags<
           ::domain::Tags::LogicalCoordinates<3>,
           // Compute tags for Frame::Grid quantities
@@ -463,15 +503,15 @@ std::array<double, 5> test(const size_t num_dg_pts,
                                  element_map.block_map().get_clone()},
       grid_to_inertial_map->get_clone(), std::move(dummy_domain),
       dg_mesh_velocity, div_dg_mesh_velocity,
-      dummy_normal_covector_and_magnitude, dummy_time,
-      clone_unique_ptrs(dummy_functions_of_time),
-      grmhd::Solutions::SmoothFlow{}, DummyEvolutionMetaVars{},
-      cell_centered_fluxes,
+      dummy_normal_covector_and_magnitude, time,
+      clone_unique_ptrs(functions_of_time), grmhd::Solutions::SmoothFlow{},
+      DummyEvolutionMetaVars{}, cell_centered_fluxes,
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
           std::nullopt, fd_derivative_order, 1, 1, 1},
-      typename evolution::dg::subcell::Tags::ReconstructionOrder<3>::type{});
+      typename evolution::dg::subcell::Tags::ReconstructionOrder<3>::type{},
+      ghost_zone_inv_jac);
 
   db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
 
@@ -531,7 +571,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
            get<Tags::TildeB<>>(output_minus_expected_dt_cons_vars))))}};
 }
 
-// [[TimeOut, 10]]
+// [[TimeOut, 20]]
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.ValenciaDivClean.Subcell.TimeDerivative",
     "[Unit][Evolution]") {
@@ -541,17 +581,47 @@ SPECTRE_TEST_CASE(
   std::array<double, 5> second_order_error_6{};
   std::optional<double> dummy_expansion_velocity{};
   using DO = ::fd::DerivativeOrder;
-  // Note: All the high order cases are commented out because we don't yet
-  // have support for high-order FD on curved meshes.
-  for (const DO fd_do : {
-           DO::Two  // , DO::Four, DO::Six, DO::Eight, DO::Ten
-       }) {
+  // Note: This test case is successful for higher derivative orders as well,
+  // but including so many checks slows down the test case, resulting in
+  // timeouts. Since it is not explicitly necessary to test to highest order,
+  // we comment out these options.
+  for (const DO fd_do :
+       {DO::Two, DO::Four /*, DO::Six , DO::Eight, DO::Ten*/}) {
     CAPTURE(fd_do);
     // This tests sets up a cube [2,3]^3 in a Bondi-Michel spacetime and
     // verifies that the time derivative vanishes. Or, more specifically, that
     // the time derivative decreases with increasing resolution.
-    const auto five_pts_data = test(5, fd_do, dummy_expansion_velocity);
-    const auto six_pts_data = test(6, fd_do, dummy_expansion_velocity);
+    const auto five_pts_data = test<true>(5, fd_do, dummy_expansion_velocity);
+    const auto six_pts_data = test<true>(6, fd_do, dummy_expansion_velocity);
+    if (fd_do == DO::Two) {
+      second_order_error_5 = five_pts_data;
+      second_order_error_6 = six_pts_data;
+    }
+
+    for (size_t i = 0; i < five_pts_data.size(); ++i) {
+      CAPTURE(i);
+      CHECK(gsl::at(six_pts_data, i) < gsl::at(five_pts_data, i));
+      // Check that as we increase the order of the FD derivative the error
+      // decreases.
+      if (previous_error_5.has_value()) {
+        CHECK(gsl::at(five_pts_data, i) < gsl::at(previous_error_5.value(), i));
+      }
+      if (previous_error_6.has_value()) {
+        CHECK(gsl::at(six_pts_data, i) < gsl::at(previous_error_6.value(), i));
+      }
+    }
+    previous_error_5 = five_pts_data;
+    previous_error_6 = six_pts_data;
+  }
+
+  // Repeat the test with non-aligned coordinate map. Note: by DO::Ten we hit an
+  // error floor in this case. Up until this point there is rapid convergence.
+  previous_error_5 = {};
+  previous_error_6 = {};
+  for (const DO fd_do : {DO::Two, DO::Four, DO::Six /*, DO::Eight*/}) {
+    CAPTURE(fd_do);
+    const auto five_pts_data = test<false>(5, fd_do, dummy_expansion_velocity);
+    const auto six_pts_data = test<false>(6, fd_do, dummy_expansion_velocity);
     if (fd_do == DO::Two) {
       second_order_error_5 = five_pts_data;
       second_order_error_6 = six_pts_data;
@@ -579,10 +649,10 @@ SPECTRE_TEST_CASE(
     // verifies that the time derivative is the same when using no mesh
     // velocity and when using a zero mesh velocity
     std::optional<double> zero_expansion_velocity(0.0);
-    const auto data_no_mesh_velocity = test(5, DO::Two,  // DO::Four,
-                                            dummy_expansion_velocity);
-    const auto data_mesh_velocity = test(5, DO::Two,  // DO::Four,
-                                         zero_expansion_velocity);
+    const auto data_no_mesh_velocity =
+        test<true>(5, DO::Four, dummy_expansion_velocity);
+    const auto data_mesh_velocity =
+        test<true>(5, DO::Four, zero_expansion_velocity);
 
     for (size_t i = 0; i < data_no_mesh_velocity.size(); ++i) {
       CAPTURE(i);
@@ -594,17 +664,15 @@ SPECTRE_TEST_CASE(
   // Now use an expansion map.
   previous_error_5 = {};
   previous_error_6 = {};
-  for (const DO fd_do : {
-           DO::Two  // , DO::Four
-       }) {
+  for (const DO fd_do : {DO::Two, DO::Four}) {
     CAPTURE(fd_do);
     std::optional<double> expansion_velocity(0.1);
     // This tests sets up a cube [2,3]^3 in a Bondi-Michel spacetime and
     // verifies that the difference between correct and expected time
     // derivative vanishes. Or, more specifically, that
     // the time derivative decreases with increasing resolution.
-    const auto five_pts_data = test(5, fd_do, expansion_velocity);
-    const auto six_pts_data = test(6, fd_do, expansion_velocity);
+    const auto five_pts_data = test<false>(5, fd_do, expansion_velocity);
+    const auto six_pts_data = test<false>(6, fd_do, expansion_velocity);
     if (fd_do == DO::Two) {
       second_order_error_5 = five_pts_data;
       second_order_error_6 = six_pts_data;

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
@@ -36,11 +36,13 @@
 #include "Evolution/BoundaryCorrection.hpp"
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
+#include "Evolution/DgSubcell/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
 #include "Evolution/DgSubcell/Tags/CellCenteredFlux.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
 #include "Evolution/DgSubcell/Tags/ReconstructionOrder.hpp"
@@ -379,6 +381,13 @@ void test_cartoon_fd_time_derivative() {
         evolution::dg::subcell::Tags::CellCenteredFlux<
             typename grmhd::ValenciaDivClean::System::flux_variables, 3>;
 
+    typename evolution::dg::subcell::Tags::GhostZoneInverseJacobian<3>::type
+        ghost_zone_inv_jac{};
+    evolution::dg::subcell::GhostZoneInverseJacobian<
+        3, grmhd::ValenciaDivClean::fd::Tags::Reconstructor>::
+        apply(make_not_null(&ghost_zone_inv_jac), subcell_mesh,
+              logical_to_grid_map, recons);
+
     auto box = db::create<
         db::AddSimpleTags<
             domain::Tags::Element<3>, evolution::dg::subcell::Tags::Mesh<3>,
@@ -409,7 +418,8 @@ void test_cartoon_fd_time_derivative() {
             Parallel::Tags::MetavariablesImpl<DummyEvolutionMetaVars>,
             CellCenteredFluxesTag,
             evolution::dg::subcell::Tags::SubcellOptions<3>,
-            evolution::dg::subcell::Tags::ReconstructionOrder<3>>,
+            evolution::dg::subcell::Tags::ReconstructionOrder<3>,
+            evolution::dg::subcell::Tags::GhostZoneInverseJacobian<3>>,
         db::AddComputeTags<
             ::domain::Tags::LogicalCoordinates<3>,
             // Compute tags for Frame::Grid quantities
@@ -482,7 +492,8 @@ void test_cartoon_fd_time_derivative() {
             1.0e8, 1_st, 1.0e-4, 1.0e-5, false, false,
             evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
             std::nullopt, ::fd::DerivativeOrder::Two, 2, 2, 2},
-        typename evolution::dg::subcell::Tags::ReconstructionOrder<3>::type{});
+        typename evolution::dg::subcell::Tags::ReconstructionOrder<3>::type{},
+        ghost_zone_inv_jac);
     db::mutate_apply<grmhd::ValenciaDivClean::ConservativeFromPrimitive>(
         make_not_null(&box));
 

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_HighOrderFluxCorrection.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_HighOrderFluxCorrection.cpp
@@ -5,24 +5,50 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <random>
 #include <unordered_set>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/BulgedCube.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Frustum.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/Rotation.hpp"
+#include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/CreateInitialElement.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DgSubcell/GhostZoneInverseJacobian.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/FiniteDifference/DerivativeOrder.hpp"
 #include "NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 
 namespace {
 struct Scalar0 : db::SimpleTag {
@@ -34,10 +60,35 @@ struct Vector0 : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
 };
 
-template <size_t Dim>
-void test(const fd::DerivativeOrder correction_order) {
-  CAPTURE(correction_order);
+class DummyReconstructor {
+ public:
+  explicit DummyReconstructor(const size_t ghost_zone_size)
+      : ghost_zone_size_(ghost_zone_size){};
+  size_t ghost_zone_size_;
+  size_t ghost_zone_size() const { return ghost_zone_size_; }
+};
+
+namespace Tags {
+struct Reconstructor : db::SimpleTag {
+  using type = std::unique_ptr<DummyReconstructor>;
+};
+}  // namespace Tags
+
+template <size_t Dim, bool AlignedCoordinates>
+using CoordinateMap = tmpl::conditional_t<
+    Dim == 1 or AlignedCoordinates, domain::CoordinateMaps::Identity<Dim>,
+    tmpl::conditional_t<Dim == 2 and not AlignedCoordinates,
+                        domain::CoordinateMaps::Wedge<2>,
+                        domain::CoordinateMaps::BulgedCube>>;
+
+template <size_t Dim, bool AlignedCoordinates>
+double test(const fd::DerivativeOrder correction_order) {
+  CAPTURE(AlignedCoordinates);
   CAPTURE(Dim);
+  if constexpr (not AlignedCoordinates) {
+    ASSERT(Dim == 2 or Dim == 3,
+           "A test for a non-aligned grid is not provided for 1-D.");
+  };
   const size_t max_degree =
       correction_order == fd::DerivativeOrder::OneHigherThanRecons
           ? 6
@@ -59,18 +110,60 @@ void test(const fd::DerivativeOrder correction_order) {
                                  Frame::Inertial>>;
   using CorrectionVars = Variables<FluxTags>;
 
-  const Mesh<Dim> mesh{points_per_dimension, Spectral::Basis::FiniteDifference,
-                       Spectral::Quadrature::CellCentered};
-  auto logical_coords = logical_coordinates(mesh);
-  // Make the logical coordinates different in each direction
-  for (size_t i = 1; i < Dim; ++i) {
-    logical_coords.get(i) += 4.0 * static_cast<double>(i);
+  const Mesh<Dim> dg_mesh{points_per_dimension, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh{points_per_dimension,
+                               Spectral::Basis::FiniteDifference,
+                               Spectral::Quadrature::CellCentered};
+  const auto logical_coords = logical_coordinates(subcell_mesh);
+  const auto dg_logical_coords = logical_coordinates(dg_mesh);
+
+  CoordinateMap<Dim, AlignedCoordinates> coordinate_map;
+  if constexpr (Dim == 1 or AlignedCoordinates) {
+    coordinate_map = domain::CoordinateMaps::Identity<Dim>();
+  } else if constexpr (Dim == 2 and not AlignedCoordinates) {
+    coordinate_map = domain::CoordinateMaps::Wedge<2>(
+        1., 4., 1., 1., OrientationMap<2>::create_aligned(), true,
+        domain::CoordinateMaps::Wedge<2>::WedgeHalves::Both,
+        domain::CoordinateMaps::Distribution::Linear,
+        std::array<double, 1>{M_PI_2});
+  } else if constexpr (Dim == 3 and not AlignedCoordinates) {
+    coordinate_map = domain::CoordinateMaps::BulgedCube(1., 0.1, false);
   }
+
+  ElementId<Dim> element_id{};
+  if constexpr (AlignedCoordinates) {
+    element_id = ElementId<Dim>{0, 0};
+  } else if constexpr (Dim == 2 and not AlignedCoordinates) {
+    element_id = ElementId<2>{0, {SegmentId{3, 4}, SegmentId{3, 4}}};
+  } else if constexpr (Dim == 3 and not AlignedCoordinates) {
+    element_id =
+        ElementId<3>{0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}};
+  }
+
+  const auto element_map = ElementMap<Dim, Frame::Grid>(
+      element_id,
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          coordinate_map));
+
+  const auto grid_coords = (element_map)(logical_coords);
+  const auto jacobian = element_map.jacobian(logical_coords);
+  const auto inv_jacobian = element_map.inv_jacobian(logical_coords);
+  const auto det_inv_jacobian = determinant(inv_jacobian);
+
+  typename evolution::dg::subcell::Tags::GhostZoneInverseJacobian<Dim>::type
+      ghost_zone_inv_jac{};
+
+  const DummyReconstructor dummy_reconstructor(number_of_ghost_points);
+  evolution::dg::subcell::GhostZoneInverseJacobian<
+      Dim, DummyReconstructor>::apply(make_not_null(&ghost_zone_inv_jac),
+                                      subcell_mesh, element_map,
+                                      dummy_reconstructor);
 
   // Compute polynomial on cell centers in FD cluster of points
   const auto set_polynomial = Overloader{
       [max_degree](const gsl::not_null<FluxVars*> vars_ptr,
-                   const auto& local_logical_coords) {
+                   const auto& local_coords) {
         (void)max_degree;
         for (size_t storage_index = 0;
              storage_index < get<Scalar0Flux>(*vars_ptr).size();
@@ -79,25 +172,24 @@ void test(const fd::DerivativeOrder correction_order) {
           for (size_t degree = 1; degree <= max_degree; ++degree) {
             for (size_t i = 0; i < Dim; ++i) {
               get<Scalar0Flux>(*vars_ptr)[storage_index] +=
-                  pow(local_logical_coords.get(i), degree);
+                  pow(local_coords.get(i), degree);
             }
           }
         }
         for (size_t storage_index = 0;
              storage_index < get<Vector0Flux>(*vars_ptr).size();
              ++storage_index) {
-          get<Vector0Flux>(*vars_ptr)[storage_index] =
-              1.0 + 0.3 * static_cast<double>(storage_index);
+          get<Vector0Flux>(*vars_ptr)[storage_index] = 0.0;
           for (size_t degree = 1; degree <= max_degree; ++degree) {
             for (size_t i = 0; i < Dim; ++i) {
               get<Vector0Flux>(*vars_ptr)[storage_index] +=
-                  pow(local_logical_coords.get(i), degree);
+                  pow(local_coords.get(i), degree);
             }
           }
         }
       },
       [max_degree](const gsl::not_null<CorrectionVars*> vars_ptr,
-                   const auto& local_logical_coords) {
+                   const auto& local_coords) {
         (void)max_degree;
         for (size_t storage_index = 0;
              storage_index < get<Scalar0>(*vars_ptr).size(); ++storage_index) {
@@ -105,26 +197,25 @@ void test(const fd::DerivativeOrder correction_order) {
           for (size_t degree = 1; degree <= max_degree; ++degree) {
             for (size_t i = 0; i < Dim; ++i) {
               get<Scalar0>(*vars_ptr)[storage_index] +=
-                  pow(local_logical_coords.get(i), degree);
+                  pow(local_coords.get(i), degree);
             }
           }
         }
         for (size_t storage_index = 0;
              storage_index < get<Vector0<Dim>>(*vars_ptr).size();
              ++storage_index) {
-          get<Vector0<Dim>>(*vars_ptr)[storage_index] =
-              100.0 + 11.0 * static_cast<double>(storage_index);
+          get<Vector0<Dim>>(*vars_ptr)[storage_index] = 0.0;
           for (size_t degree = 1; degree <= max_degree; ++degree) {
             for (size_t i = 0; i < Dim; ++i) {
               get<Vector0<Dim>>(*vars_ptr)[storage_index] +=
-                  pow(local_logical_coords.get(i), degree);
+                  pow(local_coords.get(i), degree);
             }
           }
         }
       }};
   const auto set_polynomial_divergence =
       [max_degree](const gsl::not_null<CorrectionVars*> d_vars_ptr,
-                   const auto& local_logical_coords) {
+                   const auto& local_coords) {
         (void)max_degree;
         get(get<Scalar0>(*d_vars_ptr)) = 0.0;
         for (size_t i = 0; i < Dim; ++i) {
@@ -135,19 +226,19 @@ void test(const fd::DerivativeOrder correction_order) {
         for (size_t deriv_dim = 0; deriv_dim < Dim; ++deriv_dim) {
           for (size_t degree = 1; degree <= max_degree; ++degree) {
             get(get<Scalar0>(*d_vars_ptr)) +=
-                degree * pow(local_logical_coords.get(deriv_dim), degree - 1);
+                degree * pow(local_coords.get(deriv_dim), degree - 1);
             for (size_t i = 0; i < Dim; ++i) {
               get<Vector0<Dim>>(*d_vars_ptr).get(i) +=
-                  degree * pow(local_logical_coords.get(deriv_dim), degree - 1);
+                  degree * pow(local_coords.get(deriv_dim), degree - 1);
             }
           }
         }
       };
-  std::optional<FluxVars> volume_vars(mesh.number_of_grid_points());
-  set_polynomial(&(volume_vars.value()), logical_coords);
+  std::optional<FluxVars> volume_vars(subcell_mesh.number_of_grid_points());
+  set_polynomial(&(volume_vars.value()), grid_coords);
 
-  CorrectionVars expected_divergence(mesh.number_of_grid_points());
-  set_polynomial_divergence(&expected_divergence, logical_coords);
+  CorrectionVars expected_divergence(subcell_mesh.number_of_grid_points());
+  set_polynomial_divergence(&expected_divergence, grid_coords);
 
   // Compute the polynomial at the cell center for the neighbor data that we
   // "received".
@@ -162,11 +253,12 @@ void test(const fd::DerivativeOrder correction_order) {
     auto neighbor_logical_coords = logical_coords;
     neighbor_logical_coords.get(direction.dimension()) +=
         direction.sign() * 2.0;
-    FluxVars neighbor_vars(mesh.number_of_grid_points(), 0.0);
-    set_polynomial(&neighbor_vars, neighbor_logical_coords);
+    const auto neighbor_grid_coords = (element_map)(neighbor_logical_coords);
+    FluxVars neighbor_vars(subcell_mesh.number_of_grid_points(), 0.0);
+    set_polynomial(&neighbor_vars, neighbor_grid_coords);
 
     const auto sliced_data = evolution::dg::subcell::slice_data(
-        neighbor_vars, mesh.extents(), number_of_ghost_points,
+        neighbor_vars, subcell_mesh.extents(), number_of_ghost_points,
         std::unordered_set{direction.opposite()}, 0, {});
     CAPTURE(number_of_ghost_points);
     REQUIRE(sliced_data.size() == 1);
@@ -194,6 +286,11 @@ void test(const fd::DerivativeOrder correction_order) {
   }
 
   std::array<CorrectionVars, Dim> second_order_corrections{};
+  std::array<
+      InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Grid>, Dim>
+      correction_inv_jacobians{};
+  std::array<Scalar<DataVector>, Dim> correction_det_inv_jacobians{};
+
   for (size_t i = 0; i < Dim; ++i) {
     // Compare to analytic solution on the faces.
     const auto basis = make_array<Dim>(Spectral::Basis::FiniteDifference);
@@ -203,15 +300,57 @@ void test(const fd::DerivativeOrder correction_order) {
     gsl::at(quadrature, i) = Spectral::Quadrature::FaceCentered;
     const Mesh<Dim> face_centered_mesh{extents, basis, quadrature};
     auto face_logical_coords = logical_coordinates(face_centered_mesh);
-    for (size_t j = 1; j < Dim; ++j) {
-      face_logical_coords.get(j) += 4.0 * static_cast<double>(j);
-    }
+    const auto face_grid_coords = (element_map)(face_logical_coords);
+
     gsl::at(second_order_corrections, i)
         .initialize(face_centered_mesh.number_of_grid_points());
     set_polynomial(make_not_null(&gsl::at(second_order_corrections, i)),
-                   face_logical_coords);
+                   face_grid_coords);
+
+    gsl::at(correction_inv_jacobians, i) =
+        element_map.inv_jacobian(face_logical_coords);
+    gsl::at(correction_det_inv_jacobians, i) =
+        determinant(gsl::at(correction_inv_jacobians, i));
+
     // We use n_i F^i in the code, so need to negate to get sign to agree.
     gsl::at(second_order_corrections, i) *= -1.0;
+  }
+
+  // If not using an aligned coordinate map, we must convert the boundary term
+  // to a local Cartesian flux on the logical grid. Assuming a flat spacetime,
+  // we do this by computing G^{(\hat{i})} = J \pdv{\xi^\hat{i}}{x^j} G^{(i)}.
+  // In this case, we are `cheating' a bit because the polynomial is defined
+  // such that the flux in each direction of the grid frame is the same.
+  // This is exploited in the coordinate transformation.
+  if (not AlignedCoordinates) {
+    const auto grid_second_order_corrections = second_order_corrections;
+    for (size_t storage_index = 0;
+         storage_index <
+         get(get<Scalar0>(gsl::at(second_order_corrections, 0))).size();
+         ++storage_index) {
+      for (size_t i = 0; i < Dim; ++i) {
+        get(get<Scalar0>(gsl::at(second_order_corrections, i)))[storage_index] =
+            0.;
+        for (size_t j = 0; j < Dim; ++j) {
+          get(get<Scalar0>(
+              gsl::at(second_order_corrections, i)))[storage_index] +=
+              gsl::at(correction_inv_jacobians, i).get(i, j)[storage_index] *
+              get(get<Scalar0>(
+                  gsl::at(grid_second_order_corrections, i)))[storage_index] /
+              get(gsl::at(correction_det_inv_jacobians, i))[storage_index];
+          get<Vector0<Dim>>(gsl::at(second_order_corrections, i))
+              .get(j)[storage_index] = 0.;
+          for (size_t k = 0; k < Dim; ++k) {
+            get<Vector0<Dim>>(gsl::at(second_order_corrections, i))
+                .get(j)[storage_index] +=
+                gsl::at(correction_inv_jacobians, i).get(i, k)[storage_index] *
+                get<Vector0<Dim>>(gsl::at(grid_second_order_corrections, i))
+                    .get(k)[storage_index] /
+                get(gsl::at(correction_det_inv_jacobians, i))[storage_index];
+          }
+        }
+      }
+    }
   }
 
   std::array<std::vector<std::uint8_t>, Dim> reconstruction_order_storage{};
@@ -219,7 +358,7 @@ void test(const fd::DerivativeOrder correction_order) {
   if (correction_order == fd::DerivativeOrder::OneHigherThanRecons or
       correction_order ==
           fd::DerivativeOrder::OneHigherThanReconsButFiveToFour) {
-    Index<Dim> recons_extents = mesh.extents();
+    Index<Dim> recons_extents = subcell_mesh.extents();
     recons_extents[0] += 2;
     for (size_t i = 0; i < Dim; ++i) {
       gsl::at(reconstruction_order_storage, i) =
@@ -230,18 +369,50 @@ void test(const fd::DerivativeOrder correction_order) {
     }
   }
 
-  std::optional<std::array<CorrectionVars, Dim>> high_order_corrections{};
-  ::fd::cartesian_high_order_flux_corrections(
-      make_not_null(&high_order_corrections),
+  // The unnormalized normal vector is n_j = d \xi^{\hat i}/dx^j with "i"
+  // the current face. When normalizing, we adopt a sign convention which
+  // is compatible with DG.
+  std::array<tnsr::i<DataVector, Dim, Frame::Inertial>, Dim> conormal;
+  std::array<DirectionMap<Dim, tnsr::i<DataVector, Dim, Frame::Inertial>>, Dim>
+      ghost_conormal;
+  if (not AlignedCoordinates) {
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = 0; j < Dim; j++) {
+        gsl::at(conormal, i).get(j) =
+            inv_jacobian.get(i, j) / get(det_inv_jacobian);
+      }
 
-      volume_vars, second_order_corrections, correction_order,
-      reconstruction_ghost_data, mesh, number_of_ghost_points,
-      reconstruction_order);
+      for (const auto& direction : Direction<Dim>::all_directions()) {
+        const auto& ghost_cells_grid_coords =
+            get<evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>>(
+                ghost_zone_inv_jac.at(direction));
+        const auto& ghost_cells_inv_jacobian =
+            get<evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<
+                Dim>>(ghost_zone_inv_jac.at(direction));
+        const auto ghost_cells_det_inv_jacobian =
+            determinant(ghost_cells_inv_jacobian);
+        tnsr::i<DataVector, Dim, Frame::Inertial> ghost_conormal_in_dir{
+            ghost_cells_grid_coords.size()};
+        for (size_t j = 0; j < Dim; j++) {
+          ghost_conormal_in_dir.get(j) = ghost_cells_inv_jacobian.get(i, j) /
+                                         get(ghost_cells_det_inv_jacobian);
+        }
+        gsl::at(ghost_conormal, i)
+            .insert_or_assign(direction, ghost_conormal_in_dir);
+      }
+    }
+  }
 
   // Now compute the Cartesian derivative of the high_order_corrections to
   // verify that it is computed sufficiently accurately.
-  const DataVector inv_jacobian{mesh.number_of_grid_points(), 1.0};
-  CorrectionVars flux_divergence{mesh.number_of_grid_points(), 0.0};
+  std::optional<std::array<CorrectionVars, Dim>> high_order_corrections{};
+  ::fd::cartesian_high_order_flux_corrections(
+      make_not_null(&high_order_corrections), volume_vars,
+      second_order_corrections, correction_order, reconstruction_ghost_data,
+      subcell_mesh, number_of_ghost_points, reconstruction_order,
+      AlignedCoordinates, conormal, ghost_conormal);
+
+  CorrectionVars flux_divergence{subcell_mesh.number_of_grid_points(), 0.0};
   for (size_t d = 0; d < Dim; ++d) {
     const auto& corrections_in_dim =
         high_order_corrections.has_value()
@@ -252,23 +423,48 @@ void test(const fd::DerivativeOrder correction_order) {
         -1.0 / (logical_coords.get(0)[1] - logical_coords.get(0)[0]);
     evolution::dg::subcell::add_cartesian_flux_divergence(
         make_not_null(&get(get<Scalar0>(flux_divergence))), one_over_delta_xi,
-        inv_jacobian, get(get<Scalar0>(corrections_in_dim)), mesh.extents(), d);
+        get(det_inv_jacobian), get(get<Scalar0>(corrections_in_dim)),
+        subcell_mesh.extents(), d);
     for (size_t i = 0; i < Dim; ++i) {
       evolution::dg::subcell::add_cartesian_flux_divergence(
           make_not_null(&get<Vector0<Dim>>(flux_divergence).get(i)),
-          one_over_delta_xi, inv_jacobian,
-          get<Vector0<Dim>>(corrections_in_dim).get(i), mesh.extents(), d);
+          one_over_delta_xi, get(det_inv_jacobian),
+          get<Vector0<Dim>>(corrections_in_dim).get(i), subcell_mesh.extents(),
+          d);
     }
   }
 
-  // With high-order corrections roundoff can accumulate.
-  Approx custom_approx = Approx::custom().epsilon(5.e-12);
+  // With high-order corrections roundoff can accumulate for aligned coordinates
+  // case.
+  // In the case of non aligned coordinates, we adopt a higher error since the
+  // Jacobian is more difficult to resolve. Note that this is mostly relevant
+  // for the lowest derivative orders, which use very few grid points,
+  // and the error converges rapidly with derivative order, emphasized by our
+  // use of exponential scaling with `max_degree`. We chose a case with
+  // relatively high error for 2nd order (error is ~2e-3) so that we can see the
+  // improvement with each derivative order. Starting with too low an error in
+  // 2nd order case would mean that you would approach error floors too quickly
+  // with e.g. 10th order case, and the improvement would not be apparent.
+  const Approx custom_approx =
+      AlignedCoordinates ? Approx::custom().epsilon(2.e-10)
+                         : Approx::custom().epsilon(pow(
+                               10., -0.5 - static_cast<double>(max_degree)));
   CHECK_ITERABLE_CUSTOM_APPROX(get<Scalar0>(flux_divergence),
                                get<Scalar0>(expected_divergence),
                                custom_approx);
   CHECK_ITERABLE_CUSTOM_APPROX(get<Vector0<Dim>>(flux_divergence),
                                get<Vector0<Dim>>(expected_divergence),
                                custom_approx);
+
+  CorrectionVars divergence_error(subcell_mesh.number_of_grid_points());
+  get(get<Scalar0>(divergence_error)) =
+      abs(get(get<Scalar0>(flux_divergence)) -
+          get(get<Scalar0>(expected_divergence)));
+  for (size_t i = 0; i < Dim; ++i) {
+    get<Vector0<Dim>>(divergence_error).get(i) =
+        abs(get<Vector0<Dim>>(flux_divergence).get(i) -
+            get<Vector0<Dim>>(expected_divergence).get(i));
+  }
 
   // Test assertions
 #ifdef SPECTRE_DEBUG
@@ -282,7 +478,7 @@ void test(const fd::DerivativeOrder correction_order) {
         ::fd::cartesian_high_order_flux_corrections(
             make_not_null(&high_order_corrections_assert), volume_vars,
             second_order_corrections, correction_order,
-            reconstruction_ghost_data, mesh, number_of_ghost_points),
+            reconstruction_ghost_data, subcell_mesh, number_of_ghost_points),
         Catch::Matchers::ContainsSubstring(
             "The high_order_corrections must all have size"));
   }
@@ -294,22 +490,40 @@ void test(const fd::DerivativeOrder correction_order) {
         ::fd::cartesian_high_order_flux_corrections(
             make_not_null(&high_order_corrections), volume_vars,
             second_order_corrections_copy, correction_order,
-            reconstruction_ghost_data, mesh, number_of_ghost_points),
+            reconstruction_ghost_data, subcell_mesh, number_of_ghost_points),
         Catch::Matchers::ContainsSubstring(
             "All second-order boundary corrections must be of the same size"));
   }
 #endif  // SPECTRE_DEBUG
+
+  return std::max({max(get(get<Scalar0>(divergence_error))),
+                   max(get(magnitude(get<Vector0<Dim>>(divergence_error))))});
 }
 
+// [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.FiniteDifference.CartesianHighOrderFluxCorrection",
                   "[Unit][NumericalAlgorithms]") {
   using DO = fd::DerivativeOrder;
   for (const fd::DerivativeOrder correction_order :
        {DO::Two, DO::Four, DO::Six, DO::Eight, DO::Ten, DO::OneHigherThanRecons,
         DO::OneHigherThanReconsButFiveToFour}) {
-    test<1>(correction_order);
-    test<2>(correction_order);
-    test<3>(correction_order);
+    CAPTURE(correction_order);
+    test<1, true>(correction_order);
+    test<2, true>(correction_order);
+    test<3, true>(correction_order);
+    test<2, false>(correction_order);
+    test<3, false>(correction_order);
+  }
+  // Test that error improves as we increase the correction order.
+  std::optional<double> previous_error{};
+  for (const fd::DerivativeOrder correction_order :
+       {DO::Two, DO::Four, DO::Six, DO::Eight, DO::Ten}) {
+    CAPTURE(correction_order);
+    const auto current_error = test<3, false>(correction_order);
+    if (previous_error.has_value()) {
+      CHECK(current_error < previous_error);
+    }
+    previous_error = current_error;
   }
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Introduces higher-order finite difference in the evolution of `ValenciaDivClean`. Previously, higher-order finite difference was only supported on aligned grids, preventing its use on general domain structures. This PR adds support for non-aligned grids and permits `ValenciaDivClean` to be evolved with higher-order finite difference.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
