### PR TITLE
Add and enable GH AveragedUpwindPenalty BoundaryCorrection

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -746,12 +746,12 @@ void apply_boundary_conditions_on_all_external_faces(
                 typename BoundaryCorrection::dg_package_data_volume_tags{},
                 typename BoundaryCorrection::dg_package_field_tags{},
                 typename BoundaryCorrection::dg_boundary_terms_volume_tags{},
-                tmpl::append<
+                tmpl::remove_duplicates<tmpl::append<
                     typename variables_tag::tags_list, fluxes_tags,
                     typename BoundaryCorrection::dg_package_data_temporary_tags,
                     typename detail::get_primitive_vars<
                         System::has_primitive_and_conservative_vars>::
-                        template f<BoundaryCorrection>>{},
+                        template f<BoundaryCorrection>>>{},
                 typename DerivedBoundaryCondition::dg_gridless_tags{});
             --number_of_boundaries_left;
           }

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/AveragedUpwindPenalty.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/AveragedUpwindPenalty.cpp
@@ -1,0 +1,284 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/AveragedUpwindPenalty.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/BoundaryCorrection.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace gh::BoundaryCorrections {
+template <size_t Dim>
+AveragedUpwindPenalty<Dim>::AveragedUpwindPenalty(CkMigrateMessage* msg)
+    : BoundaryCorrection(msg) {}
+
+template <size_t Dim>
+std::unique_ptr<evolution::BoundaryCorrection>
+AveragedUpwindPenalty<Dim>::get_clone() const {
+  return std::make_unique<AveragedUpwindPenalty>(*this);
+}
+
+template <size_t Dim>
+void AveragedUpwindPenalty<Dim>::pup(PUP::er& p) {
+  BoundaryCorrection::pup(p);
+}
+
+template <size_t Dim>
+double AveragedUpwindPenalty<Dim>::dg_package_data(
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+        packaged_spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+        packaged_pi,
+    const gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
+        packaged_phi,
+    const gsl::not_null<Scalar<DataVector>*> packaged_constraint_gamma1,
+    const gsl::not_null<Scalar<DataVector>*> packaged_constraint_gamma2,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        packaged_normal,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        packaged_mesh_velocity,
+
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+
+    const Scalar<DataVector>& constraint_gamma1,
+    const Scalar<DataVector>& constraint_gamma2,
+    const Scalar<DataVector>& /*lapse*/,
+    const tnsr::I<DataVector, Dim>& /*shift*/,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& /*normal_vector*/,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        mesh_velocity,
+    const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/)
+    const {
+  *packaged_spacetime_metric = spacetime_metric;
+  *packaged_pi = pi;
+  *packaged_phi = phi;
+  *packaged_constraint_gamma1 = constraint_gamma1;
+  *packaged_constraint_gamma2 = constraint_gamma2;
+  *packaged_normal = normal_covector;
+  if (mesh_velocity.has_value()) {
+    *packaged_mesh_velocity = *mesh_velocity;
+  } else {
+    for (auto& component : *packaged_mesh_velocity) {
+      component = 0.0;
+    }
+  }
+
+  // This is supposed to return the max characteristic speed, but the
+  // result is unused, so we don't do all the additional work required
+  // just to throw it away.  We don't return NaN because the product
+  // corrections for the combined systems return the max of the
+  // results of each of the individual systems' corrections.  The max
+  // double should be sufficiently obviously wrong that if anyone
+  // actually tries to use it it will fail completely.
+  return std::numeric_limits<double>::max();
+}
+
+template <size_t Dim>
+void AveragedUpwindPenalty<Dim>::dg_boundary_terms(
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+        boundary_correction_spacetime_metric,
+    const gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+        boundary_correction_pi,
+    const gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
+        boundary_correction_phi,
+
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric_int,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi_int,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi_int,
+    const Scalar<DataVector>& constraint_gamma1_int,
+    const Scalar<DataVector>& constraint_gamma2_int,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_int,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& mesh_velocity_int,
+
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric_ext,
+    const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi_ext,
+    const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi_ext,
+    const Scalar<DataVector>& constraint_gamma1_ext,
+    const Scalar<DataVector>& constraint_gamma2_ext,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_ext,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& mesh_velocity_ext,
+
+    const dg::Formulation dg_formulation) const {
+  if (dg_formulation != dg::Formulation::StrongInertial) {
+    ERROR_NO_TRACE("AveragedUpwindPenalty only coded for StrongInertial form");
+  }
+
+  const size_t num_pts = get<0, 0>(spacetime_metric_int).size();
+  Variables<tmpl::list<
+      ::Tags::Tempaa<0, Dim>, ::Tags::Tempii<1, Dim>, ::Tags::TempII<2, Dim>,
+      ::Tags::TempI<3, Dim>, ::Tags::TempScalar<4>, ::Tags::Tempi<5, Dim>,
+      ::Tags::TempScalar<6>, ::Tags::TempScalar<7>, ::Tags::TempScalar<8>,
+      ::Tags::TempScalar<9>, ::Tags::TempScalar<10>, ::Tags::Tempaa<11, Dim>>>
+      buffer(num_pts);
+
+  // Naming: Interior stuff is *_int, exterior stuff is *_ext, *_jump
+  // is _ext - _int.  Other things are averages of the function
+  // arguments or things computed from such averages.
+  auto& spacetime_metric = get<::Tags::Tempaa<0, Dim>>(buffer);
+  tenex::evaluate<ti::a, ti::b>(make_not_null(&spacetime_metric),
+                                0.5 * (spacetime_metric_int(ti::a, ti::b) +
+                                       spacetime_metric_ext(ti::a, ti::b)));
+  auto& spatial_metric = get<::Tags::Tempii<1, Dim>>(buffer);
+  gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+  auto& inverse_spatial_metric = get<::Tags::TempII<2, Dim>>(buffer);
+  {
+    auto& determinant = get<::Tags::TempScalar<4>>(buffer);
+    determinant_and_inverse(make_not_null(&determinant),
+                            make_not_null(&inverse_spatial_metric),
+                            spatial_metric);
+  }
+  auto& shift = get<::Tags::TempI<3, Dim>>(buffer);
+  gr::shift(make_not_null(&shift), spacetime_metric, inverse_spatial_metric);
+  auto& lapse = get<::Tags::TempScalar<4>>(buffer);
+  gr::lapse(make_not_null(&lapse), shift, spacetime_metric);
+  auto& normal_covector = get<::Tags::Tempi<5, Dim>>(buffer);
+  // Sign flip to make neighbor value outgoing for us.
+  tenex::evaluate<ti::i>(make_not_null(&normal_covector),
+                         0.5 * (normal_int(ti::i) - normal_ext(ti::i)));
+  {
+    auto& inverse_magnitude = get<::Tags::TempScalar<6>>(buffer);
+    tenex::evaluate(make_not_null(&inverse_magnitude),
+                    1.0 / sqrt(normal_covector(ti::i) *
+                               inverse_spatial_metric(ti::I, ti::J) *
+                               normal_covector(ti::j)));
+    tenex::update<ti::i>(make_not_null(&normal_covector),
+                         inverse_magnitude() * normal_covector(ti::i));
+  }
+  auto& constraint_gamma2 = get<::Tags::TempScalar<6>>(buffer);
+  get(constraint_gamma2) =
+      0.5 * (get(constraint_gamma2_int) + get(constraint_gamma2_ext));
+
+  auto& incoming_char_speed_0 = get<::Tags::TempScalar<7>>(buffer);
+  tenex::evaluate(make_not_null(&incoming_char_speed_0),
+                  -normal_covector(ti::i) *
+                      (shift(ti::I) + 0.5 * (mesh_velocity_int(ti::I) +
+                                             mesh_velocity_ext(ti::I))));
+  auto& incoming_char_speed_plus = get<::Tags::TempScalar<8>>(buffer);
+  get(incoming_char_speed_plus) = get(incoming_char_speed_0) + get(lapse);
+  auto& incoming_char_speed_minus = get<::Tags::TempScalar<9>>(buffer);
+  get(incoming_char_speed_minus) = get(incoming_char_speed_0) - get(lapse);
+
+  // Zero out the outgoing (average) speeds
+  get(incoming_char_speed_0) *= step_function(-get(incoming_char_speed_0));
+  get(incoming_char_speed_plus) *=
+      step_function(-get(incoming_char_speed_plus));
+  get(incoming_char_speed_minus) *=
+      step_function(-get(incoming_char_speed_minus));
+
+  auto& incoming_char_speed_g = get<::Tags::TempScalar<10>>(buffer);
+  get(incoming_char_speed_g) =
+      (1.0 + 0.5 * (get(constraint_gamma1_int) + get(constraint_gamma1_ext))) *
+      get(incoming_char_speed_0);
+
+  // lapse no longer needed, but scoping it to here would be hard, so
+  // just have to be careful.
+  auto& incoming_char_speed_sym = lapse;
+  get(incoming_char_speed_sym) =
+      0.5 * (get(incoming_char_speed_plus) + get(incoming_char_speed_minus));
+  // _plus no longer needed except for computing _antisym, but again,
+  // just have to be careful.
+  auto& incoming_char_speed_antisym = incoming_char_speed_plus;
+  get(incoming_char_speed_antisym) -= get(incoming_char_speed_minus);
+  get(incoming_char_speed_antisym) *= 0.5;
+
+  // The correction to the spatial_metric is proportional to the jump,
+  // so store that here for convenience.
+  auto& spacetime_metric_jump = *boundary_correction_spacetime_metric;
+  tenex::evaluate<ti::a, ti::b>(
+      make_not_null(&spacetime_metric_jump),
+      spacetime_metric_ext(ti::a, ti::b) - spacetime_metric_int(ti::a, ti::b));
+
+  auto& pi_jump = get<::Tags::Tempaa<11, Dim>>(buffer);
+  tenex::evaluate<ti::a, ti::b>(make_not_null(&pi_jump),
+                                pi_ext(ti::a, ti::b) - pi_int(ti::a, ti::b));
+
+  // boundary_correction_phi holds phi_jump, briefly
+  tenex::evaluate<ti::i, ti::a, ti::b>(
+      boundary_correction_phi,
+      phi_ext(ti::i, ti::a, ti::b) - phi_int(ti::i, ti::a, ti::b));
+  // spacetime_metric no longer needed, but again, just have to be
+  // careful.
+  auto& normal_phi_jump = spacetime_metric;
+  tenex::evaluate<ti::a, ti::b>(
+      make_not_null(&normal_phi_jump),
+      normal_covector(ti::i) * inverse_spatial_metric(ti::I, ti::J) *
+          (*boundary_correction_phi)(ti::j, ti::a, ti::b));
+
+  tenex::update<ti::i, ti::a, ti::b>(
+      boundary_correction_phi,
+      incoming_char_speed_0() *
+              (*boundary_correction_phi)(ti::i, ti::a, ti::b) +
+          normal_covector(ti::i) *
+              ((incoming_char_speed_sym() - incoming_char_speed_0()) *
+                   normal_phi_jump(ti::a, ti::b) +
+               incoming_char_speed_antisym() *
+                   (pi_jump(ti::a, ti::b) -
+                    constraint_gamma2() *
+                        spacetime_metric_jump(ti::a, ti::b))));
+
+  tenex::evaluate<ti::a, ti::b>(
+      boundary_correction_pi,
+      (incoming_char_speed_g() - incoming_char_speed_sym()) *
+              constraint_gamma2() * spacetime_metric_jump(ti::a, ti::b) +
+          incoming_char_speed_sym() * pi_jump(ti::a, ti::b) +
+          incoming_char_speed_antisym() * normal_phi_jump(ti::a, ti::b));
+
+  // Recall that boundary_correction_spacetime_metric already holds the jump
+  tenex::update<ti::a, ti::b>(
+      boundary_correction_spacetime_metric,
+      incoming_char_speed_g() *
+          (*boundary_correction_spacetime_metric)(ti::a, ti::b));
+}
+
+template <size_t Dim>
+bool operator==(const AveragedUpwindPenalty<Dim>& /*lhs*/,
+                const AveragedUpwindPenalty<Dim>& /*rhs*/) {
+  return true;
+}
+
+template <size_t Dim>
+bool operator!=(const AveragedUpwindPenalty<Dim>& lhs,
+                const AveragedUpwindPenalty<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID AveragedUpwindPenalty<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                               \
+  template class AveragedUpwindPenalty<DIM(data)>;                           \
+  template bool operator==(const AveragedUpwindPenalty<DIM(data)>& /*lhs*/,  \
+                           const AveragedUpwindPenalty<DIM(data)>& /*rhs*/); \
+  template bool operator!=(const AveragedUpwindPenalty<DIM(data)>& /*lhs*/,  \
+                           const AveragedUpwindPenalty<DIM(data)>& /*rhs*/);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+}  // namespace gh::BoundaryCorrections

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/AveragedUpwindPenalty.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/AveragedUpwindPenalty.hpp
@@ -1,0 +1,202 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/BoundaryCorrection.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintDampingTags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace gh::BoundaryCorrections {
+/*!
+ * \brief Computes the generalized harmonic upwind multipenalty boundary
+ * correction using the averaged fields across the interface.
+ *
+ * The correction is given by
+ *
+ * \f{equation}{
+ *   D_\beta =
+ *   T^{-1}_{\beta\hat{\beta}}(u^{\text{avg}})
+ *   \Lambda^-_{\hat{\beta}\hat{\alpha}}(u^{\text{avg}})
+ *   T_{\hat{\alpha}\alpha}(u^{\text{avg}})
+ *   \Delta u_\alpha,
+ * \f}
+ *
+ * where $u_\alpha$ are the evolved fields, $\Lambda^-$ is the
+ * diagonal matrix of incoming characteristic speeds,
+ * $T_{\hat{\alpha}\alpha}$ transforms from evolved to characteristic
+ * fields, and $\Delta u_\alpha = u_\alpha^{\text{ext}} -
+ * u_\alpha^{\text{int}}$ is the discontinuity in the evolved fields.
+ * All factors except the boundary discontinuity are calculated using
+ * the averaged of the internal and external evolved fields:
+ *
+ * \f{equation}
+ *   u^{\text{avg}} = \frac{u^{\text{int}} + u^{\text{ext}}}{2}.
+ * \f}
+ *
+ * For the first-order generalized harmonic system the correction is:
+ *
+ * \f{align}{
+ *   D_{g_{ab}} &= \lambda_{v^g}^- \Delta g_{ab} \\
+ *   D_{\Pi_{ab}}
+ *     &= \left(\lambda_{v^g}^-
+ *              - \frac{\lambda_{v^+}^- + \lambda_{v^-}^-}{2}\right)
+ *       \gamma_2 \Delta g_{ab}
+ *     + \frac{\lambda_{v^+}^- + \lambda_{v^-}^-}{2} \Delta \Pi_{ab}
+ *     + \frac{\lambda_{v^+}^- - \lambda_{v^-}^-}{2} n^j \Delta \Phi_{jab} \\
+ *   D_{\Phi_{iab}}
+ *     &= \lambda_{v^0}^- (\delta_i^j - n_i n^j) \Delta \Phi_{jab}
+ *     + \frac{\lambda_{v^+}^- - \lambda_{v^-}^-}{2} n_i
+ *       (\Delta \Pi_{ab} - \gamma_2 \Delta g_{ab})
+ *     + \frac{\lambda_{v^+}^- + \lambda_{v^-}^-}{2} n_i n^j \Delta \Phi_{jab}.
+ * \f}
+ *
+ * In the above expressions, the outgoing face normal $n_i$ is
+ * normalized using the average metric from the two sides.  Quantities
+ * such as $\gamma_2$ that should analytically be the same on both
+ * sides of the interface are also averaged, as they can differ
+ * because of truncation errors during projection.
+ *
+ * The characteristic speeds are given by
+ *
+ * \f{align}{
+ *   \lambda_{v^g} &= - (1 + \gamma_1) (\beta^i + v^i_g) n_i, \\
+ *   \lambda_{v^0} &= - (\beta^i + v^i_g) n_i, \\
+ *   \lambda_{v^\pm} &= \pm \alpha - (\beta^i + v^i_g) n_i,
+ * \f}
+ *
+ * where \f$v_g^i\f$ is the mesh velocity, with the incoming speeds
+ *
+ * \f{equation}{
+ *   \lambda^-_{\hat{\alpha}} =
+ *     \begin{cases}
+ *       \lambda_{\hat{\alpha}} & \lambda_{\hat{\alpha}} < 0 \\
+ *       0 & \text{otherwise.}
+ *     \end{cases}
+ * \f}
+ */
+template <size_t Dim>
+class AveragedUpwindPenalty final : public evolution::BoundaryCorrection {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help = {
+      "Computes the upwind penalty boundary correction term for the "
+      "generalized harmonic system using the averaged fields from the two "
+      "sides of the interface."};
+
+  AveragedUpwindPenalty() = default;
+  AveragedUpwindPenalty(const AveragedUpwindPenalty&) = default;
+  AveragedUpwindPenalty& operator=(const AveragedUpwindPenalty&) = default;
+  AveragedUpwindPenalty(AveragedUpwindPenalty&&) = default;
+  AveragedUpwindPenalty& operator=(AveragedUpwindPenalty&&) = default;
+  ~AveragedUpwindPenalty() override = default;
+
+  /// \cond
+  explicit AveragedUpwindPenalty(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(AveragedUpwindPenalty);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const override;
+
+  struct MeshVelocity : db::SimpleTag {
+    using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+  };
+
+  using dg_package_field_tags =
+      tmpl::list<gr::Tags::SpacetimeMetric<DataVector, Dim>,
+                 gh::Tags::Pi<DataVector, Dim>, gh::Tags::Phi<DataVector, Dim>,
+                 gh::Tags::ConstraintGamma1, gh::Tags::ConstraintGamma2,
+                 domain::Tags::UnnormalizedFaceNormal<Dim>, MeshVelocity>;
+  // We don't need lapse and shift, but this list must be exactly this
+  // or the boundary condition code doesn't compile.
+  using dg_package_data_temporary_tags =
+      tmpl::list<gh::Tags::ConstraintGamma1, gh::Tags::ConstraintGamma2,
+                 gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, Dim>>;
+  using dg_package_data_primitive_tags = tmpl::list<>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+  using dg_boundary_terms_volume_tags = tmpl::list<>;
+
+  double dg_package_data(
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+          packaged_spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*> packaged_pi,
+      gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*> packaged_phi,
+      gsl::not_null<Scalar<DataVector>*> packaged_constraint_gamma1,
+      gsl::not_null<Scalar<DataVector>*> packaged_constraint_gamma2,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> packaged_normal,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          packaged_mesh_velocity,
+
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi,
+      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi,
+
+      const Scalar<DataVector>& constraint_gamma1,
+      const Scalar<DataVector>& constraint_gamma2,
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, Dim>& shift,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const;
+
+  void dg_boundary_terms(
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+          boundary_correction_spacetime_metric,
+      gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
+          boundary_correction_pi,
+      gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
+          boundary_correction_phi,
+
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric_int,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi_int,
+      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi_int,
+      const Scalar<DataVector>& constraint_gamma1_int,
+      const Scalar<DataVector>& constraint_gamma2_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_int,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& mesh_velocity_int,
+
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& spacetime_metric_ext,
+      const tnsr::aa<DataVector, Dim, Frame::Inertial>& pi_ext,
+      const tnsr::iaa<DataVector, Dim, Frame::Inertial>& phi_ext,
+      const Scalar<DataVector>& constraint_gamma1_ext,
+      const Scalar<DataVector>& constraint_gamma2_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_ext,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& mesh_velocity_ext,
+
+      dg::Formulation dg_formulation) const;
+};
+
+template <size_t Dim>
+bool operator==(const AveragedUpwindPenalty<Dim>& lhs,
+                const AveragedUpwindPenalty<Dim>& rhs);
+template <size_t Dim>
+bool operator!=(const AveragedUpwindPenalty<Dim>& lhs,
+                const AveragedUpwindPenalty<Dim>& rhs);
+}  // namespace gh::BoundaryCorrections

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  AveragedUpwindPenalty.cpp
   UpwindPenalty.cpp
   )
 
@@ -11,6 +12,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  AveragedUpwindPenalty.hpp
   Factory.hpp
   NamespaceDocs.hpp
   UpwindPenalty.hpp

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Factory.hpp
@@ -5,10 +5,12 @@
 
 #include <cstddef>
 
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/AveragedUpwindPenalty.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace gh::BoundaryCorrections {
 template <size_t Dim>
-using standard_boundary_corrections = tmpl::list<UpwindPenalty<Dim>>;
+using standard_boundary_corrections =
+    tmpl::list<AveragedUpwindPenalty<Dim>, UpwindPenalty<Dim>>;
 }  // namespace gh::BoundaryCorrections

--- a/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryCorrections/ProductOfCorrections.hpp
@@ -32,27 +32,56 @@ namespace ScalarTensor::BoundaryCorrections {
  * defined separately.
  * \see gh::BoundaryCorrections and CurvedScalarWave::BoundaryCorrections.
  */
-template <typename DerivedGhCorrection, typename DerivedScalarCorrection>
-class ProductOfCorrections final : public evolution::BoundaryCorrection {
+/// @{
+template <
+    typename DerivedGhCorrection, typename DerivedScalarCorrection,
+    typename = typename DerivedGhCorrection::dg_package_field_tags,
+    typename = typename DerivedScalarCorrection::dg_package_field_tags,
+    typename = typename DerivedGhCorrection::dg_package_data_temporary_tags,
+    typename = typename DerivedScalarCorrection::dg_package_data_temporary_tags,
+    typename = typename DerivedGhCorrection::dg_package_data_volume_tags,
+    typename = typename DerivedScalarCorrection::dg_package_data_volume_tags,
+    typename = typename DerivedGhCorrection::dg_boundary_terms_volume_tags,
+    typename = typename DerivedScalarCorrection::dg_boundary_terms_volume_tags>
+class ProductOfCorrections;
+
+template <typename DerivedGhCorrection, typename DerivedScalarCorrection,
+          typename... GhDgPackagedFieldTags,
+          typename... ScalarDgPackagedFieldTags,
+          typename... GhDgPackageDataTemporaryTags,
+          typename... ScalarDgPackageDataTemporaryTags,
+          typename... GhDgPackageDataVolumeTags,
+          typename... ScalarDgPackageDataVolumeTags,
+          typename... GhDgBoundaryTermsVolumeTags,
+          typename... ScalarDgBoundaryTermsVolumeTags>
+class ProductOfCorrections<DerivedGhCorrection, DerivedScalarCorrection,
+                           tmpl::list<GhDgPackagedFieldTags...>,
+                           tmpl::list<ScalarDgPackagedFieldTags...>,
+                           tmpl::list<GhDgPackageDataTemporaryTags...>,
+                           tmpl::list<ScalarDgPackageDataTemporaryTags...>,
+                           tmpl::list<GhDgPackageDataVolumeTags...>,
+                           tmpl::list<ScalarDgPackageDataVolumeTags...>,
+                           tmpl::list<GhDgBoundaryTermsVolumeTags...>,
+                           tmpl::list<ScalarDgBoundaryTermsVolumeTags...>>
+    final : public evolution::BoundaryCorrection {
  public:
   static constexpr size_t dim = 3;
   using dg_package_field_tags =
-      tmpl::append<typename DerivedGhCorrection::dg_package_field_tags,
-                   typename DerivedScalarCorrection::dg_package_field_tags>;
+      tmpl::list<GhDgPackagedFieldTags..., ScalarDgPackagedFieldTags...>;
 
-  using dg_package_data_temporary_tags = tmpl::remove_duplicates<tmpl::append<
-      typename DerivedGhCorrection::dg_package_data_temporary_tags,
-      typename DerivedScalarCorrection::dg_package_data_temporary_tags>>;
+  using dg_package_data_temporary_tags =
+      tmpl::list<GhDgPackageDataTemporaryTags...,
+                 ScalarDgPackageDataTemporaryTags...>;
 
   using dg_package_data_primitive_tags = tmpl::list<>;
 
-  using dg_package_data_volume_tags = tmpl::append<
-      typename DerivedGhCorrection::dg_package_data_volume_tags,
-      typename DerivedScalarCorrection::dg_package_data_volume_tags>;
+  using dg_package_data_volume_tags =
+      tmpl::list<GhDgPackageDataVolumeTags...,
+                 ScalarDgPackageDataVolumeTags...>;
 
-  using dg_boundary_terms_volume_tags = tmpl::append<
-      typename DerivedGhCorrection::dg_boundary_terms_volume_tags,
-      typename DerivedScalarCorrection::dg_boundary_terms_volume_tags>;
+  using dg_boundary_terms_volume_tags =
+      tmpl::list<GhDgBoundaryTermsVolumeTags...,
+                 ScalarDgBoundaryTermsVolumeTags...>;
 
   static std::string name() {
     return "Product" + pretty_type::name<DerivedGhCorrection>() + "GH" + "And" +
@@ -78,7 +107,7 @@ class ProductOfCorrections final : public evolution::BoundaryCorrection {
     }
     static constexpr Options::String help{
         "The scalar part of the product boundary condition"};
-    };
+  };
 
   using options = tmpl::list<GhCorrection, ScalarCorrection>;
 
@@ -115,34 +144,10 @@ class ProductOfCorrections final : public evolution::BoundaryCorrection {
   }
 
   double dg_package_data(
-      // GH packaged fields
-      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speed_v_spacetime_metric,
-      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speed_v_zero,
-      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speed_v_plus,
-      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speed_v_minus,
-      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speed_n_times_v_plus,
-      const gsl::not_null<tnsr::iaa<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speed_n_times_v_minus,
-      const gsl::not_null<tnsr::aa<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speed_gamma2_v_spacetime_metric,
-      const gsl::not_null<tnsr::a<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speeds,
-      // Scalar packaged fields
-      const gsl::not_null<Scalar<DataVector>*> packaged_v_psi_scalar,
-      const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
-          packaged_v_zero_scalar,
-      const gsl::not_null<Scalar<DataVector>*> packaged_v_plus_scalar,
-      const gsl::not_null<Scalar<DataVector>*> packaged_v_minus_scalar,
-      const gsl::not_null<Scalar<DataVector>*> packaged_gamma2_scalar,
-      const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
-          packaged_interface_unit_normal_scalar,
-      const gsl::not_null<tnsr::a<DataVector, dim, Frame::Inertial>*>
-          packaged_char_speeds_scalar,
+      const gsl::not_null<
+          typename GhDgPackagedFieldTags::type*>... gh_packaged_fields,
+      const gsl::not_null<
+          typename ScalarDgPackagedFieldTags::type*>... scalar_packaged_fields,
       // GH variables
       const tnsr::aa<DataVector, dim, Frame::Inertial>& spacetime_metric,
       const tnsr::aa<DataVector, dim, Frame::Inertial>& pi,
@@ -150,54 +155,31 @@ class ProductOfCorrections final : public evolution::BoundaryCorrection {
       // Scalar variables
       const Scalar<DataVector>& psi_scalar, const Scalar<DataVector>& pi_scalar,
       const tnsr::i<DataVector, dim, Frame::Inertial>& phi_scalar,
-      // GH fluxes
-      // Scalar fluxes
-      // GH temporaries
-      const Scalar<DataVector>& constraint_gamma1,
-      const Scalar<DataVector>& constraint_gamma2,
-      const Scalar<DataVector>& lapse,
-      const tnsr::I<DataVector, dim, Frame::Inertial>& shift,
-      // Scalar temporaries
-
-      const Scalar<DataVector>& constraint_gamma1_scalar,
-      const Scalar<DataVector>& constraint_gamma2_scalar,
+      // Temporaries
+      const typename GhDgPackageDataTemporaryTags::type&... gh_temporaries,
+      const typename ScalarDgPackageDataTemporaryTags::
+          type&... scalar_temporaries,
       // Mesh variables
       const tnsr::i<DataVector, dim, Frame::Inertial>& normal_covector,
       const tnsr::I<DataVector, dim, Frame::Inertial>& normal_vector,
       const std::optional<tnsr::I<DataVector, dim, Frame::Inertial>>&
           mesh_velocity,
-      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity
-      // GH volume quantities
-      // Scalar volume quantities
-  ) const {
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+      // Volume quantities
+      const typename GhDgPackageDataVolumeTags::type&... gh_volume_quantities,
+      const typename ScalarDgPackageDataVolumeTags::
+          type&... scalar_volume_quantities) const {
     const double gh_correction_result = derived_gh_correction_.dg_package_data(
-        // GH packaged variables
-        packaged_char_speed_v_spacetime_metric, packaged_char_speed_v_zero,
-        packaged_char_speed_v_plus, packaged_char_speed_v_minus,
-        packaged_char_speed_n_times_v_plus, packaged_char_speed_n_times_v_minus,
-        packaged_char_speed_gamma2_v_spacetime_metric, packaged_char_speeds,
-        // GH variables
-        spacetime_metric, pi, phi,
-        // GH temporaries
-        constraint_gamma1, constraint_gamma2, lapse, shift,
-        // GH mesh variables
-        normal_covector, normal_vector, mesh_velocity,
-        normal_dot_mesh_velocity);
+        gh_packaged_fields..., spacetime_metric, pi, phi, gh_temporaries...,
+        normal_covector, normal_vector, mesh_velocity, normal_dot_mesh_velocity,
+        gh_volume_quantities...);
 
     const double scalar_correction_result =
         derived_scalar_correction_.dg_package_data(
-            // Scalar packaged variables
-            packaged_v_psi_scalar, packaged_v_zero_scalar,
-            packaged_v_plus_scalar, packaged_v_minus_scalar,
-            packaged_gamma2_scalar, packaged_interface_unit_normal_scalar,
-            packaged_char_speeds_scalar,
-            // Scalar variables
-            psi_scalar, pi_scalar, phi_scalar,
-            // Scalar temporaries
-            lapse, shift, constraint_gamma1_scalar, constraint_gamma2_scalar,
-            // Scalar mesh variables
-            normal_covector, normal_vector, mesh_velocity,
-            normal_dot_mesh_velocity);
+            scalar_packaged_fields..., psi_scalar, pi_scalar, phi_scalar,
+            scalar_temporaries..., normal_covector, normal_vector,
+            mesh_velocity, normal_dot_mesh_velocity,
+            scalar_volume_quantities...);
     return std::max(gh_correction_result, scalar_correction_result);
   }
 
@@ -214,80 +196,24 @@ class ProductOfCorrections final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> pi_boundary_correction_scalar,
       const gsl::not_null<tnsr::i<DataVector, dim, Frame::Inertial>*>
           phi_boundary_correction_scalar,
-      // GH internal packages field tags
-      const tnsr::aa<DataVector, dim, Frame::Inertial>&
-          char_speed_v_spacetime_metric_int,
-      const tnsr::iaa<DataVector, dim, Frame::Inertial>& char_speed_v_zero_int,
-      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_plus_int,
-      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_minus_int,
-      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
-          char_speed_normal_times_v_plus_int,
-      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
-          char_speed_normal_times_v_minus_int,
-      const tnsr::aa<DataVector, dim, Frame::Inertial>&
-          char_speed_constraint_gamma2_v_spacetime_metric_int,
-      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_int,
-      // Scalar internal packaged field tags
-      const Scalar<DataVector>& v_psi_int_scalar,
-      const tnsr::i<DataVector, dim, Frame::Inertial>& v_zero_int_scalar,
-      const Scalar<DataVector>& v_plus_int_scalar,
-      const Scalar<DataVector>& v_minus_int_scalar,
-      const Scalar<DataVector>& gamma2_int_scalar,
-      const tnsr::i<DataVector, dim, Frame::Inertial>&
-          interface_unit_normal_int_scalar,
-      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_int_scalar,
-      // GH external packaged fields
-      const tnsr::aa<DataVector, dim, Frame::Inertial>&
-          char_speed_v_spacetime_metric_ext,
-      const tnsr::iaa<DataVector, dim, Frame::Inertial>& char_speed_v_zero_ext,
-      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_plus_ext,
-      const tnsr::aa<DataVector, dim, Frame::Inertial>& char_speed_v_minus_ext,
-      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
-          char_speed_normal_times_v_plus_ext,
-      const tnsr::iaa<DataVector, dim, Frame::Inertial>&
-          char_speed_normal_times_v_minus_ext,
-      const tnsr::aa<DataVector, dim, Frame::Inertial>&
-          char_speed_constraint_gamma2_v_spacetime_metric_ext,
-      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_ext,
-      // Scalar external packaged fields
-      const Scalar<DataVector>& v_psi_ext_scalar,
-      const tnsr::i<DataVector, dim, Frame::Inertial>& v_zero_ext_scalar,
-      const Scalar<DataVector>& v_plus_ext_scalar,
-      const Scalar<DataVector>& v_minus_ext_scalar,
-      const Scalar<DataVector>& gamma2_ext_scalar,
-      const tnsr::i<DataVector, dim, Frame::Inertial>&
-          interface_unit_normal_ext_scalar,
-      const tnsr::a<DataVector, dim, Frame::Inertial>& char_speeds_ext_scalar,
+      // Packaged fields
+      const typename GhDgPackagedFieldTags::type&... gh_packaged_fields_int,
+      const typename ScalarDgPackagedFieldTags::
+          type&... scalar_packaged_fields_int,
+      const typename GhDgPackagedFieldTags::type&... gh_packaged_fields_ext,
+      const typename ScalarDgPackagedFieldTags::
+          type&... scalar_packaged_fields_ext,
       // DG formulation
       const dg::Formulation dg_formulation) const {
     derived_gh_correction_.dg_boundary_terms(
-        // GH boundary corrections
         boundary_correction_spacetime_metric, boundary_correction_pi,
-        boundary_correction_phi,
-        // GH internal packaged fields
-        char_speed_v_spacetime_metric_int, char_speed_v_zero_int,
-        char_speed_v_plus_int, char_speed_v_minus_int,
-        char_speed_normal_times_v_plus_int, char_speed_normal_times_v_minus_int,
-        char_speed_constraint_gamma2_v_spacetime_metric_int, char_speeds_int,
-        // GH external packaged fields
-        char_speed_v_spacetime_metric_ext, char_speed_v_zero_ext,
-        char_speed_v_plus_ext, char_speed_v_minus_ext,
-        char_speed_normal_times_v_plus_ext, char_speed_normal_times_v_minus_ext,
-        char_speed_constraint_gamma2_v_spacetime_metric_ext, char_speeds_ext,
-        dg_formulation);
+        boundary_correction_phi, gh_packaged_fields_int...,
+        gh_packaged_fields_ext..., dg_formulation);
 
     derived_scalar_correction_.dg_boundary_terms(
-        // Scalar boundary corrections
         psi_boundary_correction_scalar, pi_boundary_correction_scalar,
-        phi_boundary_correction_scalar,
-        // Scalar internal packaged fields
-        v_psi_int_scalar, v_zero_int_scalar, v_plus_int_scalar,
-        v_minus_int_scalar, gamma2_int_scalar, interface_unit_normal_int_scalar,
-        char_speeds_int_scalar,
-        // Scalar external packaged fields
-        v_psi_ext_scalar, v_zero_ext_scalar, v_plus_ext_scalar,
-        v_minus_ext_scalar, gamma2_ext_scalar, interface_unit_normal_ext_scalar,
-        char_speeds_ext_scalar, dg_formulation);
+        phi_boundary_correction_scalar, scalar_packaged_fields_int...,
+        scalar_packaged_fields_ext..., dg_formulation);
   }
 
   const DerivedGhCorrection& gh_correction() const {
@@ -302,11 +228,27 @@ class ProductOfCorrections final : public evolution::BoundaryCorrection {
   DerivedGhCorrection derived_gh_correction_;
   DerivedScalarCorrection derived_scalar_correction_;
 };
+/// @}
 
 /// \cond
-template <typename DerivedGhCorrection, typename DerivedScalarCorrection>
-PUP::able::PUP_ID ProductOfCorrections<DerivedGhCorrection,
-                                       DerivedScalarCorrection>::my_PUP_ID =
-    0;  // NOLINT
+template <typename DerivedGhCorrection, typename DerivedScalarCorrection,
+          typename... GhDgPackagedFieldTags,
+          typename... ScalarDgPackagedFieldTags,
+          typename... GhDgPackageDataTemporaryTags,
+          typename... ScalarDgPackageDataTemporaryTags,
+          typename... GhDgPackageDataVolumeTags,
+          typename... ScalarDgPackageDataVolumeTags,
+          typename... GhDgBoundaryTermsVolumeTags,
+          typename... ScalarDgBoundaryTermsVolumeTags>
+PUP::able::PUP_ID ProductOfCorrections<
+    DerivedGhCorrection, DerivedScalarCorrection,
+    tmpl::list<GhDgPackagedFieldTags...>,
+    tmpl::list<ScalarDgPackagedFieldTags...>,
+    tmpl::list<GhDgPackageDataTemporaryTags...>,
+    tmpl::list<ScalarDgPackageDataTemporaryTags...>,
+    tmpl::list<GhDgPackageDataVolumeTags...>,
+    tmpl::list<ScalarDgPackageDataVolumeTags...>,
+    tmpl::list<GhDgBoundaryTermsVolumeTags...>,
+    tmpl::list<ScalarDgBoundaryTermsVolumeTags...>>::my_PUP_ID = 0;  // NOLINT
 /// \endcond
 }  // namespace ScalarTensor::BoundaryCorrections

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -282,7 +282,7 @@ Filtering:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    UpwindPenalty:
+    AveragedUpwindPenalty:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -164,7 +164,7 @@ Filtering:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    UpwindPenalty:
+    AveragedUpwindPenalty:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -188,7 +188,7 @@ PhaseChangeAndTriggers:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    UpwindPenalty:
+    AveragedUpwindPenalty:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -109,7 +109,7 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: Gauss
   BoundaryCorrection:
