### PR TITLE
Don't hide tmpl::list in docs

### DIFF
--- a/docs/config/js/spectre.js
+++ b/docs/config/js/spectre.js
@@ -52,7 +52,7 @@ window.onload = function(){
 
     // Hide metafunctions that use only the template metaprogramming libraries
     $("body").children().find("td.memItemRight, td.memTemplItemRight").each(function () {
-        $(this).html( $(this).html().replace(/( =[ ]+)tmpl::.*/g,
+        $(this).html( $(this).html().replace(/( =[ ]+).*tmpl::(?!list\b).*/g,
             "$1implementation defined") );
     });
 


### PR DESCRIPTION
Hiding complicated metafunctions as "implementation defined" is reasonable, but types that are literal lists are useful to display.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
