### PR TITLE
AH finder: send only intersecting element data

### DIFF
--- a/src/Domain/Structure/ElementId.cpp
+++ b/src/Domain/Structure/ElementId.cpp
@@ -450,6 +450,9 @@ bool operator<(const ElementId<VolumeDim>& lhs,
 
 template <size_t VolumeDim>
 bool overlapping(const ElementId<VolumeDim>& a, const ElementId<VolumeDim>& b) {
+  if (a == b) {
+    return true;
+  }
   if (a.block_id() != b.block_id()) {
     return false;
   }

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -364,8 +364,8 @@ struct EvolutionMetavars {
       Parallel::GlobalCache<EvolutionMetavars>& cache,
       const std::vector<std::string>& deadlocked_components) {
     gh::deadlock::run_deadlock_analysis_simple_actions<
-        dg_element_array, tmpl::list<>, interpolation_target_tags, false>(
-        cache, deadlocked_components);
+        dg_element_array, tmpl::list<>, interpolation_target_tags, tmpl::list<>,
+        false>(cache, deadlocked_components);
   }
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/Deadlock.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/ArrayCollection/SimpleActionOnElement.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/PrintDeadlockAnalysis.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/PrintInterpolationTargetForDeadlock.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/PrintInterpolatorForDeadlock.hpp"
 #include "Utilities/FileSystem.hpp"
@@ -35,8 +36,8 @@ struct ObserverWriter;
 
 namespace gh::deadlock {
 template <typename DgElementArray, typename ControlComponents,
-          typename InterpolationTargetTags, bool HasInterpolator = true,
-          typename Metavariables>
+          typename InterpolationTargetTags, typename AhFinders,
+          bool HasInterpolator = true, typename Metavariables>
 void run_deadlock_analysis_simple_actions(
     Parallel::GlobalCache<Metavariables>& cache,
     const std::vector<std::string>& deadlocked_components) {
@@ -78,6 +79,19 @@ void run_deadlock_analysis_simple_actions(
                   intrp::InterpolationTarget<Metavariables, TargetTag>>(cache),
               intrp_target_file);
         });
+  }
+
+  if constexpr (tmpl::size<AhFinders>::value > 0) {
+    tmpl::for_each<AhFinders>([&cache,
+                               &deadlock_dir](const auto horizon_metavars_v) {
+      using HorizonMetavars = tmpl::type_from<decltype(horizon_metavars_v)>;
+      const std::string ah_finder_file =
+          deadlock_dir + "/" + pretty_type::name<HorizonMetavars>() + ".out";
+      Parallel::simple_action<ah::Actions::PrintDeadlockAnalysis>(
+          Parallel::get_parallel_component<
+              ah::Component<Metavariables, HorizonMetavars>>(cache),
+          ah_finder_file);
+    });
   }
 
   if (alg::count(deadlocked_components, pretty_type::name<DgElementArray>()) ==

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -688,7 +688,7 @@ struct EvolutionMetavars {
       const std::vector<std::string>& deadlocked_components) {
     gh::deadlock::run_deadlock_analysis_simple_actions<
         gh_dg_element_array, control_components, interpolation_target_tags,
-        false>(cache, deadlocked_components);
+        tmpl::list<AhA, AhB>, false>(cache, deadlocked_components);
   }
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -340,7 +340,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
       const std::vector<std::string>& deadlocked_components) {
     gh::deadlock::run_deadlock_analysis_simple_actions<
         gh_dg_element_array, control_components, interpolation_target_tags,
-        false>(cache, deadlocked_components);
+        tmpl::list<ApparentHorizon>, false>(cache, deadlocked_components);
   }
 
   using component_list = tmpl::flatten<tmpl::list<

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -42,6 +42,7 @@ spectre_target_headers(
   InterpolateVolumeVars.hpp
   InterpolationTarget.hpp
   OptionTags.hpp
+  PrintDeadlockAnalysis.hpp
   Storage.hpp
   Tags.hpp
   )

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/InvokeCallbacks.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/InvokeCallbacks.hpp
@@ -32,6 +32,22 @@
 #include "Utilities/TMPL.hpp"
 
 namespace ah {
+
+namespace detail {
+// Update the previous surface in the mutable global cache
+template <typename Fr>
+struct UpdatePreviousSurface {
+  static void apply(const gsl::not_null<Storage::LockedPreviousSurface<Fr>*>
+                        locked_previous_surface,
+                    Storage::PreviousSurface<Fr> previous_surface) {
+    auto& lock = locked_previous_surface->lock;
+    lock.write_lock();
+    locked_previous_surface->surface = std::move(previous_surface);
+    lock.write_unlock();
+  }
+};
+}  // namespace detail
+
 /*!
  * \brief Invoke the callbacks specified in the `horizon_find_callbacks` alias
  * of the \p HorizonMetavars.
@@ -57,15 +73,34 @@ void invoke_callbacks(const gsl::not_null<db::DataBox<DbTags>*> box,
   const auto& all_storage = db::get<ah::Tags::Storage<Fr>>(*box);
   const auto& current_time_storage = all_storage.at(current_time);
   const auto& current_iteration = current_time_storage.current_iteration;
+  const auto& current_strahlkorper = current_iteration.strahlkorper;
   auto& previous_surfaces =
       db::get_mutable_reference<ah::Tags::PreviousSurfaces<Fr>>(box);
   const auto& fast_flow = db::get<ah::Tags::FastFlow>(*box);
+
+  // Update the previous surfaces. We do this before the callbacks in case any
+  // of the callbacks need the previous strahlkorpers with the current
+  // strahlkorper already in it.
+  previous_surfaces.emplace_front(current_time, current_strahlkorper,
+                                  current_iteration.intersecting_element_ids);
+
+  // Broadcast the previous surface to the mutable global cache so that elements
+  // know whether they need to send data for the next horizon find. We do this
+  // early so that elements get this information as soon as possible.
+  Parallel::mutate<Tags::PreviousSurface<HorizonMetavars>,
+                   detail::UpdatePreviousSurface<Fr>>(
+      cache, previous_surfaces.front());
+
+  // Remove old previous_strahlkorpers that are no longer relevant.
+  const size_t num_previous_strahlkorpers = 3;
+  while (previous_surfaces.size() > num_previous_strahlkorpers) {
+    previous_surfaces.pop_back();
+  }
 
   // The interpolated variables have been interpolated from the volume to
   // the points on the prolonged_strahlkorper, not to the points on the
   // actual strahlkorper. So here we do a restriction of these quantities
   // onto the actual strahlkorper.
-  const auto& current_strahlkorper = current_iteration.strahlkorper;
   const auto& current_ylm = current_strahlkorper.ylm_spherepack();
   const size_t L_mesh = fast_flow.current_l_mesh(current_strahlkorper);
   const auto prolonged_strahlkorper =
@@ -90,20 +125,6 @@ void invoke_callbacks(const gsl::not_null<db::DataBox<DbTags>*> box,
             });
       },
       box);
-
-  // This is the number of previous strahlkorpers that we
-  // keep around.
-  const size_t num_previous_strahlkorpers = 3;
-
-  // Update the previous strahlkorpers. We do this before the callbacks
-  // in case any of the callbacks need the previous strahlkorpers with the
-  // current strahlkorper already in it.
-  previous_surfaces.emplace_front(current_time, current_strahlkorper);
-
-  // Remove old previous_strahlkorpers that are no longer relevant.
-  while (previous_surfaces.size() > num_previous_strahlkorpers) {
-    previous_surfaces.pop_back();
-  }
 
   db::mutate<ylm::Tags::Strahlkorper<Fr>, ylm::Tags::TimeDerivStrahlkorper<Fr>,
              ah::Tags::Dependency>(

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
@@ -28,6 +28,8 @@
 #include "ParallelAlgorithms/Events/Tags.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/CleanupRoutine.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -66,13 +68,14 @@ class FindApparentHorizon : public Event {
       typename HorizonMetavars::compute_tags_on_element;
 
   using return_tags = tmpl::list<>;
-  using argument_tags =
-      tmpl::append<tmpl::list<typename HorizonMetavars::time_tag,
-                              ::Events::Tags::ObserverMesh<3>>,
-                   ah::source_vars<3>>;
+  using argument_tags = tmpl::append<
+      tmpl::list<typename HorizonMetavars::time_tag,
+                 ::Events::Tags::ObserverMesh<3>, domain::Tags::Element<3>>,
+      ah::source_vars<3>>;
 
   template <typename Metavariables, typename ParallelComponent>
   void operator()(const LinkedMessageId<double>& time, const Mesh<3>& mesh,
+                  const Element<3>& element,
                   const tnsr::aa<DataVector, 3>& spacetime_metric,
                   const tnsr::aa<DataVector, 3>& pi,
                   const tnsr::iaa<DataVector, 3>& phi,
@@ -96,6 +99,70 @@ class FindApparentHorizon : public Event {
     if (not blocks_to_interpolate_for_this_target.contains(block_name)) {
       return;
     }
+
+    // Send volume data ONLY if this element intersected with the previous
+    // horizon or if it's a neighbor of an intersecting element.
+    // - WARNING: the algorithm WILL deadlock if the horizon has moved outside
+    //   of the elements that send data here. So we can't be too greedy with the
+    //   elements that send data. We may have to send data from corner neighbors
+    //   as well if deadlocks occur.
+    // - WARNING: we don't currently wait for the `PreviousSurface` to be
+    //   updated by the last horizon find. This could be done by storing the
+    //   time of the last horizon find in the element DataBox and comparing it
+    //   to the time that's stored in `PreviousSurface`. However, this added
+    //   dependency would possibly introduce waiting. So far, I (NV) haven't
+    //   found that waiting for the update is necessary, meaning that whichever
+    //   intersecting element IDs are stored are close enough to the latest
+    //   state so that they cover the new apparent horizon (no deadlocks have
+    //   occurred in testing).
+    //   Alternatives: if we find that we need the up-to-date intersecting
+    //   elements we could just send the data without waiting if the
+    //   intersecting element IDs are not up-to-date, which just risks sending
+    //   more data than necessary (and therefore doing more work, potentially
+    //   undoing this performance optimization if it happens a lot).
+    const auto& locked_previous_surface =
+        Parallel::get<ah::Tags::PreviousSurface<HorizonMetavars>>(cache);
+    {
+      // Scope to lock and unlock the read lock
+      locked_previous_surface.lock.read_lock();
+      const CleanupRoutine unlock_read_lock = [&locked_previous_surface]() {
+        locked_previous_surface.lock.read_unlock();
+      };
+      // Only skip elements if we have a previous surface
+      if (locked_previous_surface.surface.has_value()) {
+        const auto& previous_surface = locked_previous_surface.surface.value();
+        // If we already found a horizon AFTER the current time, skip sending
+        // anything (the data won't be needed anymore). Unlikely to occur.
+        if (previous_surface.time.id >= time.id) {
+          return;
+        }
+        // Check if this element or any of its neighbors overlaps an element
+        // that intersected the horizon in the last find. Only send volume data
+        // if so.
+        const bool send_volume_data = alg::any_of(
+            previous_surface.intersecting_element_ids,
+            [&element_id,
+             &element](const ElementId<3>& intersecting_element_id) {
+              return overlapping(element_id, intersecting_element_id) or
+                     alg::any_of(
+                         element.neighbors(),
+                         [&intersecting_element_id](
+                             const std::pair<Direction<3>, Neighbors<3>>&
+                                 direction_and_neighbors) {
+                           return alg::any_of(
+                               direction_and_neighbors.second.ids(),
+                               [&intersecting_element_id](
+                                   const ElementId<3>& neighbor_id) {
+                                 return overlapping(neighbor_id,
+                                                    intersecting_element_id);
+                               });
+                         });
+            });
+        if (not send_volume_data) {
+          return;
+        }
+      }  // if previous_surface.has_value()
+    }    // Unlock read lock here
 
     // Make Variables<ah::vars_to_interpolate_to_target> and
     // fill it by calling compute_vars_to_interpolate_to_target().

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
@@ -78,7 +78,7 @@ class FindApparentHorizon : public Event {
                   const tnsr::iaa<DataVector, 3>& phi,
                   const tnsr::ijaa<DataVector, 3>& deriv_phi,
                   Parallel::GlobalCache<Metavariables>& cache,
-                  const ElementId<3>& array_index,
+                  const ElementId<3>& element_id,
                   const ParallelComponent* const /*meta*/,
                   const ObservationValue& /*observation_value*/) const {
     const auto& blocks_to_interpolate =
@@ -89,7 +89,7 @@ class FindApparentHorizon : public Event {
         blocks_to_interpolate.at(name_);
     const auto& domain = Parallel::get<domain::Tags::Domain<3>>(cache);
     const auto& blocks = domain.blocks();
-    const auto& block = blocks[array_index.block_id()];
+    const auto& block = blocks[element_id.block_id()];
     const auto& block_name = block.name();
 
     // Only send data if this target needs this blocks data
@@ -110,7 +110,7 @@ class FindApparentHorizon : public Event {
             Parallel::get<domain::Tags::FunctionsOfTime>(cache);
         ah::compute_vars_to_interpolate_to_target(
             make_not_null(&vars_to_interpolate_to_target), spacetime_metric, pi,
-            phi, deriv_phi, time, domain, mesh, array_index, functions_of_time);
+            phi, deriv_phi, time, domain, mesh, element_id, functions_of_time);
       } else {
         ERROR(
             "Block is time-dependent but FunctionsOfTime are not available "
@@ -119,14 +119,14 @@ class FindApparentHorizon : public Event {
     } else {
       ah::compute_vars_to_interpolate_to_target(
           make_not_null(&vars_to_interpolate_to_target), spacetime_metric, pi,
-          phi, deriv_phi, time, domain, mesh, array_index, {});
+          phi, deriv_phi, time, domain, mesh, element_id, {});
     }
 
     auto& horizon_finder_proxy = Parallel::get_parallel_component<
         ah::Component<Metavariables, HorizonMetavars>>(cache);
 
     Parallel::simple_action<ah::FindApparentHorizon<HorizonMetavars>>(
-        horizon_finder_proxy, time, array_index, mesh,
+        horizon_finder_proxy, time, element_id, mesh,
         std::move(vars_to_interpolate_to_target), dependency_);
   }
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp
@@ -83,10 +83,10 @@ class FindApparentHorizon : public Event {
                   const ObservationValue& /*observation_value*/) const {
     const auto& blocks_to_interpolate =
         Parallel::get<ah::Tags::BlocksForHorizonFind>(cache);
-    ASSERT(blocks_to_interpolate.contains(name()),
-           "Blocks to interpolate doesn't contain target " << name());
+    ASSERT(blocks_to_interpolate.contains(name_),
+           "Blocks to interpolate doesn't contain target " << name_);
     const auto& blocks_to_interpolate_for_this_target =
-        blocks_to_interpolate.at(name());
+        blocks_to_interpolate.at(name_);
     const auto& domain = Parallel::get<domain::Tags::Domain<3>>(cache);
     const auto& blocks = domain.blocks();
     const auto& block = blocks[array_index.block_id()];
@@ -148,6 +148,8 @@ class FindApparentHorizon : public Event {
 
  private:
   std::optional<std::string> dependency_;
+  // Evaluate the static name() function only once to avoid repeated allocations
+  std::string name_ = name();
 };
 
 /// \cond

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
@@ -117,15 +117,15 @@ class FindCommonHorizon<
   void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
                   const Mesh<VolumeDim>& mesh,
                   Parallel::GlobalCache<Metavariables>& cache,
-                  const ElementId<VolumeDim>& array_index,
+                  const ElementId<VolumeDim>& element_id,
                   const ParallelComponent* const component,
                   const ObservationValue& observation_value) const {
-    observe_fields_event_(box, mesh, cache, array_index, component,
+    observe_fields_event_(box, mesh, cache, element_id, component,
                           observation_value);
 
     interpolate_event_(get<typename InterpolationTargetTag::temporal_id>(box),
                        mesh, get<InterpolatorSourceVarTags>(box)..., cache,
-                       array_index, component, observation_value);
+                       element_id, component, observation_value);
   }
 
   using observation_registration_tags = tmpl::list<::Tags::DataBox>;
@@ -141,9 +141,9 @@ class FindCommonHorizon<
 
   using is_ready_argument_tags = tmpl::list<>;
 
-  template <typename Metavariables, typename ArrayIndex, typename Component>
+  template <typename Metavariables, typename Component>
   bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
-                const ArrayIndex& /*array_index*/,
+                const ElementId<3>& /*element_id*/,
                 const Component* const /*meta*/) const {
     return true;
   }
@@ -239,10 +239,10 @@ class FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
   void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
                   const Mesh<3>& mesh,
                   Parallel::GlobalCache<Metavariables>& cache,
-                  const ElementId<3>& array_index,
+                  const ElementId<3>& element_id,
                   const ParallelComponent* const component,
                   const ObservationValue& observation_value) const {
-    observe_fields_event_(box, mesh, cache, array_index, component,
+    observe_fields_event_(box, mesh, cache, element_id, component,
                           observation_value);
 
     horizon_find_event_(
@@ -252,7 +252,7 @@ class FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
         get<gh::Tags::Phi<DataVector, 3>>(box),
         get<::Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
                           Frame::Inertial>>(box),
-        cache, array_index, component, observation_value);
+        cache, element_id, component, observation_value);
   }
 
   using observation_registration_tags = tmpl::list<::Tags::DataBox>;
