### PR TITLE
Always check if mortar data needs projecting

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -499,7 +499,7 @@ bool receive_boundary_data_local_time_stepping(
                     const TimeStepId& /*id*/,
                     const gsl::not_null<::evolution::dg::MortarData<Dim>*>
                         mortar_data) {
-                  p_project_mortar_data(mortar_data, mortar_mesh);
+                  return p_project_mortar_data(mortar_data, mortar_mesh);
                 };
 
             if (mortar_mesh != mortar_meshes->at(mortar_id)) {
@@ -508,7 +508,6 @@ bool receive_boundary_data_local_time_stepping(
                   project_boundary_mortar_data);
               boundary_data_history->at(mortar_id).remote().for_each(
                   project_boundary_mortar_data);
-              boundary_data_history->at(mortar_id).clear_coupling_cache();
             }
 
             MortarData<Dim> neighbor_mortar_data{};
@@ -536,7 +535,6 @@ bool receive_boundary_data_local_time_stepping(
                 received_mortar_data->second.boundary_correction_mesh) {
               boundary_data_history->at(mortar_id).remote().for_each(
                   project_boundary_mortar_data);
-              boundary_data_history->at(mortar_id).clear_coupling_cache();
             }
             mortar_next_time_step_id =
                 received_mortar_data->second.validity_range;

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -342,12 +342,9 @@ bool receive_boundary_data_global_time_stepping(
                   sliced_away_dim);
           const Mesh<volume_dim - 1> mortar_mesh =
               ::dg::mortar_mesh(face_mesh, neighbor_face_mesh);
-          if (mortar_mesh != mortar_meshes->at(mortar_id)) {
-            mortar_meshes->at(mortar_id) = mortar_mesh;
-            p_project_mortar_data(
-                make_not_null(&mortar_data->at(mortar_id).local()),
-                mortar_mesh);
-          }
+          mortar_meshes->at(mortar_id) = mortar_mesh;
+          p_project_mortar_data(
+              make_not_null(&mortar_data->at(mortar_id).local()), mortar_mesh);
           neighbor_mesh->insert_or_assign(
               mortar_id, received_mortar_data.second.volume_mesh);
           mortar_next_time_step_id->at(mortar_id) =
@@ -369,12 +366,9 @@ bool receive_boundary_data_global_time_stepping(
                 received_mortar_data.second.boundary_correction_mesh.value();
             mortar_data->at(mortar_id).neighbor().mortar_data = std::move(
                 received_mortar_data.second.boundary_correction_data.value());
-            if (mortar_mesh !=
-                received_mortar_data.second.boundary_correction_mesh) {
-              p_project_mortar_data(
-                  make_not_null(&mortar_data->at(mortar_id).neighbor()),
-                  mortar_mesh);
-            }
+            p_project_mortar_data(
+                make_not_null(&mortar_data->at(mortar_id).neighbor()),
+                mortar_mesh);
           }
         }
       },
@@ -502,13 +496,11 @@ bool receive_boundary_data_local_time_stepping(
                   return p_project_mortar_data(mortar_data, mortar_mesh);
                 };
 
-            if (mortar_mesh != mortar_meshes->at(mortar_id)) {
-              mortar_meshes->at(mortar_id) = mortar_mesh;
-              boundary_data_history->at(mortar_id).local().for_each(
-                  project_boundary_mortar_data);
-              boundary_data_history->at(mortar_id).remote().for_each(
-                  project_boundary_mortar_data);
-            }
+            mortar_meshes->at(mortar_id) = mortar_mesh;
+            boundary_data_history->at(mortar_id).local().for_each(
+                project_boundary_mortar_data);
+            boundary_data_history->at(mortar_id).remote().for_each(
+                project_boundary_mortar_data);
 
             MortarData<Dim> neighbor_mortar_data{};
             // Insert:
@@ -531,11 +523,8 @@ bool receive_boundary_data_local_time_stepping(
                 time_entry->first,
                 received_mortar_data->second.integration_order,
                 std::move(neighbor_mortar_data));
