### PR TITLE
Split IMEX CleanHistory out of main CleanHistory

### DIFF
--- a/docs/Tutorials/Imex.md
+++ b/docs/Tutorials/Imex.md
@@ -226,10 +226,9 @@ imex::protocols::ImexSystem \endlink and \link imex::protocols::ImplicitSector
 portion of the derivative, and the implicit portion is defined by the contents
 of the `implicit_sectors` typelist.  See those protocols for details.
 
-In order to use an IMEX system, the implicit solver must be explicitly
-instantiated for each sector.  This is done in a separate source file in the
-system directory.  As an example, the instantiation file for the sectors in one
-of the tests is
+In order to use an IMEX system, various classes must be explicitly
+instantiated.  This is done in a separate source file in the system directory.
+As an example, the instantiation file for the sectors in one of the tests is
 
 \include tests/Unit/Helpers/Evolution/Imex/DoImplicitStepInstantiate.cpp
 
@@ -257,15 +256,15 @@ actions:
 ```
 imex::Actions::RecordTimeStepperData<system>
 ```
-  must be added after each occurrence of
-  `Actions::RecordTimeStepperData<system>`.  (There may be only one.)
-
-* Again in the step actions,
+  must be added after each occurrence of `RecordTimeStepperData<system>`,
 ```
 imex::Actions::DoImplicitStep<system>
 ```
-  must be added after each occurrence of `Actions::UpdateU<system>`.  (Again,
-  there may be only one.)
+  must be added after each occurrence of `UpdateU<system>`, and
+```
+Actions::MutateApply<imex::CleanHistory<system>>
+```
+  must be added after each occurrence of `CleanHistory<system>`.
 
 Third, the `imex::ImplicitDenseOutput<system>` dense output postprocessor must
 be added to the argument of the `evolution::Actions::RunEventsAndDenseTriggers`
@@ -277,7 +276,9 @@ headers are
 ```
 #include "Evolution/Imex/Actions/DoImplicitStep.hpp"
 #include "Evolution/Imex/Actions/RecordTimeStepperData.hpp"
+#include "Evolution/Imex/CleanHistory.hpp"
 #include "Evolution/Imex/ImplicitDenseOutput.hpp"
 #include "Evolution/Imex/Initialize.hpp"
+#include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "Time/TimeSteppers/ImexTimeStepper.hpp"
 ```

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -24,7 +24,6 @@
 #include "Evolution/Imex/Actions/RecordTimeStepperData.hpp"
 #include "Evolution/Imex/ImplicitDenseOutput.hpp"
 #include "Evolution/Imex/Initialize.hpp"
-#include "Evolution/Imex/SolveImplicitSector.tpp"
 #include "Evolution/Initialization/ConservativeSystem.hpp"
 #include "Evolution/Initialization/DgDomain.hpp"
 #include "Evolution/Initialization/Evolution.hpp"

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -22,6 +22,7 @@
 #include "Evolution/DiscontinuousGalerkin/Limiters/Tags.hpp"
 #include "Evolution/Imex/Actions/DoImplicitStep.hpp"
 #include "Evolution/Imex/Actions/RecordTimeStepperData.hpp"
+#include "Evolution/Imex/CleanHistory.hpp"
 #include "Evolution/Imex/ImplicitDenseOutput.hpp"
 #include "Evolution/Imex/Initialize.hpp"
 #include "Evolution/Initialization/ConservativeSystem.hpp"
