### PR TITLE
Cast CoM integral with psi-1 terms.

### DIFF
--- a/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.cpp
+++ b/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.cpp
@@ -23,6 +23,7 @@ void local_adm_integrals(
     gsl::not_null<Scalar<double>*> adm_angular_momentum_z,
     gsl::not_null<tnsr::I<double, 3>*> center_of_mass,
     const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_minus_one,
     const tnsr::i<DataVector, 3>& deriv_conformal_factor,
     const tnsr::ii<DataVector, 3>& conformal_metric,
     const tnsr::II<DataVector, 3>& inv_conformal_metric,
@@ -84,8 +85,8 @@ void local_adm_integrals(
     }
 
     // Project fields to the boundary
-    const auto face_conformal_factor = dg::project_tensor_to_boundary(
-        conformal_factor, mesh, boundary_direction);
+    const auto face_conformal_factor_minus_one = dg::project_tensor_to_boundary(
+        conformal_factor_minus_one, mesh, boundary_direction);
     const auto face_deriv_conformal_factor = dg::project_tensor_to_boundary(
         deriv_conformal_factor, mesh, boundary_direction);
     const auto face_conformal_metric = dg::project_tensor_to_boundary(
@@ -174,8 +175,8 @@ void local_adm_integrals(
           face_conformal_christoffel_second_kind,
           face_conformal_christoffel_contracted);
       const auto center_of_mass_surface_integrand =
-          Xcts::center_of_mass_surface_integrand(face_conformal_factor,
-                                                 face_inertial_coords);
+          Xcts::center_of_mass_surface_integrand(
+              face_conformal_factor_minus_one, face_inertial_coords);
 
       // Contract surface integrands with face normal
       const auto contracted_mass_integrand = tenex::evaluate(

--- a/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp
+++ b/src/Elliptic/Systems/Xcts/Events/ObserveAdmIntegrals.hpp
@@ -45,6 +45,7 @@ void local_adm_integrals(
     gsl::not_null<Scalar<double>*> adm_angular_momentum_z,
     gsl::not_null<tnsr::I<double, 3>*> center_of_mass,
     const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_minus_one,
     const tnsr::i<DataVector, 3>& deriv_conformal_factor,
     const tnsr::ii<DataVector, 3>& conformal_metric,
     const tnsr::II<DataVector, 3>& inv_conformal_metric,
@@ -130,6 +131,7 @@ class ObserveAdmIntegrals : public Event {
 
   using argument_tags = tmpl::list<
       Xcts::Tags::ConformalFactor<DataVector>,
+      Xcts::Tags::ConformalFactorMinusOne<DataVector>,
       ::Tags::deriv<Xcts::Tags::ConformalFactor<DataVector>, tmpl::size_t<3>,
                     Frame::Inertial>,
       Xcts::Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
@@ -153,6 +155,7 @@ class ObserveAdmIntegrals : public Event {
             typename ParallelComponent>
   void operator()(
       const Scalar<DataVector>& conformal_factor,
+      const Scalar<DataVector>& conformal_factor_minus_one,
       const tnsr::i<DataVector, 3>& deriv_conformal_factor,
       const tnsr::ii<DataVector, 3>& conformal_metric,
       const tnsr::II<DataVector, 3>& inv_conformal_metric,
@@ -186,11 +189,12 @@ class ObserveAdmIntegrals : public Event {
     local_adm_integrals(
         make_not_null(&adm_mass), make_not_null(&adm_linear_momentum),
         make_not_null(&adm_angular_momentum_z), make_not_null(&center_of_mass),
-        conformal_factor, deriv_conformal_factor, conformal_metric,
-        inv_conformal_metric, conformal_christoffel_second_kind,
-        conformal_christoffel_contracted, spatial_metric, inv_spatial_metric,
-        extrinsic_curvature, trace_extrinsic_curvature, inertial_coords,
-        inv_jacobian, mesh, element, conformal_face_normals);
+        conformal_factor, conformal_factor_minus_one, deriv_conformal_factor,
+        conformal_metric, inv_conformal_metric,
+        conformal_christoffel_second_kind, conformal_christoffel_contracted,
+        spatial_metric, inv_spatial_metric, extrinsic_curvature,
+        trace_extrinsic_curvature, inertial_coords, inv_jacobian, mesh, element,
+        conformal_face_normals);
 
     // Save components of linear momentum as reduction data
     ReductionData reduction_data{

--- a/src/PointwiseFunctions/Xcts/CenterOfMass.cpp
+++ b/src/PointwiseFunctions/Xcts/CenterOfMass.cpp
@@ -9,20 +9,24 @@ namespace Xcts {
 
 void center_of_mass_surface_integrand(
     gsl::not_null<tnsr::I<DataVector, 3>*> result,
-    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_minus_one,
     const tnsr::I<DataVector, 3>& coords) {
   const auto euclidean_radius = magnitude(coords);
-  tenex::evaluate<ti::I>(result, 3. / (8. * M_PI) *
-                                     (pow<4>(conformal_factor()) - 1.) *
-                                     coords(ti::I) / euclidean_radius());
+  tenex::evaluate<ti::I>(result,
+                         3. / (8. * M_PI) *
+                             (pow<4>(conformal_factor_minus_one()) +
+                              4. * pow<3>(conformal_factor_minus_one()) +
+                              6. * pow<2>(conformal_factor_minus_one()) +
+                              4. * conformal_factor_minus_one()) *
+                             coords(ti::I) / euclidean_radius());
 }
 
 tnsr::I<DataVector, 3> center_of_mass_surface_integrand(
-    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_minus_one,
     const tnsr::I<DataVector, 3>& coords) {
   tnsr::I<DataVector, 3> result;
-  center_of_mass_surface_integrand(make_not_null(&result), conformal_factor,
-                                   coords);
+  center_of_mass_surface_integrand(make_not_null(&result),
+                                   conformal_factor_minus_one, coords);
   return result;
 }
 

--- a/src/PointwiseFunctions/Xcts/CenterOfMass.hpp
+++ b/src/PointwiseFunctions/Xcts/CenterOfMass.hpp
@@ -16,13 +16,22 @@ namespace Xcts {
  * We define the center of mass integral as
  *
  * \begin{equation}
+ *   C_\text{CoM}^i = \frac{3}{8 \pi M_\text{ADM}} \oint_{S_\infty} \Big[
+ *                      (\psi - 1)^4 + 4 (\psi - 1)^3
+ *                      + 6 (\psi - 1)^2 + 4 (\psi - 1)
+ *                    \Big] n^i \, dA,
+ * \end{equation}
+ *
+ * where $n^i = x^i / r$ and $r = \sqrt{x^2 + y^2 + z^2}$. We use $\psi-1$
+ * instead of $\psi$ because it is the variable solved for in the XCTS system.
+ * Expanding the integrand, we see that this is identical to
+ *
+ * \begin{equation}
  *   C_\text{CoM}^i = \frac{3}{8 \pi M_\text{ADM}}
  *               \oint_{S_\infty} (\psi^4 - 1) n^i \, dA,
  * \end{equation}
  *
- * where $n^i = x^i / r$ and $r = \sqrt{x^2 + y^2 + z^2}$.
- *
- * Analytically, this is identical to the definition in Eq. (25) of
+ * Analytically, this is equivalent to the definition in Eq. (25) of
  * \cite Ossokine2015yla because
  * \begin{equation}
  *   \oint_{S_\infty} n^i \, dA = 0.
@@ -39,10 +48,7 @@ namespace Xcts {
  * increasing radius of $S_\infty$), we loose numerical accuracy. In other
  * words, we are seeking the subdominant terms. Since $\psi^4 \to 1$ in
  * conformal flatness, subtracting $1$ from it in the integrand makes the
- * numbers involved in this cancellation smaller, reducing this issue. We have
- * also tried different variations of this integrand with the same motivation,
- * but $(\psi^4 - 1)$ is the best one when taking simplicity and accuracy gain
- * into consideration.
+ * numbers involved in this cancellation smaller, reducing this issue.
  *
  * \note We don't include the ADM mass $M_{ADM}$ in this integrand. After
  * integrating the result of this function, you have to divide by $M_{ADM}$.
@@ -59,17 +65,17 @@ namespace Xcts {
  * fall-off terms.
  *
  * \param result output pointer
- * \param conformal_factor the conformal factor $\psi$
+ * \param conformal_factor_minus_one the conformal factor $\psi - 1$
  * \param coords the inertial coordinates $x^i$
  */
 void center_of_mass_surface_integrand(
     gsl::not_null<tnsr::I<DataVector, 3>*> result,
-    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_minus_one,
     const tnsr::I<DataVector, 3>& coords);
 
 /// Return-by-value overload
 tnsr::I<DataVector, 3> center_of_mass_surface_integrand(
-    const Scalar<DataVector>& conformal_factor,
+    const Scalar<DataVector>& conformal_factor_minus_one,
     const tnsr::I<DataVector, 3>& coords);
 /// @}
 
@@ -99,6 +105,9 @@ tnsr::I<DataVector, 3> center_of_mass_surface_integrand(
  * integrand needs to be integrated with the Euclidean volume element.
  *
  * \see `center_of_mass_surface_integrand`
+ *
+ * \warning This integral currently suffers from significant round-off errors.
+ * It is recommended to use only the surface integral if possible.
  *
  * \param result output pointer
  * \param conformal_factor the conformal factor $\psi$

--- a/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
@@ -174,8 +174,12 @@ void test_local_adm_integrals(const double& distance,
     // Schwarzschild solution in isotropic coordinates. Other conformal factors
     // could also work.
     const auto solution_conformal_factor = solution.variables(
-        barred_coords, tmpl::list<Xcts::Tags::ConformalFactor<DataVector>>{});
+        barred_coords,
+        tmpl::list<Xcts::Tags::ConformalFactor<DataVector>,
+                   Xcts::Tags::ConformalFactorMinusOne<DataVector>>{});
     const auto& conformal_factor =
+        get<Xcts::Tags::ConformalFactor<DataVector>>(solution_conformal_factor);
+    const auto& conformal_factor_minus_one =
         get<Xcts::Tags::ConformalFactor<DataVector>>(solution_conformal_factor);
     const auto conformal_metric = tenex::evaluate<ti::i, ti::j>(
         spatial_metric(ti::i, ti::j) / pow<4>(conformal_factor()));
@@ -264,11 +268,11 @@ void test_local_adm_integrals(const double& distance,
         make_not_null(&local_adm_linear_momentum),
         make_not_null(&local_adm_angular_momentum_z),
         make_not_null(&local_center_of_mass), conformal_factor,
-        deriv_conformal_factor, conformal_metric, inv_conformal_metric,
-        conformal_christoffel_second_kind, conformal_christoffel_contracted,
-        spatial_metric, inv_spatial_metric, extrinsic_curvature,
-        trace_extrinsic_curvature, inertial_coords, inv_jacobian, mesh,
-        current_element, conformal_face_normals);
+        conformal_factor_minus_one, deriv_conformal_factor, conformal_metric,
+        inv_conformal_metric, conformal_christoffel_second_kind,
+        conformal_christoffel_contracted, spatial_metric, inv_spatial_metric,
+        extrinsic_curvature, trace_extrinsic_curvature, inertial_coords,
+        inv_jacobian, mesh, current_element, conformal_face_normals);
     total_adm_mass.get() += get(local_adm_mass);
     total_adm_angular_momentum_z.get() += get(local_adm_angular_momentum_z);
     for (int I = 0; I < 3; I++) {

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
@@ -28,14 +28,7 @@ namespace {
 /*
   The tests below shift the isotropic Schwarzschild solution and check that the
   center of mass corresponds to the coordinate shift.
-
-  We have found that the center of mass integral often diverges from the
-  expected result as we increase the outer radius. This could be due to
-  round-off errors in the calculation, making the result less accurate. Here,
-  we're simply checking that this deviation is below some fixed tolerance.
 */
-
-constexpr double TOLERANCE = 1.e-3;
 
 void test_infinite_surface_integral(const double distance,
                                     const double z_shift) {
@@ -106,9 +99,9 @@ void test_infinite_surface_integral(const double distance,
       // Get required fields on the interface
       const auto shifted_fields = solution.variables(
           shifted_coords,
-          tmpl::list<Xcts::Tags::ConformalFactor<DataVector>>{});
-      const auto& conformal_factor =
-          get<Xcts::Tags::ConformalFactor<DataVector>>(shifted_fields);
+          tmpl::list<Xcts::Tags::ConformalFactorMinusOne<DataVector>>{});
+      const auto& conformal_factor_minus_one =
+          get<Xcts::Tags::ConformalFactorMinusOne<DataVector>>(shifted_fields);
 
       // Compute area element
       const auto flat_area_element =
@@ -116,7 +109,7 @@ void test_infinite_surface_integral(const double distance,
 
       // Evaluate surface integral
       const auto surface_integrand = Xcts::center_of_mass_surface_integrand(
-          conformal_factor, inertial_coords);
+          conformal_factor_minus_one, inertial_coords);
       for (int I = 0; I < 3; I++) {
         surface_integral.get(I) += definite_integral(
             surface_integrand.get(I) * get(flat_area_element), face_mesh);
@@ -125,7 +118,7 @@ void test_infinite_surface_integral(const double distance,
   }
 
   // Check result
-  auto custom_approx = Approx::custom().epsilon(TOLERANCE).scale(1.0);
+  auto custom_approx = Approx::custom().epsilon(1. / distance).scale(1.0);
   CHECK(get<0>(surface_integral) == custom_approx(0.));
   CHECK(get<1>(surface_integral) == custom_approx(0.));
   CHECK(get<2>(surface_integral) / mass == custom_approx(z_shift));
@@ -188,10 +181,13 @@ void test_infinite_volume_integral(const double distance,
         shifted_coords,
         tmpl::list<
             Xcts::Tags::ConformalFactor<DataVector>,
+            Xcts::Tags::ConformalFactorMinusOne<DataVector>,
             ::Tags::deriv<Xcts::Tags::ConformalFactorMinusOne<DataVector>,
                           tmpl::size_t<3>, Frame::Inertial>>{});
     const auto& conformal_factor =
         get<Xcts::Tags::ConformalFactor<DataVector>>(shifted_fields);
+    const auto& conformal_factor_minus_one =
+        get<Xcts::Tags::ConformalFactorMinusOne<DataVector>>(shifted_fields);
     const auto& deriv_conformal_factor =
         get<::Tags::deriv<Xcts::Tags::ConformalFactorMinusOne<DataVector>,
                           tmpl::size_t<3>, Frame::Inertial>>(shifted_fields);
@@ -220,8 +216,8 @@ void test_infinite_volume_integral(const double distance,
       // Slice required fields to the interface
       const size_t slice_index =
           index_to_slice_at(mesh.extents(), boundary_direction);
-      const auto& face_conformal_factor =
-          data_on_slice(conformal_factor, mesh.extents(),
+      const auto& face_conformal_factor_minus_one =
+          data_on_slice(conformal_factor_minus_one, mesh.extents(),
                         boundary_direction.dimension(), slice_index);
       const auto& face_inertial_coords =
           data_on_slice(inertial_coords, mesh.extents(),
@@ -233,7 +229,7 @@ void test_infinite_volume_integral(const double distance,
 
       // Evaluate surface integral.
       const auto surface_integrand = Xcts::center_of_mass_surface_integrand(
-          face_conformal_factor, face_inertial_coords);
+          face_conformal_factor_minus_one, face_inertial_coords);
       for (int I = 0; I < 3; I++) {
         total_integral.get(I) += definite_integral(
             surface_integrand.get(I) * get(flat_area_element), face_mesh);
@@ -242,7 +238,7 @@ void test_infinite_volume_integral(const double distance,
   }
 
   // Check result
-  auto custom_approx = Approx::custom().epsilon(TOLERANCE).scale(1.0);
+  auto custom_approx = Approx::custom().epsilon(1.e-3).scale(1.0);
   CHECK(get<0>(total_integral) == custom_approx(0.));
   CHECK(get<1>(total_integral) == custom_approx(0.));
   CHECK(get<2>(total_integral) / mass == custom_approx(z_shift));
@@ -252,9 +248,20 @@ void test_infinite_volume_integral(const double distance,
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Xcts.CenterOfMass",
                   "[Unit][PointwiseFunctions]") {
-  for (const double distance : std::array<double, 3>({1.e3, 1.e4, 1.e5})) {
+  // The surface integral converges with distance up to R = 10^7, after which a
+  // residual asymptote is reached around ~ 10^-8.
+  for (const double distance :
+       std::array<double, 5>({1.e3, 1.e4, 1.e5, 1.e6, 1.e7})) {
     test_infinite_surface_integral(distance, 0.);
     test_infinite_surface_integral(distance, 0.1);
+  }
+
+  // The volume integral currently suffers more from round-off errors than the
+  // surface integral, starting to dominate at R > 10^5. Here, we simply test
+  // that its error is below a fixed tolerance of 10^-3. This is not a
+  // convergence test, but rather a check that the error does not grow too
+  // large.
+  for (const double distance : std::array<double, 3>({1.e3, 1.e4, 1.e5})) {
     test_infinite_volume_integral(distance, 0.);
     test_infinite_volume_integral(distance, 0.1);
   }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR recasts the CoM integral to use $\psi-1$ instead of $\psi$. This reduces round-off error, which becomes an issue particularly at large outer boundary radii $R >= 10^7 M$.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
