### PR TITLE
Prepare ah::set_current_iteration_coords for AH adaptivity

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.cpp
@@ -3,6 +3,8 @@
 
 #include "ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <deque>
 
@@ -14,6 +16,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -26,57 +29,201 @@ bool set_current_iteration_coords(
     const ylm::Strahlkorper<Fr>& previous_iteration_surface,
     const std::deque<ah::Storage::PreviousSurface<Fr>>& previous_surfaces,
     const size_t max_compute_coords_retries, const Domain<3>& domain,
-    const domain::FunctionsOfTimeMap& functions_of_time) {
+    const domain::FunctionsOfTimeMap& functions_of_time,
+    const std::optional<size_t>& current_resolution_l,
+    const bool rerunning_with_higher_resolution) {
+  // If we are rerunning the horizon find with higher resolution, use
+  // the previous horizon as the initial guess.
   if (fast_flow.current_iteration() == 0) {
-    // Need to set the first surface. If this is the very first, set it to the
-    // initial guess. If not, use the previous horizon surface. The surface will
-    // potentially be extrapolated below
-    current_iteration->strahlkorper = UNLIKELY(previous_surfaces.empty())
-                                          ? initial_guess
-                                          : previous_surfaces.front().surface;
+    if (rerunning_with_higher_resolution) {
+      if (not current_resolution_l.has_value()) {
+        ERROR(
+            "Current resolution L is not set, even though this iteration is "
+            "marked as a rerun with higher resolution. This is an internal "
+            "error. Please file an issue.");
+      }
+      if (previous_iteration_surface.l_max() >= *current_resolution_l) {
+        ERROR("Previous iteration surface has resolution "
+              << previous_iteration_surface.l_max()
+              << " but current resolution " << *current_resolution_l
+              << " is not higher, even though this iteration is marked as a "
+                 "rerun with higher resolution. This is an internal error. "
+                 "Please file an issue.");
+      }
+      // Just set the initial guess by prolonging or restricting the previous
+      // iteration surface, i.e., the horizon already found at a lower
+      // resolution
+      current_iteration->strahlkorper =
+          ylm::Strahlkorper<Fr>(*current_resolution_l, *current_resolution_l,
+                                previous_iteration_surface);
+    } else {
+      // Need to set the first surface. If this is the very first, set it to the
+      // initial guess. If not, use the previous horizon surface. The surface
+      // will potentially be extrapolated below.
+      //
+      // If current_resolution_l is set, make sure the initial guess has the
+      // correct resolution. Only prolong or restrict if current_resolution_l
+      // is different from the initial guess / previous surface l_max().
+      // Otherwise, just set the initial guess.
+      if (current_resolution_l.has_value()) {
+        if (UNLIKELY(previous_surfaces.empty())) {
+          if (UNLIKELY(current_resolution_l != initial_guess.l_max())) {
+            current_iteration->strahlkorper = ylm::Strahlkorper<Fr>(
+                *current_resolution_l, *current_resolution_l, initial_guess);
+          } else {
+            current_iteration->strahlkorper = initial_guess;
+          }
+        } else {
+          if (UNLIKELY(current_resolution_l !=
+                       previous_surfaces.front().surface.l_max())) {
+            current_iteration->strahlkorper = ylm::Strahlkorper<Fr>(
+                *current_resolution_l, *current_resolution_l,
+                previous_surfaces.front().surface);
+          } else {
+            current_iteration->strahlkorper = previous_surfaces.front().surface;
+          }
+        }
+      } else {
+        current_iteration->strahlkorper =
+            UNLIKELY(previous_surfaces.empty())
+                ? initial_guess
+                : previous_surfaces.front().surface;
+      }
 
-    // If we have zero previous_surfaces, then the initial guess is already
-    // in strahlkorper, so do nothing.
-    //
-    // If we have one previous_surface, then we have had a successful
-    // horizon find, and the initial guess for the next horizon find is already
-    // in strahlkorper, so again we do nothing.
-    //
-    // If we have 2 valid previous_surfaces, then we set the initial guess
-    // by linear extrapolation in time using the last 2 previous_surfaces.
-    //
-    // If we have 3 valid previous_surfaces, then we set the initial guess
-    // by quadratic extrapolation in time using the last 3
-    // previous_surfaces.
-    //
-    // For extrapolation, we assume that
-    // * Expansion center of all the Strahlkorpers are equal.
-    // * Maximum L of all the Strahlkorpers are equal. It is easy to relax the
-    //   max L assumption once we start adaptively changing the L of the
-    //   strahlkorpers.
-    if (LIKELY(previous_surfaces.size() > 2)) {
-      // Quadratic extrapolation
-      const double dt_0 = previous_surfaces[0].time.id - time.id;
-      const double dt_1 = previous_surfaces[1].time.id - time.id;
-      const double dt_2 = previous_surfaces[2].time.id - time.id;
-      const double fac_0 = dt_1 * dt_2 / ((dt_1 - dt_0) * (dt_2 - dt_0));
-      const double fac_1 = dt_0 * dt_2 / ((dt_2 - dt_1) * (dt_0 - dt_1));
-      const double fac_2 = 1.0 - fac_0 - fac_1;
-      current_iteration->strahlkorper.coefficients() =
-          fac_0 * previous_surfaces[0].surface.coefficients() +
-          fac_1 * previous_surfaces[1].surface.coefficients() +
-          fac_2 * previous_surfaces[2].surface.coefficients();
-    } else if (previous_surfaces.size() > 1) {
-      // Linear extrapolation
-      const double dt_0 = previous_surfaces[0].time.id - time.id;
-      const double dt_1 = previous_surfaces[1].time.id - time.id;
-      const double fac_0 = dt_1 / (dt_1 - dt_0);
-      const double fac_1 = 1.0 - fac_0;
-      current_iteration->strahlkorper.coefficients() =
-          fac_0 * previous_surfaces[0].surface.coefficients() +
-          fac_1 * previous_surfaces[1].surface.coefficients();
+      // If we have zero previous_surfaces, then the initial guess is already
+      // in strahlkorper, so do nothing.
+      //
+      // If we have one previous_surface, then we have had a successful
+      // horizon find, and the initial guess for the next horizon find is
+      // already in strahlkorper, so again we do nothing.
+      //
+      // If we have 2 valid previous_surfaces, then we set the initial guess
+      // by linear extrapolation in time using the last 2 previous_surfaces.
+      //
+      // If we have 3 valid previous_surfaces, then we set the initial guess
+      // by quadratic extrapolation in time using the last 3
+      // previous_surfaces.
+      //
+      // For extrapolation, we assume that the expansion center of all the
+      // Strahlkorpers are equal. If any surface has a different resolution,
+      // prolong to the max resolution, extrapolate, then restrict to either
+      // current_resolution.
+      if (LIKELY(previous_surfaces.size() > 2)) {
+        constexpr size_t number_of_previous_surfaces = 3;
+        // Quadratic extrapolation
+        const double dt_0 = previous_surfaces[0].time.id - time.id;
+        const double dt_1 = previous_surfaces[1].time.id - time.id;
+        const double dt_2 = previous_surfaces[2].time.id - time.id;
+        const double fac_0 = dt_1 * dt_2 / ((dt_1 - dt_0) * (dt_2 - dt_0));
+        const double fac_1 = dt_0 * dt_2 / ((dt_2 - dt_1) * (dt_0 - dt_1));
+        const double fac_2 = 1.0 - fac_0 - fac_1;
+
+        // Determine if resolutions are equal and, if not, which is greatest
+        const auto [min_res_it, max_res_it] = std::minmax_element(
+            previous_surfaces.begin(),
+            previous_surfaces.begin() + number_of_previous_surfaces,
+            [](const auto& a, const auto& b) {
+              return a.surface.l_max() < b.surface.l_max();
+            });
+        const size_t min_resolution_l = min_res_it->surface.l_max();
+        const size_t max_resolution_l = max_res_it->surface.l_max();
+        const auto which_surface_is_max = static_cast<size_t>(
+            std::distance(previous_surfaces.begin(), max_res_it));
+
+        if (UNLIKELY(min_resolution_l != max_resolution_l)) {
+          const std::array facs{fac_0, fac_1, fac_2};
+          DataVector new_coefs =
+              gsl::at(facs, which_surface_is_max) *
+              gsl::at(previous_surfaces, which_surface_is_max)
+                  .surface.coefficients();
+          for (size_t i = 0; i < number_of_previous_surfaces; ++i) {
+            if (i == which_surface_is_max) {
+              continue;
+            }
+            new_coefs +=
+                gsl::at(facs, i) *
+                gsl::at(previous_surfaces, i)
+                    .surface.ylm_spherepack()
+                    .prolong_or_restrict(
+                        gsl::at(previous_surfaces, i).surface.coefficients(),
+                        gsl::at(previous_surfaces, which_surface_is_max)
+                            .surface.ylm_spherepack());
+          }
+          current_iteration->strahlkorper.coefficients() =
+              gsl::at(previous_surfaces, which_surface_is_max)
+                  .surface.ylm_spherepack()
+                  .prolong_or_restrict(
+                      new_coefs,
+                      current_iteration->strahlkorper.ylm_spherepack());
+        } else {
+          if (current_iteration->strahlkorper.l_max() !=
+              previous_surfaces[0].surface.l_max()) {
+            current_iteration->strahlkorper.coefficients() =
+                previous_surfaces[0]
+                    .surface.ylm_spherepack()
+                    .prolong_or_restrict(
+                        fac_0 * previous_surfaces[0].surface.coefficients() +
+                            fac_1 *
+                                previous_surfaces[1].surface.coefficients() +
+                            fac_2 * previous_surfaces[2].surface.coefficients(),
+                        current_iteration->strahlkorper.ylm_spherepack());
+          } else {
+            current_iteration->strahlkorper.coefficients() =
+                fac_0 * previous_surfaces[0].surface.coefficients() +
+                fac_1 * previous_surfaces[1].surface.coefficients() +
+                fac_2 * previous_surfaces[2].surface.coefficients();
+          }
+        }
+      } else if (previous_surfaces.size() > 1) {
+        // Linear extrapolation
+        const double dt_0 = previous_surfaces[0].time.id - time.id;
+        const double dt_1 = previous_surfaces[1].time.id - time.id;
+        const double fac_0 = dt_1 / (dt_1 - dt_0);
+        const double fac_1 = 1.0 - fac_0;
+
+        const size_t l_0 = previous_surfaces[0].surface.l_max();
+        const size_t l_1 = previous_surfaces[1].surface.l_max();
+
+        if (l_0 == l_1) {
+          if (l_0 == current_iteration->strahlkorper.l_max()) {
+            current_iteration->strahlkorper.coefficients() =
+                fac_0 * previous_surfaces[0].surface.coefficients() +
+                fac_1 * previous_surfaces[1].surface.coefficients();
+          } else {
+            current_iteration->strahlkorper.coefficients() =
+                previous_surfaces[0]
+                    .surface.ylm_spherepack()
+                    .prolong_or_restrict(
+                        fac_0 * previous_surfaces[0].surface.coefficients() +
+                            fac_1 * previous_surfaces[1].surface.coefficients(),
+                        current_iteration->strahlkorper.ylm_spherepack());
+          }
+        } else {
+          const size_t which_surface_is_max = l_0 > l_1 ? 0 : 1;
+          const size_t which_surface_is_min = 1 - which_surface_is_max;
+          const std::array facs{fac_0, fac_1};
+          DataVector new_coefs =
+              gsl::at(facs, which_surface_is_max) *
+              gsl::at(previous_surfaces, which_surface_is_max)
+                  .surface.coefficients();
+          new_coefs += gsl::at(facs, which_surface_is_min) *
+                       gsl::at(previous_surfaces, which_surface_is_min)
+                           .surface.ylm_spherepack()
+                           .prolong_or_restrict(
+                               gsl::at(previous_surfaces, which_surface_is_min)
+                                   .surface.coefficients(),
+                               gsl::at(previous_surfaces, which_surface_is_max)
+                                   .surface.ylm_spherepack());
+          current_iteration->strahlkorper.coefficients() =
+              gsl::at(previous_surfaces, which_surface_is_max)
+                  .surface.ylm_spherepack()
+                  .prolong_or_restrict(
+                      new_coefs,
+                      current_iteration->strahlkorper.ylm_spherepack());
+        }
+      }
     }
-  }
+  }  // if fastflow.current_iteration() == 0
 
   const auto set_coords = [&]() {
     const auto& strahlkorper = current_iteration->strahlkorper;
@@ -142,7 +289,9 @@ bool set_current_iteration_coords(
       const std::deque<ah::Storage::PreviousSurface<FRAME(data)>>&      \
           previous_surfaces,                                            \
       const size_t max_compute_coords_retries, const Domain<3>& domain, \
-      const domain::FunctionsOfTimeMap& functions_of_time);
+      const domain::FunctionsOfTimeMap& functions_of_time,              \
+      const std::optional<size_t>& current_resolution_l,                \
+      const bool rerunning_with_higher_resolution);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Inertial, Frame::Distorted, Frame::Grid))

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp
@@ -39,6 +39,31 @@ namespace ah {
  *
  * This function will try recomputing the coords using the above two rules
  * \p max_compute_coords_retries times before returning false.
+ *
+ * \param current_iteration The returned pointer to the current Iteration object
+ * \param time The current time
+ * \param fast_flow The FastFlow object for the current horizon find
+ * \param initial_guess If the current iteration number is zero and
+ * rerunning_with_higher_resolution == false, current_iteration is set to
+ * this Strahlkorper
+ * \param previous_iteration_surface If empty, current_iteration is set to
+ * initial_guess; if one previous iteration, current_iteration is set to
+ * that previous iteration; if two previous iterations, current_iteration
+ * is set by linearly extrapolating in time the two pervious iterations;
+ * if three or more previous iterations, current_iteration is set by
+ * quadratic extrpolation of the three most recent iterations
+ * \param previous_surfaces Previously successful iteratios used to attempt to
+ * recover when some points are outside the domain.
+ * \param max_compute_coords_retries Retry up to this many times before
+ * returning false
+ * \param domain The spatial domain in which the horizon is being found
+ * \param functions_of_time The functions of time for the current domain
+ * \param current_resolution_l Optional; if specified, current_iteration is
+ * prolonged or restricted to this resolution
+ * \param rerunning_with_higher_resolution Must be false unless
+ * current_resolution_l is set; if true, then on iteration zero, set
+ * the initial guess to the previous iteration surface
+ * \returns Whether or not set_current_iteration_coords succeeded
  */
 template <typename Fr>
 bool set_current_iteration_coords(
@@ -48,5 +73,7 @@ bool set_current_iteration_coords(
     const ylm::Strahlkorper<Fr>& previous_iteration_surface,
     const std::deque<ah::Storage::PreviousSurface<Fr>>& previous_surfaces,
     size_t max_compute_coords_retries, const Domain<3>& domain,
-    const domain::FunctionsOfTimeMap& functions_of_time);
+    const domain::FunctionsOfTimeMap& functions_of_time,
+    const std::optional<size_t>& current_resolution_l = std::nullopt,
+    bool rerunning_with_higher_resolution = false);
 }  // namespace ah

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
@@ -49,7 +49,7 @@ void test_compute_points() {
       sphere.functions_of_time();
 
   const size_t max_compute_coords_retries = 3;
-  const LinkedMessageId<double> time{4.0, {3.0}};
+  const LinkedMessageId<double> time{.id = 4.0, .previous = {3.0}};
   ylm::Strahlkorper<Fr> initial_guess{l_max, 2.5, std::array{0.0, 0.0, 0.0}};
   ylm::Strahlkorper<Fr> previous_iteration_surface =
       current_iteration.strahlkorper;
@@ -67,7 +67,7 @@ void test_compute_points() {
     // We don't check the actual points because the function basically just
     // wraps block_logical_coordinates and that's already tested. Here we check
     // the wrapping logic
-    CHECK(coords_set_successfully);
+    REQUIRE(coords_set_successfully);
     REQUIRE(current_iteration.block_coord_holders.has_value());
     const size_t l_mesh =
         fast_flow.current_l_mesh(current_iteration.strahlkorper);
@@ -92,7 +92,7 @@ void test_compute_points() {
         previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
-    CHECK(coords_set_successfully);
+    REQUIRE(coords_set_successfully);
     REQUIRE(current_iteration.block_coord_holders.has_value());
     const size_t l_mesh =
         fast_flow.current_l_mesh(current_iteration.strahlkorper);
@@ -141,8 +141,8 @@ void test_compute_points() {
     initial_guess =
         ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}};
 
-    const LinkedMessageId<double> prev_time_1{3.0, {2.0}};
-    const LinkedMessageId<double> prev_time_2{2.0, {1.0}};
+    const LinkedMessageId<double> prev_time_1{.id = 3.0, .previous = {2.0}};
+    const LinkedMessageId<double> prev_time_2{.id = 2.0, .previous = {1.0}};
     previous_surfaces.emplace_front(
         prev_time_2,
         ylm::Strahlkorper<Fr>{l_max, 1.1, std::array{0.0, 0.0, 0.0}});
@@ -155,7 +155,7 @@ void test_compute_points() {
         previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
-    CHECK(coords_set_successfully);
+    REQUIRE(coords_set_successfully);
     REQUIRE(current_iteration.block_coord_holders.has_value());
     const size_t l_mesh =
         fast_flow.current_l_mesh(current_iteration.strahlkorper);
@@ -172,7 +172,8 @@ void test_compute_points() {
     current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
     current_iteration.compute_coords_retries = 0;
 
-    const LinkedMessageId<double> prev_time{1.0, std::nullopt};
+    const LinkedMessageId<double> prev_time{.id = 1.0,
+                                            .previous = std::nullopt};
     previous_surfaces.emplace_back(
         prev_time,
         ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
@@ -182,7 +183,7 @@ void test_compute_points() {
         previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
-    CHECK(coords_set_successfully);
+    REQUIRE(coords_set_successfully);
     REQUIRE(current_iteration.block_coord_holders.has_value());
     const size_t l_mesh =
         fast_flow.current_l_mesh(current_iteration.strahlkorper);
@@ -235,7 +236,7 @@ void test_compute_points() {
         previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
-    CHECK(coords_set_successfully);
+    REQUIRE(coords_set_successfully);
     REQUIRE(current_iteration.block_coord_holders.has_value());
     REQUIRE(current_iteration.block_coord_holders.value().size() ==
             ylm::Spherepack::physical_size(l_mesh, l_mesh));
@@ -246,10 +247,252 @@ void test_compute_points() {
     CHECK(current_iteration.compute_coords_retries == 1);
   }
 }
+
+void test_compute_points_different_resolutions() {
+  // As in test_compute_points(), only test grid frame because the only
+  // difference is a different code path is taken within block logical
+  // coordinates which we aren't testing here.
+  using Fr = ::Frame::Grid;
+
+  const size_t l_max = 4;
+  const size_t higher_l_max = 6;
+  ah::Storage::Iteration<Fr> current_iteration{};
+
+  const domain::creators::Sphere sphere{
+      1.0,          3.0,  domain::creators::Sphere::Excision{nullptr},
+      0_st,         2_st, true,
+      std::nullopt, {2.0}};
+  const Domain<3> domain = sphere.create_domain();
+  const domain::FunctionsOfTimeMap functions_of_time =
+      sphere.functions_of_time();
+
+  const size_t max_compute_coords_retries = 3;
+  const LinkedMessageId<double> time{.id = 4.0, .previous = {3.0}};
+  ylm::Strahlkorper<Fr> initial_guess{l_max, 2.5, std::array{0.0, 0.0, 0.0}};
+  ylm::Strahlkorper<Fr> previous_iteration_surface =
+      current_iteration.strahlkorper;
+  std::deque<ah::Storage::PreviousSurface<Fr>> previous_surfaces{};
+  const FastFlow fast_flow{
+      FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100};
+
+  // Test case 1: current_resolution_l is set and different from initial_guess
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, 2.5, std::array{0.0, 0.0, 0.0}};
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time, higher_l_max,
+        false);
+
+    REQUIRE(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    REQUIRE(current_iteration.strahlkorper.l_max() == higher_l_max);
+    REQUIRE(current_iteration.compute_coords_retries == 0);
+
+    // Verify that the strahlkorper is set to the initial guess but at higher
+    // resolution
+    const ylm::Strahlkorper<Fr> expected_strahlkorper{
+        higher_l_max, initial_guess.average_radius(),
+        initial_guess.expansion_center()};
+    CHECK(current_iteration.strahlkorper == expected_strahlkorper);
+  }
+
+  // Test case 2: rerunning_with_higher_resolution is true
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, 2.5, std::array{0.0, 0.0, 0.0}};
+    previous_iteration_surface =
+        ylm::Strahlkorper<Fr>{l_max, 2.0, std::array{0.0, 0.0, 0.0}};
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time, higher_l_max,
+        true);
+
+    REQUIRE(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.strahlkorper.l_max() == higher_l_max);
+    CHECK(current_iteration.compute_coords_retries == 0);
+
+    // Verify that the strahlkorper is set to the previous surface but prolonged
+    // to higher resolution
+    const ylm::Strahlkorper<Fr> expected_strahlkorper{
+        higher_l_max, previous_iteration_surface.average_radius(),
+        previous_iteration_surface.expansion_center()};
+    CHECK(current_iteration.strahlkorper == expected_strahlkorper);
+  }
+
+  // Test case 3: Different resolutions in previous_surfaces for linear
+  // extrapolation
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}};
+
+    const LinkedMessageId<double> prev_time_1{.id = 3.0, .previous = {2.0}};
+    const LinkedMessageId<double> prev_time_2{.id = 2.0, .previous = {1.0}};
+    previous_surfaces.emplace_front(
+        prev_time_2,
+        ylm::Strahlkorper<Fr>{l_max, 1.1, std::array{0.0, 0.0, 0.0}});
+    previous_surfaces.emplace_front(
+        prev_time_1,
+        ylm::Strahlkorper<Fr>{higher_l_max, 1.3, std::array{0.0, 0.0, 0.0}});
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time, higher_l_max);
+
+    REQUIRE(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.compute_coords_retries == 0);
+
+    // Verify that current_iteration.strahlkorper has resolution higher_l_max
+    CHECK(current_iteration.strahlkorper.l_max() == higher_l_max);
+  }
+
+  // Test case 4: Different resolutions in previous_surfaces for quadratic
+  // extrapolation
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}};
+
+    const LinkedMessageId<double> prev_time_1{.id = 3.0, .previous = {2.0}};
+    const LinkedMessageId<double> prev_time_2{.id = 2.0, .previous = {1.0}};
+    const LinkedMessageId<double> prev_time_3{.id = 1.0,
+                                              .previous = std::nullopt};
+    previous_surfaces.emplace_front(
+        prev_time_3,
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
+    previous_surfaces.emplace_front(
+        prev_time_2,
+        ylm::Strahlkorper<Fr>{higher_l_max, 1.1, std::array{0.0, 0.0, 0.0}});
+    previous_surfaces.emplace_front(
+        prev_time_1,
+        ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}});
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time, higher_l_max);
+
+    REQUIRE(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.compute_coords_retries == 0);
+
+    // Verify that current_iteration.strahlkorper has resolution higher_l_max
+    CHECK(current_iteration.strahlkorper.l_max() == higher_l_max);
+  }
+
+  // Test case 5: current_resolution_l is set and different from
+  // previous_surfaces
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}};
+
+    const LinkedMessageId<double> prev_time{.id = 1.0,
+                                            .previous = std::nullopt};
+    previous_surfaces.emplace_back(
+        prev_time,
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
+
+    const bool coords_set_successfully = set_current_iteration_coords(
+        make_not_null(&current_iteration), time, fast_flow, initial_guess,
+        previous_iteration_surface, previous_surfaces,
+        max_compute_coords_retries, domain, functions_of_time, higher_l_max,
+        false);
+
+    REQUIRE(coords_set_successfully);
+    REQUIRE(current_iteration.block_coord_holders.has_value());
+    const size_t l_mesh =
+        fast_flow.current_l_mesh(current_iteration.strahlkorper);
+    REQUIRE(current_iteration.block_coord_holders.value().size() ==
+            ylm::Spherepack::physical_size(l_mesh, l_mesh));
+    CHECK(alg::all_of(current_iteration.block_coord_holders.value(),
+                      [](const auto& holder) { return holder.has_value(); }));
+    CHECK(current_iteration.strahlkorper.l_max() == higher_l_max);
+    CHECK(current_iteration.compute_coords_retries == 0);
+  }
+
+  // Test assertion failures
+  {
+    current_iteration.block_coord_holders.reset();
+    current_iteration.strahlkorper = ylm::Strahlkorper<Fr>{};
+    current_iteration.compute_coords_retries = 0;
+    initial_guess =
+        ylm::Strahlkorper<Fr>{l_max, 2.5, std::array{0.0, 0.0, 0.0}};
+    previous_iteration_surface =
+        ylm::Strahlkorper<Fr>{l_max, 2.0, std::array{0.0, 0.0, 0.0}};
+
+    // Test that rerunning_with_higher_resolution=true without
+    // current_resolution_l fails
+    CHECK_THROWS_WITH(
+        set_current_iteration_coords(
+            make_not_null(&current_iteration), time, fast_flow, initial_guess,
+            previous_iteration_surface, previous_surfaces,
+            max_compute_coords_retries, domain, functions_of_time, std::nullopt,
+            true),
+        Catch::Matchers::ContainsSubstring("Current resolution L is not set"));
+
+    // Test that rerunning_with_higher_resolution=true with current_resolution_l
+    // <= previous surface resolution fails
+    CHECK_THROWS_WITH(
+        set_current_iteration_coords(
+            make_not_null(&current_iteration), time, fast_flow, initial_guess,
+            previous_iteration_surface, previous_surfaces,
+            max_compute_coords_retries, domain, functions_of_time, l_max,
+            true),  // l_max is not > previous_iteration_surface.l_max()
+        Catch::Matchers::ContainsSubstring(
+            "Previous iteration surface has resolution"));
+  }
+}
 }  // namespace
 
+// [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.ComputeCoords",
                   "[ApparentHorizonFinder][Unit]") {
   test_compute_points();
+  test_compute_points_different_resolutions();
 }
 }  // namespace ah


### PR DESCRIPTION
## Proposed changes

This PR prepares ah::set_current_iteration_coords() for use with adaptivity in the apparent horizon finder. Only when necessary, the function now prolongs or restricts the initial guess, previous surfaces, and output (current iteration's Strahlkorper). Also adds two new parameters to the function for use with adaptive apparent horizon finding: one for passing the current resolution (which no longer needs to be the same as the resolution of the initial guess or previous horizon finds) and one determining whether this is a rerun at a higher resolution (to avoid starting over with the initial guess, even though the iteration number has been reset to zero).

I used cursor AI to review the code, tab complete, and (through several back-and-forth rounds, to get it to do what I wanted) to generate the additional unit tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
