### PR TITLE
Update SetupLIBXSMM.cmake

### DIFF
--- a/cmake/SetupLIBXSMM.cmake
+++ b/cmake/SetupLIBXSMM.cmake
@@ -13,20 +13,23 @@ if (NOT LIBXSMM_FOUND)
   # This FetchContent code is adapted from the libxsmm docs:
   # https://libxsmm.readthedocs.io/en/latest/#rules-for-building-libxsmm
   include(FetchContent)
-  # Need an unreleased version for Apple Silicon chips
-  FetchContent_Declare(xsmm
-    GIT_REPOSITORY https://github.com/libxsmm/libxsmm.git
-    GIT_TAG 939f11042fc9ae4bbe975cedb2330d4f9f4bb26e
-    ${SPECTRE_FETCHCONTENT_BASE_ARGS}
-  )
+
   FetchContent_GetProperties(xsmm)
   if(NOT xsmm_POPULATED)
-    FetchContent_Populate(xsmm)
+    # Need an unreleased version to be compatible with newer glibc versions
+    FetchContent_Populate(xsmm
+      GIT_REPOSITORY https://github.com/libxsmm/libxsmm.git
+      GIT_TAG 10b7dc82b3c46157e76eb40e4e959555f895b24d
+      SUBBUILD_DIR ${CMAKE_BINARY_DIR}/_deps/xsmm-subbuild
+      SOURCE_DIR ${CMAKE_BINARY_DIR}/_deps/xsmm-src
+      BINARY_DIR ${CMAKE_BINARY_DIR}/_deps/xsmm-build
+    )
   endif()
 
   set(LIBXSMMROOT ${xsmm_SOURCE_DIR})
   file(GLOB _GLOB_XSMM_SRCS LIST_DIRECTORIES false CONFIGURE_DEPENDS ${LIBXSMMROOT}/src/*.c)
   list(REMOVE_ITEM _GLOB_XSMM_SRCS ${LIBXSMMROOT}/src/libxsmm_generator_gemm_driver.c)
+  list(REMOVE_ITEM _GLOB_XSMM_SRCS ${LIBXSMMROOT}/src/libxsmm_binaryexport_generator.c)
   set(XSMM_INCLUDE_DIRS ${LIBXSMMROOT}/include)
 
   add_library(xsmm STATIC ${_GLOB_XSMM_SRCS})


### PR DESCRIPTION
Newer glibc versions are incompatible with the current releases of xsmm. (At the moment 1.17)
(See here for the discussion: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1017469)

This means that builds with `SPECTRE_FETCH_MISSING_DEPS=ON` fail on systems with newer glibc.

## Proposed changes

SetupLIBXSMM.cmake is updated to use the currently newest development version of xsmm.

I also replaced the [deprecated](https://cmake.org/cmake/help/latest/policy/CMP0169.html) `FetchContent_Populate` form with the new one that also takes the job of `FetchContent_Declare`.

### Upgrade instructions

Cmake will reconfigure automatically on the next build.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
