### PR TITLE
RenderDomain: add optional time annotation

### DIFF
--- a/src/Visualization/Python/Render3D/Domain.py
+++ b/src/Visualization/Python/Render3D/Domain.py
@@ -23,6 +23,7 @@ def render_domain(
     output: str,
     hi_res_xmf_file: Optional[str] = None,
     time_step: int = 0,
+    show_time_annotation: bool = False,
     animate: bool = False,
     zoom_factor: float = 1.0,
     camera_theta: float = 0.0,
@@ -58,6 +59,9 @@ def render_domain(
     render_view.UseColorPaletteForBackground = 0
     render_view.Background = background_color
     render_view.OrientationAxesVisibility = 0
+    if not animate:
+        render_view.ViewTime = volume_data.TimestepValues[time_step]
+        pv.UpdatePipeline(time=render_view.ViewTime, proxy=volume_data)
 
     def slice_or_clip(triangulate, **kwargs):
         if slice:
@@ -100,6 +104,15 @@ def render_domain(
     outline_display.ColorArrayName = ("POINTS", None)
     pv.ColorBy(outline_display, None)
 
+    # Show time annotation
+    if show_time_annotation:
+        annotate_time = pv.AnnotateTimeFilter(
+            registrationName="AnnotateTimeFilter", Input=volume_data
+        )
+        annotate_time_display = pv.Show(annotate_time, render_view)
+        annotate_time_display.Color = 3 * [0.0]
+        annotate_time_display.FontSize = 24
+
     # Set resolution
     layout = pv.GetLayout()
     layout.SetSize(1200, 1200)
@@ -120,7 +133,6 @@ def render_domain(
     if animate:
         pv.SaveAnimation(output, render_view)
     else:
-        render_view.ViewTime = volume_data.TimestepValues[time_step]
         pv.Render()
         pv.SaveScreenshot(output, render_view)
 
@@ -152,6 +164,9 @@ def render_domain(
         "Select a time step. Specify '-1' or 'last' to select the last time"
         " step."
     ),
+)
+@click.option(
+    "--show-time-annotation", is_flag=True, help="Show time annotation."
 )
 @click.option(
     "--animate", is_flag=True, help="Produce an animation of all time steps."


### PR DESCRIPTION
## Proposed changes

Add a time annotation in the top left corner if `--show-time-annotation` is specified:

<img width="1200" height="1200" alt="domain" src="https://github.com/user-attachments/assets/bffa86ec-ea47-4813-909d-fc3523604621" />


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
