### PR TITLE
Add TensorYlmFilter for scalar.

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.cpp
@@ -439,15 +439,13 @@ void inner_loops_three(
 
 template <typename TensorStructure, typename SparseMatrixType>
 void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
-                const size_t ell_max, const size_t number_of_ell_modes_to_kill,
-                const std::optional<size_t> half_power) {
+                 const size_t ell_max, const size_t number_of_ell_modes_to_kill,
+                 const std::optional<size_t> half_power) {
   static constexpr size_t num_independent_components = TensorStructure::size();
   static constexpr size_t rank = TensorStructure::rank();
-  static constexpr auto tensor_index_list =
-      TensorStructure::storage_to_tensor_index();
   static constexpr double alpha = 36.0;
 
-  static_assert(rank > 0 and rank < 4, "Implemented only for ranks 1,2,3");
+  static_assert(rank >= 0 and rank < 4, "Implemented only for ranks 0,1,2,3");
 
   const auto lcutplus =
       static_cast<size_t>(ell_max - number_of_ell_modes_to_kill);
@@ -464,6 +462,28 @@ void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
                                 iter_src.spherepack_array_size() *
                                 iter_dest.spherepack_array_size(),
                             true, 1.0);
+
+  // Special case for rank 0, which is so much simpler than all the
+  // other ranks because there is actually no tensorylm
+  // transformation, no symmetry considerations, and no mixing of
+  // real/imaginary parts, just a filter based on ell.
+  if constexpr (rank == 0) {
+    for (iter_src.reset(); iter_src; ++iter_src) {
+      const size_t ell = iter_src.l();
+      if (ell >= lcutminus) {
+        const double coefl =
+            half_power.has_value() and ell <= lcutplus
+                ? (1.0 -
+                   exp(-alpha *
+                       integer_pow(double(ell) / double(lcutplus + 1),
+                                   2 * static_cast<int>(half_power.value()))))
+                : 1.0;
+        filler.add(-coefl, iter_src(), iter_src());
+      }
+    }
+    filler.fill(matrix);
+    return;
+  }
 
   // We allocate space for some (not all) of the 3J symbols here, so
   // that they can be used and re-used later inside the inner loops.
@@ -511,6 +531,9 @@ void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
 
   for (size_t dest_comp_index = 0; dest_comp_index < num_independent_components;
        dest_comp_index++) {
+    static constexpr auto tensor_index_list =
+        TensorStructure::storage_to_tensor_index();
+
     const auto dest_indices = tensor_index_list[dest_comp_index];
     const auto dest_bvs = helpers::to_cart_basis_vector(dest_indices);
 
@@ -724,5 +747,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE,
 
 #undef INSTANTIATE
 #undef TSTRUCT
+
+// Instantiation for scalars.
+template void fill_filter<typename Scalar<DataVector>::structure>(
+    gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max,
+    size_t number_of_ell_modes_to_kill, std::optional<size_t> half_power);
 
 }  // namespace ylm::TensorYlm

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.hpp
@@ -17,7 +17,7 @@ namespace ylm::TensorYlm {
  * \brief Fills a sparse matrix that does a TensorYlm filter operation.
  *
  * Assumes that $T^{\tilde A}_{\ell' m'}$ is stored in a
- * Tensor<DataVector>.  Multiplying the resulting
+ * Tensor<DataVector>.  Multiplying (one plus) the resulting
  * sparse matrix by the Tensor<DataVector> is equivalent to
  * evaluating the right-hand side of Eq. $(\ref{eq:Filter})$.
  *
@@ -45,6 +45,16 @@ namespace ylm::TensorYlm {
  * ## Explicit formulas
  *
  * The following formulas come from Klinger and Scheel, in prep.
+ *
+ * For rank-0 tensors, the expression is simple because there
+ * is no change of basis, only a filter based on $\ell$.
+ * \begin{align}
+ *  F_{l m \tilde{D}}^{\ell'' m''\tilde{A}} &=
+ *  \delta(\tilde{D},\tilde{A})\delta_{\ell \ell''}\delta_{m m''}
+ *  \left[1-
+ *  \delta(\ell_{\mathrm{cut}}^-\leq \ell \leq \ell_{\mathrm{max}}) g(\ell)
+ *  \right].
+ * \end{align}
  *
  * For rank-1 tensors, the expression for
  * $F_{l m \tilde{D}}^{\ell'' m''\tilde{A}}$ is

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmFilter.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmFilter.cpp
@@ -3,6 +3,7 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -45,7 +46,7 @@ std::string symm_to_string() {
   return "";
 }
 
-template<typename TensorType>
+template <typename TensorType>
 struct MyTag : db::SimpleTag {
   using type = TensorType;
   static std::string name() {
@@ -86,10 +87,16 @@ void test_filter_vs_transforms(const size_t ell_max,
   const gsl::span<double> a_span(A.data(), A.size());
   gsl::span<double> b_span(B.data(), B.size());
   SimpleSparseMatrix cart_to_sphere;
-  ylm::TensorYlm::fill_cart_to_sphere<typename TensorType::structure>(
-      make_not_null(&cart_to_sphere), ell_max);
-  cart_to_sphere.increment_multiply_on_right(make_not_null(&b_span), 0, a_span,
-                                             0);
+  if constexpr (TensorType::structure::rank() == 0) {
+    // Rank zero doesn't have any difference between cartesian and spherical.
+    std::memcpy(B.data(), A.data(), A.size() * sizeof(double));
+  } else {
+    ylm::TensorYlm::fill_cart_to_sphere<typename TensorType::structure>(
+        make_not_null(&cart_to_sphere), ell_max);
+    cart_to_sphere.increment_multiply_on_right(make_not_null(&b_span), 0,
+                                               a_span, 0);
+  }
+
   // Apply the filter to B.
   static constexpr double alpha = 36.0;
   const auto lcutplus =
@@ -121,10 +128,15 @@ void test_filter_vs_transforms(const size_t ell_max,
   // Convert B to C
   gsl::span<double> c_span(C.data(), C.size());
   SimpleSparseMatrix sphere_to_cart;
-  ylm::TensorYlm::fill_sphere_to_cart<typename TensorType::structure>(
-      make_not_null(&sphere_to_cart), ell_max);
-  sphere_to_cart.increment_multiply_on_right(make_not_null(&c_span), 0, b_span,
-                                             0);
+  if constexpr (TensorType::structure::rank() == 0) {
+    // Rank zero doesn't have any difference between cartesian and spherical.
+    std::memcpy(C.data(), B.data(), B.size() * sizeof(double));
+  } else {
+    ylm::TensorYlm::fill_sphere_to_cart<typename TensorType::structure>(
+        make_not_null(&sphere_to_cart), ell_max);
+    sphere_to_cart.increment_multiply_on_right(make_not_null(&c_span), 0,
+                                               b_span, 0);
+  }
 
   // Apply the filter to A directly, output into D.
   // First set D equal to A (thus computing the delta term),
@@ -1195,5 +1207,7 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmFilter",
         ell_max, num_to_kill, half_power);
     test_filter_vs_transforms<typename tnsr::ijk<DataVector, 3>>(
         ell_max, num_to_kill, half_power);
+    test_filter_vs_transforms<Scalar<DataVector>>(ell_max, num_to_kill,
+                                                  half_power);
   }
 }


### PR DESCRIPTION
## Proposed changes

TensorYlmFilter now has a special case for a scalar.
Scalars don't need all the machinery of TensorYlmFilter, but it is simpler down the line to put the scalar case here instead of coding in more special cases elsewhere.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
