### PR TITLE
Add DirichletAnalytic boundary condition for SoCcz4

### DIFF
--- a/src/Evolution/Systems/Ccz4/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
+  DirichletAnalytic.cpp
   )
 
 spectre_target_headers(
@@ -12,4 +13,6 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  DirichletAnalytic.hpp
+  Factory.hpp
   )

--- a/src/Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+
+namespace Ccz4::BoundaryConditions {
+
+// LCOV_EXCL_START
+DirichletAnalytic::DirichletAnalytic(CkMigrateMessage* const msg)
+    : BoundaryCondition(msg) {}
+// LCOV_EXCL_STOP
+DirichletAnalytic::DirichletAnalytic(const DirichletAnalytic& rhs)
+    : BoundaryCondition{dynamic_cast<const BoundaryCondition&>(rhs)},
+      analytic_prescription_(rhs.analytic_prescription_->get_clone()) {}
+
+DirichletAnalytic& DirichletAnalytic::operator=(const DirichletAnalytic& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  analytic_prescription_ = rhs.analytic_prescription_->get_clone();
+  return *this;
+}
+DirichletAnalytic::DirichletAnalytic(
+    std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription)
+    : analytic_prescription_(std::move(analytic_prescription)) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+DirichletAnalytic::get_clone() const {
+  return std::make_unique<DirichletAnalytic>(*this);
+}
+
+void DirichletAnalytic::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+  p | analytic_prescription_;
+}
+// NOLINTNEXTLINE
+PUP::able::PUP_ID DirichletAnalytic::my_PUP_ID = 0;
+
+void DirichletAnalytic::fd_ghost(
+    const gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*>
+        conformal_metric,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+    const gsl::not_null<Scalar<DataVector>*> conformal_factor,
+    const gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*> a_tilde,
+    const gsl::not_null<Scalar<DataVector>*> trace_extrinsic_curvature,
+    const gsl::not_null<Scalar<DataVector>*> theta,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> gamma_hat,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        auxiliary_shift_b,
+    const Direction<3>& direction,
+
+    // fd_interior_temporary_tags
+    const Mesh<3>& subcell_mesh,
+
+    // fd_gridless_tags
+    double time,
+    const std::unordered_map<
+        std::string,
+        std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+        functions_of_time,
+    const ElementMap<3, Frame::Grid>& logical_to_grid_map,
+    const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
+        grid_to_inertial_map,
+    const fd::Reconstructor& reconstructor) const {
+  const size_t ghost_zone_size = reconstructor.ghost_zone_size();
+
+  const auto ghost_logical_coords =
+      evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+          subcell_mesh, ghost_zone_size, direction);
+
+  const auto ghost_inertial_coords = grid_to_inertial_map(
+      logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+  // Compute FD ghost data with the analytic data or solution
+  auto boundary_values = call_with_dynamic_type<
+      tuples::TaggedTuple<
+          Tags::ConformalMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<DataVector, 3>, Tags::ConformalFactor<DataVector>,
+          Tags::ATilde<DataVector, 3>,
+          gr::Tags::TraceExtrinsicCurvature<DataVector>,
+          Tags::Theta<DataVector>, Tags::GammaHat<DataVector, 3>,
+          Tags::AuxiliaryShiftB<DataVector, 3>>,
+      Ccz4::Solutions::all_solutions>(
+      analytic_prescription_.get(),
+      [&ghost_inertial_coords, &time](const auto* const initial_data) {
+        using spacetime_tags = tmpl::list<
+            Tags::ConformalMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
+            gr::Tags::Shift<DataVector, 3>, Tags::ConformalFactor<DataVector>,
+            Tags::ATilde<DataVector, 3>,
+            gr::Tags::TraceExtrinsicCurvature<DataVector>,
+            Tags::Theta<DataVector>, Tags::GammaHat<DataVector, 3>,
+            Tags::AuxiliaryShiftB<DataVector, 3>>;
+        if constexpr (is_analytic_solution_v<
+                          std::decay_t<decltype(*initial_data)>>) {
+          return initial_data->variables(ghost_inertial_coords, time,
+                                         spacetime_tags{});
+        } else if constexpr (evolution::is_numeric_initial_data_v<
+                                 std::decay_t<decltype(*initial_data)>>) {
+          ERROR(
+              "Cannot currently use numeric initial data as an analytic "
+              "prescription for boundary conditions.");
+        } else {
+          (void)time;
+          return initial_data->variables(ghost_inertial_coords,
+                                         spacetime_tags{});
+        }
+      });
+  *conformal_metric =
+      get<Tags::ConformalMetric<DataVector, 3>>(boundary_values);
+  *lapse = get<gr::Tags::Lapse<DataVector>>(boundary_values);
+  *shift = get<gr::Tags::Shift<DataVector, 3>>(boundary_values);
+  *conformal_factor = get<Tags::ConformalFactor<DataVector>>(boundary_values);
+  *a_tilde = get<Tags::ATilde<DataVector, 3>>(boundary_values);
+  *trace_extrinsic_curvature =
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(boundary_values);
+  *theta = get<Tags::Theta<DataVector>>(boundary_values);
+  *gamma_hat = get<Tags::GammaHat<DataVector, 3>>(boundary_values);
+  *auxiliary_shift_b =
+      get<Tags::AuxiliaryShiftB<DataVector, 3>>(boundary_values);
+}
+}  // namespace Ccz4::BoundaryConditions

--- a/src/Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.hpp
+++ b/src/Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.hpp
@@ -1,0 +1,123 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Evolution/TypeTraits.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+struct Time;
+}  // namespace Tags
+/// \endcond
+
+namespace Ccz4::BoundaryConditions {
+/*!
+ * \brief Sets Dirichlet boundary conditions using the analytic solution or
+ * analytic data.
+ */
+class DirichletAnalytic final : public BoundaryCondition {
+ public:
+  /// \brief What analytic solution/data to prescribe.
+  struct AnalyticPrescription {
+    static constexpr Options::String help =
+        "What analytic solution/data to prescribe.";
+    using type = std::unique_ptr<evolution::initial_data::InitialData>;
+  };
+  using options = tmpl::list<AnalyticPrescription>;
+  static constexpr Options::String help{
+      "DirichletAnalytic boundary conditions using either analytic solution or "
+      "analytic data."};
+
+  DirichletAnalytic() = default;
+  DirichletAnalytic(DirichletAnalytic&&) = default;
+  DirichletAnalytic& operator=(DirichletAnalytic&&) = default;
+  DirichletAnalytic(const DirichletAnalytic&);
+  DirichletAnalytic& operator=(const DirichletAnalytic&);
+  ~DirichletAnalytic() override = default;
+
+  explicit DirichletAnalytic(CkMigrateMessage* msg);
+
+  explicit DirichletAnalytic(
+      std::unique_ptr<evolution::initial_data::InitialData>
+          analytic_prescription);
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, DirichletAnalytic);
+
+  auto get_clone() const
+      -> std::unique_ptr<
+          domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using fd_interior_evolved_variables_tags = tmpl::list<>;
+  using fd_interior_temporary_tags =
+      tmpl::list<evolution::dg::subcell::Tags::Mesh<3>>;
+  using fd_interior_primitive_variables_tags = tmpl::list<>;
+  using fd_gridless_tags =
+      tmpl::list<::Tags::Time, ::domain::Tags::FunctionsOfTime,
+                 domain::Tags::ElementMap<3, Frame::Grid>,
+                 domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                             Frame::Inertial>,
+                 ::Ccz4::fd::Tags::Reconstructor>;
+  void fd_ghost(
+      gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*>
+          conformal_metric,
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+      gsl::not_null<Scalar<DataVector>*> conformal_factor,
+      gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*> a_tilde,
+      gsl::not_null<Scalar<DataVector>*> trace_extrinsic_curvature,
+      gsl::not_null<Scalar<DataVector>*> theta,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> gamma_hat,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+          auxiliary_shift_b,
+      const Direction<3>& direction,
+
+      // fd_interior_temporary_tags
+      const Mesh<3>& subcell_mesh,
+
+      // fd_gridless_tags
+      double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const ElementMap<3, Frame::Grid>& logical_to_grid_map,
+      const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>&
+          grid_to_inertial_map,
+      const fd::Reconstructor& reconstructor) const;
+
+ private:
+  std::unique_ptr<evolution::initial_data::InitialData> analytic_prescription_;
+};
+}  // namespace Ccz4::BoundaryConditions

--- a/src/Evolution/Systems/Ccz4/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/Ccz4/BoundaryConditions/Factory.hpp
@@ -1,0 +1,16 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::BoundaryConditions {
+/// Typelist of standard BoundaryConditions
+using standard_boundary_conditions =
+    tmpl::list<DirichletAnalytic,
+               domain::BoundaryConditions::Periodic<BoundaryCondition>>;
+}  // namespace Ccz4::BoundaryConditions

--- a/src/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -53,6 +53,5 @@ target_link_libraries(
   INTERFACE
   )
 
-add_subdirectory(BoundaryConditions)
 add_subdirectory(FiniteDifference)
 add_subdirectory(Instantiations)

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/BoundaryConditionGhostData.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/BoundaryConditionGhostData.hpp
@@ -1,0 +1,199 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/MetavariablesTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/None.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+/*!
+ * \brief Computes finite difference ghost data for external boundary
+ * conditions.
+ *
+ * If the element is at the external boundary, computes FD ghost data with a
+ * given boundary condition and stores it into neighbor data with {direction,
+ * ElementId::external_boundary_id()} as the mortar_id key.
+ *
+ * \note Subcell needs to be enabled for boundary elements. Otherwise this
+ * function would be never called.
+ *
+ */
+struct BoundaryConditionGhostData {
+  template <typename DbTagsList>
+  static void apply(gsl::not_null<db::DataBox<DbTagsList>*> box,
+                    const Element<3>& element,
+                    const Reconstructor& reconstructor);
+
+ private:
+  template <typename FdBoundaryConditionHelper, typename DbTagsList,
+            typename... FdBoundaryConditionArgsTags>
+  // A helper function for calling fd_ghost() of BoundaryCondition subclasses
+  static void apply_subcell_boundary_condition_impl(
+      FdBoundaryConditionHelper& fd_boundary_condition_helper,
+      const gsl::not_null<db::DataBox<DbTagsList>*>& box,
+      tmpl::list<FdBoundaryConditionArgsTags...> /*unused*/) {
+    return fd_boundary_condition_helper(
+        db::get<FdBoundaryConditionArgsTags>(*box)...);
+  }
+};
+
+template <typename DbTagsList>
+void BoundaryConditionGhostData::apply(
+    const gsl::not_null<db::DataBox<DbTagsList>*> box,
+    const Element<3>& element, const Reconstructor& reconstructor) {
+  const auto& external_boundary_condition =
+      db::get<domain::Tags::ExternalBoundaryConditions<3>>(*box).at(
+          element.id().block_id());
+
+  // Check if the element is on the external boundary. If not, the caller is
+  // doing something wrong (e.g. trying to compute FD ghost data with boundary
+  // conditions at an element which is not on the external boundary).
+  ASSERT(not element.external_boundaries().empty(),
+         "The element (ID : " << element.id()
+                              << ") is not on external boundaries");
+
+  const Mesh<3> subcell_mesh =
+      db::get<evolution::dg::subcell::Tags::Mesh<3>>(*box);
+
+  const size_t ghost_zone_size{reconstructor.ghost_zone_size()};
+
+  // Tags and tags list for FD reconstruction
+  using variables_for_reconstruction = typename System::variables_tag_list;
+
+  size_t num_evolved_tensor_components = 0;
+  tmpl::for_each<variables_for_reconstruction>(
+        [&num_evolved_tensor_components]<typename Tag>
+            (const tmpl::type_<Tag> /*meta*/) {
+            num_evolved_tensor_components += Tag::type::size();
+        });
+
+  for (const auto& direction : element.external_boundaries()) {
+    const auto& boundary_condition_at_direction =
+        *external_boundary_condition.at(direction);
+
+    const size_t num_face_pts{
+        subcell_mesh.extents().slice_away(direction.dimension()).product()};
+
+    // Allocate a vector to store the computed FD ghost data and assign a
+    // non-owning Variables on it.
+    const size_t evolved_vars_size =
+        num_evolved_tensor_components * ghost_zone_size * num_face_pts;
+    const size_t fluxes_size = 0;  // CCZ4 doesn't use flux variables
+
+    auto& all_ghost_data = db::get_mutable_reference<
+        evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box);
+    // Put the computed ghost data into neighbor data with {direction,
+    // ElementId::external_boundary_id()} as the mortar_id key
+    const DirectionalId<3> mortar_id{direction,
+                                     ElementId<3>::external_boundary_id()};
+
+    all_ghost_data[mortar_id] = evolution::dg::subcell::GhostData{1};
+    DataVector& boundary_ghost_data =
+        all_ghost_data.at(mortar_id).neighbor_ghost_data_for_reconstruction();
+    boundary_ghost_data.destructive_resize(evolved_vars_size + fluxes_size);
+    Variables<variables_for_reconstruction> ghost_data_vars{
+        boundary_ghost_data.data(), evolved_vars_size};
+
+    // We don't need to care about boundary ghost data when using the periodic
+    // condition, so exclude it from the type list
+    using factory_classes =
+        typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
+            *box))>::factory_creation::factory_classes;
+    using derived_boundary_conditions_for_subcell = tmpl::remove_if<
+        tmpl::at<factory_classes, BoundaryConditions::BoundaryCondition>,
+        tmpl::or_<
+            std::is_base_of<domain::BoundaryConditions::MarkAsPeriodic,
+                            tmpl::_1>,
+            std::is_base_of<domain::BoundaryConditions::MarkAsNone, tmpl::_1>>>;
+
+    // Now apply subcell boundary conditions
+    call_with_dynamic_type<void, derived_boundary_conditions_for_subcell>(
+        &boundary_condition_at_direction,
+        [&box, &direction, &ghost_data_vars](const auto* boundary_condition) {
+          using BoundaryCondition = std::decay_t<decltype(*boundary_condition)>;
+          using bcondition_interior_evolved_vars_tags =
+              typename BoundaryCondition::fd_interior_evolved_variables_tags;
+          using bcondition_interior_temporary_tags =
+              typename BoundaryCondition::fd_interior_temporary_tags;
+          using bcondition_interior_primitive_vars_tags =
+              typename BoundaryCondition::fd_interior_primitive_variables_tags;
+          using bcondition_gridless_tags =
+              typename BoundaryCondition::fd_gridless_tags;
+
+          using bcondition_interior_tags =
+              tmpl::append<bcondition_interior_evolved_vars_tags,
+                           bcondition_interior_temporary_tags,
+                           bcondition_interior_primitive_vars_tags,
+                           bcondition_gridless_tags>;
+
+          if constexpr (BoundaryCondition::bc_type ==
+                        evolution::BoundaryConditions::Type::Ghost) {
+            const auto apply_fd_ghost =
+                [&boundary_condition, &direction,
+                 &ghost_data_vars](const auto&... boundary_ghost_data_args) {
+                  (*boundary_condition)
+                      .fd_ghost(
+                          make_not_null(
+                              &get<
+                                  ::Ccz4::Tags::ConformalMetric<DataVector, 3>>(
+                                  ghost_data_vars)),
+                          make_not_null(&get<gr::Tags::Lapse<DataVector>>(
+                              ghost_data_vars)),
+                          make_not_null(&get<gr::Tags::Shift<DataVector, 3>>(
+                              ghost_data_vars)),
+                          make_not_null(
+                              &get<::Ccz4::Tags::ConformalFactor<DataVector>>(
+                                  ghost_data_vars)),
+                          make_not_null(
+                              &get<::Ccz4::Tags::ATilde<DataVector, 3>>(
+                                  ghost_data_vars)),
+                          make_not_null(&get<gr::Tags::TraceExtrinsicCurvature<
+                                            DataVector>>(ghost_data_vars)),
+                          make_not_null(&get<::Ccz4::Tags::Theta<DataVector>>(
+                              ghost_data_vars)),
+                          make_not_null(
+                              &get<::Ccz4::Tags::GammaHat<DataVector, 3>>(
+                                  ghost_data_vars)),
+                          make_not_null(
+                              &get<
+                                  ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(
+                                  ghost_data_vars)),
+                          direction, boundary_ghost_data_args...);
+                };
+            apply_subcell_boundary_condition_impl(apply_fd_ghost, box,
+                                                  bcondition_interior_tags{});
+          } else {
+            ERROR("Unsupported boundary condition "
+                  << pretty_type::short_name<BoundaryCondition>()
+                  << " when using finite-difference");
+          }
+        });
+  }
+}
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -9,13 +9,18 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Derivatives.cpp
+  DummyReconstructor.cpp
+  Reconstructor.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  BoundaryConditionGhostData.hpp
   Derivatives.hpp
