### PR TITLE
Remove PI controller for step size adjustment 

### DIFF
--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -522,12 +522,12 @@ struct ProjectTimeStepperHistory : tt::ConformsTo<amr::protocols::Projector> {
 
     const auto& time_step_id = get<::Tags::TimeStepId>(old_items);
     const auto& errors = get<::Tags::StepperErrors<variables_tag>>(old_items);
-    if (not errors[1].has_value()) {
+    if (not errors.has_value()) {
       ERROR_NO_TRACE(
           "Evolutions performing h-refinement with variable-order local "
           "time-stepping must use ErrorControl for step size choosing.");
     }
-    ASSERT(errors[1]->errors[start_order - 1].has_value(),
+    ASSERT(errors->errors[start_order - 1].has_value(),
            "Start-order estimate not available.");
 
     // At this low an order, we are almost certainly step-size-limited
@@ -535,8 +535,8 @@ struct ProjectTimeStepperHistory : tt::ConformsTo<amr::protocols::Projector> {
     // change to the grid spacing.
     return choose_lts_step_size(
         time_step_id.step_time(),
-        errors[1]->step_size.value() *
-            pow(1.0 / std::max(*errors[1]->errors[start_order - 1], 1e-14),
+        errors->step_size.value() *
+            pow(1.0 / std::max(*errors->errors[start_order - 1], 1e-14),
                 1.0 / static_cast<double>(start_order)));
   }
 };

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -78,13 +78,7 @@ void update_one_variables(const gsl::not_null<db::DataBox<DbTags>*> box) {
             const auto error =
                 time_stepper.update_u(vars, history, time_step, tolerances);
             if (error.has_value()) {
-              // Save the previous error if there was one, but not if this is a
-              // retry of the same step.
-              if ((*errors)[1].has_value() and
-                  (*errors)[1]->step_time != error->step_time) {
-                (*errors)[0] = (*errors)[1];
-              }
-              (*errors)[1].emplace(*error);
+              errors->emplace(*error);
             }
           },
           box, db::get<history_tag>(*box), db::get<Tags::TimeStep>(*box),

--- a/src/Time/ChangeTimeStepperOrder.hpp
+++ b/src/Time/ChangeTimeStepperOrder.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <optional>
 
@@ -49,8 +48,8 @@ struct apply_impl<tmpl::list<VariablesTags...>> {
       const VariableOrderAlgorithm& order_algorithm,
       const TimeStepId& next_time_step_id,
       const typename tmpl::has_type<
-          VariablesTags, std::array<std::optional<StepperErrorEstimate>,
-                                    2>>::type&... errors) {
+          VariablesTags,
+          std::optional<StepperErrorEstimate>>::type&... errors) {
     if (next_time_step_id.substep() != 0) {
       return;
     }

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <pup.h>
 #include <string>
 #include <type_traits>
@@ -16,6 +17,7 @@
 #include "Options/String.hpp"
 #include "Time/RequestsStepperErrorTolerances.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepperErrorEstimate.hpp"
 #include "Time/StepperErrorTolerances.hpp"
 #include "Time/Tags/StepperErrorTolerancesCompute.hpp"
 #include "Time/Tags/StepperErrors.hpp"
@@ -157,20 +159,19 @@ class ErrorControl : public StepChooser<StepChooserUse>,
 
   using argument_tags = tmpl::list<::Tags::StepperErrors<EvolvedVariableTag>>;
 
-  TimeStepRequest operator()(
-      const typename ::Tags::StepperErrors<EvolvedVariableTag>::type& errors,
-      const double /*previous_step*/) const {
+  TimeStepRequest operator()(const std::optional<StepperErrorEstimate>& errors,
+                             const double /*previous_step*/) const {
     // Do not request that the step size be changed if there isn't a new error
     // estimate
-    if (not errors[1].has_value()) {
+    if (not errors.has_value()) {
       return {};
     }
     const double new_step =
-        errors[1]->step_size.value() *
-        std::clamp(safety_factor_ *
-                       pow(1.0 / std::max(errors[1]->step_error(), 1e-14),
-                           1.0 / static_cast<double>(errors[1]->order + 1)),
-                   min_factor_, max_factor_);
+        errors->step_size.value() *
+        std::clamp(
+            safety_factor_ * pow(1.0 / std::max(errors->step_error(), 1e-14),
+                                 1.0 / static_cast<double>(errors->order + 1)),
+            min_factor_, max_factor_);
     return ::TimeStepRequest{.size_goal = new_step};
   }
 

--- a/src/Time/StepChoosers/ErrorControl.hpp
+++ b/src/Time/StepChoosers/ErrorControl.hpp
@@ -53,8 +53,7 @@ namespace StepChoosers {
  * allocation in the TimeStepper and should not have a major effect on
  * the result.)
  *
- * When choosing a step size for LTS or when no record of previous
- * error is available, the step has size:
+ * We then choose the step size:
  *
  * \f[
  * h_{\text{new}} = h \cdot \min\left(F_{\text{max}},
@@ -71,24 +70,6 @@ namespace StepChoosers {
  * within the target error. \f$q\f$ is the order of the stepper error
  * calculation. Intuitively, we should change the step less drastically for a
  * higher order stepper.
- *
- * When controlling slab size, after the first error calculation, the
- * error \f$E\f$ is recorded in the \ref DataBoxGroup "DataBox", and
- * subsequent error calculations use a simple PI scheme suggested in
- * \cite NumericalRecipes section 17.2.1:
- *
- * \f[
- * h_{\text{new}} = h \cdot \min\left(F_{\text{max}},
- * \max\left(F_{\text{min}},
- * F_{\text{safety}} E^{-0.7 / (q + 1)}
- * E_{\text{prev}}^{0.4 / (q + 1)}\right)\right),
- * \f]
- *
- * where \f$E_{\text{prev}}\f$ is the error computed in the previous
- * step.  This method is never used for choosing an LTS step because
- * the restriction of step size changes to factors of two was found to
- * interfere with the more gradual increase chosen by the PI
- * controller.
  *
  * \note The template parameter `ErrorControlSelector` is used to disambiguate
  * in the input-file options between `ErrorControl` step choosers that are
@@ -184,29 +165,12 @@ class ErrorControl : public StepChooser<StepChooserUse>,
     if (not errors[1].has_value()) {
       return {};
     }
-    double new_step;
-    if (std::is_same_v<StepChooserUse, ::StepChooserUse::LtsStep> or
-        not errors[0].has_value() or errors[0]->order != errors[1]->order) {
-      new_step =
-          errors[1]->step_size.value() *
-          std::clamp(safety_factor_ *
-                         pow(1.0 / std::max(errors[1]->step_error(), 1e-14),
-                             1.0 / (errors[1]->order + 1)),
-                     min_factor_, max_factor_);
-    } else {
-      // From simple advice from Numerical Recipes 17.2.1 regarding a heuristic
-      // for PI step control.
-      const double alpha_factor = 0.7 / (errors[1]->order + 1);
-      const double beta_factor = 0.4 / (errors[0]->order + 1);
-      new_step =
-          errors[1]->step_size.value() *
-          std::clamp(
-              safety_factor_ *
-                  pow(1.0 / std::max(errors[1]->step_error(), 1e-14),
-                      alpha_factor) *
-                  pow(std::max(errors[0]->step_error(), 1e-14), beta_factor),
-              min_factor_, max_factor_);
-    }
+    const double new_step =
+        errors[1]->step_size.value() *
+        std::clamp(safety_factor_ *
+                       pow(1.0 / std::max(errors[1]->step_error(), 1e-14),
+                           1.0 / static_cast<double>(errors[1]->order + 1)),
+                   min_factor_, max_factor_);
     return ::TimeStepRequest{.size_goal = new_step};
   }
 

--- a/src/Time/Tags/StepperErrors.hpp
+++ b/src/Time/Tags/StepperErrors.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <array>
 #include <optional>
 #include <string>
 
@@ -20,7 +19,7 @@ struct StepperErrors : db::PrefixTag, db::SimpleTag {
   static std::string name() {
     return "StepperErrors(" + db::tag_name<Tag>() + ")";
   }
-  using type = std::array<std::optional<StepperErrorEstimate>, 2>;
+  using type = std::optional<StepperErrorEstimate>;
   using tag = Tag;
 };
 }  // namespace Tags

--- a/src/Time/VariableOrderAlgorithm.hpp
+++ b/src/Time/VariableOrderAlgorithm.hpp
@@ -88,8 +88,7 @@ class VariableOrderAlgorithm {
   size_t choose_order(
       const TimeSteppers::History<typename VariablesTags::type>&... histories,
       const typename tmpl::has_type<
-          VariablesTags,
-          std::array<std::optional<StepperErrorEstimate>, 2>>::type&... errors)
+          VariablesTags, std::optional<StepperErrorEstimate>>::type&... errors)
       const {
     const auto history_order =
         get_first_argument(histories...).integration_order();
@@ -103,7 +102,7 @@ class VariableOrderAlgorithm {
     } else {
       ASSERT(order_falloff_.has_value(),
              "VariableOrderAlgorithm not initialized");
-      return choose_order_falloff(history_order, std::array{&errors[1]...});
+      return choose_order_falloff(history_order, std::array{&errors...});
     }
   }
 

--- a/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
@@ -865,8 +865,7 @@ old_h_refinement_items(const TimeStepId& time_step_id, const size_t order,
     error_estimate->errors[0] = first_order_error;
   }
   return {std::move(old_history), time_step_id, time_step,
-          std::array<std::optional<StepperErrorEstimate>, 2>{
-              {std::nullopt, std::move(error_estimate)}}};
+          std::move(error_estimate)};
 }
 
 TimeDelta test_h_refine_lts_split(

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -249,33 +249,25 @@ void test_stepper_error() {
 
   using error_tag = Tags::StepperErrors<variables_tag>;
   do_substep();
-  CHECK(not db::get<error_tag>(box)[0].has_value());
-  CHECK(not db::get<error_tag>(box)[1].has_value());
+  CHECK(not db::get<error_tag>(box).has_value());
   do_substep();
-  CHECK(not db::get<error_tag>(box)[0].has_value());
-  CHECK(not db::get<error_tag>(box)[1].has_value());
+  CHECK(not db::get<error_tag>(box).has_value());
   do_substep();
-  CHECK(not db::get<error_tag>(box)[0].has_value());
-  REQUIRE(db::get<error_tag>(box)[1].has_value());
-  CHECK(db::get<error_tag>(box)[1]->step_time == slab.start());
+  REQUIRE(db::get<error_tag>(box).has_value());
+  CHECK(db::get<error_tag>(box)->step_time == slab.start());
 
-  const auto first_step_errors = db::get<error_tag>(box)[1]->errors;
+  const auto first_step_errors = db::get<error_tag>(box)->errors;
   const auto second_step = slab.start() + initial_time_step;
   do_substep();
-  CHECK(not db::get<error_tag>(box)[0].has_value());
-  REQUIRE(db::get<error_tag>(box)[1].has_value());
-  CHECK(db::get<error_tag>(box)[1]->step_time == slab.start());
+  REQUIRE(db::get<error_tag>(box).has_value());
+  CHECK(db::get<error_tag>(box)->step_time == slab.start());
   do_substep();
-  CHECK(not db::get<error_tag>(box)[0].has_value());
-  REQUIRE(db::get<error_tag>(box)[1].has_value());
-  CHECK(db::get<error_tag>(box)[1]->step_time == slab.start());
+  REQUIRE(db::get<error_tag>(box).has_value());
+  CHECK(db::get<error_tag>(box)->step_time == slab.start());
   do_substep(true);
-  REQUIRE(db::get<error_tag>(box)[0].has_value());
-  REQUIRE(db::get<error_tag>(box)[1].has_value());
-  CHECK(db::get<error_tag>(box)[0]->step_time == slab.start());
-  CHECK(db::get<error_tag>(box)[1]->step_time == second_step);
-  CHECK(db::get<error_tag>(box)[0]->errors == first_step_errors);
-  CHECK(db::get<error_tag>(box)[1]->errors != first_step_errors);
+  REQUIRE(db::get<error_tag>(box).has_value());
+  CHECK(db::get<error_tag>(box)->step_time == second_step);
+  CHECK(db::get<error_tag>(box)->errors != first_step_errors);
 }
 
 void test_errors_for_restart() {
@@ -322,7 +314,7 @@ void test_errors_for_restart() {
         tolerances, 1., std::move(history),
         Tags::StepperErrors<variables_tag>::type{});
     update_u<SingleVariableSystem>(make_not_null(&box));
-    const auto& errors = db::get<Tags::StepperErrors<variables_tag>>(box)[1];
+    const auto& errors = db::get<Tags::StepperErrors<variables_tag>>(box);
     if (not errors.has_value()) {
       return Estimates::None;
     }

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -132,28 +132,11 @@ void test_chooser() {
         REQUIRE(first_result.has_value());
         CHECK(approx(*first_result) ==
               0.95 * unit_step / pow(0.3, 1.0 / stepper_order));
-        if constexpr (std::is_same_v<StepChooserUse, ::StepChooserUse::Slab>) {
-          const auto second_result = get_suggestion(
-              error_control, {step_errors(0.0, 0.31, abs(*first_result))},
-              {step_errors(-1.0, 0.3)}, *first_result);
-          REQUIRE(second_result.has_value());
-          CHECK(approx(*second_result) == 0.95 * *first_result /
-                                              (pow(0.3, -0.4 / stepper_order) *
-                                               pow(0.31, 0.7 / stepper_order)));
-          // Check that the suggested step size is smaller if the error in
-          // increasing faster.
-          const auto adjusted_second_result = get_suggestion(
-              error_control, {step_errors(0.0, 0.31, abs(*first_result))},
-              {step_errors(-1.0, 0.1)}, *first_result);
-          REQUIRE(adjusted_second_result.has_value());
-          CHECK(abs(*adjusted_second_result) < abs(*second_result));
-        } else {
-          // Check that the result is independent of the old error
-          const auto second_result =
-              get_suggestion(error_control, {step_errors(0.0, 0.3)},
-                             {step_errors(-1.0, 0.7)}, unit_step);
-          CHECK(first_result == second_result);
-        }
+        // Check that the result is independent of the old error
+        const auto second_result =
+            get_suggestion(error_control, {step_errors(0.0, 0.3)},
+                           {step_errors(-1.0, 0.7)}, unit_step);
+        CHECK(first_result == second_result);
       }
       {
         INFO("Test error control step failure");

--- a/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_ErrorControl.cpp
@@ -3,7 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <array>
 #include <cmath>
 #include <cstddef>
 #include <memory>
@@ -69,24 +68,22 @@ std::optional<double> get_suggestion(
     const StepChoosers::ErrorControl<StepChooserUse, EvolvedVariablesTag>&
         error_control,
     const std::optional<StepperErrorEstimate>& error,
-    const std::optional<StepperErrorEstimate>& previous_error,
     const double previous_step) {
   auto box = db::create<
       db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
                         Tags::StepperErrors<EvolvedVariablesTag>>>(
-      Metavariables{}, std::array{previous_error, error});
+      Metavariables{}, error);
 
   const std::unique_ptr<StepChooser<StepChooserUse>> error_control_base =
       std::make_unique<
           StepChoosers::ErrorControl<StepChooserUse, EvolvedVariablesTag>>(
           error_control);
 
-  const auto result =
-      error_control(std::array{previous_error, error}, previous_step);
+  const auto result = error_control(error, previous_step);
   CHECK(result == TimeStepRequest{.size_goal = result.size_goal});
   CHECK(error_control_base->desired_step(previous_step, box) == result);
-  CHECK(serialize_and_deserialize(error_control)(
-            std::array{previous_error, error}, previous_step) == result);
+  CHECK(serialize_and_deserialize(error_control)(error, previous_step) ==
+        result);
   CHECK(serialize_and_deserialize(error_control_base)
             ->desired_step(previous_step, box) == result);
   return result.size_goal;
@@ -116,7 +113,7 @@ void test_chooser() {
       {
         INFO("No data available");
         const ErrorControl error_control{5.0e-4, 0.0, 2.0, 0.5, 0.95};
-        const auto result = get_suggestion(error_control, {}, {}, unit_step);
+        const auto result = get_suggestion(error_control, {}, unit_step);
         CHECK(not result.has_value());
       }
       {
@@ -127,28 +124,23 @@ void test_chooser() {
                   .estimates = StepperErrorTolerances::Estimates::StepperOrder,
                   .absolute = 5.0e-4,
                   .relative = 1.0e-3});
-        const auto first_result = get_suggestion(
-            error_control, {step_errors(0.0, 0.3)}, {}, unit_step);
-        REQUIRE(first_result.has_value());
-        CHECK(approx(*first_result) ==
+        const auto result =
+            get_suggestion(error_control, {step_errors(0.0, 0.3)}, unit_step);
+        REQUIRE(result.has_value());
+        CHECK(approx(*result) ==
               0.95 * unit_step / pow(0.3, 1.0 / stepper_order));
-        // Check that the result is independent of the old error
-        const auto second_result =
-            get_suggestion(error_control, {step_errors(0.0, 0.3)},
-                           {step_errors(-1.0, 0.7)}, unit_step);
-        CHECK(first_result == second_result);
       }
       {
         INFO("Test error control step failure");
         const ErrorControl error_control{4.0e-5, 4.0e-5, 2.0, 0.5, 0.95};
-        const auto result_start = get_suggestion(
-            error_control, {step_errors(0.0, 1.2)}, {}, unit_step);
+        const auto result_start =
+            get_suggestion(error_control, {step_errors(0.0, 1.2)}, unit_step);
         REQUIRE(result_start.has_value());
-        const auto result_end = get_suggestion(
-            error_control, {step_errors(-1.0, 1.2)}, {}, unit_step);
+        const auto result_end =
+            get_suggestion(error_control, {step_errors(-1.0, 1.2)}, unit_step);
         REQUIRE(result_end.has_value());
         const auto result_end2 = get_suggestion(
-            error_control, {step_errors(-1.0, 1.2)}, {}, *result_end);
+            error_control, {step_errors(-1.0, 1.2)}, *result_end);
         REQUIRE(result_end2.has_value());
         CHECK(approx(*result_start) ==
               0.95 * unit_step / pow(1.2, 1.0 / stepper_order));
@@ -158,16 +150,16 @@ void test_chooser() {
       {
         INFO("Test error control clamped minimum");
         const ErrorControl error_control{4.0e-5, 4.0e-5, 2.0, 0.9, 0.95};
-        const auto first_result = get_suggestion(
-            error_control, {step_errors(0.0, 10.0)}, {}, unit_step);
-        CHECK(first_result == std::optional(0.9 * unit_step));
+        const auto result =
+            get_suggestion(error_control, {step_errors(0.0, 10.0)}, unit_step);
+        CHECK(result == std::optional(0.9 * unit_step));
       }
       {
         INFO("Test error control clamped maximum");
         const ErrorControl error_control{1.0e-1, 1.0e-1, 2.0, 0.5, 0.95};
-        const auto first_result = get_suggestion(
-            error_control, {step_errors(0.0, 0.01)}, {}, unit_step);
-        CHECK(first_result == std::optional(2.0 * unit_step));
+        const auto result =
+            get_suggestion(error_control, {step_errors(0.0, 0.01)}, unit_step);
+        CHECK(result == std::optional(2.0 * unit_step));
       }
     }
   }

--- a/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
+++ b/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
@@ -3,7 +3,6 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <array>
 #include <cstddef>
 #include <iomanip>
 #include <memory>
@@ -82,13 +81,6 @@ size_t test_system(VariableOrderAlgorithm algorithm, const size_t initial_order,
                    std::optional<StepperErrorEstimate> errors2) {
   const Slab slab(0.0, 1.0);
 
-  // First entry is for the previous step, which is only used for step
-  // size control, not order.
-  std::array<std::optional<StepperErrorEstimate>, 2> stepper_errors1{};
-  std::array<std::optional<StepperErrorEstimate>, 2> stepper_errors2{};
-  stepper_errors1[1] = std::move(errors1);
-  stepper_errors2[1] = std::move(errors2);
-
   using history_tag1 = Tags::HistoryEvolvedVariables<Vars1>;
   using history_tag2 = Tags::HistoryEvolvedVariables<Vars2>;
 
@@ -103,8 +95,7 @@ size_t test_system(VariableOrderAlgorithm algorithm, const size_t initial_order,
       static_cast<std::unique_ptr<TimeStepper>>(
           std::make_unique<TimeSteppers::AdamsBashforth>(initial_order)),
       std::move(algorithm), history_tag1::type{initial_order},
-      history_tag2::type{initial_order}, stepper_errors1, stepper_errors2,
-      next_time_step_id);
+      history_tag2::type{initial_order}, errors1, errors2, next_time_step_id);
 
   // Does nothing for fixed-order
   db::mutate_apply<ChangeTimeStepperOrder<System>>(make_not_null(&box));
@@ -214,7 +205,7 @@ void test_falloff_without_errors() {
   const size_t initial_order = 4;
   const Slab slab(0.0, 1.0);
 
-  std::array<std::optional<StepperErrorEstimate>, 2> stepper_errors{};
+  std::optional<StepperErrorEstimate> stepper_errors{};
 
   using history_tag = Tags::HistoryEvolvedVariables<Vars1>;
 


### PR DESCRIPTION
Was already disabled for LTS.  In a GTS BBH, it was choosing a step
size an order of magnitude too small, with normalized error measures
around 1e-4.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
