### PR TITLE
Add SparseMatrixFiller.

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_sources(
   IndexIterator.cpp
   LeviCivitaIterator.cpp
   SliceIterator.cpp
+  SparseMatrixFiller.cpp
   StripeIterator.cpp
   Transpose.cpp
   )
@@ -56,6 +57,7 @@ spectre_target_headers(
   SliceIterator.hpp
   SliceTensorToVariables.hpp
   SliceVariables.hpp
+  SparseMatrixFiller.hpp
   SpinWeighted.hpp
   StaticDeque.hpp
   StaticMatrix.hpp

--- a/src/DataStructures/SparseMatrixFiller.cpp
+++ b/src/DataStructures/SparseMatrixFiller.cpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/SparseMatrixFiller.hpp"
+
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace {
+// Struct for sorting elements.
+struct SparseMatrixElement {
+  SparseMatrixElement(const size_t row, const size_t column, const double val)
+      : row_dest(row), column_src(column), value(val) {}
+  size_t row_dest, column_src;
+  double value;
+};
+}  // namespace
+
+SparseMatrixFiller::SparseMatrixFiller(const size_t num_cols,
+                                       const bool use_map_method)
+    : num_rows_(num_cols),
+      num_cols_(num_cols),
+      use_map_method_(use_map_method) {
+  if (not use_map_method) {
+    matrix_elements_.assign(square(num_cols), 0.0);
+  }
+}
+
+void SparseMatrixFiller::add(const double element, const size_t dest_index,
+                             const size_t src_index) {
+  if (not use_map_method_) {
+    matrix_elements_[src_index + num_cols_ * dest_index] += element;
+  } else {
+    const std::pair index{dest_index, src_index};
+    if (const auto iter = element_index_.find(index);
+        iter != element_index_.end()) {
+      matrix_elements_[iter->second] += element;
+    } else {
+      element_index_.insert({index, matrix_elements_.size()});
+      matrix_elements_.push_back(element);
+      dest_indices_.push_back(dest_index);
+      src_indices_.push_back(src_index);
+    }
+  }
+}
+
+void SparseMatrixFiller::fill(
+    const gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>
+        matrix) const {
+  // First fill data for sorting.
+  std::vector<SparseMatrixElement> data;
+  if (not use_map_method_) {
+    const auto num_rows =
+        static_cast<size_t>(sqrt(double(matrix_elements_.size())));
+    ASSERT(num_rows * num_rows == matrix_elements_.size(),
+           "Size should be a perfect square, not " << matrix_elements_.size());
+    // For this method, many elements are zero so filter them out here.
+    const auto num_zeros =
+        std::count(matrix_elements_.begin(), matrix_elements_.end(), 0.0);
+    data.reserve(matrix_elements_.size() - static_cast<size_t>(num_zeros));
+    size_t indx = 0;
+    for (size_t i_dest = 0; i_dest < num_rows; ++i_dest) {
+      for (size_t j_src = 0; j_src < num_rows; ++j_src, ++indx) {
+        const double element = matrix_elements_[indx];
+        if (element != 0.0) {
+          data.emplace_back(i_dest, j_src, element);
+        }
+      }
+    }
+  } else {
+    ASSERT(matrix_elements_.size() == dest_indices_.size(),
+           "Size mismatch value " << matrix_elements_.size() << " vs dest "
+                                  << dest_indices_.size());
+    ASSERT(matrix_elements_.size() == src_indices_.size(),
+           "Size mismatch value " << matrix_elements_.size() << " vs src "
+                                  << src_indices_.size());
+    data.reserve(matrix_elements_.size());
+    for (size_t i = 0; i < dest_indices_.size(); ++i) {
+      data.emplace_back(dest_indices_[i], src_indices_[i], matrix_elements_[i]);
+    }
+  }
+
+  // Now sort the data by row and column, so we can fill in required order.
+  std::sort(data.begin(), data.end(),
+            [](const SparseMatrixElement& a, const SparseMatrixElement& b) {
+              return a.row_dest == b.row_dest ? a.column_src < b.column_src
+                                              : a.row_dest < b.row_dest;
+            });
+
+  // Fill the matrix.
+  // Do this by reserving a size, and appending elements row by row
+  // (which must be done in order or else blaze dox say undefined
+  // behavior), which is the reason for the above sort.
+  // Note that this filling order assumes a rowMajor matrix; for columnMajor
+  // matrices (not treated here) we must fill columns in order.
+  // We need to explicitly call finalize on every row, *even empty ones*.
+  matrix->resize(num_rows_, num_cols_, false);
+  matrix->reserve(data.size());
+  size_t current_row = 0;
+  for (const auto& d : data) {
+    while (d.row_dest != current_row) {
+      matrix->finalize(current_row++);
+    }
+    matrix->append(d.row_dest, d.column_src, d.value);
+  }
+  // After the last data point, we need to finalize the last row(s).
+  while (current_row < num_rows_) {
+    matrix->finalize(current_row++);
+  }
+}

--- a/src/DataStructures/SparseMatrixFiller.hpp
+++ b/src/DataStructures/SparseMatrixFiller.hpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <blaze/math/CompressedMatrix.h>
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace sparse_matrix_filler_detail {
+/// Hash on a pair of size_ts
+struct PairHasher {
+  size_t operator()(const std::pair<size_t, size_t>& key) const {
+    ASSERT(key.first < 4294967295, "Key.first too large: " << key.first);
+    ASSERT(key.second < 4294967295, "Key.second too large: " << key.second);
+    return key.first bitor (key.second << 32);
+  }
+};
+}  // namespace sparse_matrix_filler_detail
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A data structure used to fill sparse matrices.
+ *
+ * We normally use blaze::CompressedMatrix to hold sparse matrices and to
+ * operate on them.
+ *
+ * Unfortunately to fill a blaze::CompressedMatrix efficiently you
+ * need to fill nonzero matrix elements in a well-defined order
+ * (i.e. fill all nonzero elements in the top row in the order of
+ * nonzero columns, and repeat for each other row, in order) using
+ * CompressedMatrix's reserve(), append(), and finalize() functions.
+ *
+ * However, we are interested in a use case where:
+ *
+ *   1. We are filling the matrix elements using a complicated
+ *      algorithm that computes (as opposed to systematically loops
+ *      over) the matrix element indices to be filled, so we are
+ *      effectively filling matrix elements in a random order.
+ *
+ *   2. The algorithm can traverse the same matrix element hundreds
+ *      of times, meaning that the first time an element is traversed
+ *      it should be filled, but subsequent times it is traversed it
+ *      should be incremented.
+ *
+ * SparseMatrixFiller provides a function to fill matrix elements, keeping
+ * in mind the above two issues.  And it provides a function to copy its
+ * sparse matrix into blaze::CompressedMatrix efficiently.
+ *
+ * We consider two ways to keep track of unique elements:
+ *
+ * 1. Store matrix elements in a full vector that is indexed by
+ *    matrix_elements[src_index+max_src_index*dest_index].  Set this
+ *    vector to zero initially, and increment it each time 'add' is called.
+ *    This is simple, but has a major issue: memory.
+ *    In SpEC, I (Mark Scheel) have measured that computing TensorYlm
+ *    filtering matrices using this method, after l_max=40 , the
+ *    slope of CPU-h vs l_max for this method has a kink, and CPU-h
+ *    increases like l_max^2 instead of l_max.  Presumably this is
+ *    because of cache misses when accessing the very large
+ *    matrix_elements vector at random locations.
+ *
+ * 2. Have a std::unordered_map<std::pair<size_t,size_t>, size_t>>
+ *    called `element_index` that keeps track of the unique elements.
+ *    Also have three vectors `dest_indices`, `src_indices`,
+ *    and `matrix_elements` that keep the nonzero elements.
+ *    element_index is indexed by
+ *    element_index[{dest_index,src_index}] = index-into-matrix-elements
+ *    So each time we add a new element, we check element_index to see
+ *    if that element has not already been added, and if not, we push_back
+ *    the three vectors.  If it has already been added, we simply do
+ *    matrix_elements[index-into-matrix-elements] += new_element.
+ *
+ * I (Mark Scheel) have found in SpEC for computing TensorYlm filtering
+ * matrices that the CPU cost of algorithm 2. above scales linearly
+ * with l_max at least up to l_max=140, but for l_max < 40 or so,
+ * algorithm 2. is about a factor of 3 slower than algorithm 1.
+ * So SpEC uses both algorithms, depending on the value of l_max.
+ *
+ * For SpECTRE, we plan to do the same: for small l_max we will use
+ * algorithm 1 and for large l_max we will use algorithm 2.  The
+ * cutoff for l_max will depend on other factors (like the rank of the
+ * Tensor being filtered) and will be determined by whoever calls
+ * SparseMatrixFiller.
+ */
+class SparseMatrixFiller {
+ public:
+  /// Assume num_rows and num_cols are equal.
+  /// If use_map_method is true, uses algorithm 2.
+  SparseMatrixFiller(size_t num_cols, bool use_map_method);
+
+  /// Add (or increment) an element such that for v = M x, where M is
+  /// the matrix and v and x are vectors, we compute the contribution
+  /// to v[dest_index] from x[src_index].
+  void add(double element, size_t dest_index, size_t src_index);
+
+  /// Fills the matrix.
+  /// Note that the order in which blaze matrices must be filled depends
+  /// on whether the matrix is rowMajor or columnMajor, so changing
+  /// the template parameter here will fail without changing the code.
+  void fill(gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>
+                matrix) const;
+
+ private:
+  size_t num_rows_{0}, num_cols_{0};
+  bool use_map_method_{true};
+  std::vector<double> matrix_elements_{};
+  std::unordered_map<std::pair<size_t, size_t>, size_t,
+                     sparse_matrix_filler_detail::PairHasher>
+      element_index_{};
+  std::vector<size_t> dest_indices_{};
+  std::vector<size_t> src_indices_{};
+};

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -34,6 +34,7 @@ set(LIBRARY_SOURCES
   Test_SliceIterator.cpp
   Test_SliceTensorToVariables.cpp
   Test_SliceVariables.cpp
+  Test_SparseMatrixFiller.cpp
   Test_SpinWeighted.cpp
   Test_StaticDeque.cpp
   Test_StripeIterator.cpp

--- a/tests/Unit/DataStructures/Test_SparseMatrixFiller.cpp
+++ b/tests/Unit/DataStructures/Test_SparseMatrixFiller.cpp
@@ -1,0 +1,156 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <blaze/math/CompressedMatrix.h>
+#include <cstddef>
+
+#include "DataStructures/SparseMatrixFiller.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void test_sparse_matrix_filler(const bool use_map_method) {
+  const size_t num_cols = 6;
+
+  SparseMatrixFiller filler(num_cols, use_map_method);
+  // Add in random order.
+  // Note that empty rows must be explicitly added in the blaze
+  // routines, so here we have rows with zero elements, rows with 1
+  // element, and rows with >1 element to test all the edge cases.
+  // Also note that the last row is empty, which tests another edge case.
+  filler.add(4.0, 0, 0);
+  filler.add(6.0, 1, 3);
+  filler.add(2.0, 1, 3);  // This element is repeated! Important for test.
+  filler.add(3.0, 0, 3);
+  filler.add(7.0, 2, 2);
+  filler.add(5.0, 4, 5);
+  filler.add(3.0, 4, 3);
+  filler.add(7.0, 0, 3);  // This element is repeated! Important for test.
+
+  blaze::CompressedMatrix<double, blaze::rowMajor> matrix;
+  filler.fill(make_not_null(&matrix));
+
+  // Matrix is square so number of rows and columns is the same.
+  CHECK(matrix.rows() == num_cols);
+  CHECK(matrix.columns() == num_cols);
+  CHECK(size(matrix) == num_cols * num_cols);
+
+  CHECK(matrix(0, 0) == 4.0);
+  CHECK(matrix(1, 3) == 8.0);
+  CHECK(matrix(0, 3) == 10.0);
+  CHECK(matrix(2, 2) == 7.0);
+  CHECK(matrix(4, 5) == 5.0);
+  CHECK(matrix(4, 3) == 3.0);
+
+  // Values that we did not fill
+  CHECK(matrix(1, 0) == 0.0);
+  CHECK(matrix(2, 0) == 0.0);
+  CHECK(matrix(3, 0) == 0.0);
+  CHECK(matrix(4, 0) == 0.0);
+  CHECK(matrix(5, 0) == 0.0);
+  CHECK(matrix(0, 1) == 0.0);
+  CHECK(matrix(1, 1) == 0.0);
+  CHECK(matrix(2, 1) == 0.0);
+  CHECK(matrix(3, 1) == 0.0);
+  CHECK(matrix(4, 1) == 0.0);
+  CHECK(matrix(5, 1) == 0.0);
+  CHECK(matrix(0, 2) == 0.0);
+  CHECK(matrix(1, 2) == 0.0);
+  CHECK(matrix(3, 2) == 0.0);
+  CHECK(matrix(4, 2) == 0.0);
+  CHECK(matrix(5, 2) == 0.0);
+  CHECK(matrix(2, 3) == 0.0);
+  CHECK(matrix(3, 3) == 0.0);
+  CHECK(matrix(5, 3) == 0.0);
+  CHECK(matrix(0, 4) == 0.0);
+  CHECK(matrix(1, 4) == 0.0);
+  CHECK(matrix(2, 4) == 0.0);
+  CHECK(matrix(3, 4) == 0.0);
+  CHECK(matrix(4, 4) == 0.0);
+  CHECK(matrix(5, 4) == 0.0);
+  CHECK(matrix(0, 5) == 0.0);
+  CHECK(matrix(1, 5) == 0.0);
+  CHECK(matrix(2, 5) == 0.0);
+  CHECK(matrix(3, 5) == 0.0);
+  CHECK(matrix(5, 5) == 0.0);
+}
+
+// This test touches some edge cases the other tests do not.
+void test_sparse_matrix_filler_last_row_filled(const bool use_map_method) {
+  const size_t num_cols = 3;
+
+  SparseMatrixFiller filler(num_cols, use_map_method);
+  // Add in random order.
+  // First row has only one element (unlike the other tests)
+  // Last row is nonempty with one nonzero column (unlike the other tests)
+  filler.add(6.0, 1, 2);
+  filler.add(7.0, 2, 2);
+  filler.add(4.0, 0, 0);
+  filler.add(2.0, 1, 2);  // This element is repeated! Important for test.
+
+  blaze::CompressedMatrix<double, blaze::rowMajor> matrix;
+  filler.fill(make_not_null(&matrix));
+
+  // Matrix is square so number of rows and columns is the same.
+  CHECK(matrix.rows() == num_cols);
+  CHECK(matrix.columns() == num_cols);
+  CHECK(size(matrix) == num_cols * num_cols);
+
+  CHECK(matrix(0, 0) == 4.0);
+  CHECK(matrix(1, 2) == 8.0);
+  CHECK(matrix(2, 2) == 7.0);
+
+  // Values that we did not fill
+  CHECK(matrix(1, 0) == 0.0);
+  CHECK(matrix(2, 0) == 0.0);
+  CHECK(matrix(0, 1) == 0.0);
+  CHECK(matrix(1, 1) == 0.0);
+  CHECK(matrix(2, 1) == 0.0);
+  CHECK(matrix(0, 2) == 0.0);
+}
+
+// This test touches some edge cases the other tests do not.
+void test_sparse_matrix_filler_first_row_empty(const bool use_map_method) {
+  const size_t num_cols = 3;
+
+  SparseMatrixFiller filler(num_cols, use_map_method);
+  // Add in random order.
+  // First row is empty (unlike the other tests)
+  // Last row is nonempty with multiple nonzero columns (unlike the other tests)
+  filler.add(7.0, 2, 2);
+  filler.add(6.0, 1, 2);
+  filler.add(9.0, 2, 0);
+  filler.add(2.0, 1, 2);  // This element is repeated! Important for test.
+
+  blaze::CompressedMatrix<double, blaze::rowMajor> matrix;
+  filler.fill(make_not_null(&matrix));
+
+  // Matrix is square so number of rows and columns is the same.
+  CHECK(matrix.rows() == num_cols);
+  CHECK(matrix.columns() == num_cols);
+  CHECK(size(matrix) == num_cols * num_cols);
+
+  CHECK(matrix(2, 0) == 9.0);
+  CHECK(matrix(1, 2) == 8.0);
+  CHECK(matrix(2, 2) == 7.0);
+
+  // Values that we did not fill
+  CHECK(matrix(0, 0) == 0.0);
+  CHECK(matrix(1, 0) == 0.0);
+  CHECK(matrix(0, 1) == 0.0);
+  CHECK(matrix(1, 1) == 0.0);
+  CHECK(matrix(2, 1) == 0.0);
+  CHECK(matrix(0, 2) == 0.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.SparseMatrixFiller",
+                  "[DataStructures][Unit]") {
+  test_sparse_matrix_filler(true);
+  test_sparse_matrix_filler(false);
+  test_sparse_matrix_filler_last_row_filled(true);
+  test_sparse_matrix_filler_last_row_filled(false);
+  test_sparse_matrix_filler_first_row_empty(true);
+  test_sparse_matrix_filler_first_row_empty(false);
+}


### PR DESCRIPTION
## Proposed changes

Adds a class that provides a way of adding elements to a blaze::CompressedMatrix in an arbitrary order,
with the ability to add the same matrix element multiple times (in which case it sums the elements added).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
