### PR TITLE
Compile old slatec code in legacy mode

### DIFF
--- a/external/slatec/CMakeLists.txt
+++ b/external/slatec/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
     )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})
+target_compile_options(${LIBRARY} PRIVATE -std=legacy)
 
 if(SPECTRE_Fortran_STATIC_LIBS)
   if (NOT $gfortran)


### PR DESCRIPTION
Fixes some warnings about the code not being valid modern Fortran.

Fixes #6842 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
