### PR TITLE
minor bug fixes in tests

### DIFF
--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -307,7 +307,6 @@ void test_sphere_construction(
   for (size_t block_id = 0; block_id < num_blocks; ++block_id) {
     CAPTURE(block_id);
     const auto& block = blocks[block_id];
-    const auto& boundary_conditions = all_boundary_conditions[block_id];
     const bool is_inner_cube = fill_interior and block_id == num_blocks - 1;
     const ElementMap<3, Frame::Inertial> element_map{ElementId<3>{block_id},
                                                      block};
@@ -390,6 +389,7 @@ void test_sphere_construction(
 
     if (expect_boundary_conditions) {
       INFO("Boundary conditions");
+      const auto& boundary_conditions = all_boundary_conditions[block_id];
       for (const auto& direction : block.external_boundaries()) {
         CAPTURE(direction);
         const auto& boundary_condition =

--- a/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
@@ -277,7 +277,6 @@ void test_spherical_shells_construction(
   for (size_t block_id = 0; block_id < num_blocks; ++block_id) {
     CAPTURE(block_id);
     const auto& block = blocks[block_id];
-    const auto& boundary_conditions = all_boundary_conditions[block_id];
     const ElementMap<3, Frame::Grid> grid_element_map{ElementId<3>{block_id},
                                                       block};
     const ElementMap<3, Frame::Inertial> inertial_element_map{
@@ -342,6 +341,7 @@ void test_spherical_shells_construction(
     }
     if (expect_boundary_conditions) {
       INFO("Boundary conditions");
+      const auto& boundary_conditions = all_boundary_conditions[block_id];
       for (const auto& direction : block.external_boundaries()) {
         CAPTURE(direction);
         const auto& boundary_condition =

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Hll.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryCorrections/Test_Hll.cpp
@@ -81,7 +81,7 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.BoundaryCorrections.Hll",
       helpers::Tags::Range<gr::Tags::Shift<DataVector, 3>>,
       helpers::Tags::Range<grmhd::ValenciaDivClean::Tags::TildeB<>>>
       ranges_hydro{std::array{0.3, 1.0}, std::array{0.01, 0.02},
-                   std::array{1.0e-20, 1.0e-25}};
+                   std::array{1.0e-25, 1.0e-20}};
   TestHelpers::evolution::dg::test_boundary_correction_with_python<
       system, tmpl::list<ConvertPolytropic>>(
       make_not_null(&gen), "Hll", "dg_package_data", "dg_boundary_terms",

--- a/tests/Unit/Helpers/DataStructures/MakeRandomVectorInMagnitudeRange.hpp
+++ b/tests/Unit/Helpers/DataStructures/MakeRandomVectorInMagnitudeRange.hpp
@@ -33,6 +33,8 @@ tnsr::I<DataType, Dim, Fr> make_random_vector_in_magnitude_range(
   if (max_magnitude < 0) {
     ERROR("max_magnitude < 0. Magnitude must be non-negative");
   }
+  ASSERT(min_magnitude <= max_magnitude,
+         "min = " << min_magnitude << ", max = " << max_magnitude);
 
   // generate distribution
   std::uniform_real_distribution<> dist_magnitude(min_magnitude, max_magnitude);

--- a/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
+++ b/tests/Unit/Helpers/Tests/Test_MakeRandomVectorInMagnitudeRange.cpp
@@ -61,7 +61,7 @@ void test_range(const gsl::not_null<std::mt19937*> generator,
 
   std::uniform_real_distribution<> distribution1(0.0, 100.0);
   double r1 = distribution1(*generator);
-  std::uniform_real_distribution<> distribution2(0.0, 100.0);
+  std::uniform_real_distribution<> distribution2(r1, 100.0);
   double r2 = distribution2(*generator);
   INFO("Interval is [" << r1 << "," << r2 << "]");
 

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -133,10 +133,7 @@ add_algorithm_test("AlgorithmReduction")
 add_algorithm_test("Callback")
 add_algorithm_test("DetectHangArray"
   REGEX_TO_MATCH
-  "The following components did not terminate cleanly:(.|\r|\n)*"
-  "\(ArrayComponent,SingletonComponent,GroupComponent,NodegroupComponent\)"
-  "(.|\r|\n)*"
-  "This means the executable stopped because of a hang/deadlock\.")
+  "The following components did not terminate cleanly:")
 add_algorithm_test("DynamicInsertion")
 add_algorithm_test("PhaseChangeMain")
 add_algorithm_test(


### PR DESCRIPTION
## Proposed changes

I upgraded my desktop to fedora 42 which uses clang20 and cmake 3.31.6 . 
I needed to fix several tests which triggered exceptions in the standard library.
The regex for DetectHangArray caused ctest (not the test execuatable) to segfault, so I simplified it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