+  DummyReconstructor.hpp
+  Reconstructor.hpp
   SoTimeDerivative.hpp
   System.hpp
   Tags.hpp
@@ -31,8 +36,11 @@ target_link_libraries(
   DgSubcell
   FiniteDifference
   GeneralRelativity
+  GeneralRelativitySolutions
   Options
   Spectral
   Utilities
   INTERFACE
   )
+
+add_subdirectory(../BoundaryConditions ${CMAKE_CURRENT_BINARY_DIR}/BoundaryConditions)

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp"
+
+namespace Ccz4::fd {
+DummyReconstructor::DummyReconstructor(CkMigrateMessage* const msg)
+    : Reconstructor(msg) {}
+
+std::unique_ptr<Reconstructor> DummyReconstructor::get_clone() const {
+  return std::make_unique<DummyReconstructor>(*this);
+}
+
+void DummyReconstructor::pup(PUP::er& p) { Reconstructor::pup(p); }
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID DummyReconstructor::my_PUP_ID = 0;
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp"
+#include "Options/String.hpp"
+
+namespace Ccz4::fd {
+/*!
+ * \brief Dummy reconstructor just to return the ghost zone size.
+ *
+ * This class is needed to use the SetInterpolators action in
+ * dg-subcell infrastructure.
+ */
+class DummyReconstructor : public Reconstructor {
+ public:
+  using options = tmpl::list<>;
+
+  static constexpr Options::String help{
+      "Dummy reconstructor that allows using the subcell infrastructure."};
+
+  DummyReconstructor() = default;
+  DummyReconstructor(DummyReconstructor&&) = default;
+  DummyReconstructor& operator=(DummyReconstructor&&) = default;
+  DummyReconstructor(const DummyReconstructor&) = default;
+  DummyReconstructor& operator=(const DummyReconstructor&) = default;
+  ~DummyReconstructor() override = default;
+
+  explicit DummyReconstructor(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(Reconstructor, DummyReconstructor);
+
+  auto get_clone() const -> std::unique_ptr<Reconstructor> override;
+
+  void pup(PUP::er& p) override;
+
+  // 3 ghost pts needed for 6th order KO filter
+  size_t ghost_zone_size() const override { return 3; }
+};
+
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.cpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp"
+
+#include <pup.h>
+
+namespace Ccz4::fd {
+Reconstructor::Reconstructor(CkMigrateMessage* const msg) : PUP::able(msg) {}
+
+void Reconstructor::pup(PUP::er& p) { PUP::able::pup(p); }
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+/// \cond
+class DummyReconstructor;
+/// \endcond
+
+/*!
+ * \brief The base class from which all reconstruction schemes must inherit
+ */
+class Reconstructor : public PUP::able {
+ public:
+  Reconstructor() = default;
+  Reconstructor(const Reconstructor&) = default;
+  Reconstructor& operator=(const Reconstructor&) = default;
+  Reconstructor(Reconstructor&&) = default;
+  Reconstructor& operator=(Reconstructor&&) = default;
+  ~Reconstructor() override = default;
+
+  /// \cond
+  explicit Reconstructor(CkMigrateMessage* msg);
+  WRAPPED_PUPable_abstract(Reconstructor);  // NOLINT
+  /// \endcond
+
+  using creatable_classes = tmpl::list<DummyReconstructor>;
+
+  virtual std::unique_ptr<Reconstructor> get_clone() const = 0;
+
+  virtual size_t ghost_zone_size() const = 0;
+
+  void pup(PUP::er& p) override;
+};
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
@@ -22,7 +22,9 @@
 #include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
 #include "Evolution/Systems/Ccz4/DerivLapse.hpp"
 #include "Evolution/Systems/Ccz4/DerivZ4Constraint.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/BoundaryConditionGhostData.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
 #include "Evolution/Systems/Ccz4/Ricci.hpp"
 #include "Evolution/Systems/Ccz4/RicciScalarPlusDivergenceZ4Constraint.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
@@ -172,9 +174,9 @@ static void apply(
     const tnsr::i<DataVector, Dim>& d_trace_extrinsic_curvature,
     const tnsr::i<DataVector, Dim>& d_theta,
     const tnsr::iJ<DataVector, Dim>& d_gamma_hat,
-    const tnsr::iJ<DataVector, Dim>& d_b) {
+    const tnsr::iJ<DataVector, Dim>& d_b, const bool shifting_shift,
+    const bool evolve_lapse_and_shift) {
   constexpr double one_third = 1.0 / 3.0;
-
   // quantities we need for computing eq 4, 13 - 27
 
   determinant_and_inverse(det_conformal_spatial_metric,
@@ -192,8 +194,9 @@ static void apply(
                        (*inv_conformal_spatial_metric)(ti::I, ti::K) *
                        (*inv_conformal_spatial_metric)(ti::J, ti::L));
 
-  ASSERT(min(get(lapse)) > 0.0,
-         "The lapse must be positive when using 1+log slicing.");
+  if (min(get(lapse)) <= 0.0) {
+    ERROR("The lapse must be positive when using 1+log slicing.");
+  }
 
   // slicing_condition and d_slicing_condition is not used in SO-CCZ4
   // \alpha g(\alpha)  == 2
@@ -394,15 +397,22 @@ static void apply(
           (*inv_tau_times_conformal_metric)(ti::i, ti::j) *
               ((*det_conformal_spatial_metric)() - 1.0));
 
-  // time derivative of the lapse
-  ::tenex::evaluate<>(dt_lapse, (shift(ti::K) * field_a(ti::k) -
-                                 (*lapse_times_slicing_condition)() *
-                                     (*k_minus_k0_minus_2_theta_c)()) *
-                                    lapse());
-
-  // time derivative of the shift
-  ::tenex::evaluate<ti::I>(dt_shift,
-                           f * b(ti::I) + shift(ti::K) * field_b(ti::k, ti::I));
+  if (evolve_lapse_and_shift) {
+    // time derivative of the lapse
+    ::tenex::evaluate<>(dt_lapse, (shift(ti::K) * field_a(ti::k) -
+                                   (*lapse_times_slicing_condition)() *
+                                       (*k_minus_k0_minus_2_theta_c)()) *
+                                      lapse());
+    // time derivative of the shift
+    ::tenex::evaluate<ti::I>(dt_shift, f * b(ti::I));
+    if (shifting_shift) {
+      ::tenex::update<ti::I>(
+          dt_shift, (*dt_shift)(ti::I) + shift(ti::K) * field_b(ti::k, ti::I));
+    }
+  } else {
+    *dt_lapse = make_with_value<Scalar<DataVector>>(lapse, 0.0);
+    *dt_shift = make_with_value<tnsr::I<DataVector, Dim>>(shift, 0.0);
+  }
 
   // time derivative of the the conformal factor
   ::tenex::evaluate(dt_conformal_factor,
@@ -499,9 +509,18 @@ static void apply(
                                  (*contracted_symmetrized_d_field_b)(ti::k));
 
   // time derivative b^i
-  ::tenex::evaluate<ti::I>(
-      dt_b, (*dt_gamma_hat)(ti::I)-eta() * b(ti::I) +
-                shift(ti::K) * (d_b(ti::k, ti::I) - d_gamma_hat(ti::k, ti::I)));
+  if (evolve_lapse_and_shift) {
+    ::tenex::evaluate<ti::I>(dt_b, (*dt_gamma_hat)(ti::I)-eta() * b(ti::I));
+    if (shifting_shift) {
+      ::tenex::update<ti::I>(
+          dt_b, (*dt_b)(ti::I) + shift(ti::K) * (d_b(ti::k, ti::I) -
+                                                 d_gamma_hat(ti::k, ti::I)));
+    }
+  } else {
+    (*dt_b).get(0) = 0.0;
+    (*dt_b).get(1) = 0.0;
+    (*dt_b).get(2) = 0.0;
+  }
 
   // Note that, we do not need to evolve the auxiliary variables in SO-CCZ4.
 }
@@ -520,343 +539,369 @@ static void apply(
  * The four auxiliary varialbels \f$A_i\f$, \f$B_k{}^{i}\f$,
  * \f$D_{kij}\f$, and \f$P_i\f$ are NOT evolved.
  */
-template <size_t Dim, class DbTagsList>
-void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
-  // compute the first spatial derivatives of the evolved variables
-  using evolved_vars_tag = typename System::variables_tag;
-  using gradients_tags = typename System::gradients_tags;
+struct SoTimeDerivative {
+  template <typename DbTagsList>
+  static void apply(const gsl::not_null<db::DataBox<DbTagsList>*> box) {
+    // compute the first spatial derivatives of the evolved variables
+    using evolved_vars_tag = typename System::variables_tag;
+    using gradients_tags = typename System::gradients_tags;
 
-  // only 4-th order accurate second derivatives have been implemented
-  // To keep the same order of accuracy we use the same order for
-  // both first and second derivatives
-  const size_t fd_order = 4;
-  const auto& evolved_vars = db::get<evolved_vars_tag>(*box);
-  const Mesh<Dim>& subcell_mesh =
-      db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(*box);
-  const size_t num_pts = subcell_mesh.number_of_grid_points();
-  Variables<db::wrap_tags_in<::Tags::deriv, gradients_tags, tmpl::size_t<Dim>,
-                             Frame::Inertial>>
-      cell_centered_Ccz4_derivs{num_pts};
-  const auto& cell_centered_logical_to_inertial_inv_jacobian = db::get<
-      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<Dim>>(
-      *box);
+    // only 4-th order accurate second derivatives have been implemented
+    // To keep the same order of accuracy we use the same order for
+    // both first and second derivatives
+    constexpr size_t fd_order = 4;
+    const auto& evolved_vars = db::get<evolved_vars_tag>(*box);
+    const Mesh<Dim>& subcell_mesh =
+        db::get<evolution::dg::subcell::Tags::Mesh<Dim>>(*box);
+    const size_t num_pts = subcell_mesh.number_of_grid_points();
+    Variables<db::wrap_tags_in<::Tags::deriv, gradients_tags, tmpl::size_t<Dim>,
+                               Frame::Inertial>>
+        cell_centered_Ccz4_derivs{num_pts};
+    const auto& cell_centered_logical_to_inertial_inv_jacobian =
+        db::get<evolution::dg::subcell::fd::Tags::
+                    InverseJacobianLogicalToInertial<Dim>>(*box);
 
-  ::Ccz4::fd::spacetime_derivatives(
-      make_not_null(&cell_centered_Ccz4_derivs), evolved_vars,
-      db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
-          *box),
-      fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+    constexpr bool subcell_enabled_at_external_boundary =
+        std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
+            *box))>::SubcellOptions::subcell_enabled_at_external_boundary;
 
-  // calculate the four auxiliary fields in eq. 6
-  // auxiliary variables NOT evolved in SO-CCZ4
-  const auto& d_lapse =
-      get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
-                        Frame::Inertial>>(cell_centered_Ccz4_derivs);
-  const auto& lapse = get<gr::Tags::Lapse<DataVector>>(evolved_vars);
-  const auto field_a = ::tenex::evaluate<ti::i>(d_lapse(ti::i) / lapse());
+    const Element<3>& element = db::get<domain::Tags::Element<3>>(*box);
 
-  const auto& field_b =
-      get<::Tags::deriv<gr::Tags::Shift<DataVector, Dim>, tmpl::size_t<Dim>,
-                        Frame::Inertial>>(cell_centered_Ccz4_derivs);
+    const Ccz4::fd::Reconstructor& recons =
+        db::get<Ccz4::fd::Tags::Reconstructor>(*box);
 
-  const auto& d_spatial_conformal_metric =
-      get<::Tags::deriv<Tags::ConformalMetric<DataVector, Dim>,
-                        tmpl::size_t<Dim>, Frame::Inertial>>(
-          cell_centered_Ccz4_derivs);
-  tnsr::ijj<DataVector, Dim> field_d;
-  ::tenex::evaluate<ti::i, ti::j, ti::k>(
-      make_not_null(&field_d),
-      0.5 * d_spatial_conformal_metric(ti::i, ti::j, ti::k));
+    // If the element has external boundaries and subcell is enabled for
+    // boundary elements, compute FD ghost data with a given boundary condition.
+    if constexpr (subcell_enabled_at_external_boundary) {
+      if (not element.external_boundaries().empty()) {
+        fd::BoundaryConditionGhostData::apply(box, element, recons);
+      }
+    }
 
-  const auto& conformal_factor =
-      get<Tags::ConformalFactor<DataVector>>(evolved_vars);
-  const auto& d_conformal_factor =
-      get<::Tags::deriv<Tags::ConformalFactor<DataVector>, tmpl::size_t<Dim>,
-                        Frame::Inertial>>(cell_centered_Ccz4_derivs);
-  const auto field_p =
-      ::tenex::evaluate<ti::i>(d_conformal_factor(ti::i) / conformal_factor());
+    const bool evolve_lapse_and_shift =
+        get<::Ccz4::fd::Tags::EvolveLapseAndShift>(*box);
 
-  // compute second derivatives of the evolved variables
-  Variables<db::wrap_tags_in<::Tags::second_deriv, gradients_tags,
-                             tmpl::size_t<Dim>, Frame::Inertial>>
-      cell_centered_Ccz4_second_derivs{num_pts};
+    ::Ccz4::fd::spacetime_derivatives(
+        make_not_null(&cell_centered_Ccz4_derivs), evolved_vars,
+        db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
+            *box),
+        fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
 
-  Ccz4::fd::second_spacetime_derivatives(
-      make_not_null(&cell_centered_Ccz4_second_derivs), evolved_vars,
-      db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
-          *box),
-      fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+    // calculate the four auxiliary fields in eq. 6
+    // auxiliary variables NOT evolved in SO-CCZ4
+    const auto& d_lapse =
+        get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                          Frame::Inertial>>(cell_centered_Ccz4_derivs);
+    const auto& lapse = get<gr::Tags::Lapse<DataVector>>(evolved_vars);
+    const auto field_a = ::tenex::evaluate<ti::i>(d_lapse(ti::i) / lapse());
 
-  // compute spatial derivative of the four auxiliary fields
-  const auto& d_d_lapse =
-      get<::Tags::second_deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
-                               Frame::Inertial>>(
-          cell_centered_Ccz4_second_derivs);
-  tnsr::ii<DataVector, Dim> d_field_a;
-  ::tenex::evaluate<ti::i, ti::j>(
-      make_not_null(&d_field_a),
-      (d_d_lapse(ti::i, ti::j) - d_lapse(ti::i) * d_lapse(ti::j) / lapse()) /
-          lapse());
+    const auto& field_b =
+        get<::Tags::deriv<gr::Tags::Shift<DataVector, Dim>, tmpl::size_t<Dim>,
+                          Frame::Inertial>>(cell_centered_Ccz4_derivs);
 
-  const auto& d_field_b =
-      get<::Tags::second_deriv<gr::Tags::Shift<DataVector, Dim>,
-                               tmpl::size_t<Dim>, Frame::Inertial>>(
-          cell_centered_Ccz4_second_derivs);
+    const auto& d_spatial_conformal_metric =
+        get<::Tags::deriv<::Ccz4::Tags::ConformalMetric<DataVector, Dim>,
+                          tmpl::size_t<Dim>, Frame::Inertial>>(
+            cell_centered_Ccz4_derivs);
+    tnsr::ijj<DataVector, Dim> field_d;
+    ::tenex::evaluate<ti::i, ti::j, ti::k>(
+        make_not_null(&field_d),
+        0.5 * d_spatial_conformal_metric(ti::i, ti::j, ti::k));
 
-  const auto& d_d_conformal_metric =
-      get<::Tags::second_deriv<Tags::ConformalMetric<DataVector, Dim>,
-                               tmpl::size_t<Dim>, Frame::Inertial>>(
-          cell_centered_Ccz4_second_derivs);
+    const auto& conformal_factor =
+        get<::Ccz4::Tags::ConformalFactor<DataVector>>(evolved_vars);
+    const auto& d_conformal_factor =
+        get<::Tags::deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                          tmpl::size_t<Dim>, Frame::Inertial>>(
+            cell_centered_Ccz4_derivs);
+    const auto field_p = ::tenex::evaluate<ti::i>(d_conformal_factor(ti::i) /
+                                                  conformal_factor());
 
-  tnsr::iijj<DataVector, Dim> d_field_d;
-  ::tenex::evaluate<ti::i, ti::j, ti::k, ti::l>(
-      make_not_null(&d_field_d),
-      0.5 * d_d_conformal_metric(ti::i, ti::j, ti::k, ti::l));
+    // compute second derivatives of the evolved variables
+    Variables<db::wrap_tags_in<::Tags::second_deriv, gradients_tags,
+                               tmpl::size_t<Dim>, Frame::Inertial>>
+        cell_centered_Ccz4_second_derivs{num_pts};
 
-  const auto& d_d_conformal_factor =
-      get<::Tags::second_deriv<Tags::ConformalFactor<DataVector>,
-                               tmpl::size_t<Dim>, Frame::Inertial>>(
-          cell_centered_Ccz4_second_derivs);
+    Ccz4::fd::second_spacetime_derivatives(
+        make_not_null(&cell_centered_Ccz4_second_derivs), evolved_vars,
+        db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
+            *box),
+        fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
 
-  tnsr::ii<DataVector, Dim> d_field_p;
-  ::tenex::evaluate<ti::i, ti::j>(
-      make_not_null(&d_field_p),
-      (d_d_conformal_factor(ti::i, ti::j) - d_conformal_factor(ti::i) *
-                                                d_conformal_factor(ti::j) /
-                                                conformal_factor()) /
-          conformal_factor());
+    // compute spatial derivative of the four auxiliary fields
+    const auto& d_d_lapse =
+        get<::Tags::second_deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                                 Frame::Inertial>>(
+            cell_centered_Ccz4_second_derivs);
+    tnsr::ii<DataVector, Dim> d_field_a;
+    ::tenex::evaluate<ti::i, ti::j>(
+        make_not_null(&d_field_a),
+        (d_d_lapse(ti::i, ti::j) - d_lapse(ti::i) * d_lapse(ti::j) / lapse()) /
+            lapse());
 
-  // intialize containers to be supplied in the SO-CCZ4 TimeDerivative.cpp
-  // apply() function quantities we need for computing eq 4, 13 - 27
-  using TempVars = Variables<tmpl::list<
-    Tags::ConformalFactorSquared<DataVector>,
-    Tags::DetConformalSpatialMetric<DataVector>,
-    Tags::InverseConformalMetric<DataVector, Dim>,
-    gr::Tags::InverseSpatialMetric<DataVector, Dim>,
-    Tags::InvATilde<DataVector, Dim>,
-    Tags::ATildeTimesFieldB<DataVector, Dim>,
-    Tags::ATildeMinusOneThirdConformalMetricTimesTraceATilde<DataVector, Dim>,
-    Tags::ContractedFieldB<DataVector>,
-    Tags::SymmetrizedDerivFieldB<DataVector, Dim>,
-    Tags::ContractedSymmetrizedDerivFieldB<DataVector, Dim>,
-    Tags::FieldDUpTimesATilde<DataVector, Dim>,
-    Tags::ContractedFieldDUp<DataVector, Dim>,
-    Tags::HalfConformalFactorSquared<DataVector>,
-    Tags::ConformalMetricTimesFieldB<DataVector, Dim>,
-    Tags::ConformalMetricTimesTraceATilde<DataVector, Dim>,
-    Tags::InverseConformalMetricTimesDerivATilde<DataVector, Dim>,
-    Tags::GammaHatMinusContractedConformalChristoffel<DataVector, Dim>,
-    Tags::DerivGammaHatMinusContractedConformalChristoffel<DataVector, Dim>,
-    Tags::ContractedChristoffelSecondKind<DataVector, Dim>,
-    Tags::ContractedDerivConformalChristoffelDifference<DataVector, Dim>,
-    Tags::KMinus2ThetaC<DataVector>,
-    Tags::KMinusK0Minus2ThetaC<DataVector>,
-    Tags::LapseTimesATilde<DataVector, Dim>,
-    Tags::LapseTimesDerivATilde<DataVector, Dim>,
-    Tags::LapseTimesFieldA<DataVector, Dim>,
-    Tags::LapseTimesConformalMetric<DataVector, Dim>,
-    Tags::LapseTimesSlicingCondition<DataVector>,
-    Tags::LapseTimesRicciScalarPlus2DivergenceZ4Constraint<DataVector>,
-    Tags::ShiftTimesDerivGammaHat<DataVector, Dim>,
-    Tags::InverseTauTimesConformalMetric<DataVector, Dim>,
-    Tags::TraceATilde<DataVector>,
-    Tags::FieldDUp<DataVector, Dim>,
-    Tags::ConformalChristoffelSecondKind<DataVector, Dim>,
-    Tags::DerivConformalChristoffelSecondKind<DataVector, Dim>,
-    Tags::ChristoffelSecondKind<DataVector, Dim>,
-    Tags::SpatialRicciTensor<DataVector, Dim>,
-    Tags::GradGradLapse<DataVector, Dim>,
-    Tags::DivergenceLapse<DataVector>,
-    Tags::ContractedConformalChristoffelSecondKind<DataVector, Dim>,
-    Tags::DerivContractedConformalChristoffelSecondKind<DataVector, Dim>,
-    Tags::SpatialZ4Constraint<DataVector, Dim>,
-    Tags::UpperSpatialZ4Contraint<DataVector, Dim>,
-    Tags::GradSpatialZ4Constraint<DataVector, Dim>,
-    Tags::RicciScalarPlusDivergenceZ4Constraint<DataVector>>>;
+    const auto& d_field_b =
+        get<::Tags::second_deriv<gr::Tags::Shift<DataVector, Dim>,
+                                 tmpl::size_t<Dim>, Frame::Inertial>>(
+            cell_centered_Ccz4_second_derivs);
 
-  TempVars temp_vars(num_pts);
+    const auto& d_d_conformal_metric =
+        get<::Tags::second_deriv<::Ccz4::Tags::ConformalMetric<DataVector, Dim>,
+                                 tmpl::size_t<Dim>, Frame::Inertial>>(
+            cell_centered_Ccz4_second_derivs);
 
-  // free params
-  const double c = 1.0;               // c = 1.0 in SO-CCZ4
-  const double cleaning_speed = 1.0;  // e in the paper; e = 1.0 for SO-CCZ4
-  const Scalar<DataVector>& eta = get<Tags::Eta<DataVector>>(*box);
-  const double f = get<Tags::GammaDriverParam>(*box);
-  const Scalar<DataVector>& k_0 = get<Tags::K0<DataVector>>(*box);
-  const double kappa_1 = get<Tags::Kappa1>(*box);
-  const double kappa_2 = get<Tags::Kappa2>(*box);
-  const double kappa_3 = get<Tags::Kappa3>(*box);
-  const double one_over_relaxation_time = 0.0;  // \tau^{-1} = 0 in SO-CCZ4
+    tnsr::iijj<DataVector, Dim> d_field_d;
+    ::tenex::evaluate<ti::i, ti::j, ti::k, ti::l>(
+        make_not_null(&d_field_d),
+        0.5 * d_d_conformal_metric(ti::i, ti::j, ti::k, ti::l));
 
-  // we assume the databox already has tags corresponding to dt of the evolved
-  // variables
-  using dt_variables_tag = db::add_tag_prefix<::Tags::dt, evolved_vars_tag>;
-  db::mutate<dt_variables_tag>(
-      [&](const auto dt_vars_ptr) {
-        auto& [
-            conformal_factor_squared,
-            det_conformal_spatial_metric,
-            inv_conformal_spatial_metric,
-            inv_spatial_metric,
-            inv_a_tilde,
-            a_tilde_times_field_b,
-            a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde,
-            contracted_field_b,
-            symmetrized_d_field_b,
-            contracted_symmetrized_d_field_b,
-            field_d_up_times_a_tilde,
-            contracted_field_d_up,
-            half_conformal_factor_squared,
-            conformal_metric_times_field_b,
-            conformal_metric_times_trace_a_tilde,
-            inv_conformal_metric_times_d_a_tilde,
-            gamma_hat_minus_contracted_conformal_christoffel,
-            d_gamma_hat_minus_contracted_conformal_christoffel,
-            contracted_christoffel_second_kind,
-            contracted_d_conformal_christoffel_difference,
-            k_minus_2_theta_c,
-            k_minus_k0_minus_2_theta_c,
-            lapse_times_a_tilde,
-            lapse_times_d_a_tilde,
-            lapse_times_field_a,
-            lapse_times_conformal_spatial_metric,
-            lapse_times_slicing_condition,
-            lapse_times_ricci_scalar_plus_divergence_z4_constraint,
-            shift_times_deriv_gamma_hat,
-            inv_tau_times_conformal_metric,
-            trace_a_tilde,
-            field_d_up,
-            conformal_christoffel_second_kind,
-            d_conformal_christoffel_second_kind,
-            christoffel_second_kind,
-            spatial_ricci_tensor,
-            grad_grad_lapse,
-            divergence_lapse,
-            contracted_conformal_christoffel_second_kind,
-            d_contracted_conformal_christoffel_second_kind,
-            spatial_z4_constraint,
-            upper_spatial_z4_constraint,
-            grad_spatial_z4_constraint,
-            ricci_scalar_plus_divergence_z4_constraint] = temp_vars;
-        detail::apply(
-            // LHS time derivatives of evolved variables: eq 4a - 4i
-            make_not_null(
-                &get<
-                    ::Tags::dt<::Ccz4::Tags::ConformalMetric<DataVector, Dim>>>(
-                    *dt_vars_ptr)),  // eq 4a
-            make_not_null(&get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(
-                *dt_vars_ptr)),  // eq 4g
-            make_not_null(&get<::Tags::dt<gr::Tags::Shift<DataVector, Dim>>>(
-                *dt_vars_ptr)),  // eq 4h
-            make_not_null(
-                &get<::Tags::dt<::Ccz4::Tags::ConformalFactor<DataVector>>>(
-                    *dt_vars_ptr)),  // eq 4c
-            make_not_null(
-                &get<::Tags::dt<::Ccz4::Tags::ATilde<DataVector, Dim>>>(
-                    *dt_vars_ptr)),  // eq 4b
-            make_not_null(
-                &get<::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>>(
-                    *dt_vars_ptr)),  // eq 4d
-            make_not_null(&get<::Tags::dt<::Ccz4::Tags::Theta<DataVector>>>(
-                *dt_vars_ptr)),  // eq 4e
-            make_not_null(
-                &get<::Tags::dt<::Ccz4::Tags::GammaHat<DataVector, Dim>>>(
-                    *dt_vars_ptr)),  // eq 4f
-            make_not_null(
-                &get<
-                    ::Tags::dt<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>>(
-                    *dt_vars_ptr)),  // eq 4i
+    const auto& d_d_conformal_factor =
+        get<::Tags::second_deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                                 tmpl::size_t<Dim>, Frame::Inertial>>(
+            cell_centered_Ccz4_second_derivs);
 
-            // quantities we need for computing eq 4, 13 - 27
-            make_not_null(&conformal_factor_squared),
-            make_not_null(&det_conformal_spatial_metric),
-            make_not_null(&inv_conformal_spatial_metric),
-            make_not_null(&inv_spatial_metric), make_not_null(&inv_a_tilde),
-            // temporary expressions
-            make_not_null(&a_tilde_times_field_b),
-            make_not_null(
+    tnsr::ii<DataVector, Dim> d_field_p;
+    ::tenex::evaluate<ti::i, ti::j>(
+        make_not_null(&d_field_p),
+        (d_d_conformal_factor(ti::i, ti::j) - d_conformal_factor(ti::i) *
+                                                  d_conformal_factor(ti::j) /
+                                                  conformal_factor()) /
+            conformal_factor());
+
+    // intialize containers to be supplied in the SO-CCZ4 TimeDerivative.cpp
+    // apply() function quantities we need for computing eq 4, 13 - 27
+    using TempVars = Variables<tmpl::list<
+        ::Ccz4::Tags::ConformalFactorSquared<DataVector>,
+        ::Ccz4::Tags::DetConformalSpatialMetric<DataVector>,
+        ::Ccz4::Tags::InverseConformalMetric<DataVector, Dim>,
+        gr::Tags::InverseSpatialMetric<DataVector, Dim>,
+        ::Ccz4::Tags::InvATilde<DataVector, Dim>,
+        ::Ccz4::Tags::ATildeTimesFieldB<DataVector, Dim>,
+        ::Ccz4::Tags::ATildeMinusOneThirdConformalMetricTimesTraceATilde<
+            DataVector, Dim>,
+        ::Ccz4::Tags::ContractedFieldB<DataVector>,
+        ::Ccz4::Tags::SymmetrizedDerivFieldB<DataVector, Dim>,
+        ::Ccz4::Tags::ContractedSymmetrizedDerivFieldB<DataVector, Dim>,
+        ::Ccz4::Tags::FieldDUpTimesATilde<DataVector, Dim>,
+        ::Ccz4::Tags::ContractedFieldDUp<DataVector, Dim>,
+        ::Ccz4::Tags::HalfConformalFactorSquared<DataVector>,
+        ::Ccz4::Tags::ConformalMetricTimesFieldB<DataVector, Dim>,
+        ::Ccz4::Tags::ConformalMetricTimesTraceATilde<DataVector, Dim>,
+        ::Ccz4::Tags::InverseConformalMetricTimesDerivATilde<DataVector, Dim>,
+        ::Ccz4::Tags::GammaHatMinusContractedConformalChristoffel<DataVector,
+                                                                  Dim>,
+        ::Ccz4::Tags::DerivGammaHatMinusContractedConformalChristoffel<
+            DataVector, Dim>,
+        ::Ccz4::Tags::ContractedChristoffelSecondKind<DataVector, Dim>,
+        ::Ccz4::Tags::ContractedDerivConformalChristoffelDifference<DataVector,
+                                                                    Dim>,
+        ::Ccz4::Tags::KMinus2ThetaC<DataVector>,
+        ::Ccz4::Tags::KMinusK0Minus2ThetaC<DataVector>,
+        ::Ccz4::Tags::LapseTimesATilde<DataVector, Dim>,
+        ::Ccz4::Tags::LapseTimesDerivATilde<DataVector, Dim>,
+        ::Ccz4::Tags::LapseTimesFieldA<DataVector, Dim>,
+        ::Ccz4::Tags::LapseTimesConformalMetric<DataVector, Dim>,
+        ::Ccz4::Tags::LapseTimesSlicingCondition<DataVector>,
+        ::Ccz4::Tags::LapseTimesRicciScalarPlus2DivergenceZ4Constraint<
+            DataVector>,
+        ::Ccz4::Tags::ShiftTimesDerivGammaHat<DataVector, Dim>,
+        ::Ccz4::Tags::InverseTauTimesConformalMetric<DataVector, Dim>,
+        ::Ccz4::Tags::TraceATilde<DataVector>,
+        ::Ccz4::Tags::FieldDUp<DataVector, Dim>,
+        ::Ccz4::Tags::ConformalChristoffelSecondKind<DataVector, Dim>,
+        ::Ccz4::Tags::DerivConformalChristoffelSecondKind<DataVector, Dim>,
+        ::Ccz4::Tags::ChristoffelSecondKind<DataVector, Dim>,
+        ::Ccz4::Tags::SpatialRicciTensor<DataVector, Dim>,
+        ::Ccz4::Tags::GradGradLapse<DataVector, Dim>,
+        ::Ccz4::Tags::DivergenceLapse<DataVector>,
+        ::Ccz4::Tags::ContractedConformalChristoffelSecondKind<DataVector, Dim>,
+        ::Ccz4::Tags::DerivContractedConformalChristoffelSecondKind<DataVector,
+                                                                    Dim>,
+        ::Ccz4::Tags::SpatialZ4Constraint<DataVector, Dim>,
+        ::Ccz4::Tags::GradSpatialZ4Constraint<DataVector, Dim>,
+        ::Ccz4::Tags::RicciScalarPlusDivergenceZ4Constraint<DataVector>>>;
+
+    TempVars temp_vars(num_pts);
+    tnsr::I<DataVector, Dim> upper_spatial_z4_constraint(num_pts);
+
+    // free params
+    const double c = 1.0;               // c = 1.0 in SO-CCZ4
+    const double cleaning_speed = 1.0;  // e in the paper; e = 1.0 for SO-CCZ4
+    const Scalar<DataVector>& eta = get<::Ccz4::Tags::Eta<DataVector>>(*box);
+    const double f = Ccz4::fd::System::f;
+    const Scalar<DataVector>& k_0 = get<::Ccz4::Tags::K0<DataVector>>(*box);
+    const double kappa_1 = get<::Ccz4::Tags::Kappa1>(*box);
+    const double kappa_2 = get<::Ccz4::Tags::Kappa2>(*box);
+    const double kappa_3 = get<::Ccz4::Tags::Kappa3>(*box);
+    const double one_over_relaxation_time = 0.0;  // \tau^{-1} = 0 in SO-CCZ4
+    const bool shifting_shift = Ccz4::fd::System::shifting_shift;
+
+    // we assume the databox already has tags corresponding to dt of the evolved
+    // variables
+    using dt_variables_tag = db::add_tag_prefix<::Tags::dt, evolved_vars_tag>;
+
+    // resize here
+
+    db::mutate<dt_variables_tag,
+               ::Ccz4::Tags::SpatialZ4ConstraintUp<DataVector, Dim>>(
+        [&](const auto dt_vars_ptr,
+            const auto upper_spatial_z4_constraint_ptr) {
+          dt_vars_ptr->initialize(subcell_mesh.number_of_grid_points());
+          auto& [conformal_factor_squared, det_conformal_spatial_metric,
+                 inv_conformal_spatial_metric, inv_spatial_metric, inv_a_tilde,
+                 a_tilde_times_field_b,
+                 a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde,
+                 contracted_field_b, symmetrized_d_field_b,
+                 contracted_symmetrized_d_field_b, field_d_up_times_a_tilde,
+                 contracted_field_d_up, half_conformal_factor_squared,
+                 conformal_metric_times_field_b,
+                 conformal_metric_times_trace_a_tilde,
+                 inv_conformal_metric_times_d_a_tilde,
+                 gamma_hat_minus_contracted_conformal_christoffel,
+                 d_gamma_hat_minus_contracted_conformal_christoffel,
+                 contracted_christoffel_second_kind,
+                 contracted_d_conformal_christoffel_difference,
+                 k_minus_2_theta_c, k_minus_k0_minus_2_theta_c,
+                 lapse_times_a_tilde, lapse_times_d_a_tilde,
+                 lapse_times_field_a, lapse_times_conformal_spatial_metric,
+                 lapse_times_slicing_condition,
+                 lapse_times_ricci_scalar_plus_divergence_z4_constraint,
+                 shift_times_deriv_gamma_hat, inv_tau_times_conformal_metric,
+                 trace_a_tilde, field_d_up, conformal_christoffel_second_kind,
+                 d_conformal_christoffel_second_kind, christoffel_second_kind,
+                 spatial_ricci_tensor, grad_grad_lapse, divergence_lapse,
+                 contracted_conformal_christoffel_second_kind,
+                 d_contracted_conformal_christoffel_second_kind,
+                 spatial_z4_constraint, grad_spatial_z4_constraint,
+                 ricci_scalar_plus_divergence_z4_constraint] = temp_vars;
+          detail::apply(
+              // LHS time derivatives of evolved variables: eq 4a - 4i
+              make_not_null(
+                  &get<::Tags::dt<
+                      ::Ccz4::Tags::ConformalMetric<DataVector, Dim>>>(
+                      *dt_vars_ptr)),  // eq 4a
+              make_not_null(&get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(
+                  *dt_vars_ptr)),  // eq 4g
+              make_not_null(&get<::Tags::dt<gr::Tags::Shift<DataVector, Dim>>>(
+                  *dt_vars_ptr)),  // eq 4h
+              make_not_null(
+                  &get<::Tags::dt<::Ccz4::Tags::ConformalFactor<DataVector>>>(
+                      *dt_vars_ptr)),  // eq 4c
+              make_not_null(
+                  &get<::Tags::dt<::Ccz4::Tags::ATilde<DataVector, Dim>>>(
+                      *dt_vars_ptr)),  // eq 4b
+              make_not_null(&get<::Tags::dt<
+                                gr::Tags::TraceExtrinsicCurvature<DataVector>>>(
+                  *dt_vars_ptr)),  // eq 4d
+              make_not_null(&get<::Tags::dt<::Ccz4::Tags::Theta<DataVector>>>(
+                  *dt_vars_ptr)),  // eq 4e
+              make_not_null(
+                  &get<::Tags::dt<::Ccz4::Tags::GammaHat<DataVector, Dim>>>(
+                      *dt_vars_ptr)),  // eq 4f
+              make_not_null(
+                  &get<::Tags::dt<
+                      ::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>>(
+                      *dt_vars_ptr)),  // eq 4i
+
+              // quantities we need for computing eq 4, 13 - 27
+              make_not_null(&conformal_factor_squared),
+              make_not_null(&det_conformal_spatial_metric),
+              make_not_null(&inv_conformal_spatial_metric),
+              make_not_null(&inv_spatial_metric), make_not_null(&inv_a_tilde),
+              // temporary expressions
+              make_not_null(&a_tilde_times_field_b),
+              make_not_null(
                 &a_tilde_minus_one_third_conformal_metric_times_trace_a_tilde),
-            make_not_null(&contracted_field_b),
-            make_not_null(&symmetrized_d_field_b),
-            make_not_null(&contracted_symmetrized_d_field_b),
-            make_not_null(&field_d_up_times_a_tilde),
-            make_not_null(&contracted_field_d_up),  // temp for eq 18 -20
-            make_not_null(&half_conformal_factor_squared),  // temp for eq 25
-            make_not_null(&conformal_metric_times_field_b),
-            make_not_null(&conformal_metric_times_trace_a_tilde),
-            make_not_null(&inv_conformal_metric_times_d_a_tilde),
-            make_not_null(&gamma_hat_minus_contracted_conformal_christoffel),
-            make_not_null(&d_gamma_hat_minus_contracted_conformal_christoffel),
-            make_not_null(
-                &contracted_christoffel_second_kind),  // temp for eq 18 -20
-            make_not_null(
-                &contracted_d_conformal_christoffel_difference),  // temp for eq
-                                                                  // 18 -20
-            make_not_null(&k_minus_2_theta_c),
-            make_not_null(&k_minus_k0_minus_2_theta_c),
-            make_not_null(&lapse_times_a_tilde),
-            make_not_null(&lapse_times_d_a_tilde),
-            make_not_null(&lapse_times_field_a),
-            make_not_null(&lapse_times_conformal_spatial_metric),
-            make_not_null(&lapse_times_slicing_condition),
-            make_not_null(
-                &lapse_times_ricci_scalar_plus_divergence_z4_constraint),
-            make_not_null(&shift_times_deriv_gamma_hat),
-            make_not_null(&inv_tau_times_conformal_metric),
-            // expressions and identities needed for evolution equations: eq 13
-            // - 27
-            make_not_null(&trace_a_tilde),                        // eq 13
-            make_not_null(&field_d_up),                           // eq 14
-            make_not_null(&conformal_christoffel_second_kind),    // eq 15
-            make_not_null(&d_conformal_christoffel_second_kind),  // eq 16
-            make_not_null(&christoffel_second_kind),              // eq 17
-            make_not_null(&spatial_ricci_tensor),                 // eq 18 - 20
-            make_not_null(&grad_grad_lapse),                      // eq 21
-            make_not_null(&divergence_lapse),                     // eq 22
-            make_not_null(
-                &contracted_conformal_christoffel_second_kind),  // eq 23
-            make_not_null(
-                &d_contracted_conformal_christoffel_second_kind),  // eq 24
-            make_not_null(&spatial_z4_constraint),                 // eq 25
-            make_not_null(&upper_spatial_z4_constraint),           // eq 25
-            make_not_null(&grad_spatial_z4_constraint),            // eq 26
-            make_not_null(
-                &ricci_scalar_plus_divergence_z4_constraint),  // eq 27
-            // fixed params
-            c, cleaning_speed,         // e in the paper
-            one_over_relaxation_time,  // \tau^{-1}
-            // free params
-            eta, f, kappa_1, kappa_2, kappa_3, k_0,
-            // evolved variables
-            get<Tags::ConformalMetric<DataVector, Dim>>(evolved_vars),
-            get<gr::Tags::Lapse<DataVector>>(evolved_vars),
-            get<gr::Tags::Shift<DataVector, Dim>>(evolved_vars),
-            get<Tags::ConformalFactor<DataVector>>(evolved_vars),
-            get<Tags::ATilde<DataVector, Dim>>(evolved_vars),
-            get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars),
-            get<Tags::Theta<DataVector>>(evolved_vars),
-            get<Tags::GammaHat<DataVector, Dim>>(evolved_vars),
-            get<Tags::AuxiliaryShiftB<DataVector, Dim>>(evolved_vars),
+              make_not_null(&contracted_field_b),
+              make_not_null(&symmetrized_d_field_b),
+              make_not_null(&contracted_symmetrized_d_field_b),
+              make_not_null(&field_d_up_times_a_tilde),
+              make_not_null(&contracted_field_d_up),  // temp for eq 18 -20
+              make_not_null(&half_conformal_factor_squared),  // temp for eq 25
+              make_not_null(&conformal_metric_times_field_b),
+              make_not_null(&conformal_metric_times_trace_a_tilde),
+              make_not_null(&inv_conformal_metric_times_d_a_tilde),
+              make_not_null(&gamma_hat_minus_contracted_conformal_christoffel),
+              make_not_null(
+                  &d_gamma_hat_minus_contracted_conformal_christoffel),
+              make_not_null(
+                  &contracted_christoffel_second_kind),  // temp for eq 18 -20
+              make_not_null(
+                  &contracted_d_conformal_christoffel_difference),  // temp for
+                                                                    // eq 18 -20
+              make_not_null(&k_minus_2_theta_c),
+              make_not_null(&k_minus_k0_minus_2_theta_c),
+              make_not_null(&lapse_times_a_tilde),
+              make_not_null(&lapse_times_d_a_tilde),
+              make_not_null(&lapse_times_field_a),
+              make_not_null(&lapse_times_conformal_spatial_metric),
+              make_not_null(&lapse_times_slicing_condition),
+              make_not_null(
+                  &lapse_times_ricci_scalar_plus_divergence_z4_constraint),
+              make_not_null(&shift_times_deriv_gamma_hat),
+              make_not_null(&inv_tau_times_conformal_metric),
+              // expressions and identities needed for evolution equations: eq
+              // 13
+              // - 27
+              make_not_null(&trace_a_tilde),                        // eq 13
+              make_not_null(&field_d_up),                           // eq 14
+              make_not_null(&conformal_christoffel_second_kind),    // eq 15
+              make_not_null(&d_conformal_christoffel_second_kind),  // eq 16
+              make_not_null(&christoffel_second_kind),              // eq 17
+              make_not_null(&spatial_ricci_tensor),  // eq 18 - 20
+              make_not_null(&grad_grad_lapse),       // eq 21
+              make_not_null(&divergence_lapse),      // eq 22
+              make_not_null(
+                  &contracted_conformal_christoffel_second_kind),  // eq 23
+              make_not_null(
+                  &d_contracted_conformal_christoffel_second_kind),  // eq 24
+              make_not_null(&spatial_z4_constraint),                 // eq 25
+              make_not_null(&upper_spatial_z4_constraint),           // eq 25
+              make_not_null(&grad_spatial_z4_constraint),            // eq 26
+              make_not_null(
+                  &ricci_scalar_plus_divergence_z4_constraint),  // eq 27
+              // fixed params
+              c, cleaning_speed,         // e in the paper
+              one_over_relaxation_time,  // \tau^{-1}
+              // free params
+              eta, f, kappa_1, kappa_2, kappa_3, k_0,
+              // evolved variables
+              get<::Ccz4::Tags::ConformalMetric<DataVector, Dim>>(evolved_vars),
+              get<gr::Tags::Lapse<DataVector>>(evolved_vars),
+              get<gr::Tags::Shift<DataVector, Dim>>(evolved_vars),
+              get<::Ccz4::Tags::ConformalFactor<DataVector>>(evolved_vars),
+              get<::Ccz4::Tags::ATilde<DataVector, Dim>>(evolved_vars),
+              get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars),
+              get<::Ccz4::Tags::Theta<DataVector>>(evolved_vars),
+              get<::Ccz4::Tags::GammaHat<DataVector, Dim>>(evolved_vars),
+              get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>(evolved_vars),
 
-            field_a,  // auxiliary variables NOT evolved in SO-CCZ4
-            field_b, field_d, field_p,
-            d_field_a,  // spatial derivative of auxiliary variables
-            d_field_b, d_field_d, d_field_p,
+              field_a,  // auxiliary variables NOT evolved in SO-CCZ4
+              field_b, field_d, field_p,
+              d_field_a,  // spatial derivative of auxiliary variables
+              d_field_b, d_field_d, d_field_p,
 
-            // spatial derivatives of other evolved variables
-            get<::Tags::deriv<Tags::ATilde<DataVector, Dim>, tmpl::size_t<Dim>,
-                              Frame::Inertial>>(cell_centered_Ccz4_derivs),
-            get<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
-                              tmpl::size_t<Dim>, Frame::Inertial>>(
-                cell_centered_Ccz4_derivs),
-            get<::Tags::deriv<Tags::Theta<DataVector>, tmpl::size_t<Dim>,
-                              Frame::Inertial>>(cell_centered_Ccz4_derivs),
-            get<::Tags::deriv<Tags::GammaHat<DataVector, Dim>,
-                              tmpl::size_t<Dim>, Frame::Inertial>>(
-                cell_centered_Ccz4_derivs),
-            get<::Tags::deriv<Tags::AuxiliaryShiftB<DataVector, Dim>,
-                              tmpl::size_t<Dim>, Frame::Inertial>>(
-                cell_centered_Ccz4_derivs));
-      },
-      box);
-}
+              // spatial derivatives of other evolved variables
+              get<::Tags::deriv<::Ccz4::Tags::ATilde<DataVector, Dim>,
+                                tmpl::size_t<Dim>, Frame::Inertial>>(
+                  cell_centered_Ccz4_derivs),
+              get<::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                                tmpl::size_t<Dim>, Frame::Inertial>>(
+                  cell_centered_Ccz4_derivs),
+              get<::Tags::deriv<::Ccz4::Tags::Theta<DataVector>,
+                                tmpl::size_t<Dim>, Frame::Inertial>>(
+                  cell_centered_Ccz4_derivs),
+              get<::Tags::deriv<::Ccz4::Tags::GammaHat<DataVector, Dim>,
+                                tmpl::size_t<Dim>, Frame::Inertial>>(
+                  cell_centered_Ccz4_derivs),
+              get<::Tags::deriv<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>,
+                                tmpl::size_t<Dim>, Frame::Inertial>>(
+                  cell_centered_Ccz4_derivs),
+              shifting_shift, evolve_lapse_and_shift);
+
+          *upper_spatial_z4_constraint_ptr =
+              std::move(upper_spatial_z4_constraint);
+        },
+        box);
+  }
+};
 }  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/System.hpp
@@ -5,18 +5,36 @@
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Ccz4::fd {
 struct System {
+  using flux_variables = tmpl::list<>;
+  using boundary_conditions_base = BoundaryConditions::BoundaryCondition;
+  static constexpr bool has_primitive_and_conservative_vars = false;
+  static constexpr size_t volume_dim = 3;
+  static constexpr bool is_in_flux_conservative_form = false;
+  /* shifting_shift and f should be created from options in the future */
+  // whether to add the advective terms in the Gamma-driver condition
+  static constexpr bool shifting_shift = false;
+
+  // The free parameter f in the Gamma-driver condition.
+  static constexpr double f = 0.75;
+
+  // the order of the following evolved variables is important
+  // as it is assumed in the filter
   using variables_tag = ::Tags::Variables<tmpl::list<
-      Tags::ConformalMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
-      gr::Tags::Shift<DataVector, 3>, Tags::ConformalFactor<DataVector>,
-      Tags::ATilde<DataVector, 3>,
-      gr::Tags::TraceExtrinsicCurvature<DataVector>, Tags::Theta<DataVector>,
-      Tags::GammaHat<DataVector, 3>, Tags::AuxiliaryShiftB<DataVector, 3>>>;
+      ::Ccz4::Tags::ConformalMetric<DataVector, 3>,
+      ::Ccz4::Tags::ConformalFactor<DataVector>,
+      ::Ccz4::Tags::ATilde<DataVector, 3>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      ::Ccz4::Tags::Theta<DataVector>, ::Ccz4::Tags::GammaHat<DataVector, 3>,
+      // gauge variables
+      gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+      ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>>;
 
   using variables_tag_list = typename variables_tag::tags_list;
 

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp
@@ -9,6 +9,10 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellSolver.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
 #include "Evolution/Systems/Ccz4/TagsDeclarations.hpp"
 #include "Evolution/Tags.hpp"
@@ -16,13 +20,102 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 
-namespace Ccz4::fd::Tags {
+namespace Ccz4::fd {
+/// \brief Option tags for evolving SoCcz4 with finite difference
+namespace OptionTags {
+/// \brief Option tag for the reconstructor
+struct Reconstructor {
+  using type = std::unique_ptr<fd::Reconstructor>;
+
+  static constexpr Options::String help = {"The reconstruction scheme to use."};
+  using group = evolution::dg::subcell::OptionTags::SubcellSolverGroup;
+};
+
+/// \brief Option tag for whether to evolve the lapse and shift
+struct EvolveLapseAndShift {
+  using type = bool;
+
+  static constexpr Options::String help = {
+      "The option to use time-independent laspe and shift."};
+  using group = ::Ccz4::OptionTags::Ccz4Group;
+};
+
+/// \brief Option tag for whether to use constrained evolution
+///
+/// When true, the determint of the conformal spatial metric is rescaled
+/// to one and the trace of ATilde is removed using the rescaled metric
+/// after every complete time step.
+struct ConstrainedEvolution {
+  using type = bool;
+
+  static constexpr Options::String help = {
+      "Whether to use constrained evolution."};
+  using group = ::Ccz4::OptionTags::Ccz4Group;
+};
+
+/// \brief Option tag for the epsilon parameter of the Kreiss-Oliger dissipation
+struct KreissOligerEpsilon {
+  using type = double;
+
+  static constexpr Options::String help = {
+      "The epsilon parameter for Kreiss-Oliger dissipation."};
+  using group = ::Ccz4::OptionTags::Ccz4Group;
+};
+}  // namespace OptionTags
+
+/// \brief Tags for evolving SoCcz4 with finite difference
+namespace Tags {
+/// \brief Tag for the reconstructor
+struct Reconstructor : db::SimpleTag {
+  using type = std::unique_ptr<fd::Reconstructor>;
+  using option_tags = tmpl::list<OptionTags::Reconstructor>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type& reconstructor) {
+    return reconstructor->get_clone();
+  }
+};
+
+/*!
+ * \brief Tag for whether to evolve the lapse and shif
+ */
+struct EvolveLapseAndShift : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::EvolveLapseAndShift>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const bool evolve_lapse_and_shift) {
+    return evolve_lapse_and_shift;
+  }
+};
+
+/*!
+ * \brief Tag for whether to evolve the lapse and shift
+ */
+struct ConstrainedEvolution : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::ConstrainedEvolution>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const bool constrained_evolution) {
+    return constrained_evolution;
+  }
+};
+
+/*!
+ * \brief Tag for the epsilon parameter of the Kreiss-Oliger dissipation
+ */
+struct KreissOligerEpsilon : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::KreissOligerEpsilon>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const double kreiss_oliger_epsilon) {
+    return kreiss_oliger_epsilon;
+  }
+};
+
 /// \brief Tags sent for second-order Ccz4 evolution.
