### PR TITLE
Allow non-shifting shift Gamma-driver in Ccz4

### DIFF
--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
@@ -172,7 +172,7 @@ static void apply(
     const tnsr::i<DataVector, Dim>& d_trace_extrinsic_curvature,
     const tnsr::i<DataVector, Dim>& d_theta,
     const tnsr::iJ<DataVector, Dim>& d_gamma_hat,
-    const tnsr::iJ<DataVector, Dim>& d_b) {
+    const tnsr::iJ<DataVector, Dim>& d_b, const bool shifting_shift) {
   constexpr double one_third = 1.0 / 3.0;
 
   // quantities we need for computing eq 4, 13 - 27
@@ -401,8 +401,12 @@ static void apply(
                                     lapse());
 
   // time derivative of the shift
-  ::tenex::evaluate<ti::I>(dt_shift,
-                           f * b(ti::I) + shift(ti::K) * field_b(ti::k, ti::I));
+  ::tenex::evaluate<ti::I>(dt_shift, f * b(ti::I));
+
+  if (shifting_shift) {
+    ::tenex::update<ti::I>(
+        dt_shift, (*dt_shift)(ti::I) + shift(ti::K) * field_b(ti::k, ti::I));
+  }
 
   // time derivative of the the conformal factor
   ::tenex::evaluate(dt_conformal_factor,
@@ -499,9 +503,13 @@ static void apply(
                                  (*contracted_symmetrized_d_field_b)(ti::k));
 
   // time derivative b^i
-  ::tenex::evaluate<ti::I>(
-      dt_b, (*dt_gamma_hat)(ti::I)-eta() * b(ti::I) +
-                shift(ti::K) * (d_b(ti::k, ti::I) - d_gamma_hat(ti::k, ti::I)));
+  ::tenex::evaluate<ti::I>(dt_b, (*dt_gamma_hat)(ti::I)-eta() * b(ti::I));
+
+  if (shifting_shift) {
+    ::tenex::update<ti::I>(
+        dt_b, (*dt_b)(ti::I) + shift(ti::K) * (d_b(ti::k, ti::I) -
+                                               d_gamma_hat(ti::k, ti::I)));
+  }
 
   // Note that, we do not need to evolve the auxiliary variables in SO-CCZ4.
 }
@@ -680,12 +688,13 @@ void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
   const double c = 1.0;               // c = 1.0 in SO-CCZ4
   const double cleaning_speed = 1.0;  // e in the paper; e = 1.0 for SO-CCZ4
   const Scalar<DataVector>& eta = get<Tags::Eta<DataVector>>(*box);
-  const double f = get<Tags::GammaDriverParam>(*box);
+  const double f = Ccz4::fd::System::f;
   const Scalar<DataVector>& k_0 = get<Tags::K0<DataVector>>(*box);
   const double kappa_1 = get<Tags::Kappa1>(*box);
   const double kappa_2 = get<Tags::Kappa2>(*box);
   const double kappa_3 = get<Tags::Kappa3>(*box);
   const double one_over_relaxation_time = 0.0;  // \tau^{-1} = 0 in SO-CCZ4
+  const bool shifting_shift = Ccz4::fd::System::shifting_shift;
 
   // we assume the databox already has tags corresponding to dt of the evolved
   // variables
@@ -855,7 +864,8 @@ void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
                 cell_centered_Ccz4_derivs),
             get<::Tags::deriv<Tags::AuxiliaryShiftB<DataVector, Dim>,
                               tmpl::size_t<Dim>, Frame::Inertial>>(
-                cell_centered_Ccz4_derivs));
+                cell_centered_Ccz4_derivs),
+            shifting_shift);
       },
       box);
 }

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
@@ -11,6 +11,12 @@
 
 namespace Ccz4::fd {
 struct System {
+  // The free parameter f in the Gamma-driver condition.
+  static constexpr double f = 0.75;
+  // Whether to add the advective terms in the Gamma-driver condition,
+  // i.e. in time derivatives of the shift and the auxiliary field b.
+  static constexpr bool shifting_shift = false;
+
   using variables_tag = ::Tags::Variables<tmpl::list<
       Tags::ConformalMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<DataVector, 3>, Tags::ConformalFactor<DataVector>,

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
@@ -27,6 +27,7 @@
 #include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Evolution/Systems/Ccz4/System.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
 #include "Framework/TestCreation.hpp"
@@ -101,7 +102,7 @@ void test_minkowski() {
       compute_prim_solution_for_Minkowski(x);
 
   // get other parameters
-  const double f = 0.1;
+  const double f = Ccz4::fd::System::f;
   const double kappa_1 = 0.1;
   const double kappa_2 = 0.3;
   const double kappa_3 = 0.4;
@@ -195,7 +196,7 @@ void test_kerrschild() {
   const std::array<double, SpatialDim> center{{0.2, 0.5, 0.1}};
   const gr::Solutions::KerrSchild solution(mass, spin, center);
 
-  const double f = 0.75;
+  const double f = Ccz4::fd::System::f;
   const double kappa_1 = 0.1;
   const double kappa_2 = 0.3;
   const double kappa_3 = 0.4;
@@ -364,7 +365,7 @@ void test_gauge_plane_wave(
                                                intermediate_sol);
 
   // get other parameters
-  const double f = 0.75;
+  const double f = Ccz4::fd::System::f;
   const double kappa_1 = 0.1;
   const double kappa_2 = 0.3;
   const double kappa_3 = 0.4;

--- a/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
@@ -378,7 +378,8 @@ tnsr::I<DataVector, SpatialDim, FrameType> get_b_kerr(
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_shift,
     const double f) {
   tnsr::I<DataVector, SpatialDim, FrameType> b(get<0>(shift));
-  if (not static_cast<bool>(evolve_shift)) {
+  if (not static_cast<bool>(evolve_shift) or
+      not ::Ccz4::fd::System::shifting_shift) {
     // s == 0
     // pick b = 0
     for (auto& component : b) {
@@ -488,12 +489,13 @@ tnsr::I<DataVector, SpatialDim, FrameType> get_dt_b_kerr_expected(
   if (static_cast<bool>(evolve_shift)) {
     // s == 1
     for (size_t i = 0; i < SpatialDim; i++) {
-      dt_b_kerr_expected.get(i) = -get(eta) * b.get(i) +
-                                  shift.get(0) * d_b.get(0, i) -
-                                  shift.get(0) * d_gamma_hat.get(0, i);
-      for (size_t k = 1; k < SpatialDim; k++) {
-        dt_b_kerr_expected.get(i) +=
-            shift.get(k) * d_b.get(k, i) - shift.get(k) * d_gamma_hat.get(k, i);
+      dt_b_kerr_expected.get(i) = -get(eta) * b.get(i);
+
+      if (::Ccz4::fd::System::shifting_shift) {
+        for (size_t k = 0; k < SpatialDim; k++) {
+          dt_b_kerr_expected.get(i) += shift.get(k) * d_b.get(k, i) -
+                                       shift.get(k) * d_gamma_hat.get(k, i);
+        }
       }
     }
   } else {
@@ -877,9 +879,12 @@ template <size_t SpatialDim, typename FrameType>
 tnsr::I<DataVector, SpatialDim, FrameType> get_dt_shift_gauge_plane_wave(
     const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_shift) {
-  tnsr::I<DataVector, SpatialDim, FrameType> dt_shift;
-  ::tenex::evaluate<ti::I>(make_not_null(&dt_shift),
-                           shift(ti::K) * d_shift(ti::k, ti::I));
+  auto dt_shift = make_with_value<tnsr::I<DataVector, SpatialDim, FrameType>>(
+      get<0>(shift), 0.0);
+  if (::Ccz4::fd::System::shifting_shift) {
+    ::tenex::evaluate<ti::I>(make_not_null(&dt_shift),
+                             shift(ti::K) * d_shift(ti::k, ti::I));
+  }
   return dt_shift;
 }
 
@@ -891,9 +896,12 @@ tnsr::I<DataVector, SpatialDim, FrameType> get_dt_b_gauge_plane_wave_expected(
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_gamma_hat,
     const tnsr::I<DataVector, SpatialDim, FrameType>& shift) {
   tnsr::I<DataVector, SpatialDim, FrameType> dt_b;
-  ::tenex::evaluate<ti::I>(
-      make_not_null(&dt_b),
-      dt_gamma_hat(ti::I) - shift(ti::K) * d_gamma_hat(ti::k, ti::I));
+  ::tenex::evaluate<ti::I>(make_not_null(&dt_b), dt_gamma_hat(ti::I));
+  if (::Ccz4::fd::System::shifting_shift) {
+    ::tenex::update<ti::I>(
+        make_not_null(&dt_b),
+        dt_b(ti::I) - shift(ti::K) * d_gamma_hat(ti::k, ti::I));
+  }
   return dt_b;
 }
 


### PR DESCRIPTION
## Proposed changes
Add a flag that turns on or off the "shifting shift" condition in the Gamma-driver in Ccz4, i.e. whether to include the advective terms in the time derivative of the shift and the auxiliary field b^i. For `TrumpetSchwarzschild` to be a time-independent solution, the shifting shift condition should be turned off.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
