### PR TITLE
Drop Py versions < 3.10, drop Intel MacOS, install FFTW in container

### DIFF
--- a/.github/scripts/Release.py
+++ b/.github/scripts/Release.py
@@ -5,6 +5,7 @@
 
 import datetime
 import difflib
+import json
 import logging
 import operator
 import os
@@ -16,11 +17,11 @@ import urllib
 from typing import List
 
 import git
+import jsonschema
 import pybtex.database
 import requests
 import uplink
 import yaml
-from cffconvert.citation import Citation
 from pybtex.backends.plaintext import Backend as PlaintextBackend
 from pybtex.style.formatting.plain import Style as PlainStyle
 
@@ -30,6 +31,11 @@ VERSION_PATTERN = r"(\d{4})\.(\d{2})\.(\d{2})(\.\d+)?"
 PUBLICATION_DATE_PATTERN = r"\d{4}-\d{2}-\d{2}"
 DOI_PATTERN = r"10\.\d{4,9}/zenodo\.\d+"
 ZENODO_ID_PATTERN = r"\d+"
+# Schema for the Citation File Format (CFF), fetched for the 'cff-version'
+# declared in the CITATION.cff file
+CFF_SCHEMA_URL = (
+    "https://citation-file-format.github.io/{cff_version}/schema.json"
+)
 
 
 def report_check_only(msg: str):
@@ -377,6 +383,29 @@ def collect_citation_metadata(
     }
 
 
