### PR TITLE
Ensure blas dgemm with zero size is no-op

### DIFF
--- a/src/Utilities/Blas.hpp
+++ b/src/Utilities/Blas.hpp
@@ -154,6 +154,14 @@ inline void dgemm_(const char& TRANSA, const char& TRANSB, const size_t& M,
              'C' == TRANSB or 'c' == TRANSB,
          "TRANSB must be upper or lower case N, T, or C. See the BLAS "
          "documentation for help.");
+
+  // On some BLAS implementations (e.g. Accelerate.framework on macOS) a call
+  // with a zero-sized dimension aborts instead of acting as a no-op.  Treat
+  // these cases explicitly so we behave consistently across platforms.
+  if (M == 0 or N == 0 or K == 0) {
+    return;
+  }
+
   blas_detail::dgemm_(
       TRANSA, TRANSB, gsl::narrow_cast<int>(M), gsl::narrow_cast<int>(N),
       gsl::narrow_cast<int>(K), ALPHA, A, gsl::narrow_cast<int>(LDA), B,
@@ -175,6 +183,14 @@ inline void zgemm_(const char& TRANSA, const char& TRANSB, const size_t& M,
              'C' == TRANSB or 'c' == TRANSB,
          "TRANSB must be upper or lower case N, T, or C. See the BLAS "
          "documentation for help.");
+
+  // On some BLAS implementations (e.g. Accelerate.framework on macOS) a call
+  // with a zero-sized dimension aborts instead of acting as a no-op.  Treat
+  // these cases explicitly so we behave consistently across platforms.
+  if (M == 0 or N == 0 or K == 0) {
+    return;
+  }
+
   blas_detail::zgemm_(
       TRANSA, TRANSB, gsl::narrow_cast<int>(M), gsl::narrow_cast<int>(N),
       gsl::narrow_cast<int>(K), ALPHA, A, gsl::narrow_cast<int>(LDA), B,
@@ -198,6 +214,14 @@ inline void dgemm_<true>(const char& TRANSA, const char& TRANSB,
              'C' == TRANSB or 'c' == TRANSB,
          "TRANSB must be upper or lower case N, T, or C. See the BLAS "
          "documentation for help.");
+
+  // On some BLAS implementations (e.g. Accelerate.framework on macOS) a call
+  // with a zero-sized dimension aborts instead of acting as a no-op.  Treat
+  // these cases explicitly so we behave consistently across platforms.
+  if (M == 0 or N == 0 or K == 0) {
+    return;
+  }
+
   const auto m = gsl::narrow_cast<int>(M);
   const auto n = gsl::narrow_cast<int>(N);
   const auto k = gsl::narrow_cast<int>(K);
@@ -242,6 +266,14 @@ inline void dgemv_(const char& TRANS, const size_t& M, const size_t& N,
              'C' == TRANS or 'c' == TRANS,
          "TRANS must be upper or lower case N, T, or C. See the BLAS "
          "documentation for help.");
+
+  // On some BLAS implementations (e.g. Accelerate.framework on macOS) a call
+  // with a zero-sized dimension aborts instead of acting as a no-op.  Treat
+  // these cases explicitly so we behave consistently across platforms.
+  if (M == 0 or N == 0) {
+    return;
+  }
+
   // INCX and INCY are allowed to be negative by BLAS, but we never
   // use them that way.  If needed, they can be changed here, but then
   // code providing values will also have to be changed to int to

--- a/tests/Unit/Utilities/Test_Blas.cpp
+++ b/tests/Unit/Utilities/Test_Blas.cpp
@@ -32,6 +32,33 @@ SPECTRE_TEST_CASE("Unit.Utilities.Blas", "[Unit][Utilities]") {
                         "TRANS must be upper or lower case N, T, or C. See the "
                         "BLAS documentation for help."));
 #endif
-  // so test does not fail in release mode
-  CHECK(true);
+  // Verify that zero-sized matrix multiplications are treated as no-ops.
+  const size_t zero = 0;
+  const size_t one = 1;
+  const double alpha = 1.23;
+  const double beta = 4.56;
+  const std::array<double, 1> a{{7.89}};
+  const std::array<double, 1> b{{0.12}};
+  std::array<double, 1> c{{3.45}};
+  const double original_c = c[0];
+  dgemm_('N', 'N', zero, zero, zero, alpha, a.data(), zero, b.data(), one, beta,
+         c.data(), one);
+  CHECK(c[0] == original_c);
+
+  dgemv_('N', zero, zero, alpha, a.data(), zero, b.data(), one, beta, c.data(),
+         one);
+  CHECK(c[0] == original_c);
+
+  const std::complex<double> alpha_complex = std::complex<double>{1.23, 3.21};
+  const std::complex<double> beta_complex = std::complex<double>{4.56, 6.54};
+  const std::array<std::complex<double>, 1> a_complex{
+      {std::complex<double>{7.89, 9.87}}};
+  const std::array<std::complex<double>, 1> b_complex{
+      {std::complex<double>{0.12, 2.10}}};
+  std::array<std::complex<double>, 1> c_complex{
+      {std::complex<double>{3.45, 5.43}}};
+  const std::complex<double> original_c_complex = c_complex[0];
+  zgemm_('N', 'N', zero, zero, zero, alpha_complex, a_complex.data(), zero,
+         b_complex.data(), one, beta_complex, c_complex.data(), one);
+  CHECK(c_complex[0] == original_c_complex);
 }


### PR DESCRIPTION
## Proposed changes

I ran into an issue on macOS where the `Acceleration.framework` implementation of `dgemm()` is strict about validating input matrix sizes, throwing an error if any sizes are zero. This caused a test in `Test_MortarInterpolator.cpp` to fail. But OpenBLAS on Linux just treats a call with zero size as a no-op. This PR ensures we get that behavior regardless of BLAS distribution used.

Note: I used cursor tab completion with the OpenAI codex plugin to help me understand the issue and to draft the unit test that I added here.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
