### PR TITLE
Add support for Chebyshev and B3 topology in create_initial_mesh

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -114,7 +114,8 @@ block_logical_coordinates_single_point(
   for (size_t d = 0; d < Dim; ++d) {
     const auto topology = gsl::at(block.topologies(), d);
     if (topology == domain::Topology::I1 or
-        topology == domain::Topology::B2Radial) {
+        topology == domain::Topology::B2Radial or
+        topology == domain::Topology::B3Radial) {
       // Map inverses may report logical coordinates outside [-1, 1] due to
       // numerical roundoff error. In that case we clamp them to -1 or 1 so
       // that a consistent block is chosen here independent of roundoff error.

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -100,7 +100,7 @@ std::unordered_set<ElementId<3>> neighbor_ids(
 }
 }  // namespace
 
-namespace domain::Initialization {
+namespace domain {
 template <size_t VolumeDim>
 Element<VolumeDim> create_initial_element(
     const ElementId<VolumeDim>& element_id,
@@ -232,13 +232,12 @@ Element<VolumeDim> create_initial_element(
                             std::move(neighbors_of_element),
                             block.topologies());
 }
-}  // namespace domain::Initialization
+}  // namespace domain
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                             \
-  template Element<DIM(data)>                                            \
-  domain::Initialization::create_initial_element<DIM(data)>(             \
+  template Element<DIM(data)> domain::create_initial_element<DIM(data)>( \
       const ElementId<DIM(data)>&, const std::vector<Block<DIM(data)>>&, \
       const std::vector<std::array<size_t, DIM(data)>>&);
 

--- a/src/Domain/CreateInitialElement.hpp
+++ b/src/Domain/CreateInitialElement.hpp
@@ -17,7 +17,6 @@ class ElementId;
 /// \endcond
 
 namespace domain {
-namespace Initialization {
 /*!
  * \ingroup InitializationGroup
  * \brief Creates an initial element of a Block.
@@ -33,5 +32,4 @@ Element<VolumeDim> create_initial_element(
     const std::vector<Block<VolumeDim>>& blocks,
     const std::vector<std::array<size_t, VolumeDim>>&
         initial_refinement_levels);
-}  // namespace Initialization
 }  // namespace domain

--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -61,10 +61,10 @@ double get_num_points_and_grid_spacing_cost(
     const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Spectral::Quadrature quadrature) {
-  Element<Dim> element = ::domain::Initialization::create_initial_element(
+  const Element<Dim> element = ::domain::create_initial_element(
       element_id, blocks, initial_refinement_levels);
-  const Mesh<Dim> mesh = ::domain::Initialization::create_initial_mesh(
-      initial_extents, element, quadrature);
+  const Mesh<Dim> mesh =
+      ::domain::create_initial_mesh(initial_extents, element, quadrature);
   const ElementMap<Dim, Frame::Grid> element_map{element_id,
                                                  blocks[element_id.block_id()]};
   const tnsr::I<DataVector, Dim, Frame::ElementLogical> logical_coords =

--- a/src/Domain/ElementDistribution.cpp
+++ b/src/Domain/ElementDistribution.cpp
@@ -24,6 +24,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Domain/Structure/ZCurve.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -60,11 +61,11 @@ double get_num_points_and_grid_spacing_cost(
     const ElementId<Dim>& element_id, const std::vector<Block<Dim>>& blocks,
     const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
     const std::vector<std::array<size_t, Dim>>& initial_extents,
-    const Spectral::Quadrature quadrature) {
+    const Spectral::Basis i1_basis, const Spectral::Quadrature i1_quadrature) {
   const Element<Dim> element = ::domain::create_initial_element(
       element_id, blocks, initial_refinement_levels);
-  const Mesh<Dim> mesh =
-      ::domain::create_initial_mesh(initial_extents, element, quadrature);
+  const Mesh<Dim> mesh = ::domain::create_initial_mesh(initial_extents, element,
+                                                       i1_basis, i1_quadrature);
   const ElementMap<Dim, Frame::Grid> element_map{element_id,
                                                  blocks[element_id.block_id()]};
   const tnsr::I<DataVector, Dim, Frame::ElementLogical> logical_coords =
@@ -97,7 +98,8 @@ std::unordered_map<ElementId<Dim>, double> get_element_costs(
     const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const ElementWeight element_weight,
-    const std::optional<Spectral::Quadrature>& quadrature) {
+    const std::optional<Spectral::Basis>& i1_basis,
+    const std::optional<Spectral::Quadrature>& i1_quadrature) {
   std::unordered_map<ElementId<Dim>, double> element_costs{};
 
   for (size_t block_number = 0; block_number < blocks.size(); block_number++) {
@@ -116,15 +118,16 @@ std::unordered_map<ElementId<Dim>, double> get_element_costs(
       } else {
         ASSERT(element_weight == ElementWeight::NumGridPointsAndGridSpacing,
                "Unknown element_weight");
-        ASSERT(quadrature.has_value(),
+        ASSERT(i1_basis.has_value() and i1_quadrature.has_value(),
                "Since element_weight is "
-               "ElementWeight::NumGridPointsAndGridSpacing, quadrature must "
-               "have a value");
+               "ElementWeight::NumGridPointsAndGridSpacing, i1_basis and "
+               "i1_quadrature must have values");
 
         element_costs.insert(
-            {element_id, get_num_points_and_grid_spacing_cost(
-                             element_id, blocks, initial_refinement_levels,
-                             initial_extents, quadrature.value())});
+            {element_id,
+             get_num_points_and_grid_spacing_cost(
+                 element_id, blocks, initial_refinement_levels, initial_extents,
+                 i1_basis.value(), i1_quadrature.value())});
       }
     }
   }
@@ -328,7 +331,7 @@ size_t BlockZCurveProcDistribution<Dim>::get_proc_for_element(
       const std::vector<std::array<size_t, GET_DIM(data)>>&                  \
           initial_refinement_levels,                                         \
       const std::vector<std::array<size_t, GET_DIM(data)>>& initial_extents, \
-      Spectral::Quadrature quadrature);                                      \
+      Spectral::Basis i1_basis, Spectral::Quadrature i1_quadrature);         \
   template std::unordered_map<ElementId<GET_DIM(data)>, double>              \
   get_element_costs(                                                         \
       const std::vector<Block<GET_DIM(data)>>& blocks,                       \
@@ -336,7 +339,8 @@ size_t BlockZCurveProcDistribution<Dim>::get_proc_for_element(
           initial_refinement_levels,                                         \
       const std::vector<std::array<size_t, GET_DIM(data)>>& initial_extents, \
       ElementWeight element_weight,                                          \
-      const std::optional<Spectral::Quadrature>& quadrature);
+      const std::optional<Spectral::Basis>& i1_basis,                        \
+      const std::optional<Spectral::Quadrature>& i1_quadrature);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Domain/ElementDistribution.hpp
+++ b/src/Domain/ElementDistribution.hpp
@@ -24,6 +24,7 @@ template <size_t Dim>
 class ElementId;
 
 namespace Spectral {
+enum class Basis : uint8_t;
 enum class Quadrature : uint8_t;
 }  // namespace Spectral
 /// \endcond
@@ -51,8 +52,8 @@ std::ostream& operator<<(std::ostream& os, ElementWeight weight);
 /// \brief Get the cost of each `Element` in a list of `Block`s where
 /// `element_weight` specifies which weight distribution scheme to use
 ///
-/// \details It is only necessary to pass in a value for `quadrature` if
-/// the value for `element_weight` is
+/// \details It is only necessary to pass in a value for `i1_basis` and
+/// `i1_quadrature` if the value for `element_weight` is
 /// `ElementWeight::NumGridPointsAndGridSpacing`. Otherwise, the argument isn't
 /// needed and will have no effect if it does have a value.
 template <size_t Dim>
@@ -61,7 +62,8 @@ std::unordered_map<ElementId<Dim>, double> get_element_costs(
     const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     ElementWeight element_weight,
-    const std::optional<Spectral::Quadrature>& quadrature);
+    const std::optional<Spectral::Basis>& i1_basis,
+    const std::optional<Spectral::Quadrature>& i1_quadrature);
 
 /*!
  * \brief Distribution strategy for assigning elements to CPUs using a

--- a/src/Domain/Structure/CreateInitialMesh.cpp
+++ b/src/Domain/Structure/CreateInitialMesh.cpp
@@ -41,6 +41,13 @@ std::array<Spectral::Basis, Dim> make_basis(
         [[fallthrough]];
       case (domain::Topology::B2Angular):
         return Spectral::Basis::ZernikeB2;
+      // NOLINTNEXTLINE(bugprone-branch-clone)
+      case (domain::Topology::B3Radial):
+        [[fallthrough]];
+      case (domain::Topology::B3Colatitude):
+        [[fallthrough]];
+      case (domain::Topology::B3Longitude):
+        return Spectral::Basis::ZernikeB3;
       default:
         ERROR("Invalid topology");
     }
@@ -66,11 +73,17 @@ std::array<Spectral::Quadrature, Dim> make_quadrature(
             [[fallthrough]];
           case (domain::Topology::S2Longitude):
             [[fallthrough]];
+          case (domain::Topology::B3Longitude):
+            [[fallthrough]];
           case (domain::Topology::B2Angular):
             return Spectral::Quadrature::Equiangular;
           case (domain::Topology::S2Colatitude):
+            [[fallthrough]];
+          case (domain::Topology::B3Colatitude):
             return Spectral::Quadrature::Gauss;
           case (domain::Topology::B2Radial):
+            [[fallthrough]];
+          case (domain::Topology::B3Radial):
             return Spectral::Quadrature::GaussRadauUpper;
           default:
             ERROR("Invalid topology");

--- a/src/Domain/Structure/CreateInitialMesh.cpp
+++ b/src/Domain/Structure/CreateInitialMesh.cpp
@@ -81,7 +81,7 @@ bool is_radially_refined_b2(const std::array<domain::Topology, Dim>& topologies,
 }
 }  // namespace
 
-namespace domain::Initialization {
+namespace domain {
 template <size_t Dim>
 Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
@@ -102,18 +102,16 @@ Mesh<Dim> create_initial_mesh(
   return {initial_extents[block.id()], make_basis(block.topologies()),
           make_quadrature(block.topologies(), legendre_quadrature)};
 }
-}  // namespace domain::Initialization
+}  // namespace domain
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                 \
-  template Mesh<DIM(data)>                                                   \
-  domain::Initialization::create_initial_mesh<DIM(data)>(                    \
+  template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(           \
       const std::vector<std::array<size_t, DIM(data)>>& initial_extents,     \
       const Element<DIM(data)>& element,                                     \
       const Spectral::Quadrature legendre_quadrature);                       \
-  template Mesh<DIM(data)>                                                   \
-  domain::Initialization::create_initial_mesh<DIM(data)>(                    \
+  template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(           \
       const std::vector<std::array<size_t, DIM(data)>>& initial_extents,     \
       const Block<DIM(data)>& block, const ElementId<DIM(data)>& element_id, \
       const Spectral::Quadrature legendre_quadrature);

--- a/src/Domain/Structure/CreateInitialMesh.cpp
+++ b/src/Domain/Structure/CreateInitialMesh.cpp
@@ -14,17 +14,23 @@
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 namespace {
 template <size_t Dim>
 std::array<Spectral::Basis, Dim> make_basis(
-    const std::array<domain::Topology, Dim>& topologies) {
-  const auto topology_to_basis = [](const domain::Topology topology) {
+    const std::array<domain::Topology, Dim>& topologies,
+    const Spectral::Basis i1_basis) {
+  const auto topology_to_basis = [&i1_basis](const domain::Topology topology) {
     switch (topology) {
-      case (domain::Topology::I1):
-        return Spectral::Basis::Legendre;
+      case (domain::Topology::I1): {
+        ASSERT(i1_basis == Spectral::Basis::Legendre or
+                   i1_basis == Spectral::Basis::Chebyshev,
+               "Invalid I1 Basis: " << i1_basis);
+        return i1_basis;
+      }
       case (domain::Topology::S1):
         return Spectral::Basis::Fourier;
       case (domain::Topology::S2Colatitude):
@@ -45,12 +51,16 @@ std::array<Spectral::Basis, Dim> make_basis(
 template <size_t Dim>
 std::array<Spectral::Quadrature, Dim> make_quadrature(
     const std::array<domain::Topology, Dim>& topologies,
-    const Spectral::Quadrature legendre_quadrature) {
+    const Spectral::Quadrature i1_quadrature) {
   const auto topology_to_quadrature =
-      [&legendre_quadrature](const domain::Topology topology) {
+      [&i1_quadrature](const domain::Topology topology) {
         switch (topology) {
-          case (domain::Topology::I1):
-            return legendre_quadrature;
+          case (domain::Topology::I1): {
+            ASSERT(i1_quadrature == Spectral::Quadrature::GaussLobatto or
+                       i1_quadrature == Spectral::Quadrature::Gauss,
+                   "Invalid I1 Quadrature: " << i1_quadrature);
+            return i1_quadrature;
+          }
           // NOLINTNEXTLINE(bugprone-branch-clone)
           case (domain::Topology::S1):
             [[fallthrough]];
@@ -85,22 +95,22 @@ namespace domain {
 template <size_t Dim>
 Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
-    const Element<Dim>& element,
-    const Spectral::Quadrature legendre_quadrature) {
+    const Element<Dim>& element, const Spectral::Basis i1_basis,
+    const Spectral::Quadrature i1_quadrature) {
   return {initial_extents[element.id().block_id()],
-          make_basis(element.topologies()),
-          make_quadrature(element.topologies(), legendre_quadrature)};
+          make_basis(element.topologies(), i1_basis),
+          make_quadrature(element.topologies(), i1_quadrature)};
 }
 
 template <size_t Dim>
 Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Block<Dim>& block, [[maybe_unused]] const ElementId<Dim>& element_id,
-    const Spectral::Quadrature legendre_quadrature) {
+    const Spectral::Basis i1_basis, const Spectral::Quadrature i1_quadrature) {
   ASSERT(not is_radially_refined_b2(block.topologies(), element_id),
          "Splitting Topology::B2Radial is not yet supported");
-  return {initial_extents[block.id()], make_basis(block.topologies()),
-          make_quadrature(block.topologies(), legendre_quadrature)};
+  return {initial_extents[block.id()], make_basis(block.topologies(), i1_basis),
+          make_quadrature(block.topologies(), i1_quadrature)};
 }
 }  // namespace domain
 
@@ -109,12 +119,12 @@ Mesh<Dim> create_initial_mesh(
 #define INSTANTIATE(_, data)                                                 \
   template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(           \
       const std::vector<std::array<size_t, DIM(data)>>& initial_extents,     \
-      const Element<DIM(data)>& element,                                     \
-      const Spectral::Quadrature legendre_quadrature);                       \
+      const Element<DIM(data)>& element, const Spectral::Basis i1_basis,     \
+      const Spectral::Quadrature i1_quadrature);                             \
   template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(           \
       const std::vector<std::array<size_t, DIM(data)>>& initial_extents,     \
       const Block<DIM(data)>& block, const ElementId<DIM(data)>& element_id, \
-      const Spectral::Quadrature legendre_quadrature);
+      const Spectral::Basis i1_basis, const Spectral::Quadrature _quadrature);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Domain/Structure/CreateInitialMesh.hpp
+++ b/src/Domain/Structure/CreateInitialMesh.hpp
@@ -22,7 +22,7 @@ enum class Quadrature : uint8_t;
 }  // namespace Spectral
 /// \endcond
 
-namespace domain::Initialization {
+namespace domain {
 /// \ingroup InitializationGroup
 /// \brief Construct the initial Mesh of an Element.
 ///
@@ -51,4 +51,4 @@ Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Block<Dim>& block, const ElementId<Dim>& element_id,
     Spectral::Quadrature legendre_quadrature);
-}  // namespace domain::Initialization
+}  // namespace domain

--- a/src/Domain/Structure/CreateInitialMesh.hpp
+++ b/src/Domain/Structure/CreateInitialMesh.hpp
@@ -18,6 +18,7 @@ struct ElementId;
 template <size_t Dim>
 class Mesh;
 namespace Spectral {
+enum class Basis : uint8_t;
 enum class Quadrature : uint8_t;
 }  // namespace Spectral
 /// \endcond
@@ -29,12 +30,14 @@ namespace domain {
 /// \param initial_extents initial extents for Elements in each Block of the
 ///        Domain
 /// \param element Element
-/// \param legendre_quadrature the quadrature rule/grid point distribution for
-///        dimensions that use Spectral::Basis::Legendre
+/// \param i1_basis the Spectral::Basis used for dimensions with Topology::I1
+/// \param i1_quadrature the Spectral::Quadrature for dimensions with
+///        Topology::I1
 template <size_t Dim>
 Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
-    const Element<Dim>& element, Spectral::Quadrature legendre_quadrature);
+    const Element<Dim>& element, Spectral::Basis i1_basis,
+    Spectral::Quadrature i1_quadrature);
 
 /// \ingroup InitializationGroup
 /// \brief Construct the initial Mesh of an Element from its Block and
@@ -44,11 +47,12 @@ Mesh<Dim> create_initial_mesh(
 ///        Domain
 /// \param block the Block of the Element
 /// \param element_id the ElementId of the Element
-/// \param legendre_quadrature the quadrature rule/grid point distribution for
-///        dimensions that use Spectral::Basis::Legendre
+/// \param i1_basis the Spectral::Basis used for dimensions with Topology::I1
+/// \param i1_quadrature the Spectral::Quadrature for dimensions with
+///        Topology::I1
 template <size_t Dim>
 Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Block<Dim>& block, const ElementId<Dim>& element_id,
-    Spectral::Quadrature legendre_quadrature);
+    Spectral::Basis i1_basis, Spectral::Quadrature i1_quadrature);
 }  // namespace domain

--- a/src/Domain/Structure/HasBoundary.cpp
+++ b/src/Domain/Structure/HasBoundary.cpp
@@ -9,6 +9,7 @@
 namespace domain {
 bool has_boundary(const domain::Topology topology, const Side side) {
   return topology == Topology::I1 or
-         (topology == Topology::B2Radial and side == Side::Upper);
+         (side == Side::Upper and
+          (topology == Topology::B2Radial or topology == Topology::B3Radial));
 }
 }  // namespace domain

--- a/src/Domain/Structure/NeighborIsConforming.cpp
+++ b/src/Domain/Structure/NeighborIsConforming.cpp
@@ -31,6 +31,16 @@ std::array<domain::Topology, VolumeDim - 1> boundary_topologies(
       }
     }
   }
+  if (gsl::at(topologies, dim) == domain::Topology::B3Radial) {
+    for (size_t d = 0; d < VolumeDim - 1; ++d) {
+      if (gsl::at(result, d) == domain::Topology::B3Colatitude) {
+        gsl::at(result, d) = domain::Topology::S2Colatitude;
+      }
+      if (gsl::at(result, d) == domain::Topology::B3Longitude) {
+        gsl::at(result, d) = domain::Topology::S2Longitude;
+      }
+    }
+  }
   return result;
 }
 }  // namespace

--- a/src/Domain/Structure/Topology.cpp
+++ b/src/Domain/Structure/Topology.cpp
@@ -24,6 +24,12 @@ std::ostream& operator<<(std::ostream& os, const Topology topology) {
       return os << "B2Radial";
     case Topology::B2Angular:
       return os << "B2Angular";
+    case Topology::B3Radial:
+      return os << "B3Radial";
+    case Topology::B3Colatitude:
+      return os << "B3Colatitude";
+    case Topology::B3Longitude:
+      return os << "B3Longitude";
     default:  // LCOV_EXCL_LINE
       // LCOV_EXCL_START
       ERROR("An unknown value of Topology was passed to the stream operator.");

--- a/src/Domain/Structure/Topology.hpp
+++ b/src/Domain/Structure/Topology.hpp
@@ -33,6 +33,9 @@ namespace domain {
 /// \note In consecutive dimensions, choose B2Radial and B2Angular to represent
 /// a disk (including the center) or cross-section of a cylinder
 ///
+/// \note In consecutive dimensions, choose B3Radial, B3Colatitude and
+/// B3Longitude to represent a sphere
+///
 /// \note Currently h-refinement can only be done in dimensions with
 /// Topology::I1
 ///
@@ -45,7 +48,10 @@ enum class Topology : uint8_t {
   S2Colatitude = 3,
   S2Longitude = 4,
   B2Radial = 5,
-  B2Angular = 6
+  B2Angular = 6,
+  B3Radial = 7,
+  B3Colatitude = 8,
+  B3Longitude = 9
 };
 
 /// Output operator for a Topology.
@@ -68,6 +74,9 @@ static constexpr auto cylindrical_shell =
 
 static constexpr auto full_cylinder =
     std::array{Topology::B2Radial, Topology::B2Angular, Topology::I1};
+
+static constexpr auto full_sphere = std::array{
+    Topology::B3Radial, Topology::B3Colatitude, Topology::B3Longitude};
 }  // namespace topologies
 
 }  // namespace domain

--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -24,6 +24,8 @@
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/ElementDistribution.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Parallel/Algorithms/AlgorithmArray.hpp"
 #include "Parallel/DomainDiagnosticInfo.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -77,6 +79,7 @@ struct DefaultElementsAllocator
         Parallel::get_parallel_component<ParallelComponent>(local_cache);
     const auto& initial_extents =
         get<domain::Tags::InitialExtents<Dim>>(initialization_items);
+    const auto basis = Spectral::Basis::Legendre;
     const auto& quadrature =
         Parallel::get<elliptic::dg::Tags::Quadrature>(local_cache);
 
@@ -100,7 +103,7 @@ struct DefaultElementsAllocator
       const std::unordered_map<ElementId<Dim>, double> element_costs =
           domain::get_element_costs(blocks, initial_refinement_levels,
                                     initial_extents, element_weight.value(),
-                                    quadrature);
+                                    basis, quadrature);
       element_distribution = domain::BlockZCurveProcDistribution<Dim>{
           element_costs,   num_of_procs_to_use,
           blocks,          initial_refinement_levels,

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -25,6 +25,7 @@
 #include "Domain/Structure/IndexToSliceAt.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -96,17 +97,20 @@ void InitializeGeometry<Dim>::apply(
     const std::vector<std::array<size_t, Dim>>& initial_refinement,
     const Domain<Dim>& domain,
     const domain::FunctionsOfTimeMap& functions_of_time,
-    const Spectral::Quadrature quadrature, const ElementId<Dim>& element_id) {
-  // Mesh
-  ASSERT(quadrature == Spectral::Quadrature::GaussLobatto or
-             quadrature == Spectral::Quadrature::Gauss,
-         "The elliptic DG scheme supports Gauss and Gauss-Lobatto "
-         "grids, but the chosen quadrature is: "
-             << quadrature);
+    const Spectral::Quadrature i1_quadrature,
+    const ElementId<Dim>& element_id) {
   // Element
   *element = domain::create_initial_element(element_id, domain.blocks(),
                                             initial_refinement);
-  *mesh = domain::create_initial_mesh(initial_extents, *element, quadrature);
+  // Mesh
+  const Spectral::Basis i1_basis{Spectral::Basis::Legendre};
+  ASSERT(i1_quadrature == Spectral::Quadrature::GaussLobatto or
+             i1_quadrature == Spectral::Quadrature::Gauss,
+         "The elliptic DG scheme supports Gauss and Gauss-Lobatto "
+         "grids, but the chosen quadrature is: "
+             << i1_quadrature);
+  *mesh = domain::create_initial_mesh(initial_extents, *element, i1_basis,
+                                      i1_quadrature);
   // Neighbor meshes
   for (const auto& [direction, neighbors] : element->neighbors()) {
     for (const auto& neighbor_id : neighbors) {
@@ -115,7 +119,8 @@ void InitializeGeometry<Dim>::apply(
       neighbor_meshes->emplace(
           DirectionalId<Dim>{direction, neighbor_id},
           orientation.inverse_map()(domain::create_initial_mesh(
-              initial_extents, neighbor_block, neighbor_id, quadrature)));
+              initial_extents, neighbor_block, neighbor_id, i1_basis,
+              i1_quadrature)));
     }
   }
   // Element map

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -104,10 +104,9 @@ void InitializeGeometry<Dim>::apply(
          "grids, but the chosen quadrature is: "
              << quadrature);
   // Element
-  *element = domain::Initialization::create_initial_element(
-      element_id, domain.blocks(), initial_refinement);
-  *mesh = domain::Initialization::create_initial_mesh(initial_extents, *element,
-                                                      quadrature);
+  *element = domain::create_initial_element(element_id, domain.blocks(),
+                                            initial_refinement);
+  *mesh = domain::create_initial_mesh(initial_extents, *element, quadrature);
   // Neighbor meshes
   for (const auto& [direction, neighbors] : element->neighbors()) {
     for (const auto& neighbor_id : neighbors) {
@@ -115,7 +114,7 @@ void InitializeGeometry<Dim>::apply(
       const auto& orientation = neighbors.orientation(neighbor_id);
       neighbor_meshes->emplace(
           DirectionalId<Dim>{direction, neighbor_id},
-          orientation.inverse_map()(domain::Initialization::create_initial_mesh(
+          orientation.inverse_map()(domain::create_initial_mesh(
               initial_extents, neighbor_block, neighbor_id, quadrature)));
     }
   }

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
@@ -126,7 +126,7 @@ struct InitializeGeometry {
       const std::vector<std::array<size_t, Dim>>& initial_refinement,
       const Domain<Dim>& domain,
       const domain::FunctionsOfTimeMap& functions_of_time,
-      Spectral::Quadrature quadrature, const ElementId<Dim>& element_id);
+      Spectral::Quadrature i1_quadrature, const ElementId<Dim>& element_id);
 };
 
 template <size_t Dim>

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -21,6 +21,8 @@
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Domain/Tags/ElementDistribution.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Parallel/Algorithms/AlgorithmArray.hpp"
 #include "Parallel/ArrayCollection/CreateElementsUsingDistribution.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -119,7 +121,8 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
           initialization_items);
   const auto& initial_extents =
       get<domain::Tags::InitialExtents<volume_dim>>(initialization_items);
-  const auto& quadrature =
+  const auto i1_basis = Spectral::Basis::Legendre;
+  const auto& i1_quadrature =
       get<evolution::dg::Tags::Quadrature>(initialization_items);
   const std::optional<domain::ElementWeight>& element_weight =
       Parallel::get<domain::Tags::ElementDistribution>(local_cache);
@@ -138,7 +141,7 @@ void DgElementArray<Metavariables, PhaseDepActionList>::allocate_array(
             .insert(global_cache, initialization_items, target_proc);
       },
       element_weight, blocks, initial_extents, initial_refinement_levels,
-      quadrature,
+      i1_basis, i1_quadrature,
 
       procs_to_ignore, number_of_procs, number_of_nodes, num_of_procs_to_use,
       local_cache, true);

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -34,6 +34,7 @@
 #include "Domain/TagsTimeDependent.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/TagsDomain.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -146,12 +147,13 @@ struct Domain {
       const ::Domain<dim>& domain,
       const std::vector<std::array<size_t, dim>>& initial_extents,
       const std::vector<std::array<size_t, dim>>& initial_refinement,
-      const Spectral::Quadrature& quadrature,
+      const Spectral::Quadrature& i1_quadrature,
       const ElementId<dim>& element_id) {
     *element = ::domain::create_initial_element(element_id, domain.blocks(),
                                                 initial_refinement);
-    *mesh =
-        ::domain::create_initial_mesh(initial_extents, *element, quadrature);
+    const Spectral::Basis i1_basis{Spectral::Basis::Legendre};
+    *mesh = ::domain::create_initial_mesh(initial_extents, *element, i1_basis,
+                                          i1_quadrature);
     const auto& my_block = domain.blocks()[element_id.block_id()];
     *element_map = ElementMap<dim, Frame::Grid>{element_id, my_block};
 
@@ -171,7 +173,8 @@ struct Domain {
         neighbor_mesh->emplace(
             DirectionalId{direction, neighbor},
             neighbor_orientation.inverse_map()(::domain::create_initial_mesh(
-                initial_extents, neighbor_block, neighbor, quadrature)));
+                initial_extents, neighbor_block, neighbor, i1_basis,
+                i1_quadrature)));
       }
     }
   }

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -148,10 +148,10 @@ struct Domain {
       const std::vector<std::array<size_t, dim>>& initial_refinement,
       const Spectral::Quadrature& quadrature,
       const ElementId<dim>& element_id) {
-    *element = ::domain::Initialization::create_initial_element(
-        element_id, domain.blocks(), initial_refinement);
-    *mesh = ::domain::Initialization::create_initial_mesh(initial_extents,
-                                                          *element, quadrature);
+    *element = ::domain::create_initial_element(element_id, domain.blocks(),
+                                                initial_refinement);
+    *mesh =
+        ::domain::create_initial_mesh(initial_extents, *element, quadrature);
     const auto& my_block = domain.blocks()[element_id.block_id()];
     *element_map = ElementMap<dim, Frame::Grid>{element_id, my_block};
 
@@ -170,9 +170,8 @@ struct Domain {
         const auto& neighbor_orientation = neighbors.orientation(neighbor);
         neighbor_mesh->emplace(
             DirectionalId{direction, neighbor},
-            neighbor_orientation.inverse_map()(
-                ::domain::Initialization::create_initial_mesh(
-                    initial_extents, neighbor_block, neighbor, quadrature)));
+            neighbor_orientation.inverse_map()(::domain::create_initial_mesh(
+                initial_extents, neighbor_block, neighbor, quadrature)));
       }
     }
   }

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp
@@ -83,7 +83,7 @@ struct InitializeElementFacesGridCoordinates {
         const auto direction = excision_sphere.abutting_direction(element_id);
         if (direction.has_value()) {
           const auto& current_block = blocks.at(block_id);
-          const auto mesh = ::domain::Initialization::create_initial_mesh(
+          const auto mesh = ::domain::create_initial_mesh(
               initial_extents, current_block, element_id, quadrature);
           const auto face_mesh = mesh.slice_away(direction.value().dimension());
           const ElementMap<Dim, Frame::Grid> element_map{

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/InitializeElementFacesGridCoordinates.hpp
@@ -23,6 +23,7 @@
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Gsl.hpp"
@@ -71,8 +72,9 @@ struct InitializeElementFacesGridCoordinates {
           element_faces_grid_coords,
       const std::vector<std::array<size_t, Dim>>& initial_extents,
       const std::vector<std::array<size_t, Dim>>& initial_refinement,
-      const Spectral::Quadrature& quadrature, const Domain<Dim>& domain,
+      const Spectral::Quadrature& i1_quadrature, const Domain<Dim>& domain,
       const ::ExcisionSphere<Dim>& excision_sphere) {
+    const Spectral::Basis i1_basis{Spectral::Basis::Legendre};
     const auto& blocks = domain.blocks();
     const auto& worldtube_grid_coords = excision_sphere.center();
     const auto& neighboring_blocks = excision_sphere.abutting_directions();
@@ -84,7 +86,8 @@ struct InitializeElementFacesGridCoordinates {
         if (direction.has_value()) {
           const auto& current_block = blocks.at(block_id);
           const auto mesh = ::domain::create_initial_mesh(
-              initial_extents, current_block, element_id, quadrature);
+              initial_extents, current_block, element_id, i1_basis,
+              i1_quadrature);
           const auto face_mesh = mesh.slice_away(direction.value().dimension());
           const ElementMap<Dim, Frame::Grid> element_map{
               element_id,

--- a/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
+++ b/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
@@ -19,6 +19,7 @@
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/NeighborMesh.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Parallel/Tags/ArrayIndex.hpp"
 #include "Utilities/Gsl.hpp"
@@ -61,12 +62,13 @@ struct Domain {
       const gsl::not_null<Element<Dim>*> element, const ::Domain<Dim>& domain,
       const std::vector<std::array<size_t, Dim>>& initial_extents,
       const std::vector<std::array<size_t, Dim>>& initial_refinement,
-      const Spectral::Quadrature& quadrature,
+      const Spectral::Quadrature& i1_quadrature,
       const ElementId<Dim>& element_id) {
     *element = ::domain::create_initial_element(element_id, domain.blocks(),
                                                 initial_refinement);
-    *mesh =
-        ::domain::create_initial_mesh(initial_extents, *element, quadrature);
+    const Spectral::Basis i1_basis{Spectral::Basis::Legendre};
+    *mesh = ::domain::create_initial_mesh(initial_extents, *element, i1_basis,
+                                          i1_quadrature);
   }
 };
 }  // namespace amr::Initialization

--- a/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
+++ b/src/Executables/Examples/RandomAmr/InitializeDomain.hpp
@@ -63,10 +63,10 @@ struct Domain {
       const std::vector<std::array<size_t, Dim>>& initial_refinement,
       const Spectral::Quadrature& quadrature,
       const ElementId<Dim>& element_id) {
-    *element = ::domain::Initialization::create_initial_element(
-        element_id, domain.blocks(), initial_refinement);
-    *mesh = ::domain::Initialization::create_initial_mesh(initial_extents,
-                                                          *element, quadrature);
+    *element = ::domain::create_initial_element(element_id, domain.blocks(),
+                                                initial_refinement);
+    *mesh =
+        ::domain::create_initial_mesh(initial_extents, *element, quadrature);
   }
 };
 }  // namespace amr::Initialization

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -54,8 +54,7 @@ using MortarMap = DirectionalIdMap<VolumeDim, ValueType>;
 ///
 /// \warning Make sure the two face meshes are oriented the same, i.e.
 /// their dimensions align. This is facilitated by the `orientation`
-/// passed to `domain::Initialization::create_initial_mesh`, for
-/// example.
+/// passed to `domain::create_initial_mesh`, for example.
 template <size_t Dim>
 Mesh<Dim> mortar_mesh(const Mesh<Dim>& face_mesh1, const Mesh<Dim>& face_mesh2);
 

--- a/src/NumericalAlgorithms/Spectral/Quadrature.hpp
+++ b/src/NumericalAlgorithms/Spectral/Quadrature.hpp
@@ -52,7 +52,7 @@ namespace Spectral {
  *
  * \note When using Basis::ZernikeB3 in consecutive dimensions, choose
  * `GaussRadauUpper` for the first dimension, `Gauss` for the second dimension,
- * and `Equiangular` in the second dimension.
+ * and `Equiangular` in the third dimension.
  *
  * \remark We store these effectively as a 4-bit integer using the lowest 4
  * bits of a uint8_t. Unlike Basis, this does not need a bitshift. We cannot

--- a/src/Parallel/ArrayCollection/CreateElementCollection.hpp
+++ b/src/Parallel/ArrayCollection/CreateElementCollection.hpp
@@ -19,6 +19,8 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags/ElementDistribution.hpp"
 #include "Evolution/DiscontinuousGalerkin/Initialization/QuadratureTag.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/ArrayCollection/CreateElementsUsingDistribution.hpp"
 #include "Parallel/ArrayCollection/SpawnInitializeElementsInCollection.hpp"
@@ -94,7 +96,8 @@ struct CreateElementCollection {
     const auto& initial_refinement_levels =
         get<domain::Tags::InitialRefinementLevels<Dim>>(box);
     const auto& initial_extents = get<domain::Tags::InitialExtents<Dim>>(box);
-    const auto& quadrature = get<evolution::dg::Tags::Quadrature>(box);
+    const auto i1_basis = Spectral::Basis::Legendre;
+    const auto& i1_quadrature = get<evolution::dg::Tags::Quadrature>(box);
     const std::optional<domain::ElementWeight>& element_weight =
         Parallel::get<domain::Tags::ElementDistribution>(local_cache);
 
@@ -131,7 +134,7 @@ struct CreateElementCollection {
           }
         },
         element_weight, blocks, initial_extents, initial_refinement_levels,
-        quadrature,
+        i1_basis, i1_quadrature,
         // The below arguments control how the elements are mapped to the
         // hardware.
         procs_to_ignore, number_of_procs, number_of_nodes, num_of_procs_to_use,

--- a/src/Parallel/ArrayCollection/CreateElementsUsingDistribution.hpp
+++ b/src/Parallel/ArrayCollection/CreateElementsUsingDistribution.hpp
@@ -18,6 +18,13 @@
 #include "Parallel/GlobalCache.hpp"
 #include "Utilities/Numeric.hpp"
 
+/// \cond
+namespace Spectral {
+enum class Basis : uint8_t;
+enum class Quadrature : uint8_t;
+}  // namespace Spectral
+/// \endcond
+
 namespace Parallel {
 /*!
  * \brief Creates elements using a chosen distribution.
@@ -32,7 +39,7 @@ void create_elements_using_distribution(
     const std::vector<Block<Dim>>& blocks,
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const std::vector<std::array<size_t, Dim>>& initial_refinement_levels,
-    const Spectral::Quadrature quadrature,
+    const Spectral::Basis i1_basis, const Spectral::Quadrature i1_quadrature,
 
     const std::unordered_set<size_t>& procs_to_ignore,
     const size_t number_of_procs, const size_t number_of_nodes,
@@ -47,7 +54,7 @@ void create_elements_using_distribution(
     const std::unordered_map<ElementId<Dim>, double> element_costs =
         domain::get_element_costs(blocks, initial_refinement_levels,
                                   initial_extents, element_weight.value(),
-                                  quadrature);
+                                  i1_basis, i1_quadrature);
     element_distribution = domain::BlockZCurveProcDistribution<Dim>{
         element_costs,   num_of_procs_to_use, blocks, initial_refinement_levels,
         initial_extents, procs_to_ignore};

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
@@ -52,11 +52,11 @@ namespace LinearSolver::multigrid {
  * Array elements are created for all element IDs on all grids, meaning they all
  * share the same parallel component, action list etc. Elements are connected to
  * their neighbors _on the same grid_ by the
- * `domain::Initialization::create_initial_element` function (this is
- * independent of the multigrid code, the function is typically called in an
- * initialization action). Elements are connected to their parent and children
- * _across grids_ by the multigrid-tags set here and in the multigrid
- * initialization actions (see `LinearSolver::multigrid::parent_id` and
+ * `domain::create_initial_element` function (this is independent of the
+ * multigrid code, the function is typically called in an initialization
+ * action). Elements are connected to their parent and children _across grids_
+ * by the multigrid-tags set here and in the multigrid initialization actions
+ * (see `LinearSolver::multigrid::parent_id` and
  * `LinearSolver::multigrid::child_ids`).
  *
  * This allocator also creates two sets of sections (see `Parallel::Section`):

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp
@@ -19,6 +19,7 @@
 #include "Domain/Tags/ElementDistribution.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Local.hpp"
 #include "Parallel/Printf/Printf.hpp"
@@ -110,6 +111,7 @@ struct ElementsAllocator
         get<Tags::ChildrenRefinementLevels<Dim>>(initialization_items);
     auto& parent_refinement_levels =
         get<Tags::ParentRefinementLevels<Dim>>(initialization_items);
+    const auto basis = Spectral::Basis::Legendre;
     const auto& quadrature =
         Parallel::get<elliptic::dg::Tags::Quadrature>(local_cache);
     const std::optional<domain::ElementWeight>& element_weight =
@@ -186,7 +188,7 @@ struct ElementsAllocator
         const std::unordered_map<ElementId<Dim>, double> element_costs =
             domain::get_element_costs(blocks, initial_refinement_levels,
                                       initial_extents, element_weight.value(),
-                                      quadrature);
+                                      basis, quadrature);
         const domain::BlockZCurveProcDistribution<Dim> element_distribution{
             element_costs,   num_of_procs_to_use,
             blocks,          initial_refinement_levels,

--- a/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
+++ b/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
@@ -28,31 +28,50 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
     const Element<1> interval(element_id_1d, {});
     const Element<2> rectangle(element_id_2d, {});
     const Element<3> brick(element_id_3d, {});
-    for (const auto& quadrature :
-         {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      CHECK(create_initial_mesh({{{3}}}, interval, quadrature) ==
-            Mesh<1>{3, Spectral::Basis::Legendre, quadrature});
-      CHECK(create_initial_mesh({{{3, 2}}}, rectangle, quadrature) ==
-            Mesh<2>{{{3, 2}}, Spectral::Basis::Legendre, quadrature});
-      CHECK(create_initial_mesh({{{3, 2, 4}}}, brick, quadrature) ==
-            Mesh<3>{{{3, 2, 4}}, Spectral::Basis::Legendre, quadrature});
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(create_initial_mesh({{{3}}}, interval, i1_basis, i1_quadrature) ==
+              Mesh<1>{3, i1_basis, i1_quadrature});
+        CHECK(create_initial_mesh({{{3, 2}}}, rectangle, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<2>{{{3, 2}}, i1_basis, i1_quadrature});
+        CHECK(create_initial_mesh({{{3, 2, 4}}}, brick, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<3>{{{3, 2, 4}}, i1_basis, i1_quadrature});
+      }
     }
+#ifdef SPECTRE_DEBUG
+    CHECK_THROWS_WITH(
+        create_initial_mesh({{{3}}}, interval, Spectral::Basis::Fourier,
+                            Spectral::Quadrature::Gauss),
+        Catch::Matchers::ContainsSubstring("Invalid I1 Basis"));
+    CHECK_THROWS_WITH(
+        create_initial_mesh({{{3}}}, interval, Spectral::Basis::Legendre,
+                            Spectral::Quadrature::Equiangular),
+        Catch::Matchers::ContainsSubstring("Invalid I1 Quadrature"));
+#endif  // SPECTRE_DEBUG
   }
   {
     INFO("From Block and ElementId");
     const Block<1> interval(nullptr, 0, {});
     const Block<2> rectangle(nullptr, 0, {});
     const Block<3> brick(nullptr, 0, {});
-    for (const auto& quadrature :
-         {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      CHECK(create_initial_mesh({{{3}}}, interval, element_id_1d, quadrature) ==
-            Mesh<1>{3, Spectral::Basis::Legendre, quadrature});
-      CHECK(create_initial_mesh({{{3, 2}}}, rectangle, element_id_2d,
-                                quadrature) ==
-            Mesh<2>{{{3, 2}}, Spectral::Basis::Legendre, quadrature});
-      CHECK(create_initial_mesh({{{3, 2, 4}}}, brick, element_id_3d,
-                                quadrature) ==
-            Mesh<3>{{{3, 2, 4}}, Spectral::Basis::Legendre, quadrature});
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(create_initial_mesh({{{3}}}, interval, element_id_1d, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<1>{3, i1_basis, i1_quadrature});
+        CHECK(create_initial_mesh({{{3, 2}}}, rectangle, element_id_2d,
+                                  i1_basis, i1_quadrature) ==
+              Mesh<2>{{{3, 2}}, i1_basis, i1_quadrature});
+        CHECK(create_initial_mesh({{{3, 2, 4}}}, brick, element_id_3d, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<3>{{{3, 2, 4}}, i1_basis, i1_quadrature});
+      }
     }
   }
   {
@@ -60,76 +79,90 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
     const Element<1> interval(ElementId<1>{1}, {});
     const Element<2> rectangle(ElementId<2>{1}, {});
     const Element<3> brick(ElementId<3>{1}, {});
-    for (const auto& quadrature :
-         {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      CHECK(create_initial_mesh({{{3}}, {{2}}}, interval, quadrature) ==
-            Mesh<1>{2, Spectral::Basis::Legendre, quadrature});
-      CHECK(create_initial_mesh({{{3, 3}}, {{2, 2}}}, rectangle, quadrature) ==
-            Mesh<2>{2, Spectral::Basis::Legendre, quadrature});
-      CHECK(
-          create_initial_mesh({{{3, 3, 3}}, {{2, 2, 2}}}, brick, quadrature) ==
-          Mesh<3>{2, Spectral::Basis::Legendre, quadrature});
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(create_initial_mesh({{{3}}, {{2}}}, interval, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<1>{2, i1_basis, i1_quadrature});
+        CHECK(create_initial_mesh({{{3, 3}}, {{2, 2}}}, rectangle, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<2>{2, i1_basis, i1_quadrature});
+        CHECK(create_initial_mesh({{{3, 3, 3}}, {{2, 2, 2}}}, brick, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<3>{2, i1_basis, i1_quadrature});
+      }
     }
   }
   {
     INFO("annulus");
     const Element<2> annulus(element_id_2d, {}, domain::topologies::annulus);
-    for (const auto& legendre_quadrature :
-         {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      CHECK(create_initial_mesh({{{3, 4}}}, annulus, legendre_quadrature) ==
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(
+            create_initial_mesh({{{3, 4}}}, annulus, i1_basis, i1_quadrature) ==
             Mesh<2>{
                 {{3, 4}},
-                std::array{Spectral::Basis::Legendre, Spectral::Basis::Fourier},
-                std::array{legendre_quadrature,
-                           Spectral::Quadrature::Equiangular}});
+                std::array{i1_basis, Spectral::Basis::Fourier},
+                std::array{i1_quadrature, Spectral::Quadrature::Equiangular}});
+      }
     }
   }
   {
     INFO("disk");
     const Block<2> disk(nullptr, 0, {}, "", domain::topologies::disk);
-    for (const auto& legendre_quadrature :
-         {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      CHECK(create_initial_mesh({{{3, 4}}}, disk, element_id_2d,
-                                legendre_quadrature) ==
-            Mesh<2>{{{3, 4}},
-                    std::array{Spectral::Basis::ZernikeB2,
-                               Spectral::Basis::ZernikeB2},
-                    std::array{Spectral::Quadrature::GaussRadauUpper,
-                               Spectral::Quadrature::Equiangular}});
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(create_initial_mesh({{{3, 4}}}, disk, element_id_2d, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<2>{{{3, 4}},
+                      std::array{Spectral::Basis::ZernikeB2,
+                                 Spectral::Basis::ZernikeB2},
+                      std::array{Spectral::Quadrature::GaussRadauUpper,
+                                 Spectral::Quadrature::Equiangular}});
+      }
     }
   }
   {
     INFO("cylindrical_shell");
     const Element<3> cylindrical_shell(element_id_3d, {},
                                        domain::topologies::cylindrical_shell);
-    for (const auto& legendre_quadrature :
-         {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      CHECK(
-          create_initial_mesh({{{3, 2, 4}}}, cylindrical_shell,
-                              legendre_quadrature) ==
-          Mesh<3>{
-              {{3, 2, 4}},
-              std::array{Spectral::Basis::Legendre, Spectral::Basis::Fourier,
-                         Spectral::Basis::Legendre},
-              std::array{legendre_quadrature, Spectral::Quadrature::Equiangular,
-                         legendre_quadrature}});
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(
+            create_initial_mesh({{{3, 2, 4}}}, cylindrical_shell, i1_basis,
+                                i1_quadrature) ==
+            Mesh<3>{{{3, 2, 4}},
+                    std::array{i1_basis, Spectral::Basis::Fourier, i1_basis},
+                    std::array{i1_quadrature, Spectral::Quadrature::Equiangular,
+                               i1_quadrature}});
+      }
     }
   }
   {
     INFO("full_cylinder");
     const Block<3> full_cylinder(nullptr, 0, {}, "",
                                  domain::topologies::full_cylinder);
-    for (const auto& legendre_quadrature :
-         {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-      CHECK(create_initial_mesh({{{3, 2, 4}}}, full_cylinder, element_id_3d,
-                                legendre_quadrature) ==
-            Mesh<3>{{{3, 2, 4}},
-                    std::array{Spectral::Basis::ZernikeB2,
-                               Spectral::Basis::ZernikeB2,
-                               Spectral::Basis::Legendre},
-                    std::array{Spectral::Quadrature::GaussRadauUpper,
-                               Spectral::Quadrature::Equiangular,
-                               legendre_quadrature}});
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(create_initial_mesh({{{3, 2, 4}}}, full_cylinder, element_id_3d,
+                                  i1_basis, i1_quadrature) ==
+              Mesh<3>{{{3, 2, 4}},
+                      std::array{Spectral::Basis::ZernikeB2,
+                                 Spectral::Basis::ZernikeB2, i1_basis},
+                      std::array{Spectral::Quadrature::GaussRadauUpper,
+                                 Spectral::Quadrature::Equiangular,
+                                 i1_quadrature}});
+      }
     }
   }
 #ifdef SPECTRE_DEBUG
@@ -137,7 +170,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
       create_initial_mesh(
           {{{3, 4}}}, Block<2>{nullptr, 0, {}, "", domain::topologies::disk},
           ElementId<2>{0, {{SegmentId{1, 0}, SegmentId{0, 0}}}},
-          Spectral::Quadrature::GaussLobatto),
+          Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto),
       Catch::Matchers::ContainsSubstring(
           "Splitting Topology::B2Radial is not yet supported"));
 #endif  // SPECTRE_DEBUG

--- a/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
+++ b/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
@@ -17,7 +17,7 @@
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/MakeArray.hpp"
 
-namespace domain::Initialization {
+namespace domain {
 
 SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
   const ElementId<1> element_id_1d{0};
@@ -142,4 +142,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
           "Splitting Topology::B2Radial is not yet supported"));
 #endif  // SPECTRE_DEBUG
 }
-}  // namespace domain::Initialization
+}  // namespace domain

--- a/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
+++ b/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
@@ -165,6 +165,44 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
       }
     }
   }
+  {
+    INFO("spheriical_shell");
+    const Element<3> spherical_shell(element_id_3d, {},
+                                     domain::topologies::spherical_shell);
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(create_initial_mesh({{{3, 2, 4}}}, spherical_shell, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<3>{{{3, 2, 4}},
+                      std::array{i1_basis, Spectral::Basis::SphericalHarmonic,
+                                 Spectral::Basis::SphericalHarmonic},
+                      std::array{i1_quadrature, Spectral::Quadrature::Gauss,
+                                 Spectral::Quadrature::Equiangular}});
+      }
+    }
+  }
+  {
+    INFO("full_sphere");
+    const Block<3> full_sphere(nullptr, 0, {}, "",
+                               domain::topologies::full_sphere);
+    for (const auto& i1_basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      for (const auto& i1_quadrature :
+           {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
+        CHECK(create_initial_mesh({{{3, 2, 4}}}, full_sphere, element_id_3d,
+                                  i1_basis, i1_quadrature) ==
+              Mesh<3>{{{3, 2, 4}},
+                      std::array{Spectral::Basis::ZernikeB3,
+                                 Spectral::Basis::ZernikeB3,
+                                 Spectral::Basis::ZernikeB3},
+                      std::array{Spectral::Quadrature::GaussRadauUpper,
+                                 Spectral::Quadrature::Gauss,
+                                 Spectral::Quadrature::Equiangular}});
+      }
+    }
+  }
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       create_initial_mesh(

--- a/tests/Unit/Domain/Structure/Test_HasBoundary.cpp
+++ b/tests/Unit/Domain/Structure/Test_HasBoundary.cpp
@@ -15,9 +15,13 @@ void test() {
     CHECK_FALSE(domain::has_boundary(domain::Topology::S2Colatitude, side));
     CHECK_FALSE(domain::has_boundary(domain::Topology::S2Longitude, side));
     CHECK_FALSE(domain::has_boundary(domain::Topology::B2Angular, side));
+    CHECK_FALSE(domain::has_boundary(domain::Topology::B3Colatitude, side));
+    CHECK_FALSE(domain::has_boundary(domain::Topology::B3Longitude, side));
   }
   CHECK_FALSE(domain::has_boundary(domain::Topology::B2Radial, Side::Lower));
   CHECK(domain::has_boundary(domain::Topology::B2Radial, Side::Upper));
+  CHECK_FALSE(domain::has_boundary(domain::Topology::B3Radial, Side::Lower));
+  CHECK(domain::has_boundary(domain::Topology::B3Radial, Side::Upper));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Structure/Test_NeighborIsConforming.cpp
+++ b/tests/Unit/Domain/Structure/Test_NeighborIsConforming.cpp
@@ -72,6 +72,12 @@ void test_3d() {
                                domain::topologies::spherical_shell,
                                Direction<3>::lower_xi(), aligned));
   CHECK(neighbor_is_conforming(domain::topologies::spherical_shell,
+                               domain::topologies::full_sphere,
+                               Direction<3>::lower_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::spherical_shell,
+                               domain::topologies::spherical_shell,
+                               Direction<3>::upper_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::full_sphere,
                                domain::topologies::spherical_shell,
                                Direction<3>::upper_xi(), aligned));
   CHECK(neighbor_is_conforming(domain::topologies::full_cylinder,
@@ -101,12 +107,18 @@ void test_3d() {
   CHECK_FALSE(neighbor_is_conforming(
       domain::topologies::spherical_shell, domain::topologies::hypercube<3>,
       Direction<3>::upper_xi(), radial_xi_to_zeta));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::full_sphere, domain::topologies::hypercube<3>,
+      Direction<3>::upper_xi(), radial_xi_to_zeta));
 
   CHECK_FALSE(neighbor_is_conforming(
       domain::topologies::spherical_shell, domain::topologies::full_cylinder,
       Direction<3>::lower_xi(), radial_xi_to_zeta));
   CHECK_FALSE(neighbor_is_conforming(
       domain::topologies::spherical_shell, domain::topologies::full_cylinder,
+      Direction<3>::upper_xi(), radial_xi_to_zeta));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::full_sphere, domain::topologies::full_cylinder,
       Direction<3>::upper_xi(), radial_xi_to_zeta));
 
   const OrientationMap<3> radial_aligned(std::array<Direction<3>, 3>{
@@ -117,6 +129,9 @@ void test_3d() {
   CHECK_FALSE(neighbor_is_conforming(domain::topologies::spherical_shell,
                                      domain::topologies::cylindrical_shell,
                                      Direction<3>::upper_xi(), radial_aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::full_sphere,
+                                     domain::topologies::cylindrical_shell,
+                                     Direction<3>::upper_xi(), radial_aligned));
   CHECK_FALSE(neighbor_is_conforming(domain::topologies::spherical_shell,
                                      domain::topologies::cylindrical_shell,
                                      Direction<3>::lower_xi(),
@@ -125,6 +140,9 @@ void test_3d() {
                                      domain::topologies::cylindrical_shell,
                                      Direction<3>::upper_xi(),
                                      radial_xi_to_zeta));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::full_sphere, domain::topologies::cylindrical_shell,
+      Direction<3>::upper_xi(), radial_xi_to_zeta));
 
   CHECK_FALSE(neighbor_is_conforming(domain::topologies::full_cylinder,
                                      domain::topologies::hypercube<3>,
@@ -142,6 +160,12 @@ void test_3d() {
       Direction<3>::lower_zeta(), radial_zeta_to_xi));
   CHECK_FALSE(neighbor_is_conforming(
       domain::topologies::full_cylinder, domain::topologies::spherical_shell,
+      Direction<3>::upper_zeta(), radial_zeta_to_xi));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::full_cylinder, domain::topologies::full_sphere,
+      Direction<3>::lower_zeta(), radial_zeta_to_xi));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::full_cylinder, domain::topologies::full_sphere,
       Direction<3>::upper_zeta(), radial_zeta_to_xi));
   CHECK(neighbor_is_conforming(domain::topologies::full_cylinder,
                                domain::topologies::cylindrical_shell,
@@ -179,6 +203,18 @@ void test_3d() {
                                      domain::topologies::spherical_shell,
                                      Direction<3>::upper_zeta(),
                                      radial_zeta_to_xi));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::full_sphere,
+                                     Direction<3>::lower_xi(), radial_aligned));
+  CHECK_FALSE(neighbor_is_conforming(domain::topologies::cylindrical_shell,
+                                     domain::topologies::full_sphere,
+                                     Direction<3>::upper_xi(), radial_aligned));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::cylindrical_shell, domain::topologies::full_sphere,
+      Direction<3>::lower_zeta(), radial_zeta_to_xi));
+  CHECK_FALSE(neighbor_is_conforming(
+      domain::topologies::cylindrical_shell, domain::topologies::full_sphere,
+      Direction<3>::upper_zeta(), radial_zeta_to_xi));
   CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
                                domain::topologies::full_cylinder,
                                Direction<3>::lower_xi(), aligned));

--- a/tests/Unit/Domain/Structure/Test_Topology.cpp
+++ b/tests/Unit/Domain/Structure/Test_Topology.cpp
@@ -14,4 +14,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Topology", "[Domain][Unit]") {
   CHECK(get_output(domain::Topology::S2Longitude) == "S2Longitude");
   CHECK(get_output(domain::Topology::B2Radial) == "B2Radial");
   CHECK(get_output(domain::Topology::B2Angular) == "B2Angular");
+  CHECK(get_output(domain::Topology::B3Radial) == "B3Radial");
+  CHECK(get_output(domain::Topology::B3Colatitude) == "B3Colatitude");
+  CHECK(get_output(domain::Topology::B3Longitude) == "B3Longitude");
 }

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -40,8 +40,8 @@ void test_create_initial_element(
     const DirectionMap<2, Neighbors<2>>& expected_neighbors,
     const std::array<domain::Topology, 2>& topologies =
         domain::topologies::hypercube<2>) {
-  const auto created_element = domain::Initialization::create_initial_element(
-      element_id, blocks, refinement_levels);
+  const auto created_element =
+      domain::create_initial_element(element_id, blocks, refinement_levels);
   const Element<2> expected_element{element_id, expected_neighbors, topologies};
   CHECK(created_element == expected_element);
 }
@@ -72,8 +72,7 @@ void test_h_refinement() {
           {{1, 1, 1}}, neighbor_refinement};
 
       const auto refined_neighbors =
-          domain::Initialization::create_initial_element(self_id, blocks,
-                                                         refinement_levels)
+          domain::create_initial_element(self_id, blocks, refinement_levels)
               .neighbors()
               .at(neighbor_direction)
               .ids();

--- a/tests/Unit/Domain/Test_ElementDistribution.cpp
+++ b/tests/Unit/Domain/Test_ElementDistribution.cpp
@@ -41,7 +41,7 @@ void test_uniform_cost_function() {
   const auto costs = domain::get_element_costs(
       blocks, domain_creator.initial_refinement_levels(),
       domain_creator.initial_extents(), domain::ElementWeight::Uniform,
-      std::nullopt);
+      std::nullopt, std::nullopt);
 
   for (const auto& element_id_and_cost : costs) {
     CHECK(element_id_and_cost.second == 1.0);
@@ -76,17 +76,17 @@ void test_weighted_cost_function(const domain::ElementWeight element_weight) {
   const auto costs1 = domain::get_element_costs(
       blocks1, domain_creator1.initial_refinement_levels(),
       domain_creator1.initial_extents(), element_weight,
-      Spectral::Quadrature::GaussLobatto);
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
 
   const auto costs2 = domain::get_element_costs(
       blocks2, domain_creator2.initial_refinement_levels(),
       domain_creator2.initial_extents(), element_weight,
-      Spectral::Quadrature::GaussLobatto);
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
 
   const auto costs3 = domain::get_element_costs(
       blocks3, domain_creator3.initial_refinement_levels(),
       domain_creator3.initial_extents(), element_weight,
-      Spectral::Quadrature::GaussLobatto);
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
 
   // check that all elements in each domain have the same cost
 
@@ -170,7 +170,7 @@ void test_uniform_element_distribution_construction(
 
   const auto costs = domain::get_element_costs(
       blocks, initial_refinement_levels, initial_extents,
-      domain::ElementWeight::Uniform, std::nullopt);
+      domain::ElementWeight::Uniform, std::nullopt, std::nullopt);
 
   const domain::BlockZCurveProcDistribution<Dim> element_distribution(
       costs, number_of_procs_with_elements, blocks, initial_refinement_levels,
@@ -263,7 +263,7 @@ void test_weighted_element_distribution_construction(
 
   const auto costs = domain::get_element_costs(
       blocks, initial_refinement_levels, initial_extents, element_weight,
-      Spectral::Quadrature::GaussLobatto);
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
 
   const domain::BlockZCurveProcDistribution<Dim> element_distribution(
       costs, number_of_procs_with_elements, blocks, initial_refinement_levels,
@@ -450,7 +450,7 @@ void test_proc_retrieval(
 
   const auto costs = domain::get_element_costs(
       blocks, initial_refinement_levels, initial_extents, element_weight,
-      Spectral::Quadrature::GaussLobatto);
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
 
   const domain::BlockZCurveProcDistribution<Dim> element_distribution(
       costs, number_of_procs_with_elements, blocks, initial_refinement_levels,

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -236,11 +236,12 @@ auto make_databox_with_boundary_conditions() {
   const ElementId<Dim> central_element_id{0, {{{2, 0}, {0, 0}}}};
   const ElementId<Dim> right_element_id{0, {{{2, 1}, {0, 0}}}};
   const ElementId<Dim> bottom_element_id{1, {{{1, 0}, {1, 1}}}};
-  Element<Dim> central_element = domain::Initialization::create_initial_element(
+  // NOLINTNEXTLINE(misc-const-correctness)
+  Element<Dim> central_element = domain::create_initial_element(
       central_element_id, domain.blocks(), refinement);
-  Element<Dim> right_element = domain::Initialization::create_initial_element(
+  Element<Dim> right_element = domain::create_initial_element(
       right_element_id, domain.blocks(), refinement);
-  Element<Dim> bottom_element = domain::Initialization::create_initial_element(
+  Element<Dim> bottom_element = domain::create_initial_element(
       bottom_element_id, domain.blocks(), refinement);
   // Subdomain
   LinearSolver::Schwarz::OverlapMap<Dim, Element<Dim>> overlap_elements{
@@ -268,9 +269,10 @@ auto make_databox_without_boundary_conditions() {
   const std::vector<std::array<size_t, Dim>> refinement{{{2, 2}}};
   const ElementId<Dim> central_element_id{0, {{{2, 1}, {2, 1}}}};
   const ElementId<Dim> right_element_id{0, {{{2, 2}, {2, 1}}}};
-  Element<Dim> central_element = domain::Initialization::create_initial_element(
+  // NOLINTNEXTLINE(misc-const-correctness)
+  Element<Dim> central_element = domain::create_initial_element(
       central_element_id, domain.blocks(), refinement);
-  Element<Dim> right_element = domain::Initialization::create_initial_element(
+  Element<Dim> right_element = domain::create_initial_element(
       right_element_id, domain.blocks(), refinement);
   LinearSolver::Schwarz::OverlapMap<Dim, Element<Dim>> overlap_elements{
       {{Direction<Dim>::upper_xi(), right_element_id},

--- a/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
@@ -103,8 +103,8 @@ void test_local_adm_integrals(const double& distance,
   // Compute integral by summing over each element.
   for (const auto& element_id : element_ids) {
     // Get element information.
-    const auto current_element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_ref_levels);
+    const auto current_element =
+        domain::create_initial_element(element_id, blocks, initial_ref_levels);
     const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());

--- a/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
@@ -162,7 +162,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const bool did_rollback) {
 
   const auto domain = brick.create_domain();
   const auto element_id = ElementId<3>{0};
-  Element<3> element = domain::Initialization::create_initial_element(
+  Element<3> element = domain::create_initial_element(
       element_id, domain.blocks(),
       std::vector<std::array<size_t, 3>>{{0, 0, 0}});
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -128,7 +128,8 @@ void test_impl(
   ActionTesting::emplace_component_and_initialize<component<metavars>>(
       &runner, element.id(),
       {time_step_id, next_time_step_id, element,
-       domain::create_initial_mesh(initial_extents, element, quadrature),
+       domain::create_initial_mesh(initial_extents, element,
+                                   Spectral::Basis::Legendre, quadrature),
        neighbor_mesh});
 
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -128,8 +128,7 @@ void test_impl(
   ActionTesting::emplace_component_and_initialize<component<metavars>>(
       &runner, element.id(),
       {time_step_id, next_time_step_id, element,
-       domain::Initialization::create_initial_mesh(initial_extents, element,
-                                                   quadrature),
+       domain::create_initial_mesh(initial_extents, element, quadrature),
        neighbor_mesh});
 
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BackgroundGrVars.cpp
@@ -129,7 +129,7 @@ void test(const gsl::not_null<std::mt19937*> gen) {
   }();
   const auto domain = brick.create_domain();
   const auto element_id = ElementId<3>{0};
-  Element<3> element = domain::Initialization::create_initial_element(
+  Element<3> element = domain::create_initial_element(
       element_id, domain.blocks(),
       std::vector<std::array<size_t, 3>>{{0, 0, 0}});
 

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -94,7 +94,7 @@ void test(const BoundaryConditionType& boundary_condition) {
       {{{{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
   auto domain = interval.create_domain();
   auto boundary_conditions = interval.external_boundary_conditions();
-  const auto element = domain::Initialization::create_initial_element(
+  const auto element = domain::create_initial_element(
       ElementId<1>{0, {SegmentId{0, 0}}}, domain.blocks(),
       std::vector<std::array<size_t, 1>>{{refinement_level_x}});
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
@@ -211,10 +211,10 @@ void test_iterations(const size_t max_iterations) {
     std::vector<ElementId<Dim>> non_abutting_element_ids{};
 
     for (const auto& element_id : element_ids) {
-      auto element = domain::Initialization::create_initial_element(
-          element_id, blocks, initial_refinements);
-      auto mesh = domain::Initialization::create_initial_mesh(
-          initial_extents, element, quadrature);
+      auto element = domain::create_initial_element(element_id, blocks,
+                                                    initial_refinements);
+      auto mesh =
+          domain::create_initial_mesh(initial_extents, element, quadrature);
       const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(element_id,
                                    my_block.stationary_map().get_clone());

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
@@ -40,6 +40,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -142,6 +143,7 @@ void test_iterations(const size_t max_iterations) {
   const size_t initial_extent = 3;
   const size_t face_size = initial_extent * initial_extent;
   const DataVector used_for_size(face_size);
+  const auto basis = Spectral::Basis::Legendre;
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
   const double charge = 0.1;
   const double mass = 0.1;
@@ -213,8 +215,8 @@ void test_iterations(const size_t max_iterations) {
     for (const auto& element_id : element_ids) {
       auto element = domain::create_initial_element(element_id, blocks,
                                                     initial_refinements);
-      auto mesh =
-          domain::create_initial_mesh(initial_extents, element, quadrature);
+      auto mesh = domain::create_initial_mesh(initial_extents, element, basis,
+                                              quadrature);
       const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(element_id,
                                    my_block.stationary_map().get_clone());

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -169,10 +169,10 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
         make_not_null(&element_faces_grid_coords), initial_extents,
         initial_refinements, quadrature, shell_domain, excision_sphere);
     for (const auto& element_id : element_ids) {
-      auto element = domain::Initialization::create_initial_element(
-          element_id, blocks, initial_refinements);
-      auto mesh = domain::Initialization::create_initial_mesh(
-          initial_extents, element, quadrature);
+      auto element = domain::create_initial_element(element_id, blocks,
+                                                    initial_refinements);
+      auto mesh =
+          domain::create_initial_mesh(initial_extents, element, quadrature);
       const size_t grid_size = mesh.number_of_grid_points();
 
       // we set lapse and shift to Minkowski so dt Psi = - Pi

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -32,6 +32,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
@@ -119,6 +120,7 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
   using worldtube_chare = MockWorldtubeSingleton<metavars>;
   const size_t initial_extent = 5;
   const size_t face_size = initial_extent * initial_extent;
+  const auto basis = Spectral::Basis::Legendre;
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
   // we create several differently refined shells so a different number of
   // elements sends data
@@ -171,8 +173,8 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
     for (const auto& element_id : element_ids) {
       auto element = domain::create_initial_element(element_id, blocks,
                                                     initial_refinements);
-      auto mesh =
-          domain::create_initial_mesh(initial_extents, element, quadrature);
+      auto mesh = domain::create_initial_mesh(initial_extents, element, basis,
+                                              quadrature);
       const size_t grid_size = mesh.number_of_grid_points();
 
       // we set lapse and shift to Minkowski so dt Psi = - Pi

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -214,10 +214,10 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
     const std::array<tnsr::I<double, Dim>, 2> particle_pos_vel{
         {std::move(particle_position), std::move(particle_velocity)}};
     for (const auto& element_id : element_ids) {
-      auto element = domain::Initialization::create_initial_element(
-          element_id, blocks, initial_refinements);
-      auto mesh = domain::Initialization::create_initial_mesh(
-          initial_extents, element, quadrature);
+      auto element = domain::create_initial_element(element_id, blocks,
+                                                    initial_refinements);
+      auto mesh =
+          domain::create_initial_mesh(initial_extents, element, quadrature);
       const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(element_id,
                                    my_block.stationary_map().get_clone());

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -37,6 +37,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -143,6 +144,7 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
   using worldtube_chare = MockWorldtubeSingleton<metavars>;
   const size_t initial_extent = 10;
   const size_t face_size = initial_extent * initial_extent;
+  const auto basis = Spectral::Basis::Legendre;
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
   // unused but the tag is needed to compile
   const double time = std::numeric_limits<double>::signaling_NaN();
@@ -216,8 +218,8 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
     for (const auto& element_id : element_ids) {
       auto element = domain::create_initial_element(element_id, blocks,
                                                     initial_refinements);
-      auto mesh =
-          domain::create_initial_mesh(initial_extents, element, quadrature);
+      auto mesh = domain::create_initial_mesh(initial_extents, element, basis,
+                                              quadrature);
       const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(element_id,
                                    my_block.stationary_map().get_clone());

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -37,6 +37,7 @@
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
@@ -98,6 +99,7 @@ void test_compute_face_coordinates_grid() {
 
   for (const auto& initial_refinement : std::array<size_t, 2>{{0, 1}}) {
     CAPTURE(initial_refinement);
+    const auto basis = Spectral::Basis::Legendre;
     const auto quadrature = Spectral::Quadrature::GaussLobatto;
     // we create two shells with different resolutions
     const size_t extents_1 = 5;
@@ -143,11 +145,11 @@ void test_compute_face_coordinates_grid() {
       const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(
           element_id, my_block.stationary_map().get_to_grid_frame());
-      const auto mesh_1 =
-          domain::create_initial_mesh(initial_extents_1, element, quadrature);
+      const auto mesh_1 = domain::create_initial_mesh(
+          initial_extents_1, element, basis, quadrature);
       const auto grid_coords_1 = element_map(logical_coordinates(mesh_1));
-      const auto mesh_2 =
-          domain::create_initial_mesh(initial_extents_2, element, quadrature);
+      const auto mesh_2 = domain::create_initial_mesh(
+          initial_extents_2, element, basis, quadrature);
       const auto grid_coords_2 = element_map(logical_coordinates(mesh_2));
 
       auto box =
@@ -205,6 +207,7 @@ void test_compute_face_coordinates() {
   const auto initial_extents = domain_creator->initial_extents();
   const auto initial_refinements = domain_creator->initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_refinements);
+  const auto basis = Spectral::Basis::Legendre;
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
   std::unordered_map<ElementId<Dim>, tnsr::I<DataVector, Dim, Frame::Grid>>
       all_faces_grid_coords{};
@@ -214,8 +217,8 @@ void test_compute_face_coordinates() {
   for (const auto& element_id : element_ids) {
     const auto element =
         domain::create_initial_element(element_id, blocks, initial_refinements);
-    const auto mesh =
-        domain::create_initial_mesh(initial_extents, element, quadrature);
+    const auto mesh = domain::create_initial_mesh(initial_extents, element,
+                                                  basis, quadrature);
     const auto& my_block = blocks.at(element_id.block_id());
     const ElementMap element_map(
         element_id,
@@ -549,13 +552,14 @@ void test_face_quantities_compute() {
   const auto element_ids = initial_element_ids(initial_refinements);
   const auto& blocks = shell_domain.blocks();
   std::uniform_real_distribution<> dist(-1., 1.);
+  const auto basis = Spectral::Basis::Legendre;
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
 
   for (const auto& element_id : element_ids) {
     const auto element =
         domain::create_initial_element(element_id, blocks, initial_refinements);
-    const auto mesh =
-        domain::create_initial_mesh(initial_extents, element, quadrature);
+    const auto mesh = domain::create_initial_mesh(initial_extents, element,
+                                                  basis, quadrature);
     const auto& my_block = blocks.at(element_id.block_id());
     const ElementMap element_map(element_id,
                                  my_block.stationary_map().get_clone());

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -138,16 +138,16 @@ void test_compute_face_coordinates_grid() {
         initial_refinements, quadrature, domain, excision_sphere);
 
     for (const auto& element_id : element_ids) {
-      const auto element = domain::Initialization::create_initial_element(
-          element_id, blocks, initial_refinements);
+      const auto element = domain::create_initial_element(element_id, blocks,
+                                                          initial_refinements);
       const auto& my_block = blocks.at(element_id.block_id());
       const ElementMap element_map(
           element_id, my_block.stationary_map().get_to_grid_frame());
-      const auto mesh_1 = domain::Initialization::create_initial_mesh(
-          initial_extents_1, element, quadrature);
+      const auto mesh_1 =
+          domain::create_initial_mesh(initial_extents_1, element, quadrature);
       const auto grid_coords_1 = element_map(logical_coordinates(mesh_1));
-      const auto mesh_2 = domain::Initialization::create_initial_mesh(
-          initial_extents_2, element, quadrature);
+      const auto mesh_2 =
+          domain::create_initial_mesh(initial_extents_2, element, quadrature);
       const auto grid_coords_2 = element_map(logical_coordinates(mesh_2));
 
       auto box =
@@ -212,10 +212,10 @@ void test_compute_face_coordinates() {
       make_not_null(&all_faces_grid_coords), initial_extents,
       initial_refinements, quadrature, domain, excision_sphere);
   for (const auto& element_id : element_ids) {
-    const auto element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_refinements);
-    const auto mesh = domain::Initialization::create_initial_mesh(
-        initial_extents, element, quadrature);
+    const auto element =
+        domain::create_initial_element(element_id, blocks, initial_refinements);
+    const auto mesh =
+        domain::create_initial_mesh(initial_extents, element, quadrature);
     const auto& my_block = blocks.at(element_id.block_id());
     const ElementMap element_map(
         element_id,
@@ -552,10 +552,10 @@ void test_face_quantities_compute() {
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
 
   for (const auto& element_id : element_ids) {
-    const auto element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_refinements);
-    const auto mesh = domain::Initialization::create_initial_mesh(
-        initial_extents, element, quadrature);
+    const auto element =
+        domain::create_initial_element(element_id, blocks, initial_refinements);
+    const auto mesh =
+        domain::create_initial_mesh(initial_extents, element, quadrature);
     const auto& my_block = blocks.at(element_id.block_id());
     const ElementMap element_map(element_id,
                                  my_block.stationary_map().get_clone());

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -110,7 +110,7 @@ void test(const BoundaryConditionType& boundary_condition,
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
   auto domain = brick.create_domain();
   auto boundary_conditions = brick.external_boundary_conditions();
-  const auto element = domain::Initialization::create_initial_element(
+  const auto element = domain::create_initial_element(
       ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},
       domain.blocks(), std::vector<std::array<size_t, 3>>{{refinement_levels}});
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -107,7 +107,7 @@ double test(const size_t num_dg_pts) {
       element_id, block.is_time_dependent()
                       ? block.moving_mesh_logical_to_grid_map().get_clone()
                       : block.stationary_map().get_to_grid_frame()};
-  const auto element = domain::Initialization::create_initial_element(
+  const auto element = domain::create_initial_element(
       element_id, blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -159,7 +159,7 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
   const auto grid_to_inertial_map =
       ::domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           ::domain::CoordinateMaps::Identity<3>{});
-  const auto element = domain::Initialization::create_initial_element(
+  const auto element = domain::create_initial_element(
       element_id, blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -104,7 +104,7 @@ void test(const BoundaryConditionType& boundary_condition,
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
   auto domain = brick.create_domain();
   auto boundary_conditions = brick.external_boundary_conditions();
-  const auto element = domain::Initialization::create_initial_element(
+  const auto element = domain::create_initial_element(
       ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},
       domain.blocks(), std::vector<std::array<size_t, 3>>{{refinement_levels}});
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -114,7 +114,7 @@ double test(const size_t num_dg_pts) {
       element_id, block.is_time_dependent()
                       ? block.moving_mesh_logical_to_grid_map().get_clone()
                       : block.stationary_map().get_to_grid_frame()};
-  const auto element = domain::Initialization::create_initial_element(
+  const auto element = domain::create_initial_element(
       element_id, blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -143,7 +143,7 @@ std::array<double, 5> test(const size_t num_dg_pts,
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{affine_map, affine_map, affine_map}),
       0, {}));
-  const auto element = domain::Initialization::create_initial_element(
+  const auto element = domain::create_initial_element(
       ElementId<3>{0, {SegmentId{2, 2}, SegmentId{2, 2}, SegmentId{2, 2}}},
       blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_NeighborPackagedData.cpp
@@ -107,7 +107,7 @@ auto make_element<1>() {
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           affine_map),
       0, {}));
-  return domain::Initialization::create_initial_element(
+  return domain::create_initial_element(
       ElementId<1>{0, {SegmentId{3, 4}}}, blocks,
       std::vector<std::array<size_t, 1>>{std::array<size_t, 1>{{3}}});
 }
@@ -120,7 +120,7 @@ auto make_element<2>() {
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D{affine_map, affine_map}),
       0, {}));
-  return domain::Initialization::create_initial_element(
+  return domain::create_initial_element(
       ElementId<2>{0, {SegmentId{3, 4}, SegmentId{3, 4}}}, blocks,
       std::vector<std::array<size_t, 2>>{std::array<size_t, 2>{{3, 3}}});
 }
@@ -133,7 +133,7 @@ auto make_element<3>() {
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{affine_map, affine_map, affine_map}),
       0, {}));
-  return domain::Initialization::create_initial_element(
+  return domain::create_initial_element(
       ElementId<3>{0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}},
       blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Subcell/Test_TimeDerivative.cpp
@@ -100,7 +100,7 @@ auto make_element<1>() {
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           affine_map),
       0, {}));
-  return domain::Initialization::create_initial_element(
+  return domain::create_initial_element(
       ElementId<1>{0, {SegmentId{2, 2}}}, blocks,
       std::vector<std::array<size_t, 1>>{std::array<size_t, 1>{{3}}});
 }
@@ -113,7 +113,7 @@ auto make_element<2>() {
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D{affine_map, affine_map}),
       0, {}));
-  return domain::Initialization::create_initial_element(
+  return domain::create_initial_element(
       ElementId<2>{0, {SegmentId{2, 2}, SegmentId{2, 2}}}, blocks,
       std::vector<std::array<size_t, 2>>{std::array<size_t, 2>{{3, 3}}});
 }
@@ -126,7 +126,7 @@ auto make_element<3>() {
       domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine3D{affine_map, affine_map, affine_map}),
       0, {}));
-  return domain::Initialization::create_initial_element(
+  return domain::create_initial_element(
       ElementId<3>{0, {SegmentId{2, 2}, SegmentId{2, 2}, SegmentId{2, 2}}},
       blocks,
       std::vector<std::array<size_t, 3>>{std::array<size_t, 3>{{3, 3, 3}}});

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -588,8 +588,8 @@ void test_initial_domain(const Domain<VolumeDim>& domain,
   std::unordered_map<ElementId<VolumeDim>, Element<VolumeDim>> elements;
   for (const auto& element_id : element_ids) {
     elements.emplace(element_id,
-                     domain::Initialization::create_initial_element(
-                         element_id, blocks, initial_refinement_levels));
+                     domain::create_initial_element(element_id, blocks,
+                                                    initial_refinement_levels));
   }
   domain::test_domain_connectivity(domain, elements);
   domain::test_refinement_levels_of_neighbors<1>(elements);

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -36,6 +36,7 @@
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/Tags.hpp"
 #include "NumericalAlgorithms/Convergence/HasConverged.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
@@ -288,7 +289,7 @@ struct InitializeElement {
     auto element = domain::create_initial_element(element_id, domain.blocks(),
                                                   initial_refinement);
     auto mesh = domain::create_initial_mesh(
-        initial_extents, element,
+        initial_extents, element, Spectral::Basis::Legendre,
         Parallel::get<elliptic::dg::Tags::Quadrature>(cache));
     auto logical_coords = logical_coordinates(mesh);
     // Element data

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -285,9 +285,9 @@ struct InitializeElement {
     const auto& initial_extents = db::get<domain::Tags::InitialExtents<1>>(box);
     const auto& initial_refinement =
         db::get<domain::Tags::InitialRefinementLevels<1>>(box);
-    auto element = domain::Initialization::create_initial_element(
-        element_id, domain.blocks(), initial_refinement);
-    auto mesh = domain::Initialization::create_initial_mesh(
+    auto element = domain::create_initial_element(element_id, domain.blocks(),
+                                                  initial_refinement);
+    auto mesh = domain::create_initial_mesh(
         initial_extents, element,
         Parallel::get<elliptic::dg::Tags::Quadrature>(cache));
     auto logical_coords = logical_coordinates(mesh);

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
@@ -107,7 +107,7 @@ struct InitializeElement {
         db::get<::domain::Tags::InitialExtents<1>>(box);
     const auto& domain = db::get<::domain::Tags::Domain<1>>(box);
     const auto& block = domain.blocks()[element_id.block_id()];
-    auto mesh = ::domain::Initialization::create_initial_mesh(
+    auto mesh = ::domain::create_initial_mesh(
         initial_extents, block, element_id,
         Parallel::get<elliptic::dg::Tags::Quadrature>(cache));
     const auto logical_coords = logical_coordinates(mesh);

--- a/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/LinearSolver/Multigrid/Helpers.hpp
@@ -23,6 +23,7 @@
 #include "Domain/Tags.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Tags.hpp"
 #include "Helpers/ParallelAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
@@ -108,7 +109,7 @@ struct InitializeElement {
     const auto& domain = db::get<::domain::Tags::Domain<1>>(box);
     const auto& block = domain.blocks()[element_id.block_id()];
     auto mesh = ::domain::create_initial_mesh(
-        initial_extents, block, element_id,
+        initial_extents, block, element_id, Spectral::Basis::Legendre,
         Parallel::get<elliptic::dg::Tags::Quadrature>(cache));
     const auto logical_coords = logical_coordinates(mesh);
     const ElementMap<1, Frame::Inertial> element_map{

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -232,7 +232,7 @@ void write_test_data(
   std::vector<ElementVolumeData> element_data{};
   for (const auto& element_id : element_ids) {
     const auto& block = domain.blocks()[element_id.block_id()];
-    const auto mesh = domain::Initialization::create_initial_mesh(
+    const auto mesh = domain::create_initial_mesh(
         initial_extents, block, element_id, Spectral::Quadrature::GaussLobatto);
     const size_t num_points = mesh.number_of_grid_points();
     const auto inertial_coords = inertial_coordinates(
@@ -362,7 +362,7 @@ struct InitializeElement {
     const auto& initial_extents =
         db::get<Tags::InitialExtents<Dim, SourceOrTarget::Target>>(box);
     const auto& block = domain.blocks()[element_id.block_id()];
-    const auto mesh = domain::Initialization::create_initial_mesh(
+    const auto mesh = domain::create_initial_mesh(
         initial_extents, block, element_id, Spectral::Quadrature::GaussLobatto);
     Initialization::mutate_assign<
         tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -53,6 +53,9 @@
 #include "IO/Importers/Actions/RegisterWithElementDataReader.hpp"
 #include "IO/Importers/ElementDataReader.hpp"
 #include "IO/Importers/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
@@ -233,7 +236,8 @@ void write_test_data(
   for (const auto& element_id : element_ids) {
     const auto& block = domain.blocks()[element_id.block_id()];
     const auto mesh = domain::create_initial_mesh(
-        initial_extents, block, element_id, Spectral::Quadrature::GaussLobatto);
+        initial_extents, block, element_id, Spectral::Basis::Legendre,
+        Spectral::Quadrature::GaussLobatto);
     const size_t num_points = mesh.number_of_grid_points();
     const auto inertial_coords = inertial_coordinates(
         element_id, mesh, block, observation_value, functions_of_time);
@@ -363,7 +367,8 @@ struct InitializeElement {
         db::get<Tags::InitialExtents<Dim, SourceOrTarget::Target>>(box);
     const auto& block = domain.blocks()[element_id.block_id()];
     const auto mesh = domain::create_initial_mesh(
-        initial_extents, block, element_id, Spectral::Quadrature::GaussLobatto);
+        initial_extents, block, element_id, Spectral::Basis::Legendre,
+        Spectral::Quadrature::GaussLobatto);
     Initialization::mutate_assign<
         tmpl::list<domain::Tags::Coordinates<Dim, Frame::Inertial>,
                    domain::Tags::Mesh<Dim>>>(

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
@@ -112,9 +112,8 @@ DataVector vars_cubed_sphere(
     const Domain<3>& domain, const ElementId<3>& neighbor_id,
     const std::vector<std::array<size_t, 3>>& refinement_levels,
     const Mesh<2>& cubed_sphere_mortar_mesh) {
-  const Element<3> cubed_sphere =
-      domain::Initialization::create_initial_element(
-          neighbor_id, domain.blocks(), refinement_levels);
+  const Element<3> cubed_sphere = domain::create_initial_element(
+      neighbor_id, domain.blocks(), refinement_levels);
   const auto xi = interface_logical_coordinates(cubed_sphere_mortar_mesh,
                                                 Direction<3>::upper_zeta());
   const ElementMap<3, Frame::Inertial> cubed_sphere_map{
@@ -158,7 +157,7 @@ void test_non_conforming_spheres() {
       7, std::array{2_st, 2_st, 2_st}};
   refinement_levels[6] = std::array{0_st, 0_st, 0_st};
   const ElementId<3> shell_id{6};
-  const Element<3> shell = domain::Initialization::create_initial_element(
+  const Element<3> shell = domain::create_initial_element(
       shell_id, domain.blocks(), refinement_levels);
   const auto& shell_neighbor_ids =
       shell.neighbors().at(Direction<3>::lower_xi());

--- a/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
@@ -151,9 +151,11 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.SurfaceFinder.SurfaceFinder",
   const auto refinement_levels = sphere.initial_refinement_levels();
   const auto extents = sphere.initial_extents();
   const ElementId<dim> id{0};
-  const auto quadrature = Spectral::Quadrature::GaussLobatto;
+  const auto i1_basis = Spectral::Basis::Legendre;
+  const auto i1_quadrature = Spectral::Quadrature::GaussLobatto;
   const auto& block = domain.blocks()[id.block_id()];
-  const auto mesh = domain::create_initial_mesh(extents, block, id, quadrature);
+  const auto mesh =
+      domain::create_initial_mesh(extents, block, id, i1_basis, i1_quadrature);
   const ElementMap<dim, Frame::Inertial> element_map{
       id, block.stationary_map().get_clone()};
   const auto logical_coords = logical_coordinates(mesh);

--- a/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
@@ -153,8 +153,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.SurfaceFinder.SurfaceFinder",
   const ElementId<dim> id{0};
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
   const auto& block = domain.blocks()[id.block_id()];
-  const auto mesh = domain::Initialization::create_initial_mesh(extents, block,
-                                                                id, quadrature);
+  const auto mesh = domain::create_initial_mesh(extents, block, id, quadrature);
   const ElementMap<dim, Frame::Inertial> element_map{
       id, block.stationary_map().get_clone()};
   const auto logical_coords = logical_coordinates(mesh);

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
@@ -67,8 +67,8 @@ void test_infinite_surface_integral(const double distance, const double mass,
     }
 
     // Get element information
-    const auto current_element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_ref_levels);
+    const auto current_element =
+        domain::create_initial_element(element_id, blocks, initial_ref_levels);
     const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
@@ -187,8 +187,8 @@ void test_infinite_volume_integral(const double distance, const double mass,
   // Compute integrals by summing over each element
   for (const auto& element_id : element_ids) {
     // Get element information
-    const auto current_element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_ref_levels);
+    const auto current_element =
+        domain::create_initial_element(element_id, blocks, initial_ref_levels);
     const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
@@ -74,8 +74,8 @@ void test_infinite_surface_integrals(const double distance, const double mass,
     }
 
     // Get element information
-    const auto current_element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_ref_levels);
+    const auto current_element =
+        domain::create_initial_element(element_id, blocks, initial_ref_levels);
     const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
@@ -211,8 +211,8 @@ void test_infinite_volume_integral(const double distance, const double mass,
   // Compute integrals by summing over each element
   for (const auto& element_id : element_ids) {
     // Get element information
-    const auto current_element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_ref_levels);
+    const auto current_element =
+        domain::create_initial_element(element_id, blocks, initial_ref_levels);
     const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
@@ -72,8 +72,8 @@ void test_infinite_surface_integral(const double distance,
     }
 
     // Get element information
-    const auto current_element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_ref_levels);
+    const auto current_element =
+        domain::create_initial_element(element_id, blocks, initial_ref_levels);
     const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());
@@ -160,8 +160,8 @@ void test_infinite_volume_integral(const double distance,
   // Compute integrals by summing over each element
   for (const auto& element_id : element_ids) {
     // Get element information
-    const auto current_element = domain::Initialization::create_initial_element(
-        element_id, blocks, initial_ref_levels);
+    const auto current_element =
+        domain::create_initial_element(element_id, blocks, initial_ref_levels);
     const auto& current_block = blocks.at(element_id.block_id());
     const ElementMap<3, Frame::Inertial> logical_to_inertial_map(
         element_id, current_block.stationary_map().get_clone());


### PR DESCRIPTION
## Proposed changes

- Remove domain::Initialization namespace
- Support choosing Chebyshev as a Basis for I1 in create_initial_mesh
- Add values to the enum Topology for a B3 topology, and update functions using the Topology

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
