### PR TITLE
Add options to create Strahlkorper by reading from a coefficients dat file

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   FillYlmLegendAndData.cpp
   ReadSurfaceYlm.cpp
   StrahlkorperCoordsToTextFile.cpp
+  StrahlkorperFromFile.cpp
   )
 
 spectre_target_headers(

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/StrahlkorperFromFile.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/StrahlkorperFromFile.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+
+#include <string>
+
+#include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
+#include "Options/Context.hpp"
+
+namespace Frame {
+struct Distorted;
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace ylm {
+template <typename Frame>
+Strahlkorper<Frame>::Strahlkorper(const size_t l_max,
+                                  const std::string& h5_filename,
+                                  const std::string& subfile_name,
+                                  const double time, const double time_epsilon,
+                                  const bool check_frame,
+                                  const Options::Context& /*context*/)
+    : Strahlkorper(
+          l_max, l_max,
+          ylm::read_surface_ylm_single_time<Frame>(
+              h5_filename, subfile_name, time, time_epsilon, check_frame)) {}
+
+template class Strahlkorper<Frame::Inertial>;
+template class Strahlkorper<Frame::Grid>;
+template class Strahlkorper<Frame::Distorted>;
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
@@ -5,18 +5,26 @@
 
 #include <array>
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace PUP {
 class er;
 }  // namespace PUP
+
+namespace Options {
+template <typename... AlternativeLists>
+struct Alternatives;
+}  // namespace Options
 /// \endcond
 
 namespace ylm {
@@ -40,13 +48,50 @@ class Strahlkorper {
     static constexpr Options::String help = {
         "Center of spherical Strahlkorper"};
   };
-  using options = tmpl::list<LMax, Radius, Center>;
+  struct H5Filename {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "H5 file containing the Strahlkorper coefficients"};
+  };
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "Subfile (without leading slash or .dat extension) within "
+        "the H5 file that contains the Strahlkorper coefficients"};
+  };
+  struct Time {
+    using type = double;
+    static constexpr Options::String help = {
+        "Time at which to read the Strahlkorper coefficients"};
+  };
+  struct TimeEpsilon {
+    using type = double;
+    static constexpr Options::String help = {
+        "Tolerance for matching the requested time to read the Strahlkorper "
+        "coefficients"};
+  };
+  struct CheckFrame {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Whether to check that the frame in the file matches the requested "
+        "frame"};
+  };
+  using options =
+      tmpl::list<LMax,
+                 Options::Alternatives<tmpl::list<Radius, Center>,
+                                       tmpl::list<H5Filename, SubfileName, Time,
+                                                  TimeEpsilon, CheckFrame>>>;
 
   static constexpr Options::String help{
       "A star-shaped surface expressed as an expansion in spherical "
       "harmonics.\n"
-      "Currently only a spherical Strahlkorper can be constructed from\n"
-      "Options.  To do this, specify parameters Center, Radius, and LMax."};
+      "A Strahlkorper can be constructed from Options in two ways:\n"
+      "1. Specify LMax, Center, and Radius to construct a spherical "
+      "Strahlkorper.\n"
+      "2. Specify LMax, H5Filename, SubfileName, Time, TimeEpsilon, and "
+      "CheckFrame to construct a Strahlkorper from coefficients read from an "
+      "H5 file. The Strahlkorper will be prolonged or restricted to the "
+      "specified LMax."};
 
   // Pup needs default constructor
   Strahlkorper() = default;
@@ -62,6 +107,13 @@ class Strahlkorper {
   /// Construct a sphere of radius `radius`, setting `m_max`=`l_max`.
   Strahlkorper(size_t l_max, double radius, std::array<double, 3> center)
       : Strahlkorper(l_max, l_max, radius, center) {}
+
+  /// Construct from options: either from radius and center, or from file.
+  /// These constructors handle both alternatives specified in the options.
+  Strahlkorper(size_t l_max, const std::string& h5_filename,
+               const std::string& subfile_name, double time,
+               double time_epsilon, bool check_frame,
+               const Options::Context& context);
 
   /// Construct a Strahlkorper from a DataVector containing the radius
   /// at the collocation points.

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -27,9 +27,11 @@ target_link_libraries(
   PRIVATE
   DataStructures
   GrSurfaces
+  H5
   RootFinding
   SphericalHarmonics
   SphericalHarmonicsHelpers
+  SphericalHarmonicsIO
   SpinWeightedSphericalHarmonics
   Utilities
   )

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
@@ -16,12 +16,17 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/StrahlkorperTestHelpers.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -184,16 +189,202 @@ void test_constructor_with_different_coefs(Func function) {
                         strahlkorper_test2.coefficients());
 }
 
