### PR TITLE
Use std::fabs in Test_SlabRoundingError

### DIFF
--- a/tests/Unit/Time/Test_SlabRoundingError.cpp
+++ b/tests/Unit/Time/Test_SlabRoundingError.cpp
@@ -14,14 +14,17 @@ void check_slab(const double start, const double end) {
   const double duration = end - start;
   {
     const Slab slab = Slab::with_duration_from_start(start, duration);
-    CHECK(abs(slab.end().value() - end) < slab_rounding_error(slab.start()));
-    CHECK(abs(slab.end().value() - end) < slab_rounding_error(slab.end()));
+    CHECK(std::abs(slab.end().value() - end) <
+          slab_rounding_error(slab.start()));
+    CHECK(std::abs(slab.end().value() - end) <
+          slab_rounding_error(slab.end()));
   }
   {
     const Slab slab = Slab::with_duration_to_end(end, duration);
-    CHECK(abs(slab.start().value() - start) <
+    CHECK(std::abs(slab.start().value() - start) <
           slab_rounding_error(slab.start()));
-    CHECK(abs(slab.start().value() - start) < slab_rounding_error(slab.end()));
+    CHECK(std::abs(slab.start().value() - start) <
+          slab_rounding_error(slab.end()));
   }
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Building in the spectre docker container with clang, I noticed a compiler warning that Test_SlabRoundingError.cpp used abs() even though it was dealing with floating point numbers. Changing to std::fabs() fixes the warning and makes explicit that it is operating on doubles, not integers.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
