### PR TITLE
Update H5 writing to handle cartoon simulations

### DIFF
--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -56,12 +56,35 @@ void append_element_extents_and_connectivity(
     const gsl::not_null<int*> total_points_so_far, const size_t dim,
     const ElementVolumeData& element) {
   // Process the element extents
-  const auto& extents = element.extents;
-  ASSERT(alg::none_of(extents, [](const size_t extent) { return extent == 1; }),
-         "We cannot generate connectivity for any single grid point elements.");
+  // `dim` is the dimension of the computation except when we are doing Cartoon
+  // method with a 2D computational domain. In such a case, the true dimension
+  // is 3 but we are writing as 2D for ParaView visualization
+  const auto& extents = [&element, &dim]() {
+    if (dim == 2 and element.extents.size() == 3) {
+      ASSERT(gsl::at(element.basis, 2) == Spectral::Basis::Cartoon and
+                 gsl::at(element.basis, 1) != Spectral::Basis::Cartoon,
+             "Trying to write data with mismatched dimensions (dim = 2, "
+                 << "extents = [" << element.extents[0] << ", "
+                 << element.extents[1] << ", " << element.extents[2]
+                 << "]) without a valid Cartoon basis (the computational "
+                    "dimension must be 2).");
+      return std::vector<size_t>(element.extents.begin(),
+                                 element.extents.end() - 1);
+    } else {
+      return element.extents;
+    }
+  }();
+#ifdef SPECTRE_DEBUG
+  for (size_t i = 0; i < extents.size(); ++i) {
+    // The Cartoon check is for the 1D Cartoon case
+    ASSERT(extents[i] != 1 or element.basis[i] == Spectral::Basis::Cartoon,
+           "Cannot generate connectivity for any single grid point elements "
+           "that don't use a Cartoon basis.");
+  }
+#endif  // SPECTRE_DEBUG
   if (extents.size() != dim) {
-    ERROR("Trying to write data of dimensionality"
-          << extents.size() << "but the VolumeData file has dimensionality"
+    ERROR("Trying to write data of dimensionality "
+          << extents.size() << " but the VolumeData file has dimensionality "
           << dim << ".");
   }
   total_extents->insert(total_extents->end(), extents.begin(), extents.end());
@@ -222,8 +245,19 @@ void VolumeData::write_volume_data(
   // Only written once per VolumeData file (All volume data in a single file
   // should have the same dimensionality)
   if (not contains_attribute(volume_data_group_.id(), "", "dimension")) {
-    h5::write_to_attribute(volume_data_group_.id(), "dimension",
-                           elements.front().extents.size());
+    h5::write_to_attribute(
+        volume_data_group_.id(), "dimension",
+        // Need to manually reduce dimensions with a Cartoon evolution
+        // using a 2d computational domain
+        [&elements]() -> size_t {
+          const auto& basis = elements.front().basis;
+          if (basis.size() == 3 and
+              (gsl::at(basis, 2) == Spectral::Basis::Cartoon and
+               gsl::at(basis, 1) != Spectral::Basis::Cartoon)) {
+            return 2;
+          }
+          return elements.front().extents.size();
+        }());
   }
   const auto dim =
       h5::read_value_attribute<size_t>(volume_data_group_.id(), "dimension");
@@ -260,19 +294,30 @@ void VolumeData::write_volume_data(
               grid_names += element.element_name + h5::VolumeData::separator();
               // append element basis
               alg::transform(
-                  element.basis, std::back_inserter(bases),
-                  [](const Spectral::Basis t) {
+                  // Need to ensure size == dim (Cartoon method with 2d
+                  // computational domain needs to drop last dimension)
+                  std::vector<Spectral::Basis>(
+                      element.basis.begin(),
+                      element.basis.end() -
+                          static_cast<int>(element.basis.size() - dim)),
+                  std::back_inserter(bases), [](const Spectral::Basis t) {
                     // Shift the basis to keep compatibility with old file
                     // formats.
                     return static_cast<int>(static_cast<uint8_t>(t) >>
                                             Spectral::basis_shift);
                   });
               // append element quadrature
-              alg::transform(element.quadrature,
-                             std::back_inserter(quadratures),
-                             [](const Spectral::Quadrature t) {
-                               return static_cast<int>(t);
-                             });
+              alg::transform(
+                  // Need to ensure size == dim (Cartoon method with 2d
+                  // computational domain needs to drop last dimension)
+                  std::vector<Spectral::Quadrature>(
+                      element.quadrature.begin(),
+                      element.quadrature.end() -
+                          static_cast<int>(element.basis.size() - dim)),
+                  std::back_inserter(quadratures),
+                  [](const Spectral::Quadrature t) {
+                    return static_cast<int>(t);
+                  });
 
               append_element_extents_and_connectivity(
                   &total_extents, &total_connectivity, &pole_connectivity,
@@ -340,9 +385,13 @@ void VolumeData::write_volume_data(
   h5_detail::write_dictionary("Basis dictionary", basis_dict,
                               observation_group);
   h5::write_data(observation_group.id(), bases, {bases.size()}, "bases");
-  // Write the Connectivity
-  h5::write_data(observation_group.id(), total_connectivity,
-                 {total_connectivity.size()}, "connectivity");
+  // Write the Connectivity, which will only be empty when a CartoonSphere
+  // domain is used, which has 1 computational dimension and should not be
+  // visualized with ParaView
+  if (not total_connectivity.empty()) {
+    h5::write_data(observation_group.id(), total_connectivity,
+                   {total_connectivity.size()}, "connectivity");
+  }
   // Note: pole_connectivity stores extra connections that define triangles to
   // fill in the poles on a Strahlkorper and is empty if not outputting
   // Strahlkorper surface data. Because these connections define triangles

--- a/tests/Unit/IO/H5/CMakeLists.txt
+++ b/tests/Unit/IO/H5/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   Boost::boost
   DataStructures
   Domain
+  DomainBoundaryConditionsHelpers
   DomainCreators
   H5
   Informer

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -11,12 +11,15 @@
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Domain/Creators/CartoonCylinder.hpp"
 #include "Domain/Creators/Rectilinear.hpp"
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/IO/VolumeData.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/CheckH5.hpp"
@@ -567,12 +570,182 @@ void test_extend_connectivity_data() {
     file_system::rm(h5_file_name, true);
   }
 }
+
+void test_cartoon() {
+  // For a 2D computational domain Cartoon-basis evolution, we only want to
+  // write 2D data despite the simulation being 3D. This tests the appropriate
+  // dimension reduction
+  const std::string h5_file_name("Unit.IO.H5.VolumeData.h5");
+  const uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
+  const std::vector<DataVector> tensor_components_and_coords{
+      {8.9, 7.6, 3.9, 2.1},     {0.0, 1.0, 0.0, 1.0},
+      {0.0, 0.0, 1.0, 1.0},     {0.0, 0.0, 0.0, 0.0},
+      {-78.9, -7.6, -1.9, 8.1}, {-7.9, 7.6, 1.9, -8.1},
+      {17.9, 27.6, 21.9, -28.1}};
+  const std::vector<size_t> observation_ids{8435087234, size_t(-1)};
+  const std::vector<double> observation_values{8.0, -2.3};
+  const std::vector<std::string> grid_names{"[[2,3,4]]"};
+  const std::vector<std::vector<Spectral::Basis>> bases{
+      {Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+       Spectral::Basis::Cartoon}};
+  const std::vector<std::vector<Spectral::Quadrature>> quadratures{
+      {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+       Spectral::Quadrature::SphericalSymmetry}};
+
+  const std::vector<std::vector<Spectral::Basis>> written_bases{
+      {Spectral::Basis::Legendre, Spectral::Basis::Legendre}};
+  const std::vector<std::vector<Spectral::Quadrature>> written_quadratures{
+      {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto}};
+
+  const TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>
+      test_bc{Direction<3>::lower_xi(), 0};
+  const domain::creators::CartoonCylinder domain_creator{
+      {0.0, 1.0},
+      {1.5, 2.0},
+      {0, 1},
+      {5, 4},
+      {domain::CoordinateMaps::Distribution::Linear,
+       domain::CoordinateMaps::Distribution::Linear},
+      std::make_unique<
+          domain::creators::time_dependence::UniformTranslation<3, 0>>(
+              1., std::array<double, 3>{{2., 3., 4.}}),
+      {{{{test_bc.get_clone(), test_bc.get_clone()}},
+        {{test_bc.get_clone(), test_bc.get_clone()}}}}};
+
+  domain::creators::register_derived_with_charm();
+  domain::creators::time_dependence::register_derived_with_charm();
+  domain::FunctionsOfTime::register_derived_with_charm();
+  {
+    auto& volume_file =
+        my_file.insert<h5::VolumeData>("/element_data", version_number);
+    const auto write_to_file = [&volume_file, &tensor_components_and_coords,
+                                &grid_names, &bases, &quadratures,
+                                &domain_creator](
+                                   const size_t observation_id,
+                                   const double observation_value) {
+      const std::string& first_grid = grid_names.front();
+      volume_file.write_volume_data(
+          observation_id, observation_value,
+          std::vector<ElementVolumeData>{
+              {first_grid,
+               {TensorComponent{"S", TestHelpers::io::VolumeData::multiply(
+                                         observation_value,
+                                         tensor_components_and_coords[0])},
+                TensorComponent{
+                    "x-coord",
+                    TestHelpers::io::VolumeData::multiply(
+                        observation_value, tensor_components_and_coords[1])},
+                TensorComponent{
+                    "y-coord",
+                    TestHelpers::io::VolumeData::multiply(
+                        observation_value, tensor_components_and_coords[2])},
+                TensorComponent{
+                    "z-coord",
+                    TestHelpers::io::VolumeData::multiply(
+                        observation_value, tensor_components_and_coords[3])},
+                TensorComponent{"T_x", TestHelpers::io::VolumeData::multiply(
+                                           observation_value,
+                                           tensor_components_and_coords[4])},
+                TensorComponent{"T_y", TestHelpers::io::VolumeData::multiply(
+                                           observation_value,
+                                           tensor_components_and_coords[5])},
+                TensorComponent{"T_z", TestHelpers::io::VolumeData::multiply(
+                                           observation_value,
+                                           tensor_components_and_coords[6])}},
+               {2, 2, 1},
+               bases.front(),
+               quadratures.front()}},
+          serialize(domain_creator.create_domain()),
+          serialize(domain_creator.functions_of_time()));
+    };
+    for (size_t i = 0; i < observation_ids.size(); ++i) {
+      write_to_file(observation_ids[i], observation_values[i]);
+    }
+    my_file.close_current_object();
+  }
+  // Open the read volume file and check that the observation id and values are
+  // correct. No leading slash should also find the subfile, and a ".vol"
+  // extension as well.
+  const auto& volume_file =
+      my_file.get<h5::VolumeData>("element_data.vol", version_number);
+  CHECK(volume_file.subfile_path() == "/element_data");
+  const auto read_observation_ids = volume_file.list_observation_ids();
+  // The observation IDs should be sorted by their observation value
+  CHECK(read_observation_ids == std::vector<size_t>{size_t(-1), 8435087234});
+  {
+    INFO("Test find_observation_id");
+    std::vector<size_t> found_observation_ids(observation_values.size());
+    std::transform(observation_values.begin(), observation_values.end(),
+                   found_observation_ids.begin(),
+                   [&volume_file](const double observation_value) {
+                     return volume_file.find_observation_id(observation_value);
+                   });
+    CHECK(found_observation_ids == observation_ids);
+  }
+
+  for (size_t i = 0; i < observation_ids.size(); ++i) {
+    TestHelpers::io::VolumeData::check_volume_data(
+        h5_file_name, version_number, "element_data"s, observation_ids[i],
+        observation_values[i], std::nullopt, tensor_components_and_coords,
+        grid_names, written_bases, written_quadratures, {{2, 2}},
+        {"S", "x-coord", "y-coord", "z-coord", "T_x", "T_y", "T_z"},
+        {{0, 1, 2, 3, 4, 5, 6}}, {}, observation_values[i]);
+    CHECK(volume_file.get_domain(observation_ids[i]) ==
+          serialize(domain_creator.create_domain()));
+    CHECK(volume_file.get_functions_of_time(observation_ids[i]) ==
+          serialize(domain_creator.functions_of_time()));
+  }
+
+  {
+    INFO("Cartoon dimension reduction");
+    const auto dimension = volume_file.get_dimension();
+    CHECK(dimension == 2);
+  }
+
+  {
+    INFO("Cartoon offset_and_length_for_grid");
+    const size_t observation_id = observation_ids.front();
+    const auto all_grid_names = volume_file.get_grid_names(observation_id);
+    const auto all_extents = volume_file.get_extents(observation_id);
+    const auto first_grid_offset_and_length = h5::offset_and_length_for_grid(
+        grid_names.front(), all_grid_names, all_extents);
+    CHECK(first_grid_offset_and_length.first == 0);
+    CHECK(first_grid_offset_and_length.second == 4);
+  }
+
+  {
+    INFO("Cartoon mesh_for_grid");
+    const size_t observation_id = observation_ids.front();
+    const auto all_grid_names = volume_file.get_grid_names(observation_id);
+    const auto all_extents = volume_file.get_extents(observation_id);
+    const auto all_bases = volume_file.get_bases(observation_id);
+    const auto all_quadratures = volume_file.get_quadratures(observation_id);
+    const auto first_mesh =
+        h5::mesh_for_grid<2>(grid_names.front(), all_grid_names, all_extents,
+                             all_bases, all_quadratures);
+    CHECK(first_mesh ==
+          Mesh<2>({2, 2},
+                  {Spectral::Basis::Legendre, Spectral::Basis::Legendre},
+                  {Spectral::Quadrature::GaussLobatto,
+                   Spectral::Quadrature::GaussLobatto}));
+  }
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}
 }  // namespace
 
 // [[TimeOut, 20]]
 SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   test<DataVector>();
   test<std::vector<float>>();
+  test_cartoon();
   test_strahlkorper();
   test_extend_connectivity_data<1>();
   test_extend_connectivity_data<2>();


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This commit handles cartoon simulations with computational dimensions 1D and 2D (though the code views it as 3D).

Each case must be handled separately.

**1D**: This is just a line, and it doesn't make sense to hack something into ParaView (though I initially did). I settled on not even letting this make `connectivity`, meaning it can't be visualized with some fancy software. Rather, you have to use `spectre plot along-line`, specifying the start and end points as 3D numbers, though the latter two values should always be zero, e.g. `--line-start 2.50,0,0 --line-end 5.75,0,0`

**2D**: The edits to the code now manually write the dimension as 2D (despite the serialization still PUPing as 3D objects). My edits make this dimension reduction consistent, and ParaView successfully visualizes the 2D domain.

From what I can tell, the Python CLI reconstructs by deserializing the objects and not using connectivity at all, while ParaView only uses the connectivity and doesn't care about the serialized object. The two cases here must be handled separately.

Depends on:
 - [x] #6834

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
