### PR TITLE
Add more cartoon partial derivative features

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -270,6 +270,89 @@ auto partial_derivative(
         Tensor<DataType, SymmList, IndexList>, Dim, UpLo::Lo, DerivativeFrame>;
 /// @}
 
+/// @{
+/// \ingroup NumericalAlgorithmsGroup
+/// \brief Compute the partial derivative of a `Tensor` with respect to
+/// the coordinates of `DerivativeFrame` when a Cartoon basis is being used.
+///
+/// Returns a `Tensor` with a spatial tensor index appended to the front
+/// of the input `Tensor`.
+///
+/// If you have a `Variables` with several tensors with Cartoon bases you need
+/// to differentiate, you should use the `cartoon_partial_derivatives` function
+/// that operates on `Variables` since that'll be more efficient.
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3> = nullptr>
+void cartoon_partial_derivative(
+    gsl::not_null<TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame>*>
+        du,
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3> = nullptr>
+auto cartoon_partial_derivative(
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords)
+    -> TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame>;
+/// @}
+
+/// @{
+/// \ingroup NumericalAlgorithmsGroup
+/// \brief Calls the correct partial derivatives function, either normal
+/// partials or cartoon partials, as determined by mesh basis.
+///
+/// To be used in executables that allow a Cartoon basis, a choice that is
+/// only known at runtime.
+template <typename ResultTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame>
+void partial_derivatives(
+    gsl::not_null<Variables<ResultTags>*> du,
+    const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+/// @}
+
+/// @{
+/// \ingroup NumericalAlgorithmsGroup
+/// \brief Calls the correct partial derivative function, either normal
+/// partial or cartoon partial, as determined by mesh basis.
+///
+/// To be used in executables that allow a Cartoon basis, a choice that is
+/// only known at runtime.
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame>
+void partial_derivative(
+    gsl::not_null<TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame>*>
+        du,
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame>
+auto partial_derivative(
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords)
+    -> TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame>;
+/// @}
+
 namespace Tags {
 
 /*!
@@ -282,11 +365,15 @@ namespace Tags {
  * `DerivTags` template parameter. It takes a `tmpl::list` of the desired
  * tags and defaults to the full `tags_list` of the Variables.
  *
+ * For an executable that does not allow a Cartoon basis, the last parameter,
+ * `InertialCoordsTag`, should not be passed.
+ *
  * This tag may be retrieved via `::Tags::Variables<db::wrap_tags_in<deriv,
  * DerivTags, Dim, deriv_frame>`.
  */
 template <typename VariablesTag, typename MeshTag, typename InverseJacobianTag,
-          typename DerivTags = typename VariablesTag::type::tags_list>
+          typename DerivTags = typename VariablesTag::type::tags_list,
+          typename InertialCoordsTag = void>
 struct DerivCompute
     : db::add_tag_prefix<
           deriv, ::Tags::Variables<DerivTags>,
@@ -308,15 +395,25 @@ struct DerivCompute
       typename tmpl::back<
           typename InverseJacobianTag::type::index_list>::Frame>;
   using return_type = typename base::type;
-  static constexpr void (*function)(
-      gsl::not_null<return_type*>, const typename VariablesTag::type&,
-      const Mesh<Dim>&,
+  static constexpr void function(
+      gsl::not_null<return_type*> du, const typename VariablesTag::type& u,
+      const Mesh<Dim>& mesh,
       const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                            deriv_frame>&) =
-      partial_derivatives<typename return_type::tags_list,
-                          typename VariablesTag::type::tags_list, Dim,
-                          deriv_frame>;
-  using argument_tags = tmpl::list<VariablesTag, MeshTag, InverseJacobianTag>;
+                            deriv_frame>& inverse_jacobian) {
+    partial_derivatives(du, u, mesh, inverse_jacobian);
+  }
+  static constexpr void function(
+      gsl::not_null<return_type*> du, const typename VariablesTag::type& u,
+      const Mesh<Dim>& mesh,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            deriv_frame>& inverse_jacobian,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+    partial_derivatives(du, u, mesh, inverse_jacobian, inertial_coords);
+  }
+  using argument_tags = tmpl::conditional_t<
+      std::is_same_v<void, InertialCoordsTag>,
+      tmpl::list<VariablesTag, MeshTag, InverseJacobianTag>,
+      tmpl::list<VariablesTag, MeshTag, InverseJacobianTag, InertialCoordsTag>>;
 };
 
 /*!

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -332,7 +332,7 @@ void cartoon_derivative(
   }
 }
 
-template <size_t Comp_dim, typename ResultTags, typename VariableTags,
+template <size_t CompDim, typename ResultTags, typename VariableTags,
           size_t Dim, typename DerivativeFrame>
 void cartoon_partial_derivatives_apply(
     const gsl::not_null<Variables<ResultTags>*> du,
@@ -349,9 +349,9 @@ void cartoon_partial_derivatives_apply(
           tmpl::transform<db::wrap_tags_in<Tags::deriv, DerivativeTags,
                                            tmpl::size_t<Dim>, DerivativeFrame>,
                           tmpl::bind<tmpl::type_from, tmpl::_1>>>);
-  ASSERT((Comp_dim == 2 and
+  ASSERT((CompDim == 2 and
           mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry) or
-             (Comp_dim == 1 and
+             (CompDim == 1 and
               (mesh.quadrature(1) == Spectral::Quadrature::SphericalSymmetry and
                mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry)),
          "Invalid Quadrature combinations: axial symmetry requires 2 "
@@ -372,48 +372,48 @@ void cartoon_partial_derivatives_apply(
       Variables<DerivativeTags>::number_of_independent_components;
   const auto logical_derivs_data =
       cpp20::make_unique_for_overwrite<ValueType[]>(
-          (Comp_dim > 1 ? (Comp_dim + 1) : Comp_dim) * vars_size);
+          (CompDim > 1 ? (CompDim + 1) : CompDim) * vars_size);
 
-  std::array<ValueType*, Comp_dim> logical_derivs{};
-  for (size_t i = 0; i < Comp_dim; ++i) {
+  std::array<ValueType*, CompDim> logical_derivs{};
+  for (size_t i = 0; i < CompDim; ++i) {
     gsl::at(logical_derivs, i) = &(logical_derivs_data[i * vars_size]);
   }
   Variables<DerivativeTags> temp{};
-  if constexpr (Comp_dim > 1) {
-    temp.set_data_ref(&logical_derivs_data[Comp_dim * vars_size], vars_size);
+  if constexpr (CompDim > 1) {
+    temp.set_data_ref(&logical_derivs_data[CompDim * vars_size], vars_size);
   }
 
-  if constexpr (Comp_dim == 1) {
+  if constexpr (CompDim == 1) {
     partial_derivatives_detail::
-        LogicalImpl<Comp_dim, VariableTags, DerivativeTags>::apply(
+        LogicalImpl<CompDim, VariableTags, DerivativeTags>::apply(
             make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
             mesh.slice_through(0));
   } else {
     partial_derivatives_detail::
-        LogicalImpl<Comp_dim, VariableTags, DerivativeTags>::apply(
+        LogicalImpl<CompDim, VariableTags, DerivativeTags>::apply(
             make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
             mesh.slice_through(0, 1));
   }
 
-  std::array<const ValueType*, Comp_dim> const_logical_derivs{};
-  for (size_t i = 0; i < Comp_dim; ++i) {
+  std::array<const ValueType*, CompDim> const_logical_derivs{};
+  for (size_t i = 0; i < CompDim; ++i) {
     gsl::at(const_logical_derivs, i) = gsl::at(logical_derivs, i);
   }
 
   const Spectral::Quadrature quad_type = mesh.quadrature(2);
   const auto numerical_deriv_in_this_direction = [](const size_t deriv_num) {
-    if constexpr (Comp_dim == 2) {
+    if constexpr (CompDim == 2) {
       return deriv_num == 0 or deriv_num == 1;
     } else {
       return deriv_num == 0;
     }
   };
   // only the 1st (possibly 2nd) dimensions of the Jacobian are relevant here
-  const InverseJacobian<DataVector, Comp_dim, Frame::ElementLogical,
+  const InverseJacobian<DataVector, CompDim, Frame::ElementLogical,
                         DerivativeFrame>
       inverse_jacobian{inverse_jacobian_3d.begin()->size()};
-  for (size_t i = 0; i < Comp_dim; ++i) {
-    for (size_t j = 0; j < Comp_dim; ++j) {
+  for (size_t i = 0; i < CompDim; ++i) {
+    for (size_t j = 0; j < CompDim; ++j) {
       make_const_view(make_not_null(&inverse_jacobian.get(i, j)),
                       inverse_jacobian_3d.get(i, j), 0,
                       inverse_jacobian_3d.begin()->size());
@@ -432,7 +432,7 @@ void cartoon_partial_derivatives_apply(
   // arbitrary non-zero value) and remembering to then do L'Hopital
   if (element_contains_zero_of_symmetry_axis) {
     safe_x_coords[0] = 1.0;
-    if constexpr (Comp_dim == 2) {
+    if constexpr (CompDim == 2) {
       const size_t x_extents = mesh.extents(0);
       const size_t y_extents = mesh.extents(1);
       for (size_t i = 1; i < y_extents; ++i) {
@@ -453,7 +453,7 @@ void cartoon_partial_derivatives_apply(
   // in two different tensors (hence the 0 & 1 labels) for each tensor type
   // They only have to hold the x=0 positions, so of size y_extents
   using VariableTypes = tmpl::remove_duplicates<
-      tmpl::transform<VariableTags, tmpl::bind<tmpl::type_from, tmpl::_1>>>;
+      tmpl::transform<DerivativeTags, tmpl::bind<tmpl::type_from, tmpl::_1>>>;
 
   using TempTags0 = ::Tags::convert_to_temp_tensors<VariableTypes, 0>;
   using TempTags1 = ::Tags::convert_to_temp_tensors<VariableTypes, 1>;
@@ -465,11 +465,11 @@ void cartoon_partial_derivatives_apply(
     temp_vars.initialize(y_extents);
   }
 
-  std::array<std::array<size_t, Comp_dim>, Comp_dim> indices{};
-  for (size_t deriv_index = 0; deriv_index < Comp_dim; ++deriv_index) {
-    for (size_t d = 0; d < Comp_dim; ++d) {
+  std::array<std::array<size_t, CompDim>, CompDim> indices{};
+  for (size_t deriv_index = 0; deriv_index < CompDim; ++deriv_index) {
+    for (size_t d = 0; d < CompDim; ++d) {
       gsl::at(gsl::at(indices, d), deriv_index) =
-          InverseJacobian<DataVector, Comp_dim, Frame::ElementLogical,
+          InverseJacobian<DataVector, CompDim, Frame::ElementLogical,
                           DerivativeFrame>::get_storage_index(d, deriv_index);
     }
   }
@@ -477,7 +477,7 @@ void cartoon_partial_derivatives_apply(
   // the non-cartoon derivatives need to know where they are within `u` to
   // contract with the inverse Jacobian to compute the inertial derivatives
   size_t global_component_index = 0;
-  tmpl::for_each<VariableTags>(
+  tmpl::for_each<DerivativeTags>(
       [&u, &du, &lhs, &pdu, &num_grid_points, &logical_du,
        &const_logical_derivs, &inverse_jacobian, &indices, &temp_vars,
        &global_component_index, &safe_x_coords,
@@ -511,7 +511,7 @@ void cartoon_partial_derivatives_apply(
               lhs = (*(inverse_jacobian.begin() +
                        gsl::at(indices[0], deriv_index))) *
                     logical_du;
-              if constexpr (Comp_dim == 2) {
+              if constexpr (CompDim == 2) {
                 // clang-tidy: const cast is fine since we won't modify the data
                 // and we need it to easily hook into the expression templates.
                 logical_du.set_data_ref(
@@ -538,7 +538,7 @@ void cartoon_partial_derivatives_apply(
         if (element_contains_zero_of_symmetry_axis) {
           // need to use L'Hopital
           using dtensor_type =
-              tmpl::at<ResultTags, tmpl::index_of<VariableTags, TensorTag>>;
+              tmpl::at<ResultTags, tmpl::index_of<DerivativeTags, TensorTag>>;
           auto& dtensor = get<dtensor_type>(*du);
 
           // if spherical symmetry,the zero is only at the first index
@@ -598,6 +598,7 @@ void cartoon_partial_derivatives(
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian_3d,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  static_assert(Dim == 3);
   if (mesh.basis(0) != Spectral::Basis::Cartoon and
       mesh.basis(2) == Spectral::Basis::Cartoon) {
     // computational dimension needs to be a constexpr
@@ -681,6 +682,124 @@ partial_derivatives(
   partial_derivatives(make_not_null(&partial_derivatives_of_u), u, mesh,
                       inverse_jacobian);
   return partial_derivatives_of_u;
+}
+
+template <typename ResultTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame>
+void partial_derivatives(
+    const gsl::not_null<Variables<ResultTags>*> du,
+    const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  if constexpr (Dim == 3) {
+    if (mesh.basis(2) == Spectral::Basis::Cartoon) {
+      cartoon_partial_derivatives(du, u, mesh, inverse_jacobian,
+                                  inertial_coords);
+    } else {
+      partial_derivatives(du, u, mesh, inverse_jacobian);
+    }
+  } else {
+    (void)inertial_coords;
+    partial_derivatives(du, u, mesh, inverse_jacobian);
+  }
+}
+
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3>>
+void cartoon_partial_derivative(
+    const gsl::not_null<TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame>*>
+        du,
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  auto& du_tnsr = *du;
+  using u_type = Tensor<DataVector, SymmList, IndexList>;
+  using du_type =
+      TensorMetafunctions::prepend_spatial_index<u_type, Dim, UpLo::Lo,
+                                                 DerivativeFrame>;
+  using vars_list = ::Tags::convert_to_temp_tensors<tmpl::list<u_type>, 0>;
+  using d_vars_list = ::Tags::convert_to_temp_tensors<tmpl::list<du_type>, 0>;
+  Variables<vars_list> u_vars{mesh.number_of_grid_points()};
+  get<tmpl::front<vars_list>>(u_vars) = u;
+  Variables<d_vars_list> du_vars{mesh.number_of_grid_points()};
+  cartoon_partial_derivatives(make_not_null(&du_vars), u_vars, mesh,
+                              inverse_jacobian, inertial_coords);
+  du_tnsr = get<tmpl::front<d_vars_list>>(du_vars);
+}
+
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3>>
+auto cartoon_partial_derivative(
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords)
+    -> TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame> {
+  using u_type = Tensor<DataVector, SymmList, IndexList>;
+  using du_type =
+      TensorMetafunctions::prepend_spatial_index<u_type, Dim, UpLo::Lo,
+                                                 DerivativeFrame>;
+  using vars_list = ::Tags::convert_to_temp_tensors<tmpl::list<u_type>, 0>;
+  using d_vars_list = ::Tags::convert_to_temp_tensors<tmpl::list<du_type>, 0>;
+  Variables<vars_list> u_vars{mesh.number_of_grid_points()};
+  get<tmpl::front<vars_list>>(u_vars) = u;
+  Variables<d_vars_list> du_vars{mesh.number_of_grid_points()};
+  cartoon_partial_derivatives(make_not_null(&du_vars), u_vars, mesh,
+                              inverse_jacobian, inertial_coords);
+  return get<tmpl::front<d_vars_list>>(du_vars);
+}
+
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame>
+void partial_derivative(
+    const gsl::not_null<TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame>*>
+        du,
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  if constexpr (Dim == 3) {
+    if (mesh.basis(2) == Spectral::Basis::Cartoon) {
+      cartoon_partial_derivative(du, u, mesh, inverse_jacobian,
+                                 inertial_coords);
+    } else {
+      partial_derivative(du, u, mesh, inverse_jacobian);
+    }
+  } else {
+    (void)inertial_coords;
+    partial_derivative(du, u, mesh, inverse_jacobian);
+  }
+}
+
+template <typename SymmList, typename IndexList, size_t Dim,
+          typename DerivativeFrame>
+auto partial_derivative(
+    const Tensor<DataVector, SymmList, IndexList>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords)
+    -> TensorMetafunctions::prepend_spatial_index<
+        Tensor<DataVector, SymmList, IndexList>, Dim, UpLo::Lo,
+        DerivativeFrame> {
+  if constexpr (Dim == 3) {
+    if (mesh.basis(2) == Spectral::Basis::Cartoon) {
+      return cartoon_partial_derivative(u, mesh, inverse_jacobian,
+                                        inertial_coords);
+    } else {
+      return partial_derivative(u, mesh, inverse_jacobian);
+    }
+  } else {
+    (void)inertial_coords;
+    return partial_derivative(u, mesh, inverse_jacobian);
+  }
 }
 
 namespace partial_derivatives_detail {
@@ -852,3 +971,40 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
       const Mesh<DIM>& mesh,                                                 \
       const InverseJacobian<DataVector, DIM, Frame::ElementLogical,          \
                             DERIVATIVE_FRAME>& inverse_jacobian);
+
+// Macro to explicitly instantiate cartoon_partial_derivatives()
+// for a given system of equations (distinct from non-cartoon call)
+#define INSTANTIATE_CARTOON_PARTIAL_DERIVATIVES_WITH_SYSTEM(SYSTEM, DIM,      \
+                                                            DERIVATIVE_FRAME) \
+  template void partial_derivatives(                                          \
+      gsl::not_null<Variables<                                                \
+          db::wrap_tags_in<Tags::deriv, typename SYSTEM::gradient_variables,  \
+                           tmpl::size_t<DIM>, DERIVATIVE_FRAME>>*>            \
+          du,                                                                 \
+      const Variables<typename SYSTEM::gradient_variables>& u,                \
+      const Mesh<DIM>& mesh,                                                  \
+      const InverseJacobian<DataVector, DIM, Frame::ElementLogical,           \
+                            DERIVATIVE_FRAME>& inverse_jacobian_3d,           \
+      const tnsr::I<DataVector, DIM, Frame::Inertial>& inertial_coords);
+
+// This instantiates the chooser and underlying cartoon_partial_derivative()
+#define INSTANTIATE_CARTOON_PARTIAL_DERIVATIVE(DIM, DERIVATIVE_FRAME, TENSOR) \
+  template void partial_derivative(                                           \
+      const gsl::not_null<TensorMetafunctions::prepend_spatial_index<         \
+          TENSOR<DataVector, DIM, DERIVATIVE_FRAME>, DIM, UpLo::Lo,           \
+          DERIVATIVE_FRAME>*>                                                 \
+          du,                                                                 \
+      const TENSOR<DataVector, DIM, DERIVATIVE_FRAME>& u,                     \
+      const Mesh<DIM>& mesh,                                                  \
+      const InverseJacobian<DataVector, DIM, Frame::ElementLogical,           \
+                            DERIVATIVE_FRAME>& inverse_jacobian,              \
+      const tnsr::I<DataVector, DIM, Frame::Inertial>& inertial_coords);      \
+  template TensorMetafunctions::prepend_spatial_index<                        \
+      TENSOR<DataVector, DIM, DERIVATIVE_FRAME>, DIM, UpLo::Lo,               \
+      DERIVATIVE_FRAME>                                                       \
+  partial_derivative(                                                         \
+      const TENSOR<DataVector, DIM, DERIVATIVE_FRAME>& u,                     \
+      const Mesh<DIM>& mesh,                                                  \
+      const InverseJacobian<DataVector, DIM, Frame::ElementLogical,           \
+                            DERIVATIVE_FRAME>& inverse_jacobian,              \
+      const tnsr::I<DataVector, DIM, Frame::Inertial>& inertial_coords);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -688,7 +688,7 @@ DataVector cartoon_dfunc(size_t deriv_index,
 }
 
 template <bool Spherical>
-void test_cartoon(const double x_start) {
+void test_cartoon_partial_derivatives(const double x_start) {
   Mesh<3> mesh;
   tnsr::I<DataVector, 3, Frame::Grid> coords;
   InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>
@@ -791,7 +791,7 @@ void test_cartoon(const double x_start) {
 
   const size_t dv_size = get<0>(coords).size();
 
-  // in the following, the time component of the indices is arbirarily taken
+  // in the following, the time component of the indices is arbitrarily taken
   // to be 1
   auto& scalar = get<::Tags::TempScalar<0>>(prefactor_vars);
   auto& d_scalar = get<::Tags::Tempi<0, 3>>(d_prefactor_vars);
@@ -1004,6 +1004,140 @@ void test_cartoon(const double x_start) {
   const Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
   CHECK_VARIABLES_CUSTOM_APPROX(d_vars, expected_d_vars, local_approx);
 }
+
+void test_cartoon_partial_derivative_and_choosers() {
+  // here, "chooser" means the partial_derivative()/parital_derivatives()
+  // functions that take inertial_coords and then pick the appropriate
+  // cartoon/non-cartoon implementation
+  // Testing partial_derivatives chooser, i.e. verifying it calls the correct
+  // underlying implemenation (unfortunately a lot of set up code)
+  // With cartoon basis
+  using Identity1D = domain::CoordinateMaps::Identity<1>;
+  const Identity1D identity_cartoon_map;
+
+  const Mesh<3> mesh_cartoon{
+      {{8, 1, 1}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+        Spectral::Basis::Cartoon}},
+      {{Spectral::Quadrature::GaussLobatto,
+        Spectral::Quadrature::SphericalSymmetry,
+        Spectral::Quadrature::SphericalSymmetry}}};
+
+  const Affine affine_x_map(-1.0, 1.0, 1.0, 4.0);
+
+  using Cartoon_map_combination =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D, Identity1D>;
+  const domain::CoordinateMap<Frame::ElementLogical, Frame::Grid,
+                              Cartoon_map_combination>
+      map{{affine_x_map, identity_cartoon_map, identity_cartoon_map}};
+  const auto inv_jacobian = map.inv_jacobian(logical_coordinates(mesh_cartoon));
+  const auto coords = map(logical_coordinates(mesh_cartoon));
+
+  Scalar<DataVector> tnsr_cartoon{};
+  get<>(tnsr_cartoon) = cartoon_func<true>(coords);
+  TensorMetafunctions::prepend_spatial_index<Scalar<DataVector>, 3, UpLo::Lo,
+                                             Frame::Grid>
+      expected_d_tnsr_cartoon{};
+  for (size_t i = 0; i < index_dim<0>(expected_d_tnsr_cartoon); ++i) {
+    expected_d_tnsr_cartoon.get(i) = cartoon_dfunc<true>(i, coords);
+  }
+
+  const auto to_inertial =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                            domain::CoordinateMaps::Identity<3>>{};
+  TensorMetafunctions::prepend_spatial_index<Scalar<DataVector>, 3, UpLo::Lo,
+                                             Frame::Grid>
+      d_tnsr_cartoon{};
+  using u_type = Scalar<DataVector>;
+  using du_type =
+      TensorMetafunctions::prepend_spatial_index<u_type, 3, UpLo::Lo,
+                                                 Frame::Grid>;
+  using CartoonTags = ::Tags::convert_to_temp_tensors<tmpl::list<u_type>, 0>;
+  using d_CartoonTags = ::Tags::convert_to_temp_tensors<tmpl::list<du_type>, 0>;
+  Variables<CartoonTags> u_cartoon{mesh_cartoon.number_of_grid_points()};
+  get<tmpl::front<CartoonTags>>(u_cartoon) = tnsr_cartoon;
+  Variables<d_CartoonTags> d_u_cartoon{mesh_cartoon.number_of_grid_points()};
+  partial_derivatives(make_not_null(&d_u_cartoon), u_cartoon, mesh_cartoon,
+                      inv_jacobian, to_inertial(coords));
+  Variables<d_CartoonTags> expected_d_u_cartoon{
+      mesh_cartoon.number_of_grid_points()};
+  get<tmpl::front<d_CartoonTags>>(expected_d_u_cartoon) =
+      expected_d_tnsr_cartoon;
+  const Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
+  CHECK_VARIABLES_CUSTOM_APPROX(d_u_cartoon, expected_d_u_cartoon,
+                                local_approx);
+
+  // With non-cartoon basis
+  const Mesh<3> mesh_lgl{{{3, 4, 5}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+  using VariableTags = two_vars<DataVector, 3>;
+  using GradientTags = two_vars<DataVector, 3>;
+  const size_t number_of_grid_points_lgl = mesh_lgl.number_of_grid_points();
+  const auto prod_map_lgl =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+          Affine3D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+                   Affine{-1.0, 1.0, 2.3, 2.8}});
+  const auto x = prod_map_lgl(logical_coordinates(mesh_lgl));
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>
+      inv_jacobian_lgl(number_of_grid_points_lgl, 0.0);
+  inv_jacobian_lgl.get(0, 0) = 2.0;
+  inv_jacobian_lgl.get(1, 1) = 8.0;
+  inv_jacobian_lgl.get(2, 2) = 4.0;
+
+  Variables<VariableTags> u_lgl(number_of_grid_points_lgl);
+  Variables<
+      db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<3>, Frame::Grid>>
+      expected_d_u_lgl(number_of_grid_points_lgl);
+  for (size_t a = 0; a < mesh_lgl.extents(0) / 2; ++a) {
+    for (size_t b = 0; b < mesh_lgl.extents(1) / 2; ++b) {
+      for (size_t c = 0; c < mesh_lgl.extents(2) / 2; ++c) {
+        tmpl::for_each<VariableTags>([&a, &b, &c, &x, &u_lgl](auto tag) {
+          using Tag = typename decltype(tag)::type;
+          get<Tag>(u_lgl) = Tag::f({{a, b, c}}, x);
+        });
+        tmpl::for_each<GradientTags>([&a, &b, &c, &x,
+                                      &expected_d_u_lgl](auto tag) {
+          using Tag = typename decltype(tag)::type;
+          using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<3>, Frame::Grid>;
+          get<DerivativeTag>(expected_d_u_lgl) = Tag::df({{a, b, c}}, x);
+        });
+
+        using vars_type = decltype(partial_derivatives<GradientTags>(
+            u_lgl, mesh_lgl, inv_jacobian_lgl));
+        vars_type d_u_lgl{};
+        partial_derivatives(make_not_null(&d_u_lgl), u_lgl, mesh_lgl,
+                            inv_jacobian_lgl, to_inertial(x));
+        CHECK_VARIABLES_CUSTOM_APPROX(d_u_lgl, expected_d_u_lgl, local_approx);
+      }
+    }
+  }
+  // Testing cartoon_partial_derivative() through associated choosers
+  // With Cartoon basis
+  partial_derivative(make_not_null(&d_tnsr_cartoon), tnsr_cartoon, mesh_cartoon,
+                     inv_jacobian, to_inertial(coords));
+  CHECK_ITERABLE_CUSTOM_APPROX(d_tnsr_cartoon, expected_d_tnsr_cartoon,
+                               local_approx);
+
+  d_tnsr_cartoon = partial_derivative(tnsr_cartoon, mesh_cartoon, inv_jacobian,
+                                      to_inertial(coords));
+  CHECK_ITERABLE_CUSTOM_APPROX(d_tnsr_cartoon, expected_d_tnsr_cartoon,
+                               local_approx);
+
+  // With non-cartoon basis
+  auto& tnsr_lgl = get<tmpl::front<VariableTags>>(u_lgl);
+  using d_tnsr_lgl_tag =
+      Tags::deriv<tmpl::front<GradientTags>, tmpl::size_t<3>, Frame::Grid>;
+  d_tnsr_lgl_tag::type d_tnsr_lgl{};
+  auto& expected_d_tnsr_lgl = get<d_tnsr_lgl_tag>(expected_d_u_lgl);
+  partial_derivative(make_not_null(&d_tnsr_lgl), tnsr_lgl, mesh_lgl,
+                     inv_jacobian_lgl, to_inertial(x));
+  CHECK_ITERABLE_CUSTOM_APPROX(d_tnsr_lgl, expected_d_tnsr_lgl, local_approx);
+
+  d_tnsr_lgl = partial_derivative(tnsr_lgl, mesh_lgl, inv_jacobian_lgl,
+                                  to_inertial(coords));
+  CHECK_ITERABLE_CUSTOM_APPROX(d_tnsr_lgl, expected_d_tnsr_lgl, local_approx);
+}
 }  // namespace
 
 // [[Timeout, 60]]
@@ -1128,12 +1262,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
   test_partial_derivatives_3d<two_vars<ComplexDataVector, 3>,
                               one_var<ComplexDataVector, 3>>(mesh_3d);
 
-  // testing with L'Hopital
-  test_cartoon<true>(0.0);
-  test_cartoon<false>(0.0);
+  test_cartoon_partial_derivatives<true>(0.0);
+  test_cartoon_partial_derivatives<false>(0.0);
   // testing without L'Hopital
-  test_cartoon<true>(1.0);
-  test_cartoon<false>(1.0);
+  test_cartoon_partial_derivatives<true>(1.0);
+  test_cartoon_partial_derivatives<false>(1.0);
+
+  test_cartoon_partial_derivative_and_choosers();
 
   TestHelpers::db::test_prefix_tag<
       Tags::deriv<Var1<DataVector, 3>, tmpl::size_t<3>, Frame::Grid>>(
@@ -1307,6 +1442,120 @@ void test_partial_derivatives_tensor_compute_item(
     CHECK_ITERABLE_APPROX(du[n], expected_du[n]);
   }
 }
+
+template <size_t CompDim, size_t Dim, typename T, Requires<Dim == 3> = nullptr>
+void test_cartoon_partial_derivatives_compute_item(
+    const std::array<size_t, Dim> extents_array, const T& map) {
+  using vars_tags =
+      tmpl::list<::Tags::TempScalar<0>, ::Tags::TempA<0, Dim, Frame::Inertial>>;
+  using map_tag = MapTag<std::decay_t<decltype(map)>>;
+  using inv_jac_tag = domain::Tags::InverseJacobianCompute<
+      map_tag, domain::Tags::LogicalCoordinates<Dim>>;
+  using deriv_tag =
+      Tags::DerivCompute<Tags::Variables<vars_tags>, domain::Tags::Mesh<Dim>,
+                         inv_jac_tag,
+                         typename Tags::Variables<vars_tags>::type::tags_list,
+                         domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+  using prefixed_variables_tag =
+      db::add_tag_prefix<SomePrefix, Tags::Variables<vars_tags>>;
+  using deriv_prefixed_tag = Tags::DerivCompute<
+      prefixed_variables_tag, domain::Tags::Mesh<Dim>, inv_jac_tag,
+      tmpl::list<SomePrefix<::Tags::TempScalar<0>>>,
+      domain::Tags::Coordinates<Dim, Frame::Inertial>>;
+
+  TestHelpers::db::test_compute_tag<deriv_tag>(
+      "Variables(deriv(TempTensor0),deriv(TempTensor0))");
+
+  const auto pad_at_end = []<typename ElemType>(const ElemType default_val,
+                                                const ElemType padding_val) {
+    std::array<ElemType, Dim> arr{};
+    for (size_t i = 0; i < Dim; ++i) {
+      gsl::at(arr, i) = i < CompDim ? default_val : padding_val;
+    }
+    return arr;
+  };
+  const Mesh<Dim> mesh{
+      extents_array,
+      pad_at_end(Spectral::Basis::Legendre, Spectral::Basis::Cartoon),
+      pad_at_end(Spectral::Quadrature::GaussLobatto,
+                 CompDim == 1 ? Spectral::Quadrature::SphericalSymmetry
+                              : Spectral::Quadrature::AxialSymmetry)};
+  const size_t num_grid_points = mesh.number_of_grid_points();
+  Variables<vars_tags> u(num_grid_points);
+  Variables<
+      db::wrap_tags_in<Tags::deriv, vars_tags, tmpl::size_t<Dim>, Frame::Grid>>
+      expected_du(num_grid_points);
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = map(logical_coordinates(mesh));
+
+  // setting Tensors to allowed symmetry values (easiest to just set to our
+  // coordinates)
+  auto& scalar = get<::Tags::TempScalar<0>>(u);
+  get<>(scalar) = cartoon_func<CompDim == 1>(x);
+
+  auto& vector = get<::Tags::TempA<0, 3>>(u);
+  get<0>(vector) = 1.0 * cartoon_func<CompDim == 1>(x);
+  get<1>(vector) = get<0>(x) * cartoon_func<CompDim == 1>(x);
+  get<2>(vector) = get<1>(x) * cartoon_func<CompDim == 1>(x);
+  get<3>(vector) = get<2>(x) * cartoon_func<CompDim == 1>(x);
+
+  typename prefixed_variables_tag::type prefixed_vars(u);
+
+  auto& d_scalar =
+      get<Tags::deriv<::Tags::TempScalar<0>, tmpl::size_t<Dim>, Frame::Grid>>(
+          expected_du);
+  for (size_t i = 0; i < index_dim<0>(d_scalar); ++i) {
+    d_scalar.get(i) = cartoon_dfunc<CompDim == 1>(i, x);
+  }
+
+  auto& d_vector =
+      get<Tags::deriv<::Tags::TempA<0, Dim>, tmpl::size_t<Dim>, Frame::Grid>>(
+          expected_du);
+  for (size_t i = 0; i < index_dim<0>(d_vector); ++i) {
+    for (size_t a = 0; a < index_dim<1>(d_vector); ++a) {
+      if ((i + 1) == a) {
+        d_vector.get(i, a) = cartoon_func<CompDim == 1>(x);
+      } else {
+        d_vector.get(i, a) = DataVector(num_grid_points, 0.0);
+      }
+      d_vector.get(i, a) +=
+          (a == 0 ? DataVector(num_grid_points, 1.0) : x.get(a - 1)) *
+          cartoon_dfunc<CompDim == 1>(i, x);
+    }
+  }
+
+  const auto to_inertial =
+      domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                            domain::CoordinateMaps::Identity<3>>{};
+  auto box = db::create<
+      db::AddSimpleTags<domain::Tags::Mesh<Dim>, Tags::Variables<vars_tags>,
+                        prefixed_variables_tag, map_tag,
+                        domain::Tags::Coordinates<Dim, Frame::Inertial>>,
+      db::AddComputeTags<domain::Tags::LogicalCoordinates<Dim>, inv_jac_tag,
+                         deriv_tag, deriv_prefixed_tag>>(mesh, u, prefixed_vars,
+                                                         map, to_inertial(x));
+
+  const auto& du = db::get<deriv_tag>(box);
+
+  for (size_t n = 0; n < du.size(); ++n) {
+    // clang-tidy: pointer arithmetic
+    CHECK(du.data()[n] == approx(expected_du.data()[n]));  // NOLINT
+  }
+
+  // Test prefixes are handled correctly
+  const auto& du_prefixed_vars = get<db::add_tag_prefix<
+      Tags::deriv,
+      db::add_tag_prefix<SomePrefix,
+                         Tags::Variables<tmpl::list<::Tags::TempScalar<0>>>>,
+      tmpl::size_t<Dim>, Frame::Grid>>(box);
+  const auto& du_prefixed =
+      get<Tags::deriv<SomePrefix<::Tags::TempScalar<0>>, tmpl::size_t<Dim>,
+                      Frame::Grid>>(du_prefixed_vars);
+  const auto& expected_du_prefixed =
+      get<Tags::deriv<::Tags::TempScalar<0>, tmpl::size_t<Dim>, Frame::Grid>>(
+          expected_du);
+  CHECK_ITERABLE_APPROX(du_prefixed, expected_du_prefixed);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs.ComputeItems",
@@ -1336,6 +1585,19 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs.ComputeItems",
       }
     }
   }
+  using Identity1D = domain::CoordinateMaps::Identity<1>;
+  test_cartoon_partial_derivatives_compute_item<1>(
+      std::array<size_t, 3>{{8, 1, 1}},
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+          domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D,
+                                                 Identity1D>{
+              Affine{-1.0, 1.0, 0.0, 0.7}, Identity1D{}, Identity1D{}}));
+  test_cartoon_partial_derivatives_compute_item<2>(
+      std::array<size_t, 3>{{6, 7, 1}},
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+          domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>{
+              Affine{-1.0, 1.0, 0.0, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+              Identity1D{}}));
   for (size_t a = 1; a < max_extents[0]; ++a) {
     test_partial_derivatives_tensor_compute_item(
         std::array<size_t, 1>{{a + 1}},


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This adds more infrastructure around cartoon_partial_derivatives().
1. It creates the singular partial functions that some evolution systems requires (takes tensor, not Variables), i.e. `cartoon_partial_derivative()`.
2. Creates a wrapper function called `partial_derivatives()` which takes an extra parameter, the inertial coordinates, and at runtime calls either normal partial derivatives or cartoon partials based on mesh bases.
3. Modifies `DerivCompute` to potentially call the `partial_derivatives()` function with inertial coords that in turn calls the calls the appropriate partial function.

*Note*: I couldn't keep just one structure with an optional parameter (`inertial_coords`) for `DerivCompute` because I can't have two static constexpr `function` pointer members and using brigand won't help because the parameter signature changes (either with or without `inertial_coords`)


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
