### PR TITLE
EccentricityControl: fix subfile names

### DIFF
--- a/support/Pipelines/Bbh/EccentricityControl.py
+++ b/support/Pipelines/Bbh/EccentricityControl.py
@@ -131,6 +131,7 @@ def eccentricity_control(
                     # Start from inspiral data
                     id_input_file_path=inspiral_input_file_path,
                     id_run_dir=inspiral_run_dir,
+                    id_subfile_name="PostJunkVolumeData",
                     lev=lev,
                     inspiral_input_file_template=inspiral_input_file_template,
                     continue_with_ringdown=True,

--- a/support/Pipelines/Bbh/EccentricityControl.py
+++ b/support/Pipelines/Bbh/EccentricityControl.py
@@ -147,6 +147,7 @@ def eccentricity_control(
     separation = x_A - x_B
     x_offset = x_A - target_params["MassB"] * separation
     y_offset, z_offset = binary_data["CenterOfMassOffset"]
+    binary_domain = id_input_file["DomainCreator"]["BinaryCompactObject"]
     generate_id(
         target_params,
         # New orbital parameters
@@ -156,8 +157,12 @@ def eccentricity_control(
         # Initial guesses for ID control
         conformal_mass_a=binary_data["ObjectRight"]["KerrSchild"]["Mass"],
         conformal_mass_b=binary_data["ObjectLeft"]["KerrSchild"]["Mass"],
-        conformal_spin_a=binary_data["ObjectRight"]["KerrSchild"]["Spin"],
-        conformal_spin_b=binary_data["ObjectLeft"]["KerrSchild"]["Spin"],
+        horizon_rotation_a=binary_domain["ObjectA"]["Interior"][
+            "ExciseWithBoundaryCondition"
+        ]["ApparentHorizon"]["Rotation"],
+        horizon_rotation_b=binary_domain["ObjectB"]["Interior"][
+            "ExciseWithBoundaryCondition"
+        ]["ApparentHorizon"]["Rotation"],
         center_of_mass_offset=[x_offset, y_offset, z_offset],
         linear_velocity=binary_data["LinearVelocity"],
         # Scheduling options

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import glob
 import logging
 from pathlib import Path
 from typing import Optional, Union
@@ -11,10 +12,11 @@ import yaml
 from rich.pretty import pretty_repr
 
 import spectre.IO.H5 as spectre_h5
+from spectre.support.CliExceptions import RequiredChoiceError
 from spectre.support.DirectoryStructure import PipelineStep, list_pipeline_steps
 from spectre.support.Schedule import schedule, scheduler_options
 from spectre.Visualization.OpenVolfiles import open_volfiles
-from spectre.Visualization.ReadH5 import select_observation
+from spectre.Visualization.ReadH5 import available_subfiles, select_observation
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +114,7 @@ def inspiral_parameters(
     id_input_file: dict,
     id_metadata: dict,
     id_run_dir: Union[str, Path],
+    id_subfile_name: Optional[str],
     id_horizons_path: Optional[Union[str, Path]],
 ) -> dict:
     """Determine inspiral parameters from SpECTRE initial data.
@@ -123,6 +126,9 @@ def inspiral_parameters(
       id_metadata: Metadata of the initial data input file as a dictionary.
       id_run_dir: Directory of the initial data run. Paths in the input file
         are relative to this directory.
+      id_subfile_name: Subfile name inside the H5 volume files where the
+        initial data is stored. If 'None' and only one subfile exists, that
+        subfile is used. Otherwise, the subfile must be specified.
       id_horizons_path: Path to H5 file containing information about the
         horizons in the ID (e.g. mass, spin, spherical harmonic coefficients).
         If this is 'None', the default is the 'Horizons.h5' file inside
@@ -156,12 +162,35 @@ def inspiral_parameters(
         id_domain_creator["ObjectA"]["XCoord"]
         - id_domain_creator["ObjectB"]["XCoord"]
     )
+
+    # Resolve subfile name in the H5 files
+    id_file_glob = str(
+        Path(id_run_dir).resolve()
+        / (id_input_file["Observers"]["VolumeFileName"] + "*.h5")
+    )
+    if not id_subfile_name:
+        id_subfiles = available_subfiles(
+            glob.glob(id_file_glob),
+            extension=".vol",
+        )
+        if len(id_subfiles) == 1:
+            id_subfile_name = subfiles[0]
+            logger.info(
+                f"Selected subfile {id_subfile_name} (the only available one)."
+            )
+        else:
+            raise RequiredChoiceError(
+                (
+                    "Specify '--id-subfile-name' to select a subfile containing"
+                    " volume data."
+                ),
+                choices=id_subfiles,
+            )
+
     params = {
         # Initial data files
-        "IdFileGlob": str(
-            Path(id_run_dir).resolve()
-            / (id_input_file["Observers"]["VolumeFileName"] + "*.h5")
-        ),
+        "IdFileGlob": id_file_glob,
+        "IdSubfile": id_subfile_name,
         "IdFromEvolution": id_from_evolution,
         # Domain geometry
         "ExcisionRadiusA": (
@@ -192,9 +221,9 @@ def inspiral_parameters(
 
     # Initial functions of time (set from ID or load from evolution data)
     if id_from_evolution:
-        first_volfile = params["IdFileGlob"].replace("*", "0")
+        first_volfile = id_file_glob.replace("*", "0")
         _, obs_time = select_observation(
-            open_volfiles([first_volfile], "VolumeData"), step=-1
+            open_volfiles([first_volfile], id_subfile_name), step=-1
         )
         params.update(
             {
@@ -358,6 +387,7 @@ def start_inspiral(
     refinement_level: Optional[int] = None,
     polynomial_order: Optional[int] = None,
     id_run_dir: Optional[Union[str, Path]] = None,
+    id_subfile_name: Optional[str] = None,
     inspiral_input_file_template: Union[
         str, Path
     ] = INSPIRAL_INPUT_FILE_TEMPLATE,
@@ -410,6 +440,7 @@ def start_inspiral(
             id_input_file,
             id_metadata,
             id_run_dir,
+            id_subfile_name=id_subfile_name,
             id_horizons_path=id_horizons_path,
         )
 
@@ -521,6 +552,14 @@ def start_inspiral(
         " relative to this directory."
     ),
     show_default="directory of the ID_INPUT_FILE_PATH",
+)
+@click.option(
+    "--id-subfile-name",
+    help=(
+        "Name of the subfile within the initial data H5 files containing the "
+        "volume data to read in. "
+        "Optional if the H5 files have only one subfile."
+    ),
 )
 @click.option(
     "--inspiral-input-file-template",

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -50,7 +50,7 @@ InitialData:
 {% else %}
   NumericInitialData:
     FileGlob: "{{ IdFileGlob }}"
-    Subgroup: "VolumeData"
+    Subgroup: "{{ IdSubfile }}"
   {% if IdFromEvolution %}
     ObservationValue: {{ InitialTime }}
     ObservationValueEpsilon: Auto
@@ -138,24 +138,24 @@ DomainCreator:
       InitialTime: &InitialTime {{ InitialTime }}
       ExpansionMap:
         H5Filename: "{{ FotFilename }}"
-        SubfileName: "VolumeData"
+        SubfileName: "{{ IdSubfile }}"
       RotationMap:
         H5Filename: "{{ FotFilename }}"
-        SubfileName: "VolumeData"
+        SubfileName: "{{ IdSubfile }}"
       TranslationMap:
         H5Filename: "{{ FotFilename }}"
-        SubfileName: "VolumeData"
+        SubfileName: "{{ IdSubfile }}"
       SkewMap:
         H5Filename: "{{ FotFilename }}"
-        SubfileName: "VolumeData"
+        SubfileName: "{{ IdSubfile }}"
       ShapeMapA:
         H5Filename: "{{ FotFilename }}"
-        SubfileName: "VolumeData"
+        SubfileName: "{{ IdSubfile }}"
         LMax: Auto
         TransitionEndsAtCube: True
       ShapeMapB:
         H5Filename: "{{ FotFilename }}"
-        SubfileName: "VolumeData"
+        SubfileName: "{{ IdSubfile }}"
         LMax: Auto
         TransitionEndsAtCube: True
       GridCenters: None
@@ -438,7 +438,7 @@ EventsAndTriggersAtSlabs:
     Events:
       # Save volume data for continuation
       - ObserveFields:
-          SubfileName: VolumeData
+          SubfileName: PostJunkVolumeData
           VariablesToObserve:
             - SpacetimeMetric
             - Pi

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -94,7 +94,8 @@ def postprocess_id(
     """
     # Read input file
     with open(id_input_file_path, "r") as open_input_file:
-        _, id_input_file = yaml.safe_load_all(open_input_file)
+        id_metadata, id_input_file = yaml.safe_load_all(open_input_file)
+    target_params = id_metadata["TargetParams"]
     x_B, x_A = id_input_file["Background"]["Binary"]["XCoords"]
     y_offset, z_offset = id_input_file["Background"]["Binary"][
         "CenterOfMassOffset"
@@ -179,6 +180,7 @@ def postprocess_id(
         start_inspiral(
             id_input_file_path,
             id_run_dir=id_run_dir,
+            id_subfile_name="VolumeData",
             continue_with_ringdown=not eccentricity_control,
             eccentricity_control=eccentricity_control,
             pipeline_dir=pipeline_dir,

--- a/tests/support/Pipelines/Bbh/Test_EccentricityControl.py
+++ b/tests/support/Pipelines/Bbh/Test_EccentricityControl.py
@@ -106,7 +106,25 @@ class TestEccentricityControl(unittest.TestCase):
                     },
                     "CenterOfMassOffset": [0.0, 0.0],
                 },
-            }
+            },
+            "DomainCreator": {
+                "BinaryCompactObject": {
+                    "ObjectA": {
+                        "Interior": {
+                            "ExciseWithBoundaryCondition": {
+                                "ApparentHorizon": {"Rotation": [0.0, 0.0, 0.0]}
+                            }
+                        },
+                    },
+                    "ObjectB": {
+                        "Interior": {
+                            "ExciseWithBoundaryCondition": {
+                                "ApparentHorizon": {"Rotation": [0.0, 0.0, 0.0]}
+                            }
+                        },
+                    },
+                }
+            },
         }
 
         # Pass both metadata and data1 to the YAML file

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -68,12 +68,14 @@ class TestInspiral(unittest.TestCase):
             id_input_file=id_input_file,
             id_metadata=id_metadata,
             id_run_dir=self.id_dir,
+            id_subfile_name="VolumeData",
             id_horizons_path=self.horizons_filename,
         )
         self.assertEqual(
             params["IdFileGlob"],
             str((self.id_dir).resolve() / "BbhVolume*.h5"),
         )
+        self.assertEqual(params["IdSubfile"], "VolumeData")
         self.assertAlmostEqual(params["ExcisionRadiusA"], 1.116 * 1.0385 * 0.82)
         self.assertAlmostEqual(params["ExcisionRadiusB"], 0.744 * 1.0385 * 0.82)
         self.assertEqual(params["XCoordA"], 8.0)
@@ -118,6 +120,8 @@ class TestInspiral(unittest.TestCase):
     def test_cli(self):
         common_args = [
             str(self.id_dir / "InitialData.yaml"),
+            "--id-subfile-name",
+            "VolumeData",
             "--id-horizons-path",
             str(self.horizons_filename),
             "-E",

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -68,6 +68,7 @@ class TestInitialData(unittest.TestCase):
                 dat_file.append([[0.0, 1.0, 0.3]])
         start_inspiral(
             id_input_file_path=self.test_dir / "ID" / "InitialData.yaml",
+            id_subfile_name="VolumeData",
             refinement_level=1,
             polynomial_order=5,
             segments_dir=self.test_dir / "Inspiral",


### PR DESCRIPTION
- Write post-junk volume data after ecc-control into separate H5 subfile so it doesn't conflict with other volume data.
- Support reading in volume data from a specific subfile when starting an inspiral. Use the post-junk data when continuing after ecc-control.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
