### PR TITLE
Add support for autodiff

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -267,6 +267,8 @@ jobs:
           -D USE_PCH=OFF
           -D DEBUG_SYMBOLS=OFF
           -D BUILD_PYTHON_BINDINGS=ON
+          -D SPECTRE_AUTODIFF=ON
+          -D SPECTRE_FETCH_MISSING_DEPS=ON
           $GITHUB_WORKSPACE
 
           make -j4 module_All Libsharp-external
@@ -278,7 +280,8 @@ jobs:
 
           git diff -U0 $UPSTREAM_HASH |
             clang-tidy-diff -path build -p1 -use-color -j4 \
-            -extra-arg=-I/usr/include/hdf5/serial
+            -extra-arg=-I/usr/include/hdf5/serial \
+            -extra-arg=-I$GITHUB_WORKSPACE/build/_deps/autodiff-src
 
 
   # Build the documentation and check for problems, then upload as a workflow
@@ -354,6 +357,8 @@ jobs:
           -D MEMORY_ALLOCATOR=SYSTEM
           -D BUILD_DOCS=ON
           -D BUILD_TESTING=OFF
+          -D SPECTRE_AUTODIFF=ON
+          -D SPECTRE_FETCH_MISSING_DEPS=ON
           $GITHUB_WORKSPACE
       - name: Check documentation
         working-directory: build
@@ -758,6 +763,8 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR=${TEST_TIMEOUT_FACTOR:-'1'}
           -D CMAKE_INSTALL_PREFIX=/work/spectre_install
           -D BUILD_DOCS=OFF
+          -D SPECTRE_AUTODIFF=ON
+          -D SPECTRE_FETCH_MISSING_DEPS=ON
           --warn-uninitialized
           $GITHUB_WORKSPACE 2>&1 | tee CMakeOutput.txt 2>&1
       - name: Check for CMake warnings
@@ -959,6 +966,8 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D BUILD_PYTHON_BINDINGS=${BUILD_PYTHON_BINDINGS:-'ON'}
           -D MEMORY_ALLOCATOR=${MEMORY_ALLOCATOR:-'SYSTEM'}
           -D BUILD_DOCS=OFF
+          -D SPECTRE_AUTODIFF=ON
+          -D SPECTRE_FETCH_MISSING_DEPS=ON
           ..
 
           make EvolveBurgers -j${NUMBER_OF_CORES}
@@ -1422,6 +1431,8 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             -D USE_PCH=ON\
             -D USE_CCACHE=ON\
             -D BUILD_DOCS=OFF\
+            -D SPECTRE_AUTODIFF=ON\
+            -D SPECTRE_FETCH_MISSING_DEPS=ON\
             $GITHUB_WORKSPACE
 
             make -j4 TestArchitectureVectorization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ include(SetupLapack)
 include(SetupLIBXSMM)
 include(SetupGsl)
 
+include(SetupAutodiff)
 include(SetupBlaze)
 include(SetupFuka)
 include(SetupGoogleBenchmark)

--- a/cmake/SetupAutodiff.cmake
+++ b/cmake/SetupAutodiff.cmake
@@ -1,0 +1,54 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Find autodiff (https://github.com/autodiff/autodiff)
+#
+# Note that Boost also has an autodiff module, but it uses templates to
+# distinguish multiple variables. This means a std::array or Tensor can't hold
+# the Boost autodiff variables. For example, to evaluate a 2D function f(x, y),
+# the type for x would be fvar<double> and the type for y would be the nested
+# fvar<fvar<double>>. On the other hand, the autodiff library works with a
+# simpler autodiff::dual or autodiff::var type, which can be stored in a
+# std::array or Tensor.
+
+option(SPECTRE_AUTODIFF "Enable automatic differentiation" OFF)
+
+if (NOT SPECTRE_AUTODIFF)
+  return()
+endif()
+
+# we assume the found autodiff is newer than the GIT_TAG below,
+# which has not been in autodiff's official release.
+find_package(autodiff QUIET)
+
+if (NOT autodiff_FOUND)
+  if (NOT SPECTRE_FETCH_MISSING_DEPS)
+    message(FATAL_ERROR "Could not find autodiff. If you want to fetch "
+      "missing dependencies automatically, set SPECTRE_FETCH_MISSING_DEPS=ON.")
+  endif()
+
+  message(STATUS "Fetching autodiff")
+  include(FetchContent)
+  FetchContent_Declare(autodiff
+      GIT_REPOSITORY https://github.com/autodiff/autodiff
+      # Choose an unreleased version on top of v1.1.2 that makes dependence on
+      # Eigen optional.
+      GIT_TAG cc2aa5726fdbb258d097f87b97da3d1022f8394e
+      ${SPECTRE_FETCHCONTENT_BASE_ARGS}
+  )
+  set(AUTODIFF_BUILD_TESTS OFF CACHE BOOL "Build autodiff tests")
+  set(AUTODIFF_BUILD_EXAMPLES OFF CACHE BOOL "Build autodiff examples")
+  set(AUTODIFF_BUILD_PYTHON OFF CACHE BOOL "Build autodiff Python bindings")
+  set(AUTODIFF_BUILD_DOCS OFF CACHE BOOL "Build autodiff documentation")
+  FetchContent_MakeAvailable(autodiff)
+
+  if (CMAKE_VERSION VERSION_LESS 3.25)
+    get_target_property(AUTODIFF_IID autodiff INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(autodiff PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${AUTODIFF_IID}")
+  endif()
+endif()
+
+set_property(
+  GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
+  autodiff::autodiff
+  )

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -185,6 +185,9 @@ alphabetical order):
   - Set to a path to a SpEC installation (the SpEC repository root) to link in
     SpEC libraries. In particular, the SpEC::Exporter library is linked in and
     enables loading SpEC data into SpECTRE. See \ref installation for details.
+- SPECTRE_AUTODIFF
+  - Enable automatic differentation (default is `OFF`). This is required for
+    computing Hessians.
 - SPECTRE_DEBUG
   - Defines `SPECTRE_DEBUG` macro to enable `ASSERT`s and other debug
     checks so they can be used in Release builds. That is, you get sanity checks

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -270,6 +270,8 @@ The following dependencies will be fetched automatically if you set
   matplotlib
 * [xsimd](https://github.com/xtensor-stack/xsimd) 11.0.1 or newer - for manual
   vectorization
+* [autodiff](https://github.com/autodiff/autodiff/) commit cc2aa5726fdbb258d097f87b97da3d1022f8394e
+  or newer - for automatic differentiation
 * [libbacktrace](https://github.com/ianlancetaylor/libbacktrace) - to show
   source files and line numbers in backtraces of errors and asserts. Available
   by default on many systems, so you may not have to install it at all. The

--- a/src/Utilities/Autodiff/Autodiff.hpp
+++ b/src/Utilities/Autodiff/Autodiff.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <autodiff/common/numbertraits.hpp>
+#include <autodiff/forward/dual.hpp>
+#include <autodiff/reverse/var.hpp>
+
+#include "Utilities/Simd/Simd.hpp"
+
+namespace autodiff::detail {
+/// Template specialization for simd::batch<double> to treat it as arithmetic.
+template <>
+struct ArithmeticTraits<simd::batch<double>> {
+  static constexpr bool isArithmetic = true;
+};
+
+}  // namespace autodiff::detail

--- a/src/Utilities/Autodiff/CMakeLists.txt
+++ b/src/Utilities/Autodiff/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Having a wrapper target will make it easier to replace autodiff
+# with another auto-differentiation library if we ever need to.
+
+set(LIBRARY Autodiff)
+
+add_spectre_library(${LIBRARY} INTERFACE)
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Autodiff.hpp
+  )
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  autodiff::autodiff
+  Simd
+  )
+
+message(STATUS "Enabling autodiff support")

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+if (SPECTRE_AUTODIFF)
+  add_subdirectory(Autodiff)
+endif()
 add_subdirectory(Kokkos)
 add_subdirectory(Simd)
 

--- a/tests/Unit/Utilities/Autodiff/CMakeLists.txt
+++ b/tests/Unit/Utilities/Autodiff/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_Autodiff")
+
+set(LIBRARY_SOURCES
+  Test_Autodiff.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Autodiff
+  )

--- a/tests/Unit/Utilities/Autodiff/Test_Autodiff.cpp
+++ b/tests/Unit/Utilities/Autodiff/Test_Autodiff.cpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Utilities/Autodiff/Autodiff.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace {
+using Dual = autodiff::dual;
+using Var = autodiff::var;
+
+template <typename DataType>
+DataType f1(const DataType& x, const double param) {
+  return square(x) * param;
+}
+
+template <typename DataType>
+std::array<DataType, 2> f2(const std::array<DataType, 2>& x) {
+  return {{square(x[0]) * x[1], cube(x[1])}};
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Autodiff", "[Unit][DataStructures]") {
+  {
+    INFO("Single number forward mode");
+    Dual x = 2.0;
+    const double param = 3.0;
+    const auto df_dx = autodiff::derivative(&f1<Dual>, wrt(x), at(x, param));
+    CHECK(df_dx == approx(12.0));
+  }
+  {
+    INFO("Single number reverse mode");
+    const Var x = 2.0;
+    const double param = 3.0;
+    const Var u = f1<Var>(x, param);
+    const auto [df_dx] =
+        autodiff::derivatives(u, wrt(x));
+    CHECK(df_dx == approx(12.0));
+  }
+  {
+    INFO("SIMD number forward mode");
+    using BatchType = simd::batch<double>;
+    using BatchDual = autodiff::HigherOrderDual<2, BatchType>;
+    BatchDual x = BatchType(2.0);
+    const double param = 3.0;
+    autodiff::seed<1>(x, 1.0);
+    autodiff::seed<2>(x, 1.0);
+    const auto fx = f1(x, param);
+    const auto df_dx = autodiff::derivative<1>(fx);
+    std::array<double, BatchType::size> lanes{};
+    df_dx.store_unaligned(lanes.data());
+    for (const double lane : lanes) {
+      CHECK(lane == approx(12.0));
+    }
+    const auto df_dxx = autodiff::derivative<2>(fx);
+    df_dxx.store_unaligned(lanes.data());
+    for (const double lane : lanes) {
+      CHECK(lane == approx(6.0));
+    }
+  }
+  {
+    INFO("SIMD number reverse mode");
+    using BatchType = simd::batch<double>;
+    using BatchVar = autodiff::Variable<BatchType>;
+    BatchVar x = BatchType(2.0);
+    const double param = 3.0;
+    const auto u = f1(x, param);
+    const auto [u_x] = derivativesx(u, wrt(x));
+    const auto [u_xx] = derivativesx(u_x, wrt(x));
+    std::array<double, BatchType::size> lanes{};
+    autodiff::val(u_x).store_unaligned(lanes.data());
+    for (const double lane : lanes) {
+      CHECK(lane == approx(12.0));
+    }
+    autodiff::val(u_xx).store_unaligned(lanes.data());
+    for (const double lane : lanes) {
+      CHECK(lane == approx(6.0));
+    }
+  }
+  {
+    INFO("Jacobian forward mode");
+    std::array<Dual, 2> x = {2.0, 3.0};
+    std::array<std::array<double, 2>, 2> expected_df_dx{
+        {{12.0, 4.0}, {0.0, 27.0}}};
+
+    for (size_t j = 0; j < 2; ++j) {
+      for (size_t i = 0; i < 2; ++i) {
+        autodiff::seed<1>(x.at(i), 1.0);
+        autodiff::seed<1>(x.at((i + 1) % 2), 0.0);
+        const std::array<Dual, 2> fx = f2(x);
+        const auto dfj_dxi = autodiff::derivative(gsl::at(fx, j));
+        CHECK(dfj_dxi == approx(expected_df_dx.at(j).at(i)));
+      }
+    }
+  }
+  {
+    INFO("Jacobian reverse mode");
+    std::array<Var, 2> x = {2.0, 3.0};
+    std::array<std::array<double, 2>, 2> expected_df_dx{
+        {{12.0, 4.0}, {0.0, 27.0}}};
+    std::array<Var, 2> fx = f2(x);
+
+    for (size_t j = 0; j < 2; ++j) {
+      const auto dfj_dxi = autodiff::derivatives(
+          gsl::at(fx, j), wrt(x[0], x[1]));
+      for (size_t i = 0; i < 2; ++i) {
+        CHECK(dfj_dxi.at(i) == approx(expected_df_dx.at(j).at(i)));
+      }
+    }
+  }
+}

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -55,6 +55,9 @@ set(LIBRARY_SOURCES
   Test_WrapText.cpp
   )
 
+if (SPECTRE_AUTODIFF)
+  add_subdirectory(Autodiff)
+endif()
 add_subdirectory(ErrorHandling)
 add_subdirectory(Kokkos)
 add_subdirectory(Protocols)


### PR DESCRIPTION
## Proposed changes
Add autodiff library to SpECTRE and make it compatible with xsimd type. Also update the github CI tests so that autodiff is tested on non-macOS systems. For now we have autodiff as an optional package. We will likely require autodiff in the near future to compute hessians of coordinate maps.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Autodiff can be enabled with the option `SPECTRE_AUTODIFF=ON`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
