### PR TITLE
CI: upgrade macOS runner

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -995,12 +995,10 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       matrix:
         include:
           # The number of cores is given at:
-          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-          - arch: x86
-            macos-version: 13  # Intel
-            NUM_CORES: 4
-          - arch: arm64
-            macos-version: 14  # Apple Silicon
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+          - macos-version: 14
+            NUM_CORES: 3
+          - macos-version: 26
             NUM_CORES: 3
     runs-on: macos-${{ matrix.macos-version }}
     env:


### PR DESCRIPTION
## Proposed changes

`macos-13` is deprecated, so this PR upgrades CI to `macos-26`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
