### PR TITLE
Handle missing volume subfiles when opening h5 files

### DIFF
--- a/src/Visualization/Python/OpenVolfiles.py
+++ b/src/Visualization/Python/OpenVolfiles.py
@@ -30,11 +30,26 @@ def open_volfiles(
     """
     import spectre.IO.H5 as spectre_h5
 
+    subfile_found = False
+    files_exist = False
+
     for h5_file in h5_files:
         with spectre_h5.H5File(h5_file, "r") as open_h5_file:
-            volfile = open_h5_file.get_vol(subfile_name)
+            files_exist = True
+            try:
+                volfile = open_h5_file.get_vol(subfile_name)
+            except RuntimeError:
+                continue
+
+            subfile_found = True
             if obs_id is None or obs_id in volfile.list_observation_ids():
                 yield volfile
+
+    if files_exist and not subfile_found:
+        raise ValueError(
+            f"Subfile '{subfile_name}' was not found in any of the provided"
+            " H5 files."
+        )
 
 
 def parse_step(ctx, param, value):

--- a/tests/Unit/Visualization/Python/Test_ReadH5.py
+++ b/tests/Unit/Visualization/Python/Test_ReadH5.py
@@ -11,6 +11,7 @@ import pandas.testing as pdt
 
 import spectre.Informer as spectre_informer
 import spectre.IO.H5 as spectre_h5
+from spectre.Visualization.OpenVolfiles import open_volfiles
 from spectre.Visualization.ReadH5 import (
     available_subfiles,
     select_observation,
@@ -23,6 +24,8 @@ class TestReadH5(unittest.TestCase):
         self.data_dir = Path(
             spectre_informer.unit_test_src_path(), "Visualization/Python"
         )
+        self.vol_file = str(self.data_dir / "VolTestData0.h5")
+        self.dat_file = str(self.data_dir / "DatTestData.h5")
 
     def test_available_subfiles(self):
         # Test with open file
@@ -107,6 +110,15 @@ class TestReadH5(unittest.TestCase):
                 select_observation(open_volfile, time=0.05),
                 (expected_obs_id, expected_time),
             )
+
+    def test_open_volfiles_missing_subfile(self):
+        volfiles = list(
+            open_volfiles([self.vol_file, self.dat_file], "/element_data")
+        )
+        self.assertEqual(len(volfiles), 1)
+
+        with self.assertRaises(ValueError):
+            list(open_volfiles([self.dat_file], "/element_data"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

This fixes a bug which throws an error is when calling `open_volfiles` on a set of volume files and only a subset of them contains the subfile. I encountered this as I was observing some volume quantities only in certain blocks.


