### PR TITLE
Allow ScalarWave system to use Cartoon Domain

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -143,11 +143,11 @@ struct EvolutionMetavars {
 
   using analytic_solution_fields = typename system::variables_tag::tags_list;
   using deriv_compute = ::Tags::DerivCompute<
-      typename system::variables_tag,
-      domain::Tags::Mesh<volume_dim>,
+      typename system::variables_tag, domain::Tags::Mesh<volume_dim>,
       domain::Tags::InverseJacobian<volume_dim, Frame::ElementLogical,
                                     Frame::Inertial>,
-      typename system::gradient_variables>;
+      typename system::gradient_variables,
+      domain::Tags::Coordinates<volume_dim, Frame::Inertial>>;
   using analytic_compute =
       evolution::Tags::AnalyticSolutionsCompute<Dim, analytic_solution_fields,
                                                 false, initial_data_list>;

--- a/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
@@ -54,7 +54,9 @@
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,             \
       const Scalar<DataVector>& gamma2);                                      \
   INSTANTIATE_PARTIAL_DERIVATIVES_WITH_SYSTEM(ScalarWave::System<DIM(data)>,  \
-                                              DIM(data), Frame::Inertial)
+                                              DIM(data), Frame::Inertial)     \
+  INSTANTIATE_CARTOON_PARTIAL_DERIVATIVES_WITH_SYSTEM(                        \
+      ScalarWave::System<DIM(data)>, DIM(data), Frame::Inertial)
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere.yaml
@@ -1,0 +1,99 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveScalarWave3D
+Testing:
+  Check: parse;execute
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+InitialData: &InitialData
+  RegularSphericalWave:
+    Profile:
+      Gaussian:
+        Amplitude: 2.0
+        Width: 1.0
+        Center: 0.0
+
+Amr:
+  Criteria:
+  Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
+    Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
+      ErrorBeyondLimits: False
+    AllowCoarsening: True
+  Verbosity: Verbose
+
+PhaseChangeAndTriggers:
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.001
+  MinimumTimeStep: 1e-7
+  TimeStepper:
+    AdamsBashforth:
+      Order: 3
+
+DomainCreator:
+  CartoonSphere1D:
+    InnerRadius: 0.0
+    OuterRadius: 20.0
+    InitialRadialRefinement: [3, 2]
+    InitialNumberOfRadialGridPoints: 5
+    RadialPartitioning: [10.0]
+    RadialDistributions: [Linear, Logarithmic]
+    TimeDependence: None
+    InnerBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+    OuterBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+# If filtering is enabled in the executable the filter can be controlled using:
+# Filtering:
+#   ExpFilter0:
+#     Alpha: 12
+#     HalfPower: 32
+#     Enable: false
+#     BlocksToFilter: All
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Times:
+        Specified:
+          Values: [&final_time 0.05]
+    Events:
+      - Completion
+  - Trigger: Always
+    Events:
+      - ChangeSlabSize:
+          DelayChange: 0
+          StepChoosers:
+            - StepToTimes:
+                Times:
+                  Specified:
+                    Values: [*final_time]
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "CartoonSphereGaussianWave3DVolume"
+  ReductionFileName: "CartoonSphereGaussianWave3DReductions"


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

For the ScalarWave system, the argument list for `DerivCompute` is updated to now potentially call the `cartoon_partial_derivatives()` function.

Depends on:
- [x] #6812
- [x] #6828
- [x] #6829
- [x] #6833

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
