### PR TITLE
Ignore AI markdown files in repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ TAGS
 tags
 # Keep Tags/ directories on case-insensitive file systems
 !Tags/
+
+# AI instructions
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Proposed changes

Coding agent tools, e.g. Claude Code and OpenAI Codex, use markdown instructions, in files `CLAUDE.md` or `AGENTS.md`. These files are different on different machines and include instructions on how to build the code and run the tests, along with our style requirements. The coding agents themselves are decent at creating these files, though users likely want to modify them to get the behavior they want.

I don't feel like I have enough experience to try to write a generic version of these files that could choose correctly how to work on *any* system. 

Therefore, for now, I'd like to suggest adding these files to `.gitignore`, so when you use them, they don't clutter up git status, as I do here. At some point in the future, perhaps these get removed from `.gitignore` and actually added to the repo.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