-            if (mortar_mesh !=
-                received_mortar_data->second.boundary_correction_mesh) {
-              boundary_data_history->at(mortar_id).remote().for_each(
-                  project_boundary_mortar_data);
-            }
+            boundary_data_history->at(mortar_id).remote().for_each(
+                project_boundary_mortar_data);
             mortar_next_time_step_id =
                 received_mortar_data->second.validity_range;
             time_entry->second.erase(received_mortar_data);

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -293,10 +293,10 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                     const TimeStepId& /* id */,
                     const gsl::not_null<::evolution::dg::MortarData<dim>*>
                         data) {
-                  p_project_geometric_data(data, new_face_mesh, new_mesh);
+                  return p_project_geometric_data(data, new_face_mesh,
+                                                  new_mesh);
                 };
             local_history.for_each(project_local_boundary_data);
-            boundary_history.clear_coupling_cache();
           }
         } else {
           const auto& new_mortar_size =
@@ -322,7 +322,8 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                         const TimeStepId& /* id */,
                         const gsl::not_null<::evolution::dg::MortarData<dim>*>
                             data) {
-                      p_project_geometric_data(data, new_face_mesh, new_mesh);
+                      return p_project_geometric_data(data, new_face_mesh,
+                                                      new_mesh);
                     };
                 local_history.for_each(project_face_data);
               }
@@ -340,6 +341,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                     vars = apply_matrices(mortar_projection_matrices, vars,
                                           old_mortar_mesh.extents());
                     data->mortar_mesh = new_mortar_mesh;
+                    return true;
                   };
               local_history.for_each(project_mortar_data);
             } else {
@@ -361,6 +363,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                         apply_matrices(mortar_projection_matrices,
                                        old_data.mortar_data.value(),
                                        old_mortar_mesh.extents());
+                    return true;
                   };
               local_history.for_each(project_local_mortar_data);
             }
@@ -460,6 +463,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                   vars = apply_matrices(mortar_projection_matrices, vars,
                                         old_mortar_mesh.extents());
                   data->mortar_mesh = new_mortar_mesh;
+                  return true;
                 };
             remote_history.for_each(project_mortar_data);
           } else {
@@ -534,6 +538,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                       vars = apply_matrices(mortar_projection_matrices, vars,
                                             old_mortar_mesh.extents());
                       data->mortar_mesh = new_mortar_mesh;
+                      return true;
                     };
                 remote_history.for_each(project_mortar_data);
               } else {
@@ -555,6 +560,7 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                           apply_matrices(mortar_projection_matrices,
                                          old_data.mortar_data.value(),
                                          old_mortar_mesh.extents());
+                      return true;
                     };
                 remote_history.for_each(project_mortar_data);
               }

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -34,9 +34,10 @@ void MortarData<Dim>::pup(PUP::er& p) {
 }
 
 template <size_t Dim>
-void p_project_geometric_data(
+bool p_project_geometric_data(
     const gsl::not_null<::evolution::dg::MortarData<Dim>*> mortar_data,
     const Mesh<Dim - 1>& new_face_mesh, const Mesh<Dim>& new_volume_mesh) {
+  bool changed = false;
   // nothing needs to be done in 1D as mortars/faces are a single point...
   if constexpr (Dim > 1) {
     if (mortar_data->face_normal_magnitude.has_value()) {
@@ -53,6 +54,7 @@ void p_project_geometric_data(
                                  old_face_mesh.extents());
         }
         mortar_data->face_mesh = new_face_mesh;
+        changed = true;
       }
     }
   }
@@ -65,26 +67,33 @@ void p_project_geometric_data(
       det_inv_j = apply_matrices(volume_projection_matrices, det_inv_j,
                                  old_volume_mesh.extents());
       mortar_data->volume_mesh = new_volume_mesh;
+      changed = true;
     }
   }
+  return changed;
 }
 
 template <size_t Dim>