@@ -268,9 +268,9 @@ class FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
 
   using is_ready_argument_tags = tmpl::list<>;
 
-  template <typename Metavariables, typename ArrayIndex, typename Component>
+  template <typename Metavariables, typename Component>
   bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
-                const ArrayIndex& /*array_index*/,
+                const ElementId<3>& /*element_id*/,
                 const Component* const /*meta*/) const {
     return true;
   }

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
@@ -232,12 +232,13 @@ class FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
 
   using return_tags = tmpl::list<>;
   using argument_tags =
-      tmpl::list<::Tags::ObservationBox, ::Events::Tags::ObserverMesh<3>>;
+      tmpl::list<::Tags::ObservationBox, ::Events::Tags::ObserverMesh<3>,
+                 domain::Tags::Element<3>>;
 
   template <typename DataBoxType, typename ComputeTagsList,
             typename Metavariables, typename ParallelComponent>
   void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
-                  const Mesh<3>& mesh,
+                  const Mesh<3>& mesh, const Element<3>& element,
                   Parallel::GlobalCache<Metavariables>& cache,
                   const ElementId<3>& element_id,
                   const ParallelComponent* const component,
@@ -246,7 +247,7 @@ class FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
                           observation_value);
 
     horizon_find_event_(
-        get<typename HorizonMetavars::time_tag>(box), mesh,
+        get<typename HorizonMetavars::time_tag>(box), mesh, element,
         get<gr::Tags::SpacetimeMetric<DataVector, 3>>(box),
         get<gh::Tags::Pi<DataVector, 3>>(box),
         get<gh::Tags::Phi<DataVector, 3>>(box),

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/FindApparentHorizon.hpp
@@ -397,7 +397,7 @@ struct FindApparentHorizon {
             Parallel::printf(
                 "%s: t=%.6g: L=%zu: its=%zu: %.1e<R<%.0e, |R|=%.1g, "
                 "|R_grid|=%.1g, %.4g<r<%.4g\n",
-                pretty_type::name<HorizonMetavars>(), current_time.id,
+                name, current_time.id,
                 all_storage.at(current_time)
                     .current_iteration.strahlkorper.l_max(),
                 info.iteration, info.min_residual, info.max_residual,

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Initialization.hpp
@@ -69,7 +69,8 @@ struct Initialize {
                          typename HorizonMetavars::
                              horizon_find_failure_callbacks>>>>>>;
 
-  using mutable_global_cache_tags = tmpl::list<>;
+  using mutable_global_cache_tags =
+      tmpl::list<Tags::PreviousSurface<HorizonMetavars>>;
 
   using compute_tags = ah::compute_items_on_target<3, Fr>;
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/InterpolateVolumeVars.cpp
@@ -129,6 +129,8 @@ bool interpolate_volume_data(
           }
         }
       });
+
+  current_iteration_storage->intersecting_element_ids.insert(element_id);
   return true;
 }
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/PrintDeadlockAnalysis.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/PrintDeadlockAnalysis.hpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iomanip>
+#include <ios>
+#include <limits>
+#include <sstream>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::Actions {
+/*!
+ * \brief Simple action to print deadlock info of the horizon finder.
+ */
+struct PrintDeadlockAnalysis {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const std::string& file_name) {
+    std::stringstream ss{};
+    ss << std::setprecision(std::numeric_limits<double>::digits10 + 4)
+       << std::scientific;
+
+    using HorizonMetavars = typename ParallelComponent::horizon_metavars;
+    const std::string& name = pretty_type::name<HorizonMetavars>();
+    ss << "Horizon finder " << name << ":\n";
+
+    const auto& completed_times = db::get<ah::Tags::CompletedTimes>(box);
+    ss << "  Completed times: " << completed_times << "\n";
+
+    const auto& current_time_optional = db::get<ah::Tags::CurrentTime>(box);
+    if (current_time_optional.has_value()) {
+      ss << "  Current time: " << current_time_optional.value() << "\n";
+    } else {
+      ss << "  No current time set.\n";
+    }
+
+    const auto& pending_times = db::get<ah::Tags::PendingTimes>(box);
+    ss << "  Pending times: " << pending_times << "\n";
+
+    if (current_time_optional.has_value()) {
+      const auto& current_time = current_time_optional.value();
+      const auto& all_storage =
+          db::get<ah::Tags::Storage<typename HorizonMetavars::frame>>(box);
+      if (all_storage.contains(current_time)) {
+        const auto& current_time_storage = all_storage.at(current_time);
+        const auto& all_volume_variables =
+            current_time_storage.all_volume_variables;
+        const auto& current_iteration_storage =
+            current_time_storage.current_iteration;
+        const auto& fast_flow = db::get<ah::Tags::FastFlow>(box);
+
+        ss << "  Time is ready: " << current_time_storage.time_is_ready << "\n";
+        ss << "  FastFlow iteration: " << fast_flow.current_iteration() << "\n";
+        ss << "  Coordinates are set: "
+           << current_iteration_storage.block_coord_holders.has_value() << "\n";
+
+        if (current_iteration_storage.block_coord_holders.has_value()) {
+          ss << "  Number of points to interpolate to: "
+             << current_iteration_storage.block_coord_holders->size() << "\n";
+          const bool interpolation_is_complete =
+              current_iteration_storage.interpolation_is_complete();
+          ss << "  Interpolation is complete: " << interpolation_is_complete
+             << "\n";
+          if (not interpolation_is_complete) {
+            ss << "  THE HORIZON FINDER IS STUCK IN INTERPOLATION, WHICH "
+                  "LIKELY CAUSED THIS DEADLOCK. It is likely waiting for "
+                  "volume data that will never arrive. See "
+                  "'src/ParallelAlgorithms/ApparentHorizonFinder/Events/"
+                  "FindApparentHorizon.hpp' for possible causes and "
+                  "solutions.\n";
+            const auto& block_logical_coords =
+                current_iteration_storage.block_coord_holders.value();
+            ss << "  Missing points (in block-logical coords):\n";
+            const auto& filled =
+                current_iteration_storage.indices_interpolated_to_thus_far;
+            for (size_t i = 0; i < filled.size(); ++i) {
+              if (not filled[i]) {
+                ss << "    Index " << i << ": " << block_logical_coords[i]
+                   << "\n";
+              }
+            }
+          }
+          ss << "  Intersecting element IDs: "
+             << current_iteration_storage.intersecting_element_ids << "\n";
+          ss << "  Element order: " << current_time_storage.element_order
+             << "\n";
+          ss << "  Volume data received from " << all_volume_variables.size()
+             << " elements:\n";
+          for (const auto& [element_id, volume_vars_storage] :
+               all_volume_variables) {
+            ss << "    " << element_id << "\n";
+          }
+        }
+      } else {
+        ss << "  No storage for current time " << current_time << ".\n";
+      }
+    }
+
+    Parallel::fprintf(file_name, "%s\n", ss.str());
+  }
+};
+}  // namespace ah::Actions

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.cpp
@@ -41,6 +41,7 @@ void Iteration<Fr>::reset_for_next_iteration() {
   // the next surface
   this->block_coord_holders.reset();
   this->indices_interpolated_to_thus_far.clear();
+  this->intersecting_element_ids.clear();
   this->compute_coords_retries = 0;
 }
 
