### PR TITLE
Increase the LinearOperators.PartialDerivs test timeout

### DIFF
--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -1227,7 +1227,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
   }
 }
 
-// [[Timeout, 90]]
+// [[Timeout, 120]]
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {
   test_partial_derivatives_spherical_shell<two_vars<DataVector, 3>>();


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
It was regularly timing out (due to added tests with Cartoon bases) 
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