-    UpwindPenalty:
+    AveragedUpwindPenalty:
 
 EventsAndTriggersAtSlabs:
   - Trigger:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -101,7 +101,7 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
   BoundaryCorrection:
-    UpwindPenalty:
+    AveragedUpwindPenalty:
 
 EventsAndTriggersAtSlabs:
   - Trigger:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -137,7 +137,7 @@ Filtering:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    UpwindPenalty:
+    AveragedUpwindPenalty:
   DiscontinuousGalerkin:
     Formulation: StrongInertial
     Quadrature: GaussLobatto

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -216,8 +216,8 @@ EvolutionSystem:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    ProductUpwindPenaltyAndHll:
-      UpwindPenalty:
+    ProductAveragedUpwindPenaltyAndHll:
+      AveragedUpwindPenalty:
       Hll:
         MagneticFieldMagnitudeForHydro: 1.0e-16
         LightSpeedDensityCutoff: 1.0e-8

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -139,8 +139,8 @@ EvolutionSystem:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    ProductUpwindPenaltyAndHll:
-      UpwindPenalty:
+    ProductAveragedUpwindPenaltyAndHll:
+      AveragedUpwindPenalty:
       Hll:
         MagneticFieldMagnitudeForHydro: 1.0e-16
         LightSpeedDensityCutoff: 1.0e-8

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -142,8 +142,8 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
   BoundaryCorrection:
