### PR TITLE
Add Pybindings for BCO TimeDependentOptions

### DIFF
--- a/src/Domain/Creators/Python/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/Python/BinaryCompactObject.cpp
@@ -33,7 +33,9 @@ void bind_binary_compact_object(py::module& m) {
                   const size_t initial_num_points,
                   const bool use_equiangular_map,
                   const std::vector<double>& radial_partitioning_outer_shell,
-                  const double opening_angle_in_degrees) {
+                  const double opening_angle_in_degrees,
+                  std::optional<bco::TimeDependentMapOptions<false>>
+                      time_dependent_options) {
                  return domain::creators::BinaryCompactObject<false>{
                      domain::creators::BinaryCompactObject<false>::Object{
                          inner_radius_object_a, outer_radius_object_a,
@@ -51,7 +53,8 @@ void bind_binary_compact_object(py::module& m) {
                      domain::CoordinateMaps::Distribution::Logarithmic,
                      radial_partitioning_outer_shell,
                      domain::CoordinateMaps::Distribution::Linear,
-                     opening_angle_in_degrees};
+                     opening_angle_in_degrees,
+                     std::move(time_dependent_options)};
                }),
            py::arg("inner_radius_a"), py::arg("outer_radius_a"),
            py::arg("x_coord_a"), py::arg("excise_a"),
@@ -63,6 +66,7 @@ void bind_binary_compact_object(py::module& m) {
            py::arg("initial_number_of_grid_points"),
            py::arg("use_equiangular_map"),
            py::arg("radial_partitioning_outer_shell") = std::vector<double>{},
-           py::arg("opening_angle_in_degrees") = 120);
+           py::arg("opening_angle_in_degrees") = 120,
+           py::arg("time_dependent_options"));
 }
 }  // namespace domain::creators::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -29,3 +29,5 @@ spectre_target_headers(
   Sphere.hpp
   TranslationMap.hpp
   )
+
+add_subdirectory(Python)

--- a/src/Domain/Creators/TimeDependentOptions/Python/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/BinaryCompactObject.cpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/Python/BinaryCompactObject.hpp"
+
+#include <array>
+#include <optional>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/GridCenters.hpp"
+#include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/SkewMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::time_dependent_options::py_bindings {
+void bind_binary_compact_object(py::module& m) {
+  py::class_<domain::creators::bco::TimeDependentMapOptions<false>>(
+      m, "BinaryCompactObjectTimeDependentOptions")
+      .def(py::init<
+               double,
+               std::optional<domain::creators::time_dependent_options::
+                                 ExpansionMapOptions<false>>,
+               std::optional<domain::creators::time_dependent_options::
+                                 RotationMapOptions<false>>,
+               std::optional<domain::creators::time_dependent_options::
+                                 TranslationMapOptions<3>>,
+               std::optional<
+                   domain::creators::time_dependent_options::SkewMapOptions>,
+               std::optional<domain::creators::time_dependent_options::
+                                 ShapeMapOptions<true, ObjectLabel::A>>,
+               std::optional<domain::creators::time_dependent_options::
+                                 ShapeMapOptions<true, ObjectLabel::B>>,
+               std::optional<domain::creators::time_dependent_options::
+                                 GridCentersOptions>>(),
+           py::arg("initial_time"), py::arg("expansion_map_options"),
+           py::arg("rotation_map_options"), py::arg("translation_map_options"),
+           py::arg("skew_map_options"), py::arg("shape_options_A"),
+           py::arg("shape_options_B"), py::arg("grid_centers_options"));
+}
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/BinaryCompactObject.hpp
@@ -5,8 +5,8 @@
 
 #include <pybind11/pybind11.h>
 
-namespace domain::creators::py_bindings {
+namespace domain::creators::time_dependent_options::py_bindings {
 // NOLINTNEXTLINE(google-runtime-references)
-// For now this does not support an outer-boundary condition or context.
+// For now this does not support SettleToConst maps.
 void bind_binary_compact_object(pybind11::module& m);
-}  // namespace domain::creators::py_bindings
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/Bindings.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/Bindings.cpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "Domain/Creators/TimeDependentOptions/Python/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/Python/ExpansionMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/Python/GridCenters.hpp"
+#include "Domain/Creators/TimeDependentOptions/Python/RotationMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/Python/ShapeMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/Python/SkewMap.hpp"
+#include "Domain/Creators/TimeDependentOptions/Python/TranslationMap.hpp"
+
+namespace domain::creators::time_dependent_options {
+
+PYBIND11_MODULE(_Pybindings, m) {
+  py_bindings::bind_binary_compact_object(m);
+  py_bindings::bind_expansion_map(m);
+  py_bindings::bind_grid_centers(m);
+  py_bindings::bind_translation_map(m);
+  py_bindings::bind_skew_map(m);
+  py_bindings::bind_rotation_map(m);
+  py_bindings::bind_shape_map(m);
+}
+}  // namespace domain::creators::time_dependent_options

--- a/src/Domain/Creators/TimeDependentOptions/Python/CMakeLists.txt
+++ b/src/Domain/Creators/TimeDependentOptions/Python/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PyDomainTimeDependentOptions")
+
+spectre_python_add_module(
+    TimeDependentOptions
+    LIBRARY_NAME ${LIBRARY}
+    MODULE_PATH "Domain/Creators"
+    SOURCES
+    BinaryCompactObject.cpp
+    Bindings.cpp
+    ExpansionMap.cpp
+    GridCenters.cpp
+    RotationMap.cpp
+    ShapeMap.cpp
+    SkewMap.cpp
+    TranslationMap.cpp
+    PYTHON_FILES
+    __init__.py
+)
+
+spectre_python_headers(
+    ${LIBRARY}
+    INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+    HEADERS
+    BinaryCompactObject.hpp
+    ExpansionMap.hpp
+    GridCenters.hpp
+    RotationMap.hpp
+    ShapeMap.hpp
+    SkewMap.hpp
+    TranslationMap.hpp
+)
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DomainCreators
+  DomainTimeDependence
+  pybind11::module
+  )
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyDomainCreators
+  )

