### PR TITLE
Add SimpleSparseMatrix.

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   Index.cpp
   IndexIterator.cpp
   LeviCivitaIterator.cpp
+  SimpleSparseMatrix.cpp
   SliceIterator.cpp
   SparseMatrixFiller.cpp
   StripeIterator.cpp
@@ -54,6 +55,7 @@ spectre_target_headers(
   MathWrapper.hpp
   Matrix.hpp
   ModalVector.hpp
+  SimpleSparseMatrix.hpp
   SliceIterator.hpp
   SliceTensorToVariables.hpp
   SliceVariables.hpp

--- a/src/DataStructures/SimpleSparseMatrix.cpp
+++ b/src/DataStructures/SimpleSparseMatrix.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/SimpleSparseMatrix.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <numeric>
+#include <vector>
+
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+
+double SimpleSparseMatrix::operator()(const size_t row_dest_index,
+                                      const size_t column_src_index) const {
+  bool found_dest = false;
+  const auto dest_it =
+      alg::find_if(row_dest_indices_,
+                   [&found_dest, row_dest_index](const size_t dest_index) {
+                     found_dest = row_dest_index == dest_index;
+                     return found_dest or row_dest_index < dest_index;
+                   });
+  if (not found_dest) {
+    return 0.0;
+  }
+  const auto dest_index =
+      static_cast<size_t>(std::distance(row_dest_indices_.begin(), dest_it));
+
+  const size_t src_index = std::accumulate(
+      num_columns_per_row_.begin(),
+      num_columns_per_row_.begin() + (dest_it - row_dest_indices_.begin()),
+      0_st);
+
+  bool found_src = false;
+  const auto src_it = std::find_if(
+      column_src_indices_.begin() +
+          static_cast<std::vector<size_t>::difference_type>(src_index),
+      column_src_indices_.begin() +
+          static_cast<std::vector<size_t>::difference_type>(
+              src_index + num_columns_per_row_[dest_index]),
+      [&found_src, column_src_index](const size_t val) {
+        found_src = column_src_index == val;
+        return found_src or column_src_index < val;
+      });
+  if (not found_src) {
+    return 0.0;
+  }
+  return matrix_elements_[static_cast<size_t>(src_it -
+                                              column_src_indices_.begin())];
+}
+
+void SimpleSparseMatrix::fill(const std::vector<SparseMatrixElement>& data) {
+  if (data.empty()) {
+    // Nothing to do.
+    return;
+  }
+
+  // Figure out number of rows with nonzero matrix elements.  Note that data has
+  // already been sorted by row.
+  size_t num_used_rows = 1;
+  for (size_t i = 1; i < data.size(); ++i) {
+    if (data[i].row_dest != data[i - 1].row_dest) {
+      ++num_used_rows;
+    }
+  }
+
+  num_columns_per_row_.resize(num_used_rows, 0);
+  row_dest_indices_.resize(num_used_rows);
+  matrix_elements_.resize(data.size());
+  column_src_indices_.resize(data.size());
+
+  // Current_row_index is the index of the current row in row_dest_indices
+  // and num_columns_per_row.
+  // Current_row_index goes from zero to num_used_rows - 1
+  size_t current_row_index = 0;
+  // current_row is the actual row number in the full matrix.
+  size_t current_row = data[0].row_dest;
+  row_dest_indices_[0] = current_row;
+  for (const auto& d : data) {
+    if (d.row_dest != current_row) {
+      ++current_row_index;
+      current_row = d.row_dest;
+      row_dest_indices_[current_row_index] = current_row;
+    }
+    ++num_columns_per_row_[current_row_index];
+  }
+  for (size_t i = 0; i < data.size(); ++i) {
+    matrix_elements_[i] = data[i].value;
+    column_src_indices_[i] = data[i].column_src;
+  }
+}
+
+template <typename T>
+void SimpleSparseMatrix::increment_multiply_on_right(
+    const gsl::not_null<T*> a, const size_t a_offset, const T& b,
+    const size_t b_offset) const {
+  if (matrix_elements_.empty()) {
+    // Nothing to do
+    return;
+  }
+
+  ASSERT(matrix_elements_.size() == column_src_indices_.size(),
+         "Size mismatch between the size of matrix_elements_: "
+             << matrix_elements_.size()
+             << " and column_src_indices_: " << column_src_indices_.size());
+  ASSERT(num_columns_per_row_.size() == row_dest_indices_.size(),
+         "Size mismatch between the size of num_columns_per_row_: "
+             << num_columns_per_row_.size()
+             << " and row_dest_indices_: " << row_dest_indices_.size());
+
+  // This particular implementation (with raw pointers and pointer
+  // arithmetic) was found in SpEC to be fastest, back when we
+  // tested several variations of this implementation with SpEC.
+  const double* mat = matrix_elements_.data();
+  const size_t* src_ind = column_src_indices_.data();
+  const size_t* num_inner = num_columns_per_row_.data();
+  const size_t* dest_ind = row_dest_indices_.data();
+
+  // num_comps_a is the number of components of 'a' that we will touch.
+  // (the matrix is sparse, so we don't touch all components of 'a')
+  size_t num_comps_a = num_columns_per_row_.size();
+  while (num_comps_a-- > 0) {
+    // num_comps_b is the number of components of 'b' that we will touch,
+    // for this component of 'a'.
+    // (the matrix is sparse, so we don't touch all components of 'b')
+    size_t num_comps_b = *num_inner;
+    std::advance(num_inner, 1);
+    double sum = 0.0;
+    while (num_comps_b-- > 0) {
+      sum += *mat * b[b_offset + *src_ind];
+      std::advance(mat, 1);
+      std::advance(src_ind, 1);
+    }
+    (*a)[a_offset + *dest_ind] += sum;
+    std::advance(dest_ind, 1);
+  }
+}
+
+// Explicit instantiations
+template void SimpleSparseMatrix::increment_multiply_on_right(
+    const gsl::not_null<std::vector<double>*> a, const size_t a_offset,
+    const std::vector<double>& b, const size_t b_offset) const;

--- a/src/DataStructures/SimpleSparseMatrix.hpp
+++ b/src/DataStructures/SimpleSparseMatrix.hpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Utilities/Gsl.hpp"
+
+/// Struct used to fill SimpleSparsematrix
+struct SparseMatrixElement {
+  SparseMatrixElement(const size_t row, const size_t column, const double val)
+      : row_dest(row), column_src(column), value(val) {}
+  size_t row_dest, column_src;
+  double value;
+};
+
+/*!
+ * \brief A simple fast sparse matrix.
+ *
+ * Supports only a limited number of operations to keep it simple:
+ * filling the matrix, accessing elements, and multiplication by
+ * a vector on the right.
+ *
+ * We use SimpleSparseMatrix because filling a Blaze sparse matrix is
+ * enormously slow. For example, here are timings for creating a
+ * rank-one TensorYlmFilter sparse matrix using SimpleSparseMatrix
+ * (column labeled "this") and using blaze::CompressedMatrix (column
+ * labeled "Blaze").  The column "Blaze-wo-blaze" is the same as the
+ * "Blaze" column (which includes timing of all the TensorYlmFilter
+ * code that doesn't explicitly depend on blaze) minus the timings of
+ * the blaze calls that 1. resize the matrix, 2. reserve elements, and
+ * 3. fill the blaze matrix.  The timings for those individual blaze
+ * calls are in subsequent columns.  Note that "Blaze-wo-blaze" is
+ * roughly equivalent to "this" in speed.  Also note that the "this"
+ * timings were done in SpEC, which uses SimpleSparseMatrix [which was
+ * ported from SpEC to SpECTRE and simplified here].
+ *
+ * l_max this Blaze Blaze-wo-blaze blaze.resize blaze.reserve blaze.fill
+ * ----------------------------------------------------------------------------
+ *  8    0ms     5ms     1ms              1ms           2ms          0ms
+ * 18    1ms   101ms     2ms             39ms          51ms          8ms
+ * 28    3ms   479ms     3ms            181ms         246ms         48ms
+ * 38    4ms  1555ms     4ms            571ms         822ms        157ms
+ * 48    5ms  3668ms     6ms           1395ms        1873ms        393ms
+ * 58    6ms  7604ms     6ms           2908ms        3855ms        832ms
+ * 68    7ms 14176ms     8ms           5416ms        7214ms       1536ms
+ * 78    8ms 24234ms     8ms           9288ms       12304ms       2632ms
+ *
+ */
+class SimpleSparseMatrix {
+ public:
+  SimpleSparseMatrix() = default;
+
+  /// Fills with data.
+  /// Normally called only by SparseMatrixFiller.
+  /// ASSUMES that data has already been sorted by row, then column.
+  void fill(const std::vector<SparseMatrixElement>& data);
+
+  /// Does a += m*b where m is the sparse matrix.
+  /// T is a container of doubles, like a std::vector<double>.
+  /// Assumes b points into contiguous storage that allows one
+  /// to access b[i] for b_offset <= i <= b_offset+max(column_indices).
+  /// Assumes a points into contiguous storage that allows one
+  /// to access a[i] for a_offset <= a <= a_offset+max(row_indices).
+  template <typename T>
+  void increment_multiply_on_right(gsl::not_null<T*> a, size_t a_offset,
+                                   const T& b, size_t b_offset) const;
+
+  /// Obtains element at (destindex,srcindex).
+  /// Slow, should not use very often in critical situations.
+  double operator()(size_t row_dest_index, size_t column_src_index) const;
+
+ private:
+  // Holds all nonzero matrix elements.
+  std::vector<double> matrix_elements_;
+  // Holds indices of all rows of the matrix that have nonzero matrix elements.
+  std::vector<size_t> row_dest_indices_;
+  // Holds the number of columns in every row that has nonzero matrix elements.
+  // row_dest_indices_ and num_columns_per_row_ have the same size (which is the
+  // number of rows with nonzero matrix elements).
+  // The sum of all the num_columns_per_row_ is the size of matrix_elements_.
+  std::vector<size_t> num_columns_per_row_;
+  // Holds the indices of all columns that have nonzero matrix elements.
+  // column_indices_ has the same size as matrix_elements_, so many
+  // of the column_src_indices_ might be repeated.
+  std::vector<size_t> column_src_indices_;
+};

--- a/src/DataStructures/SparseMatrixFiller.cpp
+++ b/src/DataStructures/SparseMatrixFiller.cpp
@@ -3,17 +3,9 @@
 
 #include "DataStructures/SparseMatrixFiller.hpp"
 
+#include "DataStructures/SimpleSparseMatrix.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-
-namespace {
-// Struct for sorting elements.
-struct SparseMatrixElement {
-  SparseMatrixElement(const size_t row, const size_t column, const double val)
-      : row_dest(row), column_src(column), value(val) {}
-  size_t row_dest, column_src;
-  double value;
-};
-}  // namespace
+#include "Utilities/Gsl.hpp"
 
 SparseMatrixFiller::SparseMatrixFiller(const size_t num_cols,
                                        const bool use_map_method)
@@ -43,11 +35,9 @@ void SparseMatrixFiller::add(const double element, const size_t dest_index,
   }
 }
 
