### PR TITLE
MinusLaplacian preconditioner: support complex numbers

### DIFF
--- a/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
+++ b/src/Elliptic/SubdomainPreconditioners/MinusLaplacian.hpp
@@ -85,6 +85,10 @@ struct MinusLaplacian {
  * combination of element face and boundary-condition type among the tensor
  * components.
  *
+ * \par Complex variables
+ * This preconditioner can also be applied to complex variables, in which case
+ * the Laplacian just applies to the real and imaginary part separately.
+ *
  * \tparam Dim Spatial dimension
  * \tparam OptionsGroup The options group identifying the
  * `LinearSolver::Schwarz::Schwarz` solver that defines the subdomain geometry.
@@ -421,13 +425,31 @@ void assign_component(
         lhs,
     const ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
         Dim, RhsTagsList>& rhs,
-    const size_t lhs_component, const size_t rhs_component) {
+    const size_t lhs_component, const size_t rhs_component,
+    // Use real or imaginary part of the lhs or rhs complex value. This is used
+    // to apply the Laplacian to the real or imaginary part separately.
+    const bool lhs_imag = false, const bool rhs_imag = false) {
+  using LhsValueType =
+      typename ::LinearSolver::Schwarz::ElementCenteredSubdomainData<
+          Dim, LhsTagsList>::value_type;
   // Possible optimization: Once we have non-owning Variables we can use a view
   // into the rhs here instead of copying.
   const size_t num_points_element = rhs.element_data.number_of_grid_points();
   for (size_t i = 0; i < num_points_element; ++i) {
-    lhs->element_data.data()[lhs_component * num_points_element + i] =
+    auto& lhs_i =
+        lhs->element_data.data()[lhs_component * num_points_element + i];
+    const auto& rhs_i =
         rhs.element_data.data()[rhs_component * num_points_element + i];
+    const double rhs_i_fundamental = rhs_imag ? imag(rhs_i) : real(rhs_i);
+    if constexpr (std::is_same_v<LhsValueType, std::complex<double>>) {
+      if (lhs_imag) {
+        lhs_i.imag(rhs_i_fundamental);
+      } else {
+        lhs_i.real(rhs_i_fundamental);
+      }
+    } else {
+      lhs_i = rhs_i_fundamental;
+    }
   }
   for (const auto& [overlap_id, rhs_data] : rhs.overlap_data) {
     const size_t num_points_overlap = rhs_data.number_of_grid_points();
@@ -436,8 +458,19 @@ void assign_component(
     // iteration of the loop below.
     auto& lhs_vars = lhs->overlap_data[overlap_id];
     for (size_t i = 0; i < num_points_overlap; ++i) {
-      lhs_vars.data()[lhs_component * num_points_overlap + i] =
+      auto& lhs_i = lhs_vars.data()[lhs_component * num_points_overlap + i];
+      const auto& rhs_i =
           rhs_data.data()[rhs_component * num_points_overlap + i];
+      const double rhs_i_fundamental = rhs_imag ? imag(rhs_i) : real(rhs_i);
+      if constexpr (std::is_same_v<LhsValueType, std::complex<double>>) {
+        if (lhs_imag) {
+          lhs_i.imag(rhs_i_fundamental);
+        } else {
+          lhs_i.real(rhs_i_fundamental);
+        }
+      } else {
+        lhs_i = rhs_i_fundamental;
+      }
     }
   }
 }
@@ -469,17 +502,31 @@ MinusLaplacian<Dim, OptionsGroup, Solver, LinearSolverRegistrars>::solve(
                         "component), but got "
                      << bc_signatures.size() << ".");
   // Possible optimization: elide when num_components is 1
+  using ValueType = typename VarsType::value_type;
+  constexpr auto complex_components = []() {
+    if constexpr (std::is_same_v<ValueType, std::complex<double>>) {
+      return std::array<bool, 2>{{false, true}};
+    } else {
+      return std::array<bool, 1>{{false}};
+    }
+  }();
   for (size_t component = 0; component < num_components; ++component) {
-    detail::assign_component(make_not_null(&source_), source, 0, component);
-    detail::assign_component(make_not_null(&initial_guess_in_solution_out_),
-                             *initial_guess_in_solution_out, 0, component);
     const auto& [solver, boundary_conditions] =
         get_cached_solver_and_boundary_conditions(bc_signatures, component);
-    solver.solve(make_not_null(&initial_guess_in_solution_out_),
-                 subdomain_operator_, source_,
-                 std::forward_as_tuple(box, boundary_conditions));
-    detail::assign_component(initial_guess_in_solution_out,
-                             initial_guess_in_solution_out_, component, 0);
+    // Solve real and imaginary parts separately, if applicable
+    for (const bool imag_component : complex_components) {
+      detail::assign_component(make_not_null(&source_), source, 0, component,
+                               false, imag_component);
+      detail::assign_component(make_not_null(&initial_guess_in_solution_out_),
+                               *initial_guess_in_solution_out, 0, component,
+                               false, imag_component);
+      solver.solve(make_not_null(&initial_guess_in_solution_out_),
+                   subdomain_operator_, source_,
+                   std::forward_as_tuple(box, boundary_conditions));
+      detail::assign_component(initial_guess_in_solution_out,
+                               initial_guess_in_solution_out_, component, 0,
+                               imag_component, false);
+    }
   }
   return {0, 0};
 }

--- a/src/NumericalAlgorithms/LinearSolver/BuildMatrix.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/BuildMatrix.hpp
@@ -91,6 +91,10 @@ void build_matrix(const gsl::not_null<MatrixType*> matrix,
     }
     ++i;
   }
