### PR TITLE
Move CoordsToDifferentFrame and Add Error Tol to Recenter

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   AreaElement.cpp
   Block.cpp
   BlockLogicalCoordinates.cpp
+  CoordsToDifferentFrame.cpp
   CreateInitialElement.cpp
   Domain.cpp
   DomainHelpers.cpp
@@ -37,6 +38,7 @@ spectre_target_headers(
   AreaElement.hpp
   Block.hpp
   BlockLogicalCoordinates.hpp
+  CoordsToDifferentFrame.hpp
   CreateInitialElement.hpp
   Domain.hpp
   DomainHelpers.hpp

--- a/src/Domain/CoordsToDifferentFrame.cpp
+++ b/src/Domain/CoordsToDifferentFrame.cpp
@@ -1,0 +1,153 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordsToDifferentFrame.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+// Transforms cartesian coordinates from one frame to another, by calling
+// block_logical_coordinates and calling the correct map functions.
+template <typename SrcFrame, typename DestFrame>
+void coords_to_different_frame(
+    const gsl::not_null<tnsr::I<DataVector, 3, DestFrame>*>
+        dest_cartesian_coords,
+    const tnsr::I<DataVector, 3, SrcFrame>& src_cartesian_coords,
+    const Domain<3>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const double time) {
+  // If ever additional cases besides Grid->Inertial, Grid->Distorted,
+  // and Inertial->Distorted are needed, add if constexprs below
+  static_assert(std::is_same_v<SrcFrame, ::Frame::Grid> or
+                    std::is_same_v<SrcFrame, ::Frame::Inertial>,
+                "Source frame must currently be Grid frame or Inertial frame");
+  const auto block_logical_coords = block_logical_coordinates(
+      domain, src_cartesian_coords, time, functions_of_time);
+
+  tnsr::I<double, 3, DestFrame> x_dest{};
+  tnsr::I<double, 3, SrcFrame> x_src{};
+  for (size_t s = 0; s < get<0>(src_cartesian_coords).size(); ++s) {
+    get<0>(x_src) = get<0>(src_cartesian_coords)[s];
+    get<1>(x_src) = get<1>(src_cartesian_coords)[s];
+    get<2>(x_src) = get<2>(src_cartesian_coords)[s];
+
+    // If this doesn't have a value, then the point isn't in the domain which is
+    // really bad.
+    if (UNLIKELY(not block_logical_coords[s].has_value())) {
+      ERROR("A point in the " << SrcFrame{}
+                              << " could not be mapped to a block: " << x_src);
+    }
+
+    const auto& block_id_and_coords = block_logical_coords[s].value();
+    const auto& block = domain.blocks()[block_id_and_coords.id.get_index()];
+
+    if constexpr (std::is_same_v<DestFrame, ::Frame::Distorted> and
+                  std::is_same_v<SrcFrame, ::Frame::Grid>) {
+      if (not block.has_distorted_frame()) {
+        ERROR("Point lies outside of distorted-frame region");
+      }
+      const auto& grid_to_distorted_map =
+          block.moving_mesh_grid_to_distorted_map();
+      x_dest = grid_to_distorted_map(x_src, time, functions_of_time);
+    } else if constexpr (std::is_same_v<DestFrame, ::Frame::Distorted> and
+                         std::is_same_v<SrcFrame, ::Frame::Inertial>) {
+      if (not block.has_distorted_frame()) {
+        ERROR("Point lies outside of distorted-frame region");
+      }
+      const auto& distorted_to_inertial_map =
+          block.moving_mesh_distorted_to_inertial_map();
+      const auto& inv_point =
+          distorted_to_inertial_map.inverse(x_src, time, functions_of_time);
+      if (inv_point.has_value()) {
+        x_dest = *inv_point;
+      } else {
+        ERROR("Map from Frame::Distorted to Frame::Inertial is not invertible");
+      }
+    } else if constexpr (std::is_same_v<DestFrame, ::Frame::Inertial> and
+                         std::is_same_v<SrcFrame, ::Frame::Grid>) {
+      const auto& grid_to_inertial_map =
+          block.moving_mesh_grid_to_inertial_map();
+      x_dest = grid_to_inertial_map(x_src, time, functions_of_time);
+    } else {
+      static_assert(std::is_same_v<DestFrame, ::Frame::Grid> and
+                        std::is_same_v<SrcFrame, ::Frame::Inertial>,
+                    "Source frame -> destination frame must be Grid -> "
+                    "Distorted, Grid -> Inertial, Inertial -> Distorted, or "
+                    "Inertial -> Grid");
+      const auto& grid_to_inertial_map =
+          block.moving_mesh_grid_to_inertial_map();
+      const auto inv_point =
+          grid_to_inertial_map.inverse(x_src, time, functions_of_time);
+      if (inv_point.has_value()) {
+        x_dest = inv_point.value();
+      } else {
+        ERROR("Map from Frame::Inertial to Frame::Grid is not invertible");
+      }
+    }
+
+    get<0>(*dest_cartesian_coords)[s] = get<0>(x_dest);
+    get<1>(*dest_cartesian_coords)[s] = get<1>(x_dest);
+    get<2>(*dest_cartesian_coords)[s] = get<2>(x_dest);
+  }
+}
+
+#define SRCFRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DESTFRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_GRID(_, data)                                         \
+  template void coords_to_different_frame(                                \
+      const gsl::not_null<tnsr::I<DataVector, 3, DESTFRAME(data)>*>       \
+          dest_cartesian_coords,                                          \
+      const tnsr::I<DataVector, 3, SRCFRAME(data)>& src_cartesian_coords, \
+      const Domain<3>& domain,                                            \
+      const std::unordered_map<                                           \
+          std::string,                                                    \
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&      \
+          functions_of_time,                                              \
+      const double time);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_GRID, (::Frame::Grid),
+                        (::Frame::Inertial, ::Frame::Distorted))
+
+template void coords_to_different_frame(
+    gsl::not_null<tnsr::I<DataVector, 3, ::Frame::Distorted>*>
+        dest_cartesian_coords,
+    const tnsr::I<DataVector, 3, ::Frame::Inertial>& src_cartesian_coords,
+    const Domain<3>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    double time);
+
+template void coords_to_different_frame(
+    gsl::not_null<tnsr::I<DataVector, 3, ::Frame::Grid>*> dest_cartesian_coords,
+    const tnsr::I<DataVector, 3, ::Frame::Inertial>& src_cartesian_coords,
+    const Domain<3>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    double time);
+
+#undef INSTANTIATE
+#undef INSTANTIATEGENERAL
+#undef INSTANTIATEALIGNED
+#undef DESTFRAME
+#undef SRCFRAME

