### PR TITLE
FD cartoon partial derivatives

### DIFF
--- a/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp
@@ -22,6 +22,7 @@ class Variables;
 
 namespace fd {
 /*!
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the logical partial derivatives using cell-centered finite
  * difference derivatives.
  *
@@ -48,6 +49,7 @@ void logical_partial_derivatives(
     const Mesh<Dim>& volume_mesh, size_t number_of_variables, size_t fd_order);
 
 /*!
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the partial derivative on the `DerivativeFrame` using the
  * `inverse_jacobian`.
  *
@@ -65,6 +67,7 @@ void partial_derivatives(
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian);
 /*!
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the partial derivative using the `inverse_jacobian` for
  * `Basis::FiniteDifference` dimensions and the Cartoon method for
  * `Basis::Cartoon` dimensions.
@@ -85,6 +88,7 @@ void cartoon_partial_derivatives(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
 
 /*!
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the partial derivative, either normal FD or FD/cartoon,
  * based on the mesh (only known at runtime).
  */

--- a/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp
@@ -58,10 +58,47 @@ template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
 void partial_derivatives(
     gsl::not_null<Variables<db::wrap_tags_in<
         Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
-        partial_derivatives,
+        d_volume_vars,
     const gsl::span<const double>& volume_vars,
     const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
     const Mesh<Dim>& volume_mesh, size_t number_of_variables, size_t fd_order,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian);
+/*!
+ * \brief Compute the partial derivative using the `inverse_jacobian` for
+ * `Basis::FiniteDifference` dimensions and the Cartoon method for
+ * `Basis::Cartoon` dimensions.
+ *
+ * See DG `cartoon_partial_derivatives()` for information on the Cartoon method.
+ */
+template <typename DerivativeTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3> = nullptr>
+void cartoon_partial_derivatives(
+    gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        d_volume_vars,
+    const Variables<VariableTags>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, size_t number_of_variables, size_t fd_order,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+
+/*!
+ * \brief Compute the partial derivative, either normal FD or FD/cartoon,
+ * based on the mesh (only known at runtime).
+ */
+template <typename DerivativeTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame>
+void partial_derivatives(
+    gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        d_volume_vars,
+    const Variables<VariableTags>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, size_t number_of_variables, size_t fd_order,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords);
+
 }  // namespace fd

--- a/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.tpp
@@ -17,6 +17,7 @@
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace fd {
@@ -34,20 +35,19 @@ template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
 void partial_derivatives(
     const gsl::not_null<Variables<db::wrap_tags_in<
         Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
-        partial_derivatives,
+        d_volume_vars,
     const gsl::span<const double>& volume_vars,
     const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
     const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
     const size_t fd_order,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian) {
-  ASSERT(partial_derivatives->size() == Dim * volume_vars.size(),
+  ASSERT(d_volume_vars->size() == Dim * volume_vars.size(),
          "The partial derivatives Variables must have size "
              << Dim * volume_vars.size()
              << " (Dim * volume_vars.size()) but has size "
-             << partial_derivatives->size() << " and "
-             << partial_derivatives->number_of_grid_points()
-             << " grid points.");
+             << d_volume_vars->size() << " and "
+             << d_volume_vars->number_of_grid_points() << " grid points.");
   const size_t logical_derivs_internal_buffer_size =
       Dim == 1
           ? static_cast<size_t>(0)
@@ -84,9 +84,162 @@ void partial_derivatives(
         gsl::at(logical_partial_derivs, i).data();
   }
   ::partial_derivatives_detail::partial_derivatives_impl(
-      partial_derivatives, logical_partial_derivs_ptrs,
+      d_volume_vars, logical_partial_derivs_ptrs,
       Variables<DerivativeTags>::number_of_independent_components,
       inverse_jacobian);
 }
 
+template <size_t CompDim, typename DerivativeTags, typename VariableTags,
+          size_t Dim, typename DerivativeFrame>
+void cartoon_partial_derivatives_apply(
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        d_volume_vars,
+    const Variables<VariableTags>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
+    const size_t fd_order,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  static_assert(Dim == 3);
+  static_assert(std::is_same_v<
+                tmpl::transform<DerivativeTags,
+                                tmpl::bind<tmpl::type_from, tmpl::_1>>,
+                tmpl::transform<tmpl::front<tmpl::split_at<
+                                    VariableTags, tmpl::size<DerivativeTags>>>,
+                                tmpl::bind<tmpl::type_from, tmpl::_1>>>);
+  ASSERT((CompDim == 2 and
+          volume_mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry) or
+             (CompDim == 1 and (volume_mesh.quadrature(1) ==
+                                    Spectral::Quadrature::SphericalSymmetry and
+                                volume_mesh.quadrature(2) ==
+                                    Spectral::Quadrature::SphericalSymmetry)),
+         "Invalid Quadrature combinations: axial symmetry requires 2 "
+         "non-Cartoon dimensions, spherical symmetry requires 1 non-Cartoon "
+         "dimension. Got: "
+             << volume_mesh.quadrature());
+  DirectionMap<CompDim, gsl::span<const double>> ghost_cell_vars_slice{};
+  for (const auto& direction : Direction<CompDim>::all_directions()) {
+    ghost_cell_vars_slice[direction] = ghost_cell_vars.at(
+        Direction<3>{direction.dimension(), direction.side()});
+  }
+  using first_var_tag = tmpl::front<VariableTags>;
+  constexpr size_t number_of_var_components =
+      Variables<DerivativeTags>::number_of_independent_components;
+  const auto volume_vars_span = gsl::make_span(
+      get<first_var_tag>(volume_vars)[0].data(),
+      number_of_var_components * volume_vars.number_of_grid_points());
+  ASSERT(d_volume_vars->size() == Dim * volume_vars_span.size(),
+         "The partial derivatives Variables must have size "
+             << Dim * volume_vars_span.size()
+             << " (Dim * volume_vars_span.size()) but has size "
+             << d_volume_vars->size() << " and "
+             << d_volume_vars->number_of_grid_points() << " grid points.");
+  const size_t logical_derivs_internal_buffer_size =
+      CompDim == 1
+          ? static_cast<size_t>(0)
+          : (volume_vars_span.size() +
+             2 * alg::max_element(ghost_cell_vars_slice,
+                                  [](const auto& a, const auto& b) {
+                                    return a.second.size() < b.second.size();
+                                  })
+                     ->second.size() +
+             volume_vars_span.size());
+  DataVector buffer(CompDim * volume_vars_span.size() +
+                    logical_derivs_internal_buffer_size);
+  std::array<gsl::span<double>, CompDim> logical_derivs{};
+  for (size_t i = 0; i < CompDim; ++i) {
+    gsl::at(logical_derivs, i) = gsl::make_span(
+        &buffer[i * volume_vars_span.size()], volume_vars_span.size());
+  }
+  if constexpr (CompDim == 1) {
+    // No buffer in 1d
+    logical_partial_derivatives(
+        make_not_null(&logical_derivs), volume_vars_span, ghost_cell_vars_slice,
+        volume_mesh.slice_through(0), number_of_variables, fd_order);
+  } else {
+    gsl::span<double> span_buffer =
+        gsl::make_span(&buffer[CompDim * volume_vars_span.size()],
+                       logical_derivs_internal_buffer_size);
+    detail::logical_partial_derivatives_impl(
+        make_not_null(&logical_derivs), &span_buffer, volume_vars_span,
+        ghost_cell_vars_slice, volume_mesh.slice_through(0, 1),
+        number_of_variables, fd_order);
+  }
+
+  std::array<const double*, CompDim> logical_derivs_ptrs{};
+  for (size_t i = 0; i < CompDim; ++i) {
+    gsl::at(logical_derivs_ptrs, i) = gsl::at(logical_derivs, i).data();
+  }
+  partial_derivatives_with_cartoon_impl(d_volume_vars, volume_vars,
+                                        logical_derivs_ptrs, volume_mesh,
+                                        inverse_jacobian, inertial_coords);
+}
+
+template <typename DerivativeTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame, Requires<Dim == 3>>
+void cartoon_partial_derivatives(
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        d_volume_vars,
+    const Variables<VariableTags>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
+    const size_t fd_order,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  if (volume_mesh.basis(0) != Spectral::Basis::Cartoon and
+      volume_mesh.basis(2) == Spectral::Basis::Cartoon) {
+    // computational dimension needs to be a constexpr
+    if (volume_mesh.basis(1) == Spectral::Basis::Cartoon) {
+      cartoon_partial_derivatives_apply<1, DerivativeTags>(
+          d_volume_vars, volume_vars, ghost_cell_vars, volume_mesh,
+          number_of_variables, fd_order, inverse_jacobian, inertial_coords);
+    } else {
+      cartoon_partial_derivatives_apply<2, DerivativeTags>(
+          d_volume_vars, volume_vars, ghost_cell_vars, volume_mesh,
+          number_of_variables, fd_order, inverse_jacobian, inertial_coords);
+    }
+  } else {
+    ERROR("Bases do not match valid Cartoon pattern, got "
+          << volume_mesh.basis());
+  }
+}
+
+template <typename DerivativeTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame>
+void partial_derivatives(
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        d_volume_vars,
+    const Variables<VariableTags>& volume_vars,
+    const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+    const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
+    const size_t fd_order,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  if constexpr (Dim == 3) {
+    if (volume_mesh.basis(2) == Spectral::Basis::Cartoon) {
+      cartoon_partial_derivatives<DerivativeTags>(
+          d_volume_vars, volume_vars, ghost_cell_vars, volume_mesh,
+          number_of_variables, fd_order, inverse_jacobian, inertial_coords);
+      return;
+    }
+  }
+  (void)inertial_coords;
+  ASSERT(
+      Dim != 3 or volume_mesh.basis(Dim - 1) != Spectral::Basis::Cartoon,
+      "Cartoon basis is only allowed for Dim = 3, got Cartoon basis with Dim = "
+          << Dim);
+  const auto volume_vars_span = gsl::make_span(
+      get<tmpl::front<DerivativeTags>>(volume_vars)[0].data(),
+      Variables<DerivativeTags>::number_of_independent_components *
+          volume_vars.number_of_grid_points());
+  partial_derivatives<DerivativeTags, Dim, DerivativeFrame>(
+      d_volume_vars, volume_vars_span, ghost_cell_vars, volume_mesh,
+      number_of_variables, fd_order, inverse_jacobian);
+}
 }  // namespace fd

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -326,72 +326,24 @@ void cartoon_derivative(
 }
 
 template <size_t CompDim, typename ResultTags, typename VariableTags,
-          size_t Dim, typename DerivativeFrame>
-void cartoon_partial_derivatives_apply(
+          size_t Dim, typename DerivativeFrame, Requires<Dim == 3> = nullptr,
+          typename ValueType = typename Variables<ResultTags>::value_type>
+void partial_derivatives_with_cartoon_impl(
     const gsl::not_null<Variables<ResultTags>*> du,
-    const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
+    const Variables<VariableTags>& u,
+    const std::array<const ValueType*, CompDim>& const_logical_derivs,
+    const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>& inverse_jacobian_3d,
     const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
   using DerivativeTags =
       tmpl::front<tmpl::split_at<VariableTags, tmpl::size<ResultTags>>>;
-  static_assert(Dim == 3);
   static_assert(
       std::is_same_v<
           tmpl::transform<ResultTags, tmpl::bind<tmpl::type_from, tmpl::_1>>,
           tmpl::transform<db::wrap_tags_in<Tags::deriv, DerivativeTags,
                                            tmpl::size_t<Dim>, DerivativeFrame>,
                           tmpl::bind<tmpl::type_from, tmpl::_1>>>);
-  ASSERT((CompDim == 2 and
-          mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry) or
-             (CompDim == 1 and
-              (mesh.quadrature(1) == Spectral::Quadrature::SphericalSymmetry and
-               mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry)),
-         "Invalid Quadrature combinations: axial symmetry requires 2 "
-         "non-Cartoon dimensions, spherical symmetry requires 1 non-Cartoon "
-         "dimension. Got: "
-             << mesh.quadrature());
-
-  using ValueType = typename Variables<VariableTags>::value_type;
-  auto& partial_derivatives_of_u = *du;
-
-  if (UNLIKELY(partial_derivatives_of_u.number_of_grid_points() !=
-               mesh.number_of_grid_points())) {
-    partial_derivatives_of_u.initialize(mesh.number_of_grid_points());
-  }
-
-  const size_t vars_size =
-      u.number_of_grid_points() *
-      Variables<DerivativeTags>::number_of_independent_components;
-  const auto logical_derivs_data =
-      cpp20::make_unique_for_overwrite<ValueType[]>(
-          (CompDim > 1 ? (CompDim + 1) : CompDim) * vars_size);
-
-  std::array<ValueType*, CompDim> logical_derivs{};
-  for (size_t i = 0; i < CompDim; ++i) {
-    gsl::at(logical_derivs, i) = &(logical_derivs_data[i * vars_size]);
-  }
-  Variables<DerivativeTags> temp{};
-  if constexpr (CompDim > 1) {
-    temp.set_data_ref(&logical_derivs_data[CompDim * vars_size], vars_size);
-  }
-
-  if constexpr (CompDim == 1) {
-    partial_derivatives_detail::
-        LogicalImpl<CompDim, VariableTags, DerivativeTags>::apply(
-            make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
-            mesh.slice_through(0));
-  } else {
-    partial_derivatives_detail::
-        LogicalImpl<CompDim, VariableTags, DerivativeTags>::apply(
-            make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
-            mesh.slice_through(0, 1));
-  }
-
-  std::array<const ValueType*, CompDim> const_logical_derivs{};
-  for (size_t i = 0; i < CompDim; ++i) {
-    gsl::at(const_logical_derivs, i) = gsl::at(logical_derivs, i);
-  }
 
   const Spectral::Quadrature quad_type = mesh.quadrature(2);
   const auto numerical_deriv_in_this_direction = [](const size_t deriv_num) {
@@ -413,7 +365,7 @@ void cartoon_partial_derivatives_apply(
     }
   }
   // pdu points to du
-  double* pdu = du->data();
+  ValueType* pdu = du->data();
   const size_t num_grid_points = du->number_of_grid_points();
   DataVector lhs{};
   DataVector logical_du{};
@@ -581,6 +533,76 @@ void cartoon_partial_derivatives_apply(
           }
         }
       });
