### PR TITLE
Ah adaptivity: improve criteria

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_headers(
   Criterion.hpp
   Factory.hpp
   IncreaseResolution.hpp
+  RegisterDerivedWithCharm.hpp
   Residual.hpp
   Shape.hpp
   )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp
@@ -52,6 +52,8 @@ class Criterion : public PUP::able {
 
   virtual std::string observation_name() = 0;
 
+  virtual bool is_equal(const Criterion& other) const = 0;
+
   /// Evaluates the apparent horizon criteria by selecting the appropriate
   /// derived class and forwarding its `argument_tags` from the ObservationBox
   /// (along with the GlobalCache) to the call operator of the

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp
@@ -11,6 +11,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 
 namespace ah {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.cpp
@@ -7,5 +7,9 @@ namespace ah::Criteria {
 IncreaseResolution::IncreaseResolution(CkMigrateMessage* msg)
     : Criterion(msg) {}
 
+bool IncreaseResolution::is_equal(const Criterion& other) const {
+  return dynamic_cast<const IncreaseResolution*>(&other) != nullptr;
+}
+
 PUP::able::PUP_ID IncreaseResolution::my_PUP_ID = 0;  // NOLINT
 }  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp
@@ -45,5 +45,7 @@ class IncreaseResolution : public Criterion {
                     const FastFlow::IterInfo& /*info*/) const {
     return strahlkorper.l_max() + 2;
   }
+
+  bool is_equal(const Criterion& other) const override;
 };
 }  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/RegisterDerivedWithCharm.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+
+namespace ah::Criteria {
+void register_derived_with_charm() {
+  register_classes_with_charm<Residual>();
+  register_classes_with_charm<Shape>();
+}
+}  // namespace ah::Criteria

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.cpp
@@ -41,6 +41,18 @@ void Residual::pup(PUP::er& p) {
   p | min_resolution_l_;
   p | max_resolution_l_;
 }
