### PR TITLE
Rename Bjorhus corrections

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -299,11 +299,11 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
     return {};
   }
 
-  Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_psi(
+  Bjorhus::constraint_preserving_corrections_dt_v_psi(
       make_not_null(&bc_dt_v_psi), unit_interface_normal_vector,
       three_index_constraint, char_speeds);
 
-  Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_zero(
+  Bjorhus::constraint_preserving_corrections_dt_v_zero(
       make_not_null(&bc_dt_v_zero), unit_interface_normal_vector,
       four_index_constraint, char_speeds);
 
@@ -317,7 +317,7 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
   }
 
   if (type_ == detail::ConstraintPreservingBjorhusType::ConstraintPreserving) {
-    Bjorhus::constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
+    Bjorhus::constraint_preserving_gauge_corrections_dt_v_minus(
         make_not_null(&bc_dt_v_minus), gamma2, coords, incoming_null_one_form,
         outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
         projection_ab, projection_Ab, projection_AB,
@@ -325,17 +325,16 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
         constraint_char_zero_plus, constraint_char_zero_minus, char_speeds);
   } else if (type_ == detail::ConstraintPreservingBjorhusType::
                           ConstraintPreservingPhysical) {
-    Bjorhus::
-        constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
-            make_not_null(&bc_dt_v_minus), gamma2, coords, normal_covector,
-            unit_interface_normal_vector, spacetime_unit_normal_vector,
-            incoming_null_one_form, outgoing_null_one_form,
-            incoming_null_vector, outgoing_null_vector, projection_ab,
-            projection_Ab, projection_AB, inverse_spatial_metric,
-            extrinsic_curvature, spacetime_metric, inverse_spacetime_metric,
-            three_index_constraint, char_projected_rhs_dt_v_psi,
-            char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
-            constraint_char_zero_minus, phi, d_phi, d_pi, char_speeds);
+    Bjorhus::constraint_preserving_gauge_physical_corrections_dt_v_minus(
+        make_not_null(&bc_dt_v_minus), gamma2, coords, normal_covector,
+        unit_interface_normal_vector, spacetime_unit_normal_vector,
+        incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
+        outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+        inverse_spatial_metric, extrinsic_curvature, spacetime_metric,
+        inverse_spacetime_metric, three_index_constraint,
+        char_projected_rhs_dt_v_psi, char_projected_rhs_dt_v_minus,
+        constraint_char_zero_plus, constraint_char_zero_minus, phi, d_phi, d_pi,
+        char_speeds);
   } else {
     ERROR(
         "Failed to set dtVMinus. Input option must be one of "

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -317,7 +317,7 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
   }
 
   if (type_ == detail::ConstraintPreservingBjorhusType::ConstraintPreserving) {
-    Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_minus(
+    Bjorhus::constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
         make_not_null(&bc_dt_v_minus), gamma2, coords, incoming_null_one_form,
         outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
         projection_ab, projection_Ab, projection_AB,
@@ -325,16 +325,17 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
         constraint_char_zero_plus, constraint_char_zero_minus, char_speeds);
   } else if (type_ == detail::ConstraintPreservingBjorhusType::
                           ConstraintPreservingPhysical) {
-    Bjorhus::constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
-        make_not_null(&bc_dt_v_minus), gamma2, coords, normal_covector,
-        unit_interface_normal_vector, spacetime_unit_normal_vector,
-        incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
-        outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
-        inverse_spatial_metric, extrinsic_curvature, spacetime_metric,
-        inverse_spacetime_metric, three_index_constraint,
-        char_projected_rhs_dt_v_psi, char_projected_rhs_dt_v_minus,
-        constraint_char_zero_plus, constraint_char_zero_minus, phi, d_phi, d_pi,
-        char_speeds);
+    Bjorhus::
+        constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
+            make_not_null(&bc_dt_v_minus), gamma2, coords, normal_covector,
+            unit_interface_normal_vector, spacetime_unit_normal_vector,
+            incoming_null_one_form, outgoing_null_one_form,
+            incoming_null_vector, outgoing_null_vector, projection_ab,
+            projection_Ab, projection_AB, inverse_spatial_metric,
+            extrinsic_curvature, spacetime_metric, inverse_spacetime_metric,
+            three_index_constraint, char_projected_rhs_dt_v_psi,
+            char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
+            constraint_char_zero_minus, phi, d_phi, d_pi, char_speeds);
   } else {
     ERROR(
         "Failed to set dtVMinus. Input option must be one of "

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
@@ -89,10 +89,10 @@ namespace gh::BoundaryConditions {
  * any physical gravitational waves from the outer boundary, in addition to
  * preventing the influx of constraint violations and gauge perturbations.
  *
- * We refer to `Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_psi()`,
- * `Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_zero()`,
- * `Bjorhus::constraint_preserving_gauge_bjorhus_corrections_dt_v_minus()`, and
- * `Bjorhus::constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus()`
+ * We refer to `Bjorhus::constraint_preserving_corrections_dt_v_psi()`,
+ * `Bjorhus::constraint_preserving_corrections_dt_v_zero()`,
+ * `Bjorhus::constraint_preserving_gauge_corrections_dt_v_minus()`, and
+ * `Bjorhus::constraint_preserving_gauge_physical_corrections_dt_v_minus()`
  * for the further details on implementation.
  *
  * \note These boundary conditions assume a spherical outer boundary. Also, we

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
@@ -91,8 +91,8 @@ namespace gh::BoundaryConditions {
  *
  * We refer to `Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_psi()`,
  * `Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_zero()`,
- * `Bjorhus::constraint_preserving_bjorhus_corrections_dt_v_minus()`, and
- * `Bjorhus::constraint_preserving_physical_bjorhus_corrections_dt_v_minus()`
+ * `Bjorhus::constraint_preserving_gauge_bjorhus_corrections_dt_v_minus()`, and
+ * `Bjorhus::constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus()`
  * for the further details on implementation.
  *
  * \note These boundary conditions assume a spherical outer boundary. Also, we

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -494,6 +494,35 @@ void add_physical_terms_to_dt_v_minus(
 }  // namespace detail
 
 template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_minus(
+    const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const std::array<DataType, 4>& char_speeds) {
+  for (size_t a = 0; a <= VolumeDim; ++a) {
+    for (size_t b = a; b <= VolumeDim; ++b) {
+      bc_dt_v_minus->get(a, b) = -char_projected_rhs_dt_v_minus.get(a, b);
+    }
+  }
+  detail::add_constraint_dependent_terms_to_dt_v_minus(
+      bc_dt_v_minus, outgoing_null_one_form, incoming_null_vector,
+      outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+      constraint_char_zero_plus, constraint_char_zero_minus,
+      char_projected_rhs_dt_v_minus, char_speeds);
+}
+
+template <size_t VolumeDim, typename DataType>
 void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
@@ -692,6 +721,30 @@ void constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
       const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi,       \
       const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,         \
       const std::array<DTYPE(data), 4>& char_speeds);                         \
+  template void gh::BoundaryConditions::Bjorhus::                             \
+      constraint_preserving_bjorhus_corrections_dt_v_minus(                   \
+          const gsl::not_null<                                                \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
+              bc_dt_v_minus,                                                  \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              outgoing_null_one_form,                                         \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              incoming_null_vector,                                           \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              outgoing_null_vector,                                           \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
+              projection_ab,                                                  \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&            \
+              projection_Ab,                                                  \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&            \
+              projection_AB,                                                  \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
+              char_projected_rhs_dt_v_minus,                                  \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              constraint_char_zero_plus,                                      \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              constraint_char_zero_minus,                                     \
+          const std::array<DTYPE(data), 4>& char_speeds);                     \
   template void gh::BoundaryConditions::Bjorhus::                             \
       constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(             \
           const gsl::not_null<                                                \

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -24,7 +24,7 @@
 
 namespace gh::BoundaryConditions::Bjorhus {
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_psi(
+void constraint_preserving_corrections_dt_v_psi(
     const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_psi,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
@@ -47,7 +47,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_psi(
 }
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_zero(
+void constraint_preserving_corrections_dt_v_zero(
     const gsl::not_null<tnsr::iaa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_zero,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
@@ -494,7 +494,7 @@ void add_physical_terms_to_dt_v_minus(
 }  // namespace detail
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_corrections_dt_v_minus(
     const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
@@ -523,7 +523,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_minus(
 }
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_corrections_dt_v_minus(
     const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
@@ -561,7 +561,7 @@ void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
 }
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_physical_corrections_dt_v_minus(
     const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
@@ -626,205 +626,204 @@ void constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE(_, data)                                                  \
-  template void gh::BoundaryConditions::Bjorhus::                             \
-      constraint_preserving_bjorhus_corrections_dt_v_psi(                     \
-          const gsl::not_null<                                                \
-              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
-              bc_dt_v_psi,                                                    \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              unit_interface_normal_vector,                                   \
-          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&           \
-              three_index_constraint,                                         \
-          const std::array<DTYPE(data), 4>& char_speeds);                     \
-  template void gh::BoundaryConditions::Bjorhus::                             \
-      constraint_preserving_bjorhus_corrections_dt_v_zero(                    \
-          const gsl::not_null<                                                \
-              tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>*>            \
-              bc_dt_v_zero,                                                   \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              unit_interface_normal_vector,                                   \
-          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&           \
-              four_index_constraint,                                          \
-          const std::array<DTYPE(data), 4>& char_speeds);                     \
-  template void gh::BoundaryConditions::Bjorhus::detail::                     \
-      add_gauge_sommerfeld_terms_to_dt_v_minus(                               \
-          const gsl::not_null<                                                \
-              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
-              bc_dt_v_minus,                                                  \
-          const Scalar<DTYPE(data)>& gamma2,                                  \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              inertial_coords,                                                \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_one_form,                                         \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_one_form,                                         \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_vector,                                           \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_vector,                                           \
-          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_Ab,                                                  \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              char_projected_rhs_dt_v_psi);                                   \
-  template void gh::BoundaryConditions::Bjorhus::detail::                     \
-      add_constraint_dependent_terms_to_dt_v_minus(                           \
-          const gsl::not_null<                                                \
-              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
-              bc_dt_v_minus,                                                  \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_one_form,                                         \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_vector,                                           \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_vector,                                           \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_ab,                                                  \
-          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_Ab,                                                  \
-          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_AB,                                                  \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_plus,                                      \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_minus,                                     \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              char_projected_rhs_dt_v_minus,                                  \
-          const std::array<DTYPE(data), 4>& char_speeds);                     \
-  template void                                                               \
-  gh::BoundaryConditions::Bjorhus::detail::add_physical_terms_to_dt_v_minus(  \
-      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*> \
-          bc_dt_v_minus,                                                      \
-      const Scalar<DTYPE(data)>& gamma2,                                      \
-      const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&                 \
-          unit_interface_normal_one_form,                                     \
-      const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&                 \
-          unit_interface_normal_vector,                                       \
-      const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&                 \
-          spacetime_unit_normal_vector,                                       \
-      const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>& projection_ab, \
-      const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>& projection_Ab, \
-      const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>& projection_AB, \
-      const tnsr::II<DTYPE(data), DIM(data), Frame::Inertial>&                \
-          inverse_spatial_metric,                                             \
-      const tnsr::ii<DTYPE(data), DIM(data), Frame::Inertial>&                \
-          extrinsic_curvature,                                                \
-      const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&                \
-          spacetime_metric,                                                   \
-      const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&                \
-          inverse_spacetime_metric,                                           \
-      const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&               \
-          three_index_constraint,                                             \
-      const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&                \
-          char_projected_rhs_dt_v_minus,                                      \
-      const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,          \
-      const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi,       \
-      const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,         \
-      const std::array<DTYPE(data), 4>& char_speeds);                         \
-  template void gh::BoundaryConditions::Bjorhus::                             \
-      constraint_preserving_bjorhus_corrections_dt_v_minus(                   \
-          const gsl::not_null<                                                \
-              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
-              bc_dt_v_minus,                                                  \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_one_form,                                         \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_vector,                                           \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_vector,                                           \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_ab,                                                  \
-          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_Ab,                                                  \
-          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_AB,                                                  \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              char_projected_rhs_dt_v_minus,                                  \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_plus,                                      \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_minus,                                     \
-          const std::array<DTYPE(data), 4>& char_speeds);                     \
-  template void gh::BoundaryConditions::Bjorhus::                             \
-      constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(             \
-          const gsl::not_null<                                                \
-              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
-              bc_dt_v_minus,                                                  \
-          const Scalar<DTYPE(data)>& gamma2,                                  \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              inertial_coords,                                                \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_one_form,                                         \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_one_form,                                         \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_vector,                                           \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_vector,                                           \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_ab,                                                  \
-          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_Ab,                                                  \
-          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_AB,                                                  \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              char_projected_rhs_dt_v_psi,                                    \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              char_projected_rhs_dt_v_minus,                                  \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_plus,                                      \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_minus,                                     \
-          const std::array<DTYPE(data), 4>& char_speeds);                     \
-  template void gh::BoundaryConditions::Bjorhus::                             \
-      constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(    \
-          const gsl::not_null<                                                \
-              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
-              bc_dt_v_minus,                                                  \
-          const Scalar<DTYPE(data)>& gamma2,                                  \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              inertial_coords,                                                \
-          const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              unit_interface_normal_one_form,                                 \
-          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              unit_interface_normal_vector,                                   \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              spacetime_unit_normal_vector,                                   \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_one_form,                                         \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_one_form,                                         \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              incoming_null_vector,                                           \
-          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              outgoing_null_vector,                                           \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_ab,                                                  \
-          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_Ab,                                                  \
-          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              projection_AB,                                                  \
-          const tnsr::II<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              inverse_spatial_metric,                                         \
-          const tnsr::ii<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              extrinsic_curvature,                                            \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              spacetime_metric,                                               \
-          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              inverse_spacetime_metric,                                       \
-          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&           \
-              three_index_constraint,                                         \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              char_projected_rhs_dt_v_psi,                                    \
-          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&            \
-              char_projected_rhs_dt_v_minus,                                  \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_plus,                                      \
-          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&             \
-              constraint_char_zero_minus,                                     \
-          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,      \
-          const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi,   \
-          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,     \
+#define INSTANTIATE(_, data)                                                   \
+  template void                                                                \
+  gh::BoundaryConditions::Bjorhus::constraint_preserving_corrections_dt_v_psi( \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>  \
+          bc_dt_v_psi,                                                         \
+      const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&                  \
+          unit_interface_normal_vector,                                        \
+      const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&                \
+          three_index_constraint,                                              \
+      const std::array<DTYPE(data), 4>& char_speeds);                          \
+  template void gh::BoundaryConditions::Bjorhus::                              \
+      constraint_preserving_corrections_dt_v_zero(                             \
+          const gsl::not_null<                                                 \
+              tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
+              bc_dt_v_zero,                                                    \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              unit_interface_normal_vector,                                    \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&            \
+              four_index_constraint,                                           \
+          const std::array<DTYPE(data), 4>& char_speeds);                      \
+  template void gh::BoundaryConditions::Bjorhus::detail::                      \
+      add_gauge_sommerfeld_terms_to_dt_v_minus(                                \
+          const gsl::not_null<                                                 \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>              \
+              bc_dt_v_minus,                                                   \
+          const Scalar<DTYPE(data)>& gamma2,                                   \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              inertial_coords,                                                 \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_one_form,                                          \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_one_form,                                          \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_vector,                                            \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_vector,                                            \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_Ab,                                                   \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              char_projected_rhs_dt_v_psi);                                    \
+  template void gh::BoundaryConditions::Bjorhus::detail::                      \
+      add_constraint_dependent_terms_to_dt_v_minus(                            \
+          const gsl::not_null<                                                 \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>              \
+              bc_dt_v_minus,                                                   \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_one_form,                                          \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_vector,                                            \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_vector,                                            \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_ab,                                                   \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_Ab,                                                   \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_AB,                                                   \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_plus,                                       \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_minus,                                      \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              char_projected_rhs_dt_v_minus,                                   \
+          const std::array<DTYPE(data), 4>& char_speeds);                      \
+  template void                                                                \
+  gh::BoundaryConditions::Bjorhus::detail::add_physical_terms_to_dt_v_minus(   \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>  \
+          bc_dt_v_minus,                                                       \
+      const Scalar<DTYPE(data)>& gamma2,                                       \
+      const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&                  \
+          unit_interface_normal_one_form,                                      \
+      const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&                  \
+          unit_interface_normal_vector,                                        \
+      const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&                  \
+          spacetime_unit_normal_vector,                                        \
+      const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>& projection_ab,  \
+      const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>& projection_Ab,  \
+      const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>& projection_AB,  \
+      const tnsr::II<DTYPE(data), DIM(data), Frame::Inertial>&                 \
+          inverse_spatial_metric,                                              \
+      const tnsr::ii<DTYPE(data), DIM(data), Frame::Inertial>&                 \
+          extrinsic_curvature,                                                 \
+      const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&                 \
+          spacetime_metric,                                                    \
+      const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&                 \
+          inverse_spacetime_metric,                                            \
+      const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&                \
+          three_index_constraint,                                              \
+      const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&                 \
+          char_projected_rhs_dt_v_minus,                                       \
+      const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,           \
+      const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi,        \
+      const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,          \
+      const std::array<DTYPE(data), 4>& char_speeds);                          \
+  template void gh::BoundaryConditions::Bjorhus::                              \
+      constraint_preserving_corrections_dt_v_minus(                            \
+          const gsl::not_null<                                                 \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>              \
+              bc_dt_v_minus,                                                   \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_one_form,                                          \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_vector,                                            \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_vector,                                            \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_ab,                                                   \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_Ab,                                                   \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_AB,                                                   \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              char_projected_rhs_dt_v_minus,                                   \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_plus,                                       \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_minus,                                      \
+          const std::array<DTYPE(data), 4>& char_speeds);                      \
+  template void gh::BoundaryConditions::Bjorhus::                              \
+      constraint_preserving_gauge_corrections_dt_v_minus(                      \
+          const gsl::not_null<                                                 \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>              \
+              bc_dt_v_minus,                                                   \
+          const Scalar<DTYPE(data)>& gamma2,                                   \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              inertial_coords,                                                 \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_one_form,                                          \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_one_form,                                          \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_vector,                                            \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_vector,                                            \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_ab,                                                   \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_Ab,                                                   \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_AB,                                                   \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              char_projected_rhs_dt_v_psi,                                     \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              char_projected_rhs_dt_v_minus,                                   \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_plus,                                       \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_minus,                                      \
+          const std::array<DTYPE(data), 4>& char_speeds);                      \
+  template void gh::BoundaryConditions::Bjorhus::                              \
+      constraint_preserving_gauge_physical_corrections_dt_v_minus(             \
+          const gsl::not_null<                                                 \
+              tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>              \
+              bc_dt_v_minus,                                                   \
+          const Scalar<DTYPE(data)>& gamma2,                                   \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              inertial_coords,                                                 \
+          const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              unit_interface_normal_one_form,                                  \
+          const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              unit_interface_normal_vector,                                    \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              spacetime_unit_normal_vector,                                    \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_one_form,                                          \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_one_form,                                          \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              incoming_null_vector,                                            \
+          const tnsr::A<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              outgoing_null_vector,                                            \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_ab,                                                   \
+          const tnsr::Ab<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_Ab,                                                   \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              projection_AB,                                                   \
+          const tnsr::II<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              inverse_spatial_metric,                                          \
+          const tnsr::ii<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              extrinsic_curvature,                                             \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              spacetime_metric,                                                \
+          const tnsr::AA<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              inverse_spacetime_metric,                                        \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>&            \
+              three_index_constraint,                                          \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              char_projected_rhs_dt_v_psi,                                     \
+          const tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>&             \
+              char_projected_rhs_dt_v_minus,                                   \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_plus,                                       \
+          const tnsr::a<DTYPE(data), DIM(data), Frame::Inertial>&              \
+              constraint_char_zero_minus,                                      \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,       \
+          const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi,    \
+          const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,      \
           const std::array<DTYPE(data), 4>& char_speeds);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (DataVector))

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -494,7 +494,7 @@ void add_physical_terms_to_dt_v_minus(
 }  // namespace detail
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
@@ -532,7 +532,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_minus(
 }
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
     const gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
@@ -693,7 +693,7 @@ void constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
       const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,         \
       const std::array<DTYPE(data), 4>& char_speeds);                         \
   template void gh::BoundaryConditions::Bjorhus::                             \
-      constraint_preserving_bjorhus_corrections_dt_v_minus(                   \
+      constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(             \
           const gsl::not_null<                                                \
               tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
               bc_dt_v_minus,                                                  \
@@ -724,7 +724,7 @@ void constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
               constraint_char_zero_minus,                                     \
           const std::array<DTYPE(data), 4>& char_speeds);                     \
   template void gh::BoundaryConditions::Bjorhus::                             \
-      constraint_preserving_physical_bjorhus_corrections_dt_v_minus(          \
+      constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(    \
           const gsl::not_null<                                                \
               tnsr::aa<DTYPE(data), DIM(data), Frame::Inertial>*>             \
               bc_dt_v_minus,                                                  \

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -169,7 +169,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
  * where \f$q^a\f$ is the future-directed spacetime normal vector.
  */
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
@@ -192,7 +192,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_minus(
     const std::array<DataType, 4>& char_speeds);
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -169,6 +169,24 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
  * where \f$q^a\f$ is the future-directed spacetime normal vector.
  */
 template <size_t VolumeDim, typename DataType>
+void constraint_preserving_bjorhus_corrections_dt_v_minus(
+    gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
+        bc_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataType, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataType, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataType, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::aa<DataType, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataType, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const std::array<DataType, 4>& char_speeds);
+
+template <size_t VolumeDim, typename DataType>
 void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -38,7 +38,7 @@ namespace Bjorhus {
  * \f$v^{\psi}_{ab}\f$.
  */
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_psi(
+void constraint_preserving_corrections_dt_v_psi(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*> bc_dt_v_psi,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
         unit_interface_normal_vector,
@@ -69,7 +69,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_psi(
  * C_{10ab}\f$, and in 1D \f$\hat{C}_{0ab} = 0\f$.
  */
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_zero(
+void constraint_preserving_corrections_dt_v_zero(
     gsl::not_null<tnsr::iaa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_zero,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
@@ -169,7 +169,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_zero(
  * where \f$q^a\f$ is the future-directed spacetime normal vector.
  */
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_corrections_dt_v_minus(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const tnsr::a<DataType, VolumeDim, Frame::Inertial>& outgoing_null_one_form,
@@ -187,7 +187,7 @@ void constraint_preserving_bjorhus_corrections_dt_v_minus(
     const std::array<DataType, 4>& char_speeds);
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_corrections_dt_v_minus(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
@@ -210,7 +210,7 @@ void constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     const std::array<DataType, 4>& char_speeds);
 
 template <size_t VolumeDim, typename DataType>
-void constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
+void constraint_preserving_gauge_physical_corrections_dt_v_minus(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame::Inertial>*>
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -13,7 +13,7 @@ import PointwiseFunctions.GeneralRelativity.ProjectionOperators as proj
 import PointwiseFunctions.GeneralRelativity.WeylPropagating as wp
 
 
-def constraint_preserving_bjorhus_corrections_dt_v_psi(
+def constraint_preserving_corrections_dt_v_psi(
     unit_interface_normal_vector, three_index_constraint, char_speeds
 ):
     return char_speeds[0] * np.einsum(
@@ -21,7 +21,7 @@ def constraint_preserving_bjorhus_corrections_dt_v_psi(
     )
 
 
-def constraint_preserving_bjorhus_corrections_dt_v_zero(
+def constraint_preserving_corrections_dt_v_zero(
     unit_interface_normal_vector, four_index_constraint, char_speeds
 ):
     spatial_dim = len(unit_interface_normal_vector)
@@ -343,7 +343,7 @@ def add_physical_dof_terms_to_dt_v_minus(
     return t1_ + t2_
 
 
-def constraint_preserving_bjorhus_corrections_dt_v_minus(
+def constraint_preserving_corrections_dt_v_minus(
     outgoing_null_one_form,
     incoming_null_vector,
     outgoing_null_vector,
@@ -372,7 +372,7 @@ def constraint_preserving_bjorhus_corrections_dt_v_minus(
     )
 
 
-def constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
+def constraint_preserving_gauge_corrections_dt_v_minus(
     gamma2,
     inertial_coords,
     incoming_null_one_form,
@@ -415,7 +415,7 @@ def constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     )
 
 
-def constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
+def constraint_preserving_gauge_physical_corrections_dt_v_minus(
     gamma2,
     inertial_coords,
     unit_interface_normal_one_form,
@@ -813,14 +813,14 @@ def dt_corrs_ConstraintPreservingGauge(
         char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
     if np.amin(char_speeds) >= 0.0:
         return (pi * 0, phi * 0, pi * 0, pi * 0)
-    dt_v_psi = constraint_preserving_bjorhus_corrections_dt_v_psi(
+    dt_v_psi = constraint_preserving_corrections_dt_v_psi(
         unit_interface_normal_vector, three_index_constraint, char_speeds
     )
-    dt_v_zero = constraint_preserving_bjorhus_corrections_dt_v_zero(
+    dt_v_zero = constraint_preserving_corrections_dt_v_zero(
         unit_interface_normal_vector, four_index_constraint, char_speeds
     )
     dt_v_plus = -1.0 * char_projected_rhs_dt_v_plus
-    dt_v_minus = constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
+    dt_v_minus = constraint_preserving_gauge_corrections_dt_v_minus(
         gamma2,
         coords,
         incoming_null_one_form,
@@ -924,41 +924,39 @@ def dt_corrs_ConstraintPreservingGaugePhysical(
         char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
     if np.amin(char_speeds) >= 0.0:
         return (pi * 0, phi * 0, pi * 0, pi * 0)
-    dt_v_psi = constraint_preserving_bjorhus_corrections_dt_v_psi(
+    dt_v_psi = constraint_preserving_corrections_dt_v_psi(
         unit_interface_normal_vector, three_index_constraint, char_speeds
     )
-    dt_v_zero = constraint_preserving_bjorhus_corrections_dt_v_zero(
+    dt_v_zero = constraint_preserving_corrections_dt_v_zero(
         unit_interface_normal_vector, four_index_constraint, char_speeds
     )
     dt_v_plus = -1.0 * char_projected_rhs_dt_v_plus
-    dt_v_minus = (
-        constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
-            gamma2,
-            coords,
-            normal_covector,
-            unit_interface_normal_vector,
-            spacetime_unit_normal_vector,
-            incoming_null_one_form,
-            outgoing_null_one_form,
-            incoming_null_vector,
-            outgoing_null_vector,
-            projection_ab,
-            projection_Ab,
-            projection_AB,
-            inverse_spatial_metric,
-            extrinsic_curvature,
-            spacetime_metric,
-            inverse_spacetime_metric,
-            three_index_constraint,
-            char_projected_rhs_dt_v_psi,
-            char_projected_rhs_dt_v_minus,
-            constraint_char_zero_plus,
-            constraint_char_zero_minus,
-            phi,
-            d_phi,
-            d_pi,
-            char_speeds,
-        )
+    dt_v_minus = constraint_preserving_gauge_physical_corrections_dt_v_minus(
+        gamma2,
+        coords,
+        normal_covector,
+        unit_interface_normal_vector,
+        spacetime_unit_normal_vector,
+        incoming_null_one_form,
+        outgoing_null_one_form,
+        incoming_null_vector,
+        outgoing_null_vector,
+        projection_ab,
+        projection_Ab,
+        projection_AB,
+        inverse_spatial_metric,
+        extrinsic_curvature,
+        spacetime_metric,
+        inverse_spacetime_metric,
+        three_index_constraint,
+        char_projected_rhs_dt_v_psi,
+        char_projected_rhs_dt_v_minus,
+        constraint_char_zero_plus,
+        constraint_char_zero_minus,
+        phi,
+        d_phi,
+        d_pi,
+        char_speeds,
     )
     dt_v_psi = set_bc_corr_zero_when_char_speed_is_positive(
         dt_v_psi, char_speeds[0]

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -113,7 +113,6 @@ def add_gauge_sommerfeld_terms_to_dt_v_minus(
 
 
 def add_constraint_dependent_terms_to_dt_v_minus(
-    incoming_null_one_form,
     outgoing_null_one_form,
     incoming_null_vector,
     outgoing_null_vector,
@@ -344,6 +343,35 @@ def add_physical_dof_terms_to_dt_v_minus(
     return t1_ + t2_
 
 
+def constraint_preserving_bjorhus_corrections_dt_v_minus(
+    outgoing_null_one_form,
+    incoming_null_vector,
+    outgoing_null_vector,
+    projection_ab,
+    projection_Ab,
+    projection_AB,
+    char_projected_rhs_dt_v_minus,
+    constraint_char_zero_plus,
+    constraint_char_zero_minus,
+    char_speeds,
+):
+    return (
+        add_constraint_dependent_terms_to_dt_v_minus(
+            outgoing_null_one_form,
+            incoming_null_vector,
+            outgoing_null_vector,
+            projection_ab,
+            projection_Ab,
+            projection_AB,
+            constraint_char_zero_plus,
+            constraint_char_zero_minus,
+            char_projected_rhs_dt_v_minus,
+            char_speeds,
+        )
+        - char_projected_rhs_dt_v_minus
+    )
+
+
 def constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     gamma2,
     inertial_coords,
@@ -362,7 +390,6 @@ def constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
 ):
     return (
         add_constraint_dependent_terms_to_dt_v_minus(
-            incoming_null_one_form,
             outgoing_null_one_form,
             incoming_null_vector,
             outgoing_null_vector,
@@ -417,7 +444,6 @@ def constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
 ):
     return (
         add_constraint_dependent_terms_to_dt_v_minus(
-            incoming_null_one_form,
             outgoing_null_one_form,
             incoming_null_vector,
             outgoing_null_vector,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -344,7 +344,7 @@ def add_physical_dof_terms_to_dt_v_minus(
     return t1_ + t2_
 
 
-def constraint_preserving_bjorhus_corrections_dt_v_minus(
+def constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     gamma2,
     inertial_coords,
     incoming_null_one_form,
@@ -388,7 +388,7 @@ def constraint_preserving_bjorhus_corrections_dt_v_minus(
     )
 
 
-def constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+def constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
     gamma2,
     inertial_coords,
     unit_interface_normal_one_form,
@@ -714,7 +714,7 @@ def set_bc_corr_zero_when_char_speed_is_positive(dt_v_corr, char_speeds):
     return dt_v_corr
 
 
-def dt_corrs_ConstraintPreserving(
+def dt_corrs_ConstraintPreservingGauge(
     face_mesh_velocity,
     normal_covector,
     normal_vector,
@@ -794,7 +794,7 @@ def dt_corrs_ConstraintPreserving(
         unit_interface_normal_vector, four_index_constraint, char_speeds
     )
     dt_v_plus = -1.0 * char_projected_rhs_dt_v_plus
-    dt_v_minus = constraint_preserving_bjorhus_corrections_dt_v_minus(
+    dt_v_minus = constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
         gamma2,
         coords,
         incoming_null_one_form,
@@ -825,7 +825,7 @@ def dt_corrs_ConstraintPreserving(
     return dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus
 
 
-def dt_corrs_ConstraintPreservingPhysical(
+def dt_corrs_ConstraintPreservingGaugePhysical(
     face_mesh_velocity,
     normal_covector,
     normal_vector,
@@ -905,32 +905,34 @@ def dt_corrs_ConstraintPreservingPhysical(
         unit_interface_normal_vector, four_index_constraint, char_speeds
     )
     dt_v_plus = -1.0 * char_projected_rhs_dt_v_plus
-    dt_v_minus = constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
-        gamma2,
-        coords,
-        normal_covector,
-        unit_interface_normal_vector,
-        spacetime_unit_normal_vector,
-        incoming_null_one_form,
-        outgoing_null_one_form,
-        incoming_null_vector,
-        outgoing_null_vector,
-        projection_ab,
-        projection_Ab,
-        projection_AB,
-        inverse_spatial_metric,
-        extrinsic_curvature,
-        spacetime_metric,
-        inverse_spacetime_metric,
-        three_index_constraint,
-        char_projected_rhs_dt_v_psi,
-        char_projected_rhs_dt_v_minus,
-        constraint_char_zero_plus,
-        constraint_char_zero_minus,
-        phi,
-        d_phi,
-        d_pi,
-        char_speeds,
+    dt_v_minus = (
+        constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
+            gamma2,
+            coords,
+            normal_covector,
+            unit_interface_normal_vector,
+            spacetime_unit_normal_vector,
+            incoming_null_one_form,
+            outgoing_null_one_form,
+            incoming_null_vector,
+            outgoing_null_vector,
+            projection_ab,
+            projection_Ab,
+            projection_AB,
+            inverse_spatial_metric,
+            extrinsic_curvature,
+            spacetime_metric,
+            inverse_spacetime_metric,
+            three_index_constraint,
+            char_projected_rhs_dt_v_psi,
+            char_projected_rhs_dt_v_minus,
+            constraint_char_zero_plus,
+            constraint_char_zero_minus,
+            phi,
+            d_phi,
+            d_pi,
+            char_speeds,
+        )
     )
     dt_v_psi = set_bc_corr_zero_when_char_speed_is_positive(
         dt_v_psi, char_speeds[0]
@@ -998,7 +1000,7 @@ def dt_spacetime_metric(
         d_phi,
     )
     (dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus) = (
-        dt_corrs_ConstraintPreserving(
+        dt_corrs_ConstraintPreservingGauge(
             face_mesh_velocity,
             normal_covector,
             normal_vector,
@@ -1076,7 +1078,7 @@ def dt_spacetime_metric_static_mesh(
     )
 
 
-def dt_pi_ConstraintPreserving(
+def dt_pi_ConstraintPreservingGauge(
     face_mesh_velocity,
     normal_covector,
     normal_vector,
@@ -1110,7 +1112,7 @@ def dt_pi_ConstraintPreserving(
         d_phi,
     )
     (dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus) = (
-        dt_corrs_ConstraintPreserving(
+        dt_corrs_ConstraintPreservingGauge(
             face_mesh_velocity,
             normal_covector,
             normal_vector,
@@ -1141,7 +1143,7 @@ def dt_pi_ConstraintPreserving(
     )
 
 
-def dt_pi_ConstraintPreserving_static_mesh(
+def dt_pi_ConstraintPreservingGauge_static_mesh(
     normal_covector,
     normal_vector,
     spacetime_metric,
@@ -1164,7 +1166,7 @@ def dt_pi_ConstraintPreserving_static_mesh(
     d_pi,
     d_phi,
 ):
-    return dt_pi_ConstraintPreserving(
+    return dt_pi_ConstraintPreservingGauge(
         0.0 * normal_vector,
         normal_covector,
         normal_vector,
@@ -1190,7 +1192,7 @@ def dt_pi_ConstraintPreserving_static_mesh(
     )
 
 
-def dt_pi_ConstraintPreservingPhysical(
+def dt_pi_ConstraintPreservingGaugePhysical(
     face_mesh_velocity,
     normal_covector,
     normal_vector,
@@ -1224,7 +1226,7 @@ def dt_pi_ConstraintPreservingPhysical(
         d_phi,
     )
     (dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus) = (
-        dt_corrs_ConstraintPreservingPhysical(
+        dt_corrs_ConstraintPreservingGaugePhysical(
             face_mesh_velocity,
             normal_covector,
             normal_vector,
@@ -1255,7 +1257,7 @@ def dt_pi_ConstraintPreservingPhysical(
     )
 
 
-def dt_pi_ConstraintPreservingPhysical_static_mesh(
+def dt_pi_ConstraintPreservingGaugePhysical_static_mesh(
     normal_covector,
     normal_vector,
     spacetime_metric,
@@ -1278,7 +1280,7 @@ def dt_pi_ConstraintPreservingPhysical_static_mesh(
     d_pi,
     d_phi,
 ):
-    return dt_pi_ConstraintPreservingPhysical(
+    return dt_pi_ConstraintPreservingGaugePhysical(
         0.0 * normal_vector,
         normal_covector,
         normal_vector,
@@ -1304,7 +1306,7 @@ def dt_pi_ConstraintPreservingPhysical_static_mesh(
     )
 
 
-def dt_phi_ConstraintPreserving(
+def dt_phi_ConstraintPreservingGauge(
     face_mesh_velocity,
     normal_covector,
     normal_vector,
@@ -1338,7 +1340,7 @@ def dt_phi_ConstraintPreserving(
         d_phi,
     )
     (dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus) = (
-        dt_corrs_ConstraintPreserving(
+        dt_corrs_ConstraintPreservingGauge(
             face_mesh_velocity,
             normal_covector,
             normal_vector,
@@ -1369,7 +1371,7 @@ def dt_phi_ConstraintPreserving(
     )
 
 
-def dt_phi_ConstraintPreserving_static_mesh(
+def dt_phi_ConstraintPreservingGauge_static_mesh(
     normal_covector,
     normal_vector,
     spacetime_metric,
@@ -1392,7 +1394,7 @@ def dt_phi_ConstraintPreserving_static_mesh(
     d_pi,
     d_phi,
 ):
-    return dt_phi_ConstraintPreserving(
+    return dt_phi_ConstraintPreservingGauge(
         0.0 * normal_vector,
         normal_covector,
         normal_vector,
@@ -1418,7 +1420,7 @@ def dt_phi_ConstraintPreserving_static_mesh(
     )
 
 
-def dt_phi_ConstraintPreservingPhysical(
+def dt_phi_ConstraintPreservingGaugePhysical(
     face_mesh_velocity,
     normal_covector,
     normal_vector,
@@ -1452,7 +1454,7 @@ def dt_phi_ConstraintPreservingPhysical(
         d_phi,
     )
     (dt_v_psi, dt_v_zero, dt_v_plus, dt_v_minus) = (
-        dt_corrs_ConstraintPreservingPhysical(
+        dt_corrs_ConstraintPreservingGaugePhysical(
             face_mesh_velocity,
             normal_covector,
             normal_vector,
@@ -1483,7 +1485,7 @@ def dt_phi_ConstraintPreservingPhysical(
     )
 
 
-def dt_phi_ConstraintPreservingPhysical_static_mesh(
+def dt_phi_ConstraintPreservingGaugePhysical_static_mesh(
     normal_covector,
     normal_vector,
     spacetime_metric,
@@ -1506,7 +1508,7 @@ def dt_phi_ConstraintPreservingPhysical_static_mesh(
     d_pi,
     d_phi,
 ):
-    return dt_phi_ConstraintPreservingPhysical(
+    return dt_phi_ConstraintPreservingGaugePhysical(
         0.0 * normal_vector,
         normal_covector,
         normal_vector,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
@@ -31,8 +31,10 @@ template <size_t Dim>
 void test() {
   CAPTURE(Dim);
   MAKE_GENERATOR(gen);
-  for (const std::string& bc_string :
-       {"ConstraintPreserving"s, "ConstraintPreservingPhysical"s}) {
+  for (const auto& [bc_string, bc_type] :
+       {std::pair{"ConstraintPreserving"s, "ConstraintPreservingGauge"s},
+        std::pair{"ConstraintPreservingPhysical"s,
+                  "ConstraintPreservingGaugePhysical"s}}) {
     CAPTURE(bc_string);
 
     helpers::test_boundary_condition_with_python<
@@ -49,8 +51,8 @@ void test() {
                 ::Tags::dt<gh::Tags::Pi<DataVector, Dim, frame>>>,
             helpers::Tags::PythonFunctionName<
                 ::Tags::dt<gh::Tags::Phi<DataVector, Dim, frame>>>>{
-            "error", "dt_spacetime_metric", "dt_pi_" + bc_string,
-            "dt_phi_" + bc_string},
+            "error", "dt_spacetime_metric", "dt_pi_" + bc_type,
+            "dt_phi_" + bc_type},
         "ConstraintPreservingBjorhus:\n"
         "  Type: " +
             bc_string,
@@ -70,7 +72,7 @@ void test() {
 }
 
 template <size_t Dim>
-void wrap_dt_vars_corrections_ConstraintPreserving(
+void wrap_dt_vars_corrections_ConstraintPreservingGauge(
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*>
         dt_spacetime_metric_correction,
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*> dt_pi_correction,
@@ -114,7 +116,7 @@ void wrap_dt_vars_corrections_ConstraintPreserving(
 }
 
 template <size_t Dim>
-void wrap_dt_vars_corrections_ConstraintPreserving_static_mesh(
+void wrap_dt_vars_corrections_ConstraintPreservingGauge_static_mesh(
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*>
         dt_spacetime_metric_correction,
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*> dt_pi_correction,
@@ -157,7 +159,7 @@ void wrap_dt_vars_corrections_ConstraintPreserving_static_mesh(
 }
 
 template <size_t Dim>
-void wrap_dt_vars_corrections_ConstraintPreservingPhysical(
+void wrap_dt_vars_corrections_ConstraintPreservingGaugePhysical(
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*>
         dt_spacetime_metric_correction,
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*> dt_pi_correction,
@@ -201,7 +203,7 @@ void wrap_dt_vars_corrections_ConstraintPreservingPhysical(
 }
 
 template <size_t Dim>
-void wrap_dt_vars_corrections_ConstraintPreservingPhysical_static_mesh(
+void wrap_dt_vars_corrections_ConstraintPreservingGaugePhysical_static_mesh(
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*>
         dt_spacetime_metric_correction,
     const gsl::not_null<tnsr::aa<DataVector, Dim, frame>*> dt_pi_correction,
@@ -247,32 +249,33 @@ template <size_t Dim>
 void test_with_random_values(const DataVector& used_for_size) {
   // Static mesh
   pypp::check_with_random_values<1>(
-      wrap_dt_vars_corrections_ConstraintPreserving_static_mesh<Dim>,
+      wrap_dt_vars_corrections_ConstraintPreservingGauge_static_mesh<Dim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
       {"dt_spacetime_metric_static_mesh",
-       "dt_pi_ConstraintPreserving_static_mesh",
-       "dt_phi_ConstraintPreserving_static_mesh"},
+       "dt_pi_ConstraintPreservingGauge_static_mesh",
+       "dt_phi_ConstraintPreservingGauge_static_mesh"},
       {{{0.1, 1.}}}, used_for_size, 1.e-6);
   pypp::check_with_random_values<1>(
-      wrap_dt_vars_corrections_ConstraintPreservingPhysical_static_mesh<Dim>,
+      wrap_dt_vars_corrections_ConstraintPreservingGaugePhysical_static_mesh<
+          Dim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
       {"dt_spacetime_metric_static_mesh",
-       "dt_pi_ConstraintPreservingPhysical_static_mesh",
-       "dt_phi_ConstraintPreservingPhysical_static_mesh"},
+       "dt_pi_ConstraintPreservingGaugePhysical_static_mesh",
+       "dt_phi_ConstraintPreservingGaugePhysical_static_mesh"},
       {{{0.1, 1.}}}, used_for_size, 1.e-6);
 
   // Moving mesh
   pypp::check_with_random_values<1>(
-      wrap_dt_vars_corrections_ConstraintPreserving<Dim>,
+      wrap_dt_vars_corrections_ConstraintPreservingGauge<Dim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      {"dt_spacetime_metric", "dt_pi_ConstraintPreserving",
-       "dt_phi_ConstraintPreserving"},
+      {"dt_spacetime_metric", "dt_pi_ConstraintPreservingGauge",
+       "dt_phi_ConstraintPreservingGauge"},
       {{{0.1, 1.}}}, used_for_size, 1.e-6);
   pypp::check_with_random_values<1>(
-      wrap_dt_vars_corrections_ConstraintPreservingPhysical<Dim>,
+      wrap_dt_vars_corrections_ConstraintPreservingGaugePhysical<Dim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      {"dt_spacetime_metric", "dt_pi_ConstraintPreservingPhysical",
-       "dt_phi_ConstraintPreservingPhysical"},
+      {"dt_spacetime_metric", "dt_pi_ConstraintPreservingGaugePhysical",
+       "dt_phi_ConstraintPreservingGaugePhysical"},
       {{{0.1, 1.}}}, used_for_size, 1.e-6);
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
@@ -83,11 +83,9 @@ void test_constraint_preserving_bjorhus_v_psi_vs_spec_3d(
     }
 
     // Compute rhs value
-    gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_bjorhus_corrections_dt_v_psi(
-            make_not_null(&local_bc_dt_v_psi),
-            local_unit_interface_normal_vector, local_three_index_constraint,
-            local_char_speeds);
+    gh::BoundaryConditions::Bjorhus::constraint_preserving_corrections_dt_v_psi(
+        make_not_null(&local_bc_dt_v_psi), local_unit_interface_normal_vector,
+        local_three_index_constraint, local_char_speeds);
     // Setting local_RhsVSpacetimeMetric
     for (size_t i = 0; i < slice_grid_points; ++i) {
       for (size_t a = 0; a <= VolumeDim; ++a) {
@@ -131,11 +129,9 @@ void test_constraint_preserving_bjorhus_v_psi_vs_spec_3d(
       local_unit_interface_normal_vector.get(2)[i] = 1.;
     }
     // Compute rhs value
-    gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_bjorhus_corrections_dt_v_psi(
-            make_not_null(&local_bc_dt_v_psi),
-            local_unit_interface_normal_vector, local_three_index_constraint,
-            local_char_speeds);
+    gh::BoundaryConditions::Bjorhus::constraint_preserving_corrections_dt_v_psi(
+        make_not_null(&local_bc_dt_v_psi), local_unit_interface_normal_vector,
+        local_three_index_constraint, local_char_speeds);
     // Setting local_RhsVSpacetimeMetric
     for (size_t i = 0; i < slice_grid_points; ++i) {
       for (size_t a = 0; a <= VolumeDim; ++a) {
@@ -234,7 +230,7 @@ void test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(
 
     // Compute rhs value
     gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_bjorhus_corrections_dt_v_zero(
+        constraint_preserving_corrections_dt_v_zero(
             make_not_null(&local_bc_dt_v_zero),
             local_unit_interface_normal_vector, local_four_index_constraint,
             local_char_speeds);
@@ -291,7 +287,7 @@ void test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(
     }
     // Compute rhs value
     gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_bjorhus_corrections_dt_v_zero(
+        constraint_preserving_corrections_dt_v_zero(
             make_not_null(&local_bc_dt_v_zero),
             local_unit_interface_normal_vector, local_four_index_constraint,
             local_char_speeds);
@@ -767,7 +763,7 @@ void test_constraint_preserving_gauge_physical_bjorhus_v_minus_vs_spec_3d(
   {
     // Compute the new boundary corrections for dt<vminus>
     gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
+        constraint_preserving_gauge_corrections_dt_v_minus(
             make_not_null(&local_bc_dt_v_minus), local_constraint_gamma2,
             local_inertial_coords, local_incoming_null_one_form,
             local_outgoing_null_one_form, local_incoming_null_vector,
@@ -909,7 +905,7 @@ void test_constraint_preserving_gauge_physical_bjorhus_v_minus_vs_spec_3d(
 
   {  // Compute the new boundary corrections for dt<vminus>
     gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
+        constraint_preserving_gauge_physical_corrections_dt_v_minus(
             make_not_null(&local_bc_dt_v_minus), local_constraint_gamma2,
             local_inertial_coords, local_unit_interface_normal_one_form,
             local_unit_interface_normal_vector,
@@ -1088,20 +1084,19 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_v_psi(
   auto dt_v_psi =
       make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
           interface_normal_vector, 0.);
-  gh::BoundaryConditions::Bjorhus::
-      constraint_preserving_bjorhus_corrections_dt_v_psi<VolumeDim, DataVector>(
-          make_not_null(&dt_v_psi), interface_normal_vector,
-          three_index_constraint, char_speed_array);
+  gh::BoundaryConditions::Bjorhus::constraint_preserving_corrections_dt_v_psi<
+      VolumeDim, DataVector>(make_not_null(&dt_v_psi), interface_normal_vector,
+                             three_index_constraint, char_speed_array);
   return dt_v_psi;
 }
 
 template <size_t VolumeDim>
-void test_constraint_preserving_bjorhus_corrections_dt_v_psi(
+void test_constraint_preserving_corrections_dt_v_psi(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
       &wrapper_func_v_psi<VolumeDim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      "constraint_preserving_bjorhus_corrections_dt_v_psi", {{{-1., 1.}}},
+      "constraint_preserving_corrections_dt_v_psi", {{{-1., 1.}}},
       DataVector(grid_size_each_dimension));
 }
 
@@ -1118,21 +1113,19 @@ tnsr::iaa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_v_zero(
   auto dt_v_zero =
       make_with_value<tnsr::iaa<DataVector, VolumeDim, Frame::Inertial>>(
           get<0>(interface_normal_vector), 0.);
-  gh::BoundaryConditions::Bjorhus::
-      constraint_preserving_bjorhus_corrections_dt_v_zero<VolumeDim,
-                                                          DataVector>(
-          make_not_null(&dt_v_zero), interface_normal_vector,
-          four_index_constraint, char_speed_array);
+  gh::BoundaryConditions::Bjorhus::constraint_preserving_corrections_dt_v_zero<
+      VolumeDim, DataVector>(make_not_null(&dt_v_zero), interface_normal_vector,
+                             four_index_constraint, char_speed_array);
   return dt_v_zero;
 }
 
 template <size_t VolumeDim>
-void test_constraint_preserving_bjorhus_corrections_dt_v_zero(
+void test_constraint_preserving_corrections_dt_v_zero(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
       &wrapper_func_v_zero<VolumeDim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      "constraint_preserving_bjorhus_corrections_dt_v_zero", {{{-1., 1.}}},
+      "constraint_preserving_corrections_dt_v_zero", {{{-1., 1.}}},
       DataVector(grid_size_each_dimension));
 }
 
@@ -1158,14 +1151,12 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cp_v_minus(
   auto dt_v_minus =
       make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
           get<0>(outgoing_null_one_form), 0.);
-  gh::BoundaryConditions::Bjorhus::
-      constraint_preserving_bjorhus_corrections_dt_v_minus<VolumeDim,
-                                                           DataVector>(
-          make_not_null(&dt_v_minus), outgoing_null_one_form,
-          incoming_null_vector, outgoing_null_vector, projection_ab,
-          projection_Ab, projection_AB, char_projected_rhs_dt_v_minus,
-          constraint_char_zero_plus, constraint_char_zero_minus,
-          char_speed_array);
+  gh::BoundaryConditions::Bjorhus::constraint_preserving_corrections_dt_v_minus<
+      VolumeDim, DataVector>(
+      make_not_null(&dt_v_minus), outgoing_null_one_form, incoming_null_vector,
+      outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
+      char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
+      constraint_char_zero_minus, char_speed_array);
   return dt_v_minus;
 }
 
@@ -1198,8 +1189,7 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpg_v_minus(
       make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
           get(gamma2), 0.);
   gh::BoundaryConditions::Bjorhus::
-      constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<VolumeDim,
-                                                                 DataVector>(
+      constraint_preserving_gauge_corrections_dt_v_minus<VolumeDim, DataVector>(
           make_not_null(&dt_v_minus), gamma2, inertial_coords,
           incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
           outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
@@ -1255,8 +1245,8 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpgp_v_minus(
       make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
           get(gamma2), 0.);
   gh::BoundaryConditions::Bjorhus::
-      constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<
-          VolumeDim, DataVector>(
+      constraint_preserving_gauge_physical_corrections_dt_v_minus<VolumeDim,
+                                                                  DataVector>(
           make_not_null(&dt_v_minus), gamma2, inertial_coords,
           unit_interface_normal_one_form, unit_interface_normal_vector,
           spacetime_unit_normal_vector, incoming_null_one_form,
@@ -1270,32 +1260,32 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpgp_v_minus(
 }
 
 template <size_t VolumeDim>
-void test_constraint_preserving_bjorhus_corrections_dt_v_minus(
+void test_constraint_preserving_corrections_dt_v_minus(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
       &wrapper_func_cp_v_minus<VolumeDim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      "constraint_preserving_bjorhus_corrections_dt_v_minus",
-      {{{-1., 1.}}}, DataVector(grid_size_each_dimension));
+      "constraint_preserving_corrections_dt_v_minus", {{{-1., 1.}}},
+      DataVector(grid_size_each_dimension));
 }
 
 template <size_t VolumeDim>
-void test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
+void test_constraint_preserving_gauge_corrections_dt_v_minus(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
       &wrapper_func_cpg_v_minus<VolumeDim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      "constraint_preserving_gauge_bjorhus_corrections_dt_v_minus",
-      {{{-1., 1.}}}, DataVector(grid_size_each_dimension));
+      "constraint_preserving_gauge_corrections_dt_v_minus", {{{-1., 1.}}},
+      DataVector(grid_size_each_dimension));
 }
 
 template <size_t VolumeDim>
-void test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
+void test_constraint_preserving_gauge_physical_corrections_dt_v_minus(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
       &wrapper_func_cpgp_v_minus<VolumeDim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      "constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus",
+      "constraint_preserving_gauge_physical_corrections_dt_v_minus",
       {{{-1., 1.}}}, DataVector(grid_size_each_dimension));
 }
 }  // namespace
@@ -1308,9 +1298,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VPsi",
   const size_t grid_size = 3;
 
   // Python tests
-  test_constraint_preserving_bjorhus_corrections_dt_v_psi<1>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_psi<2>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_psi<3>(grid_size);
+  test_constraint_preserving_corrections_dt_v_psi<1>(grid_size);
+  test_constraint_preserving_corrections_dt_v_psi<2>(grid_size);
+  test_constraint_preserving_corrections_dt_v_psi<3>(grid_size);
 
   // Piece-wise tests with SpEC output in 3D
   test_constraint_preserving_bjorhus_v_psi_vs_spec_3d(grid_size);
@@ -1324,9 +1314,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VZero",
   const size_t grid_size = 3;
 
   // Python tests
-  test_constraint_preserving_bjorhus_corrections_dt_v_zero<1>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_zero<2>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_zero<3>(grid_size);
+  test_constraint_preserving_corrections_dt_v_zero<1>(grid_size);
+  test_constraint_preserving_corrections_dt_v_zero<2>(grid_size);
+  test_constraint_preserving_corrections_dt_v_zero<3>(grid_size);
 
   // Piece-wise tests with SpEC output
   test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(grid_size);
@@ -1339,17 +1329,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VMinus",
   const size_t grid_size = 3;
 
   // Python tests
-  test_constraint_preserving_bjorhus_corrections_dt_v_minus<1>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_minus<2>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_minus<3>(grid_size);
-  test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<1>(grid_size);
-  test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<2>(grid_size);
-  test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<3>(grid_size);
-  test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<1>(
+  test_constraint_preserving_corrections_dt_v_minus<1>(grid_size);
+  test_constraint_preserving_corrections_dt_v_minus<2>(grid_size);
+  test_constraint_preserving_corrections_dt_v_minus<3>(grid_size);
+  test_constraint_preserving_gauge_corrections_dt_v_minus<1>(grid_size);
+  test_constraint_preserving_gauge_corrections_dt_v_minus<2>(grid_size);
+  test_constraint_preserving_gauge_corrections_dt_v_minus<3>(grid_size);
+  test_constraint_preserving_gauge_physical_corrections_dt_v_minus<1>(
       grid_size);
-  test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<2>(
+  test_constraint_preserving_gauge_physical_corrections_dt_v_minus<2>(
       grid_size);
-  test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<3>(
+  test_constraint_preserving_gauge_physical_corrections_dt_v_minus<3>(
       grid_size);
 
   // Piece-wise tests with SpEC output in 3D

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
@@ -1137,6 +1137,39 @@ void test_constraint_preserving_bjorhus_corrections_dt_v_zero(
 }
 
 template <size_t VolumeDim>
+tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cp_v_minus(
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        outgoing_null_one_form,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& incoming_null_vector,
+    const tnsr::A<DataVector, VolumeDim, Frame::Inertial>& outgoing_null_vector,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>& projection_ab,
+    const tnsr::Ab<DataVector, VolumeDim, Frame::Inertial>& projection_Ab,
+    const tnsr::AA<DataVector, VolumeDim, Frame::Inertial>& projection_AB,
+    const tnsr::aa<DataVector, VolumeDim, Frame::Inertial>&
+        char_projected_rhs_dt_v_minus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_plus,
+    const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
+        constraint_char_zero_minus,
+    const tnsr::a<DataVector, 3, Frame::Inertial>& char_speeds) {
+  const std::array<DataVector, 4> char_speed_array{
+      char_speeds.get(0), char_speeds.get(1), char_speeds.get(2),
+      char_speeds.get(3)};
+  auto dt_v_minus =
+      make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
+          get<0>(outgoing_null_one_form), 0.);
+  gh::BoundaryConditions::Bjorhus::
+      constraint_preserving_bjorhus_corrections_dt_v_minus<VolumeDim,
+                                                           DataVector>(
+          make_not_null(&dt_v_minus), outgoing_null_one_form,
+          incoming_null_vector, outgoing_null_vector, projection_ab,
+          projection_Ab, projection_AB, char_projected_rhs_dt_v_minus,
+          constraint_char_zero_plus, constraint_char_zero_minus,
+          char_speed_array);
+  return dt_v_minus;
+}
+
+template <size_t VolumeDim>
 tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpg_v_minus(
     const Scalar<DataVector>& gamma2,
     const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& inertial_coords,
@@ -1237,6 +1270,16 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpgp_v_minus(
 }
 
 template <size_t VolumeDim>
+void test_constraint_preserving_bjorhus_corrections_dt_v_minus(
+    const size_t grid_size_each_dimension) {
+  pypp::check_with_random_values<1>(
+      &wrapper_func_cp_v_minus<VolumeDim>,
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
+      "constraint_preserving_bjorhus_corrections_dt_v_minus",
+      {{{-1., 1.}}}, DataVector(grid_size_each_dimension));
+}
+
+template <size_t VolumeDim>
 void test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
@@ -1296,6 +1339,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VMinus",
   const size_t grid_size = 3;
 
   // Python tests
+  test_constraint_preserving_bjorhus_corrections_dt_v_minus<1>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_minus<2>(grid_size);
+  test_constraint_preserving_bjorhus_corrections_dt_v_minus<3>(grid_size);
   test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<1>(grid_size);
   test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<2>(grid_size);
   test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<3>(grid_size);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
@@ -336,7 +336,7 @@ void test_constraint_preserving_bjorhus_v_zero_vs_spec_3d(
   CHECK_ITERABLE_APPROX(local_bc_dt_v_zero, spec_bc_dt_v_zero);
 }
 
-void test_constraint_preserving_physical_bjorhus_v_minus_vs_spec_3d(
+void test_constraint_preserving_gauge_physical_bjorhus_v_minus_vs_spec_3d(
     const size_t grid_size_each_dimension,
     const std::array<double, 3>& lower_bound,
     const std::array<double, 3>& /* upper_bound */) {
@@ -767,7 +767,7 @@ void test_constraint_preserving_physical_bjorhus_v_minus_vs_spec_3d(
   {
     // Compute the new boundary corrections for dt<vminus>
     gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_bjorhus_corrections_dt_v_minus(
+        constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
             make_not_null(&local_bc_dt_v_minus), local_constraint_gamma2,
             local_inertial_coords, local_incoming_null_one_form,
             local_outgoing_null_one_form, local_incoming_null_vector,
@@ -909,7 +909,7 @@ void test_constraint_preserving_physical_bjorhus_v_minus_vs_spec_3d(
 
   {  // Compute the new boundary corrections for dt<vminus>
     gh::BoundaryConditions::Bjorhus::
-        constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+        constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
             make_not_null(&local_bc_dt_v_minus), local_constraint_gamma2,
             local_inertial_coords, local_unit_interface_normal_one_form,
             local_unit_interface_normal_vector,
@@ -1137,7 +1137,7 @@ void test_constraint_preserving_bjorhus_corrections_dt_v_zero(
 }
 
 template <size_t VolumeDim>
-tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cp_v_minus(
+tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpg_v_minus(
     const Scalar<DataVector>& gamma2,
     const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& inertial_coords,
     const tnsr::a<DataVector, VolumeDim, Frame::Inertial>&
@@ -1165,8 +1165,8 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cp_v_minus(
       make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
           get(gamma2), 0.);
   gh::BoundaryConditions::Bjorhus::
-      constraint_preserving_bjorhus_corrections_dt_v_minus<VolumeDim,
-                                                           DataVector>(
+      constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<VolumeDim,
+                                                                 DataVector>(
           make_not_null(&dt_v_minus), gamma2, inertial_coords,
           incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
           outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
@@ -1177,7 +1177,7 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cp_v_minus(
 }
 
 template <size_t VolumeDim>
-tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpp_v_minus(
+tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpgp_v_minus(
     const Scalar<DataVector>& gamma2,
     const tnsr::I<DataVector, VolumeDim, Frame::Inertial>& inertial_coords,
     const tnsr::i<DataVector, VolumeDim, Frame::Inertial>&
@@ -1222,8 +1222,8 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpp_v_minus(
       make_with_value<tnsr::aa<DataVector, VolumeDim, Frame::Inertial>>(
           get(gamma2), 0.);
   gh::BoundaryConditions::Bjorhus::
-      constraint_preserving_physical_bjorhus_corrections_dt_v_minus<VolumeDim,
-                                                                    DataVector>(
+      constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<
+          VolumeDim, DataVector>(
           make_not_null(&dt_v_minus), gamma2, inertial_coords,
           unit_interface_normal_one_form, unit_interface_normal_vector,
           spacetime_unit_normal_vector, incoming_null_one_form,
@@ -1237,22 +1237,22 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpp_v_minus(
 }
 
 template <size_t VolumeDim>
-void test_constraint_preserving_bjorhus_corrections_dt_v_minus(
+void test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
-      &wrapper_func_cp_v_minus<VolumeDim>,
+      &wrapper_func_cpg_v_minus<VolumeDim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      "constraint_preserving_bjorhus_corrections_dt_v_minus", {{{-1., 1.}}},
-      DataVector(grid_size_each_dimension));
+      "constraint_preserving_gauge_bjorhus_corrections_dt_v_minus",
+      {{{-1., 1.}}}, DataVector(grid_size_each_dimension));
 }
 
 template <size_t VolumeDim>
-void test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus(
+void test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus(
     const size_t grid_size_each_dimension) {
   pypp::check_with_random_values<1>(
-      &wrapper_func_cpp_v_minus<VolumeDim>,
+      &wrapper_func_cpgp_v_minus<VolumeDim>,
       "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
-      "constraint_preserving_physical_bjorhus_corrections_dt_v_minus",
+      "constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus",
       {{{-1., 1.}}}, DataVector(grid_size_each_dimension));
 }
 }  // namespace
@@ -1296,20 +1296,20 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VMinus",
   const size_t grid_size = 3;
 
   // Python tests
-  test_constraint_preserving_bjorhus_corrections_dt_v_minus<1>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_minus<2>(grid_size);
-  test_constraint_preserving_bjorhus_corrections_dt_v_minus<3>(grid_size);
-  test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus<1>(
+  test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<1>(grid_size);
+  test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<2>(grid_size);
+  test_constraint_preserving_gauge_bjorhus_corrections_dt_v_minus<3>(grid_size);
+  test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<1>(
       grid_size);
-  test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus<2>(
+  test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<2>(
       grid_size);
-  test_constraint_preserving_physical_bjorhus_corrections_dt_v_minus<3>(
+  test_constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus<3>(
       grid_size);
 
   // Piece-wise tests with SpEC output in 3D
   const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
   const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
 
-  test_constraint_preserving_physical_bjorhus_v_minus_vs_spec_3d(
+  test_constraint_preserving_gauge_physical_bjorhus_v_minus_vs_spec_3d(
       grid_size, lower_bound, upper_bound);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

The first commit renames `constraint_preserving_bjorhus_corrections_dt_v_minus()` to `constraint_preserving_gauge_bjorhus_corrections_dt_v_minus()` as well as `constraint_preserving_physical_bjorhus_corrections_dt_v_minus` to `constraint_preserving_gauge_physical_bjorhus_corrections_dt_v_minus()` (the option parser values don't change).
This allows for the second commit to create `constraint_preserving_bjorhus_corrections_dt_v_minus()` that now doesn't include the gauge term.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
