### PR TITLE
Schwarz solver: allow full-element overlaps

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.cpp
@@ -30,7 +30,7 @@ void InitializeOverlapGeometry<Dim>::operator()(
     const Element<Dim>& element, const Mesh<Dim>& mesh,
     const DirectionalIdMap<Dim, Mesh<Dim>>& neighbor_meshes,
     const ElementId<Dim>& element_id, const Direction<Dim>& overlap_direction,
-    const size_t max_overlap) const {
+    const std::optional<size_t> max_overlap) const {
   // Extruding extent
   *extruding_extent = LinearSolver::Schwarz::overlap_extent(
       mesh.extents(overlap_direction.dimension()), max_overlap);

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
@@ -93,7 +93,7 @@ struct InitializeOverlapGeometry {
       const Element<Dim>& element, const Mesh<Dim>& mesh,
       const DirectionalIdMap<Dim, Mesh<Dim>>& neighbor_meshes,
       const ElementId<Dim>& element_id, const Direction<Dim>& overlap_direction,
-      const size_t max_overlap) const;
+      std::optional<size_t> max_overlap) const;
 };
 }  // namespace detail
 

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -465,6 +465,8 @@ struct SubdomainOperator
         // overlap data to the full neighbor mesh by padding it with zeros. This
         // is necessary because spectral operators such as derivatives require
         // data on the full mesh.
+        // Possible performance optimization: this copy can be avoided if the
+        // overlap covers the full neighbor, so no padding with zeros is needed.
         if (not neighbor_data_is_zero) {
           LinearSolver::Schwarz::extended_overlap_data(
               make_not_null(&extended_operand_vars_[overlap_id]),
@@ -669,6 +671,8 @@ struct SubdomainOperator
         // inverse mass-matrix ("massless" scheme with no "mass-lumping"
         // approximation) means that lifted boundary corrections bleed into the
         // volume.
+        // Possible performance optimization: this copy can be avoided if the
+        // overlap covers the full neighbor, so no restriction is needed.
         if (UNLIKELY(
                 result->overlap_data[overlap_id].number_of_grid_points() !=
                 operand.overlap_data.at(overlap_id).number_of_grid_points())) {

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/ElementActions.hpp
@@ -250,11 +250,10 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
       const gsl::not_null<SubdomainData*> subdomain_data,
       const gsl::not_null<size_t*> observation_id,
       const gsl::not_null<SubdomainData*> /*volume_data_for_output*/,
-      const gsl::not_null<std::unique_ptr<SubdomainSolver>*>
-          subdomain_solver,
+      const gsl::not_null<std::unique_ptr<SubdomainSolver>*> subdomain_solver,
       const Element<Dim>& element, const Mesh<Dim>& mesh,
       const tnsr::I<DataVector, Dim, Frame::ElementLogical>& logical_coords,
-      const size_t max_overlap, const AmrData&... amr_data) {
+      const std::optional<size_t> max_overlap, const AmrData&... amr_data) {
     const size_t num_points = mesh.number_of_grid_points();
 
     // Intruding overlaps
@@ -273,7 +272,7 @@ struct InitializeElement : tt::ConformsTo<amr::protocols::Projector> {
     // For max_overlap > 0 all overlaps will have non-zero extents on an LGL
     // mesh (because it has at least 2 points per dimension), so we don't need
     // to check their extents are non-zero individually
-    if (LIKELY(max_overlap > 0)) {
+    if (LIKELY(max_overlap != 0)) {
       LinearSolver::Schwarz::element_weight(element_weight, logical_coords,
                                             intruding_overlap_widths,
                                             element.external_boundaries());
@@ -386,11 +385,11 @@ struct SolveSubdomain {
     const size_t iteration_id =
         get<Convergence::Tags::IterationId<OptionsGroup>>(box);
     const auto& element = db::get<domain::Tags::Element<Dim>>(box);
-    const size_t max_overlap = db::get<Tags::MaxOverlap<OptionsGroup>>(box);
+    const auto& max_overlap = db::get<Tags::MaxOverlap<OptionsGroup>>(box);
 
     // Wait for communicated overlap data
     const bool has_overlap_data =
-        max_overlap > 0 and element.number_of_neighbors() > 0;
+        max_overlap != 0 and element.number_of_neighbors() > 0;
     if (LIKELY(has_overlap_data) and
         not dg::has_received_from_all_mortars<overlap_residuals_inbox_tag>(
             iteration_id, element, inboxes)) {
@@ -481,7 +480,7 @@ struct SolveSubdomain {
     }
 
     // Apply weighting
-    if (LIKELY(max_overlap > 0)) {
+    if (LIKELY(max_overlap != 0)) {
       subdomain_solution.element_data *=
           get(db::get<Tags::Weight<OptionsGroup>>(box));
     }
@@ -494,7 +493,7 @@ struct SolveSubdomain {
         make_not_null(&box));
 
     // Send overlap solutions back to the neighbors that they are on
-    if (LIKELY(max_overlap > 0)) {
+    if (LIKELY(max_overlap != 0)) {
       auto& receiver_proxy =
           Parallel::get_parallel_component<ParallelComponent>(cache);
       for (auto& [overlap_id, overlap_solution] :

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.cpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.cpp
@@ -18,8 +18,9 @@
 
 namespace LinearSolver::Schwarz {
 
-size_t overlap_extent(const size_t volume_extent, const size_t max_overlap) {
-  return std::min(max_overlap, volume_extent - 1);
+size_t overlap_extent(const size_t volume_extent,
+                      const std::optional<size_t> max_overlap) {
+  return std::min(volume_extent, max_overlap.value_or(volume_extent));
 }
 
 namespace {
@@ -47,10 +48,10 @@ size_t overlap_num_points(const Index<Dim>& volume_extents,
 
 double overlap_width(const size_t overlap_extent,
                      const DataVector& collocation_points) {
-  ASSERT(overlap_extent < collocation_points.size(),
+  ASSERT(overlap_extent <= collocation_points.size(),
          "Overlap extent is "
              << overlap_extent
-             << " but must be strictly smaller than the number of grid points ("
+             << " but must be at most the number of grid points ("
              << collocation_points.size() << ") to compute an overlap width.");
   for (size_t i = 0; i < collocation_points.size() / 2; ++i) {
     ASSERT(equal_within_roundoff(
@@ -59,9 +60,17 @@ double overlap_width(const size_t overlap_extent,
            "Assuming the 'collocation_points' are symmetric, but they are not: "
                << collocation_points);
   }
-  // The overlap boundary index lies one point outside the region covered by the
-  // overlap coordinates (see `LinearSolver::Schwarz::overlap_extent`).
-  return collocation_points[overlap_extent] - collocation_points[0];
+  if (overlap_extent == collocation_points.size()) {
+    // Full element width. Weight function is zero at element boundary, so
+    // outermost LGL grid point does not contribute but outermost GL grid point
+    // does contribute.
+    return 2.0;
+  } else {
+    // Partial element width. Weight function is zero at first grid point
+    // outside the `overlap_extent`, so all `overlap_extent` grid points
+    // contribute on LGL and GL meshes.
+    return collocation_points[overlap_extent] + 1.0;
+  }
 }
 
 template <size_t Dim>

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp
@@ -34,24 +34,31 @@ using OverlapMap = DirectionalIdMap<Dim, ValueType>;
  * \brief The number of points that an overlap extends into the `volume_extent`
  *
  * In a dimension where an element has `volume_extent` points, the overlap
- * extent is the largest number under these constraints:
+ * extent is `min(volume_extent, max_overlap)`.
  *
- * - It is at most `max_overlap`.
- * - It is smaller than the `volume_extent`.
+ * We then define the _width_ of the overlap as the element-logical coordinate
+ * distance from the face of the element to the first collocation point
+ * _outside_ the overlap extent, or to the other element face if the overlap
+ * extent covers the full element.
  *
- * This means the overlap extent is always smaller than the `volume_extent`. The
- * reason for this constraint is that we define the _width_ of the overlap as
- * the element-logical coordinate distance from the face of the element to the
- * first collocation point _outside_ the overlap extent. Therefore, even an
- * overlap region that covers the full element in width does not include the
- * collocation point on the opposite side of the element.
  *
  * Here's a few notes on the definition of the overlap extent and width:
  *
  * - A typical smooth weighting function goes to zero at the overlap width, so
- *   if the grid points located at the overlap width were included in the
- *   subdomain, their solutions would not contribute to the weighted sum of
- *   subdomain solutions.
+ *   the grid points located at the overlap width do not contribute to the
+ *   weighted sum of subdomain solutions. However, all overlap grid points take
+ *   part in computing the subdomain solutions.
+ * - On a Gauss-Lobatto grid (with grid points on element faces): When the
+ *   overlap covers the full element then the outermost grid points (on the
+ *   element face) don't contribute to the weighted sum but take part in
+ *   computing the subdomain solutions. When the overlap extent is smaller than
+ *   the element by 1 grid point then the grid points on the element face also
+ *   don't contribute to the weighted sum _and_ they don't even take part in
+ *   computing the subdomain solutions.
+ * - On a Gauss grid (with no grid points on element faces): The outermost grid
+ *   points of the overlap always contribute to the weighted sum, as the
+ *   overlap width either extends to the next grid point or to the element face,
+ *   which is always a nonzero distance away from the outermost overlap point.
  * - Defining the overlap width as the distance to the first point _outside_ the
  *   overlap extent makes it non-zero even for a single point of overlap into a
  *   Gauss-Lobatto grid (which has points located at the element face).
@@ -63,7 +70,7 @@ using OverlapMap = DirectionalIdMap<Dim, ValueType>;
  *   the subdomain in the overlap allows to ignore that face altogether in the
  *   subdomain operator.
  */
-size_t overlap_extent(size_t volume_extent, size_t max_overlap);
+size_t overlap_extent(size_t volume_extent, std::optional<size_t> max_overlap);
 
 /*!
  * \brief Total number of grid points in an overlap region that extends

--- a/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Schwarz/Tags.hpp
@@ -27,10 +27,11 @@ namespace OptionTags {
 
 template <typename OptionsGroup>
 struct MaxOverlap {
-  using type = size_t;
+  using type = Options::Auto<size_t>;
   using group = OptionsGroup;
   static constexpr Options::String help =
-      "Number of points that subdomains can extend into neighbors";
+      "Number of points that subdomains can extend into neighbors. "
+      "'Auto' means no restriction, so the overlap covers the full neighbor.";
 };
 
 template <typename SolverType, typename OptionsGroup>
@@ -74,7 +75,7 @@ struct MaxOverlap : db::SimpleTag {
   static std::string name() {
     return "MaxOverlap(" + pretty_type::name<OptionsGroup>() + ")";
   }
-  using type = size_t;
+  using type = std::optional<size_t>;
   static constexpr bool pass_metavariables = false;
   using option_tags = tmpl::list<OptionTags::MaxOverlap<OptionsGroup>>;
   static type create_from_options(const type& value) { return value; }

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -14,8 +14,8 @@ OutputFileChecks:
     Subfile: ErrorNorms.dat
     FileGlob: ElasticHalfSpaceMirrorReductions.h5
     ExpectedData:
-      - [1, 171, 3.39481799202234e-01, 5.94500292306939e-04]
-    AbsoluteTolerance: 1e-12
+      - [1, 171, 3.394818e-01, 5.9458e-04]
+    AbsoluteTolerance: 1e-6
 
 ---
 
@@ -84,9 +84,9 @@ Observers:
 LinearSolver:
   Gmres:
     ConvergenceCriteria:
-      MaxIterations: 1
-      RelativeResidual: 1.e-4
-      AbsoluteResidual: 1.e-12
+      MaxIterations: 100
+      RelativeResidual: 0.
+      AbsoluteResidual: 1.e-6
     Verbosity: Quiet
 
   Multigrid:

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -563,7 +563,8 @@ void test_subdomain_operator(
     const Spectral::Quadrature quadrature = Spectral::Quadrature::GaussLobatto,
     const bool override_boundary_conditions = false,
     // NOLINTNEXTLINE(readability-avoid-const-params-in-decls)
-    const size_t max_overlap = 3, const double penalty_parameter = 1.2) {
+    const std::optional<size_t> max_overlap = 3,
+    const double penalty_parameter = 1.2) {
   CAPTURE(Dim);
   CAPTURE(penalty_parameter);
   CAPTURE(use_massive_dg_operator);
@@ -587,12 +588,16 @@ void test_subdomain_operator(
   register_factory_classes_with_charm<metavariables>();
 
   // Select randomly which iteration of the loops below perform expensive tests.
+  // If max_overlap=nullopt then a full-element overlap is tested and the random
+  // selection is disabled.
   MAKE_GENERATOR(gen);
-  std::uniform_int_distribution<size_t> dist_select_overlap(0, max_overlap);
-  const size_t rnd_overlap = dist_select_overlap(gen);
+  std::uniform_int_distribution<size_t> dist_select_overlap(
+      0, max_overlap.value_or(0));
+  const size_t rnd_overlap =
+      max_overlap.has_value() ? dist_select_overlap(gen) : 0;
 
   // The test should hold for any number of overlap points
-  for (size_t overlap = 0; overlap <= max_overlap; overlap++) {
+  for (size_t overlap = 0; overlap <= max_overlap.value_or(0); overlap++) {
     CAPTURE(overlap);
 
     // Re-create the domain in every iteration of this loop because it's not
@@ -626,7 +631,8 @@ void test_subdomain_operator(
         logging::Tags::Verbosity<::amr::OptionTags::AmrGroup>>{
         std::move(domain), domain_creator.functions_of_time(),
         std::move(boundary_conditions),
-        std::make_unique<RandomBackground<Dim>>(), overlap,
+        std::make_unique<RandomBackground<Dim>>(),
+        max_overlap.has_value() ? std::optional<size_t>(overlap) : std::nullopt,
         ::Verbosity::Verbose, penalty_parameter, use_massive_dg_operator,
         quadrature, ::dg::Formulation::StrongInertial, std::move(amr_criteria),
         ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true,
@@ -898,12 +904,14 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
                   elliptic::BoundaryConditionType::Dirichlet),
               make_boundary_condition<system>(
                   elliptic::BoundaryConditionType::Neumann)}}}}};
-      for (const auto& [use_massive_dg_operator, quadrature] :
-           cartesian_product(make_array(false, true),
-                             make_array(Spectral::Quadrature::GaussLobatto,
-                                        Spectral::Quadrature::Gauss))) {
+      for (const auto& [use_massive_dg_operator, quadrature, max_overlap] :
+           cartesian_product(
+               make_array(false, true),
+               make_array(Spectral::Quadrature::GaussLobatto,
+                          Spectral::Quadrature::Gauss),
+               std::array<std::optional<size_t>, 2>{{3, std::nullopt}})) {
         test_subdomain_operator<system>(domain_creator, use_massive_dg_operator,
-                                        quadrature);
+                                        quadrature, false, max_overlap);
       }
     }
     {
@@ -1141,5 +1149,12 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
         {{{{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}},
           {{dirichlet_bc->get_clone(), dirichlet_bc->get_clone()}}}}};
     test_subdomain_operator<system>(domain_creator);
+    for (const auto& [quadrature, max_overlap] : cartesian_product(
+             make_array(Spectral::Quadrature::GaussLobatto,
+                        Spectral::Quadrature::Gauss),
+             std::array<std::optional<size_t>, 2>{{3, std::nullopt}})) {
+      test_subdomain_operator<system>(domain_creator, true, quadrature, false,
+                                      std::nullopt);
+    }
   }
 }

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_OverlapHelpers.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_OverlapHelpers.cpp
@@ -14,6 +14,9 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/TMPL.hpp"
@@ -147,8 +150,8 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.OverlapHelpers",
     CHECK(overlap_extent(3, 0) == 0);
     CHECK(overlap_extent(3, 1) == 1);
     CHECK(overlap_extent(3, 2) == 2);
-    CHECK(overlap_extent(3, 3) == 2);
-    CHECK(overlap_extent(3, 4) == 2);
+    CHECK(overlap_extent(3, 3) == 3);
+    CHECK(overlap_extent(3, 4) == 3);
     CHECK(overlap_extent(0, 0) == 0);
   }
   {
@@ -179,12 +182,33 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.OverlapHelpers",
   }
   {
     INFO("Overlap width");
-    DataVector coords{-1., -0.8, 0., 0.8, 1.};
-    CHECK(overlap_width(0, coords) == approx(0.));
-    CHECK(overlap_width(1, coords) == approx(0.2));
-    CHECK(overlap_width(2, coords) == approx(1.));
-    CHECK(overlap_width(3, coords) == approx(1.8));
-    CHECK(overlap_width(4, coords) == approx(2.));
+    {
+      const DataVector coords{-1., -0.8, 0., 0.8, 1.};
+      CHECK(overlap_width(0, coords) == approx(0.));
+      CHECK(overlap_width(1, coords) == approx(0.2));
+      CHECK(overlap_width(2, coords) == approx(1.));
+      CHECK(overlap_width(3, coords) == approx(1.8));
+      CHECK(overlap_width(4, coords) == approx(2.));
+      CHECK(overlap_width(5, coords) == approx(2.));
+    }
+    {
+      const auto& coords =
+          Spectral::collocation_points<Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto>(5);
+      CHECK(overlap_width(0, coords) == approx(0.));
+      CHECK(overlap_width(2, coords) == approx(1.));
+      CHECK(overlap_width(4, coords) == approx(2.));
+      CHECK(overlap_width(5, coords) == approx(2.));
+    }
+    {
+      const auto& coords =
+          Spectral::collocation_points<Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::Gauss>(5);
+      CHECK(overlap_width(0, coords) > 0.);
+      CHECK(overlap_width(2, coords) == approx(1.));
+      CHECK(overlap_width(4, coords) < 2.);
+      CHECK(overlap_width(5, coords) == approx(2.));
+    }
   }
   {
     INFO("Overlap iterator");

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Schwarz/Test_Weighting.cpp
@@ -17,6 +17,7 @@
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/OverlapHelpers.hpp"
 #include "ParallelAlgorithms/LinearSolver/Schwarz/Weighting.hpp"
+#include "Utilities/CartesianProduct.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -68,7 +69,7 @@ void test_element_weight() {
 template <size_t Dim>
 void test_weights_conservation(const Element<Dim>& element,
                                const Mesh<Dim>& mesh,
-                               const size_t max_overlap) {
+                               const std::optional<size_t> max_overlap) {
   INFO("Weight conservation");
   CAPTURE(Dim);
   CAPTURE(element);
@@ -105,7 +106,8 @@ void test_weights_conservation(const Element<Dim>& element,
 }
 
 template <size_t Dim>
-void test_weights(const Mesh<Dim>& mesh, const size_t max_overlap) {
+void test_weights(const Mesh<Dim>& mesh,
+                  const std::optional<size_t> max_overlap) {
   typename Element<Dim>::Neighbors_t neighbors{};
   std::unordered_map<size_t, OrientationMap<Dim>> orientations{};
   for (size_t i = 0; i < two_to_the(Dim - 1); ++i) {
@@ -125,9 +127,13 @@ void test_weights(const Mesh<Dim>& mesh, const size_t max_overlap) {
       for (size_t i = 0; i < two_to_the(Dim - 1); ++i) {
         direction_neighbors.add_ids({ElementId<Dim>{i + 1}});
         const Element<Dim> element{ElementId<Dim>{0}, neighbors};
-        for (size_t max_overlap_i = 1; max_overlap_i <= max_overlap;
-             ++max_overlap_i) {
-          test_weights_conservation(element, mesh, max_overlap_i);
+        if (max_overlap.has_value()) {
+          for (size_t max_overlap_i = 1; max_overlap_i <= max_overlap;
+               ++max_overlap_i) {
+            test_weights_conservation(element, mesh, max_overlap_i);
+          }
+        } else {
+          test_weights_conservation(element, mesh, std::nullopt);
         }
       }
     }
@@ -194,17 +200,17 @@ SPECTRE_TEST_CASE("Unit.ParallelSchwarz.Weighting",
   }
   // Test weights conservation on all possible element-neighbor configurations
   {
-    test_weights(Mesh<1>{3, Spectral::Basis::Legendre,
-                         Spectral::Quadrature::GaussLobatto},
-                 4);
-    test_weights(Mesh<2>{{3, 4},
-                         Spectral::Basis::Legendre,
-                         Spectral::Quadrature::GaussLobatto},
-                 4);
-    test_weights(Mesh<3>{{2, 3, 4},
-                         Spectral::Basis::Legendre,
-                         Spectral::Quadrature::GaussLobatto},
-                 4);
+    for (const auto& [quadrature, max_overlap] : cartesian_product(
+             make_array(Spectral::Quadrature::GaussLobatto,
+                        Spectral::Quadrature::Gauss),
+             std::array<std::optional<size_t>, 2>{{4, std::nullopt}})) {
+      test_weights(Mesh<1>{3, Spectral::Basis::Legendre, quadrature},
+                   max_overlap);
+      test_weights(Mesh<2>{{3, 4}, Spectral::Basis::Legendre, quadrature},
+                   max_overlap);
+      test_weights(Mesh<3>{{2, 3, 4}, Spectral::Basis::Legendre, quadrature},
+                   max_overlap);
+    }
   }
 }
 


### PR DESCRIPTION
## Proposed changes

Allows overlap regions to extend over the full neighbors. Before, the LGL grid points on the outer element faces were never included in the subdomain because the weight function falls off to zero there. However, including them can still make the Schwarz smoother more effective, as these grid points take part in computing the subdomain solution.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