+  ASSERT(i == matrix->columns(), "Incomplete matrix. Expected "
+                                     << matrix->columns()
+                                     << " columns, but only filled " << i
+                                     << " columns.");
 }
 
 }  // namespace LinearSolver::Serial

--- a/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
+++ b/tests/Unit/Elliptic/SubdomainPreconditioners/Test_MinusLaplacian.cpp
@@ -36,12 +36,13 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
+template <typename DataType>
 struct ScalarFieldTag : db::SimpleTag {
-  using type = Scalar<DataVector>;
+  using type = Scalar<DataType>;
 };
-template <size_t Dim>
+template <typename DataType, size_t Dim>
 struct VectorFieldTag : db::SimpleTag {
-  using type = tnsr::I<DataVector, Dim>;
+  using type = tnsr::I<DataType, Dim>;
 };
 template <size_t Dim>
 using PoissonSubdomainData =
@@ -146,13 +147,18 @@ struct TestSolver {
 template <size_t Dim, typename FullData, typename Tag>
 void check_component(const PoissonSubdomainData<Dim>& poisson_data,
                      const FullData& expected_data, Tag /*meta*/,
-                     const size_t component) {
+                     const size_t component, const bool check_imag = false) {
+  const auto& expected_element_data =
+      get<std::decay_t<Tag>>(expected_data.element_data)[component];
   CHECK(get(get<Poisson::Tags::Field<DataVector>>(poisson_data.element_data)) ==
-        get<std::decay_t<Tag>>(expected_data.element_data)[component]);
+        (check_imag ? DataVector(imag(expected_element_data))
+                    : DataVector(real(expected_element_data))));
   for (const auto& [overlap_id, data] : expected_data.overlap_data) {
+    const auto& expected_overlap_data = get<std::decay_t<Tag>>(data)[component];
     CHECK(get(get<Poisson::Tags::Field<DataVector>>(
               poisson_data.overlap_data.at(overlap_id))) ==
-          get<std::decay_t<Tag>>(data)[component]);
+          (check_imag ? DataVector(imag(expected_overlap_data))
+                      : DataVector(real(expected_overlap_data))));
   }
 }
 
@@ -313,7 +319,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
     const NoSuchType linear_operator{};
     // Manufacture a source with multiple tensors
     using SubdomainData = LinearSolver::Schwarz::ElementCenteredSubdomainData<
-        Dim, tmpl::list<ScalarFieldTag, VectorFieldTag<Dim>>>;
+        Dim, tmpl::list<ScalarFieldTag<DataVector>,
+                        VectorFieldTag<DataVector, Dim>>>;
     SubdomainData source{};
     source.element_data.initialize(5);
     source
@@ -334,12 +341,58 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
       // Test the solver was applied to every tensor component in turn
       const auto& solver = minus_laplacian.solver();
       REQUIRE(solver.sources.size() == 3);
-      check_component(solver.sources[0], source, ScalarFieldTag{}, 0);
-      check_component(solver.sources[1], source, VectorFieldTag<Dim>{}, 0);
-      check_component(solver.sources[2], source, VectorFieldTag<Dim>{}, 1);
+      check_component(solver.sources[0], source, ScalarFieldTag<DataVector>{},
+                      0);
+      check_component(solver.sources[1], source,
+                      VectorFieldTag<DataVector, Dim>{}, 0);
+      check_component(solver.sources[2], source,
+                      VectorFieldTag<DataVector, Dim>{}, 1);
       CHECK(solver.bc_types[0].empty());
       CHECK(solver.bc_types[1].empty());
       CHECK(solver.bc_types[2].empty());
