### PR TITLE
Add auto ringdown excision radius to transition script

### DIFF
--- a/src/Evolution/Ringdown/CMakeLists.txt
+++ b/src/Evolution/Ringdown/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   StrahlkorperCoefsAndCenters.cpp
+  MinimumAhCExcisionRadius.cpp
   )
 
 spectre_target_headers(
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   StrahlkorperCoefsAndCenters.hpp
+  MinimumAhCExcisionRadius.hpp
   )
 
 target_link_libraries(

--- a/src/Evolution/Ringdown/MinimumAhCExcisionRadius.cpp
+++ b/src/Evolution/Ringdown/MinimumAhCExcisionRadius.cpp
@@ -1,0 +1,365 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#include "Evolution/Ringdown/MinimumAhCExcisionRadius.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/CoordsToDifferentFrame.hpp"
+#include "Domain/Creators/BinaryCompactObject.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
+#include "Domain/StrahlkorperTransformations.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace {
+void get_grid_point(
+    const BlockLogicalCoords<3>& block_logical_coord,
+    const Domain<3>& ringdown_domain,
+    const domain::FunctionsOfTimeMap& ringdown_functions_of_time,
+    const tnsr::I<double, 3, Frame::Inertial>& exc_inertial_frame_point,
+    tnsr::I<double, 3, Frame::Grid>& exc_grid_frame_point, double match_time) {
+  // If the point is mapped to a block then the ringdown excision radius
+  // chosen does not enclose excisions A/B from the inspiral
+  if (block_logical_coord.has_value()) {
+    const auto& block_id_and_coords = block_logical_coord.value();
+    const auto& block =
+        ringdown_domain.blocks()[block_id_and_coords.id.get_index()];
+    const auto& block_to_grid_map = block.moving_mesh_logical_to_grid_map();
+    const auto grid_point = block_to_grid_map(
+        block_id_and_coords.data, match_time, ringdown_functions_of_time);
+    get<0>(exc_grid_frame_point) = grid_point[0];
+    get<1>(exc_grid_frame_point) = grid_point[1];
+    get<2>(exc_grid_frame_point) = grid_point[2];
+  } else {
+    // This point is inside the excision which is why it couldn't be
+    // mapped to a block. Now we must use the shape map inverse to
+    // determine where this point is.
+    const auto inv_point = ringdown_domain.excision_spheres()
+                               .at("ExcisionSphere")
+                               .moving_mesh_grid_to_inertial_map()
+                               .inverse(exc_inertial_frame_point, match_time,
+                                        ringdown_functions_of_time);
+    if (inv_point.has_value()) {
+      get<0>(exc_grid_frame_point) = inv_point.value()[0];
+      get<1>(exc_grid_frame_point) = inv_point.value()[1];
+      get<2>(exc_grid_frame_point) = inv_point.value()[2];
+    } else {
+      ERROR("Map from Frame::Inertial to Frame::Grid is not invertible");
+    }
+  }
+}
+}  // namespace
+
+namespace evolution::Ringdown {
+double minimum_ahc_excision_radius(
+    const std::string& path_to_volume_data,
+    const std::string& volume_subfile_name,
+    const std::string& path_to_horizons_h5,
+    const std::string& surface_subfile_name,
+    const std::string& path_to_AhC_distorted_h5,
+    const std::vector<std::string>& AhC_distorted_subfile_names,
+    double match_time, double settling_timescale, double excision_A_radius,
+    double excision_B_radius, std::array<double, 3> excision_A_center,
+    std::array<double, 3> excision_B_center,
+    const std::optional<std::array<double, 3>>& exp_func_and_2_derivs,
+    const std::optional<std::array<double, 3>>&
+        exp_outer_bdry_func_and_2_derivs,
+    const std::optional<std::vector<std::array<double, 4>>>&
+        rot_func_and_2_derivs,
+    const std::optional<std::array<std::array<double, 3>, 3>>&
+        trans_func_and_2_derivs,
+    double match_time_tol) {
+  // Read the AhC coefficients from the H5 file
+  const ylm::Strahlkorper<Frame::Inertial>& ahc_inertial_at_match_time =
+      ylm::read_surface_ylm_single_time<Frame::Inertial>(
+          path_to_horizons_h5, surface_subfile_name, match_time,
+          match_time_tol);
+
+  const h5::H5File<h5::AccessType::ReadOnly> volume_file{path_to_volume_data};
+  const auto& volume_data =
+      volume_file.get<h5::VolumeData>(volume_subfile_name);
+
+  const size_t obs_id_at_match_time =
+      volume_data.find_observation_id(match_time, match_time_tol);
+
+  const auto serialized_inspiral_domain =
+      volume_data.get_domain();
+  if (not serialized_inspiral_domain.has_value()) {
+    ERROR("No domain found in volume files at the specified match time.");
+  }
+  const auto inspiral_domain =
+      deserialize<Domain<3>>(serialized_inspiral_domain->data());
+
+  const auto serialized_inspiral_functions_of_time =
+      volume_data.get_functions_of_time(obs_id_at_match_time);
+  if (not serialized_inspiral_functions_of_time.has_value()) {
+    ERROR("No functions of time found in volume files at the match time.");
+  }
+  const auto inspiral_functions_of_time =
+      deserialize<domain::FunctionsOfTimeMap>(
+          serialized_inspiral_functions_of_time->data());
+
+  // Ringdown functions of time computed using
+  // ComputeRingdownShapeAndTranslationFoT.py
+  const auto shape_map_options =
+      domain::creators::time_dependent_options::ShapeMapOptions<
+          false, domain::ObjectLabel::None>{
+          ahc_inertial_at_match_time.l_max(),
+          domain::creators::time_dependent_options::YlmsFromFile{
+              path_to_AhC_distorted_h5, AhC_distorted_subfile_names, match_time,
+              match_time_tol, true, true}};
+  const auto expansion_map_options =
+      exp_func_and_2_derivs.has_value()
+          ? domain::creators::time_dependent_options::ExpansionMapOptions<
+                true>{exp_func_and_2_derivs.value(), settling_timescale,
+                      exp_outer_bdry_func_and_2_derivs.value(),
+                      settling_timescale}
+          : std::optional<domain::creators::time_dependent_options::
+                              ExpansionMapOptions<true>>{};
+  const auto rotation_map_options =
+      rot_func_and_2_derivs.has_value()
+          ? domain::creators::time_dependent_options::RotationMapOptions<
+                true>{rot_func_and_2_derivs.value(), settling_timescale}
+          : std::optional<domain::creators::time_dependent_options::
+                              RotationMapOptions<true>>{};
+  const auto translation_map_options =
+      trans_func_and_2_derivs.has_value()
+          ? domain::creators::sphere::TimeDependentMapOptions::
+                TranslationMapOptions{trans_func_and_2_derivs.value()}
+          : std::optional<domain::creators::sphere::TimeDependentMapOptions::
+                              TranslationMapOptions>{};
+
+  const domain::creators::sphere::TimeDependentMapOptions
+      ringdown_time_dependent_map_options{match_time,
+                                          shape_map_options,
+                                          rotation_map_options,
+                                          expansion_map_options,
+                                          translation_map_options,
+                                          true};
+
+  const double ahc_average_radius = ahc_inertial_at_match_time.average_radius();
+  const std::array<double, 3> ahc_ringdown_center =
+      trans_func_and_2_derivs.has_value()
+          ? trans_func_and_2_derivs.value()[0]
+          : std::array<double, 3>{0.0, 0.0, 0.0};
+  double ringdown_excision_factor = 0.94;
+  // When constructing our domain in the inspiral, we explicitly choose the grid
+  // frame centers of the excision boundaries so that the Newtonian coordinate
+  // center of mass is at the origin. This allows us to use the formula below to
+  // get the mass ratio. If we ever change how we construct our domain, then
+  // this formula will no longer be true.
+  const double mass_ratio = abs(excision_B_center[0] / excision_A_center[0]);
+  const double eps = 1e-3 / mass_ratio;
+  bool outer_converged = false;
+  size_t current_outer_iteration = 0;
+  const size_t max_iterations = 10;
+  size_t current_l_max = 20;
+
+  // The outer loop checks that multiple l_max values for the AhA/AhB excisions
+  // fit inside the ringdown domain excision. The reason we iterate and check
+  // for multiple l_max values is because a single high l_max value might not
+  // sample the excision surfaces finely enough to yield an accurate
+  // ringdown_excision_factor, especially for extremely distorted grids. So we
+  // iterate over different l_max and demand convergence. This is more efficient
+  // and robust than simply choosing a large l_max without iterating
+  while (not outer_converged and current_outer_iteration < max_iterations) {
+    // Section for constructing strahlkorpers for AhA/AhB
+    const ylm::Strahlkorper<Frame::Grid> excision_a_inspiral_grid(
+        current_l_max, excision_A_radius, excision_A_center);
+    const ylm::Strahlkorper<Frame::Grid> excision_b_inspiral_grid(
+        current_l_max, excision_B_radius, excision_B_center);
+
+    const size_t points_size =
+        get<0>(ylm::cartesian_coords(excision_a_inspiral_grid)).size();
+    tnsr::I<DataVector, 3, Frame::Inertial> excision_a_inspiral_inertial_points{
+        points_size};
+    tnsr::I<DataVector, 3, Frame::Inertial> excision_b_inspiral_inertial_points{
+        points_size};
+    coords_to_different_frame(
+        make_not_null(&excision_a_inspiral_inertial_points),
+        ylm::cartesian_coords(excision_a_inspiral_grid), inspiral_domain,
+        inspiral_functions_of_time, match_time);
+    coords_to_different_frame(
+        make_not_null(&excision_b_inspiral_inertial_points),
+        ylm::cartesian_coords(excision_b_inspiral_grid), inspiral_domain,
+        inspiral_functions_of_time, match_time);
+
+    // Loop section finding the correct rmin_fac
+    const double previous_outer_ringdown_excision_factor =
+        ringdown_excision_factor;
+    size_t current_inner_iteration = 0;
+    bool inner_converged = false;
+
+    // The inner loop changes the excision radius of the ringdown domain until
+    // the previous ringdown radius and current are within a set tolerance
+    while (not inner_converged and current_inner_iteration < max_iterations) {
+      const double previous_inner_ringdown_excision_factor =
+          ringdown_excision_factor;
+      // This domain serves as a test domain for the ringdown using the
+      // corrected FoTs generated by ComputeRingdownShapeAndTranslationFoT.py
+      // which gives the shape map and corrected translation map that will be
+      // used in the final ringdown. This domain is only used to transform the
+      // excisions A/B from the inspiral to the ringdown grid frame to check if
+      // the current excision radius chosen encloses excisions A/B, so the
+      // resolution and outer radius of this test domain does not matter as this
+      // domain will not be used to evolve anything.
+      const domain::creators::Sphere ringdown_rmin_domain_creator{
+          ahc_average_radius * ringdown_excision_factor,
+          200.0,
+          // nullptr because no boundary condition
+          domain::creators::Sphere::Excision{nullptr},
+          static_cast<size_t>(0),
+          static_cast<size_t>(5),
+          false,
+          std::nullopt,
+          {50.0},
+          domain::CoordinateMaps::Distribution::Linear,
+          ShellWedges::All,
+          ringdown_time_dependent_map_options};
+
+      const auto temporary_ringdown_rmin_domain =
+          ringdown_rmin_domain_creator.create_domain();
+      const auto ringdown_rmin_functions_of_time =
+          ringdown_rmin_domain_creator.functions_of_time();
+
+      const auto exc_a_block_logical = block_logical_coordinates(
+          temporary_ringdown_rmin_domain, excision_a_inspiral_inertial_points,
+          match_time, ringdown_rmin_functions_of_time);
+      const auto exc_b_block_logical = block_logical_coordinates(
+          temporary_ringdown_rmin_domain, excision_b_inspiral_inertial_points,
+          match_time, ringdown_rmin_functions_of_time);
+
+      const tnsr::I<DataVector, 3, Frame::Inertial>
+          excision_a_ringdown_grid_points{points_size};
+      const tnsr::I<DataVector, 3, Frame::Inertial>
+          excision_b_ringdown_grid_points{points_size};
+
+      double min_excision_radius = 0.0;
+      tnsr::I<double, 3, Frame::Inertial> exc_a_inspiral_inertial_point{};
+      tnsr::I<double, 3, Frame::Grid> exc_a_ringdown_grid_point{};
+      tnsr::I<double, 3, Frame::Inertial> exc_b_inspiral_inertial_point{};
+      tnsr::I<double, 3, Frame::Grid> exc_b_ringdown_grid_point{};
+      for (size_t s = 0; s < get<0>(excision_a_inspiral_inertial_points).size();
+           ++s) {
+        get<0>(exc_a_inspiral_inertial_point) =
+            get<0>(excision_a_inspiral_inertial_points)[s];
+        get<1>(exc_a_inspiral_inertial_point) =
+            get<1>(excision_a_inspiral_inertial_points)[s];
+        get<2>(exc_a_inspiral_inertial_point) =
+            get<2>(excision_a_inspiral_inertial_points)[s];
+        get<0>(exc_b_inspiral_inertial_point) =
+            get<0>(excision_b_inspiral_inertial_points)[s];
+        get<1>(exc_b_inspiral_inertial_point) =
+            get<1>(excision_b_inspiral_inertial_points)[s];
+        get<2>(exc_b_inspiral_inertial_point) =
+            get<2>(excision_b_inspiral_inertial_points)[s];
+
+        get_grid_point(exc_a_block_logical[s], temporary_ringdown_rmin_domain,
+                       ringdown_rmin_functions_of_time,
+                       exc_a_inspiral_inertial_point, exc_a_ringdown_grid_point,
+                       match_time);
+
+        get_grid_point(exc_b_block_logical[s], temporary_ringdown_rmin_domain,
+                       ringdown_rmin_functions_of_time,
+                       exc_b_inspiral_inertial_point, exc_b_ringdown_grid_point,
+                       match_time);
+
+        const double excision_a_point_radius = sqrt(
+            square(get<0>(exc_a_ringdown_grid_point) - ahc_ringdown_center[0]) +
+            square(get<1>(exc_a_ringdown_grid_point) - ahc_ringdown_center[1]) +
+            square(get<2>(exc_a_ringdown_grid_point) - ahc_ringdown_center[2]));
+        const double excision_b_point_radius = sqrt(
+            square(get<0>(exc_b_ringdown_grid_point) - ahc_ringdown_center[0]) +
+            square(get<1>(exc_b_ringdown_grid_point) - ahc_ringdown_center[1]) +
+            square(get<2>(exc_b_ringdown_grid_point) - ahc_ringdown_center[2]));
+        min_excision_radius =
+            std::max(min_excision_radius, excision_a_point_radius);
+        min_excision_radius =
+            std::max(min_excision_radius, excision_b_point_radius);
+      }
+      const double min_ringdown_excision_factor =
+          min_excision_radius / ahc_average_radius;
+      // This line changes the excision radius factor to be 3/4 of the way
+      // between the minimum possible value to fit excisions A/B inside the
+      // ringdown excision and the common horizon average radius
+      ringdown_excision_factor =
+          1.0 - 0.25 * (1.0 - min_ringdown_excision_factor);
+      if (current_inner_iteration != 0 and
+          abs(ringdown_excision_factor -
+              previous_inner_ringdown_excision_factor) <= 0.5 * eps) {
+        inner_converged = true;
+      } else {
+        current_inner_iteration++;
+      }
+    }
+    if (current_outer_iteration != 0 and
+        abs(ringdown_excision_factor -
+            previous_outer_ringdown_excision_factor) <= 0.5 * eps) {
+      outer_converged = true;
+    }
+    current_outer_iteration++;
+    // Increment l max by 6 every iteration.
+    current_l_max += 6;
+    if (current_outer_iteration > max_iterations) {
+      ERROR(
+          "Max Iterations for finding a suitable excision radius exceeded. "
+          "Going to sleep.");
+    }
+  }
+  // This section makes a safe_ringdown_excision_factor by truncating any
+  // significant figures past eps and then adds a bit of safety to the
+  // safe_ringdown_excision_factor and compares to the original
+  // ringdown_excision_factor. If it's too close, add more safety padding, then,
+  // whichever is larger, choose that for the excision radius
+  double safe_ringdown_excision_factor =
+      static_cast<int>(ringdown_excision_factor / eps);
+  safe_ringdown_excision_factor *= eps;
+  safe_ringdown_excision_factor += eps;
+  if (safe_ringdown_excision_factor - ringdown_excision_factor < 0.5 * eps) {
+    safe_ringdown_excision_factor += eps;
+  }
+  const double ringdown_excision_radius =
+      ringdown_excision_factor > safe_ringdown_excision_factor
+          ? ahc_average_radius * ringdown_excision_factor
+          : ahc_average_radius * safe_ringdown_excision_factor;
+
+  // Checks for valid excision radius and potential issues
+  if (ringdown_excision_radius > ahc_average_radius + eps) {
+    ERROR("The excision radius chosen "
+          << ringdown_excision_radius
+          << " is larger than the radius of the common horizon "
+          << ahc_average_radius
+          << ". Either the common horizon does not actually contain the excised"
+             " regions, or there is a problem with the functions of time used, "
+             "or an error has occured in the excision radius finding routine.");
+  } else if (ringdown_excision_radius > ahc_average_radius - 3 * eps) {
+    ERROR(
+        "The excision radius chosen is very close to the radius of the common "
+        "horizon. Either the tolerances should be increased, or a later match "
+        "time should be chosen to increase the distance between the excised "
+        "regions and the common horizon.");
+  }
+
+  return ringdown_excision_radius;
+}
+}  // namespace evolution::Ringdown