-void SparseMatrixFiller::fill(
-    const gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>
-        matrix) const {
+void SparseMatrixFiller::fill_sparse_matrix_elements(
+    const gsl::not_null<std::vector<SparseMatrixElement>*> data) const {
   // First fill data for sorting.
-  std::vector<SparseMatrixElement> data;
   if (not use_map_method_) {
     const auto num_rows =
         static_cast<size_t>(sqrt(double(matrix_elements_.size())));
@@ -56,13 +46,13 @@ void SparseMatrixFiller::fill(
     // For this method, many elements are zero so filter them out here.
     const auto num_zeros =
         std::count(matrix_elements_.begin(), matrix_elements_.end(), 0.0);
-    data.reserve(matrix_elements_.size() - static_cast<size_t>(num_zeros));
+    data->reserve(matrix_elements_.size() - static_cast<size_t>(num_zeros));
     size_t indx = 0;
     for (size_t i_dest = 0; i_dest < num_rows; ++i_dest) {
       for (size_t j_src = 0; j_src < num_rows; ++j_src, ++indx) {
         const double element = matrix_elements_[indx];
         if (element != 0.0) {
-          data.emplace_back(i_dest, j_src, element);
+          data->emplace_back(i_dest, j_src, element);
         }
       }
     }
@@ -73,18 +63,27 @@ void SparseMatrixFiller::fill(
     ASSERT(matrix_elements_.size() == src_indices_.size(),
            "Size mismatch value " << matrix_elements_.size() << " vs src "
                                   << src_indices_.size());
-    data.reserve(matrix_elements_.size());
+    data->reserve(matrix_elements_.size());
     for (size_t i = 0; i < dest_indices_.size(); ++i) {
-      data.emplace_back(dest_indices_[i], src_indices_[i], matrix_elements_[i]);
+      data->emplace_back(dest_indices_[i], src_indices_[i],
+                         matrix_elements_[i]);
     }
   }
 
   // Now sort the data by row and column, so we can fill in required order.
-  std::sort(data.begin(), data.end(),
+  std::sort(data->begin(), data->end(),
             [](const SparseMatrixElement& a, const SparseMatrixElement& b) {
               return a.row_dest == b.row_dest ? a.column_src < b.column_src
                                               : a.row_dest < b.row_dest;
             });
+}
+
+void SparseMatrixFiller::fill(
+    const gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>
+        matrix) const {
+  // fill the elements and sort them.
+  std::vector<SparseMatrixElement> data;
+  fill_sparse_matrix_elements(make_not_null(&data));
 
   // Fill the matrix.
   // Do this by reserving a size, and appending elements row by row
@@ -106,4 +105,13 @@ void SparseMatrixFiller::fill(
   while (current_row < num_rows_) {
     matrix->finalize(current_row++);
   }
+}
+
+void SparseMatrixFiller::fill(
+    const gsl::not_null<SimpleSparseMatrix*> matrix) const {
+  // fill the elements and sort them.
+  std::vector<SparseMatrixElement> data;
+  fill_sparse_matrix_elements(make_not_null(&data));
+  // Now fill.
+  matrix->fill(data);
 }

--- a/src/DataStructures/SparseMatrixFiller.hpp
+++ b/src/DataStructures/SparseMatrixFiller.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/SimpleSparseMatrix.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -106,7 +107,12 @@ class SparseMatrixFiller {
   void fill(gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>
                 matrix) const;
 
+  /// Fills a SimpleSparseMatrix.
+  void fill(gsl::not_null<SimpleSparseMatrix*> matrix) const;
+
  private:
+  void fill_sparse_matrix_elements(
+      gsl::not_null<std::vector<SparseMatrixElement>*> data) const;
   size_t num_rows_{0}, num_cols_{0};
   bool use_map_method_{true};
   std::vector<double> matrix_elements_{};

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LIBRARY_SOURCES
   Test_MoreComplexDiagonalModalOperatorMath.cpp
   Test_MoreDiagonalModalOperatorMath.cpp
   Test_NonZeroStaticSizeVector.cpp
+  Test_SimpleSparseMatrix.cpp
   Test_SliceIterator.cpp
   Test_SliceTensorToVariables.cpp
   Test_SliceVariables.cpp

--- a/tests/Unit/DataStructures/Test_SimpleSparseMatrix.cpp
+++ b/tests/Unit/DataStructures/Test_SimpleSparseMatrix.cpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/SimpleSparseMatrix.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void test_simple_sparse_matrix() {
+  SimpleSparseMatrix A;
+
+  // Important that these are emplaced_back sorted by row.
+  // Otherwise we should use SparseMatrixFiller to fill the matrices.
+  std::vector<SparseMatrixElement> elements{
+      {0, 0, 4.0}, {0, 3, 3.0}, {1, 3, 6.0}, {1, 5, 1.0},
+      {2, 2, 7.0}, {4, 3, 3.0}, {4, 5, 5.0}};
+
+  A.fill(elements);
+
+  // Check that elements are filled correctly and that
+  // SimpleSparseMatrix indexing is working.
+  for (size_t row = 0; row < 5; ++row) {
+    for (size_t column = 0; column < 5; ++column) {
+      const auto it =
+          alg::find_if(elements, [row, column](const SparseMatrixElement& t) {
+            return t.row_dest == row and t.column_src == column;
+          });
+      if (it != elements.end()) {
+        CHECK(A(row, column) == it->value);
+      } else {
+        CHECK(A(row, column) == 0.0);
+      }
+    }
+  }
+
+  // Create vector x
+  const std::vector<double> x{2.0, 3.0, 4.0, 5.0, 6.0, 7.0};
+
+  // Create vector y = Ax
+  const std::vector<double> y{23.0, 37.0, 28.0, 0.0, 50.0};
+
+  std::vector<double> ytest(5, 0);
+  A.increment_multiply_on_right(make_not_null(&ytest), 0, x, 0);
+
+  for (size_t i = 0; i < ytest.size(); ++i) {
+    CHECK(y[i] == approx(ytest[i]));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.SimpleSparseMatrix",
+                  "[DataStructures][Unit]") {
+  test_simple_sparse_matrix();
+}

--- a/tests/Unit/DataStructures/Test_SparseMatrixFiller.cpp
+++ b/tests/Unit/DataStructures/Test_SparseMatrixFiller.cpp
@@ -10,6 +10,8 @@
 #include "Utilities/Gsl.hpp"
 
 namespace {
+
+template <typename SparseMatrixType>
 void test_sparse_matrix_filler(const bool use_map_method) {
   const size_t num_cols = 6;
 
@@ -28,13 +30,16 @@ void test_sparse_matrix_filler(const bool use_map_method) {
   filler.add(3.0, 4, 3);
   filler.add(7.0, 0, 3);  // This element is repeated! Important for test.
 
-  blaze::CompressedMatrix<double, blaze::rowMajor> matrix;
+  SparseMatrixType matrix;
   filler.fill(make_not_null(&matrix));
 
-  // Matrix is square so number of rows and columns is the same.
-  CHECK(matrix.rows() == num_cols);
-  CHECK(matrix.columns() == num_cols);
-  CHECK(size(matrix) == num_cols * num_cols);
+  if constexpr (not std::is_same_v<SparseMatrixType, SimpleSparseMatrix>) {
+    // Matrix is square so number of rows and columns is the same.
+    // SimpleSparseMatrix doesn't have rows, columns, or size member fns.
+    CHECK(matrix.rows() == num_cols);
+    CHECK(matrix.columns() == num_cols);
+    CHECK(size(matrix) == num_cols * num_cols);
+  }
 
   CHECK(matrix(0, 0) == 4.0);
   CHECK(matrix(1, 3) == 8.0);
@@ -76,7 +81,8 @@ void test_sparse_matrix_filler(const bool use_map_method) {
   CHECK(matrix(5, 5) == 0.0);
 }
 
-// This test touches some edge cases the other tests do not.
+// This test touches some edge cases for Blaze matrices
+// that the other tests do not.
 void test_sparse_matrix_filler_last_row_filled(const bool use_map_method) {
   const size_t num_cols = 3;
 
@@ -110,7 +116,8 @@ void test_sparse_matrix_filler_last_row_filled(const bool use_map_method) {
   CHECK(matrix(0, 2) == 0.0);
 }
 
-// This test touches some edge cases the other tests do not.
+// This test touches some edge cases for Blaze matrices
+// that the other tests do not.
 void test_sparse_matrix_filler_first_row_empty(const bool use_map_method) {
   const size_t num_cols = 3;
 
@@ -147,8 +154,12 @@ void test_sparse_matrix_filler_first_row_empty(const bool use_map_method) {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.SparseMatrixFiller",
                   "[DataStructures][Unit]") {
-  test_sparse_matrix_filler(true);
-  test_sparse_matrix_filler(false);
+  test_sparse_matrix_filler<SimpleSparseMatrix>(true);
+  test_sparse_matrix_filler<SimpleSparseMatrix>(false);
+  test_sparse_matrix_filler<blaze::CompressedMatrix<double, blaze::rowMajor>>(
+      true);
+  test_sparse_matrix_filler<blaze::CompressedMatrix<double, blaze::rowMajor>>(
+      false);
   test_sparse_matrix_filler_last_row_filled(true);
   test_sparse_matrix_filler_last_row_filled(false);
   test_sparse_matrix_filler_first_row_empty(true);


### PR DESCRIPTION
This is a simple sparse matrix class that supports vector-multiplication from the right and not much else.

Also, SparseMatrixFiller can now fill a SimpleSparseMatrix.
SparseMatrixFiller (and its test) still can fill a blaze::CompressedMatrix

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