+}
+
+template <size_t CompDim, typename ResultTags, typename VariableTags,
+          size_t Dim, typename DerivativeFrame>
+void cartoon_partial_derivatives_apply(
+    const gsl::not_null<Variables<ResultTags>*> du,
+    const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                          DerivativeFrame>& inverse_jacobian_3d,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  using DerivativeTags =
+      tmpl::front<tmpl::split_at<VariableTags, tmpl::size<ResultTags>>>;
+  static_assert(Dim == 3);
+  static_assert(
+      std::is_same_v<
+          tmpl::transform<ResultTags, tmpl::bind<tmpl::type_from, tmpl::_1>>,
+          tmpl::transform<db::wrap_tags_in<Tags::deriv, DerivativeTags,
+                                           tmpl::size_t<Dim>, DerivativeFrame>,
+                          tmpl::bind<tmpl::type_from, tmpl::_1>>>);
+  ASSERT((CompDim == 2 and
+          mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry) or
+             (CompDim == 1 and
+              (mesh.quadrature(1) == Spectral::Quadrature::SphericalSymmetry and
+               mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry)),
+         "Invalid Quadrature combinations: axial symmetry requires 2 "
+         "non-Cartoon dimensions, spherical symmetry requires 1 non-Cartoon "
+         "dimension. Got: "
+             << mesh.quadrature());
+
+  using ValueType = typename Variables<VariableTags>::value_type;
+  auto& partial_derivatives_of_u = *du;
+
+  if (UNLIKELY(partial_derivatives_of_u.number_of_grid_points() !=
+               mesh.number_of_grid_points())) {
+    partial_derivatives_of_u.initialize(mesh.number_of_grid_points());
+  }
+
+  const size_t vars_size =
+      u.number_of_grid_points() *
+      Variables<DerivativeTags>::number_of_independent_components;
+  const auto logical_derivs_data =
+      cpp20::make_unique_for_overwrite<ValueType[]>(
+          (CompDim > 1 ? (CompDim + 1) : CompDim) * vars_size);
+
+  std::array<ValueType*, CompDim> logical_derivs{};
+  for (size_t i = 0; i < CompDim; ++i) {
+    gsl::at(logical_derivs, i) = &(logical_derivs_data[i * vars_size]);
+  }
+  Variables<DerivativeTags> temp{};
+
+  if constexpr (CompDim == 1) {
+    partial_derivatives_detail::
+        LogicalImpl<CompDim, VariableTags, DerivativeTags>::apply(
+            make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
+            mesh.slice_through(0));
+  } else {
+    temp.set_data_ref(&logical_derivs_data[CompDim * vars_size], vars_size);
+    partial_derivatives_detail::
+        LogicalImpl<CompDim, VariableTags, DerivativeTags>::apply(
+            make_not_null(&logical_derivs), &partial_derivatives_of_u, &temp, u,
+            mesh.slice_through(0, 1));
+  }
+
+  std::array<const ValueType*, CompDim> const_logical_derivs{};
+  for (size_t i = 0; i < CompDim; ++i) {
+    gsl::at(const_logical_derivs, i) = gsl::at(logical_derivs, i);
+  }
+
+  partial_derivatives_with_cartoon_impl(du, u, const_logical_derivs, mesh,
+                                        inverse_jacobian_3d, inertial_coords);
 }
 
 template <typename ResultTags, typename VariableTags, size_t Dim,

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_PartialDerivatives.cpp
@@ -3,12 +3,21 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <unordered_set>
 
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Evolution/DgSubcell/SliceData.hpp"
@@ -209,11 +218,437 @@ void test(const gsl::not_null<std::mt19937*> generator,
   CHECK_ITERABLE_CUSTOM_APPROX(get<d_var2_tag>(partial_derivatives),
                                get<d_var2_tag>(expected_partial_derivatives),
                                custom_approx);
+
+  // Test the partial derivative "chooser" works correctly when we pass an
+  // unused inertial_coords
+  const tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords{};
+  using var_tags = tmpl::list<Tags::TempScalar<0, DataVector>,
+                              Tags::TempScalar<1, DataVector>>;
+  Variables<var_tags> volume_variables{mesh.number_of_grid_points()};
+  get(get<Tags::TempScalar<0>>(volume_variables)) = var1;
+  get(get<Tags::TempScalar<1>>(volume_variables)) = var2;
+  ::fd::partial_derivatives<var_tags>(
+      make_not_null(&partial_derivatives), volume_variables, ghost_cell_vars,
+      mesh, Variables<var_tags>::number_of_independent_components, fd_order,
+      inverse_jacobian, inertial_coords);
+  CHECK_VARIABLES_CUSTOM_APPROX(partial_derivatives,
+                                expected_partial_derivatives, custom_approx);
+}
+
+template <bool Spherical>
+void test_cartoon(const size_t points_per_dimension, const size_t fd_order) {
+  INFO("Testing FD partial derivatives with Cartoon bases");
+  CAPTURE(points_per_dimension);
+  CAPTURE(fd_order);
+  CAPTURE(Spherical);
+  constexpr size_t CompDim = Spherical ? 1 : 2;
+  const size_t max_degree = fd_order - 1;
+  const size_t stencil_width = fd_order + 1;
+
+  Mesh<3> mesh;
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords;
+  InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      inv_jacobian;
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Identity1D = domain::CoordinateMaps::Identity<1>;
+  const Identity1D identity_cartoon_map;
+
+  if constexpr (Spherical) {
+    mesh = Mesh<3>{{points_per_dimension, 1, 1},
+                   {Spectral::Basis::FiniteDifference, Spectral::Basis::Cartoon,
+                    Spectral::Basis::Cartoon},
+                   {Spectral::Quadrature::CellCentered,
+                    Spectral::Quadrature::SphericalSymmetry,
+                    Spectral::Quadrature::SphericalSymmetry}};
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                                Cartoon_map_combination>
+        map{{Affine{-1.0, 1.0, 1.5, 2.2}, identity_cartoon_map,
+             identity_cartoon_map}};
+    inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+    inertial_coords = map(logical_coordinates(mesh));
+  } else {
+    mesh = Mesh<3>{
+        {points_per_dimension, points_per_dimension, 1},
+        {Spectral::Basis::FiniteDifference, Spectral::Basis::FiniteDifference,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::CellCentered, Spectral::Quadrature::CellCentered,
+         Spectral::Quadrature::AxialSymmetry}};
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                                Cartoon_map_combination>
+        map{{Affine{-1.0, 1.0, 0.4, 0.7}, Affine{-1.0, 1.0, -0.5, 3.2},
+             identity_cartoon_map}};
+    inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+    inertial_coords = map(logical_coordinates(mesh));
+  }
+
+  const auto cartoon_func =
+      [max_degree](
+          const tnsr::I<DataVector, 3, Frame::Inertial>& coords) -> DataVector {
+    if constexpr (Spherical) {
+      // a radial function, f(r) = f(x) because the computational domain is the
+      // x axis
+      return 0.01 * pow(get<0>(coords), max_degree) +
+             0.3 * pow(get<0>(coords), max_degree - 1) - 2.0 * get<0>(coords) -
+             1.5;
+    } else {
+      // an axially symmetric function about the y axis,
+      // f(\sqrt{x^2 + z^2}, y) = f(x, y) because the computational domain is
+      // the x-y plane
+      return pow(get<1>(coords), max_degree) +
+             pow(get<0>(coords), max_degree) * get<1>(coords);
+    }
+  };
+
+  const auto cartoon_dfunc =
+      [max_degree](
+          size_t deriv_index,
+          const tnsr::I<DataVector, 3, Frame::Inertial>& coords) -> DataVector {
+    if constexpr (Spherical) {
+      if (deriv_index == 0) {
+        return 0.01 * static_cast<double>(max_degree) *
+                   pow(get<0>(coords), max_degree - 1) +
+               0.3 * static_cast<double>(max_degree - 1) *
+                   pow(get<0>(coords), max_degree - 2) -
+               2.0;
+      } else {
+        return {get<0>(coords).size(), 0.0};
+      }
+    } else {
+      if (deriv_index == 0) {
+        return max_degree * pow(get<0>(coords), max_degree - 1) *
+               get<1>(coords);
+      } else if (deriv_index == 1) {
+        return max_degree * pow(get<1>(coords), max_degree - 1) +
+               pow(get<0>(coords), max_degree);
+      } else {
+        return {get<0>(coords).size(), 0.0};
+      }
+    }
+  };
+
+  using VarTags = tmpl::list<::Tags::TempScalar<0>, ::Tags::TempA<0, 3>>;
+  const size_t number_var_components =
+      Variables<VarTags>::number_of_independent_components;
+  const size_t num_pts = get<0>(inertial_coords).size();
+  Variables<VarTags> volume_vars{mesh.number_of_grid_points()};
+
+  using d_VarTags =
+      db::wrap_tags_in<Tags::deriv, VarTags, tmpl::size_t<3>, Frame::Inertial>;
+  Variables<d_VarTags> expected_deriv{mesh.number_of_grid_points()};
+
+  auto& scalar = get<::Tags::TempScalar<0>>(volume_vars);
+  auto& d_scalar = get<tmpl::front<d_VarTags>>(expected_deriv);
+  get(scalar) = cartoon_func(inertial_coords);
+  for (size_t i = 0; i < index_dim<0>(d_scalar); ++i) {
+    d_scalar.get(i) = cartoon_dfunc(i, inertial_coords);
+  }
+
+  auto& vector = get<::Tags::TempA<0, 3>>(volume_vars);
+  auto& d_vector = get<tmpl::back<d_VarTags>>(expected_deriv);
+  if constexpr (Spherical) {
+    // spherical case, vector, using x^a
+    get<0>(vector) = cartoon_func(inertial_coords);
+    for (size_t a = 1; a < index_dim<0>(vector); ++a) {
+      vector.get(a) =
+          inertial_coords.get(a - 1) * cartoon_func(inertial_coords);
+    }
+    for (size_t i = 0; i < index_dim<0>(d_vector); ++i) {
+      for (size_t a = 0; a < index_dim<1>(d_vector); ++a) {
+        if ((i + 1) == a) {
+          d_vector.get(i, a) = cartoon_func(inertial_coords);
+        } else {
+          d_vector.get(i, a) = DataVector(num_pts, 0.0);
+        }
+        d_vector.get(i, a) +=
+            (a == 0 ? DataVector(num_pts, 1.0) : inertial_coords.get(a - 1)) *
+            cartoon_dfunc(i, inertial_coords);
+      }
+    }
+  } else {
+    // axial case, vector, using x^a = (0, -z, 0, x) (pure rotation)
+    get<0>(vector) = DataVector(num_pts, 0.0);
+    get<1>(vector) =
+        -1.0 * get<2>(inertial_coords) * cartoon_func(inertial_coords);
+    get<2>(vector) = DataVector(num_pts, 0.0);
+    get<3>(vector) = get<0>(inertial_coords) * cartoon_func(inertial_coords);
+
+    for (size_t i = 0; i < d_vector.size(); ++i) {
+      d_vector[i] = DataVector(num_pts, 0.0);
+    }
+    d_vector.get(2, 1) =
+        -1.0 * cartoon_func(inertial_coords) +
+        -1.0 * get<2>(inertial_coords) * cartoon_dfunc(2, inertial_coords);
+    d_vector.get(1, 3) =
+        get<0>(inertial_coords) * cartoon_dfunc(1, inertial_coords);
+    d_vector.get(0, 3) =
+        cartoon_func(inertial_coords) +
+        get<0>(inertial_coords) * cartoon_dfunc(0, inertial_coords);
+  }
+
+  DirectionMap<3, DataVector> neighbor_data{};
+  for (const auto& direction : Direction<CompDim>::all_directions()) {
+    auto neighbor_inertial_coords = inertial_coords;
+    auto& neighbor_coords_current_dim =
+        neighbor_inertial_coords.get(direction.dimension());
+    const double min_bounds = *std::min_element(
+        neighbor_coords_current_dim.begin(), neighbor_coords_current_dim.end());
+    const double max_bounds = *std::max_element(
+        neighbor_coords_current_dim.begin(), neighbor_coords_current_dim.end());
+    const double delta_bounds = max_bounds - min_bounds;
+    const double delta_i =
+        delta_bounds / static_cast<double>(points_per_dimension - 1);
+    neighbor_coords_current_dim += direction.sign() * (delta_bounds + delta_i);
+    DataVector neighbor_vars{
+        mesh.number_of_grid_points() * number_var_components, 0.0};
+    Scalar<DataVector> neighbor_var1(neighbor_vars.data(),
+                                     mesh.number_of_grid_points());
+    DataVector neighbor_var2_0(
+        neighbor_vars.data() + 1 * mesh.number_of_grid_points(),
+        mesh.number_of_grid_points());
+    DataVector neighbor_var2_1(
+        neighbor_vars.data() + 2 * mesh.number_of_grid_points(),
+        mesh.number_of_grid_points());
+    DataVector neighbor_var2_2(
+        neighbor_vars.data() + 3 * mesh.number_of_grid_points(),
+        mesh.number_of_grid_points());
+    DataVector neighbor_var2_3(
+        neighbor_vars.data() + 4 * mesh.number_of_grid_points(),
+        mesh.number_of_grid_points());
+
+    get(neighbor_var1) = cartoon_func(neighbor_inertial_coords);
+
+    if constexpr (Spherical) {
+      // spherical case, vector/one form, using x^a
+      neighbor_var2_0 = cartoon_func(neighbor_inertial_coords);
+      neighbor_var2_1 = get<0>(neighbor_inertial_coords) *
+                        cartoon_func(neighbor_inertial_coords);
+      neighbor_var2_2 = get<1>(neighbor_inertial_coords) *
+                        cartoon_func(neighbor_inertial_coords);
+      neighbor_var2_3 = get<2>(neighbor_inertial_coords) *
+                        cartoon_func(neighbor_inertial_coords);
+    } else {
+      // axial case, vector/one form, using x^a = (0, -z, 0, x) (pure
+      // rotation)
+      neighbor_var2_0 = DataVector(num_pts, 0.0);
+      neighbor_var2_1 = -1.0 * get<2>(neighbor_inertial_coords) *
+                        cartoon_func(neighbor_inertial_coords);
+      neighbor_var2_2 = DataVector(num_pts, 0.0);
+      neighbor_var2_3 = get<0>(neighbor_inertial_coords) *
+                        cartoon_func(neighbor_inertial_coords);
+    }
+
+    Index<CompDim> mesh_extents;
+    if constexpr (Spherical) {
+      mesh_extents = mesh.slice_through(0).extents();
+    } else {
+      mesh_extents = mesh.slice_through(0, 1).extents();
+    }
+    const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+        gsl::make_span(neighbor_vars.data(), neighbor_vars.size()),
+        mesh_extents, (stencil_width - 1) / 2 + 1,
+        std::unordered_set{direction.opposite()}, 0, {});
+    CAPTURE((stencil_width - 1) / 2 + 1);
+    REQUIRE(sliced_data.size() == 1);
+    REQUIRE(sliced_data.contains(direction.opposite()));
+    const Direction<3> direction_3D{direction.dimension(), direction.side()};
+    neighbor_data[direction_3D] = sliced_data.at(direction.opposite());
+    REQUIRE(neighbor_data.at(direction_3D).size() ==
+            number_var_components * (fd_order / 2 + 1) *
+                mesh.slice_away(0).number_of_grid_points());
+  }
+
+  DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
+  for (const auto& [direction, data] : neighbor_data) {
+    ghost_cell_vars[direction] = gsl::make_span(data.data(), data.size());
+  }
+
+  Variables<d_VarTags> deriv{mesh.number_of_grid_points()};
+  // testing the "chooser" as well as the underlying
+  // `cartoon_partial_derivatives()`
+  ::fd::partial_derivatives<VarTags>(
+      make_not_null(&deriv), volume_vars, ghost_cell_vars, mesh,
+      number_var_components, fd_order, inv_jacobian, inertial_coords);
+
+  const Approx local_approx = Approx::custom().epsilon(1.0e-10).scale(1.0);
+  CHECK_VARIABLES_CUSTOM_APPROX(deriv, expected_deriv, local_approx);
+}
+
+void test_asserts_and_errors() {
+  using var_tags = tmpl::list<Tags::TempScalar<0, DataVector>,
+                              Tags::TempScalar<1, DataVector>>;
+  constexpr size_t fd_order = 4;
+  constexpr size_t pts = 6;  // fd_order + 2
+
+#ifdef SPECTRE_DEBUG
+  using derivative_tags = tmpl::list<Tags::TempScalar<0, DataVector>,
+                                     Tags::TempScalar<1, DataVector>>;
+  {
+    INFO("Wrong output size");
+    const Mesh<2> mesh{pts, Spectral::Basis::FiniteDifference,
+                       Spectral::Quadrature::CellCentered};
+    const size_t num_pts = mesh.number_of_grid_points();
+    const size_t num_vars = 2;
+    DataVector volume_vars_dv{num_pts * num_vars, 0.0};
+    const auto volume_vars_span =
+        gsl::make_span(volume_vars_dv.data(), volume_vars_dv.size());
+
+    // Create ghost cell data for all directions
+    const size_t ghost_pts_per_face =
+        (fd_order / 2 + 1) * mesh.slice_away(0).number_of_grid_points();
+    DirectionMap<2, gsl::span<const double>> ghost_cell_vars{};
+    DataVector ghost_dv{ghost_pts_per_face * num_vars, 0.0};
+    for (const auto& dir : Direction<2>::all_directions()) {
+      ghost_cell_vars[dir] = gsl::make_span(ghost_dv.data(), ghost_dv.size());
+    }
+
+    const InverseJacobian<DataVector, 2, Frame::ElementLogical, Frame::Inertial>
+        inv_jac{num_pts, 0.0};
+
+    // Allocate with wrong size (should be Dim * volume_vars.size())
+    Variables<db::wrap_tags_in<Tags::deriv, derivative_tags, tmpl::size_t<2>,
+                               Frame::Inertial>>
+        d_vars_wrong{num_pts - 1};  // wrong number of grid points
+    CHECK_THROWS_WITH((::fd::partial_derivatives<derivative_tags>(
+                          make_not_null(&d_vars_wrong), volume_vars_span,
+                          ghost_cell_vars, mesh, num_vars, fd_order, inv_jac)),
+                      Catch::Matchers::ContainsSubstring(
+                          "The partial derivatives Variables must have size"));
+  }
+  {
+    INFO("Invalid Cartoon quadrature combination");
+    // Build a 3D mesh with Cartoon in dim 2 but wrong quadrature
+    const Mesh<3> mesh_wrong_quad{
+        {pts, pts, 1},
+        {Spectral::Basis::FiniteDifference, Spectral::Basis::FiniteDifference,
+         Spectral::Basis::Cartoon},
+        // Wrong: SphericalSymmetry instead of AxialSymmetry for 2 comp dims
+        {Spectral::Quadrature::CellCentered, Spectral::Quadrature::CellCentered,
+         Spectral::Quadrature::SphericalSymmetry}};
+    const size_t num_pts = mesh_wrong_quad.number_of_grid_points();
+    const size_t num_vars =
+        Variables<var_tags>::number_of_independent_components;
+
+    using Affine = domain::CoordinateMaps::Affine;
+    using Identity1D = domain::CoordinateMaps::Identity<1>;
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                                Cartoon_map_combination>
+        map{{Affine{-1.0, 1.0, 0.4, 0.7}, Affine{-1.0, 1.0, -0.5, 3.2},
+             Identity1D{}}};
+    const auto inv_jac = map.inv_jacobian(logical_coordinates(mesh_wrong_quad));
+    const auto inertial_coords = map(logical_coordinates(mesh_wrong_quad));
+
+    const Variables<var_tags> volume_vars{num_pts};
+    Variables<db::wrap_tags_in<Tags::deriv, var_tags, tmpl::size_t<3>,
+                               Frame::Inertial>>
+        d_vars{num_pts};
+
+    const size_t ghost_pts_per_face =
+        (fd_order / 2 + 1) *
+        mesh_wrong_quad.slice_away(0).number_of_grid_points();
+    DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
+    DataVector ghost_dv{ghost_pts_per_face * num_vars, 0.0};
+    for (const auto& dir : Direction<2>::all_directions()) {
+      ghost_cell_vars[Direction<3>{dir.dimension(), dir.side()}] =
+          gsl::make_span(ghost_dv.data(), ghost_dv.size());
+    }
+
+    CHECK_THROWS_WITH(
+        (::fd::cartoon_partial_derivatives<var_tags>(
+            make_not_null(&d_vars), volume_vars, ghost_cell_vars,
+            mesh_wrong_quad, num_vars, fd_order, inv_jac, inertial_coords)),
+        Catch::Matchers::ContainsSubstring("Invalid Quadrature combinations"));
+  }
+  {
+    INFO("cartoon impl, wrong deriv output size");
+    const Mesh<3> mesh{
+        {pts, pts, 1},
+        {Spectral::Basis::FiniteDifference, Spectral::Basis::FiniteDifference,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::CellCentered, Spectral::Quadrature::CellCentered,
+         Spectral::Quadrature::AxialSymmetry}};
+    const size_t num_pts = mesh.number_of_grid_points();
+    const size_t num_vars =
+        Variables<var_tags>::number_of_independent_components;
+
+    using Affine = domain::CoordinateMaps::Affine;
+    using Identity1D = domain::CoordinateMaps::Identity<1>;
+    using Cartoon_map_combination =
+        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>;
+    const domain::CoordinateMap<Frame::ElementLogical, Frame::Inertial,
+                                Cartoon_map_combination>
+        map{{Affine{-1.0, 1.0, 0.4, 0.7}, Affine{-1.0, 1.0, -0.5, 3.2},
+             Identity1D{}}};
+    const auto inv_jac = map.inv_jacobian(logical_coordinates(mesh));
+    const auto inertial_coords = map(logical_coordinates(mesh));
+
+    const Variables<var_tags> volume_vars{num_pts};
+    // Allocate with wrong size (one grid point too few)
+    Variables<db::wrap_tags_in<Tags::deriv, var_tags, tmpl::size_t<3>,
+                               Frame::Inertial>>
+        d_vars_wrong{num_pts - 1};
+
+    const size_t ghost_pts_per_face =
+        (fd_order / 2 + 1) * mesh.slice_away(0).number_of_grid_points();
+    DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
+    DataVector ghost_dv{ghost_pts_per_face * num_vars, 0.0};
+    for (const auto& dir : Direction<2>::all_directions()) {
+      ghost_cell_vars[Direction<3>{dir.dimension(), dir.side()}] =
+          gsl::make_span(ghost_dv.data(), ghost_dv.size());
+    }
+
+    CHECK_THROWS_WITH(
+        (::fd::cartoon_partial_derivatives<var_tags>(
+            make_not_null(&d_vars_wrong), volume_vars, ghost_cell_vars, mesh,
+            num_vars, fd_order, inv_jac, inertial_coords)),
+        Catch::Matchers::ContainsSubstring(
+            "The partial derivatives Variables must have size"));
+  }
+#endif  // SPECTRE_DEBUG
+  {
+    INFO("Invalid Cartoon basis layout");
+    // Build mesh with Cartoon in the first dimension (dim 0) — invalid layout
+    const Mesh<3> mesh_bad_basis{
+        {1, pts, 1},
+        {Spectral::Basis::Cartoon, Spectral::Basis::FiniteDifference,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::CellCentered,
+         Spectral::Quadrature::AxialSymmetry}};
+    const size_t num_pts = mesh_bad_basis.number_of_grid_points();
+    const size_t num_vars =
+        Variables<var_tags>::number_of_independent_components;
+
+    const InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+        inv_jac{num_pts, 0.0};
+    const tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{num_pts, 0.0};
+
+    const Variables<var_tags> volume_vars{num_pts};
+    Variables<db::wrap_tags_in<Tags::deriv, var_tags, tmpl::size_t<3>,
+                               Frame::Inertial>>
+        d_vars{num_pts};
+
+    const DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
+
+    CHECK_THROWS_WITH(
+        (::fd::cartoon_partial_derivatives<var_tags>(
+            make_not_null(&d_vars), volume_vars, ghost_cell_vars,
+            mesh_bad_basis, num_vars, fd_order, inv_jac, inertial_coords)),
+        Catch::Matchers::ContainsSubstring(
+            "Bases do not match valid Cartoon pattern"));
+  }
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.FiniteDifference.PartialDerivatives",
                   "[Unit][NumericalAlgorithms]") {
+  test_asserts_and_errors();
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> dist{-1.0, 1.0};
   for (const size_t fd_order : {2_st, 4_st, 6_st, 8_st}) {
@@ -223,5 +658,9 @@ SPECTRE_TEST_CASE("Unit.FiniteDifference.PartialDerivatives",
             fd_order);
     test<3>(make_not_null(&generator), make_not_null(&dist), fd_order + 2,
             fd_order);
+    if (fd_order > 2) {
+      test_cartoon<true>(fd_order + 2, fd_order);
+      test_cartoon<false>(fd_order + 2, fd_order);
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

FD derivatives use the same logic as DG, so the first commit is moving the inner working of the DG to `partial_derivatives_with_cartoon_impl()` which now both DG and FD call once they do their respective non-cartoon preparation.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
