### PR TITLE
SpherepackIterator: Allow for complex m=0 coef.

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.cpp
@@ -51,7 +51,12 @@
 // * Each "x" stands for an entry that is not referenced by SPHEREPACK
 //   (so SPHEREPACK wastes some storage space).  There is also one
 //   complete unreferenced row in the middle: the first row of the "b"
-//   array.
+//   array (unless zero_m_is_real is false).
+//
+// * Note that the first column of the "b" array is unreferenced. However,
+//   if zero_m_is_real is false, then this first column
+//   contains the imaginary parts of the m=0 modes, in the same format as
+//   the first row of the "a" array.
 //
 // Note that SPHEREPACK accepts arbitrary values of n_th and n_ph as
 // input, and then computes the corresponding l_max, m_max.  However,
@@ -76,20 +81,27 @@
 namespace ylm {
 SpherepackIterator::SpherepackIterator(const size_t l_max_input,
                                        const size_t m_max_input,
-                                       const size_t stride /*=1*/)
+                                       const size_t stride /*=1*/,
+                                       const bool zero_m_is_real)
     : l_max_(l_max_input),
       m_max_(m_max_input),
       n_th_(l_max_ + 1),
       n_ph_(2 * m_max_ + 1),
       stride_(stride),
+      zero_m_is_real_(zero_m_is_real),
       number_of_valid_entries_in_a_((m_max_ + 1) * (m_max_ + 2) / 2 +
                                     (m_max_ + 1) * (l_max_ - m_max_)),
       current_compact_index_(0) {
   // fill offset_into_spherepack_array, compact_l_ and compact_m_ with the
   // indices, l-values and m-values of all valid points
-  const size_t packed_size =
-      (m_max_ + 1) * (m_max_ + 2) / 2 + m_max_ * (m_max_ + 1) / 2 +
-      (m_max_ + 1) * (l_max_ - m_max_) + m_max_ * (l_max_ - m_max_);
+  const size_t packed_size = [this]() {
+    if (zero_m_is_real_) {
+      return (m_max_ + 1) * (m_max_ + 2) / 2 + m_max_ * (m_max_ + 1) / 2 +
+             (m_max_ + 1) * (l_max_ - m_max_) + m_max_ * (l_max_ - m_max_);
+    } else {
+      return 2 * number_of_valid_entries_in_a_;
+    }
+  }();
 
   offset_into_spherepack_array.assign(packed_size, 0);
   compact_l_.assign(packed_size, 0);
@@ -102,7 +114,8 @@ SpherepackIterator::SpherepackIterator(const size_t l_max_input,
   // index corresponding to strided coefficient array
   size_t idx = 0;
   size_t idx_no_stride = 0;
-  // index for compact offset_into_spherepack_array, compact_l_, compact_m_
+  // index for compact offset_into_spherepack_array, compact_l_,
+  // compact_m_
   size_t k = 0;
   for (size_t l = 0; l <= l_max_; ++l) {
     for (size_t m = 0; m <= m_max_; ++m) {
@@ -121,12 +134,22 @@ SpherepackIterator::SpherepackIterator(const size_t l_max_input,
   for (size_t l = 0; l <= l_max_; ++l) {
     for (size_t m = 0; m <= m_max_; ++m) {
       // note: index m varies fastest in fortran array
-      if (m >= 1 && l >= m) {  // valid entry in b
-        offset_into_spherepack_array[k] = idx;
-        offset_to_compact_index_[idx_no_stride] = k;
-        compact_l_[k] = l;
-        compact_m_[k] = m;
-        ++k;
+      if (zero_m_is_real_) {
+        if (m >= 1 and l >= m) {  // valid entry in b
+          offset_into_spherepack_array[k] = idx;
+          offset_to_compact_index_[idx_no_stride] = k;
+          compact_l_[k] = l;
+          compact_m_[k] = m;
+          ++k;
+        }
+      } else {
+        if (l >= m) {  // valid entry in b
+          offset_into_spherepack_array[k] = idx;
+          offset_to_compact_index_[idx_no_stride] = k;
+          compact_l_[k] = l;
+          compact_m_[k] = m;
+          ++k;
+        }
       }
       idx += stride;
       ++idx_no_stride;
@@ -160,14 +183,24 @@ SpherepackIterator& SpherepackIterator::set(
     }
     current_compact_index_ += m_input;
   } else {
-    ASSERT(m_input != 0, "Array b does not contain m_input=0");
-    if (l_input <= m_max_ + 1) {
-      current_compact_index_ = (l_input * (l_input - 1)) / 2;
+    if (zero_m_is_real_) {
+      ASSERT(m_input != 0, "Array b does not contain m_input=0");
+      if (l_input <= m_max_ + 1) {
+        current_compact_index_ = (l_input * (l_input - 1)) / 2;
+      } else {
+        current_compact_index_ =
+            m_max_ * (m_max_ + 1) / 2 + (l_input - m_max_ - 1) * m_max_;
+      }
+      current_compact_index_ += number_of_valid_entries_in_a_ + m_input - 1;
     } else {
-      current_compact_index_ =
-          m_max_ * (m_max_ + 1) / 2 + (l_input - m_max_ - 1) * m_max_;
+      if (l_input <= m_max_ + 1) {
+        current_compact_index_ = (l_input * (l_input + 1)) / 2;
+      } else {
+        current_compact_index_ = (m_max_ + 1) * (m_max_ + 2) / 2 +
+                                 (l_input - m_max_ - 1) * (m_max_ + 1);
+      }
+      current_compact_index_ += number_of_valid_entries_in_a_ + m_input;
     }
-    current_compact_index_ += number_of_valid_entries_in_a_ + m_input - 1;
   }
 
   ASSERT(current_compact_index_ < offset_into_spherepack_array.size(),
@@ -193,4 +226,5 @@ SpherepackIterator& SpherepackIterator::set(const size_t compact_index) {
   current_compact_index_ = compact_index;
   return *this;
 }
+
 }  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp
@@ -16,6 +16,7 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 
 namespace ylm {
+
 /*!
  * \ingroup SpectralGroup
  * \brief
@@ -53,13 +54,27 @@ class SpherepackIterator {
   /// coefficients.
   enum class CoefficientArray { a, b };
 
-  SpherepackIterator(size_t l_max_input, size_t m_max_input, size_t stride = 1);
+  /// Construct a SpherepackIterator.
+  ///
+  /// For all uses of SpherepackIterator by the SPHEREPACK routines,
+  /// zero_m_is_real should be true, indicating that the m=0 values of
+  /// the coefficients are real (or in other words, the 'b' array has
+  /// no m=0 values).
+  ///
+  /// However, we sometimes use the same storage scheme (and hence
+  /// SpherepackIterator) to hold spin-weighted-spherical-harmonic
+  /// coefficients of complex quantities, in which case the m=0 values
+  /// of the coefficients can be complex; in that case, zero_m_is_real
+  /// should be false.
+  SpherepackIterator(size_t l_max_input, size_t m_max_input, size_t stride = 1,
+                     bool zero_m_is_real = true);
 
   size_t l_max() const { return l_max_; }
   size_t m_max() const { return m_max_; }
   size_t n_th() const { return n_th_; }
   size_t n_ph() const { return n_ph_; }
   size_t stride() const { return stride_; }
+  bool zero_m_is_real() const { return zero_m_is_real_; }
 
   /// Size of a SPHEREPACK coefficient array (a and b combined), not
   /// counting stride.  For non-unit stride, the size of the array
@@ -135,6 +150,7 @@ class SpherepackIterator {
 
  private:
   size_t l_max_, m_max_, n_th_, n_ph_, stride_;
+  bool zero_m_is_real_;
   size_t number_of_valid_entries_in_a_;
   size_t current_compact_index_;
   std::vector<size_t> offset_into_spherepack_array;
@@ -145,7 +161,8 @@ class SpherepackIterator {
 inline bool operator==(const SpherepackIterator& lhs,
                        const SpherepackIterator& rhs) {
   return lhs.l_max() == rhs.l_max() and lhs.m_max() == rhs.m_max() and
-         lhs.stride() == rhs.stride() and lhs() == rhs();
+         lhs.stride() == rhs.stride() and lhs() == rhs() and
+         lhs.zero_m_is_real() == rhs.zero_m_is_real();
 }
 
 inline bool operator!=(const SpherepackIterator& lhs,

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackIterator.cpp
@@ -13,29 +13,24 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
 
-namespace ylm {
-SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
-                  "[NumericalAlgorithms][Unit]") {
-  const std::vector<size_t> test_l = {0, 1, 1, 2, 2, 2, 3, 3, 3, 4,
-                                      4, 4, 1, 2, 2, 3, 3, 4, 4};
-  const std::vector<size_t> test_m = {0, 0, 1, 0, 1, 2, 0, 1, 2, 0,
-                                      1, 2, 1, 1, 2, 1, 2, 1, 2};
-  const std::vector<size_t> test_index = {0,   15,  20,  30,  35, 40, 45,
-                                          50,  55,  60,  65,  70, 95, 110,
-                                          115, 125, 130, 140, 145};
-
+namespace {
+void test_spherepack_iterator(const std::vector<size_t>& test_l,
+                              const std::vector<size_t>& test_m,
+                              const std::vector<size_t>& test_index,
+                              const bool zero_m_is_real) {
   // [spherepack_iterator_example]
   const size_t l_max = 4;
   const size_t m_max = 2;
   const size_t stride = 5;
-  SpherepackIterator iter(l_max, m_max, stride);
+  ylm::SpherepackIterator iter(l_max, m_max, stride, zero_m_is_real);
   // Allocate space for a SPHEREPACK array
   std::vector<double> array(iter.spherepack_array_size() * stride);
   // Set each array element equal to l+m for real part
   // and l-m for imaginary part.
   size_t i = 0;
   for (iter.reset(); iter; ++iter, ++i) {
-    if (iter.coefficient_array() == SpherepackIterator::CoefficientArray::a) {
+    if (iter.coefficient_array() ==
+        ylm::SpherepackIterator::CoefficientArray::a) {
       array[iter()] = iter.l() + iter.m();
     } else {
       array[iter()] = iter.l() - iter.m();
@@ -72,13 +67,17 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
   }
 
   // Test set functions
-  CHECK(iter.set(2, 1, SpherepackIterator::CoefficientArray::b)() == 110);
+  CHECK(iter.set(2, 1, ylm::SpherepackIterator::CoefficientArray::b)() ==
+        (zero_m_is_real ? test_index[13] : test_index[16]));
   // Test the set function for the case l>m_max+1
-  CHECK(iter.set(4, 1, SpherepackIterator::CoefficientArray::a)() == 65);
-  CHECK(iter.set(4, 1, SpherepackIterator::CoefficientArray::b)() == 140);
+  CHECK(iter.set(4, 1, ylm::SpherepackIterator::CoefficientArray::a)() ==
+        test_index[10]);
+  CHECK(iter.set(4, 1, ylm::SpherepackIterator::CoefficientArray::b)() ==
+        (zero_m_is_real ? test_index[17] : test_index[22]));
   CHECK(iter.reset()() == 0);
-  CHECK(iter.set(2, 1)() == 35);
-  CHECK(iter.set(2, -1)() == 110);
+  CHECK(iter.set(2, 1)() == test_index[4]);
+  CHECK(iter.set(2, -1)() ==
+        (zero_m_is_real ? test_index[13] : test_index[16]));
   // Test setting the current compact index
   CHECK(iter.set(0)() == test_index[0]);
   CHECK(iter.set(3)() == test_index[3]);
@@ -88,16 +87,20 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
       ([&iter]() { iter.set(100); })(),
       Catch::Matchers::ContainsSubstring(
           "Trying to set the current compact index to 100 which is "
-          "beyond the size of the offset array 19"));
+          "beyond the size of the offset array"));
 #endif  // SPECTRE_DEBUG
 
-  // Test coefficient_arrya stream operator (assumes output of last 'set').
+  // Test coefficient_array stream operator (assumes output of last 'set').
   CHECK(get_output(iter.coefficient_array()) == "b");
 
   // Test inequality
-  const SpherepackIterator iter2(3, 2, 5);  // Different lmax,mmax
-  const SpherepackIterator iter3(4, 2, 4);  // Different stride
-  const SpherepackIterator iter4(4, 2, 5);  // Different current state
+  const ylm::SpherepackIterator iter2(3, 2, 5,
+                                      zero_m_is_real);  // Different lmax,mmax
+  const ylm::SpherepackIterator iter3(4, 2, 4,
+                                      zero_m_is_real);  // Different stride
+  const ylm::SpherepackIterator iter4(
+      4, 2, 5,
+      zero_m_is_real);  // Different current state
   CHECK(iter2 != iter);
   CHECK(iter != iter2);
   CHECK(iter != iter3);
@@ -108,5 +111,26 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
   const auto iter_copy = iter;
   CHECK(iter_copy == iter);
   test_move_semantics(std::move(iter), iter_copy, 3_st, 2_st, 3_st);
+}
+}  // namespace
+
+namespace ylm {
+
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackIterator",
+                  "[NumericalAlgorithms][Unit]") {
+  test_spherepack_iterator(
+      {{0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 1, 2, 2, 3, 3, 4, 4}},
+      {{0, 0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 2, 1, 1, 2, 1, 2, 1, 2}},
+      {{0, 15, 20, 30, 35, 40, 45, 50, 55, 60, 65, 70, 95, 110, 115, 125, 130,
+        140, 145}},
+      true);
+  test_spherepack_iterator(
+      {{0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4,
+        0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4}},
+      {{0, 0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 2,
+        0, 0, 1, 0, 1, 2, 0, 1, 2, 0, 1, 2}},
+      {{0,  15, 20, 30,  35,  40,  45,  50,  55,  60,  65,  70,
+        75, 90, 95, 105, 110, 115, 120, 125, 130, 135, 140, 145}},
+      false);
 }
 }  // namespace ylm


### PR DESCRIPTION
This is needed when Spherepack storage is used to hold coefficients of tensorylm components, which are complex.  For spin-weight zero, and real valued functions, the m=0 coefficients are all real.

## Proposed changes

Adds an argument to the SpherepackIterator constructor that allows m=0 coefficients to be imaginary.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