--- a/src/Evolution/Ringdown/MinimumAhCExcisionRadius.hpp
+++ b/src/Evolution/Ringdown/MinimumAhCExcisionRadius.hpp
@@ -1,0 +1,173 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+
+namespace evolution::Ringdown {
+
+/*!
+ * \brief This function finds a safe ringdown excision radius for starting
+ * the ringdown of a common horizon from a binary inspiral. It does this by
+ * finding a radius that will enclose every point on strahlkorpers that
+ * represent excisions A/B from the inspiral at the match time. It does this by
+ * taking excisions A/B from the inertial frame and transforming them to the
+ * ringdown grid frame. It iterates over all the points from excisions A/B in
+ * the ringdown-grid-frame until it finds the point that's the farthest from the
+ * geometric center of the ringdown excision. This is now the minimum radius we
+ * can choose to enclose the excisions A/B from the inspiral. This is not the
+ * ideal radius however, we then choose a radius that's 3/4 of the way between
+ * the radius of the common horizon at the match time and the minimum radius
+ * that encloses excisions A/B from the inspiral and check for multiple l_max
+ * values of excisions A/B to ensure they fit and the ringdown can start.
+
+ * \details It does this by constructing inspiral-grid-frame AhA/AhB excision
+ * strahlkorpers from the radii and centers passed to this function. It then
+ * maps those excisions to the inertial-frame using the inspiral domain
+ * and functions of time from the inspiral volume data and subfile supplied. We
+ * then construct a test ringdown domain that has all the corrected functions of
+ * time from ComputeRingdownShapeAndTranslationFoT.py and an initial guess for
+ * the inner radius. More details are outlined below.
+ * \param path_to_volume_data The full path to the volume data containing the
+ * domain and functions of time
+ * \param volume_subfile_name Subfile containing volume data output from the
+ * inspiral
+ * \param path_to_horizons_h5 Path to h5 file containing horizon data for AhA/B
+ * \param surface_subfile_name Subfile containing horizon data for AhA/B
+ * \param path_to_AhC_distorted_h5 Path to h5 file containing ringdown shape
+ * coefficients computed using ComputeRingdownShapeAndTranslationFoT.py
+ * \param AhC_distorted_subfile_names Subfiles in the h5 file containing
+ * shape coefficients
+ * \param match_time The time to match the functions of time
+ * \param settling_timescale Timescale at which the functions of time settle to
+ * constant values
+ * \param excision_A_radius The radius of excision A from the inspiral grid
+ * frame
+ * \param excision_B_radius The radius of excision B from the inspiral grid
+ * frame
+ * \param excision_A_center The center of excision A from the inspiral grid
+ * frame
+ * \param excision_B_center The center of excision B from the inspiral grid
+ * frame
+ * \param exp_func_and_2_derivs Expansion function of time from the inspiral
+ * \param exp_outer_bdry_func_and_2_derivs Outer boundary expansion function of
+ * time from the inspiral
+ * \param rot_func_and_2_derivs Rotation function of time from the inspiral
+ * \param trans_func_and_2_derivs The corrected translation function of time
+ * computed by ComputeRingdownShapeAndTranslationFoT.py
+ * \param match_time_tol The difference allowed between the match time requested
+ * and the time found in h5 files
+ *
+ * Using the corrected functions of time and our initial guess for the ringdown
+ * inner radius (the excision radius), excisions A/B are transformed from the
+ * inertial frame to the ringdown grid frame. The inner radius is iterated upon
+ * using 2 main loops, the outer loop which changes the L_max of the excisions
+ * A/B being transformed from the inspiral and the inner loop that changes the
+ * excision radius used in the ringdown. The general flow for these loops is as
+ * follows:
+ *
+ * Let $ahc\_average\_radius$ be the average radius of the common horizon in the
+ * inertial frame and since have strahlkorper data from the inertial frame AhC
+ * we set $ahc\_average\_radius$ so that lambda00=0 at the match time.
+ *
+ * Let $ringdown\_excision\_radius$ be the radius of (spherical) excision
+ * boundary in ringdown grid frame.
+ *
+ * Let $ringdown\_excision\_factor$ be the factor we multiply the
+ * $ahc\_average\_radius$ by to get the $ringdown\_excision\_radius$.
+ *
+ * The goal is to find a good $ringdown\_excision\_factor$
+ *
+ * 1) Choose an initial guess for the $ringdown\_excision\_factor$. We choose
+ * this to be 0.94 by default.
+ *
+ * 2) Choose an initial guess for current_l_max, the angular resolution of
+ * spherical Strahlkorpers that match excision A and B (not horizons) in the
+ * inspiral grid frame. We choose current_l_max=20 intially.
+ *
+ * 3) Construct Strahlkorpers in the Inspiral grid frame that correspond to
+ * excisions A/B, the excision regions (not the horizons) of the two individual
+ * holes. These are spherical in the inspiral grid frame, and have
+ * L=current_l_max.
+ *
+ * 4) Map the Strahlkorper excisions A/B to the inertial frame. Now they are not
+ * spherical.
+ *
+ * 4a) Using the current $ringdown\_excision\_factor$, construct a test domain
+ * to map excisions A/B from the inertial frame to the ringdown grid frame. This
+ * domain's functions of time should contain the scaling and rotation functions
+ * of time from the inspiral that settle to const and the shape and corrected
+ * translation function of time output by
+ * ComputeRingdownShapeAndTranslationFoT.py
+ *
+ * 4b) Map the Strahlkorper excisions A/B to the Ringdown grid frame. They are
+ * still not spherical.
+ *
+ * 4c) Loop through all the points on Ringdown grid excisions A/B, and find the
+ * point that is the maximum distance from the origin. Call that maximum
+ * distance $min\_excision\_radius$.
+ *
+ * 4d) A Ringdown grid sphere of radius $min\_excision\_radius$ centered at the
+ * origin will (barely) enclose both excisions A/B, so choose
+ * $minimum\_ringdown\_excision\_factor = \frac{min\_excision\_radius}
+ * {ahc\_average\_radius}$ as the minimum possible $ringdown\_excision\_factor$.
+ * And then choose the new value of $ringdown\_excision\_factor$ to be
+ * \f{equation}{
+ * ringdown\_excision\_factor=1-0.25*(1-minimum\_ringdown\_excision\_factor)
+ * \f}
+ * Which puts the excision radius 3/4 of the way between the
+ * $ahc\_average\_radius$ and the $min\_excision\_radius$
+ *
+ * 4e) If this is the first inner iteration, or if
+ * $|ringdown\_excision\_factor-previous\_ringdown\_excision\_factor|>eps$, then
+ * set $previous\_ringdown\_excision\_factor=ringdown\_excision\_factor$ and
+ * goto 3a, where 3a is repeated using the new $ringdown\_excision\_factor$. We
+ * choose $eps = \frac{10^{-3}}{q}$ where q is an approximation of the mass
+ * ratio. The reason this is iterative is because the new
+ * $ringdown\_excision\_factor$ in 3d depends on the ringdown_excision_factor
+ * used when constructing the test domain.
+ *
+ * 5) If we get here, then inner iteration has converged.  But that iteration
+ * depends on the $current\_l\_max$ used to construct excisions A/B in step 2.
+ * If this is the first outer iteration, or if
+ * $|ringdown\_excision\_factor-previous\_ringdown\_excision\_factor|>eps$, then
+ * set $previous\_ringdown\_excision\_factor=ringdown\_excision\_factor$, and
+ * increment $current\_l\_max$ by some increment (which we choose to be 6), and
+ * go back to 2.
+ *
+ * 6) If we get here, the outer iteration is converged and now we have a final
+ * $ringdown\_excision\_factor$.
+ *
+ * \note This implementation does not do everything SpEC does yet, it is
+ * currently missing rescaling the shape coefficients held in
+ * 'path_to_AhC_distorted_h5' by $excision\_radius / average\_ahc\_radius$ every
+ * time it constructs a test ringdown domain. This step helps the shape of the
+ * excision match the shape of the apparent horizon.
+ */
+double minimum_ahc_excision_radius(
+    const std::string& path_to_volume_data,
+    const std::string& volume_subfile_name,
+    const std::string& path_to_horizons_h5,
+    const std::string& surface_subfile_name,
+    const std::string& path_to_AhC_distorted_h5,
+    const std::vector<std::string>& AhC_distorted_subfile_names,
+    double match_time, double settling_timescale, double excision_A_radius,
+    double excision_B_radius, std::array<double, 3> excision_A_center,
+    std::array<double, 3> excision_B_center,
+    const std::optional<std::array<double, 3>>& exp_func_and_2_derivs =
+        std::nullopt,
+    const std::optional<std::array<double, 3>>&
+        exp_outer_bdry_func_and_2_derivs = std::nullopt,
+    const std::optional<std::vector<std::array<double, 4>>>&
+        rot_func_and_2_derivs = std::nullopt,
+    const std::optional<std::array<std::array<double, 3>, 3>>&
+        trans_func_and_2_derivs = std::nullopt,
+    double match_time_tol = 1e-12);
+}  // namespace evolution::Ringdown

