### PR TITLE
Use correct temporal id for each char speed sub measurement

### DIFF
--- a/src/ControlSystem/Measurements/CharSpeed.hpp
+++ b/src/ControlSystem/Measurements/CharSpeed.hpp
@@ -78,7 +78,10 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
         return "ControlSystemCharSpeedExcision" + ::domain::name(Object);
       }
 
-      using temporal_id = ::Tags::TimeAndPrevious<1>;
+      static constexpr size_t index =
+          Object == ::domain::ObjectLabel::A ? 1_st : 2_st;
+
+      using temporal_id = ::Tags::TimeAndPrevious<index>;
 
       using vars_to_interpolate_to_target = tmpl::list<
           gr::Tags::Lapse<DataVector>,
@@ -95,7 +98,7 @@ struct CharSpeed : tt::ConformsTo<protocols::Measurement> {
       using compute_vars_to_interpolate =
           ah::ComputeExcisionBoundaryVolumeQuantities;
       using compute_items_on_source =
-          tmpl::list<::Tags::TimeAndPreviousCompute<1>>;
+          tmpl::list<::Tags::TimeAndPreviousCompute<index>>;
       using compute_items_on_target =
           tmpl::list<gr::Tags::DetAndInverseSpatialMetricCompute<
               DataVector, 3, Frame::Distorted>>;


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds a fix done by Kyle in https://github.com/knelli2/spectre/commit/a2d506c04b2cf94bdb617d02c78b2b69e7a0010f that avoids deadlock early in the BBH inspiral of $q>1$. Kyle's explanation of the fix:

> Previously, only the horizon used different TimeAndPrevious tags
> for each object, but the excision didn't. Now they both do.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