-    ProductUpwindPenaltyAndRusanov:
-      UpwindPenalty:
+    ProductAveragedUpwindPenaltyAndRusanov:
+      AveragedUpwindPenalty:
       Rusanov:
 
 EventsAndTriggersAtSlabs:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -138,8 +138,8 @@ EvolutionSystem:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    ProductUpwindPenaltyAndRusanov:
-      UpwindPenalty:
+    ProductAveragedUpwindPenaltyAndRusanov:
+      AveragedUpwindPenalty:
       Rusanov:
   DiscontinuousGalerkin:
     Formulation: StrongInertial

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -132,8 +132,8 @@ Filtering:
 
 SpatialDiscretization:
   BoundaryCorrection:
-    ProductUpwindPenaltyGHAndUpwindPenaltyScalar:
-      UpwindPenaltyGH:
+    ProductAveragedUpwindPenaltyGHAndUpwindPenaltyScalar:
+      AveragedUpwindPenaltyGH:
       UpwindPenaltyScalar:
   DiscontinuousGalerkin:
     Formulation: StrongInertial

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_AveragedUpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_AveragedUpwindPenalty.cpp
@@ -1,0 +1,296 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <random>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ExtractPoint.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/AveragedUpwindPenalty.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintDampingTags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <size_t Dim>
+using gh_tags =
+    tmpl::list<gr::Tags::SpacetimeMetric<DataVector, Dim>,
+               gh::Tags::Pi<DataVector, Dim>, gh::Tags::Phi<DataVector, Dim>>;
+template <size_t Dim>
+using GhVars = Variables<gh_tags<Dim>>;
+
+template <size_t Dim>
+struct MeshVelocity : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
+};
+
+template <size_t Dim>
+using Args = Variables<tmpl::push_back<
+    gh_tags<Dim>, gh::Tags::ConstraintGamma1, gh::Tags::ConstraintGamma2,
+    domain::Tags::UnnormalizedFaceNormal<Dim>, MeshVelocity<Dim>>>;
+
+template <size_t Dim, typename Correction>
+Variables<typename Correction::dg_package_field_tags> call_dg_package_data(
+    const Correction& correction, const Args<Dim>& args,
+    const bool include_mesh_velocity) {
+  const Scalar<DataVector> unused_lapse{};
+  const tnsr::I<DataVector, Dim> unused_shift{};
+  const tnsr::I<DataVector, Dim> unused_normal_vector{};
+  const Scalar<DataVector> unused_normal_dot_mesh_velocity{};
+
+  Variables<typename Correction::dg_package_field_tags> packaged_data{
+      args.number_of_grid_points()};
+  tmpl::as_pack<typename Correction::dg_package_field_tags>(
+      [&]<typename... DgPackageFieldTags>(
+          tmpl::type_<DgPackageFieldTags>... /*meta*/) {
+        correction.dg_package_data(
+            make_not_null(&get<DgPackageFieldTags>(packaged_data))...,
+            get<gr::Tags::SpacetimeMetric<DataVector, Dim>>(args),
+            get<gh::Tags::Pi<DataVector, Dim>>(args),
+            get<gh::Tags::Phi<DataVector, Dim>>(args),
+            get<gh::Tags::ConstraintGamma1>(args),
+            get<gh::Tags::ConstraintGamma2>(args), unused_lapse, unused_shift,
+            get<domain::Tags::UnnormalizedFaceNormal<Dim>>(args),
+            unused_normal_vector,
+            include_mesh_velocity ? std::optional{get<MeshVelocity<Dim>>(args)}
+                                  : std::nullopt,
+            include_mesh_velocity
+                ? std::optional{unused_normal_dot_mesh_velocity}
+                : std::nullopt);
+      });
+  return packaged_data;
+}
+
+template <size_t Dim, typename Correction>
+GhVars<Dim> call_dg_boundary_terms(
+    const Correction& correction,
+    const Variables<typename Correction::dg_package_field_tags>& packaged_int,
+    const Variables<typename Correction::dg_package_field_tags>& packaged_ext) {
+  GhVars<Dim> boundary_terms{packaged_int.number_of_grid_points()};
+  tmpl::as_pack<gh_tags<Dim>>(
+      [&]<typename... GhVarTags>(tmpl::type_<GhVarTags>... /*meta*/) {
+        tmpl::as_pack<typename Correction::dg_package_field_tags>(
+            [&]<typename... DgPackageFieldTags>(
+                tmpl::type_<DgPackageFieldTags>... /*meta*/) {
+              correction.dg_boundary_terms(
+                  make_not_null(&get<GhVarTags>(boundary_terms))...,
+                  get<DgPackageFieldTags>(packaged_int)...,
+                  get<DgPackageFieldTags>(packaged_ext)...,
+                  dg::Formulation::StrongInertial);
+            });
+      });
+  return boundary_terms;
+}
+
+// Note: The exterior normal is negated before calling the correction
+template <size_t Dim>
+GhVars<Dim> boundary_correction(const Args<Dim>& interior, Args<Dim> exterior,
+                                const bool include_mesh_velocity = true) {
+  const gh::BoundaryCorrections::AveragedUpwindPenalty<Dim> correction{};
+
+  for (auto& component :
+       get<domain::Tags::UnnormalizedFaceNormal<Dim>>(exterior)) {
+    component *= -1.0;
+  }
+
+  const auto packaged_int =
+      call_dg_package_data<Dim>(correction, interior, include_mesh_velocity);
+  const auto packaged_ext =
+      call_dg_package_data<Dim>(correction, exterior, include_mesh_velocity);
+  return call_dg_boundary_terms<Dim>(correction, packaged_int, packaged_ext);
+}
+
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
+  register_classes_with_charm<
+      gh::BoundaryCorrections::AveragedUpwindPenalty<Dim>>();
+
+  CHECK(gh::BoundaryCorrections::AveragedUpwindPenalty<Dim>{} ==
+        gh::BoundaryCorrections::AveragedUpwindPenalty<Dim>{});
+  CHECK_FALSE(gh::BoundaryCorrections::AveragedUpwindPenalty<Dim>{} !=
+              gh::BoundaryCorrections::AveragedUpwindPenalty<Dim>{});
+
+  std::uniform_real_distribution dist(-0.1, 0.1);
+  std::uniform_real_distribution velocity_dist(-2.0, 2.0);
+  auto average_fields =
+      make_with_random_values<Args<Dim>>(gen, make_not_null(&dist), num_pts);
+  // Use a larger range for the mesh velocity so we get all sign
+  // combinations for the speeds.
+  fill_with_random_values(
+      make_not_null(&get<MeshVelocity<Dim>>(average_fields)), gen,
+      make_not_null(&velocity_dist));
+
+  // Make the metric reasonable
+  {
+    auto& metric =
+        get<gr::Tags::SpacetimeMetric<DataVector, Dim>>(average_fields);
+    get<0, 0>(metric) -= 1.0;
+    for (size_t i = 1; i <= Dim; ++i) {
+      metric.get(i, i) += 1.0;
+    }
+  }
+
+  const auto delta_fields =
+      make_with_random_values<Args<Dim>>(gen, make_not_null(&dist), num_pts);
+  const auto correction = boundary_correction<Dim>(
+      average_fields - delta_fields, average_fields + delta_fields);
+
+  // Check that the function at one point matches a single point
+  // calculation
+  {
+    const auto single_point_average =
+        extract_point(average_fields, num_pts / 2);
+    const auto single_point_delta = extract_point(delta_fields, num_pts / 2);
+    const auto single_point_correction =
+        boundary_correction<Dim>(single_point_average - single_point_delta,
+                                 single_point_average + single_point_delta);
+    CHECK_VARIABLES_APPROX(single_point_correction,
+                           extract_point(correction, num_pts / 2));
+  }
+
+  // Check that the solution is linear in the jump if the average is
+  // kept constant
+  {
+    const auto correction_minus4 =
+        boundary_correction<Dim>(average_fields + 4.0 * delta_fields,
+                                 average_fields - 4.0 * delta_fields);
+    CHECK_VARIABLES_APPROX(correction_minus4, -4.0 * correction);
+  }
+
+  // Check that zero mesh velocity gives the same result as a fixed mesh
+  {
+    auto zero_mesh_average = average_fields;
+    auto zero_mesh_delta = delta_fields;
+    for (auto& component : get<MeshVelocity<Dim>>(zero_mesh_average)) {
+      component = 0.0;
+    }
+    for (auto& component : get<MeshVelocity<Dim>>(zero_mesh_delta)) {
+      component = 0.0;
+    }
+
+    const auto zero_mesh_correction =
+        boundary_correction<Dim>(zero_mesh_average - zero_mesh_delta,
+                                 zero_mesh_average + zero_mesh_delta);
+    const auto fixed_mesh_correction = boundary_correction<Dim>(
+        average_fields - delta_fields, average_fields + delta_fields, false);
+    CHECK(zero_mesh_correction == fixed_mesh_correction);
+  }
+
+  // Actually perform the characteristic decomposition and compare to
+  // the result.
+  {
+    const auto& spacetime_metric =
+        get<gr::Tags::SpacetimeMetric<DataVector, Dim>>(average_fields);
+    const auto spatial_metric = gr::spatial_metric(spacetime_metric);
+    const auto inverse_spatial_metric =
+        determinant_and_inverse(spatial_metric).second;
+    const auto shift = gr::shift(spacetime_metric, inverse_spatial_metric);
+    const auto lapse = gr::lapse(shift, spacetime_metric);
+    // The evolved<->characteristic functions require a unit normal,
+    // but the boundary correction should do the normalization itself
+    // (since averaging the two sides doesn't preserve normalization).
+    auto unit_normal_one_form =
+        get<domain::Tags::UnnormalizedFaceNormal<Dim>>(average_fields);
+    const auto normal_magnitude =
+        magnitude(unit_normal_one_form, inverse_spatial_metric);
+    for (auto& component : unit_normal_one_form) {
+      component /= get(normal_magnitude);
+    }
+
+    auto speeds = gh::characteristic_speeds(
+        get<gh::Tags::ConstraintGamma1>(average_fields), lapse, shift,
+        unit_normal_one_form,
+        std::optional{get<MeshVelocity<Dim>>(average_fields)});
+    // Add mesh advection terms
+    const auto advection_speed =
+        tenex::evaluate(unit_normal_one_form(ti::i) *
+                        get<MeshVelocity<Dim>>(average_fields)(ti::I));
+    for (auto& speed : speeds) {
+      speed -= get(advection_speed);
+    }
+
+    using CharacteristicFields = Variables<
+        tmpl::list<gh::Tags::VSpacetimeMetric<DataVector, Dim, Frame::Inertial>,
+                   gh::Tags::VZero<DataVector, Dim, Frame::Inertial>,
+                   gh::Tags::VPlus<DataVector, Dim, Frame::Inertial>,
+                   gh::Tags::VMinus<DataVector, Dim, Frame::Inertial>>>;
+
+    // Factor of 2.0 comes from (avg + delta) - (avg - delta) = 2 delta
+    CharacteristicFields characteristic_correction =
+        2.0 * gh::characteristic_fields(
+                  get<gh::Tags::ConstraintGamma2>(average_fields),
+                  inverse_spatial_metric,
+                  get<gr::Tags::SpacetimeMetric<DataVector, Dim>>(delta_fields),
+                  get<gh::Tags::Pi<DataVector, Dim>>(delta_fields),
+                  get<gh::Tags::Phi<DataVector, Dim>>(delta_fields),
+                  unit_normal_one_form);
+    for (size_t p = 0; p < num_pts; ++p) {
+      for (auto& component :
+           get<gh::Tags::VSpacetimeMetric<DataVector, Dim, Frame::Inertial>>(
+               characteristic_correction)) {
+        component[p] *= speeds[0][p] < 0.0 ? speeds[0][p] : 0.0;
+      }
+      for (auto& component :
+           get<gh::Tags::VZero<DataVector, Dim, Frame::Inertial>>(
+               characteristic_correction)) {
+        component[p] *= speeds[1][p] < 0.0 ? speeds[1][p] : 0.0;
+      }
+      for (auto& component :
+           get<gh::Tags::VPlus<DataVector, Dim, Frame::Inertial>>(
+               characteristic_correction)) {
+        component[p] *= speeds[2][p] < 0.0 ? speeds[2][p] : 0.0;
+      }
+      for (auto& component :
+           get<gh::Tags::VMinus<DataVector, Dim, Frame::Inertial>>(
+               characteristic_correction)) {
+        component[p] *= speeds[3][p] < 0.0 ? speeds[3][p] : 0.0;
+      }
+    }
+
+    const auto expected_correction =
+        gh::evolved_fields_from_characteristic_fields(
+            get<gh::Tags::ConstraintGamma2>(average_fields),
+            get<gh::Tags::VSpacetimeMetric<DataVector, Dim, Frame::Inertial>>(
+                characteristic_correction),
+            get<gh::Tags::VZero<DataVector, Dim, Frame::Inertial>>(
+                characteristic_correction),
+            get<gh::Tags::VPlus<DataVector, Dim, Frame::Inertial>>(
+                characteristic_correction),
+            get<gh::Tags::VMinus<DataVector, Dim, Frame::Inertial>>(
+                characteristic_correction),
+            unit_normal_one_form);
+
+    CHECK_VARIABLES_APPROX(correction, expected_correction);
+  }
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.GeneralizedHarmonic.BoundaryCorrections.AveragedUpwindPenalty",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+
+  test<1>(make_not_null(&gen), 1);
+  test<2>(make_not_null(&gen), 5);
+  test<3>(make_not_null(&gen), 5);
+}
+}  // namespace

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_DirichletMinkowski.cpp
   BoundaryConditions/Test_Periodic.cpp
