### PR TITLE
AH finder: speed up by caching block/element search order 

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -190,7 +190,8 @@ BlockLogicalCoords<Dim> block_logical_coordinates_single_point(
 template <size_t Dim, typename Fr>
 std::vector<BlockLogicalCoords<Dim>> block_logical_coordinates(
     const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Fr>& x,
-    const double time, const domain::FunctionsOfTimeMap& functions_of_time) {
+    const double time, const domain::FunctionsOfTimeMap& functions_of_time,
+    const std::optional<gsl::not_null<std::vector<size_t>*>> block_order) {
   const size_t num_pts = get<0>(x).size();
   std::vector<BlockLogicalCoords<Dim>> block_coord_holders(num_pts);
   for (size_t s = 0; s < num_pts; ++s) {
@@ -198,10 +199,8 @@ std::vector<BlockLogicalCoords<Dim>> block_logical_coordinates(
     for (size_t d = 0; d < Dim; ++d) {
       x_frame.get(d) = x.get(d)[s];
     }
-    // Not using block_order here to guarantee that the block with the
-    // smallest block_id is chosen. This could be made an option.
     block_coord_holders[s] = block_logical_coordinates_single_point(
-        x_frame, domain, time, functions_of_time);
+        x_frame, domain, time, functions_of_time, block_order);
   }
   return block_coord_holders;
 }
@@ -226,7 +225,8 @@ std::vector<BlockLogicalCoords<Dim>> block_logical_coordinates(
   block_logical_coordinates(                                                   \
       const Domain<DIM(data)>& domain,                                         \
       const tnsr::I<DataVector, DIM(data), FRAME(data)>& x, const double time, \
-      const domain::FunctionsOfTimeMap& functions_of_time);
+      const domain::FunctionsOfTimeMap& functions_of_time,                     \
+      std::optional<gsl::not_null<std::vector<size_t>*>> block_order);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
                         (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -66,8 +66,9 @@ template <size_t Dim, typename Fr>
 auto block_logical_coordinates(
     const Domain<Dim>& domain, const tnsr::I<DataVector, Dim, Fr>& x,
     double time = std::numeric_limits<double>::signaling_NaN(),
-    const domain::FunctionsOfTimeMap& functions_of_time = {})
-    -> std::vector<BlockLogicalCoords<Dim>>;
+    const domain::FunctionsOfTimeMap& functions_of_time = {},
+    std::optional<gsl::not_null<std::vector<size_t>*>> block_order =
+        std::nullopt) -> std::vector<BlockLogicalCoords<Dim>>;
 
 template <size_t Dim, typename Fr>
 std::optional<tnsr::I<double, Dim, ::Frame::BlockLogical>>

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.cpp
@@ -24,6 +24,7 @@ namespace ah {
 template <typename Fr>
 bool set_current_iteration_coords(
     const gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration,
+    const gsl::not_null<std::vector<size_t>*> block_order,
     const LinkedMessageId<double>& time, const FastFlow& fast_flow,
     const ylm::Strahlkorper<Fr>& initial_guess,
     const ylm::Strahlkorper<Fr>& previous_iteration_surface,
@@ -236,7 +237,7 @@ bool set_current_iteration_coords(
     // Frames are handled within block_logical_coordinates
     current_iteration->block_coord_holders = ::block_logical_coordinates(
         domain, ylm::cartesian_coords(prolonged_strahlkorper), time.id,
-        functions_of_time);
+        functions_of_time, block_order);
   };
 
   // Set the coordinates
@@ -283,6 +284,7 @@ bool set_current_iteration_coords(
   template bool set_current_iteration_coords(                           \
       const gsl::not_null<ah::Storage::Iteration<FRAME(data)>*>         \
           current_iteration,                                            \
+      const gsl::not_null<std::vector<size_t>*> block_order,            \
       const LinkedMessageId<double>& time, const FastFlow& fast_flow,   \
       const ylm::Strahlkorper<FRAME(data)>& initial_guess,              \
       const ylm::Strahlkorper<FRAME(data)>& previous_iteration_surface, \

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/ComputeCoords.hpp
@@ -41,6 +41,8 @@ namespace ah {
  * \p max_compute_coords_retries times before returning false.
  *
  * \param current_iteration The returned pointer to the current Iteration object
+ * \param block_order Priority order to search blocks for containing points
+ * (see `::block_logical_coordinates` for details)
  * \param time The current time
  * \param fast_flow The FastFlow object for the current horizon find
  * \param initial_guess If the current iteration number is zero and
@@ -68,6 +70,7 @@ namespace ah {
 template <typename Fr>
 bool set_current_iteration_coords(
     gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration,
+    gsl::not_null<std::vector<size_t>*> block_order,
     const LinkedMessageId<double>& time, const FastFlow& fast_flow,
     const ylm::Strahlkorper<Fr>& initial_guess,
     const ylm::Strahlkorper<Fr>& previous_iteration_surface,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CurrentTime.hpp
@@ -116,7 +116,8 @@ bool check_if_current_time_is_ready(
                                  incoming_mesh,
                                  Variables<ah::vars_to_interpolate_to_target<
                                      3, horizon_frame>>{},
-                                 dependency, true));
+                                 dependency,
+                                 /* vars_have_already_been_received */ true));
           });
     }  // if (domain.is_time_dependent())
   } else {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -120,6 +120,9 @@ struct FindApparentHorizon {
 
     auto& all_storage = db::get_mutable_reference<ah::Tags::Storage<frame>>(
         make_not_null(&box));
+    auto& block_search_order =
+        db::get_mutable_reference<ah::Tags::BlockSearchOrder>(
+            make_not_null(&box));
 
     // Add volume variables and destination to the box if they haven't already
     // been received
@@ -233,8 +236,9 @@ struct FindApparentHorizon {
           if (not current_iteration_storage.block_coord_holders.has_value() or
               rerunning_with_higher_resolution) {
             const bool coords_set_successfully = set_current_iteration_coords(
-                make_not_null(&current_iteration_storage), current_time,
-                fast_flow, options.initial_guess, previous_iteration_surface,
+                make_not_null(&current_iteration_storage),
+                make_not_null(&block_search_order), current_time, fast_flow,
+                options.initial_guess, previous_iteration_surface,
                 previous_surfaces, options.max_compute_coords_retries, domain,
                 functions_of_time, current_resolution_l,
                 rerunning_with_higher_resolution);

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -127,11 +127,12 @@ struct FindApparentHorizon {
     // Add volume variables and destination to the box if they haven't already
     // been received
     if (not vars_have_already_been_received) {
-      all_storage[incoming_time].all_volume_variables.emplace(
+      auto& current_time_storage = all_storage[incoming_time];
+      current_time_storage.all_volume_variables.emplace(
           incoming_element_id,
           ah::Storage::VolumeVariables<frame>{
               incoming_mesh, std::move(incoming_vars_to_interpolate)});
-      all_storage.at(incoming_time).destination = HorizonMetavars::destination;
+      current_time_storage.destination = HorizonMetavars::destination;
     }
 
     // ========================================================================

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -57,7 +57,9 @@ struct get_tags {
  * put into the `ah::Tags::Storage`. Then, we try to set the
  * `ah::Tags::CurrentTime` with the `ah::set_current_time` function. Once we
  * have a current time, we ensure the functions of time are up-to-date at this
- * current time with `ah::check_if_current_time_is_ready`.
+ * current time with `ah::check_if_current_time_is_ready`. If they are not,
+ * we re-trigger this action with `vars_have_already_been_received` set to
+ * true and not sending any new volume data.
  *
  * Once we ensure the functions of time are ready, we compute the cartesian
  * coordinates for the current fast-flow iteration surface with

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -278,22 +278,18 @@ struct FindApparentHorizon {
           // Sanity check
           ASSERT(
               current_iteration_storage.indices_interpolated_to_thus_far
-                      .size() <=
+                      .size() ==
                   current_iteration_storage.block_coord_holders.value().size(),
-              "The number indices interpolated to is larger than the number of "
-              "coordinates. This is an internal error. Please file an issue.");
+              "The number of indices being interpolated to is not the number "
+              "of coordinates. This is an internal error. Please file an "
+              "issue.");
 
-          if (current_iteration_storage.indices_interpolated_to_thus_far
-                  .size() !=
-              current_iteration_storage.block_coord_holders.value().size()) {
+          if (not current_iteration_storage.interpolation_is_complete()) {
             if (debug_print) {
               Parallel::printf(
                   "%s: For current time %s, at iteration %zu, need more volume "
-                  "data. Missing %zu points.\n",
-                  name, current_time, fast_flow.current_iteration(),
-                  current_iteration_storage.block_coord_holders.value().size() -
-                      current_iteration_storage
-                          .indices_interpolated_to_thus_far.size());
+                  "data.\n",
+                  name, current_time, fast_flow.current_iteration());
             }
             return;
           }

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -277,13 +277,13 @@ struct FindApparentHorizon {
 
           // Sanity check
           ASSERT(
-              current_iteration_storage.indicies_interpolated_to_thus_far
+              current_iteration_storage.indices_interpolated_to_thus_far
                       .size() <=
                   current_iteration_storage.block_coord_holders.value().size(),
               "The number indices interpolated to is larger than the number of "
               "coordinates. This is an internal error. Please file an issue.");
 
-          if (current_iteration_storage.indicies_interpolated_to_thus_far
+          if (current_iteration_storage.indices_interpolated_to_thus_far
                   .size() !=
               current_iteration_storage.block_coord_holders.value().size()) {
             if (debug_print) {
@@ -293,7 +293,7 @@ struct FindApparentHorizon {
                   name, current_time, fast_flow.current_iteration(),
                   current_iteration_storage.block_coord_holders.value().size() -
                       current_iteration_storage
-                          .indicies_interpolated_to_thus_far.size());
+                          .indices_interpolated_to_thus_far.size());
             }
             return;
           }

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -142,7 +142,20 @@ struct FindApparentHorizon {
     // are ready.
     // ========================================================================
 
-    // Keep trying to find horizons for as long as we can
+    // Keep trying to find horizons for as long as we can.
+    // In the first pass, interpolate only from the incoming element because
+    // this was missing data. On subsequent passes, interpolate from all
+    // elements. Notes:
+    // - The `vars_have_already_been_received` flag is used only in
+    //   `check_if_current_time_is_ready` to re-trigger the AH find in a
+    //   callback but not sending any new data.
+    // - If the incoming time is not the current time (but later), then we have
+    //   to do the full interpolation for the current time first before moving
+    //   on to the incoming time. In this case we also need to do the full
+    //   interpolation for the incoming time once we get there.
+    bool interpolate_only_from_incoming_element =
+        current_time_optional == incoming_time and
+        not vars_have_already_been_received;
     while (true) {
       // Set current time using the pending times if it isn't already set
       set_current_time(make_not_null(&current_time_optional),
@@ -200,6 +213,10 @@ struct FindApparentHorizon {
           db::get_mutable_reference<ah::Tags::FastFlow>(make_not_null(&box));
 
       auto& all_volume_variables = current_time_storage.all_volume_variables;
+      auto& current_iteration_storage = current_time_storage.current_iteration;
+      auto& previous_iteration_surface =
+          current_time_storage.previous_iteration_surface;
+      auto& element_order = current_time_storage.element_order;
       auto& previous_surfaces =
           db::get_mutable_reference<ah::Tags::PreviousSurfaces<frame>>(
               make_not_null(&box));
@@ -228,11 +245,6 @@ struct FindApparentHorizon {
         // Keep doing fast flow iterations for as long as we can until we find a
         // horizon
         while (true) {
-          auto& current_iteration_storage =
-              current_time_storage.current_iteration;
-          auto& previous_iteration_surface =
-              current_time_storage.previous_iteration_surface;
-
           // Points haven't been set for this iteration so need to do so now
           if (not current_iteration_storage.block_coord_holders.has_value() or
               rerunning_with_higher_resolution) {
@@ -276,20 +288,75 @@ struct FindApparentHorizon {
             }
           }
 
-          // Interpolate new elements to points
-          interpolate_volume_data(make_not_null(&current_iteration_storage),
-                                  make_not_null(&all_volume_variables));
+          // Interpolate to the current iteration points
+          bool interpolation_is_complete = false;
+          if (interpolate_only_from_incoming_element) {
+            // Data is coming in one element at a time, so try to interpolate
+            // only from the incoming element
+            ASSERT(all_volume_variables.contains(incoming_element_id),
+                   "Trying to interpolate incoming data from element "
+                       << incoming_element_id
+                       << " but it's not available. This is a bug.");
+            const bool interpolated_any_points = interpolate_volume_data(
+                make_not_null(&current_iteration_storage),
+                all_volume_variables.at(incoming_element_id),
+                incoming_element_id);
+            // Store which elements we found points in for next iteration
+            if (interpolated_any_points) {
+              element_order.push_back(incoming_element_id);
+            }
+            interpolation_is_complete =
+                current_iteration_storage.interpolation_is_complete();
+          } else {
+            // We already have some element data, so go through the elements in
+            // the order we found points in before
+            for (const auto& element_id : element_order) {
+              ASSERT(all_volume_variables.contains(element_id),
+                     "Trying to interpolate data from element "
+                         << element_id
+                         << " that was found in a previous FastFlow iteration, "
+                            "but it's not available. This is a bug.");
+              interpolate_volume_data(make_not_null(&current_iteration_storage),
+                                      all_volume_variables.at(element_id),
+                                      element_id);
+              interpolation_is_complete =
+                  current_iteration_storage.interpolation_is_complete();
+              if (interpolation_is_complete) {
+                break;
+              }
+            }
+            // If we still need more points, try going through all the elements
+            // that we have received data from so far
+            if (not interpolation_is_complete) {
+              for (const auto& [element_id, volume_vars_storage] :
+                   all_volume_variables) {
+                if (std::find(element_order.begin(), element_order.end(),
+                              element_id) != element_order.end()) {
+                  // Already tried this element above
+                  continue;
+                }
+                const bool interpolated_any_points = interpolate_volume_data(
+                    make_not_null(&current_iteration_storage),
+                    volume_vars_storage, element_id);
+                if (interpolated_any_points) {
+                  element_order.push_back(element_id);
+                }
+                interpolation_is_complete =
+                    current_iteration_storage.interpolation_is_complete();
+                if (interpolation_is_complete) {
+                  break;
+                }
+              }
+            }
+          }
 
-          // Sanity check
-          ASSERT(
-              current_iteration_storage.indices_interpolated_to_thus_far
-                      .size() ==
-                  current_iteration_storage.block_coord_holders.value().size(),
-              "The number of indices being interpolated to is not the number "
-              "of coordinates. This is an internal error. Please file an "
-              "issue.");
-
-          if (not current_iteration_storage.interpolation_is_complete()) {
+          if (interpolation_is_complete) {
+            // Next iteration try to interpolate from all elements
+            interpolate_only_from_incoming_element = false;
+          } else {
+            // We need more points, return and wait for more volume data.
+            // When this action is called again, we'll try to interpolate only
+            // from the incoming element until we have enough data.
             if (debug_print) {
               Parallel::printf(
                   "%s: For current time %s, at iteration %zu, need more volume "

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
@@ -52,8 +52,8 @@ struct Initialize {
   using simple_tags = tmpl::append<
       tmpl::list<Tags::CurrentResolutionL, Tags::Verbosity, Tags::FastFlow,
                  Tags::CurrentTime, Tags::PendingTimes, Tags::CompletedTimes,
-                 Tags::Storage<Fr>, Tags::PreviousSurfaces<Fr>,
-                 ylm::Tags::Strahlkorper<Fr>,
+                 Tags::Storage<Fr>, Tags::BlockSearchOrder,
+                 Tags::PreviousSurfaces<Fr>, ylm::Tags::Strahlkorper<Fr>,
                  ylm::Tags::TimeDerivStrahlkorper<Fr>, ah::Tags::Dependency,
                  ::Tags::Variables<ah::vars_to_interpolate_to_target<3, Fr>>>,
       tmpl::conditional_t<

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
@@ -88,7 +88,7 @@ void interpolate_volume_data(
         });
 
     for (const size_t offset : offsets) {
-      current_iteration_storage->indicies_interpolated_to_thus_far.insert(
+      current_iteration_storage->indices_interpolated_to_thus_far.insert(
           offset);
     }
   }

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
@@ -25,85 +25,121 @@
 
 namespace ah {
 template <typename Fr>
-void interpolate_volume_data(
+bool interpolate_volume_data(
     const gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration_storage,
-    const gsl::not_null<
-        std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>*>
-        all_volume_variables) {
-  std::vector<ElementId<3>> element_ids;
-  element_ids.reserve(all_volume_variables->size());
-  for (const auto& [element_id, volume_vars] : *all_volume_variables) {
-    (void)volume_vars;  // Avoid clang-tidy warning
-    if (not current_iteration_storage->interpolation_is_done_for_these_elements
-                .contains(element_id)) {
-      element_ids.push_back(element_id);
-      current_iteration_storage->interpolation_is_done_for_these_elements
-          .insert(element_id);
-    }
-  }
-
+    const ah::Storage::VolumeVariables<Fr>& volume_vars_storage,
+    const ElementId<3>& element_id) {
   ASSERT(current_iteration_storage->block_coord_holders.has_value(),
          "Block logical coordinates of horizon have not been set!");
 
   const auto& block_coord_holders =
       current_iteration_storage->block_coord_holders.value();
-  const auto element_coord_holders =
-      element_logical_coordinates(element_ids, block_coord_holders);
-
-  // Initialize interpolated_vars to correct size
   auto& interpolated_vars = current_iteration_storage->interpolated_vars;
   auto& indices_interpolated_to_thus_far =
       current_iteration_storage->indices_interpolated_to_thus_far;
+  auto& offsets =
+      current_iteration_storage->offsets_of_newly_interpolated_points;
+  auto& x_element_logical =
+      current_iteration_storage->x_element_logical_of_newly_interpolated_points;
+
+  // Initialize interpolated_vars if needed and reserve memory
   const size_t expected_num_points = block_coord_holders.size();
   if (interpolated_vars.number_of_grid_points() != expected_num_points) {
     interpolated_vars.initialize(expected_num_points);
+    offsets.reserve(expected_num_points);
+    for (size_t d = 0; d < 3; ++d) {
+      gsl::at(x_element_logical, d).reserve(expected_num_points);
+    }
   }
   if (indices_interpolated_to_thus_far.size() != expected_num_points) {
     indices_interpolated_to_thus_far.resize(expected_num_points, false);
   }
 
-  for (const auto& [element_id, element_coord_holder] : element_coord_holders) {
-    const auto& offsets = element_coord_holder.offsets;
-    auto& volume_vars_storage = all_volume_variables->at(element_id);
-
-    const intrp::Irregular<3> interpolator(
-        volume_vars_storage.mesh, element_coord_holder.element_logical_coords);
-
-    // Vars interpolated to points within this element
-    auto local_interpolated_vars = interpolator.interpolate(
-        volume_vars_storage.vars_to_interpolate_to_target);
-
-    // Loop over each tensor
-    tmpl::for_each<ah::vars_to_interpolate_to_target<3, Fr>>(
-        [&]<typename Tag>(tmpl::type_<Tag>) {
-          auto& individual_interpolated_var = get<Tag>(interpolated_vars);
-          auto& local_individual_interpolated_var =
-              get<Tag>(local_interpolated_vars);
-
-          // Loop over components of tensor
-          for (size_t i = 0; i < individual_interpolated_var.size(); i++) {
-            // Loop over number of points that were interpolated
-            for (size_t j = 0; j < offsets.size(); j++) {
-              // Copy the local interpolated value into the correct
-              // position in the overall tensor
-              individual_interpolated_var[i][offsets[j]] =
-                  local_individual_interpolated_var[i][j];
-              indices_interpolated_to_thus_far[offsets[j]] = true;
-            }
-          }
-        });
+  // Find points in this element
+  offsets.clear();
+  for (size_t d = 0; d < 3; ++d) {
+    gsl::at(x_element_logical, d).clear();
   }
+  for (size_t p = 0; p < expected_num_points; ++p) {
+    if (indices_interpolated_to_thus_far[p]) {
+      // Skip points that have already been interpolated to
+      continue;
+    }
+    if (block_coord_holders[p]->id.get_index() != element_id.block_id()) {
+      // Skip points that are not in this block
+      continue;
+    }
+    const auto element_logical_coords =
+        element_logical_coordinates(block_coord_holders[p]->data, element_id);
+    if (not element_logical_coords.has_value()) {
+      // Skip points that are not in this element
+      continue;
+    }
+    // Collect points in this element
+    offsets.push_back(p);
+    for (size_t d = 0; d < 3; ++d) {
+      gsl::at(x_element_logical, d).push_back(element_logical_coords->get(d));
+    }
+  }  // for block_logical_coords
+
+  // Return early if no points are in this element
+  if (offsets.empty()) {
+    return false;
+  }
+
+  // Interpolate!
+  // Use non-owning wrappers around memory buffers to avoid allocations
+  tnsr::I<DataVector, 3, Frame::ElementLogical> element_logical_coords{};
+  for (size_t d = 0; d < 3; ++d) {
+    element_logical_coords.get(d).set_data_ref(
+        gsl::at(x_element_logical, d).data(),
+        gsl::at(x_element_logical, d).size());
+  }
+  const intrp::Irregular<3> interpolator(volume_vars_storage.mesh,
+                                         element_logical_coords);
+  auto& interpolated_vars_buffer =
+      current_iteration_storage->newly_interpolated_vars_buffer;
+  Variables<ah::vars_to_interpolate_to_target<3, Fr>> local_interpolated_vars{};
+  constexpr size_t num_components =
+      Variables<ah::vars_to_interpolate_to_target<3, Fr>>::
+          number_of_independent_components;
+  interpolated_vars_buffer.resize(offsets.size() * num_components);
+  local_interpolated_vars.set_data_ref(interpolated_vars_buffer.data(),
+                                       interpolated_vars_buffer.size());
+  interpolator.interpolate(make_not_null(&local_interpolated_vars),
+                           volume_vars_storage.vars_to_interpolate_to_target);
+
+  // Copy local results into overall result
+  // Loop over each tensor
+  tmpl::for_each<ah::vars_to_interpolate_to_target<3, Fr>>(
+      [&]<typename Tag>(tmpl::type_<Tag>) {
+        auto& individual_interpolated_var = get<Tag>(interpolated_vars);
+        const auto& local_individual_interpolated_var =
+            get<Tag>(local_interpolated_vars);
+
+        // Loop over components of tensor
+        for (size_t i = 0; i < individual_interpolated_var.size(); i++) {
+          // Loop over number of points that were interpolated
+          for (size_t p = 0; p < offsets.size(); ++p) {
+            // Copy the local interpolated value into the correct
+            // position in the overall tensor
+            individual_interpolated_var[i][offsets[p]] =
+                local_individual_interpolated_var[i][p];
+            indices_interpolated_to_thus_far[offsets[p]] = true;
+          }
+        }
+      });
+  return true;
 }
 
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                         \
-  template void interpolate_volume_data(                             \
-      const gsl::not_null<ah::Storage::Iteration<FRAME(data)>*>      \
-          current_iteration_storage,                                 \
-      const gsl::not_null<std::unordered_map<                        \
-          ElementId<3>, ah::Storage::VolumeVariables<FRAME(data)>>*> \
-          all_volume_variables);
+#define INSTANTIATE(_, data)                                                \
+  template bool interpolate_volume_data(                                    \
+      const gsl::not_null<ah::Storage::Iteration<FRAME(data)>*>             \
+          current_iteration_storage,                                        \
+      const ah::Storage::VolumeVariables<FRAME(data)>& volume_vars_storage, \
+      const ElementId<3>& element_id);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Inertial, Frame::Distorted, Frame::Grid))

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
@@ -50,16 +50,21 @@ void interpolate_volume_data(
   const auto element_coord_holders =
       element_logical_coordinates(element_ids, block_coord_holders);
 
+  // Initialize interpolated_vars to correct size
+  auto& interpolated_vars = current_iteration_storage->interpolated_vars;
+  auto& indices_interpolated_to_thus_far =
+      current_iteration_storage->indices_interpolated_to_thus_far;
+  const size_t expected_num_points = block_coord_holders.size();
+  if (interpolated_vars.number_of_grid_points() != expected_num_points) {
+    interpolated_vars.initialize(expected_num_points);
+  }
+  if (indices_interpolated_to_thus_far.size() != expected_num_points) {
+    indices_interpolated_to_thus_far.resize(expected_num_points, false);
+  }
+
   for (const auto& [element_id, element_coord_holder] : element_coord_holders) {
     const auto& offsets = element_coord_holder.offsets;
     auto& volume_vars_storage = all_volume_variables->at(element_id);
-    auto& interpolated_vars = current_iteration_storage->interpolated_vars;
-
-    // Only fill once
-    const size_t expected_num_points = block_coord_holders.size();
-    if (interpolated_vars.number_of_grid_points() != expected_num_points) {
-      interpolated_vars.initialize(expected_num_points);
-    }
 
     const intrp::Irregular<3> interpolator(
         volume_vars_storage.mesh, element_coord_holder.element_logical_coords);
@@ -83,14 +88,10 @@ void interpolate_volume_data(
               // position in the overall tensor
               individual_interpolated_var[i][offsets[j]] =
                   local_individual_interpolated_var[i][j];
+              indices_interpolated_to_thus_far[offsets[j]] = true;
             }
           }
         });
-
-    for (const size_t offset : offsets) {
-      current_iteration_storage->indices_interpolated_to_thus_far.insert(
-          offset);
-    }
   }
 }
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.hpp
@@ -31,9 +31,8 @@ namespace ah {
  * in \p current_iteration_storage.
  */
 template <typename Fr>
-void interpolate_volume_data(
+bool interpolate_volume_data(
     gsl::not_null<ah::Storage::Iteration<Fr>*> current_iteration_storage,
-    gsl::not_null<
-        std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>*>
-        all_volume_variables);
+    const ah::Storage::VolumeVariables<Fr>& volume_vars_storage,
+    const ElementId<3>& element_id);
 }  // namespace ah

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -30,6 +30,12 @@ bool operator!=(const VolumeVariables<Fr>& lhs,
 }
 
 template <typename Fr>
+bool Iteration<Fr>::interpolation_is_complete() const {
+  return alg::all_of(indices_interpolated_to_thus_far,
+                     [](const bool filled) { return filled; });
+}
+
+template <typename Fr>
 void Iteration<Fr>::reset_for_next_iteration() {
   // Leave the strahlkorper because this was set by FastFlow and is already
   // the next surface

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -41,7 +41,6 @@ void Iteration<Fr>::reset_for_next_iteration() {
   // the next surface
   this->block_coord_holders.reset();
   this->indices_interpolated_to_thus_far.clear();
-  this->interpolation_is_done_for_these_elements.clear();
   this->compute_coords_retries = 0;
 }
 
@@ -51,8 +50,8 @@ void Iteration<Fr>::pup(PUP::er& p) {
   p | block_coord_holders;
   p | interpolated_vars;
   p | indices_interpolated_to_thus_far;
-  p | interpolation_is_done_for_these_elements;
   p | compute_coords_retries;
+  // No need to serialize the memory buffers because they are resized as needed
 }
 
 template <typename Fr>
@@ -62,9 +61,8 @@ bool operator==(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {
          lhs.interpolated_vars == rhs.interpolated_vars and
          lhs.indices_interpolated_to_thus_far ==
              rhs.indices_interpolated_to_thus_far and
-         lhs.interpolation_is_done_for_these_elements ==
-             rhs.interpolation_is_done_for_these_elements and
          lhs.compute_coords_retries == rhs.compute_coords_retries;
+  // No need to compare the memory buffers
 }
 template <typename Fr>
 bool operator!=(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -34,7 +34,7 @@ void Iteration<Fr>::reset_for_next_iteration() {
   // Leave the strahlkorper because this was set by FastFlow and is already
   // the next surface
   this->block_coord_holders.reset();
-  this->indicies_interpolated_to_thus_far.clear();
+  this->indices_interpolated_to_thus_far.clear();
   this->interpolation_is_done_for_these_elements.clear();
   this->compute_coords_retries = 0;
 }
@@ -44,7 +44,7 @@ void Iteration<Fr>::pup(PUP::er& p) {
   p | strahlkorper;
   p | block_coord_holders;
   p | interpolated_vars;
-  p | indicies_interpolated_to_thus_far;
+  p | indices_interpolated_to_thus_far;
   p | interpolation_is_done_for_these_elements;
   p | compute_coords_retries;
 }
@@ -54,8 +54,8 @@ bool operator==(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {
   return lhs.strahlkorper == rhs.strahlkorper and
          lhs.block_coord_holders == rhs.block_coord_holders and
          lhs.interpolated_vars == rhs.interpolated_vars and
-         lhs.indicies_interpolated_to_thus_far ==
-             rhs.indicies_interpolated_to_thus_far and
+         lhs.indices_interpolated_to_thus_far ==
+             rhs.indices_interpolated_to_thus_far and
          lhs.interpolation_is_done_for_these_elements ==
              rhs.interpolation_is_done_for_these_elements and
          lhs.compute_coords_retries == rhs.compute_coords_retries;

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -83,10 +83,25 @@ struct Iteration {
    */
   std::vector<bool> indices_interpolated_to_thus_far{};
   /*!
-   * \brief Holds the `ElementId`s of `Element`s for which interpolation has
-   * already been done.
+   * \brief Offsets of newly interpolated points in the overall tensor (used as
+   * memory buffer)
    */
-  std::unordered_set<ElementId<3>> interpolation_is_done_for_these_elements;
+  std::vector<size_t> offsets_of_newly_interpolated_points{};
+  /*!
+   * \brief Logical coordinates of newly interpolated points (used as memory
+   * buffer)
+   *
+   * These `std::vector`s are used to reserve memory and then append points to
+   * them as we find them in an element. The memory is reused for each element.
+   * Then, a non-owning DataVector is created by pointing into this memory.
+   * That's why this is a `std::array` of `std::vector`s, not vice versa.
+   */
+  std::array<std::vector<double>, 3>
+      x_element_logical_of_newly_interpolated_points{};
+  /*!
+   * \brief Buffer for newly interpolated variables (used as memory buffer)
+   */
+  std::vector<double> newly_interpolated_vars_buffer{};
 
   /*!
    * \brief How many times we've tried to compute the coordinates for this
@@ -122,7 +137,17 @@ struct SingleTimeStorage {
    * \brief Map between `ElementId`s and the volume variables from that element.
    */
   std::unordered_map<ElementId<3>, VolumeVariables<Fr>> all_volume_variables;
-
+  /*!
+   * \brief Elements in which we have found points to interpolate to in previous
+   * iterations, to try first before searching all elements.
+   *
+   * This is not only a performance optimization, but also important for
+   * robustness. If we try to interpolate from elements in a different order in
+   * each iteration, then points that lie directly on element boundaries can
+   * fluctuate in interpolated value, preventing convergence (see
+   * https://github.com/sxs-collaboration/spectre/issues/3899).
+   */
+  std::vector<ElementId<3>> element_order{};
   /*!
    * \brief The `Iteration` data for the current fast flow iteration.
    */

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -81,7 +81,7 @@ struct Iteration {
    * \brief Keeps track of the indices in `interpolated_vars` that have
    * already been interpolated to.
    */
-  std::set<size_t> indices_interpolated_to_thus_far{};
+  std::vector<bool> indices_interpolated_to_thus_far{};
   /*!
    * \brief Holds the `ElementId`s of `Element`s for which interpolation has
    * already been done.
@@ -93,6 +93,11 @@ struct Iteration {
    * iteration.
    */
   size_t compute_coords_retries = 0;
+
+  /*!
+   * \brief Whether all points in `interpolated_vars` have been filled.
+   */
+  bool interpolation_is_complete() const;
 
   void reset_for_next_iteration();
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -79,9 +79,9 @@ struct Iteration {
   Variables<ah::vars_to_interpolate_to_target<3, Fr>> interpolated_vars{};
   /*!
    * \brief Keeps track of the indices in `interpolated_vars` that have
-   * already beed interpolated to.
+   * already been interpolated to.
    */
-  std::set<size_t> indicies_interpolated_to_thus_far;
+  std::set<size_t> indices_interpolated_to_thus_far{};
   /*!
    * \brief Holds the `ElementId`s of `Element`s for which interpolation has
    * already been done.

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -114,6 +114,14 @@ struct Storage : db::SimpleTag {
 };
 
 /*!
+ * \brief Order in which blocks are searched for horizon finding. See
+ * `::block_logical_coordinates` for details.
+ */
+struct BlockSearchOrder : db::SimpleTag {
+  using type = std::vector<size_t>;
+};
+
+/*!
  * \brief Deque of `ah::Storage::PreviousSurface`s.
  */
 template <typename Fr>

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -608,7 +608,7 @@ void test_block_and_element_logical_coordinates(
                           expected_logical_coords[s]);
     // Check the version with block order. It is no longer guaranteed that the
     // smallest block ID is chosen, so the logical coordinates at the boundary
-    // my differ by a sign.
+    // may differ by a sign.
     for (size_t d=0; d < Dim; ++d) {
       CHECK_ITERABLE_APPROX(
           abs(block_logical_result_with_order[s].value().data.get(d)),

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -596,6 +596,9 @@ void test_block_and_element_logical_coordinates(
 
   const auto block_logical_result =
       block_logical_coordinates(domain, inertial_coords);
+  const auto block_logical_result_with_order = block_logical_coordinates(
+      domain, inertial_coords, std::numeric_limits<double>::signaling_NaN(), {},
+      make_not_null(&block_order));
   for (size_t s = 0; s < x_inertial.size(); ++s) {
     CHECK(block_logical_result[s].value().id.get_index() ==
           expected_block_ids[s]);
@@ -603,6 +606,14 @@ void test_block_and_element_logical_coordinates(
                           expected_logical_coords[s]);
     CHECK_ITERABLE_APPROX(block_logical_single_point_result[s],
                           expected_logical_coords[s]);
+    // Check the version with block order. It is no longer guaranteed that the
+    // smallest block ID is chosen, so the logical coordinates at the boundary
+    // my differ by a sign.
+    for (size_t d=0; d < Dim; ++d) {
+      CHECK_ITERABLE_APPROX(
+          abs(block_logical_result_with_order[s].value().data.get(d)),
+          abs(expected_logical_coords[s].get(d)));
+    }
   }
 
   test_serialization(block_logical_result);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
@@ -56,12 +56,13 @@ void test_compute_points() {
   std::deque<ah::Storage::PreviousSurface<Fr>> previous_surfaces{};
   FastFlow fast_flow{
       FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100};
+  std::vector<size_t> block_order{};
 
   // We should find points
   {
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
     // We don't check the actual points because the function basically just
@@ -88,8 +89,8 @@ void test_compute_points() {
         ylm::Strahlkorper<Fr>{l_max, initial_radius, std::array{0.0, 0.0, 0.0}};
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
     REQUIRE(coords_set_successfully);
@@ -116,8 +117,8 @@ void test_compute_points() {
         ylm::Strahlkorper<Fr>{l_max, initial_radius, std::array{0.0, 0.0, 0.0}};
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
     CHECK_FALSE(coords_set_successfully);
@@ -151,8 +152,8 @@ void test_compute_points() {
         ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}});
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
     REQUIRE(coords_set_successfully);
@@ -179,8 +180,8 @@ void test_compute_points() {
         ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
     REQUIRE(coords_set_successfully);
@@ -232,8 +233,8 @@ void test_compute_points() {
         ylm::Strahlkorper<Fr>{l_max, 2.0, std::array{0.0, 0.0, 0.0}};
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time);
 
     REQUIRE(coords_set_successfully);
@@ -274,6 +275,7 @@ void test_compute_points_different_resolutions() {
   std::deque<ah::Storage::PreviousSurface<Fr>> previous_surfaces{};
   const FastFlow fast_flow{
       FastFlow::FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100};
+  std::vector<size_t> block_order{};
 
   // Test case 1: current_resolution_l is set and different from initial_guess
   {
@@ -284,8 +286,8 @@ void test_compute_points_different_resolutions() {
         ylm::Strahlkorper<Fr>{l_max, 2.5, std::array{0.0, 0.0, 0.0}};
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time, higher_l_max,
         false);
 
@@ -319,8 +321,8 @@ void test_compute_points_different_resolutions() {
         ylm::Strahlkorper<Fr>{l_max, 2.0, std::array{0.0, 0.0, 0.0}};
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time, higher_l_max,
         true);
 
@@ -362,8 +364,8 @@ void test_compute_points_different_resolutions() {
         ylm::Strahlkorper<Fr>{higher_l_max, 1.3, std::array{0.0, 0.0, 0.0}});
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time, higher_l_max);
 
     REQUIRE(coords_set_successfully);
@@ -404,8 +406,8 @@ void test_compute_points_different_resolutions() {
         ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}});
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time, higher_l_max);
 
     REQUIRE(coords_set_successfully);
@@ -438,8 +440,8 @@ void test_compute_points_different_resolutions() {
         ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
 
     const bool coords_set_successfully = set_current_iteration_coords(
-        make_not_null(&current_iteration), time, fast_flow, initial_guess,
-        previous_iteration_surface, previous_surfaces,
+        make_not_null(&current_iteration), make_not_null(&block_order), time,
+        fast_flow, initial_guess, previous_iteration_surface, previous_surfaces,
         max_compute_coords_retries, domain, functions_of_time, higher_l_max,
         false);
 
@@ -469,19 +471,20 @@ void test_compute_points_different_resolutions() {
     // current_resolution_l fails
     CHECK_THROWS_WITH(
         set_current_iteration_coords(
-            make_not_null(&current_iteration), time, fast_flow, initial_guess,
-            previous_iteration_surface, previous_surfaces,
-            max_compute_coords_retries, domain, functions_of_time, std::nullopt,
-            true),
+            make_not_null(&current_iteration), make_not_null(&block_order),
+            time, fast_flow, initial_guess, previous_iteration_surface,
+            previous_surfaces, max_compute_coords_retries, domain,
+            functions_of_time, std::nullopt, true),
         Catch::Matchers::ContainsSubstring("Current resolution L is not set"));
 
     // Test that rerunning_with_higher_resolution=true with current_resolution_l
     // <= previous surface resolution fails
     CHECK_THROWS_WITH(
         set_current_iteration_coords(
-            make_not_null(&current_iteration), time, fast_flow, initial_guess,
-            previous_iteration_surface, previous_surfaces,
-            max_compute_coords_retries, domain, functions_of_time, l_max,
+            make_not_null(&current_iteration), make_not_null(&block_order),
+            time, fast_flow, initial_guess, previous_iteration_surface,
+            previous_surfaces, max_compute_coords_retries, domain,
+            functions_of_time, l_max,
             true),  // l_max is not > previous_iteration_surface.l_max()
         Catch::Matchers::ContainsSubstring(
             "Previous iteration surface has resolution"));

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
@@ -57,8 +57,11 @@ void test_set_current_time() {
   const auto add_to_all_storage = [&](const LinkedMessageId<double>& time,
                                       const Destination destination) {
     all_storage.emplace(time, ah::Storage::SingleTimeStorage<Frame::Grid>{
-                                  unused_volume_vars, unused_interation,
-                                  unused_prev_strahlkorper, destination});
+                                  unused_volume_vars,
+                                  {},
+                                  unused_interation,
+                                  unused_prev_strahlkorper,
+                                  destination});
   };
 
   // Current time has value, so do nothing

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
@@ -148,7 +148,7 @@ void test_interpolate_volume_vars() {
   ah::interpolate_volume_data(make_not_null(&current_iteration),
                               make_not_null(&all_volume_variables));
   CHECK(current_iteration.interpolation_is_done_for_these_elements.empty());
-  CHECK(current_iteration.indicies_interpolated_to_thus_far.empty());
+  CHECK(current_iteration.indices_interpolated_to_thus_far.empty());
   CHECK(current_iteration.interpolated_vars.number_of_grid_points() == 0_st);
 
   size_t num_previous_indices_interpolated_to = 0;
@@ -181,17 +181,17 @@ void test_interpolate_volume_vars() {
     // We could in theory figure out which points are in which element for a
     // given l_max, but that's quite tedious and we don't need such a stringent
     // test
-    CHECK_FALSE(current_iteration.indicies_interpolated_to_thus_far.size() ==
+    CHECK_FALSE(current_iteration.indices_interpolated_to_thus_far.size() ==
                 num_previous_indices_interpolated_to);
     num_previous_indices_interpolated_to =
-        current_iteration.indicies_interpolated_to_thus_far.size();
+        current_iteration.indices_interpolated_to_thus_far.size();
     tmpl::for_each<ah::vars_to_interpolate_to_target<3, Frame::Inertial>>(
         [&]<typename Tag>(tmpl::type_<Tag>) {
           auto& interpolated_var =
               get<Tag>(current_iteration.interpolated_vars);
           for (size_t j = 0; j < interpolated_var.size(); j++) {
             for (const size_t index :
-                 current_iteration.indicies_interpolated_to_thus_far) {
+                 current_iteration.indices_interpolated_to_thus_far) {
               CHECK(interpolated_var[j][index] !=
                     std::numeric_limits<double>::max());
             }
@@ -228,7 +228,7 @@ void test_interpolate_volume_vars() {
   CHECK(current_iteration.interpolation_is_done_for_these_elements.contains(
       element_id));
   // This shouldn't have changed
-  CHECK(current_iteration.indicies_interpolated_to_thus_far.size() ==
+  CHECK(current_iteration.indices_interpolated_to_thus_far.size() ==
         num_previous_indices_interpolated_to);
   // Again check that all points are interpolated to
   check_no_max();

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
@@ -146,13 +146,6 @@ void test_interpolate_volume_vars() {
                      ah::Storage::VolumeVariables<Frame::Inertial>>
       all_volume_variables{};
 
-  // Check that if there aren't any volume variables, that nothing happens
-  ah::interpolate_volume_data(make_not_null(&current_iteration),
-                              make_not_null(&all_volume_variables));
-  CHECK(current_iteration.interpolation_is_done_for_these_elements.empty());
-  CHECK(current_iteration.indices_interpolated_to_thus_far.empty());
-  CHECK(current_iteration.interpolated_vars.number_of_grid_points() == 0_st);
-
   size_t num_previous_indices_interpolated_to = 0;
   for (const auto& element_id : element_ids) {
     const Mesh mesh{domain_creator.initial_extents()[element_id.block_id()],
@@ -162,10 +155,10 @@ void test_interpolate_volume_vars() {
     const auto source_vars = compute_source_vars(
         solution, time, element_id, blocks[element_id.block_id()], mesh);
 
-    all_volume_variables[element_id].mesh = mesh;
+    auto& volume_vars = all_volume_variables[element_id];
+    volume_vars.mesh = mesh;
     ah::compute_vars_to_interpolate_to_target(
-        make_not_null(
-            &all_volume_variables[element_id].vars_to_interpolate_to_target),
+        make_not_null(&volume_vars.vars_to_interpolate_to_target),
         get<::gr::Tags::SpacetimeMetric<DataVector, 3>>(source_vars),
         get<::gh::Tags::Pi<DataVector, 3>>(source_vars),
         get<::gh::Tags::Phi<DataVector, 3>>(source_vars),
@@ -173,13 +166,11 @@ void test_interpolate_volume_vars() {
                         Frame::Inertial>>(source_vars),
         time, domain, mesh, element_id, functions_of_time);
 
-    ah::interpolate_volume_data(make_not_null(&current_iteration),
-                                make_not_null(&all_volume_variables));
+    ah::interpolate_volume_data(make_not_null(&current_iteration), volume_vars,
+                                element_id);
 
     // Check that we finished interpolation and that the points we interpolated
     // to aren't the default fill value
-    CHECK(current_iteration.interpolation_is_done_for_these_elements.contains(
-        element_id));
     // We could in theory figure out which points are in which element for a
     // given l_max, but that's quite tedious and we don't need such a stringent
     // test
@@ -202,6 +193,7 @@ void test_interpolate_volume_vars() {
           }
         });
   }
+  CHECK(current_iteration.interpolation_is_complete());
 
   const auto check_no_max = [&]() {
     tmpl::for_each<ah::vars_to_interpolate_to_target<3, Frame::Inertial>>(
@@ -217,24 +209,6 @@ void test_interpolate_volume_vars() {
   };
 
   // Check all points have been interpolated to
-  check_no_max();
-
-  // Test sending volume data again that it doesn't do anything
-  const auto& element_id = element_ids[0];
-  const Mesh mesh{domain_creator.initial_extents()[element_id.block_id()],
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto};
-
-  ah::interpolate_volume_data(make_not_null(&current_iteration),
-                              make_not_null(&all_volume_variables));
-
-  // Check interpolation is still done
-  CHECK(current_iteration.interpolation_is_done_for_these_elements.contains(
-      element_id));
-  // This shouldn't have changed
-  CHECK(current_iteration.indices_interpolated_to_thus_far.size() ==
-        num_previous_indices_interpolated_to);
-  // Again check that all points are interpolated to
   check_no_max();
 }
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
@@ -134,6 +134,8 @@ void test_interpolate_volume_vars() {
       ylm::cartesian_coords(current_iteration.strahlkorper);
   current_iteration.block_coord_holders = ::block_logical_coordinates(
       domain, surface_coords, time.id, functions_of_time);
+  const size_t expected_num_points =
+      current_iteration.block_coord_holders->size();
 
   const gr::Solutions::KerrSchild solution(mass, spin, {0.0, 0.0, 0.0});
   const auto solution_vars = solution.variables(
@@ -181,19 +183,21 @@ void test_interpolate_volume_vars() {
     // We could in theory figure out which points are in which element for a
     // given l_max, but that's quite tedious and we don't need such a stringent
     // test
-    CHECK_FALSE(current_iteration.indices_interpolated_to_thus_far.size() ==
-                num_previous_indices_interpolated_to);
-    num_previous_indices_interpolated_to =
-        current_iteration.indices_interpolated_to_thus_far.size();
+    const auto num_indices_interpolated_to = static_cast<size_t>(
+        alg::count_if(current_iteration.indices_interpolated_to_thus_far,
+                      [](const bool filled) { return filled; }));
+    CHECK(num_indices_interpolated_to > num_previous_indices_interpolated_to);
+    num_previous_indices_interpolated_to = num_indices_interpolated_to;
     tmpl::for_each<ah::vars_to_interpolate_to_target<3, Frame::Inertial>>(
         [&]<typename Tag>(tmpl::type_<Tag>) {
           auto& interpolated_var =
               get<Tag>(current_iteration.interpolated_vars);
           for (size_t j = 0; j < interpolated_var.size(); j++) {
-            for (const size_t index :
-                 current_iteration.indices_interpolated_to_thus_far) {
-              CHECK(interpolated_var[j][index] !=
-                    std::numeric_limits<double>::max());
+            for (size_t index = 0; index < expected_num_points; index++) {
+              if (current_iteration.indices_interpolated_to_thus_far[index]) {
+                CHECK(interpolated_var[j][index] !=
+                      std::numeric_limits<double>::max());
+              }
             }
           }
         });

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
@@ -37,14 +37,20 @@ void test_storage() {
       Variables<ah::vars_to_interpolate_to_target<3, Fr>>{4, 4.321}};
   test_serialization(volume_variables);
 
-  const ah::Storage::Iteration<Fr> iteration{
+  ah::Storage::Iteration<Fr> iteration{
       ylm::Strahlkorper<Fr>{4_st, 3.0, std::array{0.0, 0.1, 0.2}},
       std::optional<std::vector<BlockLogicalCoords<3>>>{{std::nullopt}},
       Variables<ah::vars_to_interpolate_to_target<3, Fr>>{6, 9.876},
-      std::set<size_t>{1_st, 4_st, 5_st},
+      std::vector<bool>{false, true, false, false, true, true},
       std::unordered_set<ElementId<3>>{ElementId<3>{0}, ElementId<3>{1}},
       {2}};
   test_serialization(iteration);
+  CHECK_FALSE(iteration.interpolation_is_complete());
+  for (size_t i = 0; i < iteration.indices_interpolated_to_thus_far.size();
+       ++i) {
+    iteration.indices_interpolated_to_thus_far[i] = true;
+  }
+  CHECK(iteration.interpolation_is_complete());
 
   const ah::Storage::SingleTimeStorage<Fr> single_time_storage{
       std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>{

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
@@ -42,7 +42,9 @@ void test_storage() {
       std::optional<std::vector<BlockLogicalCoords<3>>>{{std::nullopt}},
       Variables<ah::vars_to_interpolate_to_target<3, Fr>>{6, 9.876},
       std::vector<bool>{false, true, false, false, true, true},
-      std::unordered_set<ElementId<3>>{ElementId<3>{0}, ElementId<3>{1}},
+      {},
+      {},
+      {},
       {2}};
   test_serialization(iteration);
   CHECK_FALSE(iteration.interpolation_is_complete());
@@ -55,7 +57,10 @@ void test_storage() {
   const ah::Storage::SingleTimeStorage<Fr> single_time_storage{
       std::unordered_map<ElementId<3>, ah::Storage::VolumeVariables<Fr>>{
           {ElementId<3>{0}, volume_variables}},
-      iteration, iteration.strahlkorper, Destination::ControlSystem};
+      {},
+      iteration,
+      iteration.strahlkorper,
+      Destination::ControlSystem};
   test_serialization(single_time_storage);
 
   const ah::Storage::PreviousSurface<Fr> previous_surface{


### PR DESCRIPTION
## Proposed changes

The "block search order" commit speeds up the single BH test used in #6879 by ~1/3 compared to current develop (not including the parallelization added in #6879). This is done just by caching the order in which blocks are searched for coordinates to interpolate to.

Not sure if the first commit has any effect, it just seemed like an easy thing to fix.

The "element search oder" commit speeds it up further, but I have only profiled this together with #6879 so not sure by how much.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