+def validate_citation_file(citation_file_content: str):
+    """Validates the CITATION.cff file against the Citation File Format schema
+
+    Downloads the schema for the 'cff-version' that the file declares from
+    https://citation-file-format.github.io and validates against it.
+
+    Args:
+      citation_file_content: Content of the CITATION.cff file
+
+    Raises:
+      jsonschema.ValidationError: If the file doesn't match the schema
+    """
+    citation_data = yaml.safe_load(citation_file_content)
+    schema_url = CFF_SCHEMA_URL.format(cff_version=citation_data["cff-version"])
+    logger.debug(f"Downloading CFF schema: {schema_url}")
+    schema_response = requests.get(schema_url)
+    schema_response.raise_for_status()
+    # The schema expects that YAML 'date' objects have been cast to strings, so
+    # round-trip the data through JSON to convert them
+    citation_data = json.loads(json.dumps(citation_data, default=str))
+    jsonschema.validate(citation_data, schema_response.json())
+
+
 def build_bibtex_entry(metadata: dict):
     """Builds a BibTeX entry that we suggest people cite in publications
 
@@ -618,7 +647,7 @@ def prepare(
     citation_file_content += yaml.safe_dump(citation_data, allow_unicode=True)
     write_file_or_check(citation_file, citation_file_content)
     # Validate the CFF file
-    Citation(citation_file_content, src=citation_file).validate()
+    validate_citation_file(citation_file_content)
 
     # Get the BibTeX entry and write to file
     bibtex_entry = build_bibtex_entry(metadata)

--- a/.github/scripts/requirements-release.txt
+++ b/.github/scripts/requirements-release.txt
@@ -2,11 +2,14 @@
 # See LICENSE.txt for details.
 
 # Required Python packages for the release workflow
+#
+# These versions are pinned so that a release can't break because a package
+# published a new version in the meantime.
 
-GitPython~=3.1.11
-pybtex~=0.24.0
-PyGithub~=1.53
-PyYAML~=5.3.1
-tqdm~=4.55.1
-uplink==0.9.7
-cffconvert==2.0.0
+GitPython~=3.1.59
+jsonschema~=4.26.0
+pybtex~=0.26.1
+PyGithub~=2.10.0
+PyYAML~=6.0.3
+tqdm~=4.70.0
+uplink~=0.10.0

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -142,12 +142,7 @@ jobs:
           git fetch --tags https://github.com/sxs-collaboration/spectre
       - name: Install Python dependencies
         run: |
-          pip3 install -r .github/scripts/requirements-release.txt
-          pip3 install -r support/Python/dev_requirements.txt
-      - name: Test tools
-        run: |
-          python3 -m unittest discover -p 'Test_CompileReleaseNotes.py' \
-            tests.tools -v
+          python3 -m pip install -r support/Python/dev_requirements.txt
       - name: Check Python formatting
         run: |
           cd $GITHUB_WORKSPACE
@@ -163,9 +158,21 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           ./tools/CheckFiles.sh
+      # Install the pinned release dependencies in a separate environment so
+      # they don't downgrade the container's packages for the other steps
+      - name: Install release dependencies
+        run: |
+          python3 -m venv /work/release-venv
+          /work/release-venv/bin/python -m pip install \
+            -r .github/scripts/requirements-release.txt
+          echo "RELEASE_PYTHON=/work/release-venv/bin/python" >> $GITHUB_ENV
+      - name: Test tools
+        run: |
+          $RELEASE_PYTHON -m unittest discover \
+            -p 'Test_CompileReleaseNotes.py' tests.tools -v
       - name: Check metadata
         run: |
-          python3 tools/CheckMetadata.py
+          $RELEASE_PYTHON tools/CheckMetadata.py
       - name: Check the metadata is consistent with the releases
         # No need to check this on forks. They would need to set a Zenodo token
         # for this test. Also disable on PRs because they don't have access to
@@ -174,16 +181,17 @@ jobs:
           github.repository == 'sxs-collaboration/spectre'
             && github.event_name != 'pull_request'
         run: |
-          python3 .github/scripts/Release.py prepare -vv --check-only \
+          $RELEASE_PYTHON .github/scripts/Release.py prepare -vv --check-only \
             --zenodo-token ${{ secrets.ZENODO_READONLY_TOKEN }} \
             --github-token ${{ secrets.GITHUB_TOKEN }}
-          python3 .github/scripts/Release.py publish -vv --check-only \
+          $RELEASE_PYTHON .github/scripts/Release.py publish -vv --check-only \
             --zenodo-token ${{ secrets.ZENODO_READONLY_TOKEN }} \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --auto-publish
       - name: Check release notes
         run: |
-          python3 tools/CompileReleaseNotes.py -vv -o release_notes.md \
+          $RELEASE_PYTHON tools/CompileReleaseNotes.py -vv \
+            -o release_notes.md \
             --github-token ${{ secrets.GITHUB_TOKEN }}
       - name: Upload release notes
         uses: actions/upload-artifact@v7
@@ -1293,10 +1301,10 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           token: ${{ secrets.GH_TOKEN_RELEASE }}
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.14'
       - name: Install Python dependencies
         run: |
-          pip3 install -r .github/scripts/requirements-release.txt
+          python3 -m pip install -r .github/scripts/requirements-release.txt
       # We use the current date as tag name, unless a tag name was specified
       # as input to the `workflow_dispatch` event
       - name: Determine release version

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -1032,7 +1032,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       fail-fast: false
       matrix:
         os:
-          - macos-15-intel
           - macos-15
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -440,7 +440,7 @@ jobs:
             # Note: currently disabled because of some unknown upstream issue
             # test_3d_rendering: ON
             # Need Python version consistent with ParaView
-            PYTHON_VERSION: "3.9"
+            # PYTHON_VERSION: "3.9"
           # Test with Kokkos enabled but without CUDA
           - compiler: gcc-10
             build_type: Release
@@ -452,12 +452,14 @@ jobs:
           # the documentation build
           # - compiler: gcc-11
           #   build_type: Debug
-          # Test with Python 3.8 so that we retain backwards compatibility. We
-          # keep track of Python versions on supercomputers in this issue:
+          # Test with newer Python. Once the container has a Python version
+          # above 3.10 (current minimum) we should also test the minimum Python
+          # version so that we retain backwards compatibility.
+          # We keep track of Python versions on supercomputers in this issue:
           # https://github.com/sxs-collaboration/spectre/issues/442
           - compiler: gcc-11
             build_type: Release
-            PYTHON_VERSION: "3.8"
+            PYTHON_VERSION: "3.14"
             # Disable building executable for this build for now because it
             # exceeds the available memory. See issue:
             # https://github.com/sxs-collaboration/spectre/issues/5472

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -652,19 +652,21 @@ jobs:
       - name: Install Python version
         if: matrix.PYTHON_VERSION
         run: |
+          VIRTUAL_ENV=/work/python${{ matrix.PYTHON_VERSION }}-venv
           add-apt-repository ppa:deadsnakes/ppa
           apt install -y python${{ matrix.PYTHON_VERSION }}-dev \
-            python${{ matrix.PYTHON_VERSION }}-venv \
-            python${{ matrix.PYTHON_VERSION }}-distutils
-          update-alternatives --install /usr/bin/python3 python3 \
-            /usr/bin/python${{ matrix.PYTHON_VERSION }} 1
+            python${{ matrix.PYTHON_VERSION }}-venv
+          python${{ matrix.PYTHON_VERSION }} -m venv $VIRTUAL_ENV
+          $VIRTUAL_ENV/bin/python -m pip install --upgrade pip
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
       - name: Install Python dependencies
         if: matrix.PYTHON_VERSION
         run: |
-          python${{ matrix.PYTHON_VERSION }} -m pip install \
+          python3 -m pip install \
             -r support/Python/requirements.txt \
             -r support/Python/dev_requirements.txt
-          python${{ matrix.PYTHON_VERSION }} -m pip list -v
+          python3 -m pip list -v
       - name: Install ParaView
         if: matrix.test_3d_rendering == 'ON'
         working-directory: /work
@@ -734,7 +736,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           ENABLE_WARNINGS=${{ matrix.ENABLE_WARNINGS }}
           WERROR="${{ matrix.WERROR != 'OFF' && '-Werror' || '' }}"
           CXX_FLAGS="${WERROR} ${{ matrix.EXTRA_CXX_FLAGS }}"
-          PYTHON_VERSION=${{ matrix.PYTHON_VERSION }}
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           BUILD_SHARED_LIBS=${{ matrix.BUILD_SHARED_LIBS }}
           KOKKOS=${{ matrix.KOKKOS }}
@@ -756,7 +757,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D CMAKE_C_COMPILER=${CC}
           -D CMAKE_CXX_COMPILER=${CXX}
           -D CMAKE_Fortran_COMPILER=${FC}
-          -D Python_EXECUTABLE=/usr/bin/python${PYTHON_VERSION:-'3'}
           -D CMAKE_CXX_FLAGS="${CXX_FLAGS}"
           -D OVERRIDE_ARCH=x86-64
           -D ENABLE_WARNINGS=${ENABLE_WARNINGS:-'ON'}
@@ -964,7 +964,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           ENABLE_WARNINGS=${{ matrix.ENABLE_WARNINGS }}
           WERROR="${{ matrix.WERROR != 'OFF' && '-Werror' || '' }}"
           CXX_FLAGS="${WERROR} ${{ matrix.EXTRA_CXX_FLAGS }}"
-          PYTHON_VERSION=${{ matrix.PYTHON_VERSION }}
           BUILD_PYTHON_BINDINGS=${{ matrix.BUILD_PYTHON_BINDINGS }}
           MATRIX_CHARM_ROOT=${{ matrix.CHARM_ROOT }}
           MEMORY_ALLOCATOR=${{ matrix.MEMORY_ALLOCATOR }};
@@ -975,7 +974,6 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D CMAKE_C_COMPILER=${CC}
           -D CMAKE_CXX_COMPILER=${CXX}
           -D CMAKE_Fortran_COMPILER=${FC}
-          -D Python_EXECUTABLE=/usr/bin/python${PYTHON_VERSION:-'3'}
           -D CMAKE_CXX_FLAGS="${CXX_FLAGS}"
           -D OVERRIDE_ARCH=x86-64
           -D ENABLE_WARNINGS=${ENABLE_WARNINGS:-'ON'}
@@ -1038,7 +1036,8 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.
       SPECTRE_BREW_DEPS: >-  # Line breaks are spaces, no trailing newline
-        autoconf automake boost catch2 ccache cmake gsl hdf5 openblas yaml-cpp xsimd
+        autoconf automake boost catch2 ccache cmake gsl fftw hdf5 openblas
+        yaml-cpp xsimd
       # We install these packages with Spack and cache them. The full specs are
       # listed below. This list is only needed to create the cache.
       SPECTRE_SPACK_DEPS: blaze charmpp libxsmm
@@ -1144,6 +1143,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         run: |
           source $HOME/spack/share/spack/setup-env.sh
           spack env activate spectre
+          pip install --upgrade pip
           pip install -r support/Python/requirements.txt
       # Replace the ccache directory that building the dependencies may have
       # generated with the cached ccache directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ include(SpectreSetSiteName)
 # early so we can rely on a consistent Python version in the build system.
 option(ENABLE_PYTHON "Enable Python" ON)
 if (ENABLE_PYTHON)
-  find_package(Python 3.8 REQUIRED)
+  find_package(Python 3.10 REQUIRED)
   # Define the location of Python code in the build directory. Unit tests etc. can
   # add this location to their `PYTHONPATH`.
   set(SPECTRE_PYTHON_PREFIX_PARENT "${CMAKE_BINARY_DIR}/bin/python")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,39 @@ if (ENABLE_PYTHON)
   set(SPECTRE_PYTHON_PREFIX_PARENT "${CMAKE_BINARY_DIR}/bin/python")
   get_filename_component(
     SPECTRE_PYTHON_PREFIX_PARENT "${SPECTRE_PYTHON_PREFIX_PARENT}" ABSOLUTE)
-  set(SPECTRE_PYTHON_SITE_PACKAGES "${CMAKE_BINARY_DIR}/lib/\
+  # Extract the site-packages directory. Python installations can have different
+  # layouts for where they install packages (in particular, Debian/Ubuntu uses
+  # `dist-packages` instead of `site-packages`), so we query Python for the
+  # correct location and fix the `Python_SITELIB` variable. CMake's `FindPython`
+  # module does not do this. We do the same for where `pip install --prefix`
+  # will install packages.
+  execute_process(
+      COMMAND "${Python_EXECUTABLE}" -c "import sys, sysconfig;\
+print(';'.join([\
+  sysconfig.get_path('purelib'),\
+  sysconfig.get_path('purelib', vars={\
+    'base': sys.argv[1], 'platbase': sys.argv[1]})\
+]))"
+          "${CMAKE_BINARY_DIR}"
+      RESULT_VARIABLE _SITELIB_RESULT
+      OUTPUT_VARIABLE _SITELIB_PATHS
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (_SITELIB_RESULT EQUAL 0)
+    list(GET _SITELIB_PATHS 0 PYTHON_TRUE_SITELIB)
+    if (NOT Python_SITELIB STREQUAL PYTHON_TRUE_SITELIB)
+      set(Python_SITELIB "${PYTHON_TRUE_SITELIB}" CACHE PATH FORCE
+        "Corrected Python site-packages directory")
+      message(STATUS
+        "Corrected Python site-packages directory: ${Python_SITELIB}")
+    endif()
+    list(GET _SITELIB_PATHS 1 SPECTRE_PYTHON_SITE_PACKAGES)
+  else()
+    message(WARNING "Failed to determine Python site-packages directory, "
+      "using default value: ${Python_SITELIB}")
+    set(SPECTRE_PYTHON_SITE_PACKAGES "${CMAKE_BINARY_DIR}/lib/\
 python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  endif()
   set(PYTHONPATH "${SPECTRE_PYTHON_PREFIX_PARENT}:\
 ${SPECTRE_PYTHON_SITE_PACKAGES}")
   if(DEFINED ENV{PYTHONPATH})

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -183,6 +183,7 @@ RUN apt-get update -y \
         libgsl-dev \
         libssl-dev \
         libhdf5-dev hdf5-tools \
+        libfftw3-dev \
         libarpack2-dev \
         libbenchmark-dev \
     && if [ ${UBUNTU_VERSION} = 18.04 ]; then \
@@ -226,17 +227,16 @@ RUN apt-get update -y \
         libboost-thread-dev libboost-tools-dev; \
     fi
 
-# Install Python packages
-# We only install packages that are needed by the build system (e.g. to compile
-# Python bindings or build documentation) or used by Python code that is
-# unit-tested. Any other packages can be installed on-demand.
-# - We use python-is-python3 because on Ubuntu 20.04 /usr/bin/python was removed
-#   to aid in tracking down anything that depends on python 2. However, many
-#   scripts use `/usr/bin/env python` to find python so restore it.
-# - We install h5py explicitly from binary so that cross compilation is quicker.
-COPY support/Python/requirements.txt requirements.txt
-COPY support/Python/dev_requirements.txt dev_requirements.txt
+# Install Python.
+#
+# Set up the Python environment in /opt/venv. It is prepended to the PATH, so
+# `python`, `python3`, `pip` and `pip3` all resolve to it and `pip install` just
+# works. Ubuntu marks its system Python as "externally managed" (PEP 668) and
+# refuses `pip install` into it, so a venv is the supported way to install
+# packages.
 ENV DEBIAN_FRONTEND noninteractive
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN apt-get update -y \
     && if [ ${UBUNTU_VERSION} = 18.04 ]; then \
     apt-get install -y zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev \
@@ -247,14 +247,22 @@ RUN apt-get update -y \
     && ./configure --enable-optimizations && make ${PARALLEL_MAKE_ARG} \
     && make altinstall && cd ../ \
     && rm -rf ./Python-3.10.1.tgz ./Python-3.10.1 \
-    && python3.10 -m pip install --upgrade pip \
-    && pip3.10 --no-cache-dir install --only-binary=h5py -r requirements.txt \
-    -r dev_requirements.txt; \
+    && python3.10 -m venv "${VIRTUAL_ENV}"; \
     else \
-    apt-get install -y python3-pip python-is-python3 pkg-config \
-    && pip3 --no-cache-dir install --only-binary=h5py -r requirements.txt \
-    -r dev_requirements.txt; \
+    apt-get install -y python3-dev python3-venv pkg-config \
+    && python3 -m venv "${VIRTUAL_ENV}"; \
     fi \
+    && python -m pip install --upgrade pip
+
+# Install Python packages. We only install packages that are needed by the
+# build system (e.g. to compile Python bindings or build documentation) or used
+# by Python code that is unit-tested. Any other packages can be installed
+# on-demand.
+# - Install h5py explicitly from binary so that cross compilation is quicker.
+COPY support/Python/requirements.txt requirements.txt
+COPY support/Python/dev_requirements.txt dev_requirements.txt
+RUN python -m pip --no-cache-dir install --only-binary=h5py \
+        -r requirements.txt -r dev_requirements.txt \
     && rm requirements.txt dev_requirements.txt
 
 # Enable bash-completion by installing it and then adding it to the .bashrc file

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -206,7 +206,7 @@ apt), or AppleClang 13.0.0 or later
 * [GNU make](https://www.gnu.org/software/make/)
 * [HDF5](https://support.hdfgroup.org/HDF5/) (non-mpi version on macOS)
   \cite Hdf5
-* [Python](https://www.python.org/) 3.8 or later.
+* [Python](https://www.python.org/) 3.10 or later.
 * [Charm++](http://charm.cs.illinois.edu/) 7.0.0, or later (8 preferred).
   See also \ref building-charm. \cite Charmpp1 \cite Charmpp2 \cite Charmpp3
 


### PR DESCRIPTION
## Proposed changes

Preparation to pull in `sxs`, `scri`, and `SimulationSupport` for waveform post-processing, CCE frame-fixing, and ecc-control.

Drops support for Py 3.8 and 3.9 (reached EOL, see https://devguide.python.org/versions/) and Intel macOS (seems not worth the effort to keep supporting).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Rerun `pip install -r support/requirements.txt` in your Python environment, or just enable `BOOTSTRAP_PY_DEPS=ON` to have CMake update Python dependencies automatically. You need `fftw` installed on systems where scri doesn't provide prebuilt binaries (ARM chips).
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