--- a/src/Domain/Creators/TimeDependentOptions/Python/ExpansionMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/ExpansionMap.cpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/Python/ExpansionMap.hpp"
+
+#include <array>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::time_dependent_options::py_bindings {
+void bind_expansion_map(py::module& m) {
+  py::class_<time_dependent_options::ExpansionMapOptions<false>>(
+      m, "ExpansionMapOptions")
+      .def(py::init<std::array<double, 3>, double, double>(),
+           py::arg("initial_values_in"),
+           py::arg("decay_timescale_outer_boundary_in"),
+           py::arg("asymptotic_velocity_outer_boundary_in"));
+}
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/ExpansionMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/ExpansionMap.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::time_dependent_options::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_expansion_map(pybind11::module& m);
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/GridCenters.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/GridCenters.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/Python/GridCenters.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/GridCenters.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::time_dependent_options::py_bindings {
+void bind_grid_centers(py::module& m) {
+  py::class_<time_dependent_options::GridCentersOptions>(m,
+                                                         "GridCentersOptions")
+      .def(py::init<std::string, std::optional<double>>(),
+           py::arg("spec_evolution_parameters_perl_file"),
+           py::arg("in_scale_inspiral_rate_by"));
+}
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/GridCenters.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/GridCenters.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::time_dependent_options::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_grid_centers(pybind11::module& m);
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/RotationMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/RotationMap.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/Python/RotationMap.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <vector>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::time_dependent_options::py_bindings {
+void bind_rotation_map(py::module& m) {
+  py::class_<time_dependent_options::RotationMapOptions<false>>(
+      m, "RotationMapOptions")
+      .def(py::init<std::vector<std::array<double, 4>>, double>(),
+           py::arg("initial_values_in"), py::arg("decay_timescale_in"));
+}
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/RotationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/RotationMap.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::time_dependent_options::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_rotation_map(pybind11::module& m);
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/ShapeMap.cpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/Python/ShapeMap.hpp"
+
+#include <array>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/ShapeMap.hpp"
+#include "Domain/Structure/ObjectLabel.hpp"
+#include "Utilities/GetOutput.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::time_dependent_options::py_bindings {
+namespace {
+void bind_kerrschild_from_boyer_lindquist_impl(py::module& m) {
+  py::class_<time_dependent_options::KerrSchildFromBoyerLindquist>(
+      m, "KerrSchildFromBoyerLindquist")
+      .def(py::init<double, std::array<double, 3>>(), py::arg("mass"),
+           py::arg("spin"));
+}
+
+void bind_ylms_from_file_impl(py::module& m) {
+  py::class_<time_dependent_options::YlmsFromFile>(m, "YlmsFromFile")
+      .def(py::init<std::string, std::vector<std::string>, double,
+                    std::optional<double>, bool, bool>(),
+           py::arg("h5_filename"), py::arg("subfile_names"),
+           py::arg("match_time"), py::arg("match_time_epsilon") = std::nullopt,
+           py::arg("set_l1_coefs_to_zero"), py::arg("check_frame"));
+}
+
+void bind_ylms_from_spec_impl(py::module& m) {
+  py::class_<time_dependent_options::YlmsFromSpEC>(m, "YlmsFromSpEC")
+      .def(py::init<std::string, double, std::optional<double>, bool>(),
+           py::arg("dat_filename"), py::arg("match_time"),
+           py::arg("match_time_epsilon"), py::arg("set_l1_coefs_to_zero"));
+}
+
+template <domain::ObjectLabel Object>
+void bind_shape_map_impl(py::module& m) {
+  py::class_<time_dependent_options::ShapeMapOptions<true, Object>>(
+      m, ("ShapeMapOptions" + get_output(name(Object))).c_str())
+      .def(
+          py::init<size_t,
+                   std::optional<std::variant<
+                       domain::creators::time_dependent_options::
+                           KerrSchildFromBoyerLindquist,
+                       domain::creators::time_dependent_options::YlmsFromFile,
+                       domain::creators::time_dependent_options::YlmsFromSpEC>>,
+                   std::optional<std::array<double, 3>>, bool>(),
+          py::arg("l_max"), py::arg("initial_values"),
+          py::arg("initial_size_values") = std::nullopt,
+          py::arg("transition_ends_at_cube") = true);
+}
+}  // namespace
+
+void bind_shape_map(py::module& m) {
+  py_bindings::bind_kerrschild_from_boyer_lindquist_impl(m);
+  py_bindings::bind_shape_map_impl<ObjectLabel::A>(m);
+  py_bindings::bind_shape_map_impl<ObjectLabel::B>(m);
+  py_bindings::bind_shape_map_impl<ObjectLabel::C>(m);
+  py_bindings::bind_shape_map_impl<ObjectLabel::None>(m);
+  py_bindings::bind_ylms_from_file_impl(m);
+  py_bindings::bind_ylms_from_spec_impl(m);
+}
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/ShapeMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/ShapeMap.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+namespace domain::creators::time_dependent_options::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_shape_map(pybind11::module& m);
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/SkewMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/SkewMap.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/Python/SkewMap.hpp"
+
+#include <array>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/SkewMap.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::time_dependent_options::py_bindings {
+void bind_skew_map(py::module& m) {
+  py::class_<time_dependent_options::SkewMapOptions>(m, "SkewMapOptions")
+      .def(py::init<std::array<double, 3>, std::array<double, 3>>(),
+           py::arg("initial_angles_y_in"), py::arg("initial_angles_z_in"));
+}
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/SkewMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/SkewMap.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::time_dependent_options::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_skew_map(pybind11::module& m);
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/TranslationMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/TranslationMap.cpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Creators/TimeDependentOptions/Python/TranslationMap.hpp"
+
+#include <array>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
+#include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
+
+namespace py = pybind11;
+
+namespace domain::creators::time_dependent_options::py_bindings {
+void bind_translation_map(py::module& m) {
+  py::class_<time_dependent_options::TranslationMapOptions<3>>(
+      m, "TranslationMapOptions")
+      .def(py::init<std::array<std::array<double, 3>, 3>>(),
+           py::arg("initial_values_in"));
+}
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/TranslationMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/TranslationMap.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace domain::creators::time_dependent_options::py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_translation_map(pybind11::module& m);
+}  // namespace domain::creators::time_dependent_options::py_bindings

--- a/src/Domain/Creators/TimeDependentOptions/Python/__init__.py
+++ b/src/Domain/Creators/TimeDependentOptions/Python/__init__.py
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._Pybindings import *
+
+ShapeMapOptions = {
+    "A": ShapeMapOptionsA,
+    "B": ShapeMapOptionsB,
+    "C": ShapeMapOptionsC,
+    "None": ShapeMapOptions,
+}

--- a/tests/Unit/Domain/Creators/Python/Test_BinaryCompactObject.py
+++ b/tests/Unit/Domain/Creators/Python/Test_BinaryCompactObject.py
@@ -4,11 +4,15 @@
 import unittest
 
 from spectre.Domain.Creators import BinaryCompactObject, DomainCreator3D
+from spectre.Domain.Creators.TimeDependentOptions import (
+    BinaryCompactObjectTimeDependentOptions,
+    RotationMapOptions,
+)
 
 
-class TestCylinder(unittest.TestCase):
+class TestBinaryCompactObject(unittest.TestCase):
     def test_construction(self):
-        binary_compact_object = BinaryCompactObject(
+        binary_compact_object_no_time_dependence = BinaryCompactObject(
             inner_radius_a=0.5,
             outer_radius_a=2.0,
             x_coord_a=5.0,
@@ -28,8 +32,51 @@ class TestCylinder(unittest.TestCase):
             use_equiangular_map=True,
             radial_partitioning_outer_shell=[],
             opening_angle_in_degrees=120.0,
+            time_dependent_options=None,
         )
-        self.assertIsInstance(binary_compact_object, DomainCreator3D)
+        rotation_map = RotationMapOptions([[0.0, 0.0, 0.0, 1.0]], 100.0)
+        bco_time_dependent_options = BinaryCompactObjectTimeDependentOptions(
+            0.0,
+            None,
+            rotation_map,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        binary_compact_object_time_dependence = BinaryCompactObject(
+            inner_radius_a=0.5,
+            outer_radius_a=2.0,
+            x_coord_a=5.0,
+            excise_a=True,
+            use_logarithmic_map_a=True,
+            inner_radius_b=0.5,
+            outer_radius_b=2.0,
+            x_coord_b=-5.0,
+            excise_b=True,
+            use_logarithmic_map_b=True,
+            center_of_mass_offset=[0.1, 0.2],
+            envelope_radius=50.0,
+            outer_radius=600.0,
+            cube_scale=1.2,
+            initial_refinement=1,
+            initial_number_of_grid_points=5,
+            use_equiangular_map=True,
+            radial_partitioning_outer_shell=[],
+            opening_angle_in_degrees=120.0,
+            time_dependent_options=bco_time_dependent_options,
+        )
+        self.assertIsInstance(
+            binary_compact_object_no_time_dependence, DomainCreator3D
+        )
+        self.assertIsInstance(
+            binary_compact_object_time_dependence, DomainCreator3D
+        )
+        self.assertNotEqual(
+            binary_compact_object_time_dependence,
+            binary_compact_object_no_time_dependence,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/CMakeLists.txt
@@ -13,3 +13,5 @@ set(LIBRARY_SOURCES
   TimeDependentOptions/Test_Sphere.cpp
   TimeDependentOptions/Test_TranslationMap.cpp
   PARENT_SCOPE)
+
+add_subdirectory(Python)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/CMakeLists.txt
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.TimeDependentOptions.Python.BinaryCompactObject"
+  Test_BinaryCompactObject.py
+  "Unit;Domain"
+  PyDomainTimeDependentOptions
+)
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.TimeDependentOptions.Python.ExpansionMap"
+  Test_ExpansionMap.py
+  "Unit;Domain"
+  PyDomainTimeDependentOptions
+)
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.TimeDependentOptions.Python.GridCenters"
+  Test_GridCenters.py
+  "Unit;Domain"
+  PyDomainTimeDependentOptions
+)
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.TimeDependentOptions.Python.RotationMap"
+  Test_RotationMap.py
+  "Unit;Domain"
+  PyDomainTimeDependentOptions
+)
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.TimeDependentOptions.Python.ShapeMap"
+  Test_ShapeMap.py
+  "Unit;Domain"
+  PyDomainTimeDependentOptions
+)
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.TimeDependentOptions.Python.SkewMap"
+  Test_SkewMap.py
+  "Unit;Domain"
+  PyDomainTimeDependentOptions
+)
+
+spectre_add_python_bindings_test(
+  "Unit.Domain.Creators.TimeDependentOptions.Python.TranslationMap"
+  Test_TranslationMap.py
+  "Unit;Domain"
+  PyDomainTimeDependentOptions
+)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_BinaryCompactObject.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_BinaryCompactObject.py
@@ -1,0 +1,61 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators.TimeDependentOptions import (
+    BinaryCompactObjectTimeDependentOptions,
+    ExpansionMapOptions,
+    KerrSchildFromBoyerLindquist,
+    RotationMapOptions,
+    ShapeMapOptions,
+    SkewMapOptions,
+    TranslationMapOptions,
+)
+
+
+class TestBinaryCompactObjectTimeDependentOptions(unittest.TestCase):
+    def test_construction(self):
+        expansion_map = ExpansionMapOptions([1.0, 1e-4, 0.0], 100.0, 1e-6)
+        rotation_map = RotationMapOptions([[0.0, 0.0, 0.0, 1.0]], 100.0)
+        translation_map = TranslationMapOptions(
+            [[1.0, -1.0, 0.5], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        )
+        shape_map_a = ShapeMapOptions["A"](
+            10, KerrSchildFromBoyerLindquist(0.66, [0.0, 0.0, 0.99]), None
+        )
+        shape_map_b = ShapeMapOptions["B"](
+            10, KerrSchildFromBoyerLindquist(0.33, [0.0, 0.0, -0.99]), None
+        )
+        skew_map = SkewMapOptions([0.0, 40.0, 50.0], [0.0, 10.0, 0.0])
+        binary_compact_object_one_map = BinaryCompactObjectTimeDependentOptions(
+            0.0,
+            None,
+            None,
+            translation_map,
+            None,
+            None,
+            None,
+            None,
+        )
+        binary_compact_object_all_maps = (
+            BinaryCompactObjectTimeDependentOptions(
+                0.0,
+                expansion_map,
+                rotation_map,
+                translation_map,
+                skew_map,
+                shape_map_a,
+                shape_map_b,
+                None,
+            )
+        )
+        self.assertNotEqual(binary_compact_object_one_map, None)
+        self.assertNotEqual(binary_compact_object_all_maps, None)
+        self.assertNotEqual(
+            binary_compact_object_one_map, binary_compact_object_all_maps
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_ExpansionMap.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_ExpansionMap.py
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators.TimeDependentOptions import ExpansionMapOptions
+
+
+class TestExpansionMap(unittest.TestCase):
+    def test_construction(self):
+        expansion_map = ExpansionMapOptions([1.0, 1e-4, 0.0], 100.0, 1e-6)
+        self.assertNotEqual(expansion_map, None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_GridCenters.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_GridCenters.py
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators.TimeDependentOptions import GridCentersOptions
+from spectre.Informer import unit_test_build_path
+
+
+class TestGridCenters(unittest.TestCase):
+    def test_construction(self):
+        grid_centers = GridCentersOptions(
+            str(unit_test_build_path())
+            + "../../../tests/InputFiles/GrMhd/GhValenciaDivClean/"
+            + "EvolutionParameters.perl",
+            2.0,
+        )
+        self.assertNotEqual(grid_centers, None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_RotationMap.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_RotationMap.py
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators.TimeDependentOptions import RotationMapOptions
+
+
+class TestRotationMap(unittest.TestCase):
+    def test_construction(self):
+        rotation_map = RotationMapOptions([[0.0, 0.0, 0.0, 1.0]], 100.0)
+        self.assertNotEqual(rotation_map, None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_ShapeMap.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_ShapeMap.py
@@ -1,0 +1,33 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators.TimeDependentOptions import (
+    KerrSchildFromBoyerLindquist,
+    ShapeMapOptions,
+)
+
+
+class TestShapeMap(unittest.TestCase):
+    def test_construction(self):
+        shape_map_A = ShapeMapOptions["A"](
+            10, KerrSchildFromBoyerLindquist(1.0, [0.0, 0.0, 0.99])
+        )
+        shape_map_B = ShapeMapOptions["B"](
+            10, KerrSchildFromBoyerLindquist(1.0, [0.0, 0.0, 0.99])
+        )
+        shape_map_C = ShapeMapOptions["C"](
+            10, KerrSchildFromBoyerLindquist(1.0, [0.0, 0.0, 0.99])
+        )
+        shape_map_no_object = ShapeMapOptions["None"](
+            10, KerrSchildFromBoyerLindquist(1.0, [0.0, 0.0, 0.99])
+        )
+        self.assertNotEqual(shape_map_A, None)
+        self.assertNotEqual(shape_map_B, None)
+        self.assertNotEqual(shape_map_C, None)
+        self.assertNotEqual(shape_map_no_object, None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_SkewMap.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_SkewMap.py
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators.TimeDependentOptions import SkewMapOptions
+
+
+class TestSkewMap(unittest.TestCase):
+    def test_construction(self):
+        skew_map = SkewMapOptions([0.0, 40.0, 50.0], [0.0, 10.0, 0.0])
+        self.assertNotEqual(skew_map, None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_TranslationMap.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_TranslationMap.py
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+from spectre.Domain.Creators.TimeDependentOptions import TranslationMapOptions
+
+
+class TestTranslationMap(unittest.TestCase):
+    def test_construction(self):
+        translation_map = TranslationMapOptions(
+            [[1.0, -1.0, 0.5], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        )
+        self.assertNotEqual(translation_map, None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

This PR adds TimeDependentOption pybindings that will be used for the transition to ringdown script tests. Currently, they're hardcoded for not SettleToConst maps and I didn't add support for grid centers options.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments