### PR TITLE
ScalarSelfForce: add hyperboloidal slicing

### DIFF
--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
@@ -15,11 +15,13 @@ namespace ScalarSelfForce::BoundaryConditions {
 
 Sommerfeld::Sommerfeld(const double black_hole_mass,
                        const double black_hole_spin,
-                       const double orbital_radius, const int m_mode_number)
+                       const double orbital_radius, const int m_mode_number,
+                       const bool hyperboloidal_slicing)
     : black_hole_mass_(black_hole_mass),
       black_hole_spin_(black_hole_spin),
       orbital_radius_(orbital_radius),
-      m_mode_number_(m_mode_number) {}
+      m_mode_number_(m_mode_number),
+      hyperboloidal_slicing_(hyperboloidal_slicing) {}
 
 Sommerfeld::Sommerfeld(CkMigrateMessage* m) : Base(m) {}
 
@@ -32,6 +34,10 @@ void Sommerfeld::apply(
     const gsl::not_null<Scalar<ComplexDataVector>*> field,
     const gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient,
     const tnsr::i<ComplexDataVector, 2>& /*deriv_field*/) const {
+  if (hyperboloidal_slicing_) {
+    get(*n_dot_field_gradient) = 0.;
+    return;
+  }
   const double a = black_hole_spin_ * black_hole_mass_;
   const double M = black_hole_mass_;
   const double r_0 = orbital_radius_;
@@ -55,13 +61,15 @@ void Sommerfeld::pup(PUP::er& p) {
   p | black_hole_spin_;
   p | orbital_radius_;
   p | m_mode_number_;
+  p | hyperboloidal_slicing_;
 }
 
 bool operator==(const Sommerfeld& lhs, const Sommerfeld& rhs) {
   return lhs.black_hole_mass_ == rhs.black_hole_mass_ and
          lhs.black_hole_spin_ == rhs.black_hole_spin_ and
          lhs.orbital_radius_ == rhs.orbital_radius_ and
-         lhs.m_mode_number_ == rhs.m_mode_number_;
+         lhs.m_mode_number_ == rhs.m_mode_number_ and
+         lhs.hyperboloidal_slicing_ == rhs.hyperboloidal_slicing_;
 }
 
 bool operator!=(const Sommerfeld& lhs, const Sommerfeld& rhs) {

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.hpp
@@ -56,11 +56,17 @@ class Sommerfeld : public elliptic::BoundaryConditions::BoundaryCondition<2> {
         "Mode number 'm' of the scalar field";
     using type = int;
   };
+  struct HyperboloidalSlicing {
+    static constexpr Options::String help =
+        "Whether hyperboloidal slicing is applied. If true, a simple Neumann "
+        "boundary condition is applied.";
+    using type = bool;
+  };
 
   static constexpr Options::String help =
       "Radial Sommerfeld boundary condition";
-  using options =
-      tmpl::list<BlackHoleMass, BlackHoleSpin, OrbitalRadius, MModeNumber>;
+  using options = tmpl::list<BlackHoleMass, BlackHoleSpin, OrbitalRadius,
+                             MModeNumber, HyperboloidalSlicing>;
 
   Sommerfeld() = default;
   Sommerfeld(const Sommerfeld&) = default;
@@ -70,12 +76,14 @@ class Sommerfeld : public elliptic::BoundaryConditions::BoundaryCondition<2> {
   ~Sommerfeld() override = default;
 
   explicit Sommerfeld(double black_hole_mass, double black_hole_spin,
-                      double orbital_radius, int m_mode_number);
+                      double orbital_radius, int m_mode_number,
+                      bool hyperboloidal_slicing);
 
   double black_hole_mass() const { return black_hole_mass_; }
   double black_hole_spin() const { return black_hole_spin_; }
   double orbital_radius() const { return orbital_radius_; }
   int m_mode_number() const { return m_mode_number_; }
+  bool hyperboloidal_slicing() const { return hyperboloidal_slicing_; }
 
   /// \cond
   explicit Sommerfeld(CkMigrateMessage* m);
@@ -116,6 +124,7 @@ class Sommerfeld : public elliptic::BoundaryConditions::BoundaryCondition<2> {
   double black_hole_spin_{std::numeric_limits<double>::signaling_NaN()};
   double orbital_radius_{std::numeric_limits<double>::signaling_NaN()};
   int m_mode_number_{};
+  bool hyperboloidal_slicing_{};
 };
 
 bool operator!=(const Sommerfeld& lhs, const Sommerfeld& rhs);

--- a/src/PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.cpp
+++ b/src/PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.cpp
@@ -17,17 +17,35 @@
 #include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TortoiseCoordinates.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
 
 namespace ScalarSelfForce::AnalyticData {
+
+namespace {
+std::pair<DataVector, DataVector> boost_function_and_deriv(
+    const DataVector& r_star, const std::array<double, 4>& transition_points) {
+  return {
+      smoothstep<1>(transition_points[0], transition_points[1], r_star) +
+          smoothstep<1>(transition_points[2], transition_points[3], r_star) -
+          1.0,
+      smoothstep_deriv<1>(transition_points[0], transition_points[1], r_star) +
+          smoothstep_deriv<1>(transition_points[2], transition_points[3],
+                              r_star)};
+}
+}  // namespace
 
 CircularOrbit::CircularOrbit(const double black_hole_mass,
                              const double black_hole_spin,
                              const double orbital_radius,
-                             const int m_mode_number)
+                             const int m_mode_number,
+                             const std::optional<std::array<double, 4>>
+                                 hyperboloidal_slicing_transitions)
     : black_hole_mass_(black_hole_mass),
       black_hole_spin_(black_hole_spin),
       orbital_radius_(orbital_radius),
-      m_mode_number_(m_mode_number) {}
+      m_mode_number_(m_mode_number),
+      hyperboloidal_slicing_transitions_(hyperboloidal_slicing_transitions) {}
 
 CircularOrbit::CircularOrbit(CkMigrateMessage* m)
     : elliptic::analytic_data::Background(m),
@@ -82,6 +100,15 @@ CircularOrbit::variables(
       2. * square(a) * get(alpha) / r;
   get<1>(gamma) = ComplexDataVector{cos_theta.size(), 0.};
   get(alpha) *= sin_theta_squared;
+  // Hyperboloidal slicing
+  if (hyperboloidal_slicing_transitions_.has_value()) {
+    const auto [H, dH] = boost_function_and_deriv(
+        r_star, hyperboloidal_slicing_transitions_.value());
+    const double k = m_mode_number_ * omega;
+    get(beta) += std::complex<double>(0., -k) * dH + square(k) * square(H) +
+                 std::complex<double>(0., k) * get<0>(gamma) * H;
+    get<0>(gamma) += std::complex<double>(0., -2. * k) * H;
+  }
   return result;
 }
 
@@ -128,6 +155,17 @@ CircularOrbit::variables(
     effsource_set_particle(&xp, e, l, 0.);
   }
   const auto& r_star = get<0>(x);
+  if (hyperboloidal_slicing_transitions_.has_value() and
+      (min(r_star) < (*hyperboloidal_slicing_transitions_)[1] or
+       max(r_star) > (*hyperboloidal_slicing_transitions_)[2])) {
+    ERROR(
+        "The effective source is only valid where no hyperboloidal slicing is "
+        "applied, which is in the r_* range ["
+        << (*hyperboloidal_slicing_transitions_)[1] << ", "
+        << (*hyperboloidal_slicing_transitions_)[2]
+        << "], but was requested in the range [" << min(r_star) << ", "
+        << max(r_star) << "]");
+  }
   const auto& cos_theta = get<1>(x);
   const DataVector r_minus_r_plus =
       gr::boyer_lindquist_radius_minus_r_plus_from_tortoise(r_star, M,
@@ -203,13 +241,16 @@ void CircularOrbit::pup(PUP::er& p) {
   p | black_hole_spin_;
   p | orbital_radius_;
   p | m_mode_number_;
+  p | hyperboloidal_slicing_transitions_;
 }
 
 bool operator==(const CircularOrbit& lhs, const CircularOrbit& rhs) {
   return lhs.black_hole_mass_ == rhs.black_hole_mass_ and
          lhs.black_hole_spin_ == rhs.black_hole_spin_ and
          lhs.orbital_radius_ == rhs.orbital_radius_ and
-         lhs.m_mode_number_ == rhs.m_mode_number_;
+         lhs.m_mode_number_ == rhs.m_mode_number_ and
+         lhs.hyperboloidal_slicing_transitions_ ==
+             rhs.hyperboloidal_slicing_transitions_;
 }
 
 bool operator!=(const CircularOrbit& lhs, const CircularOrbit& rhs) {

--- a/src/PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.hpp
+++ b/src/PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <optional>
 #include <pup.h>
 #include <vector>
 
@@ -14,6 +15,7 @@
 #include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Auto.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
@@ -69,6 +71,38 @@ namespace ScalarSelfForce::AnalyticData {
  * \end{align}
  * where $\Delta\phi = \frac{a}{r_+ - r_-} \ln(\frac{r-r_+}{r-r_-})$ (Eq. (2.7)
  * in \cite Osburn:2022bby ).
+ *
+ * \par Hyperboloidal slicing
+ * Transforming to a hyperboloidal time coordinate $s = t - h(r_*)$ can simplify
+ * the solution a lot because the slice will only intersect a finite number of
+ * wave fronts. In frequency domain this transformation means that partial
+ * derivatives transform as:
+ * \begin{align}
+ *   &\partial_{r_*} \rightarrow \partial_{r_*} + i m\Omega H(r_*) \\
+ *   &\partial_{r_*}^2 \rightarrow \partial_{r_*}^2 +
+ *     2 i m\Omega H(r_*) \partial_{r_*} + i m\Omega H'(r_*)
+ *     -m^2\Omega^2 H(r_*)^2
+ * \end{align}
+ * where $H(r_*) = h'(r_*)$ is the boost function that asymptotes to
+ * $H(r_* \rightarrow \pm \infty) = \pm 1$.
+ * This maps to the following additional terms in $\beta$ and $\gamma_{r_*}$:
+ * \begin{align}
+ *   &\beta \rightarrow \beta + i m\Omega \gamma_{r_*} H(r_*)
+ *     - i m\Omega H'(r_*) + m^2\Omega^2 H(r_*)^2 \\
+ *   &\gamma_{r_*} \rightarrow \gamma_{r_*} - 2 i m\Omega H(r_*)
+ * \end{align}
+ * For the boost function we choose here a simple sigmoid so that it is exactly
+ * zero in a finite region around the puncture where we apply the effective
+ * source, and transitions to -1 and 1 outside of this region. We choose
+ * the $C^1$ continuous `smoothstep<1>` for this. Reasonable transition points
+ * are from the boundaries of the effective source region to about $20M$
+ * away from it, though this hasn't been tested very much yet. We may also want
+ * to try jumping from $H=0$ to $H=\pm 1$ discontinuously at the boundary of the
+ * effective source region, which is supported by the DG scheme (see
+ * `fluxes_computer::is_discontinuous` in
+ * `elliptic::protocols::FirstOrderSystem`), so (1) we don't have to resolve the
+ * transition, and (2) we can more easily support the 2nd order self-force
+ * source.
  */
 class CircularOrbit : public elliptic::analytic_data::Background,
                       public elliptic::analytic_data::InitialGuess {
@@ -93,8 +127,18 @@ class CircularOrbit : public elliptic::analytic_data::Background,
         "Mode number 'm' of the scalar field";
     using type = int;
   };
-  using options =
-      tmpl::list<BlackHoleMass, BlackHoleSpin, OrbitalRadius, MModeNumber>;
+  struct HyperboloidalSlicingTransitions {
+    static constexpr Options::String help =
+        "Enable hyperboloidal slicing by specifying the transition points for "
+        "the boost function. The boost function transitions from -1 to zero "
+        "between the first two points and from zero to 1 between the last "
+        "two points. The effective source can only be evaluated where the "
+        "boost function is zero, so the regularized region must be between "
+        "the second and third points.";
+    using type = Options::Auto<std::array<double, 4>, Options::AutoLabel::None>;
+  };
+  using options = tmpl::list<BlackHoleMass, BlackHoleSpin, OrbitalRadius,
+                             MModeNumber, HyperboloidalSlicingTransitions>;
   static constexpr Options::String help =
       "Quasicircular orbit of a scalar point charge in Kerr spacetime";
 
@@ -105,8 +149,10 @@ class CircularOrbit : public elliptic::analytic_data::Background,
   CircularOrbit& operator=(CircularOrbit&&) = default;
   ~CircularOrbit() override = default;
 
-  CircularOrbit(double black_hole_mass, double black_hole_spin,
-                double orbital_radius, int m_mode_number);
+  CircularOrbit(
+      double black_hole_mass, double black_hole_spin, double orbital_radius,
+      int m_mode_number,
+      std::optional<std::array<double, 4>> hyperboloidal_slicing_transitions);
 
   explicit CircularOrbit(CkMigrateMessage* m);
   using PUP::able::register_constructor;
@@ -117,6 +163,10 @@ class CircularOrbit : public elliptic::analytic_data::Background,
   double black_hole_spin() const { return black_hole_spin_; }
   double orbital_radius() const { return orbital_radius_; }
   int m_mode_number() const { return m_mode_number_; }
+  std::optional<std::array<double, 4>> hyperboloidal_slicing_transitions()
+      const {
+    return hyperboloidal_slicing_transitions_;
+  }
 
   using background_tags = tmpl::list<Tags::Alpha, Tags::Beta, Tags::Gamma>;
   using source_tags = tmpl::list<
@@ -155,6 +205,7 @@ class CircularOrbit : public elliptic::analytic_data::Background,
   double black_hole_spin_{std::numeric_limits<double>::signaling_NaN()};
   double orbital_radius_{std::numeric_limits<double>::signaling_NaN()};
   int m_mode_number_{};
+  std::optional<std::array<double, 4>> hyperboloidal_slicing_transitions_{};
 };
 
 bool operator!=(const CircularOrbit& lhs, const CircularOrbit& rhs);

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_Sommerfeld.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_Sommerfeld.cpp
@@ -38,7 +38,8 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.BoundaryConditions.Sommerfeld",
       "  BlackHoleMass: 1.0\n"
       "  BlackHoleSpin: 0.5\n"
       "  OrbitalRadius: 10.0\n"
-      "  MModeNumber: 2\n");
+      "  MModeNumber: 2\n"
+      "  HyperboloidalSlicing: False\n");
   REQUIRE(dynamic_cast<const Sommerfeld*>(created.get()) != nullptr);
   const auto& boundary_condition = dynamic_cast<const Sommerfeld&>(*created);
   {
@@ -54,6 +55,7 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.BoundaryConditions.Sommerfeld",
     CHECK(boundary_condition.black_hole_spin() == 0.5);
     CHECK(boundary_condition.orbital_radius() == 10.0);
     CHECK(boundary_condition.m_mode_number() == 2);
+    CHECK(boundary_condition.hyperboloidal_slicing() == false);
     CHECK(boundary_condition.boundary_condition_types() ==
           std::vector<elliptic::BoundaryConditionType>{
               elliptic::BoundaryConditionType::Neumann});

--- a/tests/Unit/PointwiseFunctions/AnalyticData/SelfForce/Scalar/Test_CircularOrbit.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/SelfForce/Scalar/Test_CircularOrbit.cpp
@@ -60,7 +60,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarSelfForce.CircularOrbit",
   // Get the analytic fields
   for (int m_mode_number = 0; m_mode_number < 3; ++m_mode_number) {
     CAPTURE(m_mode_number);
-    const auto circular_orbit = CircularOrbit{1., 0.9, 6., m_mode_number};
+    const auto circular_orbit =
+        CircularOrbit{1., 0.9, 6., m_mode_number, {{-25., -5., 20., 40.}}};
     CAPTURE(circular_orbit.puncture_position());
     const auto background =
         circular_orbit.variables(x, CircularOrbit::background_tags{});


### PR DESCRIPTION
## Proposed changes

Hyperboloidal slicing makes the self-force problem much simpler because the solution only has a finite number of oscillations. This PR adds the hyperboloidal slicing, which is actually quite simple to implement (no compactification of the domain yet).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
