### PR TITLE
Fix Test_GridCenters.py in Docker

### DIFF
--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_GridCenters.py
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Python/Test_GridCenters.py
@@ -1,18 +1,21 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import os
 import unittest
 
 from spectre.Domain.Creators.TimeDependentOptions import GridCentersOptions
-from spectre.Informer import unit_test_build_path
+from spectre.Informer import unit_test_src_path
 
 
 class TestGridCenters(unittest.TestCase):
     def test_construction(self):
         grid_centers = GridCentersOptions(
-            str(unit_test_build_path())
-            + "../../../tests/InputFiles/GrMhd/GhValenciaDivClean/"
-            + "EvolutionParameters.perl",
+            os.path.join(
+                str(unit_test_src_path()),
+                "../InputFiles/GrMhd/GhValenciaDivClean/",
+                "EvolutionParameters.perl",
+            ),
             2.0,
         )
         self.assertNotEqual(grid_centers, None)


### PR DESCRIPTION
## Proposed changes

The path I used in the test was the build directory path which is different in docker, now this points to the src directory which is the same for both.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments
