### PR TITLE
Parallelize computing vars to interpolate to AH

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.cpp
@@ -42,7 +42,11 @@ namespace {
 // they won't be needed
 template <bool ForceInertialFrame = false, typename Fr>
 void compute_vars_to_interpolate_to_target_impl(
-    const gsl::not_null<ah::Storage::VolumeVariables<Fr>*> volume_vars_storage,
+    const gsl::not_null<Variables<ah::vars_to_interpolate_to_target<3, Fr>>*>
+        target_vars,
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::aa<DataVector, 3>& pi, const tnsr::iaa<DataVector, 3>& phi,
+    const tnsr::ijaa<DataVector, 3>& deriv_phi, const Mesh<3>& mesh,
     const Jacobian<DataVector, 3, Fr, Frame::Inertial>& jac_frame_to_inertial =
         {},
     const InverseJacobian<DataVector, 3, Frame::ElementLogical, Fr>&
@@ -53,20 +57,8 @@ void compute_vars_to_interpolate_to_target_impl(
       tmpl::conditional_t<ForceInertialFrame, ::Frame::Inertial, Fr>;
   Variables<ah::vars_to_interpolate_to_target<3, FrameToUse>>
       vars_to_interpolate_to_target;
-  vars_to_interpolate_to_target.set_data_ref(
-      volume_vars_storage->vars_to_interpolate_to_target.data(),
-      volume_vars_storage->vars_to_interpolate_to_target.size());
-
-  const auto& source_vars = volume_vars_storage->source_vars;
-  const auto& mesh = volume_vars_storage->mesh;
-
-  const auto& spacetime_metric =
-      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars);
-  const auto& pi = get<gh::Tags::Pi<DataVector, 3>>(source_vars);
-  const auto& phi = get<gh::Tags::Phi<DataVector, 3>>(source_vars);
-  const auto& deriv_phi =
-      get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
-                        Frame::Inertial>>(source_vars);
+  vars_to_interpolate_to_target.set_data_ref(target_vars->data(),
+                                             target_vars->size());
 
   // Inertial tags
   using inertial_metric_tag = gr::Tags::SpatialMetric<DataVector, 3>;
@@ -178,17 +170,23 @@ void compute_vars_to_interpolate_to_target_impl(
 
 template <typename Fr>
 void compute_vars_to_interpolate_to_target(
-    const gsl::not_null<ah::Storage::VolumeVariables<Fr>*> volume_vars_storage,
+    const gsl::not_null<Variables<ah::vars_to_interpolate_to_target<3, Fr>>*>
+        target_vars,
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::aa<DataVector, 3>& pi, const tnsr::iaa<DataVector, 3>& phi,
+    const tnsr::ijaa<DataVector, 3>& deriv_phi,
     const LinkedMessageId<double>& time, const Domain<3>& domain,
-    const ElementId<3>& element_id,
+    const Mesh<3>& mesh, const ElementId<3>& element_id,
     const domain::FunctionsOfTimeMap& functions_of_time) {
   // This will only change the size if it isn't already the correct size
-  volume_vars_storage->vars_to_interpolate_to_target.initialize(
-      volume_vars_storage->source_vars.number_of_grid_points());
+  target_vars->initialize(get<0, 0>(spacetime_metric).size());
 
-  const auto& mesh = volume_vars_storage->mesh;
   const auto& block = domain.blocks()[element_id.block_id()];
   if (block.is_time_dependent()) {
+    ASSERT(not functions_of_time.empty(),
+           "Functions of time are not passed to "
+           "compute_vars_to_interpolate_to_target but the block is "
+           "time-dependent.");
     if constexpr (std::is_same_v<Fr, ::Frame::Grid>) {
       const ElementMap<3, Fr> map_logical_to_grid{
           element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
@@ -200,7 +198,8 @@ void compute_vars_to_interpolate_to_target(
           map_logical_to_grid.inv_jacobian(logical_coords);
 
       compute_vars_to_interpolate_to_target_impl(
-          volume_vars_storage, jac_grid_to_inertial, invjac_logical_to_grid);
+          target_vars, spacetime_metric, pi, phi, deriv_phi, mesh,
+          jac_grid_to_inertial, invjac_logical_to_grid);
     } else if constexpr (std::is_same_v<Fr, ::Frame::Distorted>) {
       ASSERT(block.has_distorted_frame(),
              "Block doesn't have a distorted frame but this horizon is in the "
@@ -223,11 +222,12 @@ void compute_vars_to_interpolate_to_target(
           element_logical_to_distorted_map.inv_jacobian(logical_coords, time.id,
                                                         functions_of_time);
 
-      compute_vars_to_interpolate_to_target_impl(volume_vars_storage,
-                                                 jac_distorted_to_inertial,
-                                                 invjac_logical_to_distorted);
+      compute_vars_to_interpolate_to_target_impl(
+          target_vars, spacetime_metric, pi, phi, deriv_phi, mesh,
+          jac_distorted_to_inertial, invjac_logical_to_distorted);
     } else {
-      compute_vars_to_interpolate_to_target_impl(volume_vars_storage);
+      compute_vars_to_interpolate_to_target_impl(target_vars, spacetime_metric,
+                                                 pi, phi, deriv_phi, mesh);
     }
   } else {
     // No frame transformations needed, since the maps are time-independent
@@ -235,18 +235,23 @@ void compute_vars_to_interpolate_to_target(
     //
     // The frame tags may be different, but the source vars should all be in the
     // Inertial frame, so we force the inertial frame (True template).
-    compute_vars_to_interpolate_to_target_impl<true>(volume_vars_storage);
+    compute_vars_to_interpolate_to_target_impl<true>(
+        target_vars, spacetime_metric, pi, phi, deriv_phi, mesh);
   }
 }
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                          \
-  template void compute_vars_to_interpolate_to_target(                \
-      const gsl::not_null<ah::Storage::VolumeVariables<FRAME(data)>*> \
-          volume_vars_storage,                                        \
-      const LinkedMessageId<double>& time, const Domain<3>& domain,   \
-      const ElementId<3>& element_id,                                 \
+#define INSTANTIATE(_, data)                                                  \
+  template void compute_vars_to_interpolate_to_target(                        \
+      const gsl::not_null<                                                    \
+          Variables<ah::vars_to_interpolate_to_target<3, FRAME(data)>>*>      \
+          target_vars,                                                        \
+      const tnsr::aa<DataVector, 3>& spacetime_metric,                        \
+      const tnsr::aa<DataVector, 3>& pi, const tnsr::iaa<DataVector, 3>& phi, \
+      const tnsr::ijaa<DataVector, 3>& deriv_phi,                             \
+      const LinkedMessageId<double>& time, const Domain<3>& domain,           \
+      const Mesh<3>& mesh, const ElementId<3>& element_id,                    \
       const domain::FunctionsOfTimeMap& functions_of_time);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "DataStructures/LinkedMessageId.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
@@ -19,8 +20,12 @@ namespace ah {
  */
 template <typename Fr>
 void compute_vars_to_interpolate_to_target(
-    gsl::not_null<ah::Storage::VolumeVariables<Fr>*> volume_vars_storage,
+    gsl::not_null<Variables<ah::vars_to_interpolate_to_target<3, Fr>>*>
+        target_vars,
+    const tnsr::aa<DataVector, 3>& spacetime_metric,
+    const tnsr::aa<DataVector, 3>& pi, const tnsr::iaa<DataVector, 3>& phi,
+    const tnsr::ijaa<DataVector, 3>& deriv_phi,
     const LinkedMessageId<double>& time, const Domain<3>& domain,
-    const ElementId<3>& element_id,
+    const Mesh<3>& mesh, const ElementId<3>& element_id,
     const domain::FunctionsOfTimeMap& functions_of_time);
 }  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp
@@ -101,6 +101,7 @@ bool check_if_current_time_is_ready(
 
             // Success: the current time is ok.
             // Failure: the current time is not ok.
+            using horizon_frame = typename HorizonMetavars::frame;
             return current_time.id <= min_expiration_time
                        ? std::unique_ptr<Parallel::Callback>{}
                        : std::unique_ptr<Parallel::Callback>(
@@ -108,10 +109,13 @@ bool check_if_current_time_is_ready(
                                  FindApparentHorizon<HorizonMetavars>,
                                  decltype(this_proxy), LinkedMessageId<double>,
                                  ElementId<3>, Mesh<3>,
-                                 Variables<ah::source_vars<3>>,
+                                 Variables<ah::vars_to_interpolate_to_target<
+                                     3, horizon_frame>>,
                                  std::optional<std::string>, bool>(
                                  this_proxy, incoming_time, incoming_element_id,
-                                 incoming_mesh, Variables<ah::source_vars<3>>{},
+                                 incoming_mesh,
+                                 Variables<ah::vars_to_interpolate_to_target<
+                                     3, horizon_frame>>{},
                                  dependency, true));
           });
     }  // if (domain.is_time_dependent())

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <pup.h>
 #include <string>
 #include <type_traits>
@@ -17,8 +18,10 @@
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
 #include "ParallelAlgorithms/Actions/GetItemFromDistributedObject.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
@@ -84,29 +87,47 @@ class FindApparentHorizon : public Event {
            "Blocks to interpolate doesn't contain target " << name());
     const auto& blocks_to_interpolate_for_this_target =
         blocks_to_interpolate.at(name());
-    const auto& blocks = Parallel::get<domain::Tags::Domain<3>>(cache).blocks();
-    const auto& block_name = blocks[array_index.block_id()].name();
+    const auto& domain = Parallel::get<domain::Tags::Domain<3>>(cache);
+    const auto& blocks = domain.blocks();
+    const auto& block = blocks[array_index.block_id()];
+    const auto& block_name = block.name();
 
     // Only send data if this target needs this blocks data
     if (not blocks_to_interpolate_for_this_target.contains(block_name)) {
       return;
     }
 
-    // Put everything into a single variables
-    Variables<ah::source_vars<3>> source_vars{mesh.number_of_grid_points()};
-    get<gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars) =
-        spacetime_metric;
-    get<gh::Tags::Pi<DataVector, 3>>(source_vars) = pi;
-    get<gh::Tags::Phi<DataVector, 3>>(source_vars) = phi;
-    get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
-                      Frame::Inertial>>(source_vars) = deriv_phi;
+    // Make Variables<ah::vars_to_interpolate_to_target> and
+    // fill it by calling compute_vars_to_interpolate_to_target().
+    // Then pass this variables to the FindApparentHorizon simple action.
+    using horizon_frame = typename HorizonMetavars::frame;
+    Variables<ah::vars_to_interpolate_to_target<3, horizon_frame>>
+        vars_to_interpolate_to_target{mesh.number_of_grid_points()};
+    if (block.is_time_dependent()) {
+      if constexpr (Parallel::is_in_global_cache<
+                        Metavariables, domain::Tags::FunctionsOfTime>) {
+        const auto& functions_of_time =
+            Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+        ah::compute_vars_to_interpolate_to_target(
+            make_not_null(&vars_to_interpolate_to_target), spacetime_metric, pi,
+            phi, deriv_phi, time, domain, mesh, array_index, functions_of_time);
+      } else {
+        ERROR(
+            "Block is time-dependent but FunctionsOfTime are not available "
+            "in the global cache.");
+      }
+    } else {
+      ah::compute_vars_to_interpolate_to_target(
+          make_not_null(&vars_to_interpolate_to_target), spacetime_metric, pi,
+          phi, deriv_phi, time, domain, mesh, array_index, {});
+    }
 
     auto& horizon_finder_proxy = Parallel::get_parallel_component<
         ah::Component<Metavariables, HorizonMetavars>>(cache);
 
     Parallel::simple_action<ah::FindApparentHorizon<HorizonMetavars>>(
-        horizon_finder_proxy, time, array_index, mesh, std::move(source_vars),
-        dependency_);
+        horizon_finder_proxy, time, array_index, mesh,
+        std::move(vars_to_interpolate_to_target), dependency_);
   }
 
   using is_ready_argument_tags = tmpl::list<>;

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -53,11 +53,11 @@ struct get_tags {
  * volume data, finds the apparent horizon, and calls the callbacks after the
  * horizon is found.
  *
- * \details First, the volume source variables `ah::source_vars` are put into
- * the `ah::Tags::Storage`. Then, we try to set the `ah::Tags::CurrentTime` with
- * the `ah::set_current_time` function. Once we have a current time, we ensure
- * the functions of time are up-to-date at this current time with
- * `ah::check_if_current_time_is_ready`.
+ * \details First, the volume variables `ah::vars_to_interpolate_to_target` are
+ * put into the `ah::Tags::Storage`. Then, we try to set the
+ * `ah::Tags::CurrentTime` with the `ah::set_current_time` function. Once we
+ * have a current time, we ensure the functions of time are up-to-date at this
+ * current time with `ah::check_if_current_time_is_ready`.
  *
  * Once we ensure the functions of time are ready, we compute the cartesian
  * coordinates for the current fast-flow iteration surface with
@@ -83,9 +83,10 @@ struct FindApparentHorizon {
                     const LinkedMessageId<double>& incoming_time,
                     const ElementId<3>& incoming_element_id,
                     const ::Mesh<3>& incoming_mesh,
-                    Variables<ah::source_vars<3>>&& incoming_source_vars,
+                    Variables<ah::vars_to_interpolate_to_target<3, frame>>&&
+                        incoming_vars_to_interpolate,
                     const std::optional<std::string>& dependency,
-                    const bool source_vars_have_already_been_received = false) {
+                    const bool vars_have_already_been_received = false) {
     const auto& verbosity = db::get<ah::Tags::Verbosity>(box);
     const bool quiet_print = verbosity >= ::Verbosity::Quiet;
     const bool verbose_print = verbosity >= ::Verbosity::Verbose;
@@ -122,16 +123,16 @@ struct FindApparentHorizon {
 
     // Add volume variables and destination to the box if they haven't already
     // been received
-    if (not source_vars_have_already_been_received) {
+    if (not vars_have_already_been_received) {
       all_storage[incoming_time].all_volume_variables.emplace(
           incoming_element_id,
-          ah::Storage::VolumeVariables<frame>{incoming_mesh,
-                                              std::move(incoming_source_vars)});
+          ah::Storage::VolumeVariables<frame>{
+              incoming_mesh, std::move(incoming_vars_to_interpolate)});
       all_storage.at(incoming_time).destination = HorizonMetavars::destination;
     }
 
     // ========================================================================
-    // The incoming source vars are moved and used in the above code. Below, we
+    // The incoming vars are moved and used in the above code. Below, we
     // only use quantities at the current time, except for forwarding the
     // incoming quantities to a callback for checking if the functions of time
     // are ready.
@@ -272,8 +273,7 @@ struct FindApparentHorizon {
 
           // Interpolate new elements to points
           interpolate_volume_data(make_not_null(&current_iteration_storage),
-                                  make_not_null(&all_volume_variables),
-                                  current_time, domain, functions_of_time);
+                                  make_not_null(&all_volume_variables));
 
           // Sanity check
           ASSERT(

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
@@ -29,9 +29,7 @@ void interpolate_volume_data(
     const gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration_storage,
     const gsl::not_null<
         std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>*>
-        all_volume_variables,
-    const LinkedMessageId<double>& time, const Domain<3>& domain,
-    const domain::FunctionsOfTimeMap& functions_of_time) {
+        all_volume_variables) {
   std::vector<ElementId<3>> element_ids;
   element_ids.reserve(all_volume_variables->size());
   for (const auto& [element_id, volume_vars] : *all_volume_variables) {
@@ -61,16 +59,6 @@ void interpolate_volume_data(
     const size_t expected_num_points = block_coord_holders.size();
     if (interpolated_vars.number_of_grid_points() != expected_num_points) {
       interpolated_vars.initialize(expected_num_points);
-    }
-
-    // Take the ah::source_vars and convert to
-    // ah::vars_to_interpolate_to_target
-    // But only do this once.
-    if (not volume_vars_storage.done_computing_vars_to_interpolate_to_target) {
-      ah::compute_vars_to_interpolate_to_target(
-          make_not_null(&volume_vars_storage), time, domain, element_id,
-          functions_of_time);
-      volume_vars_storage.done_computing_vars_to_interpolate_to_target = true;
     }
 
     const intrp::Irregular<3> interpolator(
@@ -114,9 +102,7 @@ void interpolate_volume_data(
           current_iteration_storage,                                 \
       const gsl::not_null<std::unordered_map<                        \
           ElementId<3>, ah::Storage::VolumeVariables<FRAME(data)>>*> \
-          all_volume_variables,                                      \
-      const LinkedMessageId<double>& time, const Domain<3>& domain,  \
-      const domain::FunctionsOfTimeMap& functions_of_time);
+          all_volume_variables);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Inertial, Frame::Distorted, Frame::Grid))

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp
@@ -27,16 +27,13 @@ namespace ah {
  * finder to the target points.
  *
  * \details For each new element, the `vars_to_interpolate_to_target` in
- * \p all_volume_variables are computed using the
- * `ah::compute_vars_to_interpolate_to_target()` function, and the results are
- * interpolated to the target points and stored in \p current_iteration_storage.
+ * \p all_volume_variables are interpolated to the target points and stored
+ * in \p current_iteration_storage.
  */
 template <typename Fr>
 void interpolate_volume_data(
     gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration_storage,
     gsl::not_null<
         std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>*>
-        all_volume_variables,
-    const LinkedMessageId<double>& time, const Domain<3>& domain,
-    const domain::FunctionsOfTimeMap& functions_of_time);
+        all_volume_variables);
 }  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -14,19 +14,14 @@ namespace ah::Storage {
 template <typename Fr>
 void VolumeVariables<Fr>::pup(PUP::er& p) {
   p | mesh;
-  p | source_vars;
   p | vars_to_interpolate_to_target;
-  p | done_computing_vars_to_interpolate_to_target;
 }
 
 template <typename Fr>
 bool operator==(const VolumeVariables<Fr>& lhs,
                 const VolumeVariables<Fr>& rhs) {
-  return lhs.mesh == rhs.mesh and lhs.source_vars == rhs.source_vars and
-         lhs.vars_to_interpolate_to_target ==
-             rhs.vars_to_interpolate_to_target and
-         lhs.done_computing_vars_to_interpolate_to_target ==
-             rhs.done_computing_vars_to_interpolate_to_target;
+  return lhs.mesh == rhs.mesh and
+         lhs.vars_to_interpolate_to_target == rhs.vars_to_interpolate_to_target;
 }
 template <typename Fr>
 bool operator!=(const VolumeVariables<Fr>& lhs,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -36,22 +36,11 @@ struct VolumeVariables {
   Mesh<3> mesh;
 
   /*!
-   * \brief A `Variables` of the  `ah::source_vars` in the volume.
-   */
-  Variables<ah::source_vars<3>> source_vars;
-
-  /*!
    * \brief A `Variables` of the tensors in the volume that we need to
    * interpolate onto the horizon.
    */
   Variables<ah::vars_to_interpolate_to_target<3, Fr>>
       vars_to_interpolate_to_target{};
-
-  /*!
-   * \brief A flag that ensures that the variables to interpolate onto the
-   * horizon are only computed once.
-   */
-  bool done_computing_vars_to_interpolate_to_target = false;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "ControlSystem/UpdateFunctionOfTime.hpp"
@@ -17,6 +18,8 @@
 #include "Domain/Creators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
+#include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
@@ -25,10 +28,13 @@
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "Framework/TestCreation.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
@@ -37,6 +43,10 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolationTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Events/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Phi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
 #include "Time/Tags/TimeAndPrevious.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -44,11 +54,13 @@
 
 namespace {
 struct MockFindApparentHorizon {
+  using frame = ::Frame::Grid;
+
   struct Results {
     LinkedMessageId<double> time{};
     ElementId<3> element_id{};
     Mesh<3> mesh;
-    Variables<ah::source_vars<3>> vars;
+    Variables<ah::vars_to_interpolate_to_target<3, frame>> vars;
     std::optional<std::string> dependency;
   };
   static Results results;  // NOLINT
@@ -61,13 +73,14 @@ struct MockFindApparentHorizon {
       const ArrayIndex& /*array_index*/,
       const LinkedMessageId<double>& incoming_time,
       const ElementId<3>& incoming_element_id, const ::Mesh<3>& incoming_mesh,
-      Variables<ah::source_vars<3>>&& incoming_source_vars,
+      Variables<ah::vars_to_interpolate_to_target<3, frame>>&&
+          incoming_vars_to_interpolate,
       const std::optional<std::string>& dependency,
       const bool /*source_vars_have_already_been_received*/ = false) {
     results.time = incoming_time;
     results.element_id = incoming_element_id;
     results.mesh = incoming_mesh;
-    results.vars = incoming_source_vars;
+    results.vars = std::move(incoming_vars_to_interpolate);
     results.dependency = dependency;
   }
 };
@@ -139,29 +152,31 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
   (void)MockHorizonMetavars::destination;
   ::domain::FunctionsOfTime::register_derived_with_charm();
   ::domain::creators::register_derived_with_charm();
+  ::domain::creators::time_dependence::register_derived_with_charm();
   using metavars = MockMetavariables;
   const ElementId<3> element_id(2);
   const ElementId<3> array_index(element_id);
 
   using component = MockComponent<metavars>;
   using elem_component = MockElement<metavars>;
-  std::unordered_map<std::string,
-                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
-      functions_of_time{};
-  const double initial_expr_time = 0.1;
-  const std::string name{"FunctionToCheck"};
-  functions_of_time[name] =
-      std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<0>>(
-          0.0, std::array<DataVector, 1>{{DataVector{1, 0.0}}},
-          initial_expr_time);
+  const double initial_time = 0.0;
+  const std::array<double, 3> translation_velocity{{0.01, 0.02, 0.03}};
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dependence = std::make_unique<
+          domain::creators::time_dependence::UniformTranslation<3>>(
+          initial_time, translation_velocity);
   const auto domain_creator = domain::creators::Sphere(
-      1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
+      1.8, 2.2, domain::creators::Sphere::Excision{}, 1_st, 5_st, false,
+      std::nullopt, std::vector<double>{},
+      domain::CoordinateMaps::Distribution::Linear, ShellWedges::All,
+      std::optional{domain::creators::Sphere::TimeDepOptionType{
+          std::move(time_dependence)}});
   const auto block_names = domain_creator.block_names();
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator.create_domain(),
        std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}},
-      {std::move(functions_of_time)}};
+      {domain_creator.functions_of_time()}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_array_component<component>(
@@ -174,9 +189,89 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
   const Mesh<3> mesh(5, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const LinkedMessageId<double> observation_time{2.0, {1.0}};
-  Variables<ah::source_vars<3>> vars(mesh.number_of_grid_points(), 9.876);
-  std::optional<std::string> dependency{"FakeDependency"};
   auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
+
+  // Fill source vars with an analytic solution so that
+  // ah::vars_to_interpolate_to_target can be computed from
+  // the ah::source_vars. Previously, the source vars were all just set
+  // to a constant value in this test. But in that case, the call to
+  // FindApparentHorizon::apply() doesn't receive well-defined values, now
+  // that it receives vars_to_interpolate_to_target instead of source_vars.
+  Variables<ah::source_vars<3>> vars{};
+  {
+    const double mass = 1.0;
+    const std::array<double, 3> spin{{0.1, 0.2, 0.3}};
+    const gr::Solutions::KerrSchild solution(mass, spin, {0.0, 0.0, 0.0});
+
+    const auto& domain = Parallel::get<domain::Tags::Domain<3>>(cache);
+    const auto& block = domain.blocks()[element_id.block_id()];
+
+    const auto logical_coords = logical_coordinates(mesh);
+    InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+        inv_jacobian_logical_to_inertial{mesh.number_of_grid_points(), 0.0};
+    tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{};
+    if (block.is_time_dependent()) {
+      const ElementMap<3, Frame::Grid> map_logical_to_grid{
+          element_id, block.moving_mesh_logical_to_grid_map().get_clone()};
+      const auto& functions_of_time = domain_creator.functions_of_time();
+      inertial_coords = block.moving_mesh_grid_to_inertial_map()(
+          map_logical_to_grid(logical_coords), observation_time.id,
+          functions_of_time);
+
+      const auto inv_jacobian_logical_to_grid =
+          map_logical_to_grid.inv_jacobian(logical_coords);
+      const auto inv_jacobian_grid_to_inertial =
+          block.moving_mesh_grid_to_inertial_map().inv_jacobian(
+              map_logical_to_grid(logical_coords), observation_time.id,
+              functions_of_time);
+      inv_jacobian_logical_to_inertial = tenex::evaluate<ti::I, ti::j>(
+          inv_jacobian_logical_to_grid(ti::I, ti::k) *
+          inv_jacobian_grid_to_inertial(ti::K, ti::j));
+    } else {
+      const ElementMap<3, Frame::Inertial> map_logical_to_inertial{
+          element_id, block.stationary_map().get_clone()};
+      inertial_coords = map_logical_to_inertial(logical_coords);
+      inv_jacobian_logical_to_inertial =
+          map_logical_to_inertial.inv_jacobian(logical_coords);
+    }
+
+    const auto solution_vars = solution.variables(
+        inertial_coords, observation_time.id,
+        typename gr::Solutions::KerrSchild::tags<DataVector,
+                                                 Frame::Inertial>{});
+
+    const auto& lapse = get<gr::Tags::Lapse<DataVector>>(solution_vars);
+    const auto& dt_lapse =
+        get<Tags::dt<gr::Tags::Lapse<DataVector>>>(solution_vars);
+    const auto& d_lapse = get<typename gr::Solutions::KerrSchild::DerivLapse<
+        DataVector, Frame::Inertial>>(solution_vars);
+    const auto& shift = get<gr::Tags::Shift<DataVector, 3>>(solution_vars);
+    const auto& dt_shift =
+        get<Tags::dt<gr::Tags::Shift<DataVector, 3>>>(solution_vars);
+    const auto& d_shift = get<typename gr::Solutions::KerrSchild::DerivShift<
+        DataVector, Frame::Inertial>>(solution_vars);
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<DataVector, 3>>(solution_vars);
+    const auto& dt_spatial_metric =
+        get<Tags::dt<gr::Tags::SpatialMetric<DataVector, 3>>>(solution_vars);
+    const auto& d_spatial_metric =
+        get<typename gr::Solutions::KerrSchild::DerivSpatialMetric<
+            DataVector, Frame::Inertial>>(solution_vars);
+
+    vars.initialize(get(lapse).size());
+    get<gr::Tags::SpacetimeMetric<DataVector, 3>>(vars) =
+        gr::spacetime_metric(lapse, shift, spatial_metric);
+    get<gh::Tags::Phi<DataVector, 3>>(vars) = gh::phi(
+        lapse, d_lapse, shift, d_shift, spatial_metric, d_spatial_metric);
+    get<gh::Tags::Pi<DataVector, 3>>(vars) =
+        gh::pi(lapse, dt_lapse, shift, dt_shift, spatial_metric,
+               dt_spatial_metric, get<gh::Tags::Phi<DataVector, 3>>(vars));
+    get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                    Frame::Inertial>>(vars) =
+        partial_derivative(get<gh::Tags::Phi<DataVector, 3>>(vars), mesh,
+                           inv_jacobian_logical_to_inertial);
+  }
+  std::optional<std::string> dependency{"FakeDependency"};
 
   // Test the event version
   auto box =
@@ -209,7 +304,21 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
     CHECK(results.time == observation_time);
     CHECK(results.element_id == element_id);
     CHECK(results.mesh == mesh);
-    CHECK(results.vars == vars);
+
+    Variables<ah::vars_to_interpolate_to_target<3, ::Frame::Grid>> target_vars{
+        vars.number_of_grid_points()};
+    const auto functions_of_time = domain_creator.functions_of_time();
+    ah::compute_vars_to_interpolate_to_target(
+        make_not_null(&target_vars),
+        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(vars),
+        get<gh::Tags::Pi<DataVector, 3>>(vars),
+        get<gh::Tags::Phi<DataVector, 3>>(vars),
+        get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(vars),
+        observation_time, domain_creator.create_domain(), mesh, element_id,
+        functions_of_time);
+    CHECK(results.vars == target_vars);
+
     CHECK(results.dependency == dependency);
   };
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
@@ -317,7 +317,8 @@ struct MockFindApparentHorizon {
       const LinkedMessageId<double>& /*incoming_time*/,
       const ElementId<3>& /*incoming_element_id*/,
       const ::Mesh<3>& /*incoming_mesh*/,
-      Variables<ah::source_vars<3>>&& /*incoming_source_vars*/,
+      Variables<ah::vars_to_interpolate_to_target<3, ::Frame::Grid>>&&
+      /*incoming_vars_to_interpolate*/,
       const std::optional<std::string>& /*dependency*/,
       const bool /*source_vars_have_already_been_received*/ = false) {}
 };
@@ -418,8 +419,24 @@ void common_horizon_event() {
   const Mesh<metavars::volume_dim> mesh(5, Spectral::Basis::Legendre,
                                         Spectral::Quadrature::GaussLobatto);
   const double observation_time = 2.0;
-  const Variables<ah::source_vars<metavars::volume_dim>> vars(
-      mesh.number_of_grid_points(), 1.0);
+
+  // Formerly, every point for every component of every tensor in vars were set
+  // to a constant value of 1.0. But this leads to a metric that is not
+  // invertible, causing a floating-point exception. The following
+  // guarantees an invertible metric by supplying a flat spacetime instead.
+  // Since pi and phi are zero for Minkowski, it's actually less code to just
+  // manually set spacetime metric here than to get the analytic solution and
+  // call all the functions to assemble spacetime_metric, pi, phi.
+  Variables<ah::source_vars<metavars::volume_dim>> vars(
+      mesh.number_of_grid_points(), 0.0);
+  auto& spacetime_metric =
+      get<gr::Tags::SpacetimeMetric<DataVector, metavars::volume_dim>>(vars);
+  get<0, 0>(spacetime_metric) = DataVector(mesh.number_of_grid_points(), -1.0);
+  for (size_t spatial_index = 0; spatial_index < metavars::volume_dim;
+       ++spatial_index) {
+    spacetime_metric.get(spatial_index + 1, spatial_index + 1) =
+        DataVector(mesh.number_of_grid_points(), 1.0);
+  }
   auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
 
   const LinkedMessageId<double> temporal_id{observation_time, std::nullopt};

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <type_traits>
 
 #include "DataStructures/LinkedMessageId.hpp"
@@ -164,10 +165,8 @@ void test_compute_horizon_volume_quantities(const bool is_time_dependent) {
       inertial_coords, time.id,
       typename gr::Solutions::KerrSchild::tags<DataVector, Frame::Inertial>{});
 
-  // Fill src vars with analytic solution.
-  ah::Storage::VolumeVariables<Fr> all_volume_vars{};
-  all_volume_vars.mesh = mesh;
-
+  Variables<ah::source_vars<3>> source_vars{};
+  Variables<ah::vars_to_interpolate_to_target<3, Fr>> target_vars{};
   // Set g, pi, and phi in the inertial frame
   {
     const auto& lapse =
@@ -193,7 +192,6 @@ void test_compute_horizon_volume_quantities(const bool is_time_dependent) {
         get<typename gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector>>(
             solution_vars_inertial_frame);
 
-    auto& source_vars = all_volume_vars.source_vars;
     source_vars.initialize(get(lapse).size(), 0.0);
     get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars) =
         gr::spacetime_metric(lapse, shift, spatial_metric);
@@ -211,9 +209,14 @@ void test_compute_horizon_volume_quantities(const bool is_time_dependent) {
   }
 
   // Compute other vars
-  ah::compute_vars_to_interpolate_to_target(make_not_null(&all_volume_vars),
-                                            time, domain, element_ids[0],
-                                            functions_of_time);
+  ah::compute_vars_to_interpolate_to_target(
+      make_not_null(&target_vars),
+      get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars),
+      get<::gh::Tags::Pi<DataVector, 3>>(source_vars),
+      get<::gh::Tags::Phi<DataVector, 3>>(source_vars),
+      get<Tags::deriv<::gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                      Frame::Inertial>>(source_vars),
+      time, domain, mesh, element_ids[0], functions_of_time);
 
   // Now make sure those computed vars are correct.
   const auto solution_vars_target_frame = solution.variables(
@@ -238,19 +241,17 @@ void test_compute_horizon_volume_quantities(const bool is_time_dependent) {
       gr::ricci_tensor(expected_christoffel, deriv_christoffel);
 
   // Computed vars
-  const auto& spatial_metric = get<gr::Tags::SpatialMetric<DataVector, 3, Fr>>(
-      all_volume_vars.vars_to_interpolate_to_target);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<DataVector, 3, Fr>>(target_vars);
   const auto& inverse_spatial_metric =
-      get<gr::Tags::InverseSpatialMetric<DataVector, 3, Fr>>(
-          all_volume_vars.vars_to_interpolate_to_target);
+      get<gr::Tags::InverseSpatialMetric<DataVector, 3, Fr>>(target_vars);
   const auto& extrinsic_curvature =
-      get<gr::Tags::ExtrinsicCurvature<DataVector, 3, Fr>>(
-          all_volume_vars.vars_to_interpolate_to_target);
+      get<gr::Tags::ExtrinsicCurvature<DataVector, 3, Fr>>(target_vars);
   const auto& christoffel =
       get<gr::Tags::SpatialChristoffelSecondKind<DataVector, 3, Fr>>(
-          all_volume_vars.vars_to_interpolate_to_target);
-  const auto& ricci = get<gr::Tags::SpatialRicci<DataVector, 3, Fr>>(
-      all_volume_vars.vars_to_interpolate_to_target);
+          target_vars);
+  const auto& ricci =
+      get<gr::Tags::SpatialRicci<DataVector, 3, Fr>>(target_vars);
 
   CHECK_ITERABLE_APPROX(expected_spatial_metric, spatial_metric);
   CHECK_ITERABLE_APPROX(expected_inverse_spatial_metric,

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
@@ -214,11 +214,12 @@ struct MockFindApparentHorizon {
                     const LinkedMessageId<double>& /*incoming_time*/,
                     const ElementId<3>& /*incoming_element_id*/,
                     const ::Mesh<3>& /*incoming_mesh*/,
-                    Variables<ah::source_vars<3>>&& /*incoming_source_vars*/,
+                    Variables<ah::vars_to_interpolate_to_target<
+                        3, MockHorizonMetavars::frame>>&& /*incoming_vars*/,
                     const std::optional<std::string>& /*dependency*/,
-                    const bool source_vars_have_already_been_received = false) {
+                    const bool vars_have_already_been_received = false) {
     ++call_count;
-    CHECK(source_vars_have_already_been_received);
+    CHECK(vars_have_already_been_received);
   }
 };
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -46,6 +47,7 @@
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Callbacks/FailedHorizonFind.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Component.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Shape.hpp"
@@ -244,6 +246,22 @@ void test_apparent_horizon(
                 true}}
           : std::nullopt);
 
+  {
+    const Domain<3> domain_for_block_selection =
+        domain_creator->create_domain();
+    std::unordered_set<std::string> blocks_to_use{};
+    for (const auto& block : domain_for_block_selection.blocks()) {
+      if constexpr (std::is_same_v<Fr, ::Frame::Distorted>) {
+        if (not block.has_distorted_frame()) {
+          continue;
+        }
+      }
+      blocks_to_use.insert(block.name());
+    }
+    blocks_for_interpolation.emplace("TestingHorizonMetavars",
+                                     std::move(blocks_to_use));
+  }
+
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator->create_domain(), std::move(apparent_horizon_opts),
        blocks_for_interpolation},
@@ -271,6 +289,8 @@ void test_apparent_horizon(
   // Create element_ids.
   std::vector<ElementId<3>> element_ids{};
   const Domain<3> domain = domain_creator->create_domain();
+  const auto& blocks_to_use =
+      blocks_for_interpolation.at("TestingHorizonMetavars");
   const domain::FunctionsOfTimeMap functions_of_time =
       domain_creator->functions_of_time();
   for (const auto& block : domain.blocks()) {
@@ -297,6 +317,10 @@ void test_apparent_horizon(
   for (const auto& time : times) {
     for (const auto& element_id : element_ids) {
       const auto& block = domain.blocks()[element_id.block_id()];
+      // Only send volume data for blocks in blocks_to_use
+      if (blocks_to_use.find(block.name()) == blocks_to_use.end()) {
+        continue;
+      }
       const ::Mesh<3> mesh{
           domain_creator->initial_extents()[element_id.block_id()],
           Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
@@ -341,7 +365,7 @@ void test_apparent_horizon(
                                                    ::Frame::Inertial>{});
 
       // Fill output variables with solution.
-      Variables<ah::source_vars<3>> output_vars(mesh.number_of_grid_points());
+      Variables<ah::source_vars<3>> source_vars(mesh.number_of_grid_points());
 
       const auto& lapse = get<gr::Tags::Lapse<DataVector>>(solution_vars);
       const auto& dt_lapse =
@@ -361,24 +385,36 @@ void test_apparent_horizon(
           get<typename gr::Solutions::KerrSchild ::DerivSpatialMetric<
               DataVector, ::Frame::Inertial>>(solution_vars);
 
-      get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(output_vars) =
+      get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars) =
           gr::spacetime_metric(lapse, shift, g);
-      get<::gh::Tags::Phi<DataVector, 3>>(output_vars) =
+      get<::gh::Tags::Phi<DataVector, 3>>(source_vars) =
           gh::phi(lapse, d_lapse, shift, d_shift, g, d_g);
-      get<::gh::Tags::Pi<DataVector, 3>>(output_vars) =
+      get<::gh::Tags::Pi<DataVector, 3>>(source_vars) =
           gh::pi(lapse, dt_lapse, shift, dt_shift, g, dt_g,
-                 get<::gh::Tags::Phi<DataVector, 3>>(output_vars));
+                 get<::gh::Tags::Phi<DataVector, 3>>(source_vars));
 
       // Need to compute numerical deriv of Phi.
       get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
-                      Frame::Inertial>>(output_vars) =
-          partial_derivative(get<::gh::Tags::Phi<DataVector, 3>>(output_vars),
+                      Frame::Inertial>>(source_vars) =
+          partial_derivative(get<::gh::Tags::Phi<DataVector, 3>>(source_vars),
                              mesh, inv_jacobian_logical_to_inertial);
+
+      // TO-DO: make target_vars from the source_vars in the correct frame
+      Variables<ah::vars_to_interpolate_to_target<3, Fr>> target_vars{
+          get(lapse).size()};
+      ah::compute_vars_to_interpolate_to_target(
+          make_not_null(&target_vars),
+          get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars),
+          get<::gh::Tags::Pi<DataVector, 3>>(source_vars),
+          get<::gh::Tags::Phi<DataVector, 3>>(source_vars),
+          get<Tags::deriv<::gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                          Frame::Inertial>>(source_vars),
+          time, domain, mesh, element_id, functions_of_time);
 
       // Queue the action so we can invoke in a random order below
       ActionTesting::queue_simple_action<
           component, ah::FindApparentHorizon<horizon_metavars>>(
-          make_not_null(&runner), 0, time, element_id, mesh, output_vars,
+          make_not_null(&runner), 0, time, element_id, mesh, target_vars,
           dependency);
     }
   }

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
 #include "DataStructures/LinkedMessageId.hpp"
@@ -25,6 +26,7 @@
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/StrahlkorperFunctions.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/ComputeVarsToInterpolateToTarget.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp"
@@ -144,8 +146,7 @@ void test_interpolate_volume_vars() {
 
   // Check that if there aren't any volume variables, that nothing happens
   ah::interpolate_volume_data(make_not_null(&current_iteration),
-                              make_not_null(&all_volume_variables), time,
-                              domain, functions_of_time);
+                              make_not_null(&all_volume_variables));
   CHECK(current_iteration.interpolation_is_done_for_these_elements.empty());
   CHECK(current_iteration.indicies_interpolated_to_thus_far.empty());
   CHECK(current_iteration.interpolated_vars.number_of_grid_points() == 0_st);
@@ -156,13 +157,22 @@ void test_interpolate_volume_vars() {
                     Spectral::Basis::Legendre,
                     Spectral::Quadrature::GaussLobatto};
 
-    all_volume_variables[element_id].source_vars = compute_source_vars(
+    const auto source_vars = compute_source_vars(
         solution, time, element_id, blocks[element_id.block_id()], mesh);
+
     all_volume_variables[element_id].mesh = mesh;
+    ah::compute_vars_to_interpolate_to_target(
+        make_not_null(
+            &all_volume_variables[element_id].vars_to_interpolate_to_target),
+        get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars),
+        get<::gh::Tags::Pi<DataVector, 3>>(source_vars),
+        get<::gh::Tags::Phi<DataVector, 3>>(source_vars),
+        get<Tags::deriv<::gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
+                        Frame::Inertial>>(source_vars),
+        time, domain, mesh, element_id, functions_of_time);
 
     ah::interpolate_volume_data(make_not_null(&current_iteration),
-                                make_not_null(&all_volume_variables), time,
-                                domain, functions_of_time);
+                                make_not_null(&all_volume_variables));
 
     // Check that we finished interpolation and that the points we interpolated
     // to aren't the default fill value
@@ -212,8 +222,7 @@ void test_interpolate_volume_vars() {
                   Spectral::Quadrature::GaussLobatto};
 
   ah::interpolate_volume_data(make_not_null(&current_iteration),
-                              make_not_null(&all_volume_variables), time,
-                              domain, functions_of_time);
+                              make_not_null(&all_volume_variables));
 
   // Check interpolation is still done
   CHECK(current_iteration.interpolation_is_done_for_these_elements.contains(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
@@ -34,9 +34,7 @@ template <typename Fr>
 void test_storage() {
   const ah::Storage::VolumeVariables<Fr> volume_variables{
       Mesh<3>{3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
-      Variables<ah::source_vars<3>>{4, 1.234},
       Variables<ah::vars_to_interpolate_to_target<3, Fr>>{4, 4.321}};
-  CHECK(not volume_variables.done_computing_vars_to_interpolate_to_target);
   test_serialization(volume_variables);
 
   const ah::Storage::Iteration<Fr> iteration{


### PR DESCRIPTION
## Proposed changes

This PR changes the new AH infrastructure to call `compute_vars_to_interpolate_to_target()` (which computes the tensors the horizon finder needs, such as spatial metric, inverse spatial metric, Christoffel symbols, spatial Ricci tensor) from each element sending data to the horizon finder instead of from the horizon finder singleton.

My spin=0.8, evolve in damped harmonic gauge to time t=0.1M benchmark times on 1 node on ocean2 (192 cores):

* This PR: 4:49
* Develop: 9:48
* Don't call `compute_vars_to_interpolate_to_target()` each iteration, numerical inverse jacobian: 5:53
* Old horizon finder: 3:14

@nilsvu is working on speeding up the serial performance of the horizon finder separately.

Note that this PR does extra work: `compute_vars_to_interpolate_to_target()` runs on each element sending data to the horizon finder, instead of only those elements that intersect the Strahlkorper at the current iteration. In exchange, less data is sent (since there are many fewer tensor components being sent to the singleton) and `compute_vars_to_interpolate_to_target()`, which is the among the most expensive parts of the horizon find, is now done in parallel. The old horizon finder not only did this calculation in parallel but also did the interpolation itself in parallel, at the cost of much more communication and an implementation that won't work with the new runtime system.

Note: I used cursor tab completion and auto (in dialog mode) and gpt-5-codex + the OpenAI codex vscode plugin (in agent mode) to help fix compiler errors and unit test failures.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
