### PR TITLE
Run events at checkpoints

### DIFF
--- a/src/Evolution/Actions/RunEventsAndTriggers.hpp
+++ b/src/Evolution/Actions/RunEventsAndTriggers.hpp
@@ -72,14 +72,10 @@ void run_events_and_triggers(db::DataBox<DbTags>& box,
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies: nothing
-template <bool LocalTimeStepping>
+template <Triggers::WhenToCheck WhenToCheck>
 struct RunEventsAndTriggers {
-  static constexpr bool local_time_stepping = LocalTimeStepping;
-  using const_global_cache_tags = tmpl::conditional_t<
-      local_time_stepping,
-      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
-                 ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSteps>>,
-      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::EventsAndTriggers<WhenToCheck>>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -94,22 +90,16 @@ struct RunEventsAndTriggers {
       return {Parallel::AlgorithmExecution::Continue, std::nullopt};
     }
 
-    if constexpr (local_time_stepping) {
-      const auto& events_and_triggers_at_steps = Parallel::get<
-          ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSteps>>(cache);
-      detail::run_events_and_triggers(box, cache, array_index, component,
-                                      events_and_triggers_at_steps,
-                                      time_step_id);
+    if constexpr (WhenToCheck != Triggers::WhenToCheck::AtSteps) {
+      if (not time_step_id.step_time().is_at_slab_boundary()) {
+        return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+      }
     }
 
-    if (not time_step_id.step_time().is_at_slab_boundary()) {
-      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
-    }
-
-    const auto& events_and_triggers_at_slabs = Parallel::get<
-        ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(cache);
+    const auto& events_and_triggers =
+        Parallel::get<::Tags::EventsAndTriggers<WhenToCheck>>(cache);
     detail::run_events_and_triggers(box, cache, array_index, component,
-                                    events_and_triggers_at_slabs, time_step_id);
+                                    events_and_triggers, time_step_id);
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -338,15 +338,26 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+
+          Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -316,11 +316,21 @@ struct EvolutionMetavars {
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -337,12 +337,22 @@ struct EvolutionMetavars {
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
+              tmpl::flatten<tmpl::list<
                   domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -264,16 +264,27 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+
+          Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<dg_step_actions, system>>,
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, dg_step_actions,
                   Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -638,6 +638,11 @@ struct EvolutionMetavars {
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
           Parallel::PhaseActions<Parallel::Phase::CheckDomain,
@@ -645,11 +650,16 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
+              tmpl::flatten<tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>,
+                  PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,
               tmpl::list<Actions::RunEventsOnFailure<::Tags::Time>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -73,16 +73,25 @@ struct EvolutionMetavars
           Parallel::PhaseActions<Parallel::Phase::Restart,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<Parallel::Phase::CheckDomain,
                                  tmpl::list<::amr::Actions::SendAmrDiagnostics,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<::evolution::Actions::RunEventsAndTriggers<
-                             local_time_stepping>,
-                         Actions::ChangeSlabSize, step_actions,
-                         Actions::AdvanceTime,
-                         PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  ::evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
+                  Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = gh_dg_element_array;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -259,16 +259,26 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
           Parallel::PhaseActions<Parallel::Phase::Restart,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<Parallel::Phase::CheckDomain,
                                  tmpl::list<::amr::Actions::SendAmrDiagnostics,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
+              tmpl::flatten<tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>,
+                  PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,
               tmpl::list<Actions::RunEventsOnFailure<::Tags::Time>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -916,8 +916,13 @@ struct GhValenciaDivCleanTemplateBase<
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
+              tmpl::flatten<tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
                   parameterized_deleptonization,
                   VariableFixing::Actions::FixVariables<
@@ -925,9 +930,14 @@ struct GhValenciaDivCleanTemplateBase<
                   VariableFixing::Actions::FixVariables<
                       VariableFixing::LimitLorentzFactor>,
                   Actions::UpdateConservatives,
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>,
+                  PhaseControl::Actions::ExecutePhaseChange>>>,
 
           tmpl::conditional_t<
               UseControlSystems,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -601,11 +601,22 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                               Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+
+          Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>,
+                  PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,
               tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -398,11 +398,22 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+
+          Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -263,13 +263,23 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<Parallel::Phase::Restart,
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -231,10 +231,16 @@ struct EvolutionMetavars {
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<
                   Actions::AdvanceTime,
-                  evolution::Actions::RunEventsAndTriggers<false>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   // Monte-Carlo is only triggered at the end of a full time
                   // step
                   Particles::MonteCarlo::Actions::TriggerMonteCarloEvolution,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -362,15 +362,26 @@ struct EvolutionMetavars {
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+
+          Parallel::PhaseActions<
               Parallel::Phase::InitializeTimeStepperHistory,
               SelfStart::self_start_procedure<step_actions, system>>,
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -271,12 +271,22 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+          Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
+              tmpl::flatten<tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>,
+                  PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,
               tmpl::list<Actions::RunEventsOnFailure<::Tags::Time>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -298,16 +298,27 @@ struct EvolutionMetavars {
                                  tmpl::list<dg_registration_list,
                                             Parallel::Actions::TerminatePhase>>,
 
+          Parallel::PhaseActions<
+              Parallel::Phase::WriteCheckpoint,
+              tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtCheckpoints>,
+                         Parallel::Actions::TerminatePhase>>,
+
           Parallel::PhaseActions<Parallel::Phase::CheckDomain,
                                  tmpl::list<::amr::Actions::SendAmrDiagnostics,
                                             Parallel::Actions::TerminatePhase>>,
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::list<
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
+              tmpl::flatten<tmpl::list<
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions, Actions::AdvanceTime,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -221,9 +221,15 @@ struct CharacteristicEvolution {
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
-      tmpl::conditional_t<evolve_ccm, tmpl::list<>,
-                          evolution::Actions::RunEventsAndTriggers<
-                              Metavariables::local_time_stepping>>,
+      tmpl::conditional_t<
+          evolve_ccm, tmpl::list<>,
+          tmpl::flatten<tmpl::list<
+              std::conditional_t<Metavariables::local_time_stepping,
+                                 evolution::Actions::RunEventsAndTriggers<
+                                     Triggers::WhenToCheck::AtSteps>,
+                                 tmpl::list<>>,
+              evolution::Actions::RunEventsAndTriggers<
+                  Triggers::WhenToCheck::AtSlabs>>>>,
       compute_scri_quantities_and_observe,
       ::Actions::TakeLtsStep<cce_system,
                              typename Metavariables::cce_step_choosers>,

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -124,9 +124,15 @@ struct KleinGordonCharacteristicEvolution
           typename Metavariables::cce_boundary_component,
           KleinGordonCharacteristicEvolution<Metavariables>>,
       ::Actions::Label<CceEvolutionLabelTag>,
-      tmpl::conditional_t<evolve_ccm, tmpl::list<>,
-                          evolution::Actions::RunEventsAndTriggers<
-                              Metavariables::local_time_stepping>>,
+      tmpl::conditional_t<
+          evolve_ccm, tmpl::list<>,
+          tmpl::flatten<tmpl::list<
+              std::conditional_t<Metavariables::local_time_stepping,
+                                 evolution::Actions::RunEventsAndTriggers<
+                                     Triggers::WhenToCheck::AtSteps>,
+                                 tmpl::list<>>,
+              evolution::Actions::RunEventsAndTriggers<
+                  Triggers::WhenToCheck::AtSlabs>>>>,
       Actions::ReceiveWorldtubeData<
           Metavariables,
           typename Metavariables::cce_boundary_communication_tags>,

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -361,11 +361,16 @@ struct Metavariables {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Execute,
-              tmpl::list<
+              tmpl::flatten<tmpl::list<
                   Actions::AdvanceTime, Actions::ExportCoordinates<Dim>,
                   Actions::FindGlobalMinimumGridSpacing,
-                  evolution::Actions::RunEventsAndTriggers<local_time_stepping>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>;
+                  std::conditional_t<local_time_stepping,
+                                     evolution::Actions::RunEventsAndTriggers<
+                                         Triggers::WhenToCheck::AtSteps>,
+                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSlabs>,
+                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;

--- a/src/IO/Observer/Actions/RegisterEvents.hpp
+++ b/src/IO/Observer/Actions/RegisterEvents.hpp
@@ -163,6 +163,15 @@ struct RegisterEventsWithObservers
       triggers_and_events.for_each_event(collect_observations);
     }
 
+    if constexpr (db::tag_is_retrievable_v<
+                      ::Tags::EventsAndTriggers<
+                          Triggers::WhenToCheck::AtCheckpoints>,
+                      db::DataBox<DbTagList>>) {
+      const auto& triggers_and_events = db::get<
+          ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtCheckpoints>>(box);
+      triggers_and_events.for_each_event(collect_observations);
+    }
+
     if constexpr (db::tag_is_retrievable_v<::Tags::EventsAndDenseTriggers,
                                            db::DataBox<DbTagList>>) {
       const auto& triggers_and_events =

--- a/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.cpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.cpp
@@ -20,6 +20,9 @@ std::ostream& operator<<(std::ostream& os, const WhenToCheck& when_to_check) {
     case WhenToCheck::AtSteps:
       os << "AtSteps";
       break;
+    case WhenToCheck::AtCheckpoints:
+      os << "AtCheckpoints";
+      break;
     default:
       ERROR("An unknown check was passed to the stream operator. "
             << static_cast<int>(when_to_check));

--- a/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp
+++ b/src/ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp
@@ -14,9 +14,10 @@ namespace Triggers {
 /// \ingroup EventsAndTriggersGroup
 /// \brief Frequency at which Events and Triggers are checked
 enum class WhenToCheck : uint8_t {
-  AtIterations, /**< checked at iterations e.g. of an elliptic solve */
-  AtSlabs,      /**< checked at time Slab boundaries */
-  AtSteps,      /**< checked at time step boundaries */
+  AtIterations,  /**< checked at iterations e.g. of an elliptic solve */
+  AtSlabs,       /**< checked at time Slab boundaries */
+  AtSteps,       /**< checked at time step boundaries */
+  AtCheckpoints, /**< checked at checkpoints */
 };
 
 /// Output operator for a WhenToCheck.

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -319,6 +319,20 @@ PhaseChangeAndTriggers:
       - CheckpointAndExitAfterWallclock:
           WallclockHours: 23.5
 
+EventsAndTriggersAtCheckpoints:
+  - Trigger: Always
+    Events:
+      - ObserveFields:
+          SubfileName: Checkpoints
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          BlocksToObserve: All
+
 EventsAndTriggersAtSlabs:
   # Observe time step and cheap constraints every slab
   - Trigger:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -197,6 +197,20 @@ PhaseChangeAndTriggers:
       - CheckpointAndExitAfterWallclock:
           WallclockHours: 23.5
 
+EventsAndTriggersAtCheckpoints:
+  - Trigger: Always
+    Events:
+      - ObserveFields:
+          SubfileName: Checkpoints
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          BlocksToObserve: All
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -70,6 +70,8 @@ SpatialDiscretization:
   SubcellSolver:
     Reconstructor: MonotonisedCentral
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger: Always
     Events:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -69,6 +69,8 @@ Filtering:
     Enable: false
     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -69,6 +69,8 @@ Filtering:
     Enable: false
     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -84,6 +84,8 @@ Filtering:
     Enable: false
     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -96,6 +96,8 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -72,6 +72,8 @@ Observers:
   VolumeFileName: "ForceFreeFastWaveVolume"
   ReductionFileName: "ForceFreeFastWaveReductions"
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -201,6 +201,8 @@ Filtering:
     BlocksToFilter: All
 
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -111,6 +111,8 @@ SpatialDiscretization:
   BoundaryCorrection:
     UpwindPenalty:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -103,6 +103,8 @@ SpatialDiscretization:
   BoundaryCorrection:
     UpwindPenalty:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -142,6 +142,8 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -270,6 +270,8 @@ Filtering:
     Enable: true
     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   # Set time step at t=0
   - Trigger:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -187,6 +187,8 @@ Filtering:
     Enable: true
     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -146,6 +146,8 @@ SpatialDiscretization:
       UpwindPenalty:
       Rusanov:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -185,6 +185,8 @@ Filtering:
     BlocksToFilter: All
 
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -138,6 +138,8 @@ Observers:
   VolumeFileName: "ValenciaDivCleanBlastWaveVolume"
   ReductionFileName: "ValenciaDivCleanBlastWaveReductions"
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -151,6 +151,8 @@ PrimitiveFromConservative:
   DensityWhenSkippingInversion: *MinimumD
   KastaunMaxLorentzFactor: 10.0
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -84,6 +84,8 @@ EvolutionSystem:
   SourceTerm:
     NoSource:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -87,6 +87,8 @@ EvolutionSystem:
   SourceTerm:
     NoSource:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -90,6 +90,8 @@ EvolutionSystem:
   SourceTerm:
     NoSource:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -65,6 +65,8 @@ Limiter:
     TvbConstant: 0.0
     DisableForDebugging: false
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -66,6 +66,8 @@ SpatialDiscretization:
 InitialData:
   Krivodonova:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -67,6 +67,8 @@ SpatialDiscretization:
 InitialData:
   Kuzmin:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -66,6 +66,8 @@ SpatialDiscretization:
 InitialData:
   Sinusoid:
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -139,6 +139,8 @@ SpatialDiscretization:
     Formulation: StrongInertial
     Quadrature: GaussLobatto
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       TimeCompares:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -54,6 +54,13 @@ PhaseChangeAndTriggers:
       - VisitAndReturn(EvaluateAmrCriteria)
       - VisitAndReturn(AdjustDomain)
       - VisitAndReturn(CheckDomain)
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 3
+          Offset: 0
+    PhaseChanges:
+      - VisitAndReturn(WriteCheckpoint)
 
 Evolution:
   InitialTime: 0.0
@@ -108,6 +115,17 @@ EventsAndTriggersAtSlabs:
           Values: [5]
     Events:
       - Completion
+
+EventsAndTriggersAtCheckpoints:
+  - Trigger: Always
+    Events:
+      - ObserveFields:
+          SubfileName: CheckpointVolumeData
+          VariablesToObserve: ["Psi", "Pi", "Phi"]
+          InterpolateToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          BlocksToObserve: All
 
 EventsAndDenseTriggers:
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -84,6 +84,8 @@ SpatialDiscretization:
 
 EventsAndDenseTriggers:
 
+EventsAndTriggersAtCheckpoints:
+
 # [multiple_events]
 EventsAndTriggersAtSlabs:
   - Trigger:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -115,6 +115,8 @@ EventsAndDenseTriggers:
               NormType: L2Norm
               Components: Sum
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Slabs:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.overlay_0000.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.overlay_0000.yaml
@@ -14,6 +14,8 @@ PhaseChangeAndTriggers:
       - CheckpointAndExitAfterWallclock:
           WallclockHours: None
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       SlabCompares:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -86,6 +86,8 @@ Filtering:
     Enable: true
     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   # Added on restart by option overlay
   # - Trigger:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -71,6 +71,8 @@ SpatialDiscretization:
 #     Enable: false
 #     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Times:

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere.yaml
@@ -75,6 +75,8 @@ SpatialDiscretization:
 #     Enable: false
 #     BlocksToFilter: All
 
+EventsAndTriggersAtCheckpoints:
+
 EventsAndTriggersAtSlabs:
   - Trigger:
       Times:

--- a/tests/Unit/Evolution/Actions/Test_RunEventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/Actions/Test_RunEventsAndTriggers.cpp
@@ -89,14 +89,19 @@ struct Component {
   using array_index = int;
   using const_global_cache_tags = tmpl::list<>;
   using simple_tags = tmpl::list<Tags::Time, Tags::TimeStepId>;
-  using phase_dependent_action_list =
-      tmpl::list<Parallel::PhaseActions<
-                     Parallel::Phase::Initialization,
-                     tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
-                 Parallel::PhaseActions<
-                     Parallel::Phase::Testing,
-                     tmpl::list<evolution::Actions::RunEventsAndTriggers<
-                         local_time_stepping>>>>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::flatten<tmpl::list<
+              std::conditional_t<local_time_stepping,
+                                 evolution::Actions::RunEventsAndTriggers<
+                                     Triggers::WhenToCheck::AtSteps>,
+                                 tmpl::list<>>,
+              evolution::Actions::RunEventsAndTriggers<
+                  Triggers::WhenToCheck::AtSlabs>>>>>;
 };
 
 template <bool LocalTimeStepping>
@@ -145,6 +150,9 @@ void test(std::array<
           make_not_null(&box));
 
       TestEvent::last_value.reset();
+      if constexpr (LocalTimeStepping) {
+        ActionTesting::next_action<my_component>(make_not_null(&runner), 0);
+      }
       ActionTesting::next_action<my_component>(make_not_null(&runner), 0);
       CHECK(TestEvent::last_value == expected[test_case]);
     }

--- a/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_WhenToCheck.cpp
+++ b/tests/Unit/ParallelAlgorithms/EventsAndTriggers/Test_WhenToCheck.cpp
@@ -11,4 +11,5 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.EventsAndTriggers.WhenToCheck",
   CHECK(get_output(Triggers::WhenToCheck::AtIterations) == "AtIterations");
   CHECK(get_output(Triggers::WhenToCheck::AtSlabs) == "AtSlabs");
   CHECK(get_output(Triggers::WhenToCheck::AtSteps) == "AtSteps");
+  CHECK(get_output(Triggers::WhenToCheck::AtCheckpoints) == "AtCheckpoints");
 }


### PR DESCRIPTION
## Proposed changes

Allows to run events in the checkpoint phase, which can be used to periodically dump data from which we can restart. This helps debugging BBH simulations by restarting closer to the point of failure. We will also add the ability to dump control system data and time stepper history to be able to restart from volume data more faithfully.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
