### PR TITLE
Add BCO Python Binding

### DIFF
--- a/src/Domain/Creators/Python/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/Python/BinaryCompactObject.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/Python/BinaryCompactObject.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/Creators/BinaryCompactObject.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::py_bindings {
+void bind_binary_compact_object(py::module& m) {
+  py::class_<domain::creators::BinaryCompactObject<false>, DomainCreator<3>>(
+      m, "BinaryCompactObject")
+      .def(py::init(
+               [](const double inner_radius_object_a,
+                  const double outer_radius_object_a, const double x_coord_a,
+                  const bool excise_a, const bool use_logarithmic_map_a,
+                  const double inner_radius_object_b,
+                  const double outer_radius_object_b, const double x_coord_b,
+                  const bool excise_b, const bool use_logarithmic_map_b,
+                  const std::array<double, 2> center_of_mass_offset,
+                  const double envelope_radius, const double outer_radius,
+                  const double cube_scale, const size_t initial_refinement,
+                  const size_t initial_num_points,
+                  const bool use_equiangular_map,
+                  const std::vector<double>& radial_partitioning_outer_shell,
+                  const double opening_angle_in_degrees) {
+                 return domain::creators::BinaryCompactObject<false>{
+                     domain::creators::BinaryCompactObject<false>::Object{
+                         inner_radius_object_a, outer_radius_object_a,
+                         x_coord_a, excise_a, use_logarithmic_map_a},
+                     domain::creators::BinaryCompactObject<false>::Object{
+                         inner_radius_object_b, outer_radius_object_b,
+                         x_coord_b, excise_b, use_logarithmic_map_b},
+                     center_of_mass_offset,
+                     envelope_radius,
+                     outer_radius,
+                     cube_scale,
+                     initial_refinement,
+                     initial_num_points,
+                     use_equiangular_map,
+                     domain::CoordinateMaps::Distribution::Logarithmic,
+                     radial_partitioning_outer_shell,
+                     domain::CoordinateMaps::Distribution::Linear,
+                     opening_angle_in_degrees};
+               }),
+           py::arg("inner_radius_a"), py::arg("outer_radius_a"),
+           py::arg("x_coord_a"), py::arg("excise_a"),
+           py::arg("use_logarithmic_map_a"), py::arg("inner_radius_b"),
+           py::arg("outer_radius_b"), py::arg("x_coord_b"), py::arg("excise_b"),
+           py::arg("use_logarithmic_map_b"), py::arg("center_of_mass_offset"),
+           py::arg("envelope_radius"), py::arg("outer_radius"),
+           py::arg("cube_scale"), py::arg("initial_refinement"),
+           py::arg("initial_number_of_grid_points"),
+           py::arg("use_equiangular_map"),
+           py::arg("radial_partitioning_outer_shell") = std::vector<double>{},
+           py::arg("opening_angle_in_degrees") = 120);
+}
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/Python/BinaryCompactObject.hpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+// For now it's hard coded to not support time dependent maps, an outer-boundary
+// condition or context.
+void bind_binary_compact_object(pybind11::module& m);
+}  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/Python/Bindings.cpp
+++ b/src/Domain/Creators/Python/Bindings.cpp
@@ -3,6 +3,7 @@
 
 #include <pybind11/pybind11.h>
 
+#include "Domain/Creators/Python/BinaryCompactObject.hpp"
 #include "Domain/Creators/Python/Cylinder.hpp"
 #include "Domain/Creators/Python/DomainCreator.hpp"
 #include "Domain/Creators/Python/Rectilinear.hpp"
@@ -27,6 +28,7 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   py_bindings::bind_rectilinear(m);
   py_bindings::bind_cylinder(m);
   py_bindings::bind_sphere(m);
+  py_bindings::bind_binary_compact_object(m);
 }
 
 }  // namespace domain::creators

--- a/src/Domain/Creators/Python/CMakeLists.txt
+++ b/src/Domain/Creators/Python/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_python_add_module(
   LIBRARY_NAME ${LIBRARY}
   MODULE_PATH "Domain"
   SOURCES
+  BinaryCompactObject.cpp
   Bindings.cpp
   Cylinder.cpp
   DomainCreator.cpp
@@ -21,6 +22,7 @@ spectre_python_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BinaryCompactObject.hpp
   Cylinder.hpp
   DomainCreator.hpp
   Rectilinear.hpp

--- a/tests/Unit/Domain/Creators/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/Python/CMakeLists.txt
@@ -2,6 +2,13 @@
 # See LICENSE.txt for details.
 
 spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.Python.BinaryCompactObject"
+  Test_BinaryCompactObject.py
+  "Unit;Domain"
+  PyDomainCreators
+)
+
+spectre_add_python_bindings_test(
   "Unit.Domain.Creators.Python.Brick"
   Test_Brick.py
   "Unit;Domain"

--- a/tests/Unit/Domain/Creators/Python/Test_BinaryCompactObject.py
+++ b/tests/Unit/Domain/Creators/Python/Test_BinaryCompactObject.py
@@ -1,0 +1,36 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators import BinaryCompactObject, DomainCreator3D
+
+
+class TestCylinder(unittest.TestCase):
+    def test_construction(self):
+        binary_compact_object = BinaryCompactObject(
+            inner_radius_a=0.5,
+            outer_radius_a=2.0,
+            x_coord_a=5.0,
+            excise_a=True,
+            use_logarithmic_map_a=True,
+            inner_radius_b=0.5,
+            outer_radius_b=2.0,
+            x_coord_b=-5.0,
+            excise_b=True,
+            use_logarithmic_map_b=True,
+            center_of_mass_offset=[0.1, 0.2],
+            envelope_radius=50.0,
+            outer_radius=600.0,
+            cube_scale=1.2,
+            initial_refinement=1,
+            initial_number_of_grid_points=5,
+            use_equiangular_map=True,
+            radial_partitioning_outer_shell=[],
+            opening_angle_in_degrees=120.0,
+        )
+        self.assertIsInstance(binary_compact_object, DomainCreator3D)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

This pr adds a python binding for the binary compact object domain. It's pretty basic and doesn't allow for TimeDependentMaps to be set, but I think this will be very useful for testing the ringdown script updates in #6808 and #6809 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
