### PR TITLE
Add --num_slurm_tasks  option to Scheduler

### DIFF
--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -363,6 +363,7 @@ def schedule(
     machine = this_machine(raise_exception=False)
     num_procs = kwargs.get("num_procs")
     num_nodes = kwargs.get("num_nodes")
+    num_slurm_tasks = None
     if num_procs:
         assert (
             num_nodes is None or num_nodes == 1
@@ -374,6 +375,9 @@ def schedule(
             )
             if num_procs <= cores_per_node:
                 num_nodes = 1
+                num_slurm_tasks = int(
+                    np.ceil(num_procs / machine.DefaultProcsPerTask)
+                )
             else:
                 num_nodes = int(np.ceil(num_procs / cores_per_node))
                 logger.info(f"Rounded up to run on {num_nodes} full node(s).")
@@ -382,7 +386,11 @@ def schedule(
             num_nodes = 1
     # Update kwargs with resolved num_procs and num_nodes (used to build
     # `context` below)
-    kwargs.update(num_procs=num_procs, num_nodes=num_nodes)
+    kwargs.update(
+        num_procs=num_procs,
+        num_nodes=num_nodes,
+        num_slurm_tasks=num_slurm_tasks,
+    )
 
     # Set up template environment with basic configuration
     template_env = jinja2.Environment(
@@ -907,7 +915,8 @@ def scheduler_options(f):
         "-c",
         type=_parse_param,
         help=(
-            "Number of worker threads. "
+            "Number of worker threads. Less than a full node will only set as "
+            "many Slurm ntasks-per-node as required by machine configuration. "
             "Mutually exclusive with '--num-nodes' / '-N'."
         ),
     )

--- a/support/SubmitScripts/Anvil.sh
+++ b/support/SubmitScripts/Anvil.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -
 #SBATCH -o spectre.out
 #SBATCH -e spectre.out
-#SBATCH --ntasks-per-node 1
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(1) }}
 #SBATCH --cpus-per-task=128
 #SBATCH --no-requeue
 #SBATCH -J SpectreJob

--- a/support/SubmitScripts/CaltechHpc.sh
+++ b/support/SubmitScripts/CaltechHpc.sh
@@ -13,7 +13,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node 2
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(2) }}
 #SBATCH --cpus-per-task 28
 #SBATCH --constraint=cascadelake
 #SBATCH -p {{ queue | default("expansion") }}

--- a/support/SubmitScripts/Expanse.sh
+++ b/support/SubmitScripts/Expanse.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -
 #SBATCH -o spectre.stdout
 #SBATCH -e spectre.stderr
-#SBATCH --ntasks-per-node 128
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(128) }}
 #SBATCH --mem=248G
 #SBATCH -J KerrSchild
 #SBATCH --nodes 2

--- a/support/SubmitScripts/Mbot.sh
+++ b/support/SubmitScripts/Mbot.sh
@@ -10,7 +10,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node 6
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(6) }}
 #SBATCH --cpus-per-task 32
 #SBATCH -p {{ queue | default("nd357_0001") }}
 #SBATCH -t {{ time_limit | default("1-00:00:00") }}

--- a/support/SubmitScripts/Ocean2.sh
+++ b/support/SubmitScripts/Ocean2.sh
@@ -10,7 +10,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node 6
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(6) }}
 #SBATCH --cpus-per-task 32
 #SBATCH -p {{ queue | default("normal") }}
 #SBATCH -t {{ time_limit | default("01-00:00:00") }}

--- a/support/SubmitScripts/Ocean2_orca1.sh
+++ b/support/SubmitScripts/Ocean2_orca1.sh
@@ -11,7 +11,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node 1
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(1) }}
 #SBATCH --cpus-per-task 20
 #SBATCH -p {{ queue | default("orca-1") }}
 #SBATCH -t {{ time_limit | default("01-00:00:00") }}

--- a/support/SubmitScripts/Oscar.sh
+++ b/support/SubmitScripts/Oscar.sh
@@ -13,7 +13,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node 2
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(2) }}
 #SBATCH --cpus-per-task 16
 #SBATCH -p {{ queue | default("batch") }}
 #SBATCH -t {{ time_limit | default("1-00:00:00") }}

--- a/support/SubmitScripts/Perlmutter.sh
+++ b/support/SubmitScripts/Perlmutter.sh
@@ -11,7 +11,7 @@
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
 #SBATCH --constraint cpu
-#SBATCH --ntasks-per-node 8
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(8) }}
 #SBATCH --cpus-per-task 32
 #SBATCH -q {{ queue | default("regular") }}
 #SBATCH -t {{ time_limit | default("1-00:00:00") }}

--- a/support/SubmitScripts/Sonic.sh
+++ b/support/SubmitScripts/Sonic.sh
@@ -10,7 +10,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node 3
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(3) }}
 #SBATCH --cpus-per-task 32
 #SBATCH -p {{ queue | default("long") }}
 #SBATCH -t {{ time_limit | default("1-00:00:00") }}

--- a/support/SubmitScripts/Urania.sh
+++ b/support/SubmitScripts/Urania.sh
@@ -10,7 +10,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node=1
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(1) }}
 #SBATCH --ntasks-per-core=1
 #SBATCH --cpus-per-task=72
 #SBATCH -t {{ time_limit | default("1-00:00:00") }}

--- a/support/SubmitScripts/Viper.sh
+++ b/support/SubmitScripts/Viper.sh
@@ -10,7 +10,7 @@
 {% block head %}
 {{ super() -}}
 #SBATCH --nodes {{ num_nodes | default(1) }}
-#SBATCH --ntasks-per-node=1
+#SBATCH --ntasks-per-node {{ num_slurm_tasks | default(1) }}
 #SBATCH --ntasks-per-core=1
 #SBATCH --cpus-per-task=128
 #SBATCH -t {{ time_limit | default("1-00:00:00") }}

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -59,6 +59,7 @@ SPECTRE_CLI={{ spectre_cli }}
 {% extends "SubmitTemplateBase.sh" %}
 {% block derived %}
 NUM_NODES={{ num_nodes | default(1) }}
+NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
 {% endblock %}
 """)
 
@@ -256,6 +257,7 @@ NUM_NODES={{ num_nodes | default(1) }}
 SPECTRE_EXECUTABLE={executable}
 SPECTRE_CLI={spectre_cli}
 NUM_NODES=1
+NUM_TASKS_PER_NODE=5
 """.format(
                 executable=self.test_dir / "Segments/TestExec",
                 spectre_cli=self.spectre_cli,


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Allow the schedule CLI to have an option to specify SLURM's `--ntasks-per-node`.
This is particularly useful on a machine like MBOT where an entire compute note may not be necessary for a job
### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