@@ -209,6 +210,7 @@ struct EvolutionMetavars {
               Actions::UpdateU<system>>>,
       imex::Actions::DoImplicitStep<system>,
       Actions::CleanHistory<system, local_time_stepping>,
+      Actions::MutateApply<imex::CleanHistory<system>>,
       Limiters::Actions::SendData<EvolutionMetavars>,
       Limiters::Actions::Limit<EvolutionMetavars>,
       Actions::MutateApply<typename RadiationTransport::M1Grey::

--- a/src/Evolution/Imex/CMakeLists.txt
+++ b/src/Evolution/Imex/CMakeLists.txt
@@ -16,6 +16,8 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  CleanHistory.hpp
+  CleanHistory.tpp
   GuessResult.hpp
   ImplicitDenseOutput.hpp
   Initialize.hpp

--- a/src/Evolution/Imex/CleanHistory.hpp
+++ b/src/Evolution/Imex/CleanHistory.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class ImexTimeStepper;
+template <typename TagsList>
+class Variables;
+namespace Tags {
+template <typename StepperInterface>
+struct TimeStepper;
+}  // namespace Tags
+namespace TimeSteppers {
+template <typename Vars>
+class History;
+}  // namespace TimeSteppers
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+namespace imex::Tags {
+template <typename ImplicitSector>
+struct ImplicitHistory;
+}  // namespace imex::Tags
+/// \endcond
+
+namespace imex {
+/// Mutator to clean history objects for each sector after an IMEX substep.
+template <typename System,
+          typename ImplicitSectors = typename System::implicit_sectors>
+struct CleanHistory;
+
+/// \copydoc CleanHistory
+template <typename System, typename... ImplicitSectors>
+struct CleanHistory<System, tmpl::list<ImplicitSectors...>> {
+  using return_tags =
+      tmpl::list<imex::Tags::ImplicitHistory<ImplicitSectors>...>;
+  using argument_tags = tmpl::list<::Tags::TimeStepper<ImexTimeStepper>>;
+
+  static void apply(
+      const gsl::not_null<TimeSteppers::History<
+          Variables<typename ImplicitSectors::tensors>>*>... histories,
+      const ImexTimeStepper& time_stepper);
+};
+}  // namespace imex

--- a/src/Evolution/Imex/CleanHistory.tpp
+++ b/src/Evolution/Imex/CleanHistory.tpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Imex/CleanHistory.hpp"
+
+#include "DataStructures/Variables.hpp"
+#include "Time/History.hpp"
+#include "Time/TimeSteppers/ImexTimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace imex {
+template <typename System, typename... ImplicitSectors>
+void CleanHistory<System, tmpl::list<ImplicitSectors...>>::apply(
+    const gsl::not_null<TimeSteppers::History<
+        Variables<typename ImplicitSectors::tensors>>*>... histories,
+    const ImexTimeStepper& time_stepper) {
+  expand_pack((time_stepper.clean_history(histories), 0)...);
+}
+}  // namespace imex

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
   Events
   GeneralRelativity
   Hydro
+  Imex
   LinearOperators
   M1GreyAnalyticData
   M1GreySolutions

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/CMakeLists.txt
@@ -5,4 +5,5 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Events.cpp
+  Imex.cpp
   )

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/Imex.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/Imex.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Imex/CleanHistory.hpp"
+#include "Evolution/Imex/CleanHistory.tpp"
 #include "Evolution/Imex/SolveImplicitSector.hpp"
 #include "Evolution/Imex/SolveImplicitSector.tpp"
 #include "Evolution/Systems/RadiationTransport/M1Grey/System.hpp"
@@ -10,6 +12,7 @@
 using m1system = RadiationTransport::M1Grey::System<
     tmpl::list<neutrinos::ElectronNeutrinos<1>>>;
 
+template struct imex::CleanHistory<m1system>;
 template struct imex::SolveImplicitSector<
     m1system::variables_tag,
     m1system::ImplicitSector<neutrinos::ElectronNeutrinos<1>>>;

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/Imex.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/Imex.cpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Imex/SolveImplicitSector.hpp"
+#include "Evolution/Imex/SolveImplicitSector.tpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/System.hpp"
+#include "Evolution/Systems/RadiationTransport/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+using m1system = RadiationTransport::M1Grey::System<
+    tmpl::list<neutrinos::ElectronNeutrinos<1>>>;
+
+template struct imex::SolveImplicitSector<
+    m1system::variables_tag,
+    m1system::ImplicitSector<neutrinos::ElectronNeutrinos<1>>>;

--- a/src/Time/Actions/CleanHistory.hpp
+++ b/src/Time/Actions/CleanHistory.hpp
@@ -9,7 +9,6 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
 
@@ -30,13 +29,6 @@ namespace evolution::dg::Tags {
 template <size_t Dim, typename CouplingResult>
 struct MortarDataHistory;
 }  // namespace evolution::dg::Tags