-using spacetime_reconstruction_tags = tmpl::list<
-    ::Ccz4::Tags::ConformalMetric<DataVector, 3>, gr::Tags::Lapse<DataVector>,
-    gr::Tags::Shift<DataVector, 3>, ::Ccz4::Tags::ConformalFactor<DataVector>,
-    ::Ccz4::Tags::ATilde<DataVector, 3>,
-    gr::Tags::TraceExtrinsicCurvature<DataVector>,
-    ::Ccz4::Tags::Theta<DataVector>, ::Ccz4::Tags::GammaHat<DataVector, 3>,
-    ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>;
-}  // namespace Ccz4::fd::Tags
+using spacetime_reconstruction_tags = System::variables_tag_list;
+}  // namespace Tags
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/Tags.hpp
@@ -15,6 +15,46 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
 
 namespace Ccz4 {
+namespace OptionTags {
+/*!
+ * \ingroup OptionGroupsGroup
+ * Groups option tags related to the CCZ4 evolution system.
+ */
+struct Ccz4Group {
+  static std::string name() { return "Ccz4"; }
+  static constexpr Options::String help{
+      "Options for the CCZ4 evolution system"};
+  using group = evolution::OptionTags::SystemGroup;
+};
+
+/// \copydoc Tags::Kappa1
+struct Kappa1 {
+  using type = double;
+
+  static constexpr Options::String help = {
+      "The constraint damping parameter kappa_1."};
+  using group = Ccz4Group;
+};
+
+/// \copydoc Tags::Kappa2
+struct Kappa2 {
+  using type = double;
+
+  static constexpr Options::String help = {
+      "The constraint damping parameter kappa_2."};
+  using group = Ccz4Group;
+};
+
+/// \copydoc Tags::Kappa3
+struct Kappa3 {
+  using type = double;
+
+  static constexpr Options::String help = {
+      "The constraint damping parameter kappa_3."};
+  using group = Ccz4Group;
+};
+}  // namespace OptionTags
+
 /*!
  * \brief Tags for the CCZ4 formulation of Einstein equations.
  * \details The naming convention follows \cite Dumbser2017okk
@@ -407,6 +447,10 @@ struct GammaDriverParam
  */
 struct Kappa1 : db::SimpleTag {
   using type = double;
+  using option_tags = tmpl::list<OptionTags::Kappa1>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const double kappa_1) { return kappa_1; }
 };
 
 /*!
@@ -416,6 +460,10 @@ struct Kappa1 : db::SimpleTag {
  */
 struct Kappa2 : db::SimpleTag {
   using type = double;
+  using option_tags = tmpl::list<OptionTags::Kappa2>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const double kappa_2) { return kappa_2; }
 };
 
 /*!
@@ -425,6 +473,10 @@ struct Kappa2 : db::SimpleTag {
  */
 struct Kappa3 : db::SimpleTag {
   using type = double;
+  using option_tags = tmpl::list<OptionTags::Kappa3>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const double kappa_3) { return kappa_3; }
 };
 
 /*!
@@ -446,17 +498,4 @@ struct Eta : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 }  // namespace Tags
-
-namespace OptionTags {
-/*!
- * \ingroup OptionGroupsGroup
- * Groups option tags related to the CCZ4 evolution system.
- */
-struct Group {
-  static std::string name() { return "Ccz4"; }
-  static constexpr Options::String help{
-      "Options for the CCZ4 evolution system"};
-  using group = evolution::OptionTags::SystemGroup;
-};
-}  // namespace OptionTags
 }  // namespace Ccz4

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.cpp
@@ -6,6 +6,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.tpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -13,5 +14,5 @@
 GENERATE_INSTANTIATIONS(CCZ4_WRAPPED_GR_INSTANTIATE,
                         (gr::Solutions::GaugeWave<3>,
                          gr::Solutions::GaugePlaneWave<3>,
-                         gr::Solutions::Minkowski<3>,
+                         gr::Solutions::KerrSchild, gr::Solutions::Minkowski<3>,
                          gr::Solutions::TrumpetSchwarzschild))

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp
@@ -88,7 +88,8 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
                       Ccz4::Tags::ATilde<DataType, volume_dim>,
                       gr::Tags::TraceExtrinsicCurvature<DataType>,
                       Ccz4::Tags::Theta<DataType>,