--- a/src/Evolution/Ringdown/Python/Bindings.cpp
+++ b/src/Evolution/Ringdown/Python/Bindings.cpp
@@ -5,9 +5,9 @@
 #include <pybind11/stl.h>
 
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
-#include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Evolution/Ringdown/MinimumAhCExcisionRadius.hpp"
 #include "Evolution/Ringdown/StrahlkorperCoefsAndCenters.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -33,6 +33,28 @@ void bind_strahlkorper_coefs_and_centers(py::module& m) {
         py::arg("exp_outer_bdry_func_and_2_derivs"),
         py::arg("rot_func_and_2_derivs"), py::arg("trans_func_and_2_derivs"));
 }
+
+void bind_minimum_ahc_excision_radius(py::module& m);
+
+void bind_minimum_ahc_excision_radius(py::module& m) {
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  m.def("minimum_ahc_excision_radius",
+        &evolution::Ringdown::minimum_ahc_excision_radius,
+        py::arg("path_to_volume_data"), py::arg("volume_subfile_name"),
+        py::arg("path_to_horizons_h5"), py::arg("surface_subfile_name"),
+        py::arg("path_to_ahc_distorted_h5"),
+        py::arg("ahc_distorted_subfile_names"), py::arg("match_time"),
+        py::arg("settling_timescale"), py::arg("excision_a_radius"),
+        py::arg("excision_b_radius"), py::arg("excision_a_center"),
+        py::arg("excision_b_center"), py::arg("exp_func_and_2_derivs"),
+        py::arg("exp_outer_bdry_func_and_2_derivs"),
+        py::arg("rot_func_and_2_derivs"), py::arg("trans_func_and_2_derivs"),
+        py::arg("match_time_tol"));
+}
+
 }  // namespace evolution::Ringdown::py_bindings
 
 PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
