### PR TITLE
Don't recompute vol data to interp to AH each iteration

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
@@ -65,9 +65,13 @@ void interpolate_volume_data(
 
     // Take the ah::source_vars and convert to
     // ah::vars_to_interpolate_to_target
-    ah::compute_vars_to_interpolate_to_target(
-        make_not_null(&volume_vars_storage), time, domain, element_id,
-        functions_of_time);
+    // But only do this once.
+    if (not volume_vars_storage.done_computing_vars_to_interpolate_to_target) {
+      ah::compute_vars_to_interpolate_to_target(
+          make_not_null(&volume_vars_storage), time, domain, element_id,
+          functions_of_time);
+      volume_vars_storage.done_computing_vars_to_interpolate_to_target = true;
+    }
 
     const intrp::Irregular<3> interpolator(
         volume_vars_storage.mesh, element_coord_holder.element_logical_coords);

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -16,13 +16,17 @@ void VolumeVariables<Fr>::pup(PUP::er& p) {
   p | mesh;
   p | source_vars;
   p | vars_to_interpolate_to_target;
+  p | done_computing_vars_to_interpolate_to_target;
 }
 
 template <typename Fr>
 bool operator==(const VolumeVariables<Fr>& lhs,
                 const VolumeVariables<Fr>& rhs) {
   return lhs.mesh == rhs.mesh and lhs.source_vars == rhs.source_vars and
-         lhs.vars_to_interpolate_to_target == rhs.vars_to_interpolate_to_target;
+         lhs.vars_to_interpolate_to_target ==
+             rhs.vars_to_interpolate_to_target and
+         lhs.done_computing_vars_to_interpolate_to_target ==
+             rhs.done_computing_vars_to_interpolate_to_target;
 }
 template <typename Fr>
 bool operator!=(const VolumeVariables<Fr>& lhs,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -47,6 +47,12 @@ struct VolumeVariables {
   Variables<ah::vars_to_interpolate_to_target<3, Fr>>
       vars_to_interpolate_to_target{};
 
+  /*!
+   * \brief A flag that ensures that the variables to interpolate onto the
+   * horizon are only computed once.
+   */
+  bool done_computing_vars_to_interpolate_to_target = false;
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 };

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
@@ -36,6 +36,7 @@ void test_storage() {
       Mesh<3>{3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
       Variables<ah::source_vars<3>>{4, 1.234},
       Variables<ah::vars_to_interpolate_to_target<3, Fr>>{4, 4.321}};
+  CHECK(not volume_variables.done_computing_vars_to_interpolate_to_target);
   test_serialization(volume_variables);
 
   const ah::Storage::Iteration<Fr> iteration{


### PR DESCRIPTION
## Proposed changes

The new AH infrastructure was recomputing the tensors to interpolate from the volume to the horizon every iteration, even though they only change every time step. This PR just adds a flag to check whether the computation has already been done. This speeds up horizon finding by roughly the number of iterations.

Thanks to @nilsdeppe for finding this issue!

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
