### PR TITLE
Fix GH char speed expression in documentation

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp
@@ -106,7 +106,7 @@ namespace gh::BoundaryCorrections {
  * and characteristic speeds
  *
  * \f{align*}{
- *   \lambda_{v^g} =& -(1+\gamma_1)\beta^i n_i -v^i_g n_i, \\
+ *   \lambda_{v^g} =& -(1+\gamma_1) (\beta^i n_i + v^i_g n_i), \\
  *   \lambda_{v^0} =& -\beta^i n_i -v^i_g n_i, \\
  *   \lambda_{v^\pm} =& \pm \alpha - \beta^i n_i - v^i_g n_i,
  * \f}

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -46,7 +46,8 @@ namespace gh {
  * \f}
  *
  * The corresponding characteristic speeds \f$v\f$ are given in the text between
- * Eq.(34) and Eq.(35) of \cite Lindblom2005qh :
+ * Eq.(34) and Eq.(35) of \cite Lindblom2005qh, except for a constraint damping
+ * term used in SpEC and SpECTRE but not published anywhere:
  *
  * \f{align*}
  * v_{\psi} =& -(1 + \gamma_1) n_k \beta^k - \gamma_1 n_k v^k_g \\
@@ -57,6 +58,11 @@ namespace gh {
  * where \f$\alpha, \beta^k\f$ are the lapse and shift respectively,
  * \f$\gamma_1\f$ is a constraint damping parameter, \f$n_k\f$ is the unit
  * normal to the surface, and $v^k_g$ is the (optional) mesh velocity.
+ *
+ * \note The results of this function depend on the mesh velocity, but
+ * do not include the system-independent grid advection terms.  The
+ * included terms arise from explicit dependence on the mesh velocity
+ * in the GH time derivative.
  */
 template <size_t Dim, typename Frame>
 std::array<DataVector, 4> characteristic_speeds(


### PR DESCRIPTION
And add note explaining the non-advection mesh terms on the main function.

Fixes #6877 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