+
+bool Residual::is_equal(const Criterion& other) const {
+  const auto* other_residual = dynamic_cast<const Residual*>(&other);
+  if (other_residual == nullptr) {
+    return false;
+  }
+  return min_residual_ == other_residual->min_residual_ and
+         max_residual_ == other_residual->max_residual_ and
+         min_resolution_l_ == other_residual->min_resolution_l_ and
+         max_resolution_l_ == other_residual->max_resolution_l_;
+}
+
 Residual::Residual(CkMigrateMessage* msg) : Criterion(msg) {}
 
 PUP::able::PUP_ID ah::Criteria::Residual::my_PUP_ID = 0;  // NOLINT

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp
@@ -91,6 +91,8 @@ class Residual : public Criterion {
 
   void pup(PUP::er& p) override;
 
+  bool is_equal(const Criterion& other) const override;
+
  private:
   double min_residual_{std::numeric_limits<double>::signaling_NaN()};
   double max_residual_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.cpp
@@ -43,6 +43,18 @@ void Shape::pup(PUP::er& p) {
   p | max_resolution_l_;
 }
 
+bool Shape::is_equal(const Criterion& other) const {
+  const auto* other_shape = dynamic_cast<const Shape*>(&other);
+  if (other_shape == nullptr) {
+    return false;
+  }
+  return min_truncation_error_ == other_shape->min_truncation_error_ and
+         max_truncation_error_ == other_shape->max_truncation_error_ and
+         max_pile_up_modes_ == other_shape->max_pile_up_modes_ and
+         min_resolution_l_ == other_shape->min_resolution_l_ and
+         max_resolution_l_ == other_shape->max_resolution_l_;
+}
+
 Shape::Shape(CkMigrateMessage* msg) : Criterion(msg) {}
 
 PUP::able::PUP_ID ah::Criteria::Shape::my_PUP_ID = 0;  // NOLINT

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp
@@ -104,6 +104,8 @@ class Shape : public Criterion {
 
   void pup(PUP::er& p) override;
 
+  bool is_equal(const Criterion& other) const override;
+
  private:
   double min_truncation_error_{std::numeric_limits<double>::signaling_NaN()};
   double max_truncation_error_{std::numeric_limits<double>::signaling_NaN()};

--- a/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Criteria/Test_Criterion.cpp
@@ -70,7 +70,7 @@ class CriterionOne : public amr::Criterion {
 
   std::string observation_name() override { return "CriterionOne"; }
 
-  using compute_tags_for_observartion_box = tmpl::list<>;
+  using compute_tags_for_observation_box = tmpl::list<>;
   using argument_tags = tmpl::list<FieldOne>;
 
   template <typename Metavariables>
@@ -116,7 +116,7 @@ class CriterionTwo : public amr::Criterion {
 
   std::string observation_name() override { return "CriterionTwo"; }
 
-  using compute_tags_for_observartion_box = tmpl::list<ConstraintCompute>;
+  using compute_tags_for_observation_box = tmpl::list<ConstraintCompute>;
   using argument_tags = tmpl::list<Constraint>;
 
   template <typename Metavariables>

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Criterion.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Criterion.cpp
@@ -68,7 +68,7 @@ class CriterionOne : public ah::Criterion {
 
   std::string observation_name() override { return "CriterionOne"; }
 
-  using compute_tags_for_observartion_box = tmpl::list<>;
+  using compute_tags_for_observation_box = tmpl::list<>;
   using argument_tags = tmpl::list<FactorOne>;
 
   template <typename Metavariables, typename Fr>
@@ -83,6 +83,14 @@ class CriterionOne : public ah::Criterion {
   void pup(PUP::er& p) override {
     Criterion::pup(p);
     p | target_value_;
+  }
+
+  bool is_equal(const Criterion& other) const override {
+    const auto* other_criterion = dynamic_cast<const CriterionOne*>(&other);
+    if (other_criterion == nullptr) {
+      return false;
+    }
+    return target_value_ == other_criterion->target_value_;
   }
 
  private:
@@ -113,7 +121,7 @@ class CriterionTwo : public ah::Criterion {
 
   std::string observation_name() override { return "CriterionTwo"; }
 
-  using compute_tags_for_observartion_box = tmpl::list<ProductCompute>;
+  using compute_tags_for_observation_box = tmpl::list<ProductCompute>;
   using argument_tags = tmpl::list<Product>;
 
   template <typename Metavariables, typename Fr>
@@ -129,6 +137,14 @@ class CriterionTwo : public ah::Criterion {
   void pup(PUP::er& p) override {
     Criterion::pup(p);
     p | target_value_;
+  }
+
+  bool is_equal(const Criterion& other) const override {
+    const auto* other_criterion = dynamic_cast<const CriterionTwo*>(&other);
+    if (other_criterion == nullptr) {
+      return false;
+    }
+    return target_value_ == other_criterion->target_value_;
   }
 
  private:
@@ -197,6 +213,22 @@ void test() {
                  strahlkorper, info);
   test_criterion(*serialize_and_deserialize(criterion_two_option), 2.0, 1.5,
                  strahlkorper.l_max() - 1, strahlkorper, info);
+
+  const CriterionOne criterion_one_same{2.3};
+  CHECK(criterion_one.is_equal(criterion_one_same));
+  CHECK(not(criterion_one.is_equal(criterion_two)));
+  const auto criterion_one_serialized =
+      serialize_and_deserialize(criterion_one);
+  CHECK(criterion_one.is_equal(criterion_one_serialized));
+
+  const std::unique_ptr<ah::Criterion> criterion_four =
+      std::make_unique<CriterionOne>(1.2e-3);
+  const std::unique_ptr<CriterionOne> criterion_five =
+      std::make_unique<CriterionOne>(1.2e-3);
+  const std::unique_ptr<CriterionTwo> criterion_six =
+      std::make_unique<CriterionTwo>(1.2e-3);
+  CHECK(criterion_four->is_equal(*criterion_five));
+  CHECK(not(criterion_four->is_equal(*criterion_six)));
 }
 }  // namespace
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_IncreaseResolution.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_IncreaseResolution.cpp
@@ -9,12 +9,14 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
 #include "Utilities/Gsl.hpp"
@@ -52,5 +54,22 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Criteria.IncreaseResolution",
   const size_t new_l_max =
       criterion->evaluate(box, empty_cache, strahlkorper, iter_info);
   CHECK(new_l_max == strahlkorper.l_max() + 2);
+
+  // Test equality and inequality operators
+  const IncreaseResolution criterion_one{};
+  const IncreaseResolution criterion_two{};
+  CHECK(criterion_one.is_equal(criterion_two));
+  const auto criterion_one_serialized =
+      serialize_and_deserialize(criterion_one);
+  CHECK(criterion_one.is_equal(criterion_one_serialized));
+
+  const std::unique_ptr<ah::Criterion> criterion_four =
+      std::make_unique<ah::Criteria::IncreaseResolution>();
+  const std::unique_ptr<ah::Criterion> criterion_five =
+      std::make_unique<ah::Criteria::IncreaseResolution>();
+  const std::unique_ptr<ah::Criterion> criterion_six =
+      std::make_unique<ah::Criteria::Residual>(1.0e-6, 1.0e-4, 4, 12);
+  CHECK(criterion_four->is_equal(*criterion_five));
+  CHECK(not(criterion_four->is_equal(*criterion_six)));
 }
 }  // namespace ah::Criteria

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Residual.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Residual.cpp
@@ -17,6 +17,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/IncreaseResolution.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
@@ -208,6 +209,24 @@ void test_residual() {
         serialized.operator()(empty_cache, strahlkorper, iter_info)};
     CHECK(recommended_l_original == recommended_l_serialized);
   }
+
+  const Residual criterion_one{1.0e-6, 1.0e-4, 4, 12};
+  const Residual criterion_two{1.0e-6, 1.0e-4, 4, 8};
+  const Residual criterion_one_same{1.0e-6, 1.0e-4, 4, 12};
+  CHECK(criterion_one.is_equal(criterion_one_same));
+  CHECK(not(criterion_one.is_equal(criterion_two)));
+  const auto criterion_one_serialized =
+      serialize_and_deserialize(criterion_one);
+  CHECK(criterion_one.is_equal(criterion_one_serialized));
+
+  const std::unique_ptr<ah::Criterion> criterion_four =
+      std::make_unique<ah::Criteria::Residual>(1.0e-6, 1.0e-4, 4, 12);
+  const std::unique_ptr<ah::Criterion> criterion_five =
+      std::make_unique<ah::Criteria::Residual>(1.0e-6, 1.0e-4, 4, 12);
+  const std::unique_ptr<ah::Criterion> criterion_six =
+      std::make_unique<ah::Criteria::IncreaseResolution>();
+  CHECK(criterion_four->is_equal(*criterion_five));
+  CHECK(not(criterion_four->is_equal(*criterion_six)));
 }
 
 void test_residual_constructor_validation() {

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Shape.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Criteria/Test_Shape.cpp
@@ -245,6 +245,16 @@ void test_shape() {
       Catch::Matchers::ContainsSubstring(
           "If MinResolutionL == MaxResolutionL"));
 #endif
+
+  // Test equality and serialization
+  const Shape criterion_one{1.0e-6, 1.0e-4, 5, 4, 12};
+  const Shape criterion_two{1.0e-6, 1.0e-4, 5, 4, 12};
+  const Shape criterion_three{1.0e-6, 1.0e-3, 5, 4, 12};
+  CHECK(criterion_one.is_equal(criterion_two));
+  CHECK(not(criterion_one.is_equal(criterion_three)));
+  const auto criterion_one_serialized =
+      serialize_and_deserialize(criterion_one);
+  CHECK(criterion_one.is_equal(criterion_one_serialized));
 }
 
 void test_shape_constructor_validation() {


### PR DESCRIPTION
## Proposed changes

This PR makes some improvements to apparent horizon finder criteria needed for actually using them in adaptive horizon finding. This is the first PR of several that will culminate in adding adaptivity to the apparent horizon finder.

Note: I used cursor AI tab completion and agents in auto mode to prepare and review this pull request, including implementing the rename to `is_equals()` that @nilsdeppe requested. I reviewed each line of AI-generated code for correctness and to ensure it didn't appear to be copying any third-party code.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Apparent horizon finder criteria now support operator==() and are properly registered with charm. The criteria are not yet usable for adaptive horizon finding.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