--- a/src/Domain/CoordsToDifferentFrame.hpp
+++ b/src/Domain/CoordsToDifferentFrame.hpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.Add commentMore actions
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+template <size_t Dim>
+class Domain;
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+/*!
+ *  Transforms cartesian coordinates from one frame to another, by calling
+ *  block_logical_coordinates and calling the correct map functions. Current
+ *  supported frame changes Grid->Inertial, Grid-Distorted, Inertial->Distorted,
+ *  and Inertial->Grid
+ */
+template <typename SrcFrame, typename DestFrame>
+void coords_to_different_frame(
+    gsl::not_null<tnsr::I<DataVector, 3, DestFrame>*> dest_cartesian_coords,
+    const tnsr::I<DataVector, 3, SrcFrame>& src_cartesian_coords,
+    const Domain<3>& domain,
+    const std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    double time);

--- a/src/Domain/StrahlkorperTransformations.cpp
+++ b/src/Domain/StrahlkorperTransformations.cpp
@@ -18,6 +18,7 @@
 #include "Domain/Block.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordsToDifferentFrame.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "NumericalAlgorithms/RootFinding/RootBracketing.hpp"
@@ -30,96 +31,6 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/SetNumberOfGridPoints.hpp"
-
-namespace {
-// Transforms cartesian coordinates of a strahlkorper
-// from one frame to another, by calling block_logical_coordinates and
-// calling the correct map functions.
-template <typename SrcFrame, typename DestFrame>
-void coords_to_different_frame(
-    const gsl::not_null<tnsr::I<DataVector, 3, DestFrame>*>
-        dest_cartesian_coords,
-    const tnsr::I<DataVector, 3, SrcFrame>& src_cartesian_coords,
-    const Domain<3>& domain,
-    const std::unordered_map<
-        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time,
-    const double time) {
-  // If ever additional cases besides Grid->Inertial, Grid->Distorted,
-  // and Inertial->Distorted are needed, add if constexprs below
-  static_assert(std::is_same_v<SrcFrame, ::Frame::Grid> or
-                    std::is_same_v<SrcFrame, ::Frame::Inertial>,
-                "Source frame must currently be Grid frame or Inertial frame");
-  const auto block_logical_coords = block_logical_coordinates(
-      domain, src_cartesian_coords, time, functions_of_time);
-
-  tnsr::I<double, 3, DestFrame> x_dest{};
-  tnsr::I<double, 3, SrcFrame> x_src{};
-  for (size_t s = 0; s < get<0>(src_cartesian_coords).size(); ++s) {
-    get<0>(x_src) = get<0>(src_cartesian_coords)[s];
-    get<1>(x_src) = get<1>(src_cartesian_coords)[s];
-    get<2>(x_src) = get<2>(src_cartesian_coords)[s];
-
-    // If this doesn't have a value, then the point isn't in the domain which is
-    // really bad.
-    if (UNLIKELY(not block_logical_coords[s].has_value())) {
-      ERROR("A point on the Strahlkorper in the "
-            << SrcFrame{} << " could not be mapped to a block: " << x_src);
-    }
-
-    const auto& block_id_and_coords = block_logical_coords[s].value();
-    const auto& block = domain.blocks()[block_id_and_coords.id.get_index()];
-
-    if constexpr (std::is_same_v<DestFrame, ::Frame::Distorted> and
-                  std::is_same_v<SrcFrame, ::Frame::Grid>) {
-      if (not block.has_distorted_frame()) {
-        ERROR("Strahlkorper lies outside of distorted-frame region");
-      }
-      const auto& grid_to_distorted_map =
-          block.moving_mesh_grid_to_distorted_map();
-      x_dest = grid_to_distorted_map(x_src, time, functions_of_time);
-    } else if constexpr (std::is_same_v<DestFrame, ::Frame::Distorted> and
-                         std::is_same_v<SrcFrame, ::Frame::Inertial>) {
-      if (not block.has_distorted_frame()) {
-        ERROR("Strahlkorper lies outside of distorted-frame region");
-      }
-      const auto& distorted_to_inertial_map =
-          block.moving_mesh_distorted_to_inertial_map();
-      const auto& inv_point =
-          distorted_to_inertial_map.inverse(x_src, time, functions_of_time);
-      if (inv_point.has_value()) {
-        x_dest = *inv_point;
-      } else {
-        ERROR("Map from Frame::Distorted to Frame::Inertial is not invertible");
-      }
-    } else if constexpr (std::is_same_v<DestFrame, ::Frame::Inertial> and
-                         std::is_same_v<SrcFrame, ::Frame::Grid>) {
-      const auto& grid_to_inertial_map =
-          block.moving_mesh_grid_to_inertial_map();
-      x_dest = grid_to_inertial_map(x_src, time, functions_of_time);
-    } else {
-      static_assert(std::is_same_v<DestFrame, ::Frame::Grid> and
-                        std::is_same_v<SrcFrame, ::Frame::Inertial>,
-                    "Source frame -> destination frame must be Grid -> "
-                    "Distorted, Grid -> Inertial, Inertial -> Distorted, or "
-                    "Inertial -> Grid");
-      const auto& grid_to_inertial_map =
-          block.moving_mesh_grid_to_inertial_map();
-      const auto inv_point =
-          grid_to_inertial_map.inverse(x_src, time, functions_of_time);
-      if (inv_point.has_value()) {
-        x_dest = inv_point.value();
-      } else {
-        ERROR("Map from Frame::Inertial to Frame::Grid is not invertible");
-      }
-    }
-
-    get<0>(*dest_cartesian_coords)[s] = get<0>(x_dest);
-    get<1>(*dest_cartesian_coords)[s] = get<1>(x_dest);
-    get<2>(*dest_cartesian_coords)[s] = get<2>(x_dest);
-  }
-}
-}  // namespace
 
 template <typename SrcFrame, typename DestFrame>
 void strahlkorper_in_different_frame(
@@ -158,9 +69,9 @@ void strahlkorper_in_different_frame(
   ylm::cartesian_coords(make_not_null(&src_cartesian_coords), src_strahlkorper,
                         src_radius, r_hat);
 
-  coords_to_different_frame(make_not_null(&dest_cartesian_coords),
-                            src_cartesian_coords, domain, functions_of_time,
-                            time);
+  coords_to_different_frame<SrcFrame, DestFrame>(
+      make_not_null(&dest_cartesian_coords), src_cartesian_coords, domain,
+      functions_of_time, time);
 
   // To find the expansion center of the destination surface, take a
   // simple average of the Cartesian coordinates of the surface in the
@@ -331,9 +242,9 @@ void strahlkorper_in_different_frame_aligned(
   ylm::cartesian_coords(make_not_null(&src_cartesian_coords), src_strahlkorper,
                         radius, r_hat);
 
-  coords_to_different_frame(make_not_null(&dest_cartesian_coords),
-                            src_cartesian_coords, domain, functions_of_time,
-                            time);
+  coords_to_different_frame<SrcFrame, DestFrame>(
+      make_not_null(&dest_cartesian_coords), src_cartesian_coords, domain,
+      functions_of_time, time);
 
   // Fill radius with the radius in the destination frame.
   const auto center = src_strahlkorper.expansion_center();

--- a/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.cpp
@@ -115,7 +115,8 @@ void change_expansion_center_of_strahlkorper(
 
 template <typename Frame>
 void change_expansion_center_of_strahlkorper_to_physical(
-    const gsl::not_null<Strahlkorper<Frame>*> strahlkorper) {
+    const gsl::not_null<Strahlkorper<Frame>*> strahlkorper,
+    double relative_tolerance) {
   const auto r_hat = get_rhat(*strahlkorper);
 
   // Zeroth iteration.
@@ -133,7 +134,7 @@ void change_expansion_center_of_strahlkorper_to_physical(
                                        square(exp_center[1] - phys_center[1]) +
                                        square(exp_center[2] - phys_center[2])) /
                                   average_radius;
-    if (relative_error <= 2.0 * std::numeric_limits<double>::epsilon()) {
+    if (relative_error <= relative_tolerance) {
       return;
     }
     change_expansion_center(strahlkorper, phys_center, r_hat);
@@ -147,9 +148,11 @@ void change_expansion_center_of_strahlkorper_to_physical(
       const gsl::not_null<Strahlkorper<FRAME(data)>*> strahlkorper,  \
       const std::array<double, 3>& new_center);                      \
   template void change_expansion_center_of_strahlkorper_to_physical( \
-      const gsl::not_null<Strahlkorper<FRAME(data)>*> strahlkorper);
+      const gsl::not_null<Strahlkorper<FRAME(data)>*> strahlkorper,  \
+      double relative_tolerance);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (::Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::Frame::Inertial, ::Frame::Distorted, ::Frame::Grid))
 
 #undef INSTANTIATE
 #undef FRAME

--- a/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 
 /// \cond
 namespace ylm {
@@ -35,5 +36,6 @@ void change_expansion_center_of_strahlkorper(
 /// `change_expansion_center_of_strahlkorper`.
 template <typename Frame>
 void change_expansion_center_of_strahlkorper_to_physical(
-    gsl::not_null<Strahlkorper<Frame>*> strahlkorper);
+    gsl::not_null<Strahlkorper<Frame>*> strahlkorper,
+    double relative_tolerance = 2.0 * std::numeric_limits<double>::epsilon());
 }  // namespace ylm

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Block.cpp
   Test_BlockAndElementLogicalCoordinates.cpp
   Test_CoordinatesTag.cpp
+  Test_CoordsToDifferentFrame.cpp
   Test_CreateInitialElement.cpp
   Test_Domain.cpp
   Test_DomainHelpers.cpp

--- a/tests/Unit/Domain/Test_CoordsToDifferentFrame.cpp
+++ b/tests/Unit/Domain/Test_CoordsToDifferentFrame.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordsToDifferentFrame.hpp"
+#include "Domain/Creators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/Shape.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/StrahlkorperTransformations.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <typename SrcFrame, typename DestFrame>
+void test_coords_to_different_frame() {
+  const tnsr::I<DataVector, 3, SrcFrame> src_center{DataVector{0.03}};
+
+  const std::vector<double> radial_partitioning{};
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Linear};
+
+  const domain::creators::Sphere domain_creator{
+      0.001,
+      10.0,
+      domain::creators::Sphere::Excision{},
+      1_st,
+      5_st,
+      false,
+      std::nullopt,
+      radial_partitioning,
+      radial_distribution,
+      ShellWedges::All,
+      std::make_unique<
+          domain::creators::time_dependence::UniformTranslation<3>>(
+          0.0, std::array<double, 3>({{0.0, 0.0, 0.0}}),
+          std::array<double, 3>({{0.01, 0.02, 0.03}}))};
+
+  const Domain<3> domain = domain_creator.create_domain();
+  const auto functions_of_time = domain_creator.functions_of_time();
+
+  const double time = 0.5;
+  tnsr::I<DataVector, 3, DestFrame> dest_center{DataVector{0.0}};
+
+  coords_to_different_frame(make_not_null(&dest_center), src_center, domain,
+                            functions_of_time, time);
+
+  tnsr::I<DataVector, 3, DestFrame> expected_center{DataVector{0.0}};
+
+  if constexpr (std::is_same_v<SrcFrame, ::Frame::Inertial>) {
+    expected_center[0] = src_center[0] - 0.005;
+    expected_center[1] = src_center[1] - 0.01;
+    expected_center[2] = src_center[2] - 0.015;
+  } else if (std::is_same_v<DestFrame, ::Frame::Inertial>) {
+    expected_center[0] = src_center[0] + 0.005;
+    expected_center[1] = src_center[1] + 0.01;
+    expected_center[2] = src_center[2] + 0.015;
+  } else {
+    expected_center[0] = src_center[0];
+    expected_center[1] = src_center[1];
+    expected_center[2] = src_center[2];
+  }
+  CHECK(expected_center == dest_center);
+}
+SPECTRE_TEST_CASE("Unit.Domain.CoordsToDifferentFrame", "[Unit]") {
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+  test_coords_to_different_frame<Frame::Grid, Frame::Inertial>();
+  test_coords_to_different_frame<Frame::Inertial, Frame::Distorted>();
+  test_coords_to_different_frame<Frame::Inertial, Frame::Grid>();
+  test_coords_to_different_frame<Frame::Grid, Frame::Inertial>();
+  test_coords_to_different_frame<Frame::Grid, Frame::Distorted>();
+}
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ChangeCenterOfStrahlkorper.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ChangeCenterOfStrahlkorper.cpp
@@ -91,10 +91,24 @@ void test_change_center_of_strahlkorper_to_physical() {
   change_expansion_center_of_strahlkorper_to_physical(
       make_not_null(&strahlkorper));
 
-  const auto new_physical_center = strahlkorper.physical_center();
-  const auto new_center = strahlkorper.expansion_center();
+  auto new_physical_center = strahlkorper.physical_center();
+  auto new_center = strahlkorper.expansion_center();
   for (size_t i = 0; i < 3; ++i) {
     CHECK(approx(gsl::at(new_physical_center, i)) == gsl::at(new_center, i));
+  }
+
+  // Checking relative tolerance
+  auto strahlkorper_with_higher_tolerance = make_strahlkorper();
+  const double relative_tolerance = 1e-8;
+  const Approx custom_approx =
+      Approx::custom().epsilon(relative_tolerance).scale(10.0);
+  change_expansion_center_of_strahlkorper_to_physical(
+      make_not_null(&strahlkorper_with_higher_tolerance), relative_tolerance);
+  new_physical_center = strahlkorper_with_higher_tolerance.physical_center();
+  new_center = strahlkorper_with_higher_tolerance.expansion_center();
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK_ITERABLE_CUSTOM_APPROX(gsl::at(new_physical_center, i),
+                                 gsl::at(new_center, i), custom_approx);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

I decided to split this commit from #6808 and #6809 into its own pr cause I think that'd be easier. This moves the coords_to_different_frame function from StrahlkorperTransformations into its own file cause it's very useful for the ringdown transition. The error tolerance was added to the change_expansion_center_of_strahlkorper_to_physical because SpEC has a recenter tolerance in ConstructPostMergerDataFromAhC.pl of 1.0e-8 and right now it's hard coded to 2.0 * epsilon in SpECTRE

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