+  BoundaryCorrections/Test_AveragedUpwindPenalty.cpp
   BoundaryCorrections/Test_UpwindPenalty.cpp
   Test_Characteristics.cpp
   Test_Constraints.cpp

--- a/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryCorrections/Test_ProductOfCorrections.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryCorrections/Test_ProductOfCorrections.cpp
@@ -104,7 +104,8 @@ void test_boundary_correction_combination(
       typename derived_product_correction_type::dg_package_field_tags>;
 
   using temporary_variables_type = Variables<
-      typename derived_product_correction_type::dg_package_data_temporary_tags>;
+      tmpl::remove_duplicates<typename derived_product_correction_type::
+                                  dg_package_data_temporary_tags>>;
 
   using volume_variables_type = Variables<
       typename derived_product_correction_type::dg_package_data_volume_tags>;


### PR DESCRIPTION
## Proposed changes

This adds and enables by default a new GH boundary correction.  I haven't done extensive testing, but in a q=4 test basically every diagnostic I could measure was improved, and usually significantly improved.

![time_step](https://github.com/user-attachments/assets/24ca94fe-1423-408c-ac40-f4ea60dde919)

![speed](https://github.com/user-attachments/assets/027a3f1d-ddee-4173-b9a7-4acb6f0dfea8)
The vertical lines are a visualization artifact that occur at each restart.  I didn't remove them because that's actually useful information.  The new penalty cut about a day and a half off of what previously took just under a week.

![constraints](https://github.com/user-attachments/assets/02498c52-697d-4220-ac7a-d10f0131dd34)
The constraint violation for most of the run appears to be mostly in the inner cubes now, outside the spheres.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