@@ -40,4 +62,5 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   // So return types are converted to DataVectors
   py::module_::import("spectre.DataStructures");
   evolution::Ringdown::py_bindings::bind_strahlkorper_coefs_and_centers(m);
+  evolution::Ringdown::py_bindings::bind_minimum_ahc_excision_radius(m);
 }

--- a/support/Pipelines/Bbh/Ringdown.py
+++ b/support/Pipelines/Bbh/Ringdown.py
@@ -10,6 +10,7 @@ import numpy as np
 import yaml
 from rich.pretty import pretty_repr
 
+import spectre.Evolution.Ringdown as Ringdown
 import spectre.IO.H5 as spectre_h5
 from spectre.Evolution.Ringdown.ComputeRingdownShapeAndTranslationFoT import (
     compute_ringdown_shape_and_translation_fot,
@@ -286,6 +287,57 @@ def start_ringdown(
             version=0,
         )
         ahc_dt2_datfile.append(ringdown_ylm_coefs[2])
+
+    # Section for finding the excision radius
+    inspiral_domain = inspiral_input_file["DomainCreator"][
+        "BinaryCompactObject"
+    ]
+    object_a = inspiral_domain["ObjectA"]
+    object_b = inspiral_domain["ObjectB"]
+    excision_radius_A = object_a["InnerRadius"]
+    excision_A_x_coord = object_a["XCoord"]
+    excision_radius_B = object_b["InnerRadius"]
+    excision_B_x_coord = object_b["XCoord"]
+    center_of_mass_offset_y = inspiral_domain["CenterOfMassOffset"][0]
+    center_of_mass_offset_z = inspiral_domain["CenterOfMassOffset"][1]
+
+    excision_center_A = [
+        excision_A_x_coord,
+        center_of_mass_offset_y,
+        center_of_mass_offset_z,
+    ]
+    excision_center_B = [
+        excision_B_x_coord,
+        center_of_mass_offset_y,
+        center_of_mass_offset_z,
+    ]
+
+    ringdown_excision_radius = Ringdown.minimum_ahc_excision_radius(
+        path_to_volume_data=str(fot_vol_h5_path),
+        volume_subfile_name=fot_vol_subfile,
+        path_to_horizons_h5=str(ahc_reductions_path),
+        surface_subfile_name=ahc_subfile,
+        path_to_ahc_distorted_h5=str(path_to_output_h5),
+        ahc_distorted_subfile_names=[
+            output_subfile_ahc,
+            output_subfile_dt_ahc,
+            output_subfile_dt2_ahc,
+        ],
+        match_time=match_time,
+        settling_timescale=settling_timescale,
+        excision_a_radius=excision_radius_A,
+        excision_b_radius=excision_radius_B,
+        excision_a_center=excision_center_A,
+        excision_b_center=excision_center_B,
+        exp_func_and_2_derivs=evaluated_fot_dict["Expansion"],
+        exp_outer_bdry_func_and_2_derivs=evaluated_fot_dict[
+            "ExpansionOuterBoundary"
+        ],
+        rot_func_and_2_derivs=evaluated_fot_dict["Rotation"],
+        trans_func_and_2_derivs=ahc_translation_fot,
+        match_time_tol=1e-12,
+    )
+
     logger.debug("Obtained ringdown coefs")
     # Print out coefficients for insertion into BBH domain
     logger.debug("Expansion: " + str(evaluated_fot_dict["Expansion"]))
@@ -317,6 +369,8 @@ def start_ringdown(
         default_flow_style=True,
         width=float("inf"),
     ).strip()
+
+    ringdown_params["ExcisionRadius"] = ringdown_excision_radius
 
     ringdown_params["OuterBdryRadius"] = inspiral_input_file["DomainCreator"][
         "BinaryCompactObject"

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -28,9 +28,7 @@ InitialData:
 
 DomainCreator:
   Sphere:
-    # InnerRadius is not yet set automatically. The value of 1.45 works
-    # for equal-mass, zero spin, quasicircular.
-    InnerRadius: &InnerRadius 1.45
+    InnerRadius: &InnerRadius {{ ExcisionRadius }}
     OuterRadius: "{{ OuterBdryRadius }}"
     Interior:
       ExciseWithBoundaryCondition:

--- a/tests/Unit/Evolution/Ringdown/CMakeLists.txt
+++ b/tests/Unit/Evolution/Ringdown/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Ringdown")
 
 set(LIBRARY_SOURCES
+  Test_MinimumAhCExcisionRadius.cpp
   Test_StrahlkorperCoefsAndCenters.cpp
   )
 

--- a/tests/Unit/Evolution/Ringdown/Test_MinimumAhCExcisionRadius.cpp
+++ b/tests/Unit/Evolution/Ringdown/Test_MinimumAhCExcisionRadius.cpp
@@ -1,0 +1,273 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/Creators/BinaryCompactObject.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/StrahlkorperTransformations.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "Evolution/Ringdown/MinimumAhCExcisionRadius.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "PointwiseFunctions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+// [[TimeOut, 45]]
+SPECTRE_TEST_CASE("Unit.Evolution.Ringdown.MinimumAhCExcisionRadius",
+                  "[Unit][Evolution]") {
+  // Write a temporary H5 file with Strahlkorpers at different times, then
+  // pass that file's path to strahlkorper_coefs_in_ringdown_distorted_frame().
+  // First, if the temporary file exists, remove it
+  const std::string inertial_horizons_file_name{
+      "Unit.Evolution.Ringdown.InertialCoefs.h5"};
+  const std::string inertial_horizons_subfile_name{"/ObservationAhC__Ylm.dat"};
+  const std::string distorted_horizons_file_name{
+      "Unit.Evolution.Ringdown.DisCoefs.h5"};
+  const std::string distorted_horizons_subfile_name{"/DistortedAhC_Ylm.dat"};
+  if (file_system::check_if_file_exists(inertial_horizons_file_name)) {
+    file_system::rm(inertial_horizons_file_name, true);
+  }
+  if (file_system::check_if_file_exists(distorted_horizons_file_name)) {
+    file_system::rm(distorted_horizons_file_name, true);
+  }
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  MAKE_GENERATOR(generator);
+
+  // Start out with a Strahlkorper at rest in a grid frame, then map it
+  // to the inertial frame. The shape map is an identity map (it's initialized
+  // with Schwarzschild coefficients), so the grid->distorted map
+  // here is the identity. But start in a grid frame to use the available
+  // grid->distorted instantiation of strahlkorper_in_different_frame.
+  constexpr const size_t l_max = 12;
+  constexpr const size_t m_max = 12;
+  const auto kerr_horizon_radius = get(gr::Solutions::kerr_horizon_radius(
+      ::ylm::Spherepack(l_max, m_max).theta_phi_points(), 1.0,
+      {{0.0, 0.0, 0.8}}));
+  auto expected_strahlkorper = ylm::Strahlkorper<Frame::Grid>(
+      l_max, m_max, kerr_horizon_radius, std::array<double, 3>{1.0, 2.0, 3.0});
+  auto distorted_strahlkorper = ylm::Strahlkorper<Frame::Distorted>(
+      l_max, m_max, kerr_horizon_radius, std::array<double, 3>{1.0, 2.0, 3.0});
+
+  // Make a set of times to evaluate the functions of time at
+  static constexpr size_t number_of_times{9};
+  const std::array<double, number_of_times> times{0.0, 0.2, 0.4, 0.6, 0.8,
+                                                  1.0, 1.2, 1.4, 1.6};
+
+  const double match_time{0.6};
+
+  // Next, set up a temporary domain (just to hold functions of time)
+  // and some functions of time defining the ringdown Distorted->Inertial map.
+  std::uniform_real_distribution<double> fot_dist{0.1, 0.5};
+  std::uniform_real_distribution<double> exp_dist{0.8, 1.};
+  const auto exp_func_and_2_derivs =
+      make_with_random_values<std::array<double, 3>>(make_not_null(&generator),
+                                                     make_not_null(&exp_dist));
+  const auto exp_outer_bdry_func_and_2_derivs =
+      make_with_random_values<std::array<double, 3>>(make_not_null(&generator),
+                                                     make_not_null(&exp_dist));
+  auto initial_unit_quaternion = make_with_random_values<std::array<double, 4>>(
+      make_not_null(&generator), make_not_null(&fot_dist));
+  const double initial_unit_quaternion_magnitude = sqrt(
+      square(initial_unit_quaternion[0]) + square(initial_unit_quaternion[1]) +
+      square(initial_unit_quaternion[2]) + square(initial_unit_quaternion[3]));
+  for (size_t i = 0; i < 4; ++i) {
+    gsl::at(initial_unit_quaternion, i) /= initial_unit_quaternion_magnitude;
+  }
+  const std::vector<std::array<double, 4>> rot_func_and_2_derivs{
+      initial_unit_quaternion,
+      make_with_random_values<std::array<double, 4>>(make_not_null(&generator),
+                                                     make_not_null(&fot_dist)),
+      make_with_random_values<std::array<double, 4>>(make_not_null(&generator),
+                                                     make_not_null(&fot_dist))};
+
+  std::uniform_real_distribution<double> settling_dist{0.5, 1.5};
+  const double settling_timescale{settling_dist(generator)};
+
+  const domain::creators::time_dependent_options::ShapeMapOptions<
+      false, domain::ObjectLabel::None>
+      shape_map_options{l_max, std::nullopt};
+  const domain::creators::time_dependent_options::ExpansionMapOptions<true>
+      expansion_map_options{exp_func_and_2_derivs, settling_timescale,
+                            exp_outer_bdry_func_and_2_derivs,
+                            settling_timescale};
+  const domain::creators::time_dependent_options::RotationMapOptions<true>
+      rotation_map_options{rot_func_and_2_derivs, settling_timescale};
+  const domain::creators::sphere::TimeDependentMapOptions
+      time_dependent_map_options{times.at(0),          shape_map_options,
+                                 rotation_map_options, expansion_map_options,
+                                 std::nullopt,         true};
+
+  const domain::creators::Sphere domain_creator{
+      0.01,
+      100.0,
+      // nullptr because no boundary condition
+      domain::creators::Sphere::Excision{nullptr},
+      static_cast<size_t>(0),
+      static_cast<size_t>(5),
+      false,
+      std::nullopt,
+      {50.0},
+      domain::CoordinateMaps::Distribution::Linear,
+      ShellWedges::All,
+      time_dependent_map_options};
+  const auto temporary_domain = domain_creator.create_domain();
+  const auto functions_of_time = domain_creator.functions_of_time();
+
+  // For each Strahlkorper, transform from distorted -> inertial using
+  // strahlkorper_in_different_frame, then
+  // get its inertial coefficients, and write them out to the h5 file
+  std::vector<std::vector<double>> strahlkorper_ringdown_inertial_coefs{
+      number_of_times};
+  std::vector<std::string> inertial_legend{};
+  std::vector<std::string> distorted_legend{};
+  ylm::Strahlkorper<Frame::Inertial> current_inertial_strahlkorper;
+  for (size_t i = 0; i < number_of_times; ++i) {
+    inertial_legend.resize(0);  // clear and reuse for next row of data
+    strahlkorper_in_different_frame(
+        make_not_null(&current_inertial_strahlkorper), expected_strahlkorper,
+        temporary_domain, functions_of_time, gsl::at(times, i));
+    ylm::change_expansion_center_of_strahlkorper_to_physical(
+        make_not_null(&current_inertial_strahlkorper), 1e-8);
+    ylm::fill_ylm_legend_and_data(
+        make_not_null(&inertial_legend),
+        make_not_null(&strahlkorper_ringdown_inertial_coefs[i]),
+        current_inertial_strahlkorper, gsl::at(times, i), l_max);
+  }
+  std::vector<double> data{};
+  distorted_legend.resize(0);
+  ylm::fill_ylm_legend_and_data(make_not_null(&distorted_legend),
+                                make_not_null(&data), distorted_strahlkorper,
+                                match_time, l_max);
+  {
+    h5::H5File<h5::AccessType::ReadWrite> inertial_strahlkorper_file{
+        inertial_horizons_file_name, true};
+    auto& inertial_coefs_file = inertial_strahlkorper_file.insert<h5::Dat>(
+        inertial_horizons_subfile_name, inertial_legend, 4);
+    inertial_coefs_file.append(strahlkorper_ringdown_inertial_coefs);
+    h5::H5File<h5::AccessType::ReadWrite> distorted_strahlkorper_file{
+        distorted_horizons_file_name, true};
+    auto& distorted_coefs_file = distorted_strahlkorper_file.insert<h5::Dat>(
+        distorted_horizons_subfile_name, distorted_legend, 4);
+    distorted_coefs_file.append(strahlkorper_ringdown_inertial_coefs);
+  }
+
+  // Next, set up a binary domain and make fake volume data where the functions
+  // of time from the inspiral and domain can be extracted
+  const domain::creators::time_dependent_options::RotationMapOptions<false>
+      rotation_map_options_bco{std::array{0.0, 0.0, 0.0}};
+  const domain::creators::time_dependent_options::ExpansionMapOptions<false>
+      expansion_map_options_bco{{1.0, 1e-5, 0.0}, 50, -1.0e-6};
+  const domain::creators::bco::TimeDependentMapOptions<false>
+      time_dependent_map_options_bco{
+          times.at(0),
+          expansion_map_options_bco,
+          rotation_map_options_bco,
+          std::nullopt,
+          std::nullopt,
+          domain::creators::time_dependent_options::ShapeMapOptions<
+              true, domain::ObjectLabel::A>{
+              32_st, domain::creators::time_dependent_options::
+                         KerrSchildFromBoyerLindquist{0.2, {0.0, 0.0, 0.0}}},
+          domain::creators::time_dependent_options::ShapeMapOptions<
+              true, domain::ObjectLabel::B>{
+              32_st, domain::creators::time_dependent_options::
+                         KerrSchildFromBoyerLindquist{0.4, {0.0, 0.0, 0.0}}},
+          std::nullopt};
+
+  using Object = domain::creators::BinaryCompactObject<false>::Object;
+  const domain::creators::BinaryCompactObject<false> domain_creator_bco{
+      Object{0.2, 0.5, 1.0, true, true},
+      Object{0.1, 0.5, -1.5, true, true},
+      std::array<double, 2>{{0.0, 0.0}},
+      60.0,
+      300.0,
+      1.0,
+      0_st,
+      6_st,
+      true,
+      domain::CoordinateMaps::Distribution::Projective,
+      std::vector<double>{},
+      domain::CoordinateMaps::Distribution::Inverse,
+      120.,
+      time_dependent_map_options_bco};
+  const auto domain_bco = domain_creator_bco.create_domain();
+  const auto functions_of_time_bco = domain_creator_bco.functions_of_time();
+  auto serialized_fots_bco = serialize(functions_of_time_bco);
+  auto serialized_domain_bco = serialize(domain_bco);
+
+  if (file_system::check_if_file_exists("BbhVolume0.h5")) {
+    file_system::rm("BbhVolume0.h5", true);
+  }
+  h5::H5File<h5::AccessType::ReadWrite> h5_file{"BbhVolume0.h5", true};
+  auto& vol_file = h5_file.insert<h5::VolumeData>("ForContinuation");
+
+  // Write fake volume data
+  for (size_t i = 0; i < times.size(); i++) {
+    vol_file.write_volume_data(
+        i, times.at(i),
+        {ElementVolumeData{
+            "MightyMorphin",
+            {TensorComponent{"PowerRangers", DataVector{3, 0.0}}},
+            {3},
+            {Spectral::Basis::Legendre},
+            {Spectral::Quadrature::GaussLobatto}}},
+        serialized_domain_bco, serialized_fots_bco);
+  }
+  h5_file.close_current_object();
+
+  const double ringdown_excision_radius =
+      evolution::Ringdown::minimum_ahc_excision_radius(
+          "BbhVolume0.h5", "ForContinuation", inertial_horizons_file_name,
+          inertial_horizons_subfile_name, distorted_horizons_file_name,
+          std::vector<std::string>{distorted_horizons_subfile_name}, match_time,
+          settling_timescale, 0.2, 0.1, {1.0, 0.0, 0.0}, {-1.5, 0.0, 0.0},
+          exp_func_and_2_derivs, exp_outer_bdry_func_and_2_derivs,
+          rot_func_and_2_derivs, std::nullopt);
+
+  // Checks
+  CHECK(ringdown_excision_radius <
+        current_inertial_strahlkorper.average_radius());
+
+  if (file_system::check_if_file_exists(inertial_horizons_file_name)) {
+    file_system::rm(inertial_horizons_file_name, true);
+  }
+  if (file_system::check_if_file_exists(distorted_horizons_file_name)) {
+    file_system::rm(distorted_horizons_file_name, true);
+  }
+}

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -108,7 +108,7 @@ class TestInitialData(unittest.TestCase):
                 "coef(2,2)",
             ]
             shape_coefs = [5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
-            times = [4990, 4992, 4994, 4996, 4998, 5000]
+            times = [4999.5, 4999.6, 4999.7, 4999.8, 4999.9, 5000]
             reduction_dat = reduction_file.try_insert_dat(
                 "ObservationAhC_Ylm.dat", legend, 0
             )
@@ -143,7 +143,7 @@ class TestInitialData(unittest.TestCase):
             math.inf,
         )
         expansion_fot = PiecewisePolynomial3(
-            times[0], 4 * [DataVector(size=1, fill=1.0)], math.inf
+            times[0], 4 * [DataVector(size=1, fill=0.01)], math.inf
         )
         expansion_outer_fot = PiecewisePolynomial3(
             times[0], 4 * [DataVector(size=1, fill=1.0)], math.inf
@@ -207,13 +207,12 @@ class TestInitialData(unittest.TestCase):
         serialized_binary_domain = serialize_domain(bco_domain)
 
         self.inspiral_volume_data = self.inspiral_dir / "BbhVolume0.h5"
-        obs_values = [4990.0, 4992.0, 4994.0, 4996.0, 4998.0, 5000.0]
         with spectre_h5.H5File(self.inspiral_volume_data, "w") as volume_file:
             volfile = volume_file.insert_vol("ForContinuation", version=0)
             for x in range(0, 5):
                 volfile.write_volume_data(
                     observation_id=x,
-                    observation_value=obs_values[x],
+                    observation_value=times[x],
                     elements=[
                         ElementVolumeData(
                             element_name="foo",


### PR DESCRIPTION
## Proposed changes

This pr allows the transition to ringdown script to decide what it thinks a good excision radius would be for the ringdown. This currently has been tested to produce a good excision radius for q = 1 and 2 non spinning inspirals.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
