### PR TITLE
Save functions of time and domain only once per volume subfile

### DIFF
--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.cpp
@@ -36,17 +36,8 @@ std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime> get_function_of_time(
     const std::string& subfile_name, const std::optional<double>& time) {
   const h5::H5File<h5::AccessType::ReadOnly> h5_file{h5_filename};
   const auto& vol_file = h5_file.get<h5::VolumeData>(subfile_name);
-
-  const std::vector<size_t> obs_ids = vol_file.list_observation_ids();
-  if (obs_ids.empty()) {
-    ERROR_NO_TRACE(function_of_time_name
-                   << ": There are no observation IDs in the subfile "
-                   << subfile_name << " of H5 file " << h5_filename);
-  }
-  // Take last observation ID so we have all possible times available
   std::optional<std::vector<char>> serialized_functions_of_time =
-      vol_file.get_functions_of_time(obs_ids[obs_ids.size() - 1]);
-
+      vol_file.get_global_functions_of_time();
   if (not serialized_functions_of_time.has_value()) {
     ERROR_NO_TRACE(function_of_time_name
                    << ": There are no functions of time in the subfile "

--- a/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp
@@ -49,8 +49,8 @@ struct FromVolumeFile {
                  bool replay = false);
 
   /*!
-   * \brief Searches the last observation in the volume subfile and returns
-   * clones of all functions of time in \p function_of_time_names.
+   * \returns clones of all global functions of time
+   * in \p function_of_time_names
    *
    * \details If a value for \p time is specified, will ensure that \p time is
    * within the `domain::FunctionsOfTime::FunctionOfTime::time_bounds()` of each

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -413,8 +413,7 @@ auto parse_volume_files(const std::variant<std::vector<std::string>,
       std::visit(SelectObservation{first_volfile}, observation);
   const double time = first_volfile.get_observation_value(obs_id);
   // Get domain, functions of time
-  auto domain =
-      deserialize<Domain<Dim>>(first_volfile.get_domain(obs_id)->data());
+  auto domain = deserialize<Domain<Dim>>(first_volfile.get_domain()->data());
   auto functions_of_time = [&first_volfile, &obs_id]() {
     const auto serialized_fot = first_volfile.get_functions_of_time(obs_id);
     if (not serialized_fot.has_value()) {

--- a/src/IO/Exporter/SpacetimeInterpolator.cpp
+++ b/src/IO/Exporter/SpacetimeInterpolator.cpp
@@ -24,36 +24,9 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Overloader.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
 
 namespace spectre::Exporter {
-
-namespace {
-
-auto load_observation_ids(const std::variant<std::vector<std::string>,
-                                             std::string>& volume_files_or_glob,
-                          const std::string& subfile_name) {
-  const std::vector<std::string> filenames =
-      std::visit(Overloader{[](const std::vector<std::string>& volume_files) {
-                              return volume_files;
-                            },
-                            [](const std::string& volume_files_glob) {
-                              return file_system::glob(volume_files_glob);
-                            }},
-                 volume_files_or_glob);
-  const h5::H5File<h5::AccessType::ReadOnly> first_h5file(filenames.front());
-  const auto& first_volfile = first_h5file.get<h5::VolumeData>(subfile_name);
-  const auto all_observation_ids = first_volfile.list_observation_ids();
-  std::vector<double> all_observation_values(all_observation_ids.size());
-  std::transform(all_observation_ids.begin(), all_observation_ids.end(),
-                 all_observation_values.begin(),
-                 [&first_volfile](const size_t obs_id) {
-                   return first_volfile.get_observation_value(obs_id);
-                 });
-  first_h5file.close();
-  return std::make_pair(all_observation_ids, all_observation_values);
-}
-
-}  // namespace
 
 template <size_t Dim, typename Frame>
 SpacetimeInterpolator<Dim, Frame>::SpacetimeInterpolator(
@@ -62,8 +35,26 @@ SpacetimeInterpolator<Dim, Frame>::SpacetimeInterpolator(
     : volume_files_or_glob_(std::move(volume_files_or_glob)),
       subfile_name_(std::move(subfile_name)),
       tensor_components_(std::move(tensor_components)) {
-  std::tie(all_observation_ids_, all_observation_values_) =
-      load_observation_ids(volume_files_or_glob_, subfile_name_);
+  const std::vector<std::string> filenames =
+      std::visit(Overloader{[](const std::vector<std::string>& volume_files) {
+                              return volume_files;
+                            },
+                            [](const std::string& volume_files_glob) {
+                              return file_system::glob(volume_files_glob);
+                            }},
+                 volume_files_or_glob_);
+  if (filenames.empty()) {
+    ERROR("No volume data files found.");
+  }
+  const h5::H5File<h5::AccessType::ReadOnly> first_h5file(filenames.front());
+  const auto& first_volfile = first_h5file.get<h5::VolumeData>(subfile_name_);
+  all_observation_ids_ = first_volfile.list_observation_ids();
+  all_observation_values_.resize(all_observation_ids_.size());
+  std::transform(all_observation_ids_.begin(), all_observation_ids_.end(),
+                 all_observation_values_.begin(),
+                 [&first_volfile](const size_t obs_id) {
+                   return first_volfile.get_observation_value(obs_id);
+                 });
   if (all_observation_ids_.empty()) {
     ERROR("No observation IDs found in the volume data files.");
   }
@@ -74,6 +65,12 @@ SpacetimeInterpolator<Dim, Frame>::SpacetimeInterpolator(
         << time_interpolation_order_ + 1 << "), but "
         << all_observation_ids_.size() << " observations were found.");
   }
+  auto serialized_fots = first_volfile.get_global_functions_of_time();
+  if (serialized_fots.has_value()) {
+    functions_of_time_ =
+        deserialize<domain::FunctionsOfTimeMap>(serialized_fots->data());
+  }
+  first_h5file.close();
 }
 
 template <size_t Dim, typename Frame>
@@ -243,8 +240,8 @@ void SpacetimeInterpolator<Dim, Frame>::interpolate_to_point(
   // yet.
   const auto& any_interpolator = *lower;
   const auto block_logical_coords = block_logical_coordinates_single_point(
-      target_point, any_interpolator.domain(), time,
-      any_interpolator.functions_of_time(), block_order);
+      target_point, any_interpolator.domain(), time, functions_of_time_,
+      block_order);
   if (not block_logical_coords.has_value()) {
     ERROR("Point is not in any block:\n" << target_point);
   }

--- a/src/IO/Exporter/SpacetimeInterpolator.hpp
+++ b/src/IO/Exporter/SpacetimeInterpolator.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "IO/Exporter/PointwiseInterpolator.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -125,6 +126,7 @@ struct SpacetimeInterpolator {
   constexpr static size_t time_interpolation_order_ = 3;  // must be odd
   constexpr static size_t num_ghost_slices_ =
       (time_interpolation_order_ + 1) / 2 - 1;
+  domain::FunctionsOfTimeMap functions_of_time_;
   // Metadata collected from data files
   std::vector<size_t> all_observation_ids_;
   std::vector<double> all_observation_values_;

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -219,7 +219,8 @@ void combine_h5_vol(
 
     double obs_val = 0.0;
     std::optional<std::vector<char>> serialized_domain{};
-    std::optional<std::vector<char>> serialized_functions_of_time{};
+    std::optional<std::vector<char>> serialized_observation_functions_of_time{};
+    std::optional<std::vector<char>> serialized_global_functions_of_time{};
 
     // Loops over input files to append element data into a single vector to be
     // stored in a single H5
@@ -232,7 +233,7 @@ void combine_h5_vol(
       obs_val = original_volume_file.get_observation_value(obs_id);
       if (not printed) {
         Parallel::printf(
-            "Processing obsevation ID %lo (%lo/%lo) with value %1.14e\n",
+            "Processing observation ID %lo (%lo/%lo) with value %1.14e\n",
             obs_id, obs_index, observation_ids_and_values.size(), obs_val);
         printed = true;
       }
@@ -240,9 +241,10 @@ void combine_h5_vol(
 
       const auto dim = original_volume_file.get_dimension();
       serialized_domain = original_volume_file.get_domain(obs_id);
-      serialized_functions_of_time =
+      serialized_observation_functions_of_time =
           original_volume_file.get_functions_of_time(obs_id);
-
+      serialized_global_functions_of_time =
+          original_volume_file.get_global_functions_of_time();
       // Get vector of element data for this `obs_id` and `file_name`
       std::vector<ElementVolumeData> data_by_element =
           std::move(std::get<2>(original_volume_file.get_data_by_element(
@@ -284,7 +286,9 @@ void combine_h5_vol(
     auto& new_volume_file = new_file.get<h5::VolumeData>(subfile_name);
     new_volume_file.write_volume_data(obs_id, obs_val, element_data,
                                       serialized_domain,
-                                      serialized_functions_of_time);
+                                      serialized_observation_functions_of_time,
+                                      serialized_global_functions_of_time);
+
     new_file.close_current_object();
   }
 }

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -80,7 +80,6 @@ size_t get_number_of_elements(const std::vector<std::string>& input_filenames,
 
 std::optional<std::unordered_set<size_t>> get_block_numbers_to_use(
     const std::string& file_name, const std::string& subfile_name,
-    const size_t observation_id,
     const std::optional<std::vector<std::string>>& blocks_to_combine) {
   if (not blocks_to_combine.has_value() or blocks_to_combine.value().empty()) {
     return std::nullopt;
@@ -90,7 +89,7 @@ std::optional<std::unordered_set<size_t>> get_block_numbers_to_use(
   const auto& volume_file = original_file.get<h5::VolumeData>(subfile_name);
 
   const auto dim = volume_file.get_dimension();
-  auto serialized_domain = volume_file.get_domain(observation_id);
+  auto serialized_domain = volume_file.get_domain();
   if (not serialized_domain.has_value()) {
     ERROR("Could not read the domain the from file "
           << file_name << " and subfile " << subfile_name
@@ -194,9 +193,7 @@ void combine_h5_vol(
   }
 
   const std::optional<std::unordered_set<size_t>> blocks_to_use =
-      get_block_numbers_to_use(file_names[0], subfile_name,
-                               observation_ids_and_values[0].first,
-                               blocks_to_combine);
+      get_block_numbers_to_use(file_names[0], subfile_name, blocks_to_combine);
 
   // Loops over observation ids to write volume data by observation id
   for (size_t obs_index = 0; obs_index < observation_ids_and_values.size();
@@ -240,7 +237,7 @@ void combine_h5_vol(
       Parallel::printf("  Processing file: %s\n", file_name.c_str());
 
       const auto dim = original_volume_file.get_dimension();
-      serialized_domain = original_volume_file.get_domain(obs_id);
+      serialized_domain = original_volume_file.get_domain();
       serialized_observation_functions_of_time =
           original_volume_file.get_functions_of_time(obs_id);
       serialized_global_functions_of_time =

--- a/src/IO/H5/Python/IterElements.py
+++ b/src/IO/H5/Python/IterElements.py
@@ -208,7 +208,7 @@ def iter_elements(
             ]
             # Deserialize domain and functions of time
             if not domain:
-                serialized_domain = volfile.get_domain(obs_id)
+                serialized_domain = volfile.get_domain()
                 if serialized_domain:
                     domain = deserialize_domain[dim](serialized_domain)
             time = volfile.get_observation_value(obs_id)

--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -49,7 +49,7 @@ void bind_h5vol(py::module& m) {
       .def("get_quadratures", &h5::VolumeData::get_quadratures,
            py::arg("observation_id"))
       .def("get_bases", &h5::VolumeData::get_bases, py::arg("observation_id"))
-      .def("get_domain", &h5::VolumeData::get_domain, py::arg("observation_id"))
+      .def("get_domain", &h5::VolumeData::get_domain)
       .def("get_functions_of_time", &h5::VolumeData::get_functions_of_time,
            py::arg("observation_id"))
       .def("get_global_functions_of_time",

--- a/src/IO/H5/Python/VolumeData.cpp
+++ b/src/IO/H5/Python/VolumeData.cpp
@@ -24,7 +24,8 @@ void bind_h5vol(py::module& m) {
       .def("write_volume_data", &h5::VolumeData::write_volume_data,
            py::arg("observation_id"), py::arg("observation_value"),
            py::arg("elements"), py::arg("serialized_domain") = std::nullopt,
-           py::arg("serialized_functions_of_time") = std::nullopt)
+           py::arg("serialized_observation_functions_of_time") = std::nullopt,
+           py::arg("serialized_global_functions_of_time") = std::nullopt)
       .def("write_tensor_component",
            py::overload_cast<size_t, const std::string&, const DataVector&,
                              bool>(&h5::VolumeData::write_tensor_component),
@@ -51,6 +52,8 @@ void bind_h5vol(py::module& m) {
       .def("get_domain", &h5::VolumeData::get_domain, py::arg("observation_id"))
       .def("get_functions_of_time", &h5::VolumeData::get_functions_of_time,
            py::arg("observation_id"))
+      .def("get_global_functions_of_time",
+           &h5::VolumeData::get_global_functions_of_time)
       .def("get_data_by_element", &h5::VolumeData::get_data_by_element,
            py::arg("start_observation_value"), py::arg("end_observation_value"),
            py::arg("components_to_retrieve") = std::nullopt)

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -49,6 +50,9 @@ namespace h5 {
 namespace {
 // Append the element extents and connectivity to the total extents and
 // connectivity
+constexpr const char* global_functions_of_time_observation_value_attr =
+    "global_functions_of_time_observation_value";
+
 void append_element_extents_and_connectivity(
     const gsl::not_null<std::vector<size_t>*> total_extents,
     const gsl::not_null<std::vector<int>*> total_connectivity,
@@ -169,7 +173,6 @@ void append_element_extents_and_connectivity(
     }
   }
 }
-
 }  // namespace
 
 VolumeData::VolumeData(const bool subfile_exists, detail::OpenGroup&& group,
@@ -214,7 +217,10 @@ void VolumeData::write_volume_data(
     const size_t observation_id, const double observation_value,
     const std::vector<ElementVolumeData>& elements,
     const std::optional<std::vector<char>>& serialized_domain,
-    const std::optional<std::vector<char>>& serialized_functions_of_time) {
+    const std::optional<std::vector<char>>&
+        serialized_observation_functions_of_time,
+    const std::optional<std::vector<char>>&
+        serialized_global_functions_of_time) {
   const std::string path = "ObservationId" + std::to_string(observation_id);
   detail::OpenGroup observation_group(volume_data_group_.id(), path,
                                       AccessType::ReadWrite);
@@ -401,15 +407,46 @@ void VolumeData::write_volume_data(
     h5::write_data(observation_group.id(), pole_connectivity,
                    {pole_connectivity.size()}, "pole_connectivity");
   }
-  // Write the serialized domain
-  if (serialized_domain.has_value()) {
-    h5::write_data(observation_group.id(), *serialized_domain,
+  // Store the serialized domain and functions of time at the subfile level
+  if (serialized_domain.has_value() and
+      not contains_dataset_or_group(volume_data_group_.id(), "", "domain")) {
+    h5::write_data(volume_data_group_.id(), *serialized_domain,
                    {serialized_domain->size()}, "domain");
   }
-  // Write the serialized functions of time
-  if (serialized_functions_of_time.has_value()) {
-    h5::write_data(observation_group.id(), *serialized_functions_of_time,
-                   {serialized_functions_of_time->size()}, "functions_of_time");
+  if (serialized_observation_functions_of_time.has_value()) {
+    h5::write_data(observation_group.id(),
+                   *serialized_observation_functions_of_time,
+                   {serialized_observation_functions_of_time->size()},
+                   "functions_of_time");
+  }
+  if (serialized_global_functions_of_time.has_value()) {
+    bool should_write_global_functions_of_time = true;
+    if (h5::contains_attribute(
+            volume_data_group_.id(), "",
+            global_functions_of_time_observation_value_attr)) {
+      const auto stored_observation_value = h5::read_value_attribute<double>(
+          volume_data_group_.id(),
+          global_functions_of_time_observation_value_attr);
+      should_write_global_functions_of_time =
+          observation_value > stored_observation_value;
+    }
+    if (should_write_global_functions_of_time) {
+      h5::write_data(volume_data_group_.id(),
+                     *serialized_global_functions_of_time,
+                     {serialized_global_functions_of_time->size()},
+                     "global_functions_of_time", true);
+      if (h5::contains_attribute(
+              volume_data_group_.id(), "",
+              global_functions_of_time_observation_value_attr)) {
+        CHECK_H5(H5Adelete(volume_data_group_.id(),
+                           global_functions_of_time_observation_value_attr),
+                 "Failed to delete existing attribute '"
+                     << global_functions_of_time_observation_value_attr << "'");
+      }
+      h5::write_to_attribute(volume_data_group_.id(),
+                             global_functions_of_time_observation_value_attr,
+                             observation_value);
+    }
   }
 }
 
@@ -459,14 +496,27 @@ void VolumeData::write_tensor_component(
                  overwrite_existing);
 }
 
+bool VolumeData::has_domain() const {
+  return contains_dataset_or_group(volume_data_group_.id(), "", "domain");
+}
+
+bool VolumeData::has_global_functions_of_time() const {
+  return contains_dataset_or_group(volume_data_group_.id(), "",
+                                   "global_functions_of_time");
+}
+
 std::vector<size_t> VolumeData::list_observation_ids() const {
   const auto names = get_group_names(volume_data_group_.id(), "");
-  const auto helper = [](const std::string& s) {
-    return std::stoul(s.substr(std::string("ObservationId").size()));
-  };
-  std::vector<size_t> obs_ids{
-      boost::make_transform_iterator(names.begin(), helper),
-      boost::make_transform_iterator(names.end(), helper)};
+  std::vector<size_t> obs_ids{};
+  obs_ids.reserve(names.size());
+  constexpr std::string_view observation_prefix{"ObservationId"};
+  for (const auto& name : names) {
+    if (name.size() <= observation_prefix.size() or
+        name.compare(0, observation_prefix.size(), observation_prefix) != 0) {
+      continue;
+    }
+    obs_ids.push_back(std::stoul(name.substr(observation_prefix.size())));
+  }
   // pre-compute the observation values as they are expensive to evaluate
   std::unordered_map<size_t, double> obs_values{obs_ids.size()};
   for (const auto& id : obs_ids) {
@@ -640,15 +690,7 @@ auto VolumeData::get_data_by_element(
     const std::optional<std::vector<std::string>>& components_to_retrieve) const
     -> std::vector<std::tuple<size_t, double, std::vector<ElementVolumeData>>> {
   // First get list of all observations we need to retrieve
-  const auto names = get_group_names(volume_data_group_.id(), "");
-  const auto get_observation_id_from_group_name = [](const std::string& s) {
-    return std::stoul(s.substr(std::string("ObservationId").size()));
-  };
-  std::vector<size_t> obs_ids{
-      boost::make_transform_iterator(names.begin(),
-                                     get_observation_id_from_group_name),
-      boost::make_transform_iterator(names.end(),
-                                     get_observation_id_from_group_name)};
+  const std::vector<size_t> obs_ids = list_observation_ids();
   std::vector<std::tuple<size_t, double, std::vector<ElementVolumeData>>>
       result{};
   result.reserve(obs_ids.size());
@@ -796,14 +838,26 @@ std::vector<std::vector<Spectral::Quadrature>> VolumeData::get_quadratures(
 }
 
 std::optional<std::vector<char>> VolumeData::get_domain(
-    const size_t observation_id) const {
+    const std::optional<size_t> observation_id) const {
+  // we write the domain independently of the observation_id since a refactor
+  if (contains_dataset_or_group(volume_data_group_.id(), "", "domain")) {
+    return h5::read_data<1, std::vector<char>>(volume_data_group_.id(),
+                                               "domain");
+  }
+  // default to old location
+  const auto& observation_ids = list_observation_ids();
+  if (observation_ids.empty()) {
+    return std::nullopt;
+  }
+  const size_t observation_id = observation_ids.back();
   const std::string path = "ObservationId" + std::to_string(observation_id);
   detail::OpenGroup observation_group(volume_data_group_.id(), path,
                                       AccessType::ReadOnly);
-  if (not contains_dataset_or_group(observation_group.id(), "", "domain")) {
-    return std::nullopt;
+  if (contains_dataset_or_group(observation_group.id(), "", "domain")) {
+    return h5::read_data<1, std::vector<char>>(observation_group.id(),
+                                               "domain");
   }
-  return h5::read_data<1, std::vector<char>>(observation_group.id(), "domain");
+  return std::nullopt;
 }
 
 std::optional<std::vector<char>> VolumeData::get_functions_of_time(
@@ -817,6 +871,21 @@ std::optional<std::vector<char>> VolumeData::get_functions_of_time(
   }
   return h5::read_data<1, std::vector<char>>(observation_group.id(),
                                              "functions_of_time");
+}
+
+std::optional<std::vector<char>> VolumeData::get_global_functions_of_time()
+    const {
+  if (contains_dataset_or_group(volume_data_group_.id(), "",
+                                "global_functions_of_time")) {
+    return h5::read_data<1, std::vector<char>>(volume_data_group_.id(),
+                                               "global_functions_of_time");
+  }
+  // fall back to old location if global not present
+  const auto& observation_ids = list_observation_ids();
+  if (observation_ids.empty()) {
+    return std::nullopt;
+  }
+  return get_functions_of_time(observation_ids.back());
 }
 
 template <size_t Dim>

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -837,8 +837,7 @@ std::vector<std::vector<Spectral::Quadrature>> VolumeData::get_quadratures(
   return element_quadratures;
 }
 
-std::optional<std::vector<char>> VolumeData::get_domain(
-    const std::optional<size_t> observation_id) const {
+std::optional<std::vector<char>> VolumeData::get_domain() const {
   // we write the domain independently of the observation_id since a refactor
   if (contains_dataset_or_group(volume_data_group_.id(), "", "domain")) {
     return h5::read_data<1, std::vector<char>>(volume_data_group_.id(),

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -236,8 +236,7 @@ class VolumeData : public h5::Object {
   /*!
    * \brief Get the serialized domain if it was written.
    */
-  std::optional<std::vector<char>> get_domain(
-      std::optional<size_t> observation_id = std::nullopt) const;
+  std::optional<std::vector<char>> get_domain() const;
 
   /*!
    * \brief Get the observation-specific serialized functions of time at an \p

--- a/src/IO/H5/VolumeData.hpp
+++ b/src/IO/H5/VolumeData.hpp
@@ -106,17 +106,40 @@ class VolumeData : public h5::Object {
    */
   uint32_t get_version() const { return version_; }
 
-  /// Insert tensor components at `observation_id` with floating point value
-  /// `observation_value`. Optionally write a serialized representation of the
-  /// domain and the functions of time into the subfile as well.
-  ///
-  /// All `elements` must contain the same tensor components in the same order.
+  /*!
+   * \brief Write volume data at an observation id and observation value.
+   *
+   * \param observation_id The integral observation id at which the data is
+   * written.
+   * \param observation_value The floating point observation value (e.g. time)
+   * at which the data is written.
+   * \param elements The volume data to write, passed as a vector of
+   * ElementVolumeData structs.
+   * \param serialized_domain An optional serialized domain. It will only be
+   * written if there is not already a domain stored in the subfile.
+   * \param serialized_observation_functions_of_time An optional serialized
+   * observation-specific functions of time. It should be valid at the given
+   * observation value, but not contain the entire history to save space.
+   * \param serialized_global_functions_of_time An optional serialized global
+   * functions of time oject. It should be valid for the entire simulation. It
+   * will be used to overwrite the existing global functions of time iff the old
+   * object was written at a smaller observation_value (i.e. an earlier time).
+   */
   void write_volume_data(
       size_t observation_id, double observation_value,
       const std::vector<ElementVolumeData>& elements,
       const std::optional<std::vector<char>>& serialized_domain = std::nullopt,
-      const std::optional<std::vector<char>>& serialized_functions_of_time =
-          std::nullopt);
+      const std::optional<std::vector<char>>&
+          serialized_observation_functions_of_time = std::nullopt,
+      const std::optional<std::vector<char>>&
+          serialized_global_functions_of_time = std::nullopt);
+
+  /// \returns true if a serialized domain has been written to the subfile.
+  bool has_domain() const;
+
+  /// \returns true if serialized functions of time have been written to the
+  /// subfile.
+  bool has_global_functions_of_time() const;
 
   /// Overwrites the current connectivity dataset with a new one. This new
   /// connectivity dataset builds connectivity within each block in the domain
@@ -210,14 +233,24 @@ class VolumeData : public h5::Object {
   std::vector<std::vector<Spectral::Quadrature>> get_quadratures(
       size_t observation_id) const;
 
-  /// Get the serialized domain in the subfile at this observation ID, or
-  /// `std::nullopt` if no domain was written.
-  std::optional<std::vector<char>> get_domain(size_t observation_id) const;
+  /*!
+   * \brief Get the serialized domain if it was written.
+   */
+  std::optional<std::vector<char>> get_domain(
+      std::optional<size_t> observation_id = std::nullopt) const;
 
-  /// Get the serialized functions of time in the subfile at this observation
-  /// ID, or `std::nullopt` if none were written.
+  /*!
+   * \brief Get the observation-specific serialized functions of time at an \p
+   * observation_id if they were written.
+   */
   std::optional<std::vector<char>> get_functions_of_time(
       size_t observation_id) const;
+
+  /*!
+   * \brief Get the serialized global functions of time in the subfile if they
+   * were written.
+   */
+  std::optional<std::vector<char>> get_global_functions_of_time() const;
 
   const std::string& subfile_path() const override { return path_; }
 

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -540,7 +540,7 @@ struct ReadAllVolumeDataAndDistribute {
       }
       // Reconstruct domain from volume data file
       const std::optional<std::vector<char>> serialized_domain =
-          volume_file.get_domain(observation_id);
+          volume_file.get_domain();
       if (serialized_domain.has_value()) {
         if (source_domain.has_value()) {
 #ifdef SPECTRE_DEBUG

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <iterator>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -221,24 +224,40 @@ void write_combined_volume_data(
     // The domain is retrieved from the global cache using the standard
     // domain tag. If more flexibility is required here later, then the
     // domain can be passed along with the `ContributeVolumeData` action.
-    const auto serialized_domain = serialize(
-        Parallel::get<domain::Tags::Domain<Metavariables::volume_dim>>(cache));
-    const auto serialized_functions_of_time =
-        [&cache]() -> std::optional<std::vector<char>> {
-      // Functions-of-time are in the _mutable_ global cache, so they aren't
-      // accessible through the DataBox by default
-      if constexpr (Parallel::is_in_global_cache<
-                        Metavariables, domain::Tags::FunctionsOfTime>) {
-        return serialize(get<domain::Tags::FunctionsOfTime>(cache));
-      } else {
-        (void)cache;
-        return std::nullopt;
+    std::optional<std::vector<char>> serialized_domain{};
+    if (not volume_file.has_domain()) {
+      serialized_domain = serialize(
+          Parallel::get<domain::Tags::Domain<Metavariables::volume_dim>>(
+              cache));
+    }
+
+    std::optional<std::vector<char>> serialized_global_functions_of_time =
+        std::nullopt;
+    std::optional<std::vector<char>> serialized_observation_functions_of_time =
+        std::nullopt;
+    if constexpr (Parallel::is_in_global_cache<Metavariables,
+                                               domain::Tags::FunctionsOfTime>) {
+      const auto& functions_of_time = get<domain::Tags::FunctionsOfTime>(cache);
+      // NOLINTNEXTLINE(misc-const-correctness)
+      domain::FunctionsOfTimeMap observation_functions_of_time{};
+      const double obs_time = observation_id.value();
+      // create a new function of time, effectively truncating the history.
+      for (const auto& [name, fot_ptr] : functions_of_time) {
+        observation_functions_of_time[name] = fot_ptr->create_at_time(
+            obs_time, obs_time + 100.0 *
+                                     std::numeric_limits<double>::epsilon() *
+                                     std::max(std::abs(obs_time), 1.0));
       }
-    }();
+      serialized_global_functions_of_time = serialize(functions_of_time);
+      serialized_observation_functions_of_time =
+          serialize(observation_functions_of_time);
+    }
+
     // Write the data to the file
     volume_file.write_volume_data(observation_id.hash(), observation_id.value(),
                                   volume_data_to_write, serialized_domain,
-                                  serialized_functions_of_time);
+                                  serialized_observation_functions_of_time,
+                                  serialized_global_functions_of_time);
   }
 }
 }  // namespace VolumeActions_detail

--- a/src/ParallelAlgorithms/SurfaceFinder/Python/FindRadialSurface.py
+++ b/src/ParallelAlgorithms/SurfaceFinder/Python/FindRadialSurface.py
@@ -86,7 +86,7 @@ def find_radial_surface(
     # Deserialize domain and functions of time
     for volfile in open_volfiles(h5_files, subfile_name, obs_id):
         dim = volfile.get_dimension()
-        domain = deserialize_domain[dim](volfile.get_domain(obs_id))
+        domain = deserialize_domain[dim](volfile.get_domain())
         time = volfile.get_observation_value(obs_id)
         functions_of_time = (
             deserialize_functions_of_time(volfile.get_functions_of_time(obs_id))

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -422,6 +422,7 @@ def generate_xdmf(
             [
                 (key, vol_subfile[key].attrs["observation_value"])
                 for key in vol_subfile.keys()
+                if key.startswith("ObservationId")
             ],
             key=lambda key_and_time: key_and_time[1],
         )

--- a/src/Visualization/Python/PlotPowerMonitors.py
+++ b/src/Visualization/Python/PlotPowerMonitors.py
@@ -365,10 +365,7 @@ def plot_power_monitors_command(
     open_h5_file = spectre_h5.H5File(h5_files[0], "r")
     volfile = open_h5_file.get_vol(subfile_name)
     dim = volfile.get_dimension()
-    any_obs_id = (
-        obs_id if obs_id is not None else volfile.list_observation_ids()[0]
-    )
-    domain = deserialize_domain[dim](volfile.get_domain(any_obs_id))
+    domain = deserialize_domain[dim](volfile.get_domain())
     all_block_groups = list(domain.block_groups.keys())
     all_block_names = [block.name for block in domain.blocks]
     if list_blocks:

--- a/src/Visualization/Python/Render1D.py
+++ b/src/Visualization/Python/Render1D.py
@@ -359,7 +359,7 @@ def render_1d_command(
     obs_value = volfiles[0].get_observation_value(obs_id)
 
     # For Lagrange interpolation
-    domain = deserialize_domain[1](volfiles[0].get_domain(obs_id))
+    domain = deserialize_domain[1](volfiles[0].get_domain())
     if domain.is_time_dependent():
         functions_of_time = deserialize_functions_of_time(
             volfiles[0].get_functions_of_time(obs_id)

--- a/support/Pipelines/Bbh/FindHorizon.py
+++ b/support/Pipelines/Bbh/FindHorizon.py
@@ -362,7 +362,7 @@ def use_excision_as_horizon(
     # Deserialize domain and get the excision in the inertial frame
     for volfile in open_volfiles(h5_files, subfile_name, obs_id):
         dim = volfile.get_dimension()
-        domain = deserialize_domain[dim](volfile.get_domain(obs_id))
+        domain = deserialize_domain[dim](volfile.get_domain())
         if domain.is_time_dependent():
             functions_of_time = deserialize_functions_of_time(
                 volfile.get_functions_of_time(obs_id)

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_FromVolumeFile.cpp
@@ -103,11 +103,6 @@ void test_errors() {
   auto from_volume_file = TestHelpers::test_creation<FromVolumeFile>(
       "H5Filename: " + filename + "\nSubfileName: " + subfile_name);
 
-  CHECK_THROWS_WITH(
-      (from_volume_file.retrieve_function_of_time({"Expansion"}, 0.0)),
-      Catch::Matchers::ContainsSubstring(
-          "Expansion: There are no observation IDs in the subfile "));
-
   // Need new subfile to write to
   subfile_name += "0";
   TestHelpers::domain::creators::write_volume_data(filename, subfile_name);

--- a/tests/Unit/Domain/Python/Test_BlockAndElementLogicalCoordinates.py
+++ b/tests/Unit/Domain/Python/Test_BlockAndElementLogicalCoordinates.py
@@ -44,7 +44,7 @@ class TestBlockAndElementLogicalCoordinates(unittest.TestCase):
         with spectre_h5.H5File(volfile_name, "r") as open_h5_file:
             volfile = open_h5_file.get_vol("/element_data")
             obs_id = volfile.list_observation_ids()[0]
-            serialized_domain = volfile.get_domain(obs_id)
+            serialized_domain = volfile.get_domain()
             serialized_fot = volfile.get_functions_of_time(obs_id)
 
         # This domain is [0, 2 pi]^3

--- a/tests/Unit/Domain/Python/Test_Domain.py
+++ b/tests/Unit/Domain/Python/Test_Domain.py
@@ -40,7 +40,7 @@ class TestDomain(unittest.TestCase):
             volfile = open_h5_file.get_vol("/element_data")
             obs_id = volfile.list_observation_ids()[0]
             time = volfile.get_observation_value(obs_id)
-            serialized_domain = volfile.get_domain(obs_id)
+            serialized_domain = volfile.get_domain()
             serialized_fot = volfile.get_functions_of_time(obs_id)
 
         domain = deserialize_domain[3](serialized_domain)

--- a/tests/Unit/Domain/Python/Test_ElementMap.py
+++ b/tests/Unit/Domain/Python/Test_ElementMap.py
@@ -70,7 +70,7 @@ class TestElementMap(unittest.TestCase):
         with spectre_h5.H5File(volfile_name, "r") as open_h5_file:
             volfile = open_h5_file.get_vol("/element_data")
             obs_id = volfile.list_observation_ids()[0]
-            domain = deserialize_domain[3](volfile.get_domain(obs_id))
+            domain = deserialize_domain[3](volfile.get_domain())
             functions_of_time = deserialize_functions_of_time(
                 volfile.get_functions_of_time(obs_id)
             )

--- a/tests/Unit/Domain/Python/Test_StrahlkorperTransformations.py
+++ b/tests/Unit/Domain/Python/Test_StrahlkorperTransformations.py
@@ -22,7 +22,7 @@ class TestStrahlkorperTransformations(unittest.TestCase):
         with spectre_h5.H5File(volfile_name, "r") as open_h5_file:
             volfile = open_h5_file.get_vol("/element_data")
             obs_id = volfile.list_observation_ids()[0]
-            domain = deserialize_domain[3](volfile.get_domain(obs_id))
+            domain = deserialize_domain[3](volfile.get_domain())
             functions_of_time = deserialize_functions_of_time(
                 volfile.get_functions_of_time(obs_id)
             )

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -1354,7 +1354,7 @@ void test_versioning() {
                                               "/Domain/SerializedDomain.h5"};
   const auto& volfile = h5file.get<h5::VolumeData>("/element_data");
   const size_t obs_id = volfile.list_observation_ids().front();
-  const auto serialized_domain = *volfile.get_domain(obs_id);
+  const auto serialized_domain = *volfile.get_domain();
   const auto domain = deserialize<Domain<3>>(serialized_domain.data());
   const Domain<3> expected_domain = create_serialized_domain();
   CHECK(domain == expected_domain);

--- a/tests/Unit/Helpers/Domain/Creators/TimeDependent/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/Creators/TimeDependent/TestHelpers.cpp
@@ -30,6 +30,9 @@ void write_volume_data(
   h5::H5File<h5::AccessType::ReadWrite> h5_file{filename, true};
   auto& vol_file = h5_file.insert<h5::VolumeData>(subfile_name);
 
+  const auto serialized_fots =
+      functions_of_time.empty() ? std::nullopt
+                                : std::optional{serialize(functions_of_time)};
   // We don't care about the volume data here, just the functions of time
   vol_file.write_volume_data(
       0, 0.0,
@@ -38,8 +41,6 @@ void write_volume_data(
                          {3},
                          {Spectral::Basis::Legendre},
                          {Spectral::Quadrature::GaussLobatto}}},
-      std::nullopt,
-      functions_of_time.empty() ? std::nullopt
-                                : std::optional{serialize(functions_of_time)});
+      std::nullopt, serialized_fots, serialized_fots);
 }
 }  // namespace TestHelpers::domain::creators

--- a/tests/Unit/IO/Exporter/Test_SpacetimeInterpolator.cpp
+++ b/tests/Unit/IO/Exporter/Test_SpacetimeInterpolator.cpp
@@ -80,7 +80,8 @@ void write_data_to_file(const std::string& h5_file_name) {
   size_t obs_id = 0;
   for (const double time : times) {
     volfile.write_volume_data(obs_id, time, element_volume_data,
-                              serialize(domain), serialize(functions_of_time));
+                              serialize(domain), serialize(functions_of_time),
+                              serialize(functions_of_time));
     ++obs_id;
   }
 }

--- a/tests/Unit/IO/H5/Python/Test_FunctionsOfTimeFromVolume.py
+++ b/tests/Unit/IO/H5/Python/Test_FunctionsOfTimeFromVolume.py
@@ -82,7 +82,7 @@ class TestFunctionsOfTimeFromVolume(unittest.TestCase):
                             quadrature=[Spectral.Quadrature.GaussLobatto],
                         )
                     ],
-                    serialized_functions_of_time=serialized_fots,
+                    serialized_observation_functions_of_time=serialized_fots,
                 )
 
     def tearDown(self):

--- a/tests/Unit/IO/H5/Test_CombineH5.py
+++ b/tests/Unit/IO/H5/Test_CombineH5.py
@@ -10,6 +10,12 @@ from click.testing import CliRunner
 import spectre.IO.H5 as spectre_h5
 from spectre import Informer
 from spectre.DataStructures import DataVector
+from spectre.Domain import (
+    PiecewisePolynomial3,
+    serialize_domain,
+    serialize_functions_of_time,
+)
+from spectre.Domain.Creators import Brick
 from spectre.IO.H5 import ElementVolumeData, TensorComponent, combine_h5_vol
 from spectre.IO.H5.CombineH5 import combine_h5_command
 from spectre.Spectral import Basis, Quadrature
@@ -47,6 +53,37 @@ class TestCombineH5(unittest.TestCase):
         basis = Basis.Legendre
         quad = Quadrature.Gauss
         self.observation_ids = [0, 1]
+        domain_creator = Brick(
+            lower_bounds=[0.0, 0.0, 0.0],
+            upper_bounds=[1.0, 1.0, 1.0],
+            initial_refinement_levels=[0, 0, 0],
+            initial_num_points=[2, 2, 2],
+            is_periodic=[False, False, False],
+        )
+        self.serialized_domain = serialize_domain(
+            domain_creator.create_domain()
+        )
+
+        def make_translation_fot(fill_value, expiration):
+            coefficients = [
+                DataVector(size=3, fill=fill_value) for _ in range(4)
+            ]
+            return PiecewisePolynomial3(0.0, coefficients, expiration)
+
+        self.serialized_global_fots = serialize_functions_of_time(
+            {"Translation": make_translation_fot(0.0, 100.0)}
+        )
+        self.serialized_observation_fots = {
+            obs_id: serialize_functions_of_time(
+                {
+                    "Translation": make_translation_fot(
+                        observation_values[obs_id],
+                        observation_values[obs_id] + 0.01,
+                    )
+                }
+            )
+            for obs_id in self.observation_ids
+        }
 
         # Writing ElementVolume data and TensorComponent Data to first file
         self.h5_file1 = spectre_h5.H5File(file_name=self.file_name1, mode="a")
@@ -87,6 +124,9 @@ class TestCombineH5(unittest.TestCase):
                 [
                     self.element_vol_data_file_1[i],
                 ],
+                self.serialized_domain,
+                self.serialized_observation_fots[observation_id],
+                self.serialized_global_fots,
             )
 
         # Store initial connectivity data
@@ -135,6 +175,9 @@ class TestCombineH5(unittest.TestCase):
                 [
                     self.element_vol_data_file_2[i],
                 ],
+                self.serialized_domain,
+                self.serialized_observation_fots[observation_id],
+                self.serialized_global_fots,
             )
         self.h5_file2.close()
 
@@ -182,6 +225,19 @@ class TestCombineH5(unittest.TestCase):
 
         self.assertEqual(actual_obs_value, expected_obs_value)
 
+        for obs_to_check in actual_obs_ids:
+            self.assertEqual(
+                output_vol.get_domain(obs_to_check), self.serialized_domain
+            )
+            self.assertEqual(
+                output_vol.get_functions_of_time(obs_to_check),
+                self.serialized_observation_fots[obs_to_check],
+            )
+
+        self.assertEqual(
+            output_vol.get_global_functions_of_time(),
+            self.serialized_global_fots,
+        )
         # Test tensor components
 
         actual_tensor_component_names = output_vol.list_tensor_components(

--- a/tests/Unit/IO/H5/Test_CombineH5.py
+++ b/tests/Unit/IO/H5/Test_CombineH5.py
@@ -226,9 +226,7 @@ class TestCombineH5(unittest.TestCase):
         self.assertEqual(actual_obs_value, expected_obs_value)
 
         for obs_to_check in actual_obs_ids:
-            self.assertEqual(
-                output_vol.get_domain(obs_to_check), self.serialized_domain
-            )
+            self.assertEqual(output_vol.get_domain(), self.serialized_domain)
             self.assertEqual(
                 output_vol.get_functions_of_time(obs_to_check),
                 self.serialized_observation_fots[obs_to_check],

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -332,7 +332,7 @@ void test() {
                    });
     CHECK(found_observation_ids == observation_ids);
   }
-
+  CHECK(volume_file.get_domain() == serialize(domain_creator.create_domain()));
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     TestHelpers::io::VolumeData::check_volume_data(
         h5_file_name, version_number, "element_data"s, observation_ids[i],
@@ -341,8 +341,6 @@ void test() {
         {"S", "x-coord", "y-coord", "z-coord", "T_x", "T_y", "T_z"},
         {{0, 1, 2, 3, 4, 5, 6}, {1, 0, 5, 3, 6, 4, 2}}, {},
         observation_values[i]);
-    CHECK(volume_file.get_domain(observation_ids[i]) ==
-          serialize(domain_creator.create_domain()));
     CHECK(volume_file.get_functions_of_time(observation_ids[i]) ==
           serialize(domain_creator.functions_of_time()));
     const auto global_fot_buffer = volume_file.get_global_functions_of_time();
@@ -813,6 +811,7 @@ void test_cartoon() {
     CHECK(found_observation_ids == observation_ids);
   }
 
+  CHECK(volume_file.get_domain() == serialize(domain_creator.create_domain()));
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     TestHelpers::io::VolumeData::check_volume_data(
         h5_file_name, version_number, "element_data"s, observation_ids[i],
@@ -820,8 +819,6 @@ void test_cartoon() {
         grid_names, written_bases, written_quadratures, {{2, 2}},
         {"S", "x-coord", "y-coord", "z-coord", "T_x", "T_y", "T_z"},
         {{0, 1, 2, 3, 4, 5, 6}}, {}, observation_values[i]);
-    CHECK(volume_file.get_domain(observation_ids[i]) ==
-          serialize(domain_creator.create_domain()));
     CHECK(volume_file.get_functions_of_time(observation_ids[i]) ==
           serialize(domain_creator.functions_of_time()));
   }

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <hdf5.h>
@@ -18,12 +19,16 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/IO/VolumeData.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/CheckH5.hpp"
 #include "IO/H5/File.hpp"
+#include "IO/H5/Helpers.hpp"
+#include "IO/H5/OpenGroup.hpp"
 #include "IO/H5/TensorData.hpp"
 #include "IO/H5/VolumeData.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
@@ -32,6 +37,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 
 namespace {
@@ -265,6 +271,7 @@ void test() {
                bases.back(),
                quadratures.back()}},
           serialize(domain_creator.create_domain()),
+          serialize(domain_creator.functions_of_time()),
           serialize(domain_creator.functions_of_time()));
       // Write another tensor component separately
       volume_file.write_tensor_component(observation_id, "U",
@@ -283,12 +290,38 @@ void test() {
   // Open the read volume file and check that the observation id and values are
   // correct. No leading slash should also find the subfile, and a ".vol"
   // extension as well.
-  const auto& volume_file =
+  auto& volume_file =
       my_file.get<h5::VolumeData>("element_data.vol", version_number);
   CHECK(volume_file.subfile_path() == "/element_data");
   const auto read_observation_ids = volume_file.list_observation_ids();
   // The observation IDs should be sorted by their observation value
   CHECK(read_observation_ids == std::vector<size_t>{size_t(-1), 8435087234});
+  CHECK(volume_file.has_domain());
+  CHECK(volume_file.has_global_functions_of_time());
+  const std::string subfile_group_path =
+      std::string(volume_file.subfile_path()) + h5::VolumeData::extension();
+  const hid_t read_only_file_id =
+      H5Fopen(h5_file_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+  CHECK(read_only_file_id >= 0);
+  {
+    const h5::detail::OpenGroup subfile_group(
+        read_only_file_id, subfile_group_path, h5::AccessType::ReadOnly);
+    CHECK(h5::contains_dataset_or_group(subfile_group.id(), "", "domain"));
+    CHECK(h5::contains_dataset_or_group(subfile_group.id(), "",
+                                        "global_functions_of_time"));
+  }
+  {
+    const std::string observation_group_path =
+        subfile_group_path + "/ObservationId" +
+        std::to_string(observation_ids.front());
+    const h5::detail::OpenGroup observation_group(
+        read_only_file_id, observation_group_path, h5::AccessType::ReadOnly);
+    CHECK_FALSE(
+        h5::contains_dataset_or_group(observation_group.id(), "", "domain"));
+    CHECK(h5::contains_dataset_or_group(observation_group.id(), "",
+                                        "functions_of_time"));
+  }
+  CHECK_H5(H5Fclose(read_only_file_id), "Failed to close HDF5 file");
   {
     INFO("Test find_observation_id");
     std::vector<size_t> found_observation_ids(observation_values.size());
@@ -311,6 +344,10 @@ void test() {
     CHECK(volume_file.get_domain(observation_ids[i]) ==
           serialize(domain_creator.create_domain()));
     CHECK(volume_file.get_functions_of_time(observation_ids[i]) ==
+          serialize(domain_creator.functions_of_time()));
+    const auto global_fot_buffer = volume_file.get_global_functions_of_time();
+    CHECK(global_fot_buffer.has_value());
+    CHECK(global_fot_buffer.value() ==
           serialize(domain_creator.functions_of_time()));
     CHECK(get<DataType>(
               volume_file.get_tensor_component(observation_ids[i], "U").data) ==
@@ -351,6 +388,94 @@ void test() {
                              all_bases, all_quadratures);
     CHECK(last_mesh == Mesh<3>(2, Spectral::Basis::Legendre,
                                Spectral::Quadrature::GaussLobatto));
+  }
+
+  {
+    INFO("Functions of time overwrite ordering");
+    const size_t fot_observation_id_base = 9100;
+    const double fot_observation_value_base = 12.5;
+    const std::vector<ElementVolumeData> simple_element_data{
+        {"[FOTGrid]",
+         {TensorComponent{"SimpleScalar", DataVector(8, 1.0)}},
+         {2, 2, 2},
+         {Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+          Spectral::Basis::Legendre},
+         {Spectral::Quadrature::Gauss, Spectral::Quadrature::Gauss,
+          Spectral::Quadrature::Gauss}}};
+    const auto serialized_domain = serialize(domain_creator.create_domain());
+    const auto make_serialized_functions_of_time =
+        [](const double expiration_time) {
+          domain::FunctionsOfTimeMap map{};
+          const std::array<DataVector, 3> initial_data{
+              DataVector{1.0}, DataVector{0.0}, DataVector{0.0}};
+          map["Translation"] =
+              std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+                  0.0, initial_data, expiration_time);
+          return serialize(map);
+        };
+    const auto write_volume_with_data =
+        [&](const size_t observation_id, const double observation_value,
+            std::vector<char> serialized_functions_of_time) {
+          volume_file.write_volume_data(observation_id, observation_value,
+                                        simple_element_data, serialized_domain,
+                                        serialized_functions_of_time,
+                                        serialized_functions_of_time);
+        };
+    const auto read_observation_value_attribute = [&]() {
+      const hid_t read_file_id =
+          H5Fopen(h5_file_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+      CHECK(read_file_id >= 0);
+      const h5::detail::OpenGroup read_subfile_group(
+          read_file_id, subfile_group_path, h5::AccessType::ReadOnly);
+      const auto stored_value = h5::read_value_attribute<double>(
+          read_subfile_group.id(),
+          "global_functions_of_time_observation_value");
+      CHECK_H5(H5Fclose(read_file_id), "Failed to close HDF5 file");
+      return stored_value;
+    };
+
+    const auto initial_fot = make_serialized_functions_of_time(5.0);
+    write_volume_with_data(fot_observation_id_base, fot_observation_value_base,
+                           initial_fot);
+
+    auto observation_fot =
+        volume_file.get_functions_of_time(fot_observation_id_base);
+    CHECK(observation_fot.has_value());
+    CHECK(observation_fot.value() == initial_fot);
+    auto global_fot = volume_file.get_global_functions_of_time();
+    CHECK(global_fot.has_value());
+    CHECK(global_fot.value() == initial_fot);
+    CHECK(read_observation_value_attribute() ==
+          approx(fot_observation_value_base));
+
+    const auto earlier_fot = make_serialized_functions_of_time(3.0);
+    write_volume_with_data(fot_observation_id_base + 1,
+                           fot_observation_value_base - 0.1, earlier_fot);
+    observation_fot =
+        volume_file.get_functions_of_time(fot_observation_id_base + 1);
+    CHECK(observation_fot.has_value());
+    // observation fot should just be written every time
+    CHECK(observation_fot.value() == earlier_fot);
+    global_fot = volume_file.get_global_functions_of_time();
+    CHECK(global_fot.has_value());
+    // global fot should not change because earlier_fot has an earlier
+    // observation_value
+    CHECK(global_fot.value() == initial_fot);
+    CHECK(read_observation_value_attribute() ==
+          approx(fot_observation_value_base));
+
+    const auto later_fot = make_serialized_functions_of_time(7.0);
+    write_volume_with_data(fot_observation_id_base + 2,
+                           fot_observation_value_base + 0.1, later_fot);
+    observation_fot =
+        volume_file.get_functions_of_time(fot_observation_id_base + 2);
+    CHECK(observation_fot.has_value());
+    CHECK(observation_fot.value() == later_fot);
+    global_fot = volume_file.get_global_functions_of_time();
+    CHECK(global_fot.has_value());
+    CHECK(global_fot.value() == later_fot);
+    CHECK(read_observation_value_attribute() ==
+          approx(fot_observation_value_base + 0.1));
   }
 
   if (file_system::check_if_file_exists(h5_file_name)) {
@@ -613,7 +738,7 @@ void test_cartoon() {
        domain::CoordinateMaps::Distribution::Linear},
       std::make_unique<
           domain::creators::time_dependence::UniformTranslation<3, 0>>(
-              1., std::array<double, 3>{{2., 3., 4.}}),
+          1., std::array<double, 3>{{2., 3., 4.}}),
       {{{{test_bc.get_clone(), test_bc.get_clone()}},
         {{test_bc.get_clone(), test_bc.get_clone()}}}}};
 

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -6,11 +6,14 @@
 #include <algorithm>
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/range/combine.hpp>
+#include <cmath>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -23,6 +26,7 @@
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
 #include "Domain/FunctionsOfTime/Tags.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -53,6 +57,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Numeric.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 // NOLINTNEXTLINE(google-build-using-namespace)
@@ -186,6 +191,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
       std::make_unique<
           domain::creators::time_dependence::UniformTranslation<3, 0>>(
           1., std::array<double, 3>{{2., 3., 4.}})};
+  const double initial_expiration_time = 100.0;
+  const std::unordered_map<std::string, double> initial_expiration_times{
+      {"Translation", initial_expiration_time}};
   domain::creators::register_derived_with_charm();
   domain::creators::time_dependence::register_derived_with_charm();
   domain::FunctionsOfTime::register_derived_with_charm();
@@ -193,7 +201,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
                       observers::Tags::VolumeFileName, domain::Tags::Domain<3>,
                       domain::Tags::FunctionsOfTimeInitialize>
       cache_data{"", output_file_prefix, domain_creator.create_domain(),
-                 domain_creator.functions_of_time()};
+                 domain_creator.functions_of_time(initial_expiration_times)};
   ActionTesting::MockRuntimeSystem<metavariables> runner{std::move(cache_data)};
   ActionTesting::emplace_group_component<obs_component>(&runner);
   for (size_t i = 0; i < 2; ++i) {
@@ -411,6 +419,41 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
       }
       points_processed += stride;
     }
+
+    const auto observation_fots =
+        volume_file.get_functions_of_time(temporal_id);
+    CHECK(observation_fots.has_value());
+    auto observation_functions_of_time =
+        deserialize<domain::FunctionsOfTimeMap>(
+            observation_fots.value().data());
+    auto original_functions_of_time =
+        domain_creator.functions_of_time(initial_expiration_times);
+    CHECK(observation_functions_of_time.size() ==
+          original_functions_of_time.size());
+    const double expected_observation_time = observation_id.value();
+    const double expected_expiration_time =
+        expected_observation_time +
+        100.0 * std::numeric_limits<double>::epsilon() *
+            std::max(std::abs(expected_observation_time), 1.0);
+    for (const auto& [name, fot_ptr] : observation_functions_of_time) {
+      CHECK(original_functions_of_time.count(name) == 1);
+      const auto observation_bounds = fot_ptr->time_bounds();
+      const auto original_bounds =
+          original_functions_of_time.at(name)->time_bounds();
+      CHECK(observation_bounds[0] == approx(expected_observation_time));
+      CHECK(observation_bounds[0] >= original_bounds[0]);
+      if (std::isfinite(expected_observation_time)) {
+        CHECK(observation_bounds[1] == approx(expected_expiration_time));
+        CHECK(observation_bounds[1] <= original_bounds[1]);
+      } else {
+        CHECK(observation_bounds[1] == expected_observation_time);
+      }
+    }
+    const auto global_fot_buffer = volume_file.get_global_functions_of_time();
+    CHECK(global_fot_buffer.has_value());
+    CHECK(
+        global_fot_buffer.value() ==
+        serialize(domain_creator.functions_of_time(initial_expiration_times)));
 
     if (file_system::check_if_file_exists(h5_file_name)) {
       file_system::rm(h5_file_name, true);

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -168,7 +168,7 @@ class TestInitialData(unittest.TestCase):
                             quadrature=[Spectral.Quadrature.GaussLobatto],
                         )
                     ],
-                    serialized_functions_of_time=serialized_fots,
+                    serialized_observation_functions_of_time=serialized_fots,
                 )
 
     def tearDown(self):


### PR DESCRIPTION
## Proposed changes

The functions of time are currently written once per observation per volume file with the full history. I found that the object can be larger than ~100MB and can therefore take up a very large amount of storage. see #6943 

In this PR, I change it so the functions of time are saved only once per volume file and are overwritten every time there is a new observation. An attribute "functions_of_time_observation_value" ensures that they are only overwritten with new values (in case the observations are written out of order). The domain is now only saved once during the first observation as it should not change within the same volume file.

The functions to retrieve the domain and functions of time require an observation id. They were adjusted to first look for the objects in the new location and then fall back to the old location in the observation id subfile, so we are backwards compatible. The observation id argument could be made optional.