### PR TITLE
Support profiling in submit scripts

### DIFF
--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -138,6 +138,7 @@ def schedule(
     clean_output: bool = False,
     force: bool = False,
     validate: Optional[bool] = True,
+    profile_with: Optional[str] = None,
     extra_params: dict = {},
     **kwargs,
 ) -> Optional[subprocess.CompletedProcess]:
@@ -310,6 +311,12 @@ def schedule(
         in the 'run_dir' instead of raising an error when they already exist.
       validate: Optional. When 'True', validate that the input file is parsed
         correctly. When 'False' skip this step.
+      profile_with: Optional. When set to "hpctoolkit", enable profiling with
+        HPCToolkit. No other profilers are currently supported. The executable
+        must be compiled so that it's compatible with HPCToolkit (see
+        https://spectre-code.org/profiling.html). This will modify the submit
+        script to run the executable with 'hpcrun' and postprocess the profiling
+        data with 'hpcstruct' and 'hpcprof'. (Default: False).
       extra_params: Optional. Dictionary of extra parameters passed to input
         file and submit script templates. Parameters can also be passed as
         keyword arguments to this function instead.
@@ -604,11 +611,30 @@ def schedule(
         logger.info(
             f"Run '{executable.name}' in '{run_dir}' on {provision_info}."
         )
-        run_command = (machine.launch_command if machine else []) + [
-            str(executable),
-            "--input-file",
-            str(input_file_path.resolve()),
-        ]
+        machine = this_machine(raise_exception=False)
+        if profile_with is None:
+            profiling_command = []
+        elif profile_with == "hpctoolkit":
+            profiling_command = [
+                "hpcrun",
+                "-t",
+                "-o",
+                "hpctoolkit-measurements",
+            ]
+        else:
+            raise ValueError(
+                f"Unsupported profiler: {profile_with}. Currently, only"
+                " 'hpctoolkit' is supported."
+            )
+        run_command = (
+            (machine.launch_command if machine else [])
+            + profiling_command
+            + [
+                str(executable),
+                "--input-file",
+                str(input_file_path.resolve()),
+            ]
+        )
         if auto_provision:
             run_command += ["+auto-provision"]
         else:
@@ -627,6 +653,22 @@ def schedule(
         if process.returncode != 0:
             raise subprocess.CalledProcessError(
                 returncode=process.returncode, cmd=run_command
+            )
+        if profile_with == "hpctoolkit":
+            subprocess.run(
+                ["hpcstruct", "hpctoolkit-measurements"],
+                cwd=run_dir,
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "hpcprof",
+                    "-o",
+                    "hpctoolkit-database",
+                    "hpctoolkit-measurements",
+                ],
+                cwd=run_dir,
+                check=True,
             )
         # Run the 'Next' entrypoint listed in the input file metadata
         if metadata and "Next" in metadata:
@@ -873,6 +915,19 @@ def scheduler_options(f):
         "--validate/--no-validate",
         default=True,
         help="Validate or skip the validation of the input file.",
+    )
+    @click.option(
+        "--profile-with",
+        type=click.Choice(["hpctoolkit"], case_sensitive=True),
+        default=None,
+        help=(
+            "Set to 'hpctoolkit' to enable profiling with HPCToolkit. No other"
+            " profilers are currently supported. The executable must be"
+            " compiled so that it's compatible with HPCToolkit (see"
+            " https://spectre-code.org/profiling.html). This will modify the"
+            " submit script to run the executable with 'hpcrun' and postprocess"
+            " the profiling data with 'hpcstruct' and 'hpcprof'."
+        ),
     )
     # Scheduling options
     @click.option(

--- a/support/SubmitScripts/CaltechHpc.sh
+++ b/support/SubmitScripts/CaltechHpc.sh
@@ -26,6 +26,7 @@
 
 {% block run_command %}
 mpirun -n ${SLURM_NTASKS} \
+  ${SPECTRE_PROFILING_PREFIX} \
   ${SPECTRE_EXECUTABLE} --input-file ${SPECTRE_INPUT_FILE} \
   ++ppn ${CHARM_PPN} +setcpuaffinity +no_isomalloc_sync \
   ${SPECTRE_CHECKPOINT:+ +restart "${SPECTRE_CHECKPOINT}"}

--- a/support/SubmitScripts/Perlmutter.sh
+++ b/support/SubmitScripts/Perlmutter.sh
@@ -19,6 +19,7 @@
 
 {% block run_command %}
 srun -n ${SLURM_NTASKS} \
+  ${SPECTRE_PROFILING_PREFIX} \
   ${SPECTRE_EXECUTABLE} --input-file ${SPECTRE_INPUT_FILE} \
   ++ppn ${CHARM_PPN} +setcpuaffinity \
   ${SPECTRE_CHECKPOINT:+ +restart "${SPECTRE_CHECKPOINT}"}

--- a/support/SubmitScripts/SubmitTemplateBase.sh
+++ b/support/SubmitScripts/SubmitTemplateBase.sh
@@ -57,12 +57,25 @@ echo
 
 cd ${RUN_DIR}
 
+{% if profile_with is defined and profile_with == "hpctoolkit" %}
+# Enable profiling with HPCToolkit
+# - Enable time tracing with '-t'
+export SPECTRE_PROFILING_PREFIX="hpcrun -t -o hpctoolkit-measurements"
+{% endif %}
+
 {% block run_command %}
 mpirun -n ${SLURM_NTASKS} \
+  ${SPECTRE_PROFILING_PREFIX} \
   ${SPECTRE_EXECUTABLE} --input-file ${SPECTRE_INPUT_FILE} \
   ++ppn ${CHARM_PPN} +setcpuaffinity \
   ${SPECTRE_CHECKPOINT:+ +restart "${SPECTRE_CHECKPOINT}"}
 {% endblock %}
+
+{% if profile_with is defined and profile_with == "hpctoolkit" %}
+# Postprocess profiling data
+hpcstruct hpctoolkit-measurements
+hpcprof -o hpctoolkit-database hpctoolkit-measurements
+{% endif %}
 
 exit_code=$?
 

--- a/support/SubmitScripts/Urania.sh
+++ b/support/SubmitScripts/Urania.sh
@@ -30,8 +30,9 @@ spectre_load_modules
 {% endblock %}
 
 {% block run_command %}
-srun -n ${SLURM_NTASKS} ${SPECTRE_EXECUTABLE} \
-    --input-file ${SPECTRE_INPUT_FILE} \
+srun -n ${SLURM_NTASKS} \
+    ${SPECTRE_PROFILING_PREFIX} \
+    ${SPECTRE_EXECUTABLE} --input-file ${SPECTRE_INPUT_FILE} \
     ++ppn ${CHARM_PPN} +pemap 0-34,36-70 +commap 35,71 \
     ${SPECTRE_CHECKPOINT:+ +restart "${SPECTRE_CHECKPOINT}"}
 {% endblock %}

--- a/support/SubmitScripts/Viper.sh
+++ b/support/SubmitScripts/Viper.sh
@@ -29,8 +29,9 @@ spectre_load_modules
 {% endblock %}
 
 {% block run_command %}
-srun -n ${SLURM_NTASKS} ${SPECTRE_EXECUTABLE} \
-    --input-file ${SPECTRE_INPUT_FILE} \
+srun -n ${SLURM_NTASKS} \
+    ${SPECTRE_PROFILING_PREFIX} \
+    ${SPECTRE_EXECUTABLE} --input-file ${SPECTRE_INPUT_FILE} \
     ++ppn ${CHARM_PPN} +pemap 0-62,64-126 +commap 63,127 \
     ${SPECTRE_CHECKPOINT:+ +restart "${SPECTRE_CHECKPOINT}"}
 {% endblock %}


### PR DESCRIPTION
## Proposed changes

Allows to run `spectre run INPUT_FILE --enable-profiling` to quickly launch a run with profiling enabled. An HPCToolkit module must be loaded.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
