### PR TITLE
Ah adaptivity: Compute time derivatives of Strahlkorpers of different resolutions

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <limits>
 #include <utility>
 
 #include "DataStructures/DataVector.hpp"
@@ -467,17 +468,55 @@ void time_deriv_of_strahlkorper(
         previous_strahlkorpers) {
   std::deque<double> times{};
   std::deque<const DataVector*> coefficients{};
+  std::deque<DataVector> prolonged_or_restricted_coefficients{};
 
-  // Can't take time deriv of 1 strahlkorper
+  // Can't take time deriv of 1 strahlkorper, so just zero the time derivative's
+  // coefficients
   if (previous_strahlkorpers.size() == 1) {
-    time_deriv->coefficients() = DataVector{
-        previous_strahlkorpers.front().second.coefficients().size(), 0.0};
+    time_deriv->coefficients() = 0.0;
     return;
   }
 
-  for (const auto& [time, strahlkorper] : previous_strahlkorpers) {
-    times.emplace_back(time);
-    coefficients.emplace_back(&strahlkorper.coefficients());
+  // Find the min and max l_max of each previous Strahlkorper, along with the
+  // index of max(l_max). Getting both min(l_max) and max(l_max) enables
+  // skipping the prolong/restrict call when min(l_max) == max(l_max), and
+  // getting the index of max(l_max) enables skipping the prolong/restrict
+  // call on whichever previous Strahlkorper has the highest l_max.
+  const auto max_l_it = std::max_element(
+      previous_strahlkorpers.begin(), previous_strahlkorpers.end(),
+      [](const auto& a, const auto& b) {
+        return a.second.l_max() < b.second.l_max();
+      });
+  const size_t max_prev_l = max_l_it->second.l_max();
+
+  // OK to static_cast to size_t from long here because
+  // max_l_it is inside the std::deque container, so distance
+  // from previous_strahlkorpers.begin() to max_l_it must be nonnegative.
+  const auto max_prev_l_index = static_cast<size_t>(
+      std::distance(previous_strahlkorpers.begin(), max_l_it));
+
+  // If needed, prolong the coefficients of the previous
+  // strahlkorpers to the highest resolution of the previous.
+  // Note: only need to restrict if min(l_max) and max(l_max) differ, and even
+  // then, no need to call prolong_or_restrict() on whichever previous
+  // Strahlkorper has the highest l_max.
+  for (size_t i = 0; i < previous_strahlkorpers.size(); ++i) {
+    ASSERT(previous_strahlkorpers[i].second.l_max() <= max_prev_l,
+           "Calculated incorrect max(l_max) = "
+               << max_prev_l << " but got a surface with l_max ="
+               << previous_strahlkorpers[i].second.l_max());
+    times.emplace_back(previous_strahlkorpers[i].first);
+    if (previous_strahlkorpers[i].second.l_max() != max_prev_l) {
+      prolonged_or_restricted_coefficients.emplace_back(
+          previous_strahlkorpers[i].second.ylm_spherepack().prolong_or_restrict(
+              previous_strahlkorpers[i].second.coefficients(),
+              previous_strahlkorpers[max_prev_l_index]
+                  .second.ylm_spherepack()));
+      coefficients.emplace_back(&(prolonged_or_restricted_coefficients.back()));
+    } else {
+      coefficients.emplace_back(
+          &(previous_strahlkorpers[i].second.coefficients()));
+    }
   }
 
   DataVector new_coefficients{};
@@ -498,6 +537,14 @@ void time_deriv_of_strahlkorper(
             << previous_strahlkorpers.size());
   }
 
+  // If needed, prolong or restrict the new coefficients to match the
+  // resolution of the Strahlkorper whose time derivative is being taken here
+  if (new_coefficients.size() != time_deriv->coefficients().size()) {
+    new_coefficients = previous_strahlkorpers[max_prev_l_index]
+                           .second.ylm_spherepack()
+                           .prolong_or_restrict(new_coefficients,
+                                                time_deriv->ylm_spherepack());
+  }
   time_deriv->coefficients() = std::move(new_coefficients);
 }
 

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_StrahlkorperFunctions.cpp
@@ -510,6 +510,68 @@ void test_time_deriv_strahlkorper() {
       CHECK_ITERABLE_APPROX(coefs, expected_coefs);
     }
   }
+
+  // Check that time derivative works when previous strahlkorpers have a
+  // different resolution than the output Strahlkorper. First, repeat the
+  // test that the time derivative should vanish, but this time, have
+  // use different l
+  constexpr size_t l_max_mid = 6;
+  constexpr size_t l_max_min = l_max_mid - 2;
+  constexpr size_t l_max_max = l_max_mid + 2;
+
+  Strahlkorper<Frame::Inertial> strahlkorper_mid{l_max_mid, l_max_mid, 1.0,
+                                                 std::array{0.0, 0.0, 0.0}};
+  Strahlkorper<Frame::Inertial> strahlkorper_min{l_max_min, l_max_min, 1.0,
+                                                 std::array{0.0, 0.0, 0.0}};
+  Strahlkorper<Frame::Inertial> strahlkorper_max{l_max_max, l_max_max, 1.0,
+                                                 std::array{0.0, 0.0, 0.0}};
+
+  // Set a random coefficient of each Strahlorper to be 1.3
+  SpherepackIterator iter_mid{l_max_mid, l_max_mid};
+  SpherepackIterator iter_min{l_max_min, l_max_min};
+  SpherepackIterator iter_max{l_max_max, l_max_max};
+
+  strahlkorper_mid.coefficients()[iter_mid.set(2, 1)()] = 1.3;
+  strahlkorper_min.coefficients()[iter_min.set(2, 1)()] = 1.3;
+  strahlkorper_max.coefficients()[iter_max.set(2, 1)()] = 1.3;
+
+  // Set all Strahlkorpers to have the same coefficients, and make sure
+  // that the time derivative is zero
+  std::deque<std::pair<double, Strahlkorper<Frame::Inertial>>>
+      previous_strahlkorpers_different_resolutions{};
+  previous_strahlkorpers_different_resolutions.emplace_front(0.0,
+                                                             strahlkorper_mid);
+  previous_strahlkorpers_different_resolutions.emplace_front(1.0,
+                                                             strahlkorper_min);
+  previous_strahlkorpers_different_resolutions.emplace_front(2.0,
+                                                             strahlkorper_max);
+  auto time_deriv_different_resolutions = strahlkorper_mid;
+  ylm::time_deriv_of_strahlkorper(
+      make_not_null(&time_deriv_different_resolutions),
+      previous_strahlkorpers_different_resolutions);
+  CHECK_ITERABLE_APPROX(
+      time_deriv_different_resolutions.coefficients(),
+      (DataVector{time_deriv_different_resolutions.coefficients().size(),
+                  0.0}));
+
+  // Now, test that a time derivative with two horizons with different
+  // resolutions returns the expected value
+  previous_strahlkorpers_different_resolutions.pop_front();
+  previous_strahlkorpers_different_resolutions.front()
+      .second.coefficients()[iter_min.set(2, 1)()] = 4.0;
+  previous_strahlkorpers_different_resolutions.back()
+      .second.coefficients()[iter_mid.set(2, 1)()] = 4.5;
+  auto time_deriv_2_resolutions = strahlkorper_max;
+  ylm::time_deriv_of_strahlkorper(make_not_null(&time_deriv_2_resolutions),
+                                  previous_strahlkorpers_different_resolutions);
+  const DataVector& coefs_different_resolutions =
+      time_deriv_2_resolutions.coefficients();
+  DataVector expected_coefs_different_resolutions{
+      coefs_different_resolutions.size(), 0.0};
+  expected_coefs_different_resolutions[iter_max.set(2, 1)()] = -0.5;
+
+  CHECK_ITERABLE_APPROX(coefs_different_resolutions,
+                        expected_coefs_different_resolutions);
 }
 
 void test_power_monitor() {


### PR DESCRIPTION
## Proposed changes

Allow computing time derivative of Strahlkorpers even when the Strahlkorpers have different resolutions, by prolonging or restricting as needed. This is necessary for enabling adaptive horizon finding.

Note: I used Cursor AI and ChatGPT to look up syntax, tab complete, and review code in this PR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Computing time derivatives of Strahlkorpers now works if the Strahlkorpers at different times have different resolutions. The resolution of each Strahlkorper is prolonged or restricted as needed.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