+      CHECK(minus_laplacian.cached_solvers().empty());
+    }
+    minus_laplacian.reset();
+    {
+      INFO("Complex variables");
+      using SubdomainDataComplex =
+          LinearSolver::Schwarz::ElementCenteredSubdomainData<
+              Dim, tmpl::list<ScalarFieldTag<ComplexDataVector>,
+                              VectorFieldTag<ComplexDataVector, Dim>>>;
+      SubdomainDataComplex source_complex{};
+      source_complex.element_data.initialize(5);
+      source_complex
+          .overlap_data[DirectionalId<Dim>{Direction<Dim>::lower_xi(),
+                                           ElementId<Dim>{0}}]
+          .initialize(3);
+      std::iota(source_complex.begin(), source_complex.end(), 1.);
+      // Apply the solver
+      auto initial_guess_in_solution_out_complex =
+          make_with_value<SubdomainDataComplex>(source_complex, 0.);
+      minus_laplacian.solve(
+          make_not_null(&initial_guess_in_solution_out_complex),
+          linear_operator, source,
+          std::make_tuple(make_databox_without_boundary_conditions()));
+      // Test the solver was applied to every tensor component in turn, for both
+      // the real and imaginary part
+      const auto& solver = minus_laplacian.solver();
+      REQUIRE(solver.sources.size() == 6);  // 3 components, real and imaginary
+      check_component(solver.sources[0], source_complex,
+                      ScalarFieldTag<ComplexDataVector>{}, 0, false);
+      check_component(solver.sources[1], source_complex,
+                      ScalarFieldTag<ComplexDataVector>{}, 0, true);
+      check_component(solver.sources[2], source_complex,
+                      VectorFieldTag<ComplexDataVector, Dim>{}, 0, false);
+      check_component(solver.sources[3], source_complex,
+                      VectorFieldTag<ComplexDataVector, Dim>{}, 0, true);
+      check_component(solver.sources[4], source_complex,
+                      VectorFieldTag<ComplexDataVector, Dim>{}, 1, false);
+      check_component(solver.sources[5], source_complex,
+                      VectorFieldTag<ComplexDataVector, Dim>{}, 1, true);
+      CHECK(solver.bc_types.size() == 6);
+      for (const auto& bc_types : solver.bc_types) {
+        CHECK(bc_types.empty());
+      }
       CHECK(minus_laplacian.cached_solvers().empty());
     }
     minus_laplacian.reset();
@@ -363,7 +416,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
            elliptic::BoundaryConditionType::Dirichlet}};
       REQUIRE(cached_solvers.at(signature_dnd).sources.size() == 1);
       check_component(cached_solvers.at(signature_dnd).sources[0], source,
-                      ScalarFieldTag{}, 0);
+                      ScalarFieldTag<DataVector>{}, 0);
       CHECK(cached_solvers.at(signature_dnd).bc_types[0] == signature_dnd);
       // - The solver for (D, D, N) should be used for both vector components
       const BcSignature signature_ddn{
@@ -375,9 +428,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
            elliptic::BoundaryConditionType::Neumann}};
       REQUIRE(cached_solvers.at(signature_ddn).sources.size() == 2);
       check_component(cached_solvers.at(signature_ddn).sources[0], source,
-                      VectorFieldTag<Dim>{}, 0);
+                      VectorFieldTag<DataVector, Dim>{}, 0);
       check_component(cached_solvers.at(signature_ddn).sources[1], source,
-                      VectorFieldTag<Dim>{}, 1);
+                      VectorFieldTag<DataVector, Dim>{}, 1);
       CHECK(cached_solvers.at(signature_ddn).bc_types[0] == signature_ddn);
       CHECK(cached_solvers.at(signature_ddn).bc_types[1] == signature_ddn);
       // - The factory-constructed solver is not invoked, because it is only
@@ -407,11 +460,12 @@ SPECTRE_TEST_CASE("Unit.Elliptic.SubdomainPreconditioners.MinusLaplacian",
            elliptic::BoundaryConditionType::Dirichlet}};
       const auto& cached_solver = cached_solvers.at(signature_ddd);
       REQUIRE(cached_solver.sources.size() == 3);
-      check_component(cached_solver.sources[0], source, ScalarFieldTag{}, 0);
-      check_component(cached_solver.sources[1], source, VectorFieldTag<Dim>{},
-                      0);
-      check_component(cached_solver.sources[2], source, VectorFieldTag<Dim>{},
-                      1);
+      check_component(cached_solver.sources[0], source,
+                      ScalarFieldTag<DataVector>{}, 0);
+      check_component(cached_solver.sources[1], source,
+                      VectorFieldTag<DataVector, Dim>{}, 0);
+      check_component(cached_solver.sources[2], source,
+                      VectorFieldTag<DataVector, Dim>{}, 1);
       CHECK(cached_solver.bc_types[0] == signature_ddd);
       CHECK(cached_solver.bc_types[1] == signature_ddd);
       CHECK(cached_solver.bc_types[2] == signature_ddd);


### PR DESCRIPTION
## Proposed changes

Support complex numbers in the MinusLaplacian preconditioner, which approximates the equations with a simple Laplacian. For complex numbers the Laplacian is just applied to the real and the imaginary part separately.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
