### PR TITLE
Add helper functions for a Fourier basis

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -375,6 +375,14 @@ eprint = {https://doi.org/10.1137/0916035}
                   M.Vázquez and G.Houzeaux}
 }
 
+@book{Boyd2001,
+  author =       {Boyd, John P.},
+  title =        {Chebyshev and Fourier Spectral Methods},
+  year =         2001,
+  isbn =         {0-486-41183-4},
+  publisher =    {Dover Publications}
+}
+
 @article{Boyle:2015nqa,
   author =       "Boyle, Michael",
   title =        "{Transformations of asymptotic gravitational-wave data}",
@@ -1034,6 +1042,16 @@ eprint = {https://doi.org/10.1137/0916035}
   adsurl =       {https://ui.adsabs.harvard.edu/abs/1998ApJ...494..297F},
 }
 
+@book{Fornberg1996,
+  author =       {Fornberg, Bengt},
+  title =        {A Practical Guide to Pseudospectral Methods},
+  year =         1996,
+  isbn =         {0-521-49582-2},
+  url =          {https://doi.org/10.1017/CBO9780511626357},
+  doi =          {10.1017/CBO9780511626357},
+  publisher =    {Cambridge University Press}
+}
+
 @article{Fornberg1998,
   author =       {Fornberg, Bengt},
   title =        {Classroom Note: Calculation of Weights in Finite
@@ -1271,18 +1289,20 @@ eprint = {https://doi.org/10.1137/0916035}
 }
 
 @article{Hannam2008,
-  title = {Wormholes and trumpets: Schwarzschild spacetime for the moving-puncture generation},
-  author = {Hannam, Mark and Husa, Sascha and Ohme, Frank and Br\"ugmann, Bernd and \'O Murchadha, Niall},
-  journal = {Phys. Rev. D},
-  volume = {78},
-  issue = {6},
-  pages = {064020},
-  numpages = {19},
-  year = {2008},
-  month = {Sep},
-  publisher = {American Physical Society},
-  doi = {10.1103/PhysRevD.78.064020},
-  url = {https://link.aps.org/doi/10.1103/PhysRevD.78.064020}
+  title =        {Wormholes and trumpets: Schwarzschild spacetime for
+                  the moving-puncture generation},
+  author =       {Hannam, Mark and Husa, Sascha and Ohme, Frank and
+                  Br\"ugmann, Bernd and \'O Murchadha, Niall},
+  journal =      {Phys. Rev. D},
+  volume =       78,
+  issue =        6,
+  pages =        064020,
+  numpages =     19,
+  year =         2008,
+  month =        {Sep},
+  publisher =    {American Physical Society},
+  doi =          {10.1103/PhysRevD.78.064020},
+  url =          {https://link.aps.org/doi/10.1103/PhysRevD.78.064020}
 }
 
 @article{Harten1983,
@@ -1894,6 +1914,17 @@ journal = {The Astrophysical Journal}
   pages         = {124051},
   year          = {2023},
   url           = {https://doi.org/10.1103/PhysRevD.107.124051}
+}
+
+@article{Mathar2009,
+  author =       {Mathar, Richard J.},
+  title =        {Zernike basis to cartesian transformations},
+  journal =      {Serbian Astronomical Journal},
+  year =         2009,
+  url =          {http://dx.doi.org/10.2298/SAJ0979107M},
+  doi =          {10.2298/saj0979107m},
+  number =       179,
+  pages =        {107–120}
 }
 
 @Article{Michel1972,

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Fourier.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Fourier.hpp
+  )

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/Fourier.cpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/Fourier.cpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionNormalizationSquare.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace Spectral {
+template <typename T>
+T Fourier::basis_function_value(const int k, const T& x) {
+  if (UNLIKELY(k == 0)) {
+    return make_with_value<T>(x, 1.);
+  }
+  if (k > 0) {
+    return cos(k * x);
+  }
+  return sin(-k * x);
+}
+
+double Fourier::basis_function_normalization_square(const int k) {
+  if (UNLIKELY(k == 0)) {
+    return 2.0 * M_PI;
+  }
+  return M_PI;
+}
+
+DataVector Fourier::collocation_points(const size_t num_points) {
+  DataVector x{num_points, 2.0 * M_PI / static_cast<double>(num_points)};
+  for (size_t i = 0; i < num_points; ++i) {
+    x[i] *= static_cast<double>(i);
+  }
+  return x;
+}
+
+DataVector Fourier::quadrature_weights(const size_t num_points) {
+  return DataVector{num_points, 2.0 * M_PI / static_cast<double>(num_points)};
+}
+
+size_t Fourier::modal_storage_index(const int k) {
+  if (UNLIKELY(k == 0)) {
+    return size_t{0};
+  }
+  if (k > 0) {
+    return static_cast<size_t>(2 * k - 1);
+  }
+  return 2 * static_cast<size_t>(-k);
+}
+
+int Fourier::mode_at_storage_index(const size_t storage_index) {
+  if (UNLIKELY(storage_index == 0)) {
+    return 0;
+  }
+  if (storage_index % 2 == 1) {
+    return 1 + static_cast<int>(storage_index) / 2;
+  }
+  return -static_cast<int>(storage_index) / 2;
+}
+
+// As the collocation points are evenly spaced and this is a periodic
+// domain, each row is identical to the previous row right-shifted by
+// one element.  Furthermore the matrix is anti-symmetric.  Thus there
+// are only N/2 unique elements that need to be computed; the rest can
+// be determined from them
+Matrix Fourier::differentiation_matrix(const size_t num_points) {
+  const bool n_is_even = num_points % 2 == 0;
+  Matrix result{num_points, num_points, 0.0};
+  const double half_dx = M_PI / static_cast<double>(num_points);
+  double coef = -0.5;
+  for (size_t j = 1; j < (num_points + 1) / 2; ++j) {
+    coef = -coef;
+    const double y = static_cast<double>(j) * half_dx;
+    result(0, j) = n_is_even ? coef * cos(y) / sin(y) : coef / sin(y);
+    result(0, num_points - j) = -result(0, j);
+  }
+  for (size_t i = 1; i < num_points; ++i) {
+    result(i, 0) = result(i - 1, num_points - 1);
+    for (size_t j = 1; j < num_points; ++j) {
+      result(i, j) = result(i - 1, j - 1);
+    }
+  }
+  return result;
+}
+
+DataVector Fourier::interpolation_weights(const size_t num_points,
+                                          const double x_target) {
+  const bool n_is_even = num_points % 2 == 0;
+  DataVector result{num_points, 1.0 / static_cast<double>(num_points)};
+  const DataVector half_dx = 0.5 * (x_target - collocation_points(num_points));
+  if (n_is_even) {
+    result *= sin(static_cast<double>(num_points) * half_dx) * cos(half_dx) /
+              sin(half_dx);
+  } else {
+    result *= sin(static_cast<double>(num_points) * half_dx) / sin(half_dx);
+  }
+  return result;
+}
+
+template <>
+DataVector compute_basis_function_value<Basis::Fourier>(const size_t k,
+                                                        const DataVector& x) {
+  return Fourier::basis_function_value(Fourier::mode_at_storage_index(k), x);
+}
+
+template <>
+double compute_basis_function_value<Basis::Fourier>(const size_t k,
+                                                    const double& x) {
+  return Fourier::basis_function_value(Fourier::mode_at_storage_index(k), x);
+}
+
+template <>
+double compute_basis_function_normalization_square<Basis::Fourier>(
+    const size_t k) {
+  return Fourier::basis_function_normalization_square(
+      Fourier::mode_at_storage_index(k));
+}
+
+template <>
+std::pair<DataVector, DataVector>
+compute_collocation_points_and_weights<Basis::Fourier, Quadrature::Equiangular>(
+    const size_t num_points) {
+  return std::make_pair(Fourier::collocation_points(num_points),
+                        Fourier::quadrature_weights(num_points));
+}
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+class Matrix;
+/// \endcond
+
+namespace Spectral {
+
+/*!
+ * \ingroup SpectralGroup
+ *
+ * \brief A collection of helper functions for using a Fourier series
+ *
+ * \details The general real-valued Fourier series is given by:
+ * \f[
+ * f(x) = a_0 + \sum_{n=1}^{\infty} a_n \cos(nx) + b_n \sin(nx)
+ * \f]
+ * where
+ * \f{align*}
+ * a_0 &= \frac{1}{2\pi} \int_0^{2\pi} f(x) dx \\
+ * a_n &= \frac{1}{\pi} \int_0^{2\pi} f(x) \cos(nx) dx \\
+ * b_n &= \frac{1}{\pi} \int_0^{2\pi} f(x) \sin(nx) dx
+ * \f}
+ *
+ * If a function is discretized at \f$N\f$ collocation points, the modal
+ * representation will have \f$N\f$ spectral coefficients consisting of
+ * \f{align*}
+ * a_n & \qquad \text{for } n = 0, \ldots, \frac{N}{2} \\
+ * b_n & \qquad \text{for } n = 1, \ldots, \frac{N-1}{2}
+ * \f}
+ * Thus to represent all terms through the harmonic \f$M\f$ requires \f$N = 2M
+ * +1\f$ collocation points.
+ *
+ * For more details about using Fourier series see e.g. \cite Boyd2001 and
+ * \cite Fornberg1996.
+ */
+class Fourier {
+ public:
+  /*!
+   * \brief Value of the basis function \f$\Phi_k(x)\f$
+   *
+   * \details We define the basis functions as
+   * \f{align*}{
+   *   \Phi_k(x)
+   *   &=\begin{cases}
+   *     \hfil \cos(kx) \hfil & \text{if } k \geq 0 \\
+   *     \hfil \sin(-kx) \hfil & \text{if } k < 0
+   *   \end{cases}
+   * \f}
+   */
+  template <typename T>
+  static T basis_function_value(int k, const T& x);
+
+  /*!
+   * \brief The normalization square \f$c_k\f$ of the basis function
+   * \f$\Phi_k(x)\f$, i.e. the definite integral of its square.
+   *
+   * \details
+   * In particular,
+   * \f{align*}{
+   *   c_k
+   *   &=\begin{cases}
+   *     \hfil 2 \pi \hfil & \text{if } k = 0 \\
+   *     \hfil \pi \hfil & \text{otherwise}
+   *   \end{cases}
+   * \f}
+   */
+  static double basis_function_normalization_square(int k);
+
+  /*!
+   * \brief Collocation points \f$\{x_i\}\f$
+   *
+   * \details The collocation points on the interval \f$0 \leq x < 2 \pi\f$ are
+   * given by
+   * \f[
+   * x_i = \frac{2 \pi i}{N}
+   * \f]
+   */
+  static DataVector collocation_points(size_t num_points);
+
+  /*!
+   * \brief Quadrature weights \f$\{w_i\}\f$
+   *
+   * \details The quadrature weights are given by
+   * \f[
+   * w_i = \frac{2 \pi}{N}
+   * \f]
+   */
+  static DataVector quadrature_weights(size_t num_points);
+
+  /*!
+   * \brief Storage index (offset) \f$i\f$ into a ModalVector (representing the
+   * coefficients) of the given mode \f$k\f$
+   *
+   * \details The modal coefficients are stored in a ModalVector as
+   * \f$\{u_0, u_1, u_{-1}, u_2, u_{-2}, \ldots, u_M, u_{-M}\}\f$,
+   * where \f$u_{-M}\f$ is omitted if the number of coefficients is even.
+   * Therefore the storage index \f$i\f$ for the mode \f$u_k\f$ is:
+   * \f{align*}{
+   *   i
+   *   &=\begin{cases}
+   *     \hfil 0 \hfil & \text{if } k = 0 \\
+   *     \hfil 2k-1 \hfil & \text{if } k > 0 \\
+   *     \hfil -2k \hfil & \text{if } k < 0
+   *   \end{cases}
+   * \f}
+   */
+  static size_t modal_storage_index(int k);
+
+  /*!
+   * \brief Mode \f$k\f$ corresponding to given storage index (offset) \f$i\f$
+   * into a ModalVector (representing the coefficients)
+   *
+   * \details The modal coefficients are stored in a ModalVector as
+   * \f$\{u_0, u_1, u_{-1}, u_2, u_{-2}, \ldots, u_M, u_{-M}\}\f$,
+   * where \f$u_{-M}\f$ is omitted if the number of coefficients is even.
+   * Therefore the storage index \f$i\f$ for the mode \f$u_k\f$ is:
+   * \f{align*}{
+   *   k
+   *   &=\begin{cases}
+   *     \hfil 0 \hfil & \text{if } i = 0 \\
+   *     \hfil 1 + \frac{i}{2} \hfil & \text{if } i \text{ is odd} \\
+   *     \hfil -\frac{i}{2} \hfil & \text{if } i \text{ is even}
+   *   \end{cases}
+   * \f}
+   */
+  static int mode_at_storage_index(size_t storage_index);
+
+  /*!
+   * \brief Matrix \f$D_{i,j}\f$ used to obtain the first derivative
+   *
+   * \details The differentiation matrix is given by:
+   * \f{align*}{
+   *   D_{i,j}
+   *   &=\begin{cases}
+   *     \hfil 0 \hfil & \text{if } i = j \\
+   *     \hfil \frac{1}{2} (-1)^{i-j} \csc \left[0.5 (x_i - x_j)\right] \hfil &
+   *     \text{if } i \neq j,\; N \text{ is odd} \\
+   *     \hfil \frac{1}{2} (-1)^{i-j} \cot \left[0.5 (x_i - x_j)\right] \hfil &
+   *     \text{if } i \neq j,\; N \text{ is even}
+   *   \end{cases}
+   * \f}
+   */
+  static Matrix differentiation_matrix(size_t num_points);
+
+  /*!
+   * \brief Interpolation weights \f$C_k(x)\f$ used to interpolate to
+   * \f$x_{target}\f$
+   *
+   * \details The interpolation weights are given by:
+   * \f{align*}{
+   *   C_k(x)
+   *   &=\begin{cases}
+   *     \hfil \frac{1}{N} \sin \left[0.5 N(x - x_j)\right]
+   *     \csc \left[0.5 (x - x_j)\right] \hfil & \text{if } N \text{ is odd} \\
+   *     \hfil \frac{1}{N} \sin \left[0.5 N (x - x_j)\right]
+   *     \cot \left[0.5 (x - x_j)\right] \hfil & \text{if } N \text{ is even}
+   *   \end{cases}
+   * \f}
+   */
+  static DataVector interpolation_weights(size_t num_points, double x_target);
+};
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -83,4 +83,5 @@ target_link_libraries(
   SPHEREPACK
   )
 
+add_subdirectory(BasisFunctions)
 add_subdirectory(Python)

--- a/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
@@ -45,4 +45,6 @@ template const DataVector& collocation_points<Basis::FiniteDifference,
                                               Quadrature::CellCentered>(size_t);
 template const DataVector& collocation_points<Basis::FiniteDifference,
                                               Quadrature::FaceCentered>(size_t);
+template const DataVector&
+collocation_points<Basis::Fourier, Quadrature::Equiangular>(size_t);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
@@ -35,4 +35,6 @@ template struct CollocationPointsAndWeightsGenerator<Basis::FiniteDifference,
                                                      Quadrature::CellCentered>;
 template struct CollocationPointsAndWeightsGenerator<Basis::FiniteDifference,
                                                      Quadrature::FaceCentered>;
+template struct CollocationPointsAndWeightsGenerator<Basis::Fourier,
+                                                     Quadrature::Equiangular>;
 }  // namespace Spectral::detail

--- a/src/NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp
+++ b/src/NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp
@@ -22,5 +22,7 @@ namespace Spectral {
  */
 template <Basis basis>
 constexpr size_t maximum_number_of_points =
-    basis == Basis::FiniteDifference ? 40 : 20;
+    basis == Basis::Fourier            ? 81
+    : basis == Basis::FiniteDifference ? 40
+                                       : 20;
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
@@ -57,6 +57,8 @@ template const Matrix&
 template const Matrix&
     modal_to_nodal_matrix<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);
 template const Matrix&
+modal_to_nodal_matrix<Basis::Fourier, Quadrature::Equiangular>(size_t);
+template const Matrix&
     modal_to_nodal_matrix<Basis::Legendre, Quadrature::Gauss>(size_t);
 template const Matrix&
     modal_to_nodal_matrix<Basis::Legendre, Quadrature::GaussLobatto>(size_t);

--- a/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
@@ -75,6 +75,8 @@ template const Matrix&
 template const Matrix&
     nodal_to_modal_matrix<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);
 template const Matrix&
+nodal_to_modal_matrix<Basis::Fourier, Quadrature::Equiangular>(size_t);
+template const Matrix&
     nodal_to_modal_matrix<Basis::Legendre, Quadrature::Gauss>(size_t);
 template const Matrix&
     nodal_to_modal_matrix<Basis::Legendre, Quadrature::GaussLobatto>(size_t);

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere1D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere1D.cpp
@@ -247,7 +247,6 @@ void test_cartoon_sphere_construction(
   for (size_t block_id = 0; block_id < num_blocks; ++block_id) {
     CAPTURE(block_id);
     const auto& block = blocks[block_id];
-    const auto& boundary_conditions = all_boundary_conditions[block_id];
     const ElementMap<3, Frame::Inertial> inertial_element_map{
         ElementId<3>{block_id}, block};
     {
@@ -298,6 +297,7 @@ void test_cartoon_sphere_construction(
     }
     if (expect_boundary_conditions) {
       INFO("Boundary conditions");
+      const auto& boundary_conditions = all_boundary_conditions[block_id];
       for (const auto& direction : block.external_boundaries()) {
         CAPTURE(direction);
         const auto& boundary_condition =

--- a/tests/Unit/Helpers/DataStructures/ApplyMatrix.cpp
+++ b/tests/Unit/Helpers/DataStructures/ApplyMatrix.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/DataStructures/ApplyMatrix.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+
+DataVector apply_matrix(const Matrix& m, const DataVector& v) {
+  ASSERT(m.columns() == v.size(), "Bad apply_matrix");
+  DataVector result(m.rows(), 0.);
+  for (size_t i = 0; i < m.rows(); ++i) {
+    for (size_t j = 0; j < m.columns(); ++j) {
+      result[i] += m(i, j) * v[j];
+    }
+  }
+  return result;
+}

--- a/tests/Unit/Helpers/DataStructures/ApplyMatrix.hpp
+++ b/tests/Unit/Helpers/DataStructures/ApplyMatrix.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \cond
+class DataVector;
+class Matrix;
+/// \endcond
+
+/// Multiply a matrix and a vector
+DataVector apply_matrix(const Matrix& m, const DataVector& v);

--- a/tests/Unit/Helpers/DataStructures/CMakeLists.txt
+++ b/tests/Unit/Helpers/DataStructures/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "DataStructuresHelpers")
 
 set(LIBRARY_SOURCES
+  ApplyMatrix.cpp
   MathWrapperDetail.cpp
   RandomUnitNormal.cpp
   )

--- a/tests/Unit/Helpers/NumericalAlgorithms/CMakeLists.txt
+++ b/tests/Unit/Helpers/NumericalAlgorithms/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Spectral)
 add_subdirectory(SphericalHarmonics)
 add_subdirectory(SpinWeightedSphericalHarmonics)

--- a/tests/Unit/Helpers/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "SpectralHelpers")
+
+set(LIBRARY_SOURCES
+  FourierTestFunctions.cpp
+  )
+
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  PUBLIC
+  DataStructures
+  Spectral
+  SphericalHarmonics
+  Utilities
+  )

--- a/tests/Unit/Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.cpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.hpp"
+
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace FourierTestFunctions {
+
+ProductOfPolynomials::ProductOfPolynomials(const size_t pow_nx,
+                                           const size_t pow_ny)
+    : pow_nx_{pow_nx}, pow_ny_{pow_ny} {}
+
+DataVector ProductOfPolynomials::operator()(const DataVector& phi) const {
+  return pow(cos(phi), static_cast<double>(pow_nx_)) *
+         pow(sin(phi), static_cast<double>(pow_ny_));
+}
+
+double ProductOfPolynomials::operator()(const double phi) const {
+  return pow(cos(phi), static_cast<double>(pow_nx_)) *
+         pow(sin(phi), static_cast<double>(pow_ny_));
+}
+
+DataVector ProductOfPolynomials::df_dph(const DataVector& phi) const {
+  if (pow_nx_ + pow_ny_ == 0) {
+    return DataVector{phi.size(), 0.0};
+  }
+  if (pow_nx_ == 0) {
+    return static_cast<double>(pow_ny_) * cos(phi) *
+           pow(sin(phi), static_cast<double>(pow_ny_ - 1));
+  }
+  if (pow_ny_ == 0) {
+    return -static_cast<double>(pow_nx_) *
+           pow(cos(phi), static_cast<double>(pow_nx_ - 1)) * sin(phi);
+  }
+  return static_cast<double>(pow_ny_) *
+             pow(cos(phi), static_cast<double>(pow_nx_ + 1)) *
+             pow(sin(phi), static_cast<double>(pow_ny_ - 1)) -
+         static_cast<double>(pow_nx_) *
+             pow(cos(phi), static_cast<double>(pow_nx_ - 1)) *
+             pow(sin(phi), static_cast<double>(pow_ny_ + 1));
+}
+
+double ProductOfPolynomials::definite_integral() const {
+  if ((pow_nx_ % 2 == 1) or (pow_ny_ % 2 == 1)) {
+    return 0.0;
+  }
+  double product = 1.0;
+  double m = 0.0;
+  for (size_t i = 1; i <= pow_nx_ / 2; ++i) {
+    m += 2.0;
+    product *= (m - 1.0) / m;
+  }
+  double n = 0.0;
+  for (size_t j = 1; j <= pow_ny_ / 2; ++j) {
+    n += 2.0;
+    product *= (n - 1.0) / (m + n);
+  }
+
+  return 2.0 * M_PI * product;
+}
+
+DataVector ProductOfPolynomials::modes() const {
+  const size_t p = pow_nx_;
+  const size_t q = pow_ny_;
+  const size_t j = p + q;
+  DataVector result{2 * j + 1, 0.0};
+  const bool q_is_odd = q % 2 == 1;
+  const double overall_sign = (q / 2) % 2 == 0 ? 1.0 : -1.0;
+  const auto two_to_the_j = static_cast<double>(two_to_the(j));
+  for (size_t s = 0; s <= p; ++s) {
+    const auto bin_p_s = static_cast<double>(binomial(p, s));
+    for (size_t l = 0; l <= q; ++l) {
+      const auto bin_q_l = static_cast<double>(binomial(q, l));
+      const double sign = (q - l) % 2 == 0 ? 1.0 : -1.0;
+      const int m = static_cast<int>(2 * s + 2 * l) - static_cast<int>(j);
+      const size_t storage_index =
+          Spectral::Fourier::modal_storage_index(q_is_odd ? -abs(m) : abs(m));
+      const double parity = (q_is_odd and m < 0) ? -1.0 : 1.0;
+      result[storage_index] += parity * sign * bin_q_l * bin_p_s;
+    }
+  }
+  result *= (overall_sign / two_to_the_j);
+  return result;
+}
+}  // namespace FourierTestFunctions

--- a/tests/Unit/Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+/// \endcond
+
+namespace FourierTestFunctions {
+
+/*!
+ * \brief Product of polynomials regular on the surface of a circle
+ *
+ * \details Computes \f$ n_x^{k_x} n_y^{k_y} \f$ where \f$n_x = \cos \phi\f$
+ * and \f$n_y = \sin \phi\f$.  The function and its first derivatives are
+ * exactly representable by Fourier modes of order \f$(M)\f$ if \f$M > k_x +
+ * k_y\f$.
+ */
+class ProductOfPolynomials {
+ public:
+  ProductOfPolynomials(size_t pow_nx, size_t pow_ny);
+  DataVector operator()(const DataVector& phi) const;
+  double operator()(double phi) const;
+  DataVector df_dph(const DataVector& phi) const;
+  double definite_integral() const;
+  /*!
+   * \brief A modal vector of the Fourier modes
+   *
+   * \details The modal coefficients are stored in a ModalVector as
+   * \f$\{u_0, u_1, u_{-1}, u_2, u_{-2}, \ldots, u_M, u_{-M}\}\f$.
+   *
+   * The modes can be determined from Equation 18 of \cite Mathar2009
+   * \f{align*}{
+   * \cos^p \phi \sin^q \phi = \frac{(-1)^{q/2}}{2^{p+q}} \sum_{s=0}^p
+   * \sum_{\ell=0}^q \binom{p}{s} \binom{q}{\ell} (-1)^{q-\ell} \times &
+   *  \begin{cases}
+   *     \cos \left[(2s-p+2\ell-q)\phi\right],\; q \text{ is even} \\
+   *     \sin \left[(2s-p+2\ell-q)\phi\right],\; q \text{ is odd}
+   *  \end{cases}
+   * \f}
+   */
+  DataVector modes() const;
+
+ private:
+  size_t pow_nx_;
+  size_t pow_ny_;
+};
+}  // namespace FourierTestFunctions

--- a/tests/Unit/NumericalAlgorithms/Spectral/BasisFunctions/Test_Fourier.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/BasisFunctions/Test_Fourier.cpp
@@ -1,0 +1,228 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/ApplyMatrix.hpp"
+#include "Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionNormalizationSquare.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
+#include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace Spectral {
+namespace {
+
+enum class Source : uint8_t { Boyd, Fornberg, SpEC };
+
+void test_mode_number_to_storage_index() {
+  for (size_t n = 0; n <= 3; ++n) {
+    CAPTURE(n);
+    CHECK(Fourier::modal_storage_index(Fourier::mode_at_storage_index(n)) == n);
+  }
+}
+
+void test_collocation_points_and_weights() {
+  constexpr Basis basis = Basis::Fourier;
+  constexpr Quadrature quadrature = Quadrature::Equiangular;
+  for (size_t n = 1; n <= 81; ++n) {
+    const auto& [xi, w] =
+        compute_collocation_points_and_weights<basis, quadrature>(n);
+    for (size_t k = 1; k < n; ++k) {
+      const auto f_k = compute_basis_function_value<basis>(k, xi);
+      for (size_t j = 0; j < k; ++j) {
+        const auto f_j = compute_basis_function_value<basis>(j, xi);
+        const double should_be_zero = sum(f_j * f_k * w);
+        CHECK(should_be_zero == approx(0.0));
+      }
+    }
+  }
+}
+
+void test_basis_function_normalization_square() {
+  constexpr Basis basis = Basis::Fourier;
+  constexpr Quadrature quadrature = Quadrature::Equiangular;
+  for (size_t n = 1; n <= 81; ++n) {
+    CAPTURE(n);
+    const auto& [xi, w] =
+        compute_collocation_points_and_weights<basis, quadrature>(n);
+    for (size_t k = 0; k < (n % 2 == 0 ? n - 1 : n); ++k) {
+      CAPTURE(k);
+      const auto f = compute_basis_function_value<basis>(k, xi);
+      const double expected = sum(square(f) * w);
+      CHECK(approx(expected) ==
+            compute_basis_function_normalization_square<basis>(k));
+    }
+  }
+}
+
+void test_modal_to_nodal_matrix() {
+  constexpr Basis basis = Basis::Fourier;
+  constexpr Quadrature quadrature = Quadrature::Equiangular;
+  for (size_t n = 1; n <= 81; n += 1) {
+    CAPTURE(n);
+    const DataVector& x = collocation_points<basis, quadrature>(n);
+    const Matrix& m_to_n = modal_to_nodal_matrix<basis, quadrature>(n);
+    const Matrix& n_to_m = nodal_to_modal_matrix<basis, quadrature>(n);
+    for (size_t j = 0; j < n; ++j) {
+      CAPTURE(j);
+      DataVector u_k{n, 0.0};
+      u_k[j] = 1.0;
+      const DataVector u = apply_matrix(m_to_n, u_k);
+      const int k = Fourier::mode_at_storage_index(j);
+      const DataVector expected_u =
+          k < 0 ? DataVector{sin(-k * x)} : DataVector{cos(k * x)};
+      CHECK_ITERABLE_APPROX(u, expected_u);
+      const DataVector computed_u_k = apply_matrix(n_to_m, u);
+      CHECK_ITERABLE_APPROX(u_k, computed_u_k);
+    }
+  }
+}
+
+void test_definite_integral(
+    const DataVector& u, const DataVector& weights,
+    const FourierTestFunctions::ProductOfPolynomials& f) {
+  const double result = ddot_(u.size(), weights.data(), 1, u.data(), 1);
+  CHECK(f.definite_integral() == approx(result));
+}
+
+void test_derivative(const DataVector& u, const Matrix& m,
+                     const FourierTestFunctions::ProductOfPolynomials& f,
+                     const DataVector& phi) {
+  const auto custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  const DataVector expected_du = f.df_dph(phi);
+  const DataVector du = apply_matrix(m, u);
+  CHECK_ITERABLE_CUSTOM_APPROX(du, expected_du, custom_approx);
+}
+
+void test_interpolation(const DataVector& u, const double phi_target,
+                        const DataVector& interp_weights,
+                        const FourierTestFunctions::ProductOfPolynomials& f) {
+  const auto custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  for (size_t i = 0; i < 5; ++i) {
+    const double u_target =
+        ddot_(u.size(), interp_weights.data(), 1, u.data(), 1);
+    CHECK(u_target == custom_approx(f(phi_target)));
+  }
+}
+
+void test_transforms(const DataVector& u, const Matrix& modal_to_nodal_matrix,
+                     const Matrix& nodal_to_modal_matrix,
+                     const FourierTestFunctions::ProductOfPolynomials& f) {
+  const DataVector expected_u_k = f.modes();
+  const DataVector u_k = apply_matrix(nodal_to_modal_matrix, u);
+  for (size_t i = 0; i < expected_u_k.size(); ++i) {
+    CHECK(u_k[i] == approx(expected_u_k[i]));
+  }
+  const DataVector transformed_u = apply_matrix(modal_to_nodal_matrix, u_k);
+  CHECK_ITERABLE_APPROX(u, transformed_u);
+}
+
+void test() {
+  constexpr Basis basis = Basis::Fourier;
+  constexpr Quadrature quadrature = Quadrature::Equiangular;
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> phi_distribution(0.0, 2.0 * M_PI);
+  const double phi_target = phi_distribution(generator);
+  CAPTURE(phi_target);
+  for (size_t num_points = 1; num_points < 65; ++num_points) {
+    CAPTURE(num_points);
+    const DataVector phi = Fourier::collocation_points(num_points);
+    const Matrix dm = Fourier::differentiation_matrix(num_points);
+    const DataVector integration_weights =
+        Fourier::quadrature_weights(num_points);
+    const DataVector interp_weights =
+        Fourier::interpolation_weights(num_points, phi_target);
+    const Matrix& m_to_n = modal_to_nodal_matrix<basis, quadrature>(num_points);
+    const Matrix& n_to_m = nodal_to_modal_matrix<basis, quadrature>(num_points);
+    const size_t k_max = num_points / 2;
+    CAPTURE(k_max);
+    for (size_t pow_nx = 0; pow_nx < k_max; ++pow_nx) {
+      CAPTURE(pow_nx);
+      for (size_t pow_ny = 0; pow_ny < k_max - pow_nx; ++pow_ny) {
+        CAPTURE(pow_ny);
+        const FourierTestFunctions::ProductOfPolynomials f{pow_nx, pow_ny};
+        const DataVector u = f(phi);
+        CAPTURE(u);
+        test_definite_integral(u, integration_weights, f);
+        test_interpolation(u, phi_target, interp_weights, f);
+        test_derivative(u, dm, f, phi);
+        test_transforms(u, m_to_n, n_to_m, f);
+      }
+    }
+  }
+}
+
+DataVector expected_modes(const size_t pow_nx, const size_t pow_ny) {
+  if (pow_nx == 0 and pow_ny == 0) {
+    return {1.0};
+  } else if (pow_nx == 1 and pow_ny == 0) {
+    return {0.0, 1.0, 0.0};
+  } else if (pow_nx == 0 and pow_ny == 1) {
+    return {0.0, 0.0, 1.0};
+  } else if (pow_nx == 2 and pow_ny == 0) {
+    return {0.5, 0.0, 0.0, 0.5, 0.0};
+  } else if (pow_nx == 1 and pow_ny == 1) {
+    return {0.0, 0.0, 0.0, 0.0, 0.5};
+  } else if (pow_nx == 0 and pow_ny == 2) {
+    return {0.5, 0.0, 0.0, -0.5, 0.0};
+  } else if (pow_nx == 3 and pow_ny == 0) {
+    return {0.0, 0.75, 0.0, 0.0, 0.0, 0.25, 0.0};
+  } else if (pow_nx == 2 and pow_ny == 1) {
+    return {0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 0.25};
+  } else if (pow_nx == 1 and pow_ny == 2) {
+    return {0.0, 0.25, 0.0, 0.0, 0.0, -0.25, 0.0};
+  } else if (pow_nx == 0 and pow_ny == 3) {
+    return {0.0, 0.0, 0.75, 0.0, 0.0, 0.0, -0.25};
+  } else if (pow_nx == 4 and pow_ny == 0) {
+    return {0.375, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.125, 0.0};
+  } else if (pow_nx == 3 and pow_ny == 1) {
+    return {0.0, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 0.125};
+  } else if (pow_nx == 2 and pow_ny == 2) {
+    return {0.125, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.125, 0.0};
+  } else if (pow_nx == 1 and pow_ny == 3) {
+    return {0.0, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0, 0.0, -0.125};
+  } else if (pow_nx == 0 and pow_ny == 4) {
+    return {0.375, 0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 0.125, 0.0};
+  }
+  return DataVector{};
+}
+
+void test_modes() {
+  for (size_t k_max = 0; k_max < 5; ++k_max) {
+    for (size_t pow_nx = 0; pow_nx <= k_max; ++pow_nx) {
+      CAPTURE(pow_nx);
+      for (size_t pow_ny = 0; pow_ny <= k_max - pow_nx; ++pow_ny) {
+        CAPTURE(pow_ny);
+        const FourierTestFunctions::ProductOfPolynomials f{pow_nx, pow_ny};
+        CHECK_ITERABLE_APPROX(expected_modes(pow_nx, pow_ny), f.modes());
+      }
+    }
+  }
+}
+}  // namespace
+
+// [[Timeout, 10]]
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.BasisFunctions.Fourier",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_mode_number_to_storage_index();
+  test_collocation_points_and_weights();
+  test_basis_function_normalization_square();
+  test_modal_to_nodal_matrix();
+  test();
+  test_modes();
+}
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory("Python")
 set(LIBRARY "Test_Spectral")
 
 set(LIBRARY_SOURCES
+  BasisFunctions/Test_Fourier.cpp
   Test_Basis.cpp
   Test_Cartoon.cpp
   Test_ChebyshevGauss.cpp
@@ -36,6 +37,7 @@ target_link_libraries(
   ErrorHandling
   LinearOperators
   Spectral
+  SpectralHelpers
   SphericalHarmonics
   Utilities
   )


### PR DESCRIPTION
## Proposed changes

Add functions for computing collocation points, quadrature weights, derivative matrices, transform matrices, and interpolation weights for a real-valued Fourier series.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
