### PR TITLE
Update Ocean2 to Intel MPI

### DIFF
--- a/support/Environments/ocean2.sh
+++ b/support/Environments/ocean2.sh
@@ -9,53 +9,53 @@ spectre_setup_modules() {
 
 spectre_unload_modules() {
     module unload gnu12/12.3.0
-    module unload openmpi5/5.0.3
+    module unload intel/mpi/2021.16
     module unload cmake/3.24.2
     module unload openblas/0.3.27
     module unload blaze/3.8
     module unload boost/1.85.0
     module unload catch2/3.5.4
     module unload gsl/2.8
-    module unload hdf5/1.12.3
+    module unload hdf5/1.14.6
     module unload jemalloc/5.3.0
     module unload libxsmm/1.17
     module unload yaml-cpp/0.7.0
     module unload libffi/3.4.5
     module unload python/3.12.4
-    module unload python/spectre-python-2024.07.11
+    module unload python/spectre-python-2025.08.19
     module unload llvm/18.1.8
     module unload libbacktrace/2024.07.09
     module unload yasm/1.3.0
     module unload ffmpeg/7.0.1
     module unload fftw/3.3.10
     module unload petsc/3.21.3
-    module unload charm/7.0.0
+    module unload charm/8.0.0
     module unload libbacktrace/2024.07.09
 }
 
 spectre_load_modules() {
     module load gnu12/12.3.0
-    module load openmpi5/5.0.3
+    module load intel/mpi/2021.16
     module load cmake/3.24.2
     module load openblas/0.3.27
     module load blaze/3.8
     module load boost/1.85.0
     module load catch2/3.5.4
     module load gsl/2.8
-    module load hdf5/1.12.3
+    module load hdf5/1.14.6
     module load jemalloc/5.3.0
     module load libxsmm/1.17
     module load yaml-cpp/0.7.0
     module load libffi/3.4.5
     module load python/3.12.4
-    module load python/spectre-python-2024.07.11
+    module load python/spectre-python-2025.08.19
     module load llvm/18.1.8
     module load libbacktrace/2024.07.09
     module load yasm/1.3.0
     module load ffmpeg/7.0.1
     module load fftw/3.3.10
     module load petsc/3.21.3
-    module load charm/7.0.0
+    module load charm/8.0.0
     module load libbacktrace/2024.07.09
 }
 

--- a/support/SubmitScripts/Ocean2.sh
+++ b/support/SubmitScripts/Ocean2.sh
@@ -15,39 +15,3 @@
 #SBATCH -p {{ queue | default("normal") }}
 #SBATCH -t {{ time_limit | default("01-00:00:00") }}
 {% endblock %}
-
-{% block run_command %}
-export OPENBLAS_NUM_THREADS=1
-
-# Generate nodelist file
-echo "Running on the following nodes:"
-echo ${SLURM_NODELIST}
-touch nodelist.$SLURM_JOBID
-for node in $(echo $SLURM_NODELIST | scontrol show hostnames); do
-  echo "host ${node}" >> nodelist.$SLURM_JOBID
-done
-
-# Set worker threads and run command
-WORKER_THREADS=$((SLURM_NTASKS * CHARM_PPN))
-SPECTRE_COMMAND="${SPECTRE_EXECUTABLE} ++np ${SLURM_NTASKS} \
-++p ${WORKER_THREADS} ++ppn ${CHARM_PPN} \
-++nodelist nodelist.${SLURM_JOBID}"
-
-
-# When invoking through `charmrun`, charm will initiate remote sessions which
-# will wipe out environment settings unless it is forced to re-initialize the
-# spectre environment between the start of the remote session and starting the
-# spectre executable
-echo "#!/bin/sh
-source ${SPECTRE_HOME}/support/Environments/ocean2.sh
-spectre_load_modules
-\$@
-" > ${RUN_DIR}/runscript.${SLURM_JOBID}
-chmod u+x ${RUN_DIR}/runscript.${SLURM_JOBID}
-
-# Run
-charmrun ++runscript ${RUN_DIR}/runscript.${SLURM_JOBID} \
-          ${SPECTRE_COMMAND} --input-file ${SPECTRE_INPUT_FILE} \
-          ${SPECTRE_CHECKPOINT:+ +restart "${SPECTRE_CHECKPOINT}"}
-{% endblock %}
-


### PR DESCRIPTION
## Proposed changes

Updates Ocean2 and some modules to use intel mpi as well as a newer spectre python.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