@@ -50,6 +51,7 @@ void Iteration<Fr>::pup(PUP::er& p) {
   p | block_coord_holders;
   p | interpolated_vars;
   p | indices_interpolated_to_thus_far;
+  p | intersecting_element_ids;
   p | compute_coords_retries;
   // No need to serialize the memory buffers because they are resized as needed
 }
@@ -61,6 +63,7 @@ bool operator==(const Iteration<Fr>& lhs, const Iteration<Fr>& rhs) {
          lhs.interpolated_vars == rhs.interpolated_vars and
          lhs.indices_interpolated_to_thus_far ==
              rhs.indices_interpolated_to_thus_far and
+         lhs.intersecting_element_ids == rhs.intersecting_element_ids and
          lhs.compute_coords_retries == rhs.compute_coords_retries;
   // No need to compare the memory buffers
 }
@@ -94,20 +97,25 @@ bool operator!=(const SingleTimeStorage<Fr>& lhs,
 }
 
 template <typename Fr>
-PreviousSurface<Fr>::PreviousSurface(const LinkedMessageId<double>& time_in,
-                                     ylm::Strahlkorper<Fr> surface_in)
-    : time(time_in), surface(std::move(surface_in)) {}
+PreviousSurface<Fr>::PreviousSurface(
+    const LinkedMessageId<double>& time_in, ylm::Strahlkorper<Fr> surface_in,
+    std::unordered_set<ElementId<3>> intersecting_element_ids_in)
+    : time(time_in),
+      surface(std::move(surface_in)),
+      intersecting_element_ids(std::move(intersecting_element_ids_in)) {}
 
 template <typename Fr>
 void PreviousSurface<Fr>::pup(PUP::er& p) {
   p | time;
   p | surface;
+  p | intersecting_element_ids;
 }
 
 template <typename Fr>
 bool operator==(const PreviousSurface<Fr>& lhs,
                 const PreviousSurface<Fr>& rhs) {
-  return lhs.time == rhs.time and lhs.surface == rhs.surface;
+  return lhs.time == rhs.time and lhs.surface == rhs.surface and
+         lhs.intersecting_element_ids == rhs.intersecting_element_ids;
 }
 template <typename Fr>
 bool operator!=(const PreviousSurface<Fr>& lhs,
@@ -115,29 +123,77 @@ bool operator!=(const PreviousSurface<Fr>& lhs,
   return not(lhs == rhs);
 }
 
+template <typename Fr>
+void LockedPreviousSurface<Fr>::pup(PUP::er& p) {
+  // Don't pup the lock
+  p | surface;
+}
+
+template <typename Fr>
+LockedPreviousSurface<Fr>::LockedPreviousSurface() = default;
+template <typename Fr>
+LockedPreviousSurface<Fr>::LockedPreviousSurface(const PreviousSurface<Fr>& rhs)
+    : surface(rhs) {}
+template <typename Fr>
+LockedPreviousSurface<Fr>::LockedPreviousSurface(
+    const LockedPreviousSurface<Fr>& rhs)
+    : surface(rhs.surface) {}
+template <typename Fr>
+LockedPreviousSurface<Fr>& LockedPreviousSurface<Fr>::operator=(
+    const LockedPreviousSurface<Fr>& rhs) {
+  surface = rhs.surface;
+  return *this;
+}
+template <typename Fr>
+LockedPreviousSurface<Fr>::LockedPreviousSurface(
+    LockedPreviousSurface<Fr>&& rhs)
+    : surface(std::move(rhs.surface)) {}
+template <typename Fr>
+LockedPreviousSurface<Fr>& LockedPreviousSurface<Fr>::operator=(
+    LockedPreviousSurface<Fr>&& rhs) {
+  surface = std::move(rhs.surface);
+  return *this;
+}
+
+template <typename Fr>
+bool operator==(const LockedPreviousSurface<Fr>& lhs,
+                const LockedPreviousSurface<Fr>& rhs) {
+  return lhs.surface == rhs.surface;
+}
+template <typename Fr>
+bool operator!=(const LockedPreviousSurface<Fr>& lhs,
+                const LockedPreviousSurface<Fr>& rhs) {
+  return not(lhs == rhs);
+}
+
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                       \
-  template struct VolumeVariables<FRAME(data)>;                    \
-  template struct Iteration<FRAME(data)>;                          \
-  template struct SingleTimeStorage<FRAME(data)>;                  \
-  template struct PreviousSurface<FRAME(data)>;                    \
-  template bool operator==(const VolumeVariables<FRAME(data)>&,    \
-                           const VolumeVariables<FRAME(data)>&);   \
-  template bool operator!=(const VolumeVariables<FRAME(data)>&,    \
-                           const VolumeVariables<FRAME(data)>&);   \
-  template bool operator==(const Iteration<FRAME(data)>&,          \
-                           const Iteration<FRAME(data)>&);         \
-  template bool operator!=(const Iteration<FRAME(data)>&,          \
-                           const Iteration<FRAME(data)>&);         \
-  template bool operator==(const SingleTimeStorage<FRAME(data)>&,  \
-                           const SingleTimeStorage<FRAME(data)>&); \
-  template bool operator!=(const SingleTimeStorage<FRAME(data)>&,  \
-                           const SingleTimeStorage<FRAME(data)>&); \
-  template bool operator==(const PreviousSurface<FRAME(data)>&,    \
-                           const PreviousSurface<FRAME(data)>&);   \
-  template bool operator!=(const PreviousSurface<FRAME(data)>&,    \
-                           const PreviousSurface<FRAME(data)>&);
+#define INSTANTIATE(_, data)                                           \
+  template struct VolumeVariables<FRAME(data)>;                        \
+  template struct Iteration<FRAME(data)>;                              \
+  template struct SingleTimeStorage<FRAME(data)>;                      \
+  template struct PreviousSurface<FRAME(data)>;                        \
+  template struct LockedPreviousSurface<FRAME(data)>;                  \
+  template bool operator==(const VolumeVariables<FRAME(data)>&,        \
+                           const VolumeVariables<FRAME(data)>&);       \
+  template bool operator!=(const VolumeVariables<FRAME(data)>&,        \
+                           const VolumeVariables<FRAME(data)>&);       \
+  template bool operator==(const Iteration<FRAME(data)>&,              \
+                           const Iteration<FRAME(data)>&);             \
+  template bool operator!=(const Iteration<FRAME(data)>&,              \
+                           const Iteration<FRAME(data)>&);             \
+  template bool operator==(const SingleTimeStorage<FRAME(data)>&,      \
+                           const SingleTimeStorage<FRAME(data)>&);     \
+  template bool operator!=(const SingleTimeStorage<FRAME(data)>&,      \
+                           const SingleTimeStorage<FRAME(data)>&);     \
+  template bool operator==(const PreviousSurface<FRAME(data)>&,        \
+                           const PreviousSurface<FRAME(data)>&);       \
+  template bool operator!=(const PreviousSurface<FRAME(data)>&,        \
+                           const PreviousSurface<FRAME(data)>&);       \
+  template bool operator==(const LockedPreviousSurface<FRAME(data)>&,  \
+                           const LockedPreviousSurface<FRAME(data)>&); \
+  template bool operator!=(const LockedPreviousSurface<FRAME(data)>&,  \
+                           const LockedPreviousSurface<FRAME(data)>&);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (Frame::Inertial, Frame::Distorted, Frame::Grid))

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Storage.hpp
@@ -19,6 +19,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Parallel/MultiReaderSpinlock.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
@@ -82,6 +83,12 @@ struct Iteration {
    * already been interpolated to.
    */
   std::vector<bool> indices_interpolated_to_thus_far{};
+  /*!
+   * \brief Holds the element IDs of all elements that intersect with the
+   * current iteration surface. Used to determine which elements will send
+   * data for the next horizon find.
+   */
+  std::unordered_set<ElementId<3>> intersecting_element_ids{};
   /*!
    * \brief Offsets of newly interpolated points in the overall tensor (used as
    * memory buffer)
@@ -184,10 +191,12 @@ template <typename Fr>
 struct PreviousSurface {
   PreviousSurface() = default;
   PreviousSurface(const LinkedMessageId<double>& time_in,
-                  ylm::Strahlkorper<Fr> surface_in);
+                  ylm::Strahlkorper<Fr> surface_in,
+                  std::unordered_set<ElementId<3>> intersecting_element_ids_in);
 
   LinkedMessageId<double> time;
   ylm::Strahlkorper<Fr> surface;
+  std::unordered_set<ElementId<3>> intersecting_element_ids;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
@@ -197,4 +206,38 @@ template <typename Fr>
 bool operator==(const PreviousSurface<Fr>& lhs, const PreviousSurface<Fr>& rhs);
 template <typename Fr>
 bool operator!=(const PreviousSurface<Fr>& lhs, const PreviousSurface<Fr>& rhs);
+
+/*!
+ * \brief Holds a previous surface and a lock that protects it.
+ *
+ * \details This is used to store and update a previous surface in the global
+ * cache and allow multiple readers (elements) to access it simultaneously.
+ */
+template <typename Fr>
+struct LockedPreviousSurface {
+  std::optional<PreviousSurface<Fr>> surface;
+  // Lock is mutable so it can be retrieved from the const global cache and put
+  // in read-lock mode by elements.
+  // NOLINTNEXTLINE(spectre-mutable)
+  mutable Parallel::MultiReaderSpinlock lock;
+
+  LockedPreviousSurface();
+  explicit LockedPreviousSurface(const PreviousSurface<Fr>& rhs);
+  LockedPreviousSurface(const LockedPreviousSurface& rhs);
+  LockedPreviousSurface& operator=(const LockedPreviousSurface& rhs);
+  LockedPreviousSurface(LockedPreviousSurface&& rhs);
+  LockedPreviousSurface& operator=(LockedPreviousSurface&& rhs);
+  ~LockedPreviousSurface() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+};
+
+template <typename Fr>
+bool operator==(const LockedPreviousSurface<Fr>& lhs,
+                const LockedPreviousSurface<Fr>& rhs);
+template <typename Fr>
+bool operator!=(const LockedPreviousSurface<Fr>& lhs,
+                const LockedPreviousSurface<Fr>& rhs);
+
 }  // namespace ah::Storage

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -99,7 +99,7 @@ struct Dependency : db::SimpleTag {
  * \details The value of this tag is `std::nullopt` if the current resolution L
  * isn't set.
  */
- struct CurrentResolutionL : db::SimpleTag {
+struct CurrentResolutionL : db::SimpleTag {
   using type = std::optional<size_t>;
 };
 

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp
@@ -130,6 +130,19 @@ struct PreviousSurfaces : db::SimpleTag {
 };
 
 /*!
+ * \brief Holds the previous surface. Used to determine which elements will send
+ * data for the next horizon find.
+ */
+template <typename HorizonMetavars>
+struct PreviousSurface : db::SimpleTag {
+  using type =
+      ah::Storage::LockedPreviousSurface<typename HorizonMetavars::frame>;
+  using option_tags = tmpl::list<>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return {}; }
+};
+
+/*!
  * \brief Global cache tag that holds horizon finder options
  */
 template <typename HorizonMetavars>

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -192,7 +192,7 @@ def inspiral_parameters(
             extension=".vol",
         )
         if len(id_subfiles) == 1:
-            id_subfile_name = subfiles[0]
+            id_subfile_name = id_subfiles[0]
             logger.info(
                 f"Selected subfile {id_subfile_name} (the only available one)."
             )

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_InvokeCallbacks.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_InvokeCallbacks.cpp
@@ -100,10 +100,12 @@ struct HorizonMetavars : tt::ConformsTo<ah::protocols::HorizonMetavars> {
   static std::string name() { return "TestingHorizonMetavars"; }
 };
 
+template <typename Fr>
 struct Metavariables {
   using const_global_cache_tags = tmpl::list<domain::Tags::Domain<3>>;
   using mutable_global_cache_tags =
-      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize,
+                 ah::Tags::PreviousSurface<HorizonMetavars<Fr>>>;
   using component_list = tmpl::list<>;
 };
 
@@ -112,8 +114,10 @@ void run_test() {
   const domain::creators::Sphere sphere_creator{
       0.9, 2.0, domain::creators::Sphere::Excision{nullptr}, 0_st, 4_st, true};
 
-  Parallel::GlobalCache<Metavariables> cache{
-      {sphere_creator.create_domain()}, {sphere_creator.functions_of_time()}};
+  Parallel::GlobalCache<Metavariables<Fr>> cache{
+      {sphere_creator.create_domain()},
+      {sphere_creator.functions_of_time(),
+       ah::Storage::LockedPreviousSurface<Fr>{}}};
 
   const LinkedMessageId<double> time{2.0, {1.0}};
   const FastFlow fast_flow{
@@ -123,6 +127,8 @@ void run_test() {
   ah::Storage::Iteration<Fr> current_iteration{};
   current_iteration.strahlkorper =
       ylm::Strahlkorper<Fr>{l_max, radius, std::array{0.0, 0.0, 0.0}};
+  current_iteration.intersecting_element_ids = {ElementId<3>{0},
+                                                ElementId<3>{1}};
   const size_t l_mesh =
       fast_flow.current_l_mesh(current_iteration.strahlkorper);
   // The actual values don't matter for this test
@@ -162,6 +168,11 @@ void run_test() {
   CHECK(box_previous_surfaces.front().time == time);
   CHECK(box_previous_surfaces.front().surface ==
         current_iteration.strahlkorper);
+  CHECK(box_previous_surfaces.front().intersecting_element_ids ==
+        current_iteration.intersecting_element_ids);
+  const auto& cache_previous_surface =
+      get<ah::Tags::PreviousSurface<HorizonMetavars<Fr>>>(cache);
+  CHECK(cache_previous_surface.surface == box_previous_surfaces.front());
   CHECK(db::get<ylm::Tags::Strahlkorper<Fr>>(box) ==
         current_iteration.strahlkorper);
   CHECK(db::get<ylm::Tags::TimeDerivStrahlkorper<Fr>>(box).coefficients() ==

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
@@ -155,7 +155,6 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
   ::domain::creators::time_dependence::register_derived_with_charm();
   using metavars = MockMetavariables;
   const ElementId<3> element_id(2);
-  const ElementId<3> array_index(element_id);
 
   using component = MockComponent<metavars>;
   using elem_component = MockElement<metavars>;
@@ -183,13 +182,13 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0}, 0);
   ActionTesting::emplace_array_component<elem_component>(
       &runner, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
-      array_index);
+      element_id);
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
   const Mesh<3> mesh(5, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
   const LinkedMessageId<double> observation_time{2.0, {1.0}};
-  auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
+  auto& cache = ActionTesting::cache<elem_component>(runner, element_id);
 
   // Fill source vars with an analytic solution so that
   // ah::vars_to_interpolate_to_target can be computed from
@@ -289,7 +288,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
   auto obs_box = make_observation_box<
       typename metavars::event::compute_tags_for_observation_box>(
       make_not_null(&box));
-  serialized_event.run(make_not_null(&obs_box), cache, array_index,
+  serialized_event.run(make_not_null(&obs_box), cache, element_id,
                        std::add_pointer_t<elem_component>{}, {});
 
   const auto check_results = [&]() {
@@ -298,7 +297,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
 
     // No more queued simple actions.
     CHECK(runner.is_simple_action_queue_empty<component>(0));
-    CHECK(runner.is_simple_action_queue_empty<elem_component>(array_index));
+    CHECK(runner.is_simple_action_queue_empty<elem_component>(element_id));
 
     const auto& results = MockFindApparentHorizon::results;
     CHECK(results.time == observation_time);
@@ -332,7 +331,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
   const metavars::event serialized_option_event =
       serialize_and_deserialize(option_event);
 
-  serialized_option_event.run(make_not_null(&obs_box), cache, array_index,
+  serialized_option_event.run(make_not_null(&obs_box), cache, element_id,
                               std::add_pointer_t<elem_component>{}, {});
 
   check_results();

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
@@ -113,7 +113,8 @@ struct MockComponent {
   using const_global_cache_tags =
       tmpl::list<domain::Tags::Domain<3>, ah::Tags::BlocksForHorizonFind>;
   using mutable_global_cache_tags =
-      tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
+      tmpl::list<domain::Tags::FunctionsOfTimeInitialize,
+                 ah::Tags::PreviousSurface<MockHorizonMetavars>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
@@ -175,7 +176,8 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
       {domain_creator.create_domain(),
        std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}},
-      {domain_creator.functions_of_time()}};
+      {domain_creator.functions_of_time(),
+       ah::Storage::LockedPreviousSurface<Frame::Grid>{}}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_array_component<component>(
@@ -273,12 +275,11 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
   std::optional<std::string> dependency{"FakeDependency"};
 
   // Test the event version
-  auto box =
-      db::create<db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<metavars>,
-                                   typename MockHorizonMetavars::time_tag,
-                                   ::Events::Tags::ObserverMesh<3>,
-                                   ::Tags::Variables<ah::source_vars<3>>>>(
-          metavars{}, observation_time, mesh, vars);
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<metavars>,
+      typename MockHorizonMetavars::time_tag, ::Events::Tags::ObserverMesh<3>,
+      domain::Tags::Element<3>, ::Tags::Variables<ah::source_vars<3>>>>(
+      metavars{}, observation_time, mesh, Element<3>{element_id, {}}, vars);
 
   const metavars::event event{dependency};
   const metavars::event serialized_event = serialize_and_deserialize(event);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
@@ -205,7 +205,8 @@ struct MockMetavariables {
 void common_horizon_event() {
   ::domain::creators::register_derived_with_charm();
   using metavars = MockMetavariables;
-  const ElementId<metavars::volume_dim> element_id(0);
+  constexpr size_t Dim = metavars::volume_dim;
+  const ElementId<Dim> element_id(0);
 
   using obs_component = MockObserver<metavars>;
   using interp_component = MockInterpolator<metavars>;
@@ -249,8 +250,8 @@ void common_horizon_event() {
   // No events queued yet
   check_results(0);
 
-  const Mesh<metavars::volume_dim> mesh(5, Spectral::Basis::Legendre,
-                                        Spectral::Quadrature::GaussLobatto);
+  const Mesh<Dim> mesh(5, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
   const double observation_time = 2.0;
   const Variables<metavars::interpolator_source_vars> vars(
       mesh.number_of_grid_points(), 1.0);
@@ -262,20 +263,20 @@ void common_horizon_event() {
 
   // Actual coords don't matter
   const auto logical_coords = logical_coordinates(mesh);
-  auto box = db::create<db::AddSimpleTags<
-      Parallel::Tags::MetavariablesImpl<metavars>,
-      Parallel::Tags::GlobalCache<metavars>,
-      metavars::InterpolationTargetA::temporal_id, ::Tags::Time,
-      ::Events::Tags::ObserverMesh<metavars::volume_dim>,
-      ::domain::Tags::Coordinates<3, ::Frame::Inertial>,
-      ::Tags::Variables<typename decltype(vars)::tags_list>>>(
+  auto box = db::create<
+      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<metavars>,
+                        Parallel::Tags::GlobalCache<metavars>,
+                        metavars::InterpolationTargetA::temporal_id,
+                        ::Tags::Time, ::Events::Tags::ObserverMesh<Dim>,
+                        ::domain::Tags::Coordinates<3, ::Frame::Inertial>,
+                        ::Tags::Variables<typename decltype(vars)::tags_list>>>(
       metavars{}, &cache, temporal_id, observation_time, mesh,
       tnsr::I<DataVector, 3, ::Frame::Inertial>{
           std::array{logical_coords[0], logical_coords[1], logical_coords[2]}},
       vars);
 
   using FindCommonHorizon = intrp::Events::FindCommonHorizon<
-      metavars::volume_dim, typename metavars::InterpolationTargetA,
+      Dim, typename metavars::InterpolationTargetA,
       typename metavars::interpolator_source_vars,
       tmpl::push_back<typename metavars::interpolator_source_vars,
                       ::domain::Tags::Coordinates<3, ::Frame::Inertial>>>;
@@ -291,10 +292,9 @@ void common_horizon_event() {
 
   // Only compute tags for cache items necessary for observation box since this
   // test just puts the tags in the regular box
-  auto obs_box =
-      make_observation_box<tmpl::list<Parallel::Tags::FromGlobalCache<
-          ::domain::Tags::Domain<metavars::volume_dim>, metavars>>>(
-          make_not_null(&box));
+  auto obs_box = make_observation_box<tmpl::list<
+      Parallel::Tags::FromGlobalCache<::domain::Tags::Domain<Dim>, metavars>>>(
+      make_not_null(&box));
   find_common_horizon(obs_box, mesh, cache, element_id,
                       std::add_pointer_t<elem_component>{}, observation_value);
 
@@ -378,7 +378,8 @@ void common_horizon_event() {
   (void)MockHorizonMetavars::destination;
   ::domain::creators::register_derived_with_charm();
   using metavars = MockMetavariables;
-  const ElementId<metavars::volume_dim> element_id(0);
+  constexpr size_t Dim = metavars::volume_dim;
+  const ElementId<Dim> element_id(0);
 
   using obs_component = MockObserver<metavars>;
   using horizon_component = MockHorizonComponent<metavars>;
@@ -414,8 +415,8 @@ void common_horizon_event() {
   // No events queued yet
   check_results(0);
 
-  const Mesh<metavars::volume_dim> mesh(5, Spectral::Basis::Legendre,
-                                        Spectral::Quadrature::GaussLobatto);
+  const Mesh<Dim> mesh(5, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
   const double observation_time = 2.0;
 
   // Formerly, every point for every component of every tensor in vars were set
@@ -425,13 +426,11 @@ void common_horizon_event() {
   // Since pi and phi are zero for Minkowski, it's actually less code to just
   // manually set spacetime metric here than to get the analytic solution and
   // call all the functions to assemble spacetime_metric, pi, phi.
-  Variables<ah::source_vars<metavars::volume_dim>> vars(
-      mesh.number_of_grid_points(), 0.0);
+  Variables<ah::source_vars<Dim>> vars(mesh.number_of_grid_points(), 0.0);
   auto& spacetime_metric =
-      get<gr::Tags::SpacetimeMetric<DataVector, metavars::volume_dim>>(vars);
+      get<gr::Tags::SpacetimeMetric<DataVector, Dim>>(vars);
   get<0, 0>(spacetime_metric) = DataVector(mesh.number_of_grid_points(), -1.0);
-  for (size_t spatial_index = 0; spatial_index < metavars::volume_dim;
-       ++spatial_index) {
+  for (size_t spatial_index = 0; spatial_index < Dim; ++spatial_index) {
     spacetime_metric.get(spatial_index + 1, spatial_index + 1) =
         DataVector(mesh.number_of_grid_points(), 1.0);
   }
@@ -446,7 +445,7 @@ void common_horizon_event() {
   auto box = db::create<db::AddSimpleTags<
       Parallel::Tags::MetavariablesImpl<metavars>,
       Parallel::Tags::GlobalCache<metavars>, MockHorizonMetavars::time_tag,
-      Tags::Time, ::Events::Tags::ObserverMesh<metavars::volume_dim>,
+      Tags::Time, ::Events::Tags::ObserverMesh<Dim>,
       ::domain::Tags::Coordinates<3, ::Frame::Inertial>,
       ::Tags::Variables<typename decltype(vars)::tags_list>>>(
       metavars{}, &cache, temporal_id, observation_time, mesh,
@@ -456,7 +455,7 @@ void common_horizon_event() {
 
   using FindCommonHorizon = ah::Events::FindCommonHorizon<
       MockHorizonMetavars,
-      tmpl::push_back<ah::source_vars<metavars::volume_dim>,
+      tmpl::push_back<ah::source_vars<Dim>,
                       ::domain::Tags::Coordinates<3, ::Frame::Inertial>>>;
 
   const FindCommonHorizon find_common_horizon{"SubfileName",
@@ -470,10 +469,9 @@ void common_horizon_event() {
 
   // Only compute tags for cache items necessary for observation box since this
   // test just puts the tags in the regular box
-  auto obs_box =
-      make_observation_box<tmpl::list<Parallel::Tags::FromGlobalCache<
-          ::domain::Tags::Domain<metavars::volume_dim>, metavars>>>(
-          make_not_null(&box));
+  auto obs_box = make_observation_box<tmpl::list<
+      Parallel::Tags::FromGlobalCache<::domain::Tags::Domain<Dim>, metavars>>>(
+      make_not_null(&box));
   find_common_horizon(obs_box, mesh, cache, element_id,
                       std::add_pointer_t<elem_component>{}, observation_value);
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
@@ -347,6 +347,8 @@ struct MockHorizonComponent {
       ah::Component<Metavariables, MockHorizonMetavars>;
   using const_global_cache_tags =
       tmpl::list<domain::Tags::Domain<3>, ah::Tags::BlocksForHorizonFind>;
+  using mutable_global_cache_tags =
+      tmpl::list<ah::Tags::PreviousSurface<MockHorizonMetavars>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
@@ -380,6 +382,7 @@ void common_horizon_event() {
   using metavars = MockMetavariables;
   constexpr size_t Dim = metavars::volume_dim;
   const ElementId<Dim> element_id(0);
+  const Element<Dim> element{element_id, {}};
 
   using obs_component = MockObserver<metavars>;
   using horizon_component = MockHorizonComponent<metavars>;
@@ -391,7 +394,8 @@ void common_horizon_event() {
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {brick.create_domain(),
        std::unordered_map<std::string, std::unordered_set<std::string>>{
-           {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}}};
+           {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}},
+      {ah::Storage::LockedPreviousSurface<Frame::Grid>{}}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_group_component<obs_component>(make_not_null(&runner));
@@ -472,7 +476,7 @@ void common_horizon_event() {
   auto obs_box = make_observation_box<tmpl::list<
       Parallel::Tags::FromGlobalCache<::domain::Tags::Domain<Dim>, metavars>>>(
       make_not_null(&box));
-  find_common_horizon(obs_box, mesh, cache, element_id,
+  find_common_horizon(obs_box, mesh, element, cache, element_id,
                       std::add_pointer_t<elem_component>{}, observation_value);
 
   // Since this event is a combination of two events, and those two events are

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
@@ -206,7 +206,6 @@ void common_horizon_event() {
   ::domain::creators::register_derived_with_charm();
   using metavars = MockMetavariables;
   const ElementId<metavars::volume_dim> element_id(0);
-  const ElementId<metavars::volume_dim> array_index(element_id);
 
   using obs_component = MockObserver<metavars>;
   using interp_component = MockInterpolator<metavars>;
@@ -231,7 +230,7 @@ void common_horizon_event() {
   ActionTesting::emplace_component<interp_target_component>(
       make_not_null(&runner), 0);
   ActionTesting::emplace_component<elem_component>(make_not_null(&runner),
-                                                   array_index);
+                                                   element_id);
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
   const auto check_results = [&runner,
@@ -255,7 +254,7 @@ void common_horizon_event() {
   const double observation_time = 2.0;
   const Variables<metavars::interpolator_source_vars> vars(
       mesh.number_of_grid_points(), 1.0);
-  auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
+  auto& cache = ActionTesting::cache<elem_component>(runner, element_id);
 
   const LinkedMessageId<double> temporal_id{observation_time, std::nullopt};
   const ::Event::ObservationValue observation_value{"FindCommonHorizon",
@@ -287,7 +286,7 @@ void common_horizon_event() {
                                               {"Pi"}};
 
   CHECK(find_common_horizon.needs_evolved_variables());
-  CHECK(find_common_horizon.is_ready(cache, 0,
+  CHECK(find_common_horizon.is_ready(cache, element_id,
                                      std::add_pointer_t<elem_component>{}));
 
   // Only compute tags for cache items necessary for observation box since this
@@ -296,7 +295,7 @@ void common_horizon_event() {
       make_observation_box<tmpl::list<Parallel::Tags::FromGlobalCache<
           ::domain::Tags::Domain<metavars::volume_dim>, metavars>>>(
           make_not_null(&box));
-  find_common_horizon(obs_box, mesh, cache, array_index,
+  find_common_horizon(obs_box, mesh, cache, element_id,
                       std::add_pointer_t<elem_component>{}, observation_value);
 
   // Since this event is a combination of two events, and those two events are
@@ -380,7 +379,6 @@ void common_horizon_event() {
   ::domain::creators::register_derived_with_charm();
   using metavars = MockMetavariables;
   const ElementId<metavars::volume_dim> element_id(0);
-  const ElementId<metavars::volume_dim> array_index(element_id);
 
   using obs_component = MockObserver<metavars>;
   using horizon_component = MockHorizonComponent<metavars>;
@@ -400,7 +398,7 @@ void common_horizon_event() {
       make_not_null(&runner), ActionTesting::NodeId{0},
       ActionTesting::LocalCoreId{0}, 0);
   ActionTesting::emplace_component<elem_component>(make_not_null(&runner),
-                                                   array_index);
+                                                   element_id);
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
   const auto check_results = [&runner,
@@ -437,7 +435,7 @@ void common_horizon_event() {
     spacetime_metric.get(spatial_index + 1, spatial_index + 1) =
         DataVector(mesh.number_of_grid_points(), 1.0);
   }
-  auto& cache = ActionTesting::cache<elem_component>(runner, array_index);
+  auto& cache = ActionTesting::cache<elem_component>(runner, element_id);
 
   const LinkedMessageId<double> temporal_id{observation_time, std::nullopt};
   const ::Event::ObservationValue observation_value{"FindCommonHorizon",
@@ -467,7 +465,7 @@ void common_horizon_event() {
                                               {"Pi"}};
 
   CHECK(find_common_horizon.needs_evolved_variables());
-  CHECK(find_common_horizon.is_ready(cache, 0,
+  CHECK(find_common_horizon.is_ready(cache, element_id,
                                      std::add_pointer_t<elem_component>{}));
 
   // Only compute tags for cache items necessary for observation box since this
@@ -476,7 +474,7 @@ void common_horizon_event() {
       make_observation_box<tmpl::list<Parallel::Tags::FromGlobalCache<
           ::domain::Tags::Domain<metavars::volume_dim>, metavars>>>(
           make_not_null(&box));
-  find_common_horizon(obs_box, mesh, cache, array_index,
+  find_common_horizon(obs_box, mesh, cache, element_id,
                       std::add_pointer_t<elem_component>{}, observation_value);
 
   // Since this event is a combination of two events, and those two events are

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
@@ -146,10 +146,12 @@ void test_compute_points() {
     const LinkedMessageId<double> prev_time_2{.id = 2.0, .previous = {1.0}};
     previous_surfaces.emplace_front(
         prev_time_2,
-        ylm::Strahlkorper<Fr>{l_max, 1.1, std::array{0.0, 0.0, 0.0}});
+        ylm::Strahlkorper<Fr>{l_max, 1.1, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
     previous_surfaces.emplace_front(
         prev_time_1,
-        ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}});
+        ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
 
     const bool coords_set_successfully = set_current_iteration_coords(
         make_not_null(&current_iteration), make_not_null(&block_order), time,
@@ -176,8 +178,8 @@ void test_compute_points() {
     const LinkedMessageId<double> prev_time{.id = 1.0,
                                             .previous = std::nullopt};
     previous_surfaces.emplace_back(
-        prev_time,
-        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
+        prev_time, ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
 
     const bool coords_set_successfully = set_current_iteration_coords(
         make_not_null(&current_iteration), make_not_null(&block_order), time,
@@ -358,10 +360,12 @@ void test_compute_points_different_resolutions() {
     const LinkedMessageId<double> prev_time_2{.id = 2.0, .previous = {1.0}};
     previous_surfaces.emplace_front(
         prev_time_2,
-        ylm::Strahlkorper<Fr>{l_max, 1.1, std::array{0.0, 0.0, 0.0}});
+        ylm::Strahlkorper<Fr>{l_max, 1.1, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
     previous_surfaces.emplace_front(
         prev_time_1,
-        ylm::Strahlkorper<Fr>{higher_l_max, 1.3, std::array{0.0, 0.0, 0.0}});
+        ylm::Strahlkorper<Fr>{higher_l_max, 1.3, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
 
     const bool coords_set_successfully = set_current_iteration_coords(
         make_not_null(&current_iteration), make_not_null(&block_order), time,
@@ -397,13 +401,16 @@ void test_compute_points_different_resolutions() {
                                               .previous = std::nullopt};
     previous_surfaces.emplace_front(
         prev_time_3,
-        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
+        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
     previous_surfaces.emplace_front(
         prev_time_2,
-        ylm::Strahlkorper<Fr>{higher_l_max, 1.1, std::array{0.0, 0.0, 0.0}});
+        ylm::Strahlkorper<Fr>{higher_l_max, 1.1, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
     previous_surfaces.emplace_front(
         prev_time_1,
-        ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}});
+        ylm::Strahlkorper<Fr>{l_max, 1.3, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
 
     const bool coords_set_successfully = set_current_iteration_coords(
         make_not_null(&current_iteration), make_not_null(&block_order), time,
@@ -436,8 +443,8 @@ void test_compute_points_different_resolutions() {
     const LinkedMessageId<double> prev_time{.id = 1.0,
                                             .previous = std::nullopt};
     previous_surfaces.emplace_back(
-        prev_time,
-        ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}});
+        prev_time, ylm::Strahlkorper<Fr>{l_max, 1.0, std::array{0.0, 0.0, 0.0}},
+        std::unordered_set<ElementId<3>>{});
 
     const bool coords_set_successfully = set_current_iteration_coords(
         make_not_null(&current_iteration), make_not_null(&block_order), time,

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
@@ -265,7 +265,8 @@ void test_apparent_horizon(
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {domain_creator->create_domain(), std::move(apparent_horizon_opts),
        blocks_for_interpolation},
-      {domain_creator->functions_of_time()}};
+      {domain_creator->functions_of_time(),
+       ah::Storage::LockedPreviousSurface<Fr>{}}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
@@ -166,8 +166,11 @@ void test_interpolate_volume_vars() {
                         Frame::Inertial>>(source_vars),
         time, domain, mesh, element_id, functions_of_time);
 
-    ah::interpolate_volume_data(make_not_null(&current_iteration), volume_vars,
-                                element_id);
+    const bool interpolated_any_points = ah::interpolate_volume_data(
+        make_not_null(&current_iteration), volume_vars, element_id);
+
+    CHECK(current_iteration.intersecting_element_ids.contains(element_id) ==
+          interpolated_any_points);
 
     // Check that we finished interpolation and that the points we interpolated
     // to aren't the default fill value

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_Storage.cpp
@@ -64,16 +64,25 @@ void test_storage() {
   test_serialization(single_time_storage);
 
   const ah::Storage::PreviousSurface<Fr> previous_surface{
-      LinkedMessageId<double>{3.0, {2.0}}, iteration.strahlkorper};
+      LinkedMessageId<double>{3.0, {2.0}},
+      iteration.strahlkorper,
+      {ElementId<3>{1}, ElementId<3>{3}}};
   test_serialization(previous_surface);
 
   // Check we can use PreviousSurface with `emplace`
   std::deque<ah::Storage::PreviousSurface<Fr>> previous_surfaces{};
-  previous_surfaces.emplace_front(LinkedMessageId<double>{1.0, std::nullopt},
-                                  iteration.strahlkorper);
+  previous_surfaces.emplace_front(
+      LinkedMessageId<double>{1.0, std::nullopt}, iteration.strahlkorper,
+      std::unordered_set<ElementId<3>>{ElementId<3>{4}, ElementId<3>{5}});
   CHECK(previous_surfaces.front().time ==
         LinkedMessageId<double>{1.0, std::nullopt});
   CHECK(previous_surfaces.front().surface == iteration.strahlkorper);
+  CHECK(previous_surfaces.front().intersecting_element_ids ==
+        std::unordered_set<ElementId<3>>{ElementId<3>{4}, ElementId<3>{5}});
+
+  ah::Storage::LockedPreviousSurface<Fr> locked_previous_surface{};
+  locked_previous_surface.surface = previous_surface;
+  test_serialization(locked_previous_surface);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Reduces work on the elements and on the AH finder by sending only data from elements that intersected the horizon before and their neighbors. Currently a draft because I'm not sure about thread safety in the global cache.

- [x] Check thread-safety
- [x] Check for deadlocks

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