-void p_project_mortar_data(
+bool p_project_mortar_data(
     const gsl::not_null<::evolution::dg::MortarData<Dim>*> mortar_data,
     const Mesh<Dim - 1>& new_mortar_mesh) {
   // nothing needs to be done in 1D as mortars are a single point...
   if constexpr (Dim > 1) {
     const auto& old_mortar_mesh = mortar_data->mortar_mesh.value();
+    if (old_mortar_mesh == new_mortar_mesh) {
+      return false;
+    }
     const auto mortar_projection_matrices =
         Spectral::p_projection_matrices(old_mortar_mesh, new_mortar_mesh);
     DataVector& vars = mortar_data->mortar_data.value();
     vars = apply_matrices(mortar_projection_matrices, vars,
                           old_mortar_mesh.extents());
     mortar_data->mortar_mesh = new_mortar_mesh;
+    return true;
   } else {
     (void)mortar_data;
     (void)new_mortar_mesh;
+    return false;
   }
 }
 
@@ -119,12 +128,12 @@ std::ostream& operator<<(std::ostream& os, const MortarData<Dim>& mortar_data) {
 
 #define INSTANTIATION(r, data)                                     \
   template class MortarData<DIM(data)>;                            \
-  template void p_project_geometric_data(                          \
+  template bool p_project_geometric_data(                          \
       const gsl::not_null<::evolution::dg::MortarData<DIM(data)>*> \
           mortar_data,                                             \
       const Mesh<DIM(data) - 1>& new_face_mesh,                    \
       const Mesh<DIM(data)>& volume_mesh);                         \
-  template void p_project_mortar_data(                             \
+  template bool p_project_mortar_data(                             \
       const gsl::not_null<::evolution::dg::MortarData<DIM(data)>*> \
           mortar_data,                                             \
       const Mesh<DIM(data) - 1>& new_mortar_mesh);                 \

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.hpp
@@ -80,8 +80,10 @@ struct MortarData {
 /// \note The DG-subcell code stores the face mesh in the MortarData even when
 /// the geometric data are not used.  Currently projection of MortarData is only
 ///  needed for local time-stepping which is not yet supported for DG-subcell.
+///
+/// \returns If the data was modified
 template <size_t Dim>
-void p_project_geometric_data(
+bool p_project_geometric_data(
     gsl::not_null<::evolution::dg::MortarData<Dim>*> mortar_data,
     const Mesh<Dim - 1>& new_face_mesh, const Mesh<Dim>& new_volume_mesh);
 
@@ -91,8 +93,10 @@ void p_project_geometric_data(
 /// reactively after the neighbor face mesh is received.  In this case, the
 /// geometric data does not need to be updated as it already used the correct
 /// face/volume mesh.
+///
+/// \returns If the data was modified
 template <size_t Dim>
-void p_project_mortar_data(
+bool p_project_mortar_data(
     gsl::not_null<::evolution::dg::MortarData<Dim>*> mortar_data,
     const Mesh<Dim - 1>& new_mortar_mesh);
 

--- a/src/Time/BoundaryHistory.hpp
+++ b/src/Time/BoundaryHistory.hpp
@@ -156,10 +156,11 @@ class BoundaryHistory {
     ///
     /// The function \p func must accept two arguments, one of type
     /// `const TimeStepId&` and a second of either type `const Data&`
-    /// or `gsl::not_null<Data*>`.  (Note that `Data` may be a
-    /// const-qualified type.)  If entries are modified, the coupling
-    /// cache must be cleared by calling `clear_coupling_cache()` on
-    /// the parent `BoundaryHistory` object.
+    /// or `gsl::not_null<Data*>`, with the `not_null` version only
+    /// available if this is a `MutableSideAccess`.  If \p func takes
+    /// a `not_null`, it must return a `bool` indicating if it
+    /// modified the entry.  If any entries are modified, the coupling
+    /// cache of parent `BoundaryHistory` will be cleared.
     template <typename Func>
     void for_each(Func&& func) const;
 
@@ -359,14 +360,27 @@ template <bool Local, bool Mutable>
 template <typename Func>
 void BoundaryHistory<LocalData, RemoteData, CouplingResult>::SideAccessCommon<
     Local, Mutable>::for_each(Func&& func) const {
+  bool entries_changed = false;
   for (auto& step : parent_data()) {
     for (auto& substep : step.substeps) {
       if constexpr (std::is_invocable_v<Func&, const TimeStepId&,
                                         const Data&>) {
         func(std::as_const(substep.id), std::as_const(substep.data));
       } else {
-        func(std::as_const(substep.id), make_not_null(&substep.data));
+        static_assert(Mutable,
+                      "Cannot perform mutating for_each on a ConstSideAccess");
+        if (func(std::as_const(substep.id), make_not_null(&substep.data))) {
+          entries_changed = true;
+        }
       }
+    }
+  }
+  if constexpr (Mutable) {
+    if (entries_changed) {
+      // A minor optimization would be to only clear the cache entries
+      // that have actually been invalidated, but most things that
+      // modify the history modify all the entries.
+      parent_->clear_coupling_cache();
     }
   }
 }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -223,8 +223,17 @@ struct SetLocalMortarData {
         const Mesh<Metavariables::volume_dim - 1>& mortar_mesh =
             mortar_meshes.at(mortar_id);
 
+        // Provide data of the wrong size to make sure it is projected
+        // properly.
+        auto unprojected_mortar_extents = mortar_mesh.extents().indices();
+        if constexpr (not unprojected_mortar_extents.empty()) {
+          ++unprojected_mortar_extents[0];
+        }
+        const Mesh<Metavariables::volume_dim - 1> unprojected_mortar_mesh(
+            unprojected_mortar_extents, mortar_mesh.basis(),
+            mortar_mesh.quadrature());
         DataVector type_erased_boundary_data_on_mortar{
-            mortar_mesh.number_of_grid_points() *
+            unprojected_mortar_mesh.number_of_grid_points() *
                 number_of_dg_package_tags_components,
             0.0};
         alg::iota(type_erased_boundary_data_on_mortar,
@@ -233,14 +242,15 @@ struct SetLocalMortarData {
                       100 * count + 1000);
 
         db::mutate<evolution::dg::Tags::MortarData<Metavariables::volume_dim>>(
-            [&face_mesh, &mortar_id, &mortar_mesh,
+            [&face_mesh, &mortar_id, &unprojected_mortar_mesh,
              &type_erased_boundary_data_on_mortar](const auto mortar_data_ptr) {
               // when using local time stepping, we reset the local mortar data
               // at the end of the SetLocalMortarData action since the
               // ComputeTimeDerivative action would've moved the data into the
               // boundary history.
               mortar_data_ptr->at(mortar_id).local().face_mesh = face_mesh;
-              mortar_data_ptr->at(mortar_id).local().mortar_mesh = mortar_mesh;
+              mortar_data_ptr->at(mortar_id).local().mortar_mesh =
+                  unprojected_mortar_mesh;
               mortar_data_ptr->at(mortar_id).local().mortar_data =
                   std::move(type_erased_boundary_data_on_mortar);
             },
@@ -942,6 +952,17 @@ void test_impl(const Spectral::Quadrature quadrature,
       const auto& mortar_id = mortar_id_and_data.first;
       const auto& direction = mortar_id.direction();
       auto& mortar_data_hist = mortar_id_and_data.second;
+      const auto& mortar_mesh = mortar_meshes.at(mortar_id);
+      mortar_data_hist.local().for_each(
+          [&](const TimeStepId& /*id*/,
+              const gsl::not_null<evolution::dg::MortarData<Dim>*> data) {
+            return p_project_mortar_data(data, mortar_mesh);
+          });
+      mortar_data_hist.remote().for_each(
+          [&](const TimeStepId& /*id*/,
+              const gsl::not_null<evolution::dg::MortarData<Dim>*> data) {
+            return p_project_mortar_data(data, mortar_mesh);
+          });
       mortar_id_ptr = &mortar_id;
       Variables<variables_tags> lifted_volume_data{
           quadrature == Spectral::Quadrature::GaussLobatto
@@ -975,6 +996,10 @@ void test_impl(const Spectral::Quadrature quadrature,
       if (mortar_id.id() == ElementId<Dim>::external_boundary_id()) {
         continue;
       }
+      const auto& mortar_mesh = mortar_meshes.at(mortar_id);
+      p_project_mortar_data(make_not_null(&mortar_data.local()), mortar_mesh);
+      p_project_mortar_data(make_not_null(&mortar_data.neighbor()),
+                            mortar_mesh);
       mortar_id_ptr = &mortar_id;
       compute_correction_coupling(mortar_data.local(), mortar_data.neighbor());
     }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarData.cpp
@@ -273,8 +273,8 @@ void test_p_project() {
                                    std::optional(initial_mortar_mesh),
                                    std::nullopt,
                                    std::nullopt};
-  p_project_geometric_data(make_not_null(&only_mortar_data), final_face_mesh,
-                           final_volume_mesh);
+  CHECK(not p_project_geometric_data(make_not_null(&only_mortar_data),
+                                     final_face_mesh, final_volume_mesh));
   check_mortar_data(only_mortar_data,
                     MortarData<Dim>{std::optional(initial_mortar_data),
                                     std::nullopt, std::nullopt, std::nullopt,
@@ -287,7 +287,15 @@ void test_p_project() {
                                      std::optional(initial_mortar_mesh),
                                      std::nullopt,
                                      std::nullopt};
-  p_project_mortar_data(make_not_null(&only_mortar_data_2), final_mortar_mesh);
+  CHECK(p_project_mortar_data(make_not_null(&only_mortar_data_2),
+                              final_mortar_mesh) == (Dim > 1));
+  check_mortar_data(only_mortar_data_2,
+                    MortarData<Dim>{std::optional(final_mortar_data),
+                                    std::nullopt, std::nullopt, std::nullopt,
+                                    std::optional(final_mortar_mesh),
+                                    std::nullopt, std::nullopt});
+  CHECK(not p_project_mortar_data(make_not_null(&only_mortar_data_2),
+                                  final_mortar_mesh));
   check_mortar_data(only_mortar_data_2,
                     MortarData<Dim>{std::optional(final_mortar_data),
                                     std::nullopt, std::nullopt, std::nullopt,
@@ -300,8 +308,16 @@ void test_p_project() {
                                std::optional(initial_mortar_mesh),
                                std::optional(initial_face_mesh),
                                std::nullopt};
-  p_project_geometric_data(make_not_null(&only_gl_data), final_face_mesh,
-                           final_volume_mesh);
+  CHECK(p_project_geometric_data(make_not_null(&only_gl_data), final_face_mesh,
+                                 final_volume_mesh) == (Dim > 1));
+  check_mortar_data(
+      only_gl_data,
+      MortarData<Dim>{std::optional(initial_mortar_data),
+                      std::optional(final_face_normal_magnitude), std::nullopt,
+                      std::nullopt, std::optional(initial_mortar_mesh),
+                      std::optional(final_face_mesh), std::nullopt});
+  CHECK(not p_project_geometric_data(make_not_null(&only_gl_data),
+                                     final_face_mesh, final_volume_mesh));
   check_mortar_data(
       only_gl_data,
       MortarData<Dim>{std::optional(initial_mortar_data),
@@ -315,8 +331,18 @@ void test_p_project() {
                          std::optional(initial_mortar_mesh),
                          std::optional(initial_face_mesh),
                          std::optional(initial_volume_mesh)};
-  p_project_geometric_data(make_not_null(&g_data), final_face_mesh,
-                           final_volume_mesh);
+  CHECK(p_project_geometric_data(make_not_null(&g_data), final_face_mesh,
+                                 final_volume_mesh));
+  check_mortar_data(
+      g_data, MortarData<Dim>{std::optional(initial_mortar_data),
+                              std::optional(final_face_normal_magnitude),
+                              std::optional(final_face_det_jacobian),
+                              std::optional(final_volume_det_inv_jacobian),
+                              std::optional(initial_mortar_mesh),
+                              std::optional(final_face_mesh),
+                              std::optional(final_volume_mesh)});
+  CHECK(not p_project_geometric_data(make_not_null(&g_data), final_face_mesh,
+                                     final_volume_mesh));
   check_mortar_data(
       g_data, MortarData<Dim>{std::optional(initial_mortar_data),
                               std::optional(final_face_normal_magnitude),

--- a/tests/Unit/Time/Test_BoundaryHistory.cpp
+++ b/tests/Unit/Time/Test_BoundaryHistory.cpp
@@ -622,7 +622,7 @@ struct ReferenceFunctor {
   }
 };
 
-template <bool Local, bool Modified, bool Const>
+template <bool Local, bool Modified, bool Modify>
 struct NotNullFunctor {
   using ExpectedData =
       tmpl::conditional_t<Local, std::string, std::vector<int>>;
@@ -631,25 +631,25 @@ struct NotNullFunctor {
 
   // Templated to test that the correct types are passed.
   template <typename Id, typename Data>
-  void operator()(Id& id, const gsl::not_null<Data*> data) {
+  bool operator()(Id& id, const gsl::not_null<Data*> data) {
     static_assert(std::is_same_v<Id, const TimeStepId>);
-    static_assert(std::is_same_v<std::remove_const_t<Data>, ExpectedData>);
-    static_assert(std::is_const_v<Data> == Const);
+    static_assert(std::is_same_v<Data, ExpectedData>);
 
     CHECK(ids.insert(id).second);
     CHECK(entries.insert(*data).second);
     if constexpr (Local) {
       CHECK(static_cast<bool>(std::islower((*data)[0])) == Modified);
-      if constexpr (not Const) {
+      if constexpr (Modify) {
         (*data)[0] =
             Modified ? std::toupper((*data)[0]) : std::tolower((*data)[0]);
       }
     } else {
       CHECK(((*data)[0] < 0) == Modified);
-      if constexpr (not Const) {
+      if constexpr (Modify) {
         (*data)[0] *= -1;
       }
     }
+    return Modify;
   }
 };
 
@@ -660,11 +660,24 @@ void check_reference(const Times& times, const size_t expected_size) {
   CHECK(func.ids.size() == expected_size);
 }
 
-template <bool Local, bool Modified, bool Const, typename Times>
+template <bool Local, bool Modified, bool Modify, typename Times>
 void check_not_null(const Times& times, const size_t expected_size) {
-  NotNullFunctor<Local, Modified, Const> func{};
+  NotNullFunctor<Local, Modified, Modify> func{};
   times.for_each(func);
   CHECK(func.ids.size() == expected_size);
+}
+
+template <typename LocalData, typename RemoteData, typename CouplingResult>
+bool cache_filled(
+    const TimeSteppers::BoundaryHistory<LocalData, RemoteData, CouplingResult>&
+        history) {
+  bool called = false;
+  history.evaluator(
+      [&called](const LocalData& /*unused*/, const RemoteData& /*unused*/) {
+        called = true;
+        return CouplingResult{};
+      })(history.local().front(), history.remote().front());
+  return not called;
 }
 
 void test_for_each() {
@@ -689,27 +702,46 @@ void test_for_each() {
   // The second template parameter indicates whether the data is
   // expected to have been modified from its original state at that
   // point.  Modification happens with each call to
-  // `check_not_null<..., ..., false>`.  Modifying twice gives the
+  // `check_not_null<..., ..., true>`.  Modifying twice gives the
   // original data.
+  CHECK(not cache_filled(history));
   check_reference<true, false>(const_history.local(), local_size);
+  CHECK(cache_filled(history));
   check_reference<true, false>(history.local(), local_size);
-  check_not_null<true, false, true>(const_history.local(), local_size);
+  CHECK(cache_filled(history));
   check_not_null<true, false, false>(history.local(), local_size);
+  CHECK(cache_filled(history));
+  check_not_null<true, false, true>(history.local(), local_size);
+  CHECK(not cache_filled(history));
   check_reference<true, true>(const_history.local(), local_size);
+  CHECK(cache_filled(history));
   check_reference<true, true>(history.local(), local_size);
-  check_not_null<true, true, true>(const_history.local(), local_size);
+  CHECK(cache_filled(history));
   check_not_null<true, true, false>(history.local(), local_size);
+  CHECK(cache_filled(history));
+  check_not_null<true, true, true>(history.local(), local_size);
+  CHECK(not cache_filled(history));
   check_reference<true, false>(const_history.local(), local_size);
+  CHECK(cache_filled(history));
 
   check_reference<false, false>(const_history.remote(), remote_size);
+  CHECK(cache_filled(history));
   check_reference<false, false>(history.remote(), remote_size);
-  check_not_null<false, false, true>(const_history.remote(), remote_size);
+  CHECK(cache_filled(history));
   check_not_null<false, false, false>(history.remote(), remote_size);
+  CHECK(cache_filled(history));
+  check_not_null<false, false, true>(history.remote(), remote_size);
+  CHECK(not cache_filled(history));
   check_reference<false, true>(const_history.remote(), remote_size);
+  CHECK(cache_filled(history));
   check_reference<false, true>(history.remote(), remote_size);
-  check_not_null<false, true, true>(const_history.remote(), remote_size);
+  CHECK(cache_filled(history));
   check_not_null<false, true, false>(history.remote(), remote_size);
+  CHECK(cache_filled(history));
+  check_not_null<false, true, true>(history.remote(), remote_size);
+  CHECK(not cache_filled(history));
   check_reference<false, false>(const_history.remote(), remote_size);
+  CHECK(cache_filled(history));
 }
 }  // namespace
 


### PR DESCRIPTION
Fixes a bug introduced in #6799.  After that PR, the MortarMesh tag may not agree with the stored data, which would prevent projection if the tag value happened to be correct but the data wrong.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
