### PR TITLE
Add option to remove delay in FoT update

### DIFF
--- a/src/ControlSystem/Actions/InitializeMeasurements.hpp
+++ b/src/ControlSystem/Actions/InitializeMeasurements.hpp
@@ -27,14 +27,18 @@
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+class TimeStepper;
 namespace Tags {
-struct TimeStep;
 struct EventsAndDenseTriggers;
+struct TimeStep;
+template <typename StepperInterface>
+struct TimeStepper;
 }  // namespace Tags
 namespace domain::Tags {
 struct FunctionsOfTime;
@@ -58,7 +62,8 @@ struct InitializeMeasurements {
   using simple_tags =
       tmpl::transform<control_system_groups,
                       tmpl::bind<Tags::FutureMeasurements, tmpl::_1>>;
-  using const_global_cache_tags = tmpl::list<Tags::MeasurementsPerUpdate>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::MeasurementsPerUpdate, Tags::DelayUpdate>;
   using mutable_global_cache_tags =
       tmpl::list<control_system::Tags::MeasurementTimescales>;
 
@@ -71,6 +76,12 @@ struct InitializeMeasurements {
       const Parallel::GlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
+    if (not db::get<Tags::DelayUpdate>(box) and
+        not db::get<::Tags::TimeStepper<TimeStepper>>(box).monotonic()) {
+      ERROR_NO_TRACE(
+          "Chosen TimeStepper requires DelayUpdate: true to avoid deadlocks");
+    }
+
     const double initial_time = db::get<::Tags::Time>(box);
     const int measurements_per_update =
         db::get<Tags::MeasurementsPerUpdate>(box);

--- a/src/ControlSystem/ExpirationTimes.cpp
+++ b/src/ControlSystem/ExpirationTimes.cpp
@@ -9,18 +9,28 @@ namespace control_system {
 double function_of_time_expiration_time(
     const double time, const DataVector& old_measurement_timescales,
     const DataVector& new_measurement_timescales,
-    const int measurements_per_update) {
-  return time + min(old_measurement_timescales) +
-         measurements_per_update * min(new_measurement_timescales);
+    const int measurements_per_update, const bool delay_update) {
+  const int new_intervals =
+      delay_update ? measurements_per_update : measurements_per_update - 1;
+  const double min_new_timescale = min(new_measurement_timescales);
+  double expiration = time + min(old_measurement_timescales);
+  // Mathematically, this is just += new_intervals *
+  // min_new_timescale, but that can differ by roundoff from repeated
+  // addition.  Particularly with delay_update = false, it is critical
+  // that the expiration time not be before the measurement time.  The
+  // actual measurement times are calculated by adding the timescale
+  // to the previous time, so we do that here to match.
+  for (int i = 0; i < new_intervals; ++i) {
+    expiration += min_new_timescale;
+  }
+  return expiration;
 }
 
 double measurement_expiration_time(const double time,
                                    const DataVector& old_measurement_timescales,
                                    const DataVector& new_measurement_timescales,
                                    const int measurements_per_update) {
-  return function_of_time_expiration_time(time, old_measurement_timescales,
-                                          new_measurement_timescales,
-                                          measurements_per_update) -
-         0.5 * min(new_measurement_timescales);
+  return time + min(old_measurement_timescales) +
+         (measurements_per_update - 0.5) * min(new_measurement_timescales);
 }
 }  // namespace control_system

--- a/src/ControlSystem/ExpirationTimes.cpp
+++ b/src/ControlSystem/ExpirationTimes.cpp
@@ -10,27 +10,49 @@ double function_of_time_expiration_time(
     const double time, const DataVector& old_measurement_timescales,
     const DataVector& new_measurement_timescales,
     const int measurements_per_update, const bool delay_update) {
-  const int new_intervals =
-      delay_update ? measurements_per_update : measurements_per_update - 1;
   const double min_new_timescale = min(new_measurement_timescales);
-  double expiration = time + min(old_measurement_timescales);
-  // Mathematically, this is just += new_intervals *
+  double expiration = time;
+  if (delay_update) {
+    expiration += min(old_measurement_timescales);
+  }
+  // Mathematically, this is just += measurements_per_update *
   // min_new_timescale, but that can differ by roundoff from repeated
   // addition.  Particularly with delay_update = false, it is critical
   // that the expiration time not be before the measurement time.  The
   // actual measurement times are calculated by adding the timescale
   // to the previous time, so we do that here to match.
-  for (int i = 0; i < new_intervals; ++i) {
+  for (int i = 0; i < measurements_per_update; ++i) {
     expiration += min_new_timescale;
   }
   return expiration;
 }
 
+double function_of_time_initial_expiration_time(
+    const double time, const DataVector& measurement_timescales,
+    const int measurements_per_update, const bool delay_update) {
+  return function_of_time_expiration_time(
+      time, DataVector{}, measurement_timescales,
+      delay_update ? measurements_per_update : measurements_per_update - 1,
+      false);
+}
+
 double measurement_expiration_time(const double time,
                                    const DataVector& old_measurement_timescales,
                                    const DataVector& new_measurement_timescales,
-                                   const int measurements_per_update) {
-  return time + min(old_measurement_timescales) +
-         (measurements_per_update - 0.5) * min(new_measurement_timescales);
+                                   const int measurements_per_update,
+                                   const bool delay_update) {
+  return function_of_time_expiration_time(
+             time, old_measurement_timescales, new_measurement_timescales,
+             measurements_per_update, delay_update) -
+         0.5 * min(new_measurement_timescales);
+}
+
+double measurement_initial_expiration_time(
+    const double time, const DataVector& new_measurement_timescales,
+    const int measurements_per_update, const bool delay_update) {
+  return function_of_time_initial_expiration_time(
+             time, new_measurement_timescales, measurements_per_update,
+             delay_update) -
+         0.5 * min(new_measurement_timescales);
 }
 }  // namespace control_system

--- a/src/ControlSystem/ExpirationTimes.hpp
+++ b/src/ControlSystem/ExpirationTimes.hpp
@@ -31,9 +31,10 @@ namespace control_system {
  * where \f$T_\mathrm{expr}^\mathrm{FoT}\f$ is the expiration time for the
  * FunctionsOfTime, \f$t\f$ is the update time,
  * \f$\tau_\mathrm{m}^\mathrm{old/new}\f$ is the measurement timescale, and
- * \f$N\f$ is the number of measurements per update.
+ * \f$N\f$ is the number of measurements per update if \p delay_update is true,
+ * or one less if it is false.
  *
- * The expiration is calculated this way because we update the functions of time
+ * If \p delay_update is true, we update the functions of time
  * one (old) measurement before they actually expire.
  *
  * The choice of having the functions of time expire exactly one old measurement
@@ -49,11 +50,16 @@ namespace control_system {
  * meantime). If the expiration time was earlier than the next measurement, we'd
  * have to pause the Algorithm on the DG elements and wait until all the
  * functions of time have been updated.
+ *
+ * If \p delay_update is false, we update the functions of time
+ * immediately, which allows for less parallelization but potentially
+ * makes the control system more responsive.  For simplicity, we still
+ * delay the change in the measurement interval by one measurement.
  */
 double function_of_time_expiration_time(
-    const double time, const DataVector& old_measurement_timescales,
-    const DataVector& new_measurement_timescales,
-    const int measurements_per_update);
+    double time, const DataVector& old_measurement_timescales,
+    const DataVector& new_measurement_timescales, int measurements_per_update,
+    bool delay_update);
 
 /*!
  * \ingroup ControlSystemGroup
@@ -124,6 +130,7 @@ double measurement_expiration_time(const double time,
 template <size_t Dim, typename... OptionHolders>
 std::unordered_map<std::string, double> initial_expiration_times(
     const double initial_time, const int measurements_per_update,
+    const bool delay_update,
     const std::unique_ptr<::DomainCreator<Dim>>& domain_creator,
     const std::optional<OptionHolders>&... option_holders) {
   std::unordered_map<std::string, double> initial_expiration_times{};
@@ -146,8 +153,8 @@ std::unordered_map<std::string, double> initial_expiration_times(
   }
 
   [[maybe_unused]] const auto combine_expiration_times =
-      [&initial_time, &measurements_per_update, &domain_creator, &map_of_names,
-       &combined_expiration_times,
+      [&initial_time, &measurements_per_update, &delay_update, &domain_creator,
+       &map_of_names, &combined_expiration_times,
        &infinite_expiration_times](const auto& option_holder) {
         const std::string& control_system_name = std::decay_t<
             decltype(option_holder)>::value_type::control_system::name();
@@ -171,7 +178,8 @@ std::unordered_map<std::string, double> initial_expiration_times(
 
         const double initial_expiration_time = function_of_time_expiration_time(
             initial_time, DataVector{1, 0.0},
-            DataVector{1, min_measurement_timescale}, measurements_per_update);
+            DataVector{1, min_measurement_timescale}, measurements_per_update,
+            delay_update);
 
         combined_expiration_times[combined_name] = std::min(
             combined_expiration_times[combined_name], initial_expiration_time);

--- a/src/ControlSystem/ExpirationTimes.hpp
+++ b/src/ControlSystem/ExpirationTimes.hpp
@@ -23,16 +23,23 @@ namespace control_system {
  * \ingroup ControlSystemGroup
  * \brief Calculate the next expiration time for the FunctionsOfTime.
  *
- * \f{align}
- * T_\mathrm{expr}^\mathrm{FoT} &= t + \tau_\mathrm{m}^\mathrm{old}
- *      + N * \tau_\mathrm{m}^\mathrm{new} \\
+ * If \p delay_update is false, this returns
+ *
+ * \f{equation}
+ * T_\mathrm{expr}^\mathrm{FoT} = t + N * \tau_\mathrm{m}^\mathrm{new},
+ * \f}
+ *
+ * and if it is true,
+ *
+ * \f{equation}
+ * T_\mathrm{expr}^\mathrm{FoT} = t + \tau_\mathrm{m}^\mathrm{old}
+ *      + N * \tau_\mathrm{m}^\mathrm{new},
  * \f}
  *
  * where \f$T_\mathrm{expr}^\mathrm{FoT}\f$ is the expiration time for the
  * FunctionsOfTime, \f$t\f$ is the update time,
  * \f$\tau_\mathrm{m}^\mathrm{old/new}\f$ is the measurement timescale, and
- * \f$N\f$ is the number of measurements per update if \p delay_update is true,
- * or one less if it is false.
+ * \f$N\f$ is the number of measurements per update.
  *
  * If \p delay_update is true, we update the functions of time
  * one (old) measurement before they actually expire.
@@ -53,13 +60,30 @@ namespace control_system {
  *
  * If \p delay_update is false, we update the functions of time
  * immediately, which allows for less parallelization but potentially
- * makes the control system more responsive.  For simplicity, we still
- * delay the change in the measurement interval by one measurement.
+ * makes the control system more responsive.
  */
 double function_of_time_expiration_time(
     double time, const DataVector& old_measurement_timescales,
     const DataVector& new_measurement_timescales, int measurements_per_update,
     bool delay_update);
+
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief Calculate the first expiration time for the FunctionsOfTime.
+ *
+ * The first expiration time is
+ *
+ * \f{equation}
+ * T_\mathrm{expr}^\mathrm{FoT} = t + N * \tau_\mathrm{m},
+ * \f}
+ *
+ * where $t$ is the initial time, $\tau_\mathrm{m}$ is the measurement
+ * timescale, and \f$N\f$ is the number of measurements per update if
+ * \p delay_update is true, and one less if it is false.
+ */
+double function_of_time_initial_expiration_time(
+    double time, const DataVector& measurement_timescales,
+    int measurements_per_update, bool delay_update);
 
 /*!
  * \ingroup ControlSystemGroup
@@ -90,10 +114,23 @@ double function_of_time_expiration_time(
  * just to guarantee we are more than epsilon before the function of time
  * expiration time and more than epsilon after the update measurement.
  */
-double measurement_expiration_time(const double time,
+double measurement_expiration_time(double time,
                                    const DataVector& old_measurement_timescales,
                                    const DataVector& new_measurement_timescales,
-                                   const int measurements_per_update);
+                                   int measurements_per_update,
+                                   bool delay_update);
+
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief Calculate the first expiration time for the MeasurementTimescales.
+ *
+ * This is related to `function_of_time_initial_expiration_time()` in
+ * the same way that `measurement_expiration_time()` is related to
+ * `function_of_time_expiration_time()`.
+ */
+double measurement_initial_expiration_time(
+    double time, const DataVector& measurement_timescales,
+    int measurements_per_update, bool delay_update);
 
 /*!
  * \ingroup ControlSystemGroup
@@ -176,10 +213,10 @@ std::unordered_map<std::string, double> initial_expiration_times(
                                              measurements_per_update);
         const double min_measurement_timescale = min(measurement_timescales);
 
-        const double initial_expiration_time = function_of_time_expiration_time(
-            initial_time, DataVector{1, 0.0},
-            DataVector{1, min_measurement_timescale}, measurements_per_update,
-            delay_update);
+        const double initial_expiration_time =
+            function_of_time_initial_expiration_time(
+                initial_time, DataVector{1, min_measurement_timescale},
+                measurements_per_update, delay_update);
 
         combined_expiration_times[combined_name] = std::min(
             combined_expiration_times[combined_name], initial_expiration_time);

--- a/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
+++ b/src/ControlSystem/Tags/FunctionsOfTimeInitialize.hpp
@@ -69,6 +69,7 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime {
           metavars_has_control_systems<Metavariables>,
           tmpl::flatten<tmpl::list<
               control_system::OptionTags::MeasurementsPerUpdate,
+              control_system::OptionTags::DelayUpdate,
               ::OptionTags::InitialTime, option_holders<Metavariables>>>,
           tmpl::list<>>,
       domain::OptionTags::DomainCreator<Metavariables::volume_dim>>;
@@ -80,11 +81,12 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime {
   static type create_from_options(
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
-      const int measurements_per_update, const double initial_time,
+      const int measurements_per_update, const bool delay_update,
+      const double initial_time,
       const Options::Auto<OptionHolders,
                           Options::AutoLabel::None>&... option_holders) {
     return create_from_options<Metavariables>(
-        domain_creator, measurements_per_update, initial_time,
+        domain_creator, measurements_per_update, delay_update, initial_time,
         static_cast<const std::optional<OptionHolders>&>(option_holders)...);
   }
 
@@ -92,11 +94,12 @@ struct FunctionsOfTimeInitialize : domain::Tags::FunctionsOfTime {
   static type create_from_options(
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
-      const int measurements_per_update, const double initial_time,
+      const int measurements_per_update, const bool delay_update,
+      const double initial_time,
       const std::optional<OptionHolders>&... option_holders) {
     const auto initial_expiration_times =
         control_system::initial_expiration_times(
-            initial_time, measurements_per_update, domain_creator,
+            initial_time, measurements_per_update, delay_update, domain_creator,
             option_holders...);
 
     // We need to check the expiration times so we can ensure a proper domain

--- a/src/ControlSystem/Tags/MeasurementTimescales.hpp
+++ b/src/ControlSystem/Tags/MeasurementTimescales.hpp
@@ -75,26 +75,27 @@ struct MeasurementTimescales : db::SimpleTag {
   using option_tags = tmpl::push_front<
       option_holders<Metavariables>,
       control_system::OptionTags::MeasurementsPerUpdate,
+      control_system::OptionTags::DelayUpdate,
       domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
       ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep>;
 
   template <typename Metavariables, typename... OptionHolders>
   static type create_from_options(
-      const int measurements_per_update,
+      const int measurements_per_update, const bool delay_update,
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
       const double initial_time, const double initial_time_step,
       const Options::Auto<OptionHolders,
                           Options::AutoLabel::None>&... option_holders) {
     return create_from_options<Metavariables>(
-        measurements_per_update, domain_creator, initial_time,
+        measurements_per_update, delay_update, domain_creator, initial_time,
         initial_time_step,
         static_cast<std::optional<OptionHolders>>(option_holders)...);
   }
 
   template <typename Metavariables, typename... OptionHolders>
   static type create_from_options(
-      const int measurements_per_update,
+      const int measurements_per_update, const bool delay_update,
       const std::unique_ptr<::DomainCreator<Metavariables::volume_dim>>&
           domain_creator,
       const double initial_time, const double initial_time_step,
@@ -126,7 +127,8 @@ struct MeasurementTimescales : db::SimpleTag {
 
     [[maybe_unused]] const auto combine_measurement_timescales =
         [&initial_time, &initial_time_step, &domain_creator,
-         &measurements_per_update, &map_of_names, &min_measurement_timescales,
+         &measurements_per_update, &delay_update, &map_of_names,
+         &min_measurement_timescales,
          &expiration_times](const auto& option_holder) {
           // This check is intentionally inside the lambda so that it will not
           // trigger for domains without control systems.
@@ -165,10 +167,10 @@ struct MeasurementTimescales : db::SimpleTag {
 
           if (min_measurement_timescales[combined_name] !=
               std::numeric_limits<double>::infinity()) {
-            const double expiration_time = measurement_expiration_time(
-                initial_time, DataVector{1_st, 0.0},
+            const double expiration_time = measurement_initial_expiration_time(
+                initial_time,
                 DataVector{1_st, min_measurement_timescales[combined_name]},
-                measurements_per_update);
+                measurements_per_update, delay_update);
             expiration_times[combined_name] =
                 std::min(expiration_times[combined_name], expiration_time);
           }

--- a/src/ControlSystem/Tags/OptionTags.hpp
+++ b/src/ControlSystem/Tags/OptionTags.hpp
@@ -155,6 +155,18 @@ struct MeasurementsPerUpdate {
 
 /// \ingroup OptionTagsGroup
 /// \ingroup ControlSystemGroup
+/// Option tag on whether to delay FunctionOfTime updates by one
+/// measurement to improve parallelization.
+struct DelayUpdate {
+  using type = bool;
+  static constexpr Options::String help = {
+      "Whether FunctionOfTime updates are delayed by one measurement to "
+      "improve parallelization."};
+  using group = ControlSystemGroup;
+};
+
+/// \ingroup OptionTagsGroup
+/// \ingroup ControlSystemGroup
 /// Verbosity tag for printing diagnostics about the control system algorithm.
 /// This does not control when data is written to disk.
 struct Verbosity {

--- a/src/ControlSystem/Tags/SystemTags.hpp
+++ b/src/ControlSystem/Tags/SystemTags.hpp
@@ -208,6 +208,21 @@ struct MeasurementsPerUpdate : db::SimpleTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ControlSystemGroup
+/// Tag that determines whether FunctionOfTime updates will be delayed
+/// by one measurement.  This will usually be stored in the global
+/// cache.
+struct DelayUpdate : db::SimpleTag {
+  using type = bool;
+
+  using option_tags = tmpl::list<OptionTags::DelayUpdate>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const bool delay_update) {
+    return delay_update;
+  }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ControlSystemGroup
 /// DataBox tag that keeps track of which measurement we are on.
 struct CurrentNumberOfMeasurements : db::SimpleTag {
   using type = int;

--- a/src/ControlSystem/UpdateControlSystem.hpp
+++ b/src/ControlSystem/UpdateControlSystem.hpp
@@ -246,11 +246,8 @@ struct UpdateControlSystem {
         function_of_time->time_bounds()[1];
     const double current_measurement_expiration_time =
         measurement_timescale->time_bounds()[1];
-    // This call is ok because the measurement timescales are still valid
-    // because the measurement timescales expire half a measurement after this
-    // time.
     const DataVector old_measurement_timescale =
-        measurement_timescale->func(time)[0];
+        measurement_timescale->func(current_measurement_expiration_time)[0];
 
     // Begin step 8
     // Calculate the next expiration times for both the functions of time and
@@ -262,7 +259,7 @@ struct UpdateControlSystem {
 
     const double new_measurement_expiration_time = measurement_expiration_time(
         time, old_measurement_timescale, new_measurement_timescale,
-        measurements_per_update);
+        measurements_per_update, delay_update);
 
     if (Parallel::get<Tags::Verbosity>(cache) >= ::Verbosity::Verbose) {
       Parallel::printf("%s, time = %.16f: Control signal = %s\n",

--- a/src/ControlSystem/UpdateControlSystem.hpp
+++ b/src/ControlSystem/UpdateControlSystem.hpp
@@ -122,6 +122,7 @@ struct UpdateControlSystem {
     // Begin step 2
     const int measurements_per_update =
         get<control_system::Tags::MeasurementsPerUpdate>(cache);
+    const bool delay_update = get<control_system::Tags::DelayUpdate>(cache);
     int& current_measurement = db::get_mutable_reference<
         control_system::Tags::CurrentNumberOfMeasurements>(box);
 
@@ -257,7 +258,7 @@ struct UpdateControlSystem {
     // update the functions of time and measurement timescales
     const double new_fot_expiration_time = function_of_time_expiration_time(
         time, old_measurement_timescale, new_measurement_timescale,
-        measurements_per_update);
+        measurements_per_update, delay_update);
 
     const double new_measurement_expiration_time = measurement_expiration_time(
         time, old_measurement_timescale, new_measurement_timescale,

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -569,6 +569,7 @@ InterpolationTargets:
 ControlSystems:
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
+  DelayUpdate: true
   Verbosity: Silent
   Expansion: &KinematicControlSystem
     Averager: &KinematicAverager

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -360,6 +360,7 @@ Cce:
 ControlSystems:
   WriteDataToDisk: false
   MeasurementsPerUpdate: 4
+  DelayUpdate: true
   Verbosity: Silent
   Translation:
     Averager:

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -369,6 +369,7 @@ Cce:
 ControlSystems:
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
+  DelayUpdate: true
   Verbosity: Silent
   Expansion:
     Averager:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -283,6 +283,7 @@ Cce:
 ControlSystems:
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
+  DelayUpdate: true
   Verbosity: Silent
   Translation: None
   Shape: None

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -488,6 +488,7 @@ ControlSystems:
     RotationDecayTimescale: 60.0
   WriteDataToDisk: true
   MeasurementsPerUpdate: 4
+  DelayUpdate: true
   Verbosity: Silent
   Expansion: None
   Rotation:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -278,6 +278,7 @@ Cce:
 ControlSystems:
   WriteDataToDisk: false
   MeasurementsPerUpdate: 4
+  DelayUpdate: true
   Verbosity: Silent
   Shape: None
   Translation: None

--- a/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
+++ b/tests/Unit/ControlSystem/Actions/Test_InitializeMeasurements.cpp
@@ -45,6 +45,9 @@
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStep.hpp"
 #include "Time/Tags/TimeStepId.hpp"
+#include "Time/Tags/TimeStepper.hpp"
+#include "Time/TimeSteppers/AdamsMoultonPc.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/CartesianProduct.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -143,9 +146,13 @@ struct Component {
   using simple_tags_from_options = tmpl::list<::Tags::EventsAndDenseTriggers>;
 
   using simple_tags = tmpl::list<Tags::TimeStepId, Tags::Time, Tags::TimeStep>;
-  using compute_tags = tmpl::list<Parallel::Tags::FromGlobalCache<
-      ::domain::Tags::FunctionsOfTimeInitialize, Metavariables>>;
-  using const_global_cache_tags = tmpl::list<control_system::Tags::Verbosity>;
+  using compute_tags = tmpl::push_back<
+      time_stepper_ref_tags<TimeStepper>,
+      Parallel::Tags::FromGlobalCache<::domain::Tags::FunctionsOfTimeInitialize,
+                                      Metavariables>>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::ConcreteTimeStepper<TimeStepper>,
+                 control_system::Tags::Verbosity>;
   using mutable_global_cache_tags =
       tmpl::list<domain::Tags::FunctionsOfTimeInitialize>;
 
@@ -172,15 +179,20 @@ struct Metavariables {
   };
 };
 
-template <bool LocalTimeStepping>
-void test_initialize_measurements(const bool ab_active, const bool c_active) {
+template <bool LocalTimeStepping, bool MonotonicTimeStepper>
+void test_initialize_measurements(const bool ab_active, const bool c_active,
+                                  const bool delay_update) {
   CAPTURE(LocalTimeStepping);
+  CAPTURE(MonotonicTimeStepper);
   CAPTURE(ab_active);
   CAPTURE(c_active);
+  CAPTURE(delay_update);
+
+  using TimeStepperType = TimeSteppers::AdamsMoultonPc<MonotonicTimeStepper>;
 
   register_factory_classes_with_charm<Metavariables<LocalTimeStepping>>();
-  register_classes_with_charm<
-      domain::FunctionsOfTime::PiecewisePolynomial<0>>();
+  register_classes_with_charm<domain::FunctionsOfTime::PiecewisePolynomial<0>,
+                              TimeStepperType>();
 
   using MockRuntimeSystem =
       ActionTesting::MockRuntimeSystem<Metavariables<LocalTimeStepping>>;
@@ -196,6 +208,8 @@ void test_initialize_measurements(const bool ab_active, const bool c_active) {
   const double fot_expiration = 4.0;
 
   const double step_to_expiration_ratio = c_active ? 3.0 : 0.2;
+
+  auto time_stepper = std::make_unique<TimeStepperType>(4);
 
   const auto initial_slab = Slab::with_duration_from_start(
       initial_time, step_to_expiration_ratio * (fot_expiration - initial_time));
@@ -227,7 +241,8 @@ void test_initialize_measurements(const bool ab_active, const bool c_active) {
   functions.emplace("B", fot->get_clone());
   functions.emplace("C", fot->get_clone());
 
-  MockRuntimeSystem runner{{::Verbosity::Silent, measurements_per_update},
+  MockRuntimeSystem runner{{std::move(time_stepper), ::Verbosity::Silent,
+                            measurements_per_update, delay_update},
                            {std::move(functions), std::move(timescales)}};
   ActionTesting::emplace_array_component_and_initialize<component>(
       make_not_null(&runner), ActionTesting::NodeId{0},
@@ -237,6 +252,13 @@ void test_initialize_measurements(const bool ab_active, const bool c_active) {
 
   // InitializeRunEventsAndDenseTriggers
   ActionTesting::next_action<component>(make_not_null(&runner), element_id);
+  if (not delay_update and not MonotonicTimeStepper) {
+    CHECK_THROWS_WITH(ActionTesting::next_action<component>(
+                          make_not_null(&runner), element_id),
+                      Catch::Matchers::ContainsSubstring(
+                          "Chosen TimeStepper requires DelayUpdate: true"));
+    return;
+  }
   // InitializeMeasurements
   ActionTesting::next_action<component>(make_not_null(&runner), element_id);
 
@@ -301,10 +323,14 @@ void test_initialize_measurements(const bool ab_active, const bool c_active) {
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.InitializeMeasurements",
                   "[ControlSystem][Unit]") {
-  for (const auto& [ab_active, c_active] :
-       cartesian_product(std::array{true, false}, std::array{true, false})) {
-    test_initialize_measurements<false>(ab_active, c_active);
-    test_initialize_measurements<true>(ab_active, c_active);
+  for (const auto& [ab_active, c_active, delay_update] :
+       cartesian_product(std::array{true, false}, std::array{true, false},
+                         std::array{true, false})) {
+    test_initialize_measurements<false, true>(ab_active, c_active,
+                                              delay_update);
+    test_initialize_measurements<false, false>(ab_active, c_active,
+                                               delay_update);
+    test_initialize_measurements<true, true>(ab_active, c_active, delay_update);
   }
 }
 }  // namespace

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Expansion.cpp
@@ -44,6 +44,7 @@ void test_expansion_control_error() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n"
       "  Expansion:\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
@@ -85,7 +86,7 @@ void test_expansion_control_error() {
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map), std::move(grid_center_A),
        std::move(grid_center_B), std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Rotation.cpp
@@ -48,6 +48,7 @@ void test_rotation_control_error() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n"
       "  Rotation:\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
@@ -89,7 +90,7 @@ void test_rotation_control_error() {
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map), std::move(grid_center_A),
        std::move(grid_center_B), std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -153,9 +153,10 @@ void test_shape_control_error() {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   // Excision centers aren't used so their values can be anything
   MockRuntimeSystem runner{
-      {"DummyFilename", std::move(fake_domain), 4, false, ::Verbosity::Silent,
-       std::unordered_map<std::string, bool>{}, std::move(grid_center_A),
-       std::move(grid_center_B), std::move(system_to_combined_names)},
+      {"DummyFilename", std::move(fake_domain), 4, true, false,
+       ::Verbosity::Silent, std::unordered_map<std::string, bool>{},
+       std::move(grid_center_A), std::move(grid_center_B),
+       std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),
        std::move(initial_measurement_timescales)}};
   ActionTesting::emplace_array_component<element_component>(

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Translation.cpp
@@ -57,6 +57,7 @@ void test_translation_control_error() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n"
       "  Translation:\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
@@ -98,7 +99,7 @@ void test_translation_control_error() {
   // global cache
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map), std::move(grid_center_A),
        std::move(grid_center_B), std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Expansion.cpp
@@ -66,6 +66,7 @@ void test_expansion_control_system() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n"
       "  Expansion:\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
@@ -106,7 +107,7 @@ void test_expansion_control_system() {
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map), std::move(grid_center_A),
        std::move(grid_center_B), std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/Systems/Test_GridCenters.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_GridCenters.cpp
@@ -123,7 +123,7 @@ void test_grid_centers_process_measurement() {
   using component = MockComponent<Metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   MockRuntimeSystem runner{
-      {creator.create_domain(), ::Verbosity::Silent, 4, false,
+      {creator.create_domain(), ::Verbosity::Silent, 4, true, false,
        std::unordered_map<std::string, bool>{},
        tnsr::I<double, 3, Frame::Grid>{std::array{-16.0, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{std::array{16.0, 0.0, 0.0}},

--- a/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_RotScaleTrans.cpp
@@ -112,7 +112,8 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
       "      Expansion: 1\n"
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
-      "  MeasurementsPerUpdate: 4\n";
+      "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n";
   input_options += create_input_string(translation_name);
   input_options += create_input_string(rotation_name);
   input_options += create_input_string(expansion_name);
@@ -161,7 +162,7 @@ void test_rotscaletrans_control_system(const double rotation_eps = 5.0e-5) {
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map),
        tnsr::I<double, 3, Frame::Grid>{{0.5 * initial_separation, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{{-0.5 * initial_separation, 0.0, 0.0}},

--- a/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Rotation.cpp
@@ -71,6 +71,7 @@ void test_rotation_control_system(const bool newtonian) {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n"
       "  Rotation:\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
@@ -111,7 +112,7 @@ void test_rotation_control_system(const bool newtonian) {
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map), std::move(grid_center_A),
        std::move(grid_center_B), std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Shape.cpp
@@ -86,7 +86,7 @@ void test_shape_control(
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   // Excision centers aren't used so their values can be anything
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map), std::move(grid_center_A),
        std::move(grid_center_B), std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),
@@ -256,6 +256,7 @@ void test_suite(const gsl::not_null<Generator*> generator, const size_t l_max,
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n"
       "  ShapeA:\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"

--- a/tests/Unit/ControlSystem/Systems/Test_Size.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Size.cpp
@@ -121,7 +121,7 @@ void test_size_process_measurement() {
   using component = MockComponent<Metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   MockRuntimeSystem runner{
-      {creator.create_domain(), ::Verbosity::Silent, 4, false,
+      {creator.create_domain(), ::Verbosity::Silent, 4, true, false,
        std::unordered_map<std::string, bool>{},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},

--- a/tests/Unit/ControlSystem/Systems/Test_Skew.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Skew.cpp
@@ -118,7 +118,7 @@ void test_skew_process_measurement() {
   using component = MockComponent<Metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   MockRuntimeSystem runner{
-      {creator.create_domain(), ::Verbosity::Silent, 4, false,
+      {creator.create_domain(), ::Verbosity::Silent, 4, true, false,
        std::unordered_map<std::string, bool>{},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},

--- a/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Translation.cpp
@@ -73,6 +73,7 @@ void test_translation_control_system() {
       "ControlSystems:\n"
       "  WriteDataToDisk: false\n"
       "  MeasurementsPerUpdate: 4\n"
+      "  DelayUpdate: true\n"
       "  Translation:\n"
       "    Averager:\n"
       "      AverageTimescaleFraction: 0.25\n"
@@ -115,7 +116,7 @@ void test_translation_control_system() {
   // Setup runner and all components
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   MockRuntimeSystem runner{
-      {"DummyFileName", std::move(domain), 4, false, ::Verbosity::Silent,
+      {"DummyFileName", std::move(domain), 4, true, false, ::Verbosity::Silent,
        std::move(is_active_map), std::move(grid_center_A),
        std::move(grid_center_B), std::move(system_to_combined_names)},
       {std::move(initial_functions_of_time),

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -195,8 +195,9 @@ using ControlSysInputs =
 
 constexpr int measurements_per_update = 4;
 
-void test_functions_of_time_tag() {
+void test_functions_of_time_tag(const bool delay_update) {
   INFO("Test FunctionsOfTimeInitialize tag");
+  CAPTURE(delay_update);
   using fot_tag = control_system::Tags::FunctionsOfTimeInitialize;
   using Creator = std::unique_ptr<::DomainCreator<1>>;
 
@@ -225,15 +226,20 @@ void test_functions_of_time_tag() {
 
   // First test construction with only control systems
   fot_tag::type functions_of_time = fot_tag::create_from_options<Metavariables>(
-      creator, measurements_per_update, initial_time, option_holder1,
-      option_holder2, option_holder3);
+      creator, measurements_per_update, delay_update, initial_time,
+      option_holder1, option_holder2, option_holder3);
 
-  const double expiration_controlled_2 =
-      initial_time + update_fraction * timescale;
-  const double expiration_controlled_3 =
-      initial_time + update_fraction * timescale2;
-  const double min_expiration_time =
-      std::min(expiration_controlled_2, expiration_controlled_3);
+  const double min_measurement_timescale = update_fraction *
+                                           std::min(timescale, timescale2) /
+                                           measurements_per_update;
+  double min_expiration_time = initial_time;
+  // First measurement is initial_time, so start counter at 1
+  for (int measure = 1; measure < measurements_per_update; ++measure) {
+    min_expiration_time += min_measurement_timescale;
+  }
+  if (delay_update) {
+    min_expiration_time += min_measurement_timescale;
+  }
 
   // 1 isn't active
   CHECK(functions_of_time.at("Controlled1")->time_bounds()[1] ==
@@ -251,6 +257,7 @@ void test_functions_of_time_tag() {
           tmpl::list<
               domain::OptionTags::DomainCreator<Metavariables::volume_dim>,
               control_system::OptionTags::MeasurementsPerUpdate,
+              control_system::OptionTags::DelayUpdate,
               ::OptionTags::InitialTime, ControlSysInputs<FakeControlSystem<1>>,
               ControlSysInputs<FakeControlSystem<2>>,
               ControlSysInputs<FakeControlSystem<3>>>>);
@@ -286,6 +293,7 @@ void not_controlling(const bool is_active) {
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
+  constexpr bool delay_update = true;
 
   const std::optional<OptionHolder<1>> option_holder1 =
       is_active ? std::optional{OptionHolder<1>{averager, controller, tuner,
@@ -306,8 +314,8 @@ void not_controlling(const bool is_active) {
 
   [[maybe_unused]] fot_tag::type functions_of_time =
       fot_tag::create_from_options<Metavariables>(
-          creator, measurements_per_update, initial_time, option_holder1,
-          option_holder2, option_holder3, option_holder4);
+          creator, measurements_per_update, delay_update, initial_time,
+          option_holder1, option_holder2, option_holder3, option_holder4);
 }
 
 void incompatible(const bool is_active) {
@@ -319,6 +327,7 @@ void incompatible(const bool is_active) {
   const double update_fraction = 0.3;
   const Controller<2> controller(update_fraction);
   const control_system::TestHelpers::ControlError control_error{};
+  constexpr bool delay_update = true;
 
   const std::optional<OptionHolder<1>> option_holder1 =
       is_active ? std::optional{OptionHolder<1>{averager, controller, tuner,
@@ -335,8 +344,8 @@ void incompatible(const bool is_active) {
 
   [[maybe_unused]] fot_tag::type functions_of_time =
       fot_tag::create_from_options<Metavariables>(
-          creator, measurements_per_update, initial_time, option_holder1,
-          option_holder2, option_holder3);
+          creator, measurements_per_update, delay_update, initial_time,
+          option_holder1, option_holder2, option_holder3);
 }
 
 void test_errors(const bool is_active) {
@@ -359,7 +368,8 @@ void test_errors(const bool is_active) {
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.Tags.FunctionsOfTimeInitialize",
                   "[ControlSystem][Unit]") {
-  test_functions_of_time_tag();
+  test_functions_of_time_tag(true);
+  test_functions_of_time_tag(false);
   test_errors(true);
   test_errors(false);
 }

--- a/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_MeasurementTimescales.cpp
@@ -96,7 +96,7 @@ void test_measurement_tag() {
   INFO("Test measurement tag");
   using measurement_tag = control_system::Tags::MeasurementTimescales;
   static_assert(
-      tmpl::size<measurement_tag::option_tags<Metavariables>>::value == 9);
+      tmpl::size<measurement_tag::option_tags<Metavariables>>::value == 10);
 
   using FakeCreator = TestHelpers::control_system::FakeCreator;
 
@@ -142,6 +142,7 @@ void test_measurement_tag() {
         std::is_same_v<
             measurement_tag::option_tags<Metavariables>,
             tmpl::list<control_system::OptionTags::MeasurementsPerUpdate,
+                       control_system::OptionTags::DelayUpdate,
                        domain::OptionTags::DomainCreator<3>,
                        ::OptionTags::InitialTime, ::OptionTags::InitialTimeStep,
                        control_system::OptionTags::ControlSystemInputs<
@@ -155,11 +156,12 @@ void test_measurement_tag() {
                        control_system::OptionTags::ControlSystemInputs<
                            FakeControlSystem<6>>>>);
     const int measurements_per_update = 4;
+    const bool delay_update = true;
     const measurement_tag::type timescales =
         measurement_tag::create_from_options<Metavariables>(
-            measurements_per_update, creator, initial_time, time_step,
-            option_holder1, option_holder2, option_holder4, option_holder5,
-            option_holder6);
+            measurements_per_update, delay_update, creator, initial_time,
+            time_step, option_holder1, option_holder2, option_holder4,
+            option_holder5, option_holder6);
     CHECK(timescales.size() == 3);
     CHECK(timescales.count("Controlled1Controlled4") == 1);
     CHECK(timescales.count("Controlled2Controlled5") == 1);
@@ -222,9 +224,8 @@ void test_measurement_tag() {
                     {FakeControlSystem<3>::name(), 1}});
 
         measurement_tag::create_from_options<Metavariables>(
-            4, creator, initial_time, -1.0, option_holder1, option_holder2,
-
-            option_holder3);
+            4, true, creator, initial_time, -1.0, option_holder1,
+            option_holder2, option_holder3);
       })(),
       Catch::Matchers::ContainsSubstring(
           "Control systems can only be used in forward-in-time evolutions."));

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -119,8 +119,8 @@ void test_expiration_time_construction() {
           expected_initial_expiration_times{
               {FakeControlSystem<1>::name(),
                // This is ok to use here because we test it below
-               control_system::function_of_time_expiration_time(
-                   initial_time, DataVector{0.0},
+               control_system::function_of_time_initial_expiration_time(
+                   initial_time,
                    control_system::calculate_measurement_timescales(
                        controller, tuner1, measurements_per_update),
                    measurements_per_update, delay_update)}};
@@ -141,10 +141,9 @@ void test_expiration_time_construction() {
                    min(control_system::calculate_measurement_timescales(
                        controller, tuner2, measurements_per_update)));
       const double min_expiration_time =
-          control_system::function_of_time_expiration_time(
-              initial_time, DataVector{0.0},
-              DataVector{min_measurement_timescale}, measurements_per_update,
-              delay_update);
+          control_system::function_of_time_initial_expiration_time(
+              initial_time, DataVector{min_measurement_timescale},
+              measurements_per_update, delay_update);
 
       const std::unordered_map<std::string, double>
           expected_initial_expiration_times{
@@ -175,22 +174,49 @@ void test_fot_measurement_expr_time() {
           time, old_measurement_timescales, new_measurement_timescales,
           measurements_per_update, true);
   CHECK(fot_expr_time_delayed ==
-        fot_expr_time_nondelayed + min(new_measurement_timescales));
-  const double expected_fot_expr_time = time + min(old_measurement_timescales) +
+        fot_expr_time_nondelayed + min(old_measurement_timescales));
+  const double expected_fot_expr_time = time + min(new_measurement_timescales) +
                                         min(new_measurement_timescales) +
                                         min(new_measurement_timescales);
 
   CHECK(fot_expr_time_nondelayed == expected_fot_expr_time);
 
-  const double measurement_expr_time =
+  const double fot_initial_expr_time_nondelayed =
+      control_system::function_of_time_initial_expiration_time(
+          time, new_measurement_timescales, measurements_per_update, false);
+  const double fot_initial_expr_time_delayed =
+      control_system::function_of_time_initial_expiration_time(
+          time, new_measurement_timescales, measurements_per_update, true);
+  CHECK(fot_initial_expr_time_delayed ==
+        fot_initial_expr_time_nondelayed + min(new_measurement_timescales));
+  CHECK(fot_initial_expr_time_delayed == expected_fot_expr_time);
+
+  const double measurement_expr_time_delayed =
       control_system::measurement_expiration_time(
           time, old_measurement_timescales, new_measurement_timescales,
-          measurements_per_update);
-  const double expected_measurement_expr_time =
-      time + min(old_measurement_timescales) +
-      (double(measurements_per_update) - 0.5) * min(new_measurement_timescales);
+          measurements_per_update, true);
+  const double measurement_expr_time_nondelayed =
+      control_system::measurement_expiration_time(
+          time, old_measurement_timescales, new_measurement_timescales,
+          measurements_per_update, false);
+  CHECK(measurement_expr_time_delayed ==
+        approx(fot_expr_time_delayed - 0.5 * min(new_measurement_timescales)));
+  CHECK(
+      measurement_expr_time_nondelayed ==
+      approx(fot_expr_time_nondelayed - 0.5 * min(new_measurement_timescales)));
 
-  CHECK(measurement_expr_time == expected_measurement_expr_time);
+  const double measurement_initial_expr_time_delayed =
+      control_system::measurement_initial_expiration_time(
+          time, new_measurement_timescales, measurements_per_update, true);
+  const double measurement_initial_expr_time_nondelayed =
+      control_system::measurement_initial_expiration_time(
+          time, new_measurement_timescales, measurements_per_update, false);
+  CHECK(measurement_initial_expr_time_delayed ==
+        approx(fot_initial_expr_time_delayed -
+               0.5 * min(new_measurement_timescales)));
+  CHECK(measurement_initial_expr_time_nondelayed ==
+        approx(fot_initial_expr_time_nondelayed -
+               0.5 * min(new_measurement_timescales)));
 }
 }  // namespace
 

--- a/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
+++ b/tests/Unit/ControlSystem/Test_ExpirationTimes.cpp
@@ -94,63 +94,68 @@ void test_expiration_time_construction() {
           {FakeControlSystem<2>::name(), 2},
           {FakeControlSystem<3>::name(), 1}});
 
-  {
-    INFO("No control systems");
-    const auto initial_expiration_times =
-        control_system::initial_expiration_times(
-            initial_time, measurements_per_update, creator1);
+  for (const bool delay_update : {true, false}) {
+    CAPTURE(delay_update);
+    {
+      INFO("No control systems");
+      const auto initial_expiration_times =
+          control_system::initial_expiration_times(
+              initial_time, measurements_per_update, delay_update, creator1);
 
-    const std::unordered_map<std::string, double>
-        expected_initial_expiration_times{};
+      const std::unordered_map<std::string, double>
+          expected_initial_expiration_times{};
 
-    check_expiration_times(initial_expiration_times,
-                           expected_initial_expiration_times);
-  }
-  {
-    INFO("One control system");
-    const auto initial_expiration_times =
-        control_system::initial_expiration_times(
-            initial_time, measurements_per_update, creator2, option_holder1);
+      check_expiration_times(initial_expiration_times,
+                             expected_initial_expiration_times);
+    }
+    {
+      INFO("One control system");
+      const auto initial_expiration_times =
+          control_system::initial_expiration_times(
+              initial_time, measurements_per_update, delay_update, creator2,
+              option_holder1);
 
-    const std::unordered_map<std::string, double>
-        expected_initial_expiration_times{
-            {FakeControlSystem<1>::name(),
-             // This is ok to use here because we test it below
-             control_system::function_of_time_expiration_time(
-                 initial_time, DataVector{0.0},
-                 control_system::calculate_measurement_timescales(
-                     controller, tuner1, measurements_per_update),
-                 measurements_per_update)}};
+      const std::unordered_map<std::string, double>
+          expected_initial_expiration_times{
+              {FakeControlSystem<1>::name(),
+               // This is ok to use here because we test it below
+               control_system::function_of_time_expiration_time(
+                   initial_time, DataVector{0.0},
+                   control_system::calculate_measurement_timescales(
+                       controller, tuner1, measurements_per_update),
+                   measurements_per_update, delay_update)}};
 
-    check_expiration_times(initial_expiration_times,
-                           expected_initial_expiration_times);
-  }
-  {
-    INFO("Three control system");
-    const auto initial_expiration_times =
-        control_system::initial_expiration_times(
-            initial_time, measurements_per_update, creator3, option_holder1,
-            option_holder2, option_holder3);
+      check_expiration_times(initial_expiration_times,
+                             expected_initial_expiration_times);
+    }
+    {
+      INFO("Three control system");
+      const auto initial_expiration_times =
+          control_system::initial_expiration_times(
+              initial_time, measurements_per_update, delay_update, creator3,
+              option_holder1, option_holder2, option_holder3);
 
-    const double min_measurement_timescale =
-        std::min(min(control_system::calculate_measurement_timescales(
-                     controller, tuner1, measurements_per_update)),
-                 min(control_system::calculate_measurement_timescales(
-                     controller, tuner2, measurements_per_update)));
-    const double min_expiration_time =
-        control_system::function_of_time_expiration_time(
-            initial_time, DataVector{0.0},
-            DataVector{min_measurement_timescale}, measurements_per_update);
+      const double min_measurement_timescale =
+          std::min(min(control_system::calculate_measurement_timescales(
+                       controller, tuner1, measurements_per_update)),
+                   min(control_system::calculate_measurement_timescales(
+                       controller, tuner2, measurements_per_update)));
+      const double min_expiration_time =
+          control_system::function_of_time_expiration_time(
+              initial_time, DataVector{0.0},
+              DataVector{min_measurement_timescale}, measurements_per_update,
+              delay_update);
 
-    const std::unordered_map<std::string, double>
-        expected_initial_expiration_times{
-            {FakeControlSystem<1>::name(), min_expiration_time},
-            {FakeControlSystem<2>::name(), min_expiration_time},
-            {FakeControlSystem<3>::name(),
-             std::numeric_limits<double>::infinity()}};
+      const std::unordered_map<std::string, double>
+          expected_initial_expiration_times{
+              {FakeControlSystem<1>::name(), min_expiration_time},
+              {FakeControlSystem<2>::name(), min_expiration_time},
+              {FakeControlSystem<3>::name(),
+               std::numeric_limits<double>::infinity()}};
 
-    check_expiration_times(initial_expiration_times,
-                           expected_initial_expiration_times);
+      check_expiration_times(initial_expiration_times,
+                             expected_initial_expiration_times);
+    }
   }
 }
 
@@ -161,14 +166,21 @@ void test_fot_measurement_expr_time() {
   const double time = 0.6;
   const int measurements_per_update = 3;
 
-  const double fot_expr_time = control_system::function_of_time_expiration_time(
-      time, old_measurement_timescales, new_measurement_timescales,
-      measurements_per_update);
-  const double expected_fot_expr_time =
-      time + min(old_measurement_timescales) +
-      measurements_per_update * min(new_measurement_timescales);
+  const double fot_expr_time_nondelayed =
+      control_system::function_of_time_expiration_time(
+          time, old_measurement_timescales, new_measurement_timescales,
+          measurements_per_update, false);
+  const double fot_expr_time_delayed =
+      control_system::function_of_time_expiration_time(
+          time, old_measurement_timescales, new_measurement_timescales,
+          measurements_per_update, true);
+  CHECK(fot_expr_time_delayed ==
+        fot_expr_time_nondelayed + min(new_measurement_timescales));
+  const double expected_fot_expr_time = time + min(old_measurement_timescales) +
+                                        min(new_measurement_timescales) +
+                                        min(new_measurement_timescales);
 
-  CHECK(fot_expr_time == expected_fot_expr_time);
+  CHECK(fot_expr_time_nondelayed == expected_fot_expr_time);
 
   const double measurement_expr_time =
       control_system::measurement_expiration_time(

--- a/tests/Unit/ControlSystem/Test_Tags.cpp
+++ b/tests/Unit/ControlSystem/Test_Tags.cpp
@@ -75,6 +75,8 @@ void test_all_tags() {
       control_system::Tags::MeasurementsPerUpdate;
   TestHelpers::db::test_simple_tag<measurements_per_update_tag>(
       "MeasurementsPerUpdate");
+  TestHelpers::db::test_simple_tag<control_system::Tags::DelayUpdate>(
+      "DelayUpdate");
   using current_measurement_tag =
       control_system::Tags::CurrentNumberOfMeasurements;
   TestHelpers::db::test_simple_tag<current_measurement_tag>(

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -572,9 +572,9 @@ struct SystemHelper {
       averager.assign_time_between_measurements(min_measurement_timescale);
 
       const double measurement_expr_time =
-          ::control_system::measurement_expiration_time(
-              initial_time_, DataVector{0.0},
-              DataVector{min_measurement_timescale}, measurements_per_update_);
+          ::control_system::measurement_initial_expiration_time(
+              initial_time_, DataVector{min_measurement_timescale},
+              measurements_per_update_, delay_update_);
 
       individual_minimums[name<system>()] =
           std::make_pair(min_measurement_timescale, measurement_expr_time);
@@ -603,9 +603,8 @@ struct SystemHelper {
          individual_minimums) {
       (void)min_measure_expr_time;
       initial_expiration_times[system_name] =
-          ::control_system::function_of_time_expiration_time(
-              initial_time_, DataVector{0.0},
-              DataVector{overall_min_measurement_timescale},
+          ::control_system::function_of_time_initial_expiration_time(
+              initial_time_, DataVector{overall_min_measurement_timescale},
               measurements_per_update_, delay_update_);
     }
 

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -199,6 +199,7 @@ struct MockControlComponent {
 
   using const_global_cache_tags =
       tmpl::list<::control_system::Tags::MeasurementsPerUpdate,
+                 ::control_system::Tags::DelayUpdate,
                  ::control_system::Tags::WriteDataToDisk,
                  ::control_system::Tags::Verbosity,
                  ::control_system::Tags::IsActiveMap,
@@ -605,7 +606,7 @@ struct SystemHelper {
           ::control_system::function_of_time_expiration_time(
               initial_time_, DataVector{0.0},
               DataVector{overall_min_measurement_timescale},
-              measurements_per_update_);
+              measurements_per_update_, delay_update_);
     }
 
     const double excision_radius =
@@ -784,7 +785,8 @@ struct SystemHelper {
           control_components, tmpl::bind<option_tag, tmpl::_1>>>,
       ::control_system::OptionTags::WriteDataToDisk, ::OptionTags::InitialTime,
       domain::OptionTags::DomainCreator<3>,
-      ::control_system::OptionTags::MeasurementsPerUpdate>;
+      ::control_system::OptionTags::MeasurementsPerUpdate,
+      ::control_system::OptionTags::DelayUpdate>;
   template <typename System>
   using creatable_tags = tmpl::list_difference<
       init_simple_tags<System>,
@@ -810,6 +812,12 @@ struct SystemHelper {
     measurements_per_update_ =
         get<::control_system::Tags::MeasurementsPerUpdate>(
             created_measurements_per_update);
+
+    const auto created_delay_update = Parallel::create_from_options<Metavars>(
+        options, tmpl::list<::control_system::Tags::DelayUpdate>{});
+
+    delay_update_ =
+        get<::control_system::Tags::DelayUpdate>(created_delay_update);
 
     std::unordered_map<std::string, ::control_system::UpdateAggregator>
         update_aggregators{};
@@ -881,6 +889,7 @@ struct SystemHelper {
   ylm::Strahlkorper<Frame::Distorted> horizon_a_{};
   ylm::Strahlkorper<Frame::Distorted> horizon_b_{};
   int measurements_per_update_{};
+  bool delay_update_{};
   double initial_time_{std::numeric_limits<double>::signaling_NaN()};
   std::unordered_map<std::string, std::string> system_to_combined_names_{
       ::control_system::system_to_combined_names<control_systems>()};


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Executables with control systems have a new input file option:
```yaml
ControlSystems:
  DelayUpdate: true
```
Use "true" for the old behavior.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