-namespace imex::Tags {
-template <typename ImplicitSector>
-struct ImplicitHistory;
-}  // namespace imex::Tags
-namespace imex::protocols {
-struct ImexSystem;
-}  // namespace imex::protocols
 namespace tuples {
 template <class... Tags>
 class TaggedTuple;
@@ -57,7 +49,6 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies:
 ///   - Tags::HistoryEvolvedVariables<variables_tag>
-///   - imex::Tags::ImplicitHistory<sector> for each IMEX sector
 ///   - evolution::dg::Tags::MortarDataHistory<...> if CleanBoundaryHistory
 template <typename System, bool CleanBoundaryHistory>
 struct CleanHistory {
@@ -98,17 +89,6 @@ struct CleanHistory {
     // stepping structures are in Evolution, so everything past here
     // has to only depend on Evolution classes through the DataBox
     // type.
-
-    if constexpr (tt::conforms_to_v<System, imex::protocols::ImexSystem>) {
-      using implicit_history_tags =
-          tmpl::transform<typename System::implicit_sectors,
-                          tmpl::bind<imex::Tags::ImplicitHistory, tmpl::_1>>;
-      db::mutate_apply<implicit_history_tags, tmpl::list<>>(
-          [&time_stepper](const auto... histories) {
-            expand_pack((time_stepper.clean_history(histories), 0)...);
-          },
-          make_not_null(&box));
-    }
 
     if constexpr (CleanBoundaryHistory) {
       using boundary_history_tags =

--- a/tests/Unit/Evolution/Imex/CMakeLists.txt
+++ b/tests/Unit/Evolution/Imex/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Imex")
 
 set(LIBRARY_SOURCES
+  Test_CleanHistory.cpp
   Test_GuessResult.cpp
   Test_ImplicitDenseOutput.cpp
   Test_Initialize.cpp

--- a/tests/Unit/Evolution/Imex/Test_CleanHistory.cpp
+++ b/tests/Unit/Evolution/Imex/Test_CleanHistory.cpp
@@ -1,0 +1,59 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Imex/CleanHistory.hpp"
+#include "Evolution/Imex/Tags/ImplicitHistory.hpp"
+#include "Helpers/Evolution/Imex/DoImplicitStepSector.hpp"
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Time/TimeSteppers/Heun2.hpp"
+#include "Time/TimeSteppers/ImexTimeStepper.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename Var>
+TimeSteppers::History<Variables<tmpl::list<Var>>> create_history() {
+  const Slab slab(1., 3.);
+  TimeSteppers::History<Variables<tmpl::list<Var>>> history{2};
+  history.insert(TimeStepId(true, 0, slab.start()), {5, 0.0}, {5, 0.0});
+  history.insert(
+      TimeStepId(true, 0, slab.start(), 1, slab.duration(), slab.end().value()),
+      {5, 0.0}, {5, 0.0});
+  history.insert(TimeStepId(true, 1, slab.end()), {5, 0.0}, {5, 0.0});
+  return history;
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Imex.CleanHistory", "[Unit][Evolution]") {
+  namespace helpers = do_implicit_step_helpers;
+
+  auto box = db::create<
+      db::AddSimpleTags<
+          Tags::ConcreteTimeStepper<ImexTimeStepper>,
+          imex::Tags::ImplicitHistory<helpers::Sector<helpers::Var1>>,
+          imex::Tags::ImplicitHistory<helpers::Sector<helpers::Var2>>>,
+      time_stepper_ref_tags<ImexTimeStepper>>(
+      static_cast<std::unique_ptr<ImexTimeStepper>>(
+          std::make_unique<TimeSteppers::Heun2>()),
+      create_history<helpers::Var1>(), create_history<helpers::Var2>());
+
+  db::mutate_apply<imex::CleanHistory<helpers::System>>(make_not_null(&box));
+
+  CHECK(
+      db::get<imex::Tags::ImplicitHistory<helpers::Sector<helpers::Var1>>>(box)
+          .size() == 1);
+  CHECK(
+      db::get<imex::Tags::ImplicitHistory<helpers::Sector<helpers::Var2>>>(box)
+          .size() == 1);
+}
+}  // namespace

--- a/tests/Unit/Helpers/Evolution/Imex/DoImplicitStepInstantiate.cpp
+++ b/tests/Unit/Helpers/Evolution/Imex/DoImplicitStepInstantiate.cpp
@@ -1,11 +1,14 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "Evolution/Imex/CleanHistory.hpp"
+#include "Evolution/Imex/CleanHistory.tpp"
 #include "Evolution/Imex/SolveImplicitSector.hpp"
 #include "Evolution/Imex/SolveImplicitSector.tpp"
 #include "Helpers/Evolution/Imex/DoImplicitStepSector.hpp"
 
 namespace helpers = do_implicit_step_helpers;
+template struct imex::CleanHistory<helpers::System>;
 template struct imex::SolveImplicitSector<helpers::System::variables_tag,
                                           helpers::Sector<helpers::Var1>>;
 template struct imex::SolveImplicitSector<helpers::System::variables_tag,

--- a/tests/Unit/Time/Actions/Test_CleanHistory.cpp
+++ b/tests/Unit/Time/Actions/Test_CleanHistory.cpp
@@ -20,10 +20,6 @@
 #include "Domain/Structure/Side.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
-#include "Evolution/Imex/GuessResult.hpp"
-#include "Evolution/Imex/Protocols/ImexSystem.hpp"
-#include "Evolution/Imex/Protocols/ImplicitSector.hpp"
-#include "Evolution/Imex/Tags/ImplicitHistory.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -35,11 +31,8 @@
 #include "Time/Tags/TimeStepper.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
-#include "Time/TimeSteppers/Heun2.hpp"
-#include "Time/TimeSteppers/ImexTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -172,100 +165,12 @@ void test_lts() {
               .size() == 1);
   }
 }
-
-struct FieldVar : db::SimpleTag {
-  using type = Scalar<DataVector>;
-};
-
-struct ImexSystem : tt::ConformsTo<imex::protocols::ImexSystem> {
-  using variables_tag = Tags::Variables<tmpl::list<FieldVar>>;
-
-  struct Sector : tt::ConformsTo<imex::protocols::ImplicitSector> {
-    using tensors = tmpl::list<FieldVar>;
-    using initial_guess = imex::GuessExplicitResult;
-    struct Attempt {
-      using tags_from_evolution = tmpl::list<>;
-      using simple_tags = tmpl::list<>;
-      using compute_tags = tmpl::list<>;
-      struct source : tt::ConformsTo<imex::protocols::ImplicitSource>,
-                      tt::ConformsTo<::protocols::StaticReturnApplyable> {
-        using return_tags = tmpl::list<Tags::Source<FieldVar>>;
-        using argument_tags = tmpl::list<>;
-        static void apply(gsl::not_null<Scalar<DataVector>*> var_source);
-      };
-      using jacobian = imex::NoJacobianBecauseSolutionIsAnalytic;
-      using source_prep = tmpl::list<>;
-      using jacobian_prep = tmpl::list<>;
-    };
-    using solve_attempts = tmpl::list<Attempt>;
-  };
-
-  using implicit_sectors = tmpl::list<Sector>;
-};
-
-static_assert(
-    tt::assert_conforms_to_v<ImexSystem, imex::protocols::ImexSystem>);
-
-struct ImexMetavariables;
-
-struct ImexComponent {
-  using metavariables = ImexMetavariables;
-  using chare_type = ActionTesting::MockArrayChare;
-  using array_index = int;
-  using const_global_cache_tags = tmpl::list<>;
-  using simple_tags =
-      tmpl::list<Tags::ConcreteTimeStepper<ImexTimeStepper>,
-                 Tags::HistoryEvolvedVariables<ImexSystem::variables_tag>,
-                 imex::Tags::ImplicitHistory<ImexSystem::Sector>>;
-  using compute_tags = time_stepper_ref_tags<ImexTimeStepper>;
-
-  using phase_dependent_action_list = tmpl::list<
-      Parallel::PhaseActions<Parallel::Phase::Initialization,
-                             tmpl::list<ActionTesting::InitializeDataBox<
-                                 simple_tags, compute_tags>>>,
-      Parallel::PhaseActions<
-          Parallel::Phase::Testing,
-          tmpl::list<Actions::CleanHistory<ImexSystem, false>>>>;
-};
-
-struct ImexMetavariables {
-  using component_list = tmpl::list<ImexComponent>;
-
-  void pup(PUP::er& /*p*/) {}
-};
-
-void test_imex() {
-  const Slab slab(1., 3.);
-  TimeSteppers::History<Variables<tmpl::list<FieldVar>>> history{2};
-  history.insert(TimeStepId(true, 0, slab.start()), {5, 0.0}, {5, 0.0});
-  history.insert(
-      TimeStepId(true, 0, slab.start(), 1, slab.duration(), slab.end().value()),
-      {5, 0.0}, {5, 0.0});
-  history.insert(TimeStepId(true, 1, slab.end()), {5, 0.0}, {5, 0.0});
-
-  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<ImexMetavariables>;
-  MockRuntimeSystem runner{{}};
-  ActionTesting::emplace_component_and_initialize<ImexComponent>(
-      &runner, 0, {std::make_unique<TimeSteppers::Heun2>(), history, history});
-
-  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
-
-  ActionTesting::next_action<ImexComponent>(make_not_null(&runner), 0);
-
-  const auto& box = ActionTesting::get_databox<ImexComponent>(runner, 0);
-  CHECK(db::get<Tags::HistoryEvolvedVariables<ImexSystem::variables_tag>>(box)
-            .size() == 1);
-  CHECK(db::get<imex::Tags::ImplicitHistory<ImexSystem::Sector>>(box).size() ==
-        1);
-}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Actions.CleanHistory", "[Unit][Time][Actions]") {
-  register_classes_with_charm<TimeSteppers::AdamsBashforth,
-                              TimeSteppers::Heun2>();
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
 
   test_action<false>();
   test_action<true>();
   test_lts();
-  test_imex();
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
If you are writing an IMEX evolution executable, you must now use `imex::CleanHistory`.  See the IMEX tutorial for details.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
