### PR TITLE
Update transition to ringdown pipeline

### DIFF
--- a/src/IO/H5/Python/FunctionsOfTimeFromVolume.py
+++ b/src/IO/H5/Python/FunctionsOfTimeFromVolume.py
@@ -12,6 +12,7 @@ from rich.pretty import pretty_repr
 
 import spectre.IO.H5 as spectre_h5
 from spectre.Domain import deserialize_functions_of_time
+from spectre.Visualization.ReadH5 import select_observation
 
 logger = logging.getLogger(__name__)
 
@@ -37,21 +38,22 @@ def functions_of_time_from_volume(
         if fot_vol_subfile.split(".")[-1] == "vol":
             fot_vol_subfile = fot_vol_subfile.split(".")[0]
         volfile = h5file.get_vol("/" + fot_vol_subfile)
-        obs_ids = volfile.list_observation_ids()
-        fot_times = np.array(list(map(volfile.get_observation_value, obs_ids)))
-        which_obs_id = np.argmin(np.abs(fot_times - match_time))
-        serialized_fots = volfile.get_functions_of_time(obs_ids[which_obs_id])
+        # If match time not specified, choose the last available time in the
+        # volume data
+        if match_time is None:
+            obs_id, match_time = select_observation(volfile, step=-1)
+        else:
+            obs_id, match_time = select_observation(volfile, time=match_time)
+        serialized_fots = volfile.get_functions_of_time(obs_id)
         functions_of_time = deserialize_functions_of_time(serialized_fots)
         logger.debug("Desired match time: " + str(match_time))
-        logger.debug("Selected ObservationID: " + str(which_obs_id))
-        logger.debug("Selected match time: " + str(fot_times[which_obs_id]))
+        logger.debug("Selected ObservationID: " + str(obs_id))
+        logger.debug("Selected match time: " + str(match_time))
 
-        functions_of_time_at_match_time_dict["MatchTime"] = fot_times[
-            which_obs_id
-        ]
+        functions_of_time_at_match_time_dict["MatchTime"] = match_time
 
         for fot_name, fot in functions_of_time.items():
-            fot_at_match_time = fot.func_and_2_derivs(fot_times[which_obs_id])
+            fot_at_match_time = fot.func_and_2_derivs(match_time)
             if len(fot_at_match_time[0]) != 1:
                 functions_of_time_at_match_time_dict[fot_name] = [
                     [coef for coef in x] for x in fot_at_match_time

--- a/support/Pipelines/Bbh/Ringdown.py
+++ b/support/Pipelines/Bbh/Ringdown.py
@@ -19,6 +19,7 @@ from spectre.Evolution.Ringdown.ComputeAhCCoefsInRingdownDistortedFrame import (
 from spectre.IO.H5.FunctionsOfTimeFromVolume import (
     functions_of_time_from_volume,
 )
+from spectre.support.DirectoryStructure import PipelineStep, list_pipeline_steps
 from spectre.support.Schedule import schedule, scheduler_options
 
 logger = logging.getLogger(__name__)
@@ -157,10 +158,22 @@ def start_ringdown(
     if pipeline_dir:
         pipeline_dir = Path(pipeline_dir).resolve()
     if pipeline_dir and not segments_dir and not run_dir:
-        segments_dir = pipeline_dir / "003_Ringdown"
+        pipeline_steps = list_pipeline_steps(pipeline_dir)
+        if pipeline_steps:
+            segments_dir = pipeline_steps[-1].next(label="Ringdown").path
+        else:
+            segments_dir = PipelineStep.first(
+                directory=pipeline_dir, label="Ringdown"
+            ).path
 
-    if path_to_output_h5 is None:
-        path_to_output_h5 = pipeline_dir / "RingdownDistortedCoefs.h5"
+    if path_to_output_h5 == None:
+        ringdown_dir = Path(segments_dir or run_dir)
+        ringdown_dir.mkdir(parents=True, exist_ok=True)
+        path_to_output_h5 = (
+            Path(ringdown_dir).resolve() / "RingdownShapeCoefs.h5"
+        )
+    else:
+        path_to_output_h5 = Path(path_to_output_h5).resolve()
 
     ringdown_params = ringdown_parameters(
         inspiral_input_file,
@@ -393,20 +406,20 @@ def start_ringdown(
 @click.option(
     "--number-of-ahc-finds-for-fit",
     type=int,
-    required=True,
+    default=10,
     help="Number of AhC finds that will be used for the fit.",
 )
 @click.option(
     "--match-time",
-    required=True,
     type=float,
+    default=None,
     help="Desired match time (volume data must contain data at this time)",
 )
 @click.option(
     "--settling-timescale",
-    required=True,
     type=float,
-    help="Damping timescale for settle to const",
+    default=10.0,
+    help="Damping timescale for settle to const functions of time",
 )
 @click.option(
     "--zero-coefs-eps",


### PR DESCRIPTION
## Proposed changes

This simplifies how to start a ringdown dramatically. Before, you had to use a command like this
```
spectre bbh start-ringdown Segment 0001/ --path-to-output-h5 /home/alexcarpenter46/Ringdown_Testing/Ringdown_Coefs.h5 --number-of-ahc-finds-for-fit 10 --match-time 4879.18 --settling-timescale 10.0 -O EM_Ringdown -N 1
```
and now you only need to pass the path to the last segment of an inspiral
```
spectre bbh start-ringdown Segment_0001/ -N 1 -O EM_Ringdown
```
This also makes it so that if you specify --continue-with-ringdown it will actually try to continue with ringdown!
If you only pass the last segment of the inspiral, then it will choose the last time available in the inspiral volume data as the match time. This may cause issues with how we currently stop the inspiral, but I tested this for the equal mass Lev1 from the paper and it was able to ringdown from the last available time.

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments