### PR TITLE
Add multi-reader spinlock

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -47,6 +47,7 @@ spectre_target_headers(
   Local.hpp
   Main.hpp
   MaxInlineMethodsReached.hpp
+  MultiReaderSpinlock.hpp
   NodeLock.hpp
   OutputInbox.hpp
   ParallelComponentHelpers.hpp

--- a/src/Parallel/MultiReaderSpinlock.hpp
+++ b/src/Parallel/MultiReaderSpinlock.hpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <atomic>
+#include <limits>
+#include <new>  // for hardware_destructive_interference_size
+
+namespace Parallel {
+/*!
+ * \brief A two-state spinlock that allows multiple readers of a shared resource
+ * to acquire the lock simultaneously.
+ *
+ * A spinlock (i.e. a non-yielding lock) that can be used to guard a resource
+ * where multiple threads can safely perform some types of operations
+ * (e.g. reader entries from a container), while only one thread can safely
+ * perform other types of operations (e.g. modifying the container).
+ *
+ * ### Implementation
+ * We lock by using a `std::atomic<std::int64_t>` (a signed integer). The lock
+ * is not locked if the integer is `0`. It is read-locked if it is positive
+ * and write-locked if it is negative. To read-lock we first check that the
+ * integer is non-negative and then `fetch_add(1, std::memory_order_acq_rel)`,
+ * then check that the number _before_ the increment is non-negative. The
+ * reason for the second check is that between checking that the lock is not
+ * write-locked and the `fetch_add()` operation, it could be write-locked by
+ * another thread. To write-lock, we check that the integer is `0` and if so
+ * we set it to `std::numeric_limits<std::int64_t>::lowest()` (i.e. `-2^{63}`).
+ * We achieve this by using a `compare_exchange_strong()` with failure memory
+ * order `relaxed` and success memory order `acq_rel`. This guarantees that
+ * different threads synchronize using the lock.
+ *
+ * A thread read-unlocks the lock using a
+ * `fetch_sub(1, std::memory_order_acq_rel)` operation.
+ *
+ * A thread write-unlocks the lock using a `store(0, std::memory_order_release)`
+ * operation.
+ */
+class MultiReaderSpinlock {
+ public:
+  MultiReaderSpinlock() = default;
+  MultiReaderSpinlock(const MultiReaderSpinlock&) = delete;
+  MultiReaderSpinlock& operator=(const MultiReaderSpinlock&) = delete;
+  MultiReaderSpinlock(MultiReaderSpinlock&&) = delete;
+  MultiReaderSpinlock& operator=(MultiReaderSpinlock&&) = delete;
+  ~MultiReaderSpinlock() = default;
+
+  /// \brief Acquire the lock in a reader state.
+  ///
+  /// \note Multiple threads can acquire a reader state simultaneously.
+  void read_lock() noexcept {
+    for (;;) {
+      while (lock_.load(std::memory_order_relaxed) < 0) {
+      }
+
+      if (lock_.fetch_add(1, std::memory_order_acquire) > -1) {
+        return;
+      }
+    }
+  }
+
+  /// \brief Release the lock from a reader state.
+  ///
+  /// \note Since multiple threads can simultaneously acquire a reader state,
+  /// unlock from a single reader does not guarantee a writer can acquire the
+  /// lock in a write state.
+  void read_unlock() noexcept { lock_.fetch_sub(1, std::memory_order_release); }
+
+  /// \brief Acquire the lock in a writer state.
+  ///
+  /// Once acquired, no other thread can acquire the lock in either a read or
+  /// a write state until this thread unlocks it.
+  void write_lock() noexcept {
+    for (;;) {
+      std::int64_t current_value{0};
+      if (lock_.compare_exchange_strong(
+              current_value, std::numeric_limits<std::int64_t>::lowest(),
+              std::memory_order_acq_rel, std::memory_order_relaxed)) {
+        return;
+      }
+
+      while (lock_.load(std::memory_order_relaxed) != 0) {
+      }
+    }
+  }
+
+  /// \brief Release the lock from a reader state.
+  void write_unlock() noexcept { lock_.store(0, std::memory_order_release); }
+
+ private:
+#ifdef __cpp_lib_hardware_interference_size
+  static constexpr size_t cache_line_size_ =
+      std::hardware_destructive_interference_size;
+#else
+  static constexpr size_t cache_line_size_ = 64;
+#endif
+
+  alignas(cache_line_size_) std::atomic<std::int64_t> lock_{0};
+  // Ensure we pad the end to avoid false sharing. Unlikely to happen because
+  // of the layout, but better to be safe.
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+#endif
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  char padding_[cache_line_size_ - sizeof(std::atomic<std::int64_t>)] = {};
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+};
+}  // namespace Parallel

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -167,6 +167,7 @@ set(LIBRARY_SOURCES
   Test_GlobalCacheDataBox.cpp
   Test_InboxInserters.cpp
   Test_MemoryMonitor.cpp
+  Test_MultiReaderSpinlock.cpp
   Test_NodeLock.cpp
   Test_OutputInbox.cpp
   Test_Parallel.cpp

--- a/tests/Unit/Parallel/Test_MultiReaderSpinlock.cpp
+++ b/tests/Unit/Parallel/Test_MultiReaderSpinlock.cpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "Parallel/MultiReaderSpinlock.hpp"
+
+SPECTRE_TEST_CASE("Unit.Parallel.MultiReaderSpinlock", "[Parallel][Unit]") {
+  // It's very difficult to test a lock since they are designed to prevent race
+  // conditions (undefined behavior). We try to do the following just as a
+  // basic sanity check that attempts to make sure things "work"
+
+  Parallel::MultiReaderSpinlock mrsl{};
+  {
+    // Test two readers can lock at the same time
+    std::thread t0{[&mrsl]() {
+      mrsl.read_lock();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      mrsl.read_unlock();
+    }};
+    std::thread t1{[&mrsl]() {
+      const auto start = std::chrono::high_resolution_clock::now();
+      mrsl.read_lock();
+      const auto end = std::chrono::high_resolution_clock::now();
+      mrsl.read_unlock();
+      const std::chrono::duration<long, std::nano> diff{end - start};
+      // Verify it took less than 1 millisecond to lock and unlock the readlock.
+      // This is a lot less than the 10ms we sleep the other thread for, even in
+      // a debug build, and the lock should be acquired in about 1us in a debug
+      // build.
+      CHECK(diff.count() < 1000000);
+    }};
+    t0.join();
+    t1.join();
+  }
+  {
+    // Test that if a reader has a read-lock the writer cannot acquire a
+    // write-lock.
+    std::atomic<bool> locked{false};
+    std::thread t0{[&mrsl, &locked]() {
+      mrsl.read_lock();
+      locked.store(true, std::memory_order_release);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      mrsl.read_unlock();
+    }};
+    while (not locked.load(std::memory_order_acquire)) {
+    }
+    std::thread t1{[&mrsl]() {
+      const auto start = std::chrono::high_resolution_clock::now();
+      mrsl.write_lock();
+      const auto end = std::chrono::high_resolution_clock::now();
+      mrsl.write_unlock();
+      const std::chrono::duration<long, std::nano> diff{end - start};
+      // Verify it took more than 1ms to retrieve the lock.
+      CHECK(diff.count() > 1000000);
+    }};
+    t0.join();
+    t1.join();
+  }
+  {
+    // Test that if a writer has a write-lock another writer cannot acquire a
+    // write-lock.
+    std::atomic<bool> locked{false};
+    std::thread t0{[&mrsl, &locked]() {
+      mrsl.write_lock();
+      locked.store(true, std::memory_order_release);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      mrsl.write_unlock();
+    }};
+    while (not locked.load(std::memory_order_acquire)) {
+    }
+    std::thread t1{[&mrsl]() {
+      const auto start = std::chrono::high_resolution_clock::now();
+      mrsl.write_lock();
+      const auto end = std::chrono::high_resolution_clock::now();
+      mrsl.write_unlock();
+      const std::chrono::duration<long, std::nano> diff{end - start};
+      // Verify it took more than 1ms to retrieve the lock.
+      CHECK(diff.count() > 1000000);
+    }};
+    t0.join();
+    t1.join();
+  }
+  {
+    // Test that if a writer has a write-lock reader cannot acquire a
+    // read-lock.
+    std::atomic<bool> locked{false};
+    std::thread t0{[&mrsl, &locked]() {
+      mrsl.write_lock();
+      locked.store(true, std::memory_order_release);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      mrsl.write_unlock();
+    }};
+    while (not locked.load(std::memory_order_acquire)) {
+    }
+    std::thread t1{[&mrsl]() {
+      const auto start = std::chrono::high_resolution_clock::now();
+      mrsl.read_lock();
+      const auto end = std::chrono::high_resolution_clock::now();
+      mrsl.read_unlock();
+      const std::chrono::duration<long, std::nano> diff{end - start};
+      // Verify it took more than 1ms to retrieve the lock.
+      CHECK(diff.count() > 1000000);
+    }};
+    t0.join();
+    t1.join();
+  }
+}

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -635,6 +635,7 @@ standard_checks+=(enable_if)
 noexcept() {
     whitelist "$1" \
               "src/Utilities/StdHelpers/Bit.hpp" \
+              "src/Parallel/MultiReaderSpinlock.hpp$" \
               'src/Parallel/StaticSpscQueue.hpp' \
               "src/Parallel/NodeLock..pp$" \
               "src/Evolution/DiscontinuousGalerkin/\


### PR DESCRIPTION
## Proposed changes

Multi-reader spinlock:
- Allows multiple threads to acquire the lock in a "read" state where no data is changed.
- Allows a single thread to acquire the lock in a "write" state where data is changed. No threads can acquire the lock in a read or write state if one thread already has a write lock.

Lockfree unordered_set:
- Extremely minimal unordered set that is lock free. The reason it is minimal is in part it's unclear what other features we might need and that in order to maintain performance, we want to be extremely minimal.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