-void test_construct_from_options() {
+// Helper function to create a random Strahlkorper and write it to an H5 file
+Strahlkorper<Frame::Inertial> create_and_write_test_strahlkorper(
+    const std::string& filename, const std::string& subfile_name,
+    const size_t l_max, const std::array<double, 3>& center,
+    const double time) {
+  MAKE_GENERATOR(gen);
+  const std::uniform_real_distribution<> dist(0.5, 2.0);
+  const auto radius = make_with_random_values<DataVector>(
+      make_not_null(&gen), dist,
+      DataVector(ylm::Spherepack::physical_size(l_max, l_max),
+                 std::numeric_limits<double>::signaling_NaN()));
+  Strahlkorper<Frame::Inertial> strahlkorper(l_max, l_max, radius, center);
+
+  h5::H5File<h5::AccessType::ReadWrite> h5_file(filename, true);
+  std::vector<std::string> legend{};
+  std::vector<double> data{};
+  ylm::fill_ylm_legend_and_data(make_not_null(&legend), make_not_null(&data),
+                                strahlkorper, time, l_max);
+  auto& dat_file = h5_file.insert<h5::Dat>("/" + subfile_name, legend);
+  dat_file.append(std::vector<std::vector<double>>{data});
+  h5_file.close_current_object();
+
+  return strahlkorper;
+}
+
+// Helper function to parse Strahlkorper options from a string
+Strahlkorper<Frame::Inertial> parse_strahlkorper_from_options(
+    const std::string& options_string) {
   Options::Parser<tmpl::list<OptionTags::Strahlkorper<Frame::Inertial>>> opts(
       "");
-  opts.parse(
-      "Strahlkorper:\n"
-      " LMax : 6\n"
-      " Center: [1.,2.,3.]\n"
-      " Radius: 4.5\n");
-  CHECK(opts.get<OptionTags::Strahlkorper<Frame::Inertial>>() ==
-        Strahlkorper<Frame::Inertial>(6, 6, 4.5, {{1., 2., 3.}}));
+  opts.parse(options_string);
+  return opts.get<OptionTags::Strahlkorper<Frame::Inertial>>();
+}
+
+void test_construct_from_options() {
+  // Test construction from Radius and Center
+  {
+    CHECK(parse_strahlkorper_from_options("Strahlkorper:\n"
+                                          " LMax : 6\n"
+                                          " Center: [1.,2.,3.]\n"
+                                          " Radius: 4.5\n") ==
+          Strahlkorper<Frame::Inertial>(6, 6, 4.5, {{1., 2., 3.}}));
+  }
+
+  // Test construction from file
+  {
+    const std::string test_filename = "TestStrahlkorperOptions.h5";
+    const std::string subfile_name = "TestSurface_Ylm";
+    const std::array<double, 3> expansion_center{{1.5, -0.5, 2.0}};
+    const size_t l_max_original = 4;
+    const double time = 1.23;
+
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
+
+    const auto original_strahlkorper = create_and_write_test_strahlkorper(
+        test_filename, subfile_name, l_max_original, expansion_center, time);
+
+    // Test reading from file with the same l_max (no prolong/restrict)
+    {
+      const auto read_strahlkorper = parse_strahlkorper_from_options(
+          "Strahlkorper:\n"
+          " LMax : 4\n"
+          " H5Filename: TestStrahlkorperOptions.h5\n"
+          " SubfileName: TestSurface_Ylm\n"
+          " Time: 1.23\n"
+          " TimeEpsilon: 1.0e-10\n"
+          " CheckFrame: true\n");
+
+      CHECK(read_strahlkorper.l_max() == l_max_original);
+      CHECK(read_strahlkorper.m_max() == l_max_original);
+      CHECK(read_strahlkorper.expansion_center() == expansion_center);
+      CHECK_ITERABLE_APPROX(read_strahlkorper.coefficients(),
+                            original_strahlkorper.coefficients());
+    }
+
+    // Test reading from file with prolong to higher l_max
+    {
+      const size_t l_max_requested = 6;
+      const auto read_strahlkorper = parse_strahlkorper_from_options(
+          "Strahlkorper:\n"
+          " LMax : 6\n"
+          " H5Filename: TestStrahlkorperOptions.h5\n"
+          " SubfileName: TestSurface_Ylm\n"
+          " Time: 1.23\n"
+          " TimeEpsilon: 1.0e-10\n"
+          " CheckFrame: true\n");
+
+      CHECK(read_strahlkorper.l_max() == l_max_requested);
+      CHECK(read_strahlkorper.m_max() == l_max_requested);
+      CHECK(read_strahlkorper.expansion_center() == expansion_center);
+
+      const Strahlkorper<Frame::Inertial> expected_prolonged(
+          l_max_requested, l_max_requested, original_strahlkorper);
+      CHECK_ITERABLE_APPROX(read_strahlkorper.coefficients(),
+                            expected_prolonged.coefficients());
+    }
+
+    // Test reading from file with restrict to lower l_max
+    {
+      const auto read_strahlkorper = parse_strahlkorper_from_options(
+          "Strahlkorper:\n"
+          " LMax : 2\n"
+          " H5Filename: TestStrahlkorperOptions.h5\n"
+          " SubfileName: TestSurface_Ylm\n"
+          " Time: 1.23\n"
+          " TimeEpsilon: 1.0e-10\n"
+          " CheckFrame: true\n");
+
+      CHECK(read_strahlkorper.l_max() == 2);
+      CHECK(read_strahlkorper.m_max() == 2);
+      CHECK(read_strahlkorper.expansion_center() == expansion_center);
+
+      const Strahlkorper<Frame::Inertial> expected_restricted(
+          2, 2, original_strahlkorper);
+      CHECK_ITERABLE_APPROX(read_strahlkorper.coefficients(),
+                            expected_restricted.coefficients());
+    }
+
+    file_system::rm(test_filename, true);
+  }
+
+  // Test failure case: missing H5 file
+  {
+    Options::Parser<tmpl::list<OptionTags::Strahlkorper<Frame::Inertial>>> opts(
+        "");
+    opts.parse(
+        "Strahlkorper:\n"
+        " LMax : 4\n"
+        " H5Filename: NonexistentFile.h5\n"
+        " SubfileName: TestSurface_Ylm\n"
+        " Time: 1.23\n"
+        " TimeEpsilon: 1.0e-10\n"
+        " CheckFrame: true\n");
+    CHECK_THROWS_WITH(opts.get<OptionTags::Strahlkorper<Frame::Inertial>>(),
+                      Catch::Matchers::ContainsSubstring(
+                          "Trying to open the file 'NonexistentFile.h5'") &&
+                          Catch::Matchers::ContainsSubstring("does not exist"));
+  }
+
+  // Test failure case: error reading from file (invalid subfile)
+  {
+    const std::string test_filename = "TestStrahlkorperOptionsFailure.h5";
+
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
+
+    create_and_write_test_strahlkorper(test_filename, "ValidSurface", 4,
+                                       {{1.5, -0.5, 2.0}}, 1.23);
+
+    Options::Parser<tmpl::list<OptionTags::Strahlkorper<Frame::Inertial>>> opts(
+        "");
+    opts.parse(
+        "Strahlkorper:\n"
+        " LMax : 4\n"
+        " H5Filename: TestStrahlkorperOptionsFailure.h5\n"
+        " SubfileName: InvalidSurface\n"
+        " Time: 1.23\n"
+        " TimeEpsilon: 1.0e-10\n"
+        " CheckFrame: true\n");
+    CHECK_THROWS_WITH(
+        opts.get<OptionTags::Strahlkorper<Frame::Inertial>>(),
+        Catch::Matchers::ContainsSubstring("Cannot open the object"));
+
+    file_system::rm(test_filename, true);
+  }
+
+  // Test failure case: time differs by more than epsilon.
+  {
+    const std::string test_filename = "TestStrahlkorperOptionsTimeEpsilon.h5";
+
+    if (file_system::check_if_file_exists(test_filename)) {
+      file_system::rm(test_filename, true);
+    }
+
+    create_and_write_test_strahlkorper(test_filename, "TestSurface_Ylm", 4,
+                                       {{1.5, -0.5, 2.0}}, 1.23);
+
+    Options::Parser<tmpl::list<OptionTags::Strahlkorper<Frame::Inertial>>> opts(
+        "");
+    opts.parse(
+        "Strahlkorper:\n"
+        " LMax : 4\n"
+        " H5Filename: TestStrahlkorperOptionsTimeEpsilon.h5\n"
+        " SubfileName: TestSurface_Ylm\n"
+        " Time: 1.2300000003\n"  // Differs by 3.0e-10 from actual time
+        " TimeEpsilon: 1.0e-10\n"
+        " CheckFrame: true\n");
+    CHECK_THROWS_WITH(
+        opts.get<OptionTags::Strahlkorper<Frame::Inertial>>(),
+        Catch::Matchers::ContainsSubstring("Could not find time"));
+
+    file_system::rm(test_filename, true);
+  }
 }
 
 void test_strahlkorper_from_other_strahlkorper() {
@@ -236,7 +427,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Strahlkorper",
       [](Strahlkorper<Frame::Inertial>& sk, double add_to_r) {
         auto coefs = sk.coefficients();  // make a copy
         coefs[0] += sqrt(8.0) * add_to_r;
-        return Strahlkorper<Frame::Inertial>(coefs, std::move(sk));
+        return Strahlkorper<Frame::Inertial>(coefs, sk);
       });
   test_constructor_with_different_coefs(
       [](const Strahlkorper<Frame::Inertial>& sk, double add_to_r) {


### PR DESCRIPTION
## Proposed changes

Currently, constructing a Strahlkorper from options requires specifying LMax, Center, and Radius—only spherical Strahlkorpers can be constructed in this way. This PR adds another way to create Strahlkorpers from options: point to the coefficients dat file inside an H5 file, and read the coefficients at a desired time. This is useful for starting an evolution from data written by a previous evolution, since it allows specifying the initial guess for the apparent horizon finder using the horizon found in the previous evolution.

**NOTE**: I used Claude Code to generate the changes in this PR, starting from a request I gave it outlining the desired feature. I cleaned up its code a bit by hand, and I used some followup back and forth with the agent to further clean it up, e.g., to fix some clang-tidy failures and to fix a circular dependency in its original solution, which only became apparent when CI tests failed. I reviewed each line of generated code generated before opening this PR, and it looks reasonable to me so far (though of course I welcome any feedback, especially if I've missed something!).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