-                      Ccz4::Tags::GammaHat<DataType, volume_dim>>;
+                      Ccz4::Tags::GammaHat<DataType, volume_dim>,
+                      Ccz4::Tags::AuxiliaryShiftB<DataType, volume_dim>>;
 
   template <typename... Tags>
   tuples::TaggedTuple<Tags...> variables(
@@ -195,6 +196,11 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
       const tnsr::I<DataVector, volume_dim>& /*x*/,
       tmpl::list<Ccz4::Tags::GammaHat<DataVector, volume_dim>> /*meta*/,
       const IntermediateVars& intermediate_vars) const;
+  tuples::TaggedTuple<Ccz4::Tags::AuxiliaryShiftB<DataVector, volume_dim>>
+  variables(
+      const tnsr::I<DataVector, volume_dim>& /*x*/,
+      tmpl::list<Ccz4::Tags::AuxiliaryShiftB<DataVector, volume_dim>> /*meta*/,
+      const IntermediateVars& intermediate_vars) const;
 
   tuples::TaggedTuple<Ccz4::Tags::ConformalMetric<DataVector, volume_dim>>
   variables(
@@ -230,6 +236,13 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
   tuples::TaggedTuple<Ccz4::Tags::GammaHat<DataVector, volume_dim>> variables(
       const tnsr::I<DataVector, volume_dim>& x, double /*t*/,
       tmpl::list<Ccz4::Tags::GammaHat<DataVector, volume_dim>> meta,
+      const IntermediateVars& intermediate_vars) const {
+    return variables(x, meta, intermediate_vars);
+  }
+  tuples::TaggedTuple<Ccz4::Tags::AuxiliaryShiftB<DataVector, volume_dim>>
+  variables(
+      const tnsr::I<DataVector, volume_dim>& x, double /*t*/,
+      tmpl::list<Ccz4::Tags::AuxiliaryShiftB<DataVector, volume_dim>> meta,
       const IntermediateVars& intermediate_vars) const {
     return variables(x, meta, intermediate_vars);
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.tpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.tpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Ccz4/ATilde.hpp"
 #include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 namespace Ccz4::Solutions {
@@ -202,6 +203,42 @@ Ccz4WrappedGr<SolutionType>::variables(
   // Similar to Theta, we assume the spatial Z4 constraints are zero,
   // so \hat{Gamma}^i = \tilde{Gamma}^i
   return {std::move(contracted_conformal_christoffel_second_kind)};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<Ccz4::Tags::AuxiliaryShiftB<
+    DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>
+Ccz4WrappedGr<SolutionType>::variables(
+    const tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<
+                                  SolutionType>::volume_dim>& /*x*/,
+    tmpl::list<Ccz4::Tags::AuxiliaryShiftB<
+        DataVector,
+        Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>> /*meta*/,
+    const IntermediateVars& intermediate_vars) const {
+  const double one_over_f = 1. / ::Ccz4::fd::System::f;
+  const bool shifting_shift = ::Ccz4::fd::System::shifting_shift;
+
+  tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>
+      auxiliary_shift_b;
+  const auto& shift = get<gr::Tags::Shift<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>(
+      intermediate_vars);
+  const auto& d_shift = get<DerivShift>(intermediate_vars);
+  const auto& dt_shift = get<::Tags::dt<gr::Tags::Shift<
+      DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>>>(
+      intermediate_vars);
+
+  if (shifting_shift) {
+    ::tenex::evaluate<ti::I>(
+        make_not_null(&auxiliary_shift_b),
+        one_over_f * dt_shift(ti::I) -
+            one_over_f * shift(ti::K) * d_shift(ti::k, ti::I));
+  } else {
+    ::tenex::evaluate<ti::I>(make_not_null(&auxiliary_shift_b),
+                             one_over_f * dt_shift(ti::I));
+  }
+
+  return {std::move(auxiliary_shift_b)};
 }
 
 template <typename SolutionType>

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HarmonicSchwarzschild.hpp"
@@ -16,7 +17,7 @@
 #include "Utilities/TMPL.hpp"
 
 namespace gh::Solutions {
-/// \brief List of all analytic solutions
+/// \brief List of all GH analytic solutions
 template <size_t Dim>
 using all_solutions =
     tmpl::append<tmpl::list<WrappedGr<gr::Solutions::GaugePlaneWave<Dim>>,
@@ -30,3 +31,15 @@ using all_solutions =
                                 WrappedGr<gr::Solutions::TrumpetSchwarzschild>>,
                      tmpl::list<>>>;
 }  // namespace gh::Solutions
+
+namespace Ccz4::Solutions {
+/// \brief List of all Ccz4 analytic solutions
+/// Right now it only makes sense to do TrumpetSchwarzschild or time-independent
+/// solutions because we can either use 1+log slicing with Gamma-driver
+/// or not evolve the lapse and shift at all. We will allow analytic
+/// lapse and shift in the future.
+using all_solutions =
+    tmpl::list<Ccz4WrappedGr<gr::Solutions::KerrSchild>,
+               Ccz4WrappedGr<gr::Solutions::Minkowski<3>>,
+               Ccz4WrappedGr<gr::Solutions::TrumpetSchwarzschild>>;
+}  // namespace Ccz4::Solutions

--- a/tests/Unit/Evolution/Systems/Ccz4/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -1,0 +1,193 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/ElementMap.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Ccz4WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/Factory.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeVector.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace {
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<Ccz4::BoundaryConditions::BoundaryCondition,
+                   tmpl::list<Ccz4::BoundaryConditions::DirichletAnalytic>>,
+        tmpl::pair<evolution::initial_data::InitialData,
+                   Ccz4::Solutions::all_solutions>,
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   MathFunctions::all_math_functions<1, Frame::Inertial>>>;
+  };
+};
+
+template <typename T, typename U>
+void test_fd(const U& boundary_condition, const T& analytic_solution_or_data) {
+  const double time = 1.3;
+  const Mesh<3> subcell_mesh{9, Spectral::Basis::FiniteDifference,
+                             Spectral::Quadrature::CellCentered};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  const std::array<double, 3> lower_bound{{0.78, 1.18, 1.28}};
+  const std::array<double, 3> upper_bound{{0.82, 1.22, 1.32}};
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map<Frame::Grid, Frame::Inertial>(
+          Affine3D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
+                   Affine{-1., 1., lower_bound[1], upper_bound[1]},
+                   Affine{-1., 1., lower_bound[2], upper_bound[2]}});
+
+  const ElementId<3> element_id{0};
+  const ElementMap logical_to_grid_map{
+      element_id,
+      domain::make_coordinate_map<Frame::BlockLogical, Frame::Grid>(
+          Affine3D{Affine{-1., 1., 2.0 * lower_bound[0], 2.0 * upper_bound[0]},
+                   Affine{-1., 1., 2.0 * lower_bound[1], 2.0 * upper_bound[1]},
+                   Affine{-1., 1., 2.0 * lower_bound[2], 2.0 * upper_bound[2]}})
+          .get_clone()};
+  const auto direction = Direction<3>::lower_xi();
+
+  const Ccz4::fd::DummyReconstructor reconstructor{};
+  const size_t ghost_zone_size = reconstructor.ghost_zone_size();
+
+  using Vars = Variables<Ccz4::fd::Tags::spacetime_reconstruction_tags>;
+  Vars vars{ghost_zone_size * subcell_mesh.extents().slice_away(0).product()};
+  const auto expected_vars = [&analytic_solution_or_data, &direction,
+                              &functions_of_time, &grid_to_inertial_map,
+                              &logical_to_grid_map, &subcell_mesh, time,
+                              ghost_zone_size]() {
+    const auto ghost_logical_coords =
+        evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+            subcell_mesh, ghost_zone_size, direction);
+
+    const auto ghost_inertial_coords = grid_to_inertial_map(
+        logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+    using tags =
+        tmpl::list<::Ccz4::Tags::ConformalMetric<DataVector, 3>,
+                   gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, 3>,
+                   ::Ccz4::Tags::ConformalFactor<DataVector>,
+                   ::Ccz4::Tags::ATilde<DataVector, 3>,
+                   gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                   ::Ccz4::Tags::Theta<DataVector>,
+                   ::Ccz4::Tags::GammaHat<DataVector, 3>,
+                   ::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>;
+
+    tuples::tagged_tuple_from_typelist<tags> analytic_vars{};
+
+    if constexpr (::is_analytic_solution_v<T>) {
+      analytic_vars = analytic_solution_or_data.variables(ghost_inertial_coords,
+                                                          time, tags{});
+    } else {
+      (void)time;
+      analytic_vars =
+          analytic_solution_or_data.variables(ghost_inertial_coords, tags{});
+    }
+
+    Vars expected{get<0>(ghost_inertial_coords).size()};
+
+    get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(expected) =
+        get<::Ccz4::Tags::ConformalMetric<DataVector, 3>>(analytic_vars);
+    get<gr::Tags::Lapse<DataVector>>(expected) =
+        get<gr::Tags::Lapse<DataVector>>(analytic_vars);
+    get<gr::Tags::Shift<DataVector, 3>>(expected) =
+        get<gr::Tags::Shift<DataVector, 3>>(analytic_vars);
+    get<::Ccz4::Tags::ConformalFactor<DataVector>>(expected) =
+        get<::Ccz4::Tags::ConformalFactor<DataVector>>(analytic_vars);
+    get<::Ccz4::Tags::ATilde<DataVector, 3>>(expected) =
+        get<::Ccz4::Tags::ATilde<DataVector, 3>>(analytic_vars);
+    get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(expected) =
+        get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(analytic_vars);
+    get<::Ccz4::Tags::Theta<DataVector>>(expected) =
+        get<::Ccz4::Tags::Theta<DataVector>>(analytic_vars);
+    get<::Ccz4::Tags::GammaHat<DataVector, 3>>(expected) =
+        get<::Ccz4::Tags::GammaHat<DataVector, 3>>(analytic_vars);
+    get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(expected) =
+        get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, 3>>(analytic_vars);
+    return expected;
+  }();
+  auto& [conformal_metric, conformal_factor, a_tilde, trace_extrinsic_curvature,
+         theta, gamma_hat, lapse, shift, auxiliary_shift_b] = vars;
+
+  boundary_condition.fd_ghost(
+      make_not_null(&conformal_metric), make_not_null(&lapse),
+      make_not_null(&shift), make_not_null(&conformal_factor),
+      make_not_null(&a_tilde), make_not_null(&trace_extrinsic_curvature),
+      make_not_null(&theta), make_not_null(&gamma_hat),
+      make_not_null(&auxiliary_shift_b), direction, subcell_mesh, time,
+      functions_of_time, logical_to_grid_map, grid_to_inertial_map,
+      reconstructor);
+  // failing line
+  CHECK(vars == expected_vars);
+}
+
+SPECTRE_TEST_CASE("Unit.Ccz4.BoundaryConditions.DirichletAnalytic",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  register_factory_classes_with_charm<Metavariables>();
+  {
+    INFO("Test with analytic solution");
+    const auto product_boundary_condition =
+        TestHelpers::test_creation<
+            std::unique_ptr<Ccz4::BoundaryConditions::BoundaryCondition>,
+            Metavariables>(
+            "DirichletAnalytic:\n"
+            "  AnalyticPrescription:\n"
+            "      Ccz4(KerrSchild):\n"
+            "        Mass: 1.0\n"
+            "        Spin: [0.5, -0.2, 0.0]\n"
+            "        Center: [-0.2, 0.0, 0.3]\n"
+            "        Velocity: [0.0, 0.0, 0.0]\n")
+            ->get_clone();
+
+    const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::KerrSchild>
+        analytic_solution_or_data{1.0,
+            {0.5, -0.2, 0.0}, {-0.2, 0.0, 0.3}, {0.0, 0.0, 0.0}};
+    const auto serialized_and_deserialized_condition =
+        serialize_and_deserialize(
+            *dynamic_cast<Ccz4::BoundaryConditions::DirichletAnalytic*>(
+                product_boundary_condition.get()));
+
+    test_fd<Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::KerrSchild>,
+            Ccz4::BoundaryConditions::DirichletAnalytic>(
+        serialized_and_deserialized_condition, analytic_solution_or_data);
+  }
+}
+}  // namespace

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -4,8 +4,12 @@
 set(LIBRARY "Test_Ccz4")
 
 set(LIBRARY_SOURCES
+  BoundaryConditions/Test_DirichletAnalytic.cpp
+  FiniteDifference/Test_BoundaryConditionGhostData.cpp
   FiniteDifference/Test_Derivatives.cpp
+  FiniteDifference/Test_DummyReconstructor.cpp
   FiniteDifference/Test_SoTimeDerivative.cpp
+  FiniteDifference/Test_Tags.cpp
   Test_ATilde.cpp
   Test_Christoffel.cpp
   Test_DerivChristoffel.cpp

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -1,0 +1,223 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/MetavariablesTag.hpp"
+#include "DataStructures/TaggedContainers.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Creators/Rectilinear.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/InterfaceLogicalCoordinates.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/DirichletAnalytic.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/BoundaryConditionGhostData.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+namespace {
+
+// Metavariables to parse the list of derived classes of boundary conditions
+struct EvolutionMetaVars {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<BoundaryConditions::BoundaryCondition,
+                             BoundaryConditions::standard_boundary_conditions>,
+                  tmpl::pair<evolution::initial_data::InitialData,
+                             Ccz4::Solutions::all_solutions>>;
+  };
+};
+
+using SolutionForTest = Solutions::Ccz4WrappedGr<gr::Solutions::Minkowski<3>>;
+
+template <typename BoundaryConditionType>
+void test(const BoundaryConditionType& boundary_condition,
+          const SolutionForTest& solution) {
+  const size_t num_dg_pts = 3;
+
+  // Create a 3D element [-1, 1]^3 and use it for test
+  const std::array<double, 3> lower_bounds{-1.0, -1.0, -1.0};
+  const std::array<double, 3> upper_bounds{1.0, 1.0, 1.0};
+  const std::array<size_t, 3> refinement_levels{0, 0, 0};
+  const std::array<size_t, 3> number_of_grid_points{num_dg_pts, num_dg_pts,
+                                                    num_dg_pts};
+  const domain::creators::Brick brick(
+      lower_bounds, upper_bounds, refinement_levels, number_of_grid_points,
+      {{{{boundary_condition.get_clone(), boundary_condition.get_clone()}},
+        {{boundary_condition.get_clone(), boundary_condition.get_clone()}},
+        {{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
+  auto domain = brick.create_domain();
+  auto boundary_conditions = brick.external_boundary_conditions();
+  const auto element = domain::create_initial_element(
+      ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},
+      domain.blocks(), std::vector<std::array<size_t, 3>>{{refinement_levels}});
+
+  // Mesh and coordinates
+  const Mesh<3> dg_mesh{num_dg_pts, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  // use MC reconstruction for test
+  using ReconstructorForTest = DummyReconstructor;
+  const size_t ghost_zone_size{ReconstructorForTest{}.ghost_zone_size()};
+
+  // Below are tags required by DirichletAnalytic boundary condition to compute
+  // inertial coords of ghost FD cells:
+  //  - time
+  //  - functions of time
+  //  - element map
+  //  - coordinate map
+  //  - subcell logical coordinates
+
+  const double time{0.5};
+
+  const std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  const ElementMap<3, Frame::Grid> logical_to_grid_map(
+      ElementId<3>{0},
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          domain::CoordinateMaps::Identity<3>{}));
+
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{});
+
+  const auto subcell_logical_coords = logical_coordinates(subcell_mesh);
+
+  // dummy neighbor data to put into DataBox
+  typename evolution::dg::subcell::Tags::GhostDataForReconstruction<3>::type
+      ghost_data{};
+
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<EvolutionMetaVars>,
+      domain::Tags::Domain<3>, domain::Tags::ExternalBoundaryConditions<3>,
+      evolution::dg::subcell::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Coordinates<3, Frame::ElementLogical>,
+      evolution::dg::subcell::Tags::GhostDataForReconstruction<3>,
+      Ccz4::fd::Tags::Reconstructor, ::Tags::Time,
+      domain::Tags::FunctionsOfTimeInitialize,
+      domain::Tags::ElementMap<3, Frame::Grid>,
+      domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                  Frame::Inertial>>>(
+      EvolutionMetaVars{}, std::move(domain), std::move(boundary_conditions),
+      subcell_mesh, subcell_logical_coords, ghost_data,
+      std::unique_ptr<Ccz4::fd::Reconstructor>{
+          std::make_unique<ReconstructorForTest>()},
+      time, clone_unique_ptrs(functions_of_time),
+      ElementMap<3, Frame::Grid>{
+          ElementId<3>{0},
+          domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+              domain::CoordinateMaps::Identity<3>{})},
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{}));
+
+  // compute FD ghost data and retrieve the result
+  fd::BoundaryConditionGhostData::apply(make_not_null(&box), element,
+                                        ReconstructorForTest{});
+  const auto direction = Direction<3>::upper_xi();
+  const DirectionalId<3> mortar_id = {direction,
+                                      ElementId<3>::external_boundary_id()};
+  const DataVector& fd_ghost_data =
+      get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box)
+          .at(mortar_id)
+          .neighbor_ghost_data_for_reconstruction();
+
+  // now check values for each types of boundary conditions
+  if (typeid(BoundaryConditionType) ==
+      typeid(Ccz4::BoundaryConditions::DirichletAnalytic)) {
+    const size_t num_face_pts{
+        subcell_mesh.extents().slice_away(direction.dimension()).product()};
+    Variables<System::variables_tag_list> ghost_zone_vars{num_face_pts *
+                                                          ghost_zone_size};
+    std::copy(fd_ghost_data.begin(),
+              std::next(fd_ghost_data.begin(),
+                        static_cast<std::ptrdiff_t>(ghost_zone_vars.size())),
+              ghost_zone_vars.data());
+
+    const auto ghost_logical_coords =
+        evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+            subcell_mesh, ghost_zone_size, direction);
+
+    const auto ghost_inertial_coords = (*grid_to_inertial_map)(
+        logical_to_grid_map(ghost_logical_coords), time, functions_of_time);
+
+    const auto& expected_ghost_vars = solution.variables(
+        ghost_inertial_coords, time, typename System::variables_tag_list{});
+
+    tmpl::for_each<System::variables_tag_list>([&]<typename Tag>(
+                                                   tmpl::type_<Tag> /*meta*/) {
+      const std::string tag_name = db::tag_name<Tag>();
+      CAPTURE(tag_name);
+      CAPTURE(ghost_inertial_coords);
+      CHECK(tuples::get<Tag>(expected_ghost_vars) == get<Tag>(ghost_zone_vars));
+    });
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Fd.BCondGhostData",
+                  "[Unit][Evolution]") {
+  const SolutionForTest solution{};
+
+  test(TestHelpers::test_creation<Ccz4::BoundaryConditions::DirichletAnalytic,
+                                  EvolutionMetaVars>("AnalyticPrescription:\n"
+                                                     "  Ccz4(Minkowski)\n"),
+       solution);
+  test(Ccz4::BoundaryConditions::DirichletAnalytic{std::make_unique<
+           Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::Minkowski<3>>>()},
+       solution);
+
+  // check that the periodic BC fails
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      ([&solution]() {
+        test(domain::BoundaryConditions::Periodic<
+                 Ccz4::BoundaryConditions::BoundaryCondition>{},
+             solution);
+      })(),
+      Catch::Matchers::ContainsSubstring("not on external boundaries"));
+#endif
+}
+}  // namespace
+}  // namespace Ccz4::fd

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_DummyReconstructor.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_DummyReconstructor.cpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+
+namespace Ccz4::fd {
+namespace {
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Fd.DummyReconstructor",
+                  "[Unit][Evolution]") {
+  const auto dummy_from_options_base =
+      TestHelpers::test_factory_creation<Ccz4::fd::Reconstructor,
+                                         Ccz4::fd::OptionTags::Reconstructor>(
+          "DummyReconstructor:\n");
+  auto* const dummy_from_options =
+      dynamic_cast<const Ccz4::fd::DummyReconstructor*>(
+          dummy_from_options_base.get());
+  REQUIRE(dummy_from_options != nullptr);
+  CHECK(dummy_from_options->ghost_zone_size() == 3);
+}
+
+}  // namespace
+}  // namespace Ccz4::fd

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
@@ -23,10 +23,15 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/Ccz4/ATilde.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/Ccz4/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/Ccz4/Christoffel.hpp"
 #include "Evolution/Systems/Ccz4/DerivChristoffel.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/DummyReconstructor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Evolution/Systems/Ccz4/System.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
 #include "Framework/TestCreation.hpp"
@@ -46,12 +51,25 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
+namespace Ccz4::fd {
 namespace {
+struct DummyEvolutionMetaVars {
+  struct SubcellOptions {
+    static constexpr bool subcell_enabled_at_external_boundary = false;
+  };
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<BoundaryConditions::BoundaryCondition,
+                             BoundaryConditions::standard_boundary_conditions>>;
+  };
+};
+
 using Affine = domain::CoordinateMaps::Affine;
 using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
 // Test second order CCZ4 in Minkowski spacetime
-void test_minkowski() {
+void test_minkowski(const bool evolve_lapse_and_shift) {
   // set up subcell grid
   const size_t SpatialDim = 3;
   using FrameType = Frame::Inertial;
@@ -100,38 +118,50 @@ void test_minkowski() {
   const auto evolved_vars = TestHelpers::Ccz4::fd::detail::Minkowski::
       compute_prim_solution_for_Minkowski(x);
 
-  // get other parameters
-  const double f = 0.1;
-  const double kappa_1 = 0.1;
-  const double kappa_2 = 0.3;
-  const double kappa_3 = 0.4;
-
   const DataVector used_for_size =
       DataVector(subcell_mesh.number_of_grid_points(),
                  std::numeric_limits<double>::signaling_NaN());
   const auto k_0 = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
   const auto eta = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  const auto upper_spatial_z4_constraint =
+      make_with_value<tnsr::I<DataVector, 3>>(
+          used_for_size, std::numeric_limits<double>::signaling_NaN());
+
+  const Ccz4::fd::DummyReconstructor recons{};
+
+  const double kappa_1 = 0.1;
+  const double kappa_2 = 0.2;
+  const double kappa_3 = 0.3;
 
   // put needed quantities into databox
   using dt_variables_tag =
       db::add_tag_prefix<::Tags::dt, Ccz4::fd::System::variables_tag>;
 
   auto box = db::create<db::AddSimpleTags<
-      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
-      ::Ccz4::Tags::K0<DataVector>, ::Ccz4::Tags::GammaDriverParam,
       ::Ccz4::Tags::Kappa1, ::Ccz4::Tags::Kappa2, ::Ccz4::Tags::Kappa3,
-      dt_variables_tag, evolution::dg::subcell::Tags::Mesh<SpatialDim>,
+      ::Ccz4::fd::Tags::EvolveLapseAndShift,
+      domain::Tags::Element<SpatialDim>,
+      fd::Tags::Reconstructor,
+      Parallel::Tags::MetavariablesImpl<DummyEvolutionMetaVars>,
+      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
+      ::Ccz4::Tags::K0<DataVector>,
+      ::Ccz4::Tags::SpatialZ4ConstraintUp<DataVector, 3>, dt_variables_tag,
+      evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>>>(
-      evolved_vars, eta, k_0, f, kappa_1, kappa_2, kappa_3,
+      kappa_1, kappa_2, kappa_3, evolve_lapse_and_shift, element,
+      std::unique_ptr<Ccz4::fd::Reconstructor>{
+          std::make_unique<std::decay_t<decltype(recons)>>(recons)},
+      DummyEvolutionMetaVars{}, evolved_vars, eta, k_0,
+      upper_spatial_z4_constraint,
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
       all_ghost_data);
 
   // Check that all time derivatives are 0
-  ::Ccz4::fd::apply<SpatialDim>(make_not_null(&box));
+  ::Ccz4::fd::SoTimeDerivative::apply(make_not_null(&box));
   const auto zero = DataVector(used_for_size.size(), 0.0);
 
   tmpl::for_each<Ccz4::fd::System::variables_tag_list>(
@@ -149,9 +179,8 @@ void test_minkowski() {
 // evolve_shift: whether or not to evolve the shift (always true for SO-CCZ4);
 // slicing_condition_type: which slicing condition to use (always 1+log for
 // SO-CCZ4)
-void test_kerrschild() {
-  const Ccz4::EvolveShift evolve_shift =
-      Ccz4::EvolveShift::True;  // always evolve shift in SO-CCZ4; this is s=1.
+void test_kerrschild(const bool evolve_lapse_and_shift) {
+  const bool evolve_shift = evolve_lapse_and_shift;
   const Ccz4::SlicingConditionType slicing_condition_type =
       Ccz4::SlicingConditionType::Log;  // always use 1+log slicing
 
@@ -195,13 +224,10 @@ void test_kerrschild() {
   const std::array<double, SpatialDim> center{{0.2, 0.5, 0.1}};
   const gr::Solutions::KerrSchild solution(mass, spin, center);
 
-  const double f = 0.75;
-  const double kappa_1 = 0.1;
-  const double kappa_2 = 0.3;
-  const double kappa_3 = 0.4;
-
   // Arbitrary time for time-independent solution.
   const double t = std::numeric_limits<double>::signaling_NaN();
+
+  const double f = Ccz4::fd::System::f;
 
   const DirectionalIdMap<SpatialDim, evolution::dg::subcell::GhostData>
       all_ghost_data =
@@ -230,27 +256,45 @@ void test_kerrschild() {
       d_lapse, slicing_condition,
       get<::Ccz4::Tags::Theta<DataVector>>(evolved_vars),
       get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars));
+  const auto upper_spatial_z4_constraint =
+      make_with_value<tnsr::I<DataVector, 3>>(
+          used_for_size, std::numeric_limits<double>::signaling_NaN());
+
+  const Ccz4::fd::DummyReconstructor recons{};
+
+  const double kappa_1 = 0.1;
+  const double kappa_2 = 0.2;
+  const double kappa_3 = 0.3;
 
   // put needed quantities into databox
   using dt_variables_tag =
       db::add_tag_prefix<::Tags::dt, Ccz4::fd::System::variables_tag>;
 
   auto box = db::create<db::AddSimpleTags<
-      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
-      ::Ccz4::Tags::K0<DataVector>, ::Ccz4::Tags::GammaDriverParam,
       ::Ccz4::Tags::Kappa1, ::Ccz4::Tags::Kappa2, ::Ccz4::Tags::Kappa3,
-      dt_variables_tag, evolution::dg::subcell::Tags::Mesh<SpatialDim>,
+      ::Ccz4::fd::Tags::EvolveLapseAndShift,
+      domain::Tags::Element<SpatialDim>,
+      fd::Tags::Reconstructor,
+      Parallel::Tags::MetavariablesImpl<DummyEvolutionMetaVars>,
+      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
+      ::Ccz4::Tags::K0<DataVector>,
+      ::Ccz4::Tags::SpatialZ4ConstraintUp<DataVector, 3>, dt_variables_tag,
+      evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>>>(
-      evolved_vars, eta, k_0, f, kappa_1, kappa_2, kappa_3,
+      kappa_1, kappa_2, kappa_3, evolve_lapse_and_shift, element,
+      std::unique_ptr<Ccz4::fd::Reconstructor>{
+          std::make_unique<std::decay_t<decltype(recons)>>(recons)},
+      DummyEvolutionMetaVars{}, evolved_vars, eta, k_0,
+      upper_spatial_z4_constraint,
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
       all_ghost_data);
 
   // Check that all time derivatives are 0
-  ::Ccz4::fd::apply<SpatialDim>(make_not_null(&box));
+  ::Ccz4::fd::SoTimeDerivative::apply(make_not_null(&box));
   const auto zero = DataVector(used_for_size.size(), 0.0);
   const Approx custom_approx =
       Approx::custom().epsilon(1.0e-9).scale(*std::max_element(
@@ -289,7 +333,8 @@ void test_kerrschild() {
 // Test second-order CCZ4 in a GaugePlaneWave spacetime
 void test_gauge_plane_wave(
     const std::array<double, 3>& wave_vector,
-    std::unique_ptr<MathFunction<1, Frame::Inertial>> profile, const double t) {
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> profile, const double t,
+    const bool evolve_lapse_and_shift) {
   // set up subcell grid
   const size_t SpatialDim = 3;
   using FrameType = Frame::Inertial;
@@ -363,37 +408,49 @@ void test_gauge_plane_wave(
       compute_prim_solution_for_GaugePlaneWave(x, t, solution,
                                                intermediate_sol);
 
-  // get other parameters
-  const double f = 0.75;
-  const double kappa_1 = 0.1;
-  const double kappa_2 = 0.3;
-  const double kappa_3 = 0.4;
-
   const auto& k_0 =
       get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars);
 
   const auto eta = make_with_value<Scalar<DataVector>>(used_for_size, 0.0);
+  const auto upper_spatial_z4_constraint =
+      make_with_value<tnsr::I<DataVector, 3>>(
+          used_for_size, std::numeric_limits<double>::signaling_NaN());
+
+  const Ccz4::fd::DummyReconstructor recons{};
+
+  const double kappa_1 = 0.1;
+  const double kappa_2 = 0.2;
+  const double kappa_3 = 0.3;
 
   // put needed quantities into databox
   using dt_variables_tag =
       db::add_tag_prefix<::Tags::dt, Ccz4::fd::System::variables_tag>;
 
   auto box = db::create<db::AddSimpleTags<
-      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
-      ::Ccz4::Tags::K0<DataVector>, ::Ccz4::Tags::GammaDriverParam,
       ::Ccz4::Tags::Kappa1, ::Ccz4::Tags::Kappa2, ::Ccz4::Tags::Kappa3,
-      dt_variables_tag, evolution::dg::subcell::Tags::Mesh<SpatialDim>,
+      ::Ccz4::fd::Tags::EvolveLapseAndShift,
+      domain::Tags::Element<SpatialDim>,
+      fd::Tags::Reconstructor,
+      Parallel::Tags::MetavariablesImpl<DummyEvolutionMetaVars>,
+      Ccz4::fd::System::variables_tag, ::Ccz4::Tags::Eta<DataVector>,
+      ::Ccz4::Tags::K0<DataVector>,
+      ::Ccz4::Tags::SpatialZ4ConstraintUp<DataVector, 3>, dt_variables_tag,
+      evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>>>(
-      evolved_vars, eta, k_0, f, kappa_1, kappa_2, kappa_3,
+      kappa_1, kappa_2, kappa_3, evolve_lapse_and_shift, element,
+      std::unique_ptr<Ccz4::fd::Reconstructor>{
+          std::make_unique<std::decay_t<decltype(recons)>>(recons)},
+      DummyEvolutionMetaVars{}, evolved_vars, eta, k_0,
+      upper_spatial_z4_constraint,
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
       all_ghost_data);
 
   // Check all time derivatives
-  ::Ccz4::fd::apply<SpatialDim>(make_not_null(&box));
+  ::Ccz4::fd::SoTimeDerivative::apply(make_not_null(&box));
 
   const Approx custom_approx =
       Approx::custom().epsilon(1.0e-9).scale(*std::max_element(
@@ -428,12 +485,16 @@ void test_gauge_plane_wave(
   const auto& dt_lapse_actual =
       get<::Tags::dt<gr::Tags::Lapse<DataVector>>>(box);
   const auto& d_lapse =
-      get<Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<SpatialDim>,
-                      FrameType>>(gauge_plane_wave_vars);
-  const auto dt_lapse_expected = TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
+      get<::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<SpatialDim>,
+                        FrameType>>(gauge_plane_wave_vars);
+  auto dt_lapse_expected = make_with_value<Scalar<DataVector>>(
+          used_for_size, 0.0);
+  if (evolve_lapse_and_shift) {
+      dt_lapse_expected = TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
       get_dt_lapse_gauge_plane_wave(
           d_lapse, get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
                        gauge_plane_wave_vars));
+  }
   CHECK_ITERABLE_CUSTOM_APPROX(dt_lapse_actual, dt_lapse_expected,
                                custom_approx);
 
@@ -441,14 +502,18 @@ void test_gauge_plane_wave(
   const auto& dt_shift_actual =
       get<::Tags::dt<gr::Tags::Shift<DataVector, SpatialDim>>>(box);
   const auto& d_shift =
-      get<Tags::deriv<gr::Tags::Shift<DataVector, SpatialDim, FrameType>,
-                      tmpl::size_t<SpatialDim>, FrameType>>(
+      get<::Tags::deriv<gr::Tags::Shift<DataVector, SpatialDim, FrameType>,
+                        tmpl::size_t<SpatialDim>, FrameType>>(
           gauge_plane_wave_vars);
-  const auto dt_shift_expected = TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
-      get_dt_shift_gauge_plane_wave(
-          get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
-              gauge_plane_wave_vars),
-          d_shift);
+  auto dt_shift_expected = make_with_value<tnsr::I<DataVector, 3>>(
+        used_for_size, 0.0);
+  if (evolve_lapse_and_shift) {
+    dt_shift_expected = TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
+        get_dt_shift_gauge_plane_wave(
+            get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
+                gauge_plane_wave_vars),
+            d_shift);
+  }
   CHECK_ITERABLE_CUSTOM_APPROX(dt_shift_actual, dt_shift_expected,
                                custom_approx);
 
@@ -530,8 +595,8 @@ void test_gauge_plane_wave(
       TestHelpers::Ccz4::fd::detail::GaugePlaneWave::
           get_dt_d_spatial_metric_gauge_plane_wave(k_tnsr, du_du_h, omega);
   const auto& d_spatial_metric =
-      get<Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
-                      tmpl::size_t<SpatialDim>, FrameType>>(
+      get<::Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
+                        tmpl::size_t<SpatialDim>, FrameType>>(
           gauge_plane_wave_vars);
   const auto d_conformal_factor = TestHelpers::Ccz4::fd::detail::
       GaugePlaneWave::get_d_conformal_factor_gauge_plane_wave(
@@ -553,8 +618,8 @@ void test_gauge_plane_wave(
           det_spatial_metric,
           get<gr::Tags::InverseSpatialMetric<DataVector, SpatialDim,
                                              FrameType>>(gauge_plane_wave_vars),
-          get<Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
-                          tmpl::size_t<SpatialDim>, FrameType>>(
+          get<::Tags::deriv<gr::Tags::SpatialMetric<DataVector, SpatialDim>,
+                            tmpl::size_t<SpatialDim>, FrameType>>(
               gauge_plane_wave_vars));
   const tnsr::ijj<DataVector, SpatialDim, FrameType>
       d_conformal_spatial_metric = TestHelpers::Ccz4::fd::detail::KerrSchild::
@@ -569,30 +634,34 @@ void test_gauge_plane_wave(
                                custom_approx);
 
   // eq 12i
-  const tnsr::ijj<DataVector, SpatialDim, FrameType> field_d =
-      TestHelpers::Ccz4::fd::detail::KerrSchild::get_field_d(
-          d_conformal_spatial_metric);
-  const tnsr::iJJ<DataVector, SpatialDim, FrameType> field_d_up =
-      TestHelpers::Ccz4::fd::detail::GaugePlaneWave::get_field_d_up(
-          inverse_conformal_spatial_metric, field_d);
-  const auto d_field_d = partial_derivative(
-      field_d, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
-  const auto d_conformal_christoffel_second_kind =
-      ::Ccz4::deriv_conformal_christoffel_second_kind(
-          inverse_conformal_spatial_metric, field_d, d_field_d, field_d_up);
-  const auto conformal_christoffel_second_kind =
-      ::Ccz4::conformal_christoffel_second_kind(
-          inverse_conformal_spatial_metric, field_d);
-  const auto d_gamma_hat =
-      ::Ccz4::deriv_contracted_conformal_christoffel_second_kind(
-          inverse_conformal_spatial_metric, field_d_up,
-          conformal_christoffel_second_kind,
-          d_conformal_christoffel_second_kind);
-  const tnsr::I<DataVector, SpatialDim, FrameType> dt_b_expected = TestHelpers::
-      Ccz4::fd::detail::GaugePlaneWave::get_dt_b_gauge_plane_wave_expected(
-          dt_gamma_hat_expected, d_gamma_hat,
-          get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
-              gauge_plane_wave_vars));
+  auto dt_b_expected =
+        make_with_value<tnsr::I<DataVector, 3>>(used_for_size, 0.0);
+  if (evolve_lapse_and_shift) {
+    const tnsr::ijj<DataVector, SpatialDim, FrameType> field_d =
+        TestHelpers::Ccz4::fd::detail::KerrSchild::get_field_d(
+            d_conformal_spatial_metric);
+    const tnsr::iJJ<DataVector, SpatialDim, FrameType> field_d_up =
+        TestHelpers::Ccz4::fd::detail::GaugePlaneWave::get_field_d_up(
+            inverse_conformal_spatial_metric, field_d);
+    const auto d_field_d = partial_derivative(
+        field_d, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+    const auto d_conformal_christoffel_second_kind =
+        ::Ccz4::deriv_conformal_christoffel_second_kind(
+            inverse_conformal_spatial_metric, field_d, d_field_d, field_d_up);
+    const auto conformal_christoffel_second_kind =
+        ::Ccz4::conformal_christoffel_second_kind(
+            inverse_conformal_spatial_metric, field_d);
+    const auto d_gamma_hat =
+        ::Ccz4::deriv_contracted_conformal_christoffel_second_kind(
+            inverse_conformal_spatial_metric, field_d_up,
+            conformal_christoffel_second_kind,
+            d_conformal_christoffel_second_kind);
+    dt_b_expected = TestHelpers::
+        Ccz4::fd::detail::GaugePlaneWave::get_dt_b_gauge_plane_wave_expected(
+            dt_gamma_hat_expected, d_gamma_hat,
+            get<gr::Tags::Shift<DataVector, SpatialDim, FrameType>>(
+                gauge_plane_wave_vars));
+  }
   const auto& dt_b_actual =
       get<::Tags::dt<::Ccz4::Tags::AuxiliaryShiftB<DataVector, SpatialDim>>>(
           box);
@@ -601,23 +670,31 @@ void test_gauge_plane_wave(
 
 // Test first order CCZ4 against Minkowski and KerrSchild
 void test() {
-  test_minkowski();
-  test_kerrschild();
+  test_minkowski(true);
+  test_kerrschild(true);
+  test_minkowski(false);
+  test_kerrschild(false);
 
   const std::array<double, 3> k{{0.5, 0.1, -0.2}};
   test_gauge_plane_wave(
       k,
       std::make_unique<MathFunctions::Sinusoid<1, Frame::Inertial>>(0.6, 0.8,
                                                                     2.0),
-      0.4);
+      0.4, true);
+  test_gauge_plane_wave(
+      k,
+      std::make_unique<MathFunctions::Sinusoid<1, Frame::Inertial>>(0.6, 0.8,
+                                                                    2.0),
+      0.4, false);
 }
 }  // namespace
 
 // The tests run relatively long as we use much higher spatial
 // resolution (~8000 grid points per element) to reach a relative
 // error of 1e-9.
-// [[TimeOut, 20]]
+// [[TimeOut, 40]]
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.TimeDerivative",
                   "[Unit][Evolution]") {
   test();
 }
+}  // namespace Ccz4::fd

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Tags.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace {
+struct ArbitraryFrame;
+
+void test_simple_tags() {
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::Reconstructor>(
+      "Reconstructor");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::EvolveLapseAndShift>(
+      "EvolveLapseAndShift");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::ConstrainedEvolution>(
+      "ConstrainedEvolution");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::KreissOligerEpsilon>(
+      "KreissOligerEpsilon");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.fd.Ccz4.Tags", "[Unit][Evolution]") {
+  test_simple_tags();
+}
+}  // namespace

--- a/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
@@ -206,8 +206,6 @@ compute_prim_solution_for_second_deriv(
 }
 
 inline Element<3> set_element(const bool skip_last = false) {
-  /* I don't know what this is doing; it seems to set up */
-  /* some element adjacency relations */
   DirectionMap<3, Neighbors<3>> neighbors{};
   for (size_t i = 0; i < 6; ++i) {
     if (skip_last and i == 5) {
@@ -221,11 +219,9 @@ inline Element<3> set_element(const bool skip_last = false) {
 
 inline tnsr::I<DataVector, 3, Frame::ElementLogical> set_logical_coordinates(
     const Mesh<3>& subcell_mesh) {
-  /* this computes the positions of the grid points in [-1,1]^3 */
   auto logical_coords = logical_coordinates(subcell_mesh);
   // Make the logical coordinates different in each direction
   for (size_t i = 1; i < 3; ++i) {
-    /* this seems to shift all grid points in [-1,1]^3 by some number */
     logical_coords.get(i) += static_cast<double>(4 * i);
   }
   return logical_coords;
@@ -373,12 +369,13 @@ tnsr::ijj<DataVector, SpatialDim, FrameType> get_field_d(
 //   0 = s f b + s \beta^k \partial_k \beta^i
 template <size_t SpatialDim, typename FrameType>
 tnsr::I<DataVector, SpatialDim, FrameType> get_b_kerr(
-    const ::Ccz4::EvolveShift evolve_shift,
+    const bool evolve_shift,
     const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_shift,
     const double f) {
   tnsr::I<DataVector, SpatialDim, FrameType> b(get<0>(shift));
-  if (not static_cast<bool>(evolve_shift)) {
+  if (not evolve_shift or
+      not ::Ccz4::fd::System::shifting_shift) {
     // s == 0
     // pick b = 0
     for (auto& component : b) {
@@ -479,21 +476,22 @@ Scalar<DataVector> get_k_0_kerr(
 // \partial_t b will not be 0 for KerrSchild if evolve_shift == true
 template <size_t SpatialDim, typename FrameType>
 tnsr::I<DataVector, SpatialDim, FrameType> get_dt_b_kerr_expected(
-    const ::Ccz4::EvolveShift evolve_shift, const Scalar<DataVector>& eta,
+    const bool evolve_shift, const Scalar<DataVector>& eta,
     const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_gamma_hat,
     const tnsr::I<DataVector, SpatialDim, FrameType>& b,
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_b) {
   tnsr::I<DataVector, SpatialDim, FrameType> dt_b_kerr_expected(get(eta));
-  if (static_cast<bool>(evolve_shift)) {
+  if (evolve_shift) {
     // s == 1
     for (size_t i = 0; i < SpatialDim; i++) {
-      dt_b_kerr_expected.get(i) = -get(eta) * b.get(i) +
-                                  shift.get(0) * d_b.get(0, i) -
-                                  shift.get(0) * d_gamma_hat.get(0, i);
-      for (size_t k = 1; k < SpatialDim; k++) {
-        dt_b_kerr_expected.get(i) +=
-            shift.get(k) * d_b.get(k, i) - shift.get(k) * d_gamma_hat.get(k, i);
+      dt_b_kerr_expected.get(i) = -get(eta) * b.get(i);
+
+      if (::Ccz4::fd::System::shifting_shift) {
+        for (size_t k = 0; k < SpatialDim; k++) {
+          dt_b_kerr_expected.get(i) += shift.get(k) * d_b.get(k, i) -
+                                       shift.get(k) * d_gamma_hat.get(k, i);
+        }
       }
     }
   } else {
@@ -509,7 +507,7 @@ inline Variables<
     ::Ccz4::fd::Tags::spacetime_reconstruction_tags>
 compute_prim_solution_for_KerrSchild(
     const tnsr::I<DataVector, 3, Frame::Inertial>& coords, const double t,
-    const double f, const ::Ccz4::EvolveShift& evolve_shift,
+    const double f, const bool evolve_shift,
     const gr::Solutions::KerrSchild& solution) {
   // Evaluate solution
   const auto kerrschild_vars = solution.variables(
@@ -877,9 +875,12 @@ template <size_t SpatialDim, typename FrameType>
 tnsr::I<DataVector, SpatialDim, FrameType> get_dt_shift_gauge_plane_wave(
     const tnsr::I<DataVector, SpatialDim, FrameType>& shift,
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_shift) {
-  tnsr::I<DataVector, SpatialDim, FrameType> dt_shift;
-  ::tenex::evaluate<ti::I>(make_not_null(&dt_shift),
-                           shift(ti::K) * d_shift(ti::k, ti::I));
+  auto dt_shift = make_with_value<tnsr::I<DataVector, SpatialDim, FrameType>>(
+      get<0>(shift), 0.0);
+  if (::Ccz4::fd::System::shifting_shift) {
+    ::tenex::evaluate<ti::I>(make_not_null(&dt_shift),
+                             shift(ti::K) * d_shift(ti::k, ti::I));
+  }
   return dt_shift;
 }
 
@@ -891,9 +892,12 @@ tnsr::I<DataVector, SpatialDim, FrameType> get_dt_b_gauge_plane_wave_expected(
     const tnsr::iJ<DataVector, SpatialDim, FrameType>& d_gamma_hat,
     const tnsr::I<DataVector, SpatialDim, FrameType>& shift) {
   tnsr::I<DataVector, SpatialDim, FrameType> dt_b;
-  ::tenex::evaluate<ti::I>(
-      make_not_null(&dt_b),
-      dt_gamma_hat(ti::I) - shift(ti::K) * d_gamma_hat(ti::k, ti::I));
+  ::tenex::evaluate<ti::I>(make_not_null(&dt_b), dt_gamma_hat(ti::I));
+  if (::Ccz4::fd::System::shifting_shift) {
+    ::tenex::update<ti::I>(
+        make_not_null(&dt_b),
+        dt_b(ti::I) - shift(ti::K) * d_gamma_hat(ti::k, ti::I));
+  }
   return dt_b;
 }
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Ccz4WrappedGr.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_Ccz4WrappedGr.cpp
@@ -13,6 +13,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Ccz4/ATilde.hpp"
 #include "Evolution/Systems/Ccz4/Christoffel.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -76,7 +77,8 @@ void test_ccz4_solution(
           Ccz4::Tags::ATilde<DataVector, SolutionType::volume_dim>,
           gr::Tags::TraceExtrinsicCurvature<DataVector>,
           Ccz4::Tags::Theta<DataVector>,
-          Ccz4::Tags::GammaHat<DataVector, SolutionType::volume_dim>>{});
+          Ccz4::Tags::GammaHat<DataVector, SolutionType::volume_dim>,
+          Ccz4::Tags::AuxiliaryShiftB<DataVector, SolutionType::volume_dim>>{});
 
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<DataVector, SolutionType::volume_dim>>(vars);
@@ -155,6 +157,32 @@ void test_ccz4_solution(
       contracted_conformal_christoffel_second_kind,
       (get<Ccz4::Tags::GammaHat<DataVector, SolutionType::volume_dim>>(
           wrapped_Ccz4_vars)));
+
+  const double one_over_f = 1. / ::Ccz4::fd::System::f;
+  const bool shifting_shift = ::Ccz4::fd::System::shifting_shift;
+  tnsr::I<DataVector, Ccz4::Solutions::Ccz4WrappedGr<SolutionType>::volume_dim>
+      auxiliary_shift_b;
+  const auto& shift =
+      get<gr::Tags::Shift<DataVector, SolutionType::volume_dim>>(vars);
+  using DerivShift =
+      ::Tags::deriv<gr::Tags::Shift<DataVector, SolutionType::volume_dim>,
+                    tmpl::size_t<SolutionType::volume_dim>, Frame::Inertial>;
+  const auto& d_shift = get<DerivShift>(vars);
+  const auto& dt_shift =
+      get<::Tags::dt<gr::Tags::Shift<DataVector, SolutionType::volume_dim>>>(
+          vars);
+  if (shifting_shift) {
+    ::tenex::evaluate<ti::I>(
+        make_not_null(&auxiliary_shift_b),
+        one_over_f * dt_shift(ti::I) -
+            one_over_f * shift(ti::K) * d_shift(ti::k, ti::I));
+  } else {
+    ::tenex::evaluate<ti::I>(make_not_null(&auxiliary_shift_b),
+                             one_over_f * dt_shift(ti::I));
+  }
+  CHECK(auxiliary_shift_b ==
+        get<Ccz4::Tags::AuxiliaryShiftB<DataVector, SolutionType::volume_dim>>(
+            wrapped_Ccz4_vars));
 
   // Weak test of operators == and !=
   CHECK(wrapped_solution == wrapped_solution);


### PR DESCRIPTION
## Proposed changes
Add `DirichletAnalytic` boundary condition for the second-order CCZ4 system.

**Overview of changes:**
1. `Ccz4WrappedGr` now wraps the gauge variables auxiliary `b`. This allows us to easily provide initial and boundary data for the gauge variables in the same way as for the evolved variables. But this limits us to using solutions compatible with Gamma-driver and 1+log slicing (i.e. TrumpetSchwarzschild, and other time-independent solutions if not evolving the lapse and shift). We also need to specify `Ccz4::fd::System::f` in the Gamma-driver and `Ccz4::fd::System::shifting_shift` at compile time for now to compute `b`. We will improve this in the future by separating the gauge variables from the evolved variables.

2. `src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Factory.hpp` adds the currently allowed analytic solutions for Ccz4.

3. `System.hpp` add several type aliases expected by the executable to be submitted in future PRs.

4. Other SoCcz4 parameters and options are now coded as `OptionTags` creatable from input files in `Ccz4/Tags.hpp` and `Ccz4/FiniteDifference/Tags.hpp`. The `ConstrainedEvolution` and `KreissOligerEpsilon` tags are currently just placeholders to be used in future PRs.

5. Add `Reconstructor` and `DummyReconstructor` expected in some DG-FD infrastructures. But for CCZ4 these serve to just return the ghost zone size.

6. Add `Ccz4/BoundaryConditions` directory that contains the `BoundaryCondition` base class and `DirichletAnalytic` concrete class. 

7. Add `BoundaryConditionGhostData` used to put values from the external boundary conditions into external boundary ghost cells.

8. Modify `SoTimeDerivative` to allow turning off the advective terms in Gamma-drivers (using `Ccz4::fd::System::shifting_shift`), turning off the evolution of lapse and shift entirely (using `evolve_lapse_and_shift`), and applying external boundary condition on external boundary ghost cells.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
