### PR TITLE
Fix CartoonSphere2D collocation mismatch

### DIFF
--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -257,7 +257,11 @@ Domain<3> CartoonSphere2D::create_domain() const {
             make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
                 CoordinateMaps::ProductOf2Maps<Equiangular2D, Identity1D>{
                     Equiangular2D{
-                        Equiangular(-1.0, 1.0, 0.0, inner_radius_ / sqrt(2.0)),
+                        // note the non-standard logical coordinate bounds, such
+                        // that the eta-neighbor collocation points match the
+                        // half-wedges'
+                        Equiangular(-3.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
+                                    inner_radius_ / sqrt(2.0)),
                         Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
                                     inner_radius_ / sqrt(2.0))},
                     Identity1D{}}));

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -61,7 +61,7 @@ void test_sphere_construction(
     const std::unordered_map<std::string, double>& initial_expiration_times =
         {}) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
-      sphere, expect_boundary_conditions);
+      sphere, expect_boundary_conditions, false, std::vector<double>{5.0});
   const bool fill_interior =
       std::holds_alternative<domain::creators::detail::InnerSquare>(interior);
   const size_t num_shells = expected_radial_partitioning.size() + 1;
@@ -313,7 +313,8 @@ void test_sphere_construction(
           make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
               CoordinateMaps::ProductOf2Maps<Equiangular2D, Identity1D>{
                   Equiangular2D{
-                      Equiangular(-1.0, 1.0, 0.0, inner_radius / sqrt(2.0)),
+                      Equiangular(-3.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
+                                  inner_radius / sqrt(2.0)),
                       Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
                                   inner_radius / sqrt(2.0))},
                   Identity1D{}}));

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -38,6 +38,7 @@
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
@@ -278,8 +279,21 @@ void check_block_face_grid_points_align(
       find_neighbor_orientation(host_block, neighbor_block);
   // Set up a Mesh on the shared face. Corner points are already checked by
   // physical_separation, so check on Gauss points
-  const Mesh<VolumeDim - 1> face_mesh{3_st, Spectral::Basis::Legendre,
-                                      Spectral::Quadrature::Gauss};
+  Mesh<VolumeDim - 1> face_mesh;
+  if (host_block.topologies()[VolumeDim - 1] ==
+      domain::Topology::CartoonCylinder) {
+    if constexpr (VolumeDim == 3) {
+      face_mesh = Mesh<VolumeDim - 1>{
+          {3, 1},
+          {Spectral::Basis::Legendre, Spectral::Basis::Cartoon},
+          {Spectral::Quadrature::Gauss, Spectral::Quadrature::AxialSymmetry}};
+    } else {
+      ERROR("Cartoon basis used with non 3D mesh, got dim = " << VolumeDim);
+    }
+  } else {
+    face_mesh = Mesh<VolumeDim - 1>{3_st, Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::Gauss};
+  }
   // We want block logical coordinates on face_mesh on the host side and the
   // neighbor. The following returns element logical coordinates in the host
   // frame, which we then copy into tensors holding block logical coordinates,
@@ -317,9 +331,13 @@ void check_block_face_grid_points_align(
   }
   CAPTURE(xi_host);
   CAPTURE(xi_neighbor);
-  // Check that each grid point on the face Mesh has the same grid and inertial
-  // coordinates when mapped from the logical coordinates of each Block.
+  // Check that each grid point on the face Mesh has the same grid and
+  // inertial coordinates when mapped from the logical coordinates of each
+  // Block.
   if (host_block.is_time_dependent()) {
+    ASSERT(not std::isnan(time),
+           "Blocks have time dependent maps but a time to evaluate at was "
+           "not passed");
     const auto& host_map_logical_to_grid =
         host_block.moving_mesh_logical_to_grid_map();
     const auto& host_map_grid_to_inertial =
@@ -379,6 +397,9 @@ double physical_separation(
         << " and block2 has: " << block2.is_time_dependent());
   }
   if (block1.is_time_dependent()) {
+    ASSERT(not std::isnan(time),
+           "Blocks have time dependent maps but a time to evaluate at was "
+           "not passed");
     const auto& map1_logical_to_grid = block1.moving_mesh_logical_to_grid_map();
     const auto& map1_grid_to_inertial =
         block1.moving_mesh_grid_to_inertial_map();
@@ -510,10 +531,12 @@ void test_physical_separation(
       if (domain::blocks_are_neighbors(blocks[i], blocks[j])) {
         CAPTURE(i);
         CAPTURE(j);
-        if (blocks[i].topologies() ==
+        if ((blocks[i].topologies() ==
                 domain::topologies::hypercube<VolumeDim> and
             blocks[j].topologies() ==
-                domain::topologies::hypercube<VolumeDim>) {
+             domain::topologies::hypercube<VolumeDim>) or
+            blocks[i].topologies()[VolumeDim - 1] ==
+            domain::Topology::CartoonCylinder) {
           CHECK(domain::physical_separation(blocks[i], blocks[j], time,
                                             functions_of_time) < tolerance);
           if constexpr (VolumeDim > 1) {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Half-wedge next to equiangular map needs to have matching focal points. 
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
