### PR TITLE
Add inverse hessian to CoordinateMap and Composition

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -506,6 +506,7 @@ jobs:
             install: ON
           # Test compiling with nvcc and CUDA
           - compiler: nvcc-12-6
+            SPECTRE_AUTODIFF: OFF
             CUDA: ON
             KOKKOS: ON
             # Compile for NVIDIA Ampere architecture. Can't run this on
@@ -726,6 +727,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           COVERAGE=${{ matrix.COVERAGE }}
           TEST_TIMEOUT_FACTOR=${{ matrix.TEST_TIMEOUT_FACTOR }}
           INPUT_FILE_MIN_PRIO=${{ matrix.input_file_tests_min_priority }}
+          SPECTRE_AUTODIFF=${{ matrix.SPECTRE_AUTODIFF }}
 
           cmake --version
 
@@ -764,7 +766,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D SPECTRE_PYTHON_TEST_TIMEOUT_FACTOR=${TEST_TIMEOUT_FACTOR:-'1'}
           -D CMAKE_INSTALL_PREFIX=/work/spectre_install
           -D BUILD_DOCS=OFF
-          -D SPECTRE_AUTODIFF=ON
+          -D SPECTRE_AUTODIFF=${SPECTRE_AUTODIFF:-'ON'}
           -D SPECTRE_FETCH_MISSING_DEPS=ON
           --warn-uninitialized
           $GITHUB_WORKSPACE 2>&1 | tee CMakeOutput.txt 2>&1

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -188,7 +188,8 @@ SEARCH_INCLUDES        = YES
 
 PREDEFINED             = SPECTRE_ALWAYS_INLINE= \
                          OVERLOADER_CONSTEXPR= \
-                         SPECTRE_DOXYGEN_INVOKED
+                         SPECTRE_DOXYGEN_INVOKED \
+                         SPECTRE_AUTODIFF
 
 #---------------------------------------------------------------------------
 # Configuration::additions related to external references

--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -78,6 +78,7 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  Autodiff
   Blaze
   Boost::boost
   Charmxx::pup

--- a/src/DataStructures/Tensor/Expressions/DataTypeSupport.hpp
+++ b/src/DataStructures/Tensor/Expressions/DataTypeSupport.hpp
@@ -21,6 +21,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/VectorImpl.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/NoSuchType.hpp"
 
 namespace tenex {
@@ -62,6 +63,10 @@ template <typename X>
 struct is_supported_tensor_datatype
     : std::disjunction<
           std::is_same<X, double>, std::is_same<X, std::complex<double>>,
+#ifdef SPECTRE_AUTODIFF
+          std::is_same<X, autodiff::HigherOrderDual<2, simd::batch<double>>>,
+          std::is_same<X, autodiff::HigherOrderDual<2, double>>,
+#endif
           std::is_same<X, DataVector>, std::is_same<X, ComplexDataVector>> {};
 
 template <typename X>

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -31,6 +31,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
@@ -605,6 +606,30 @@ struct MakeWithValueImpl<Tensor<std::complex<double>, Structure...>, T> {
     return Tensor<std::complex<double>, Structure...>(value);
   }
 };
+
+#ifdef SPECTRE_AUTODIFF
+template <typename... Structure, typename T>
+struct MakeWithValueImpl<
+    Tensor<autodiff::HigherOrderDual<2, double>, Structure...>, T> {
+  static SPECTRE_ALWAYS_INLINE
+      Tensor<autodiff::HigherOrderDual<2, double>, Structure...>
+      apply(const T& /*input*/, const double value) {
+    return Tensor<autodiff::HigherOrderDual<2, double>, Structure...>(value);
+  }
+};
+
+template <typename... Structure, typename T>
+struct MakeWithValueImpl<
+    Tensor<autodiff::HigherOrderDual<2, simd::batch<double>>, Structure...>,
+    T> {
+  static SPECTRE_ALWAYS_INLINE
+      Tensor<autodiff::HigherOrderDual<2, simd::batch<double>>, Structure...>
+      apply(const T& /*input*/, const double value) {
+    return Tensor<autodiff::HigherOrderDual<2, simd::batch<double>>,
+                  Structure...>(simd::batch<double>::broadcast(value));
+  }
+};
+#endif  // SPECTRE_AUTODIFF
 }  // namespace MakeWithValueImpls
 
 template <typename T, typename... Structure>

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -479,3 +479,34 @@ template <typename DataType, size_t Dim, typename SourceFrame,
 using Jacobian = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
                         index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
                                    SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>;
+
+/*!
+ * \brief Inverse Hessian $(H^{-1})^\hat{i}_{jk} =
+ * \frac{\partial \xi^\hat{i}}{\partial x^j \partial x^k}$
+ *
+ * The first (upper) index is in the \p SourceFrame with coordinates
+ * $\xi^\hat{i}$ (often "logical"), and the second and third (lower) indices are
+ * in the \p TargetFrame with coordinates $x^j$ (often "inertial").
+ */
+template <typename DataType, size_t Dim, typename SourceFrame,
+          typename TargetFrame>
+using InverseHessian =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+           index_list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
+                      SpatialIndex<Dim, UpLo::Lo, TargetFrame>,
+                      SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>;
+
+/*!
+ * \brief Hessian $H^i_{\hat{j}\hat{k}} =
+ * \frac{\partial x^i}{\partial \xi^\hat{j} \partial \xi^\hat{k}}$
+ *
+ * The first (upper) index is in the \p TargetFrame with coordinates $x^i$
+ * (often "inertial"), and the second and third (lower) indices are in the
+ * \p SourceFrame with coordinates $\xi^\hat{j}$ (often "logical").
+ */
+template <typename DataType, size_t Dim, typename SourceFrame,
+          typename TargetFrame>
+using Hessian = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+                       index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
+                                  SpatialIndex<Dim, UpLo::Lo, SourceFrame>,
+                                  SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>;

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -65,6 +65,7 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  Autodiff
   Boost::boost
   CoordinateMaps
   DataStructures

--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -7,6 +7,8 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -93,9 +95,13 @@ bool operator==(const CoordinateMaps::Affine& lhs,
   template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
   Affine::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (double, DataVector,
+                  std::reference_wrapper<const double>,
+                  std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, MAP_AUTODIFF_TYPES)
+
 #undef DTYPE
 #undef INSTANTIATE
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -71,6 +71,8 @@ class Affine {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   friend bool operator==(const Affine& lhs, const Affine& rhs);
 

--- a/src/Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp
+++ b/src/Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/Autodiff/Autodiff.hpp"
+
+#ifdef SPECTRE_AUTODIFF
+#define MAP_AUTODIFF_TYPES                                  \
+  (autodiff::SecondOrderDual, autodiff::SecondOrderDualNum, \
+   std::reference_wrapper<const autodiff::SecondOrderDual>, \
+   std::reference_wrapper<const autodiff::SecondOrderDualNum>)
+#else
+#define MAP_AUTODIFF_TYPES
+#endif

--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -12,7 +12,9 @@
 
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -311,9 +313,12 @@ bool operator!=(const BulgedCube& lhs, const BulgedCube& rhs) {
   BulgedCube::inv_jacobian(const std::array<DTYPE(data), 3>& source_coords)    \
       const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (double, DataVector,
+                  std::reference_wrapper<const double>,
+                  std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, MAP_AUTODIFF_TYPES)
 
 #undef DTYPE
 #undef INSTANTIATE

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -522,6 +522,8 @@ class BulgedCube {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> xi_derivative(

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -47,6 +47,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Affine.hpp
+  AutodiffInstantiationTypes.hpp
   BulgedCube.hpp
   Composition.hpp
   CoordinateMap.hpp

--- a/src/Domain/CoordinateMaps/Composition.cpp
+++ b/src/Domain/CoordinateMaps/Composition.cpp
@@ -8,9 +8,36 @@
 
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/PrettyType.hpp"
 
 namespace domain::CoordinateMaps {
+
+namespace Composition_detail {
+// Helper function to generate error message for unsupported autodiff maps
+template <typename Frames, size_t Dim, size_t... Is>
+std::string get_unsupported_autodiff_maps_error(
+    const std::tuple<std::unique_ptr<
+        CoordinateMapBase<tmpl::at<Frames, tmpl::size_t<Is>>,
+                          tmpl::at<Frames, tmpl::size_t<Is + 1>>, Dim>>...>&
+        maps) {
+  std::string unsupported_maps;
+  const auto check_map = [&unsupported_maps, &maps](const auto index_v) {
+    constexpr size_t index = decltype(index_v)::value;
+    if (not get<index>(maps)->supports_hessian()) {
+      if (not unsupported_maps.empty()) {
+        unsupported_maps += ", ";
+      }
+      unsupported_maps +=
+          "Map " + std::to_string(index) + " (" +
+          pretty_type::get_runtime_type_name(*get<index>(maps)) + ")";
+    }
+  };
+  EXPAND_PACK_LEFT_TO_RIGHT(check_map(tmpl::size_t<Is>{}));
+  return unsupported_maps;
+}
+}  // namespace Composition_detail
 
 template <typename Frames, size_t Dim, size_t... Is>
 Composition<Frames, Dim, std::index_sequence<Is...>>::Composition(
@@ -35,6 +62,12 @@ bool Composition<Frames, Dim, std::index_sequence<Is...>>::is_identity() const {
   EXPAND_PACK_LEFT_TO_RIGHT(
       (result = result and get<Is>(maps_)->is_identity()));
   return result;
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+bool Composition<Frames, Dim, std::index_sequence<Is...>>::supports_hessian()
+    const {
+  return (... and get<Is>(maps_)->supports_hessian());
 }
 
 template <typename Frames, size_t Dim, size_t... Is>
@@ -96,6 +129,57 @@ Composition<Frames, Dim, std::index_sequence<Is...>>::inv_jacobian(
     const FuncOfTimeMap& functions_of_time) const {
   return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
 }
+
+#ifdef SPECTRE_AUTODIFF
+template <typename Frames, size_t Dim, size_t... Is>
+InverseJacobian<autodiff::HigherOrderDual<2, double>, Dim, tmpl::front<Frames>,
+                tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inv_jacobian(
+    tnsr::I<autodiff::HigherOrderDual<2, double>, Dim, SourceFrame>
+        source_point,
+    const double time, const FuncOfTimeMap& functions_of_time) const {
+  if (supports_hessian()) {
+    return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
+  } else {
+    ERROR("At least one of the Maps does not support autodiff: "
+          << (Composition_detail::get_unsupported_autodiff_maps_error<
+                 Frames, Dim, Is...>(maps_)));
+  }
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+InverseHessian<double, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inv_hessian(
+    tnsr::I<double, Dim, SourceFrame> source_point,
+    const InverseJacobian<double, Dim, SourceFrame, TargetFrame>& inverse_jac,
+    const double time, const FuncOfTimeMap& functions_of_time) const {
+  if (supports_hessian()) {
+    return inv_hessian_impl(std::move(source_point), inverse_jac, time,
+                            functions_of_time);
+  } else {
+    ERROR("At least one of the Maps does not support autodiff: "
+          << (Composition_detail::get_unsupported_autodiff_maps_error<
+                 Frames, Dim, Is...>(maps_)));
+  }
+}
+
+template <typename Frames, size_t Dim, size_t... Is>
+InverseHessian<DataVector, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inv_hessian(
+    tnsr::I<DataVector, Dim, SourceFrame> source_point,
+    const InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>&
+        inverse_jac,
+    const double time, const FuncOfTimeMap& functions_of_time) const {
+  if (supports_hessian()) {
+    return inv_hessian_impl(std::move(source_point), inverse_jac, time,
+                            functions_of_time);
+  } else {
+    ERROR("At least one of the Maps does not support autodiff: "
+          << (Composition_detail::get_unsupported_autodiff_maps_error<
+                 Frames, Dim, Is...>(maps_)));
+  }
+}
+#endif  // SPECTRE_AUTODIFF
 
 template <typename Frames, size_t Dim, size_t... Is>
 Jacobian<double, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
@@ -298,6 +382,109 @@ Composition<Frames, Dim, std::index_sequence<Is...>>::inv_jacobian_impl(
   return get<InverseJacobian<DataType, Dim, SourceFrame, TargetFrame>>(
       inv_jacobians);
 }
+
+#ifdef SPECTRE_AUTODIFF
+template <typename Frames, size_t Dim, size_t... Is>
+template <typename DataType>
+InverseHessian<DataType, Dim, tmpl::front<Frames>, tmpl::back<Frames>>
+Composition<Frames, Dim, std::index_sequence<Is...>>::inv_hessian_impl(
+    tnsr::I<DataType, Dim, SourceFrame> source_point,
+    const ::InverseJacobian<DataType, Dim, SourceFrame, TargetFrame>&
+        inverse_jac,
+    const double time, const FuncOfTimeMap& functions_of_time) const {
+  // first compute hessian
+  using BatchType = simd::batch<double>;
+  using SecondOrderDual = autodiff::HigherOrderDual<2, BatchType>;
+  using SecondOrderDualNum = autodiff::HigherOrderDual<2, double>;
+
+  // NOLINTNEXTLINE(misc-const-correctness)
+  size_t num_pts = 1;
+  // NOLINTNEXTLINE(misc-const-correctness)
+  size_t vec_end = 0;
+  if constexpr (std::is_same_v<DataType, DataVector>) {
+    num_pts = get<0>(source_point).size();
+    vec_end = (num_pts / BatchType::size) * BatchType::size;
+  }
+  ::Hessian<DataType, Dim, SourceFrame, TargetFrame> hessian{num_pts};
+  ::InverseHessian<DataType, Dim, SourceFrame, TargetFrame> inverse_hessian{
+      num_pts};
+
+  // manual vectorization with xsimd
+  if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t pts_index = 0; pts_index < vec_end;
+         pts_index += BatchType::size) {
+      for (size_t i = 0; i < Dim; ++i) {
+        for (size_t j = i; j < Dim; ++j) {
+          tnsr::I<SecondOrderDual, Dim, SourceFrame> dual_source_coords;
+
+          [&]<std::size_t... Ins>(std::index_sequence<Ins...>) {
+            ((get<Ins>(dual_source_coords) = BatchType::load_unaligned(
+                  &(get<Ins>(source_point))[pts_index])),
+             ...);
+          }
+          (std::make_index_sequence<Dim>{});
+
+          autodiff::seed<1>(dual_source_coords.get(i), 1.0);
+          autodiff::seed<2>(dual_source_coords.get(j), 1.0);
+
+          const auto dual_target_coords =
+              call_impl(std::move(dual_source_coords), time, functions_of_time);
+          for (size_t k = 0; k < Dim; ++k) {
+            const auto deriv_kij =
+                autodiff::derivative<2>(dual_target_coords.get(k));
+            deriv_kij.store_unaligned(&hessian.get(k, i, j)[pts_index]);
+          }
+        }
+      }
+    }
+  }
+  // dealing with the tail
+  for (size_t pts_index = vec_end; pts_index < num_pts; ++pts_index) {
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = i; j < Dim; ++j) {
+        tnsr::I<SecondOrderDualNum, Dim, SourceFrame> dual_source_coords;
+
+        if constexpr (std::is_same_v<DataType, double>) {
+          [&]<std::size_t... Ins>(std::index_sequence<Ins...>) {
+            ((get<Ins>(dual_source_coords) = get<Ins>(source_point)), ...);
+          }
+          (std::make_index_sequence<Dim>{});
+        } else {
+          [&]<std::size_t... Ins>(std::index_sequence<Ins...>) {
+            ((get<Ins>(dual_source_coords) =
+                  gsl::at(get<Ins>(source_point), pts_index)),
+             ...);
+          }
+          (std::make_index_sequence<Dim>{});
+        }
+
+        autodiff::seed<1>(dual_source_coords.get(i), 1.0);
+        autodiff::seed<2>(dual_source_coords.get(j), 1.0);
+
+        const auto dual_target_coords =
+            call_impl(std::move(dual_source_coords), time, functions_of_time);
+        for (size_t k = 0; k < Dim; ++k) {
+          if constexpr (std::is_same_v<DataType, double>) {
+            hessian.get(k, i, j) =
+                autodiff::derivative<2>(dual_target_coords.get(k));
+          } else {
+            hessian.get(k, i, j)[pts_index] =
+                autodiff::derivative<2>(dual_target_coords.get(k));
+          }
+        }
+      }
+    }
+  }
+
+  // piece together the inverse hessian from hessian and inverse jacobian
+  ::tenex::evaluate<ti::I, ti::m, ti::n>(
+      make_not_null(&inverse_hessian),
+      -1.0 * inverse_jac(ti::I, ti::j) * inverse_jac(ti::K, ti::m) *
+          inverse_jac(ti::L, ti::n) * hessian(ti::J, ti::k, ti::l));
+
+  return inverse_hessian;
+}
+#endif  // SPECTRE_AUTODIFF
 
 template <typename Frames, size_t Dim, size_t... Is>
 template <typename DataType>

--- a/src/Domain/CoordinateMaps/Composition.hpp
+++ b/src/Domain/CoordinateMaps/Composition.hpp
@@ -18,6 +18,8 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
+#include "Utilities/Simd/Simd.hpp"
 
 namespace domain::CoordinateMaps {
 
@@ -59,6 +61,34 @@ namespace domain::CoordinateMaps {
  * `Frames`. For example, if `Frames = tmpl::list<Frame::ElementLogical,
  * Frame::BlockLogical, Frame::Inertial>`, then the composition has two maps:
  * ElementLogical -> BlockLogical and BlockLogical -> Inertial.
+ *
+ * ## Note on inverse Hessian computation
+ * Below we work out the algebra for computing the inverse Hessian
+ * used in this struct (if SPECTRE_AUTODIFF=ON). Suppose we have
+ * a composition of maps \f$ \xi^i \longrightarrow \cdots \longrightarrow x^i
+ * \longrightarrow y^i \f$, where \f$ \xi^i \f$ are the source coordinates, \f$
+ * x^i \f$ are some intermediate coordinates, and \f$ y^i \f$ are the final
+ * target coordinates,  We compute inverse Hessian by first
+ * propagating autodiff dual types through the composed `call_impl` function to
+ * automatically get the Hessian \f$ \frac{\partial^2 y^i}{\partial\xi^j
+ * \partial\xi^k} \f$ Then the inverse Hessian is computed by the identity
+ * \f[ \frac{\partial^2\xi^i}{\partial y^m \partial y^n} =
+ * -\frac{\partial\xi^i}{\partial y^j}\frac{\partial\xi^k}{\partial y^m}
+ * \frac{\partial\xi^l}{\partial y^n}\frac{\partial^2 y^j}{\partial\xi^k
+ * \partial\xi^l}, \f] where the inverse Jacobian is passed in as a function
+ * argument.
+ *
+ * See Test_Composition.cpp for a different implementation. The current
+ * implementation is chosen in production as it is faster when we have
+ * the inverse Jacobian already, and in most cases we do.
+ *
+ * ## Note on auto differentiation
+ * We use forward mode autodiff here as it is simpler to implement and
+ * has better optimization than the reverse mode. Reverse mode in
+ * the [Autodiff](https://github.com/autodiff/autodiff) library
+ * has higher cost per propagation and does not support taping.
+ * Also see this
+ * [github issue](https://github.com/autodiff/autodiff/issues/332).
  */
 template <typename Frames, size_t Dim,
           typename Is = std::make_index_sequence<tmpl::size<Frames>::value - 1>>
@@ -74,6 +104,7 @@ struct Composition<Frames, Dim, std::index_sequence<Is...>>
   using Base = CoordinateMapBase<SourceFrame, TargetFrame, Dim>;
   using FuncOfTimeMap = std::unordered_map<
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
+  using Base::operator();
 
   Composition() = default;
   Composition(const Composition& rhs) { *this = rhs; }
@@ -121,6 +152,8 @@ struct Composition<Frames, Dim, std::index_sequence<Is...>>
     return function_of_time_names_;
   }
 
+  bool supports_hessian() const override;
+
   tnsr::I<double, Dim, TargetFrame> operator()(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
@@ -145,6 +178,30 @@ struct Composition<Frames, Dim, std::index_sequence<Is...>>
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
       const FuncOfTimeMap& functions_of_time = {}) const override;
+
+#ifdef SPECTRE_AUTODIFF
+  InverseJacobian<autodiff::HigherOrderDual<2, double>, Dim, SourceFrame,
+                  TargetFrame>
+  inv_jacobian(tnsr::I<autodiff::HigherOrderDual<2, double>, Dim, SourceFrame>
+                   source_point,
+               double time = std::numeric_limits<double>::signaling_NaN(),
+               const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  // Compute inverse hessian by calling operator()
+  InverseHessian<double, Dim, SourceFrame, TargetFrame> inv_hessian(
+      tnsr::I<double, Dim, SourceFrame> source_point,
+      const InverseJacobian<double, Dim, SourceFrame, TargetFrame>& inverse_jac,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+
+  // Compute inverse hessian by calling operator()
+  InverseHessian<DataVector, Dim, SourceFrame, TargetFrame> inv_hessian(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point,
+      const InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>&
+          inverse_jac,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const override;
+#endif  // SPECTRE_AUTODIFF
 
   Jacobian<double, Dim, SourceFrame, TargetFrame> jacobian(
       tnsr::I<double, Dim, SourceFrame> source_point,
@@ -186,25 +243,33 @@ struct Composition<Frames, Dim, std::index_sequence<Is...>>
   template <typename DataType>
   tnsr::I<DataType, Dim, TargetFrame> call_impl(
       tnsr::I<DataType, Dim, SourceFrame> source_point,
-      const double time = std::numeric_limits<double>::signaling_NaN(),
+      double time = std::numeric_limits<double>::signaling_NaN(),
       const FuncOfTimeMap& functions_of_time = {}) const;
 
   template <typename DataType>
   std::optional<tnsr::I<DataType, Dim, SourceFrame>> inverse_impl(
       tnsr::I<DataType, Dim, TargetFrame> target_point,
-      const double time = std::numeric_limits<double>::signaling_NaN(),
+      double time = std::numeric_limits<double>::signaling_NaN(),
       const FuncOfTimeMap& functions_of_time = {}) const;
 
   template <typename DataType>
   InverseJacobian<DataType, Dim, SourceFrame, TargetFrame> inv_jacobian_impl(
       tnsr::I<DataType, Dim, SourceFrame> source_point,
-      const double time = std::numeric_limits<double>::signaling_NaN(),
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FuncOfTimeMap& functions_of_time = {}) const;
+
+  template <typename DataType>
+  InverseHessian<DataType, Dim, SourceFrame, TargetFrame> inv_hessian_impl(
+      tnsr::I<DataType, Dim, SourceFrame> source_point,
+      const ::InverseJacobian<DataType, Dim, SourceFrame, TargetFrame>&
+          inverse_jac,
+      double time = std::numeric_limits<double>::signaling_NaN(),
       const FuncOfTimeMap& functions_of_time = {}) const;
 
   template <typename DataType>
   Jacobian<DataType, Dim, SourceFrame, TargetFrame> jacobian_impl(
       tnsr::I<DataType, Dim, SourceFrame> source_point,
-      const double time = std::numeric_limits<double>::signaling_NaN(),
+      double time = std::numeric_limits<double>::signaling_NaN(),
       const FuncOfTimeMap& functions_of_time = {}) const;
 
   bool is_equal_to(const CoordinateMapBase<SourceFrame, TargetFrame, Dim>&

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -22,7 +22,10 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/Simd/Simd.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateIsCallable.hpp"
 
@@ -81,6 +84,26 @@ std::unordered_set<std::string> initialize_names(
 
   return function_of_time_names;
 }
+
+template <typename... Maps>
+std::string get_unsupported_autodiff_maps_error() {
+  std::string unsupported_maps;
+  size_t index = 0;
+  (
+      [&]() {
+        if constexpr (not Maps::supports_hessian) {
+          if (not unsupported_maps.empty()) {
+            unsupported_maps += ", ";
+          }
+          unsupported_maps += "Map " + std::to_string(index) + " (" +
+                              pretty_type::get_name<Maps>() + ")";
+        }
+        ++index;
+      }(),
+      ...);
+  return unsupported_maps;
+}
+
 }  // namespace CoordinateMap_detail
 
 /*!
@@ -128,6 +151,9 @@ class CoordinateMapBase : public PUP::able {
   virtual const std::unordered_set<std::string>& function_of_time_names()
       const = 0;
 
+  /// Returns `true` if this CoordinateMap supports autodiff
+  virtual bool supports_hessian() const = 0;
+
   /// @{
   /// Apply the `Maps` to the point(s) `source_point`
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
@@ -139,6 +165,29 @@ class CoordinateMapBase : public PUP::able {
       double time = std::numeric_limits<double>::signaling_NaN(),
       const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
   /// @}
+
+#ifdef SPECTRE_AUTODIFF
+  /// @{
+  /// Apply the `Maps` to the point(s) `source_point`
+  ///
+  /// \note Require SPECTRE_AUTODIFF=ON.
+  virtual tnsr::I<autodiff::HigherOrderDual<2, double>, Dim, TargetFrame>
+  operator()(tnsr::I<autodiff::HigherOrderDual<2, double>, Dim,
+                     SourceFrame> /*source_point*/,
+             double /*time*/ = std::numeric_limits<double>::signaling_NaN(),
+             const FunctionsOfTimeMap& /*functions_of_time*/ = {}) const {
+    ERROR("Call operator for autodiff types must be overriden.");
+  }
+  virtual tnsr::I<autodiff::HigherOrderDual<2, simd::batch<double>>, Dim,
+                  TargetFrame>
+  operator()(tnsr::I<autodiff::HigherOrderDual<2, simd::batch<double>>, Dim,
+                     SourceFrame> /*source_point*/,
+             double /*time*/ = std::numeric_limits<double>::signaling_NaN(),
+             const FunctionsOfTimeMap& /*functions_of_time*/ = {}) const {
+    ERROR("Call operator for autodiff types must be overriden.");
+  }
+  /// @}
+#endif  // SPECTRE_AUTODIFF
 
   /// @{
   /// Apply the inverse `Maps` to the point(s) `target_point`.
@@ -167,7 +216,35 @@ class CoordinateMapBase : public PUP::able {
   inv_jacobian(tnsr::I<DataVector, Dim, SourceFrame> source_point,
                double time = std::numeric_limits<double>::signaling_NaN(),
                const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
+#ifdef SPECTRE_AUTODIFF
+  virtual InverseJacobian<autodiff::HigherOrderDual<2, double>, Dim,
+                          SourceFrame, TargetFrame>
+  inv_jacobian(tnsr::I<autodiff::HigherOrderDual<2, double>, Dim, SourceFrame>
+                   source_point,
+               double time = std::numeric_limits<double>::signaling_NaN(),
+               const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
+#endif  // SPECTRE_AUTODIFF
   /// @}
+
+#ifdef SPECTRE_AUTODIFF
+  /// @{
+  /// Compute the inverse Hessian of the `Maps` at the point(s)
+  /// `source_point`
+  ///
+  /// \note Require SPECTRE_AUTODIFF=ON.
+  virtual InverseHessian<double, Dim, SourceFrame, TargetFrame> inv_hessian(
+      tnsr::I<double, Dim, SourceFrame> source_point,
+      const InverseJacobian<double, Dim, SourceFrame, TargetFrame>& inverse_jac,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
+  virtual InverseHessian<DataVector, Dim, SourceFrame, TargetFrame> inv_hessian(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point,
+      const InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>&
+          inverse_jac,
+      double time = std::numeric_limits<double>::signaling_NaN(),
+      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
+  /// @}
+#endif  // SPECTRE_AUTODIFF
 
   /// @{
   /// Compute the Jacobian of the `Maps` at the point(s) `source_point`
@@ -285,6 +362,11 @@ class CoordinateMap
     return function_of_time_names_;
   }
 
+  /// Returns `true` if this coordinate map supports hessian
+  bool supports_hessian() const override {
+    return (Maps::supports_hessian && ...);
+  }
+
   /// @{
   /// Apply the `Maps...` to the point(s) `source_point`
   tnsr::I<double, dim, TargetFrame> operator()(
@@ -302,6 +384,43 @@ class CoordinateMap
                      std::make_index_sequence<sizeof...(Maps)>{});
   }
   /// @}
+
+#ifdef SPECTRE_AUTODIFF
+  /// @{
+  /// Apply the `Maps...` to the point(s) `source_point`
+  ///
+  /// \note Require SPECTRE_AUTODIFF=ON.
+  tnsr::I<autodiff::HigherOrderDual<2, double>, dim, TargetFrame> operator()(
+      tnsr::I<autodiff::HigherOrderDual<2, double>, dim, SourceFrame>
+          source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
+    if constexpr ((Maps::supports_hessian && ...)) {
+      return call_impl(std::move(source_point), time, functions_of_time,
+                       std::make_index_sequence<sizeof...(Maps)>{});
+    } else {
+      ERROR("At least one of the Maps does not support autodiff: "
+            << CoordinateMap_detail::get_unsupported_autodiff_maps_error<
+                   Maps...>());
+    }
+  }
+  tnsr::I<autodiff::HigherOrderDual<2, simd::batch<double>>, dim, TargetFrame>
+  operator()(tnsr::I<autodiff::HigherOrderDual<2, simd::batch<double>>, dim,
+                     SourceFrame>
+                 source_point,
+             const double time = std::numeric_limits<double>::signaling_NaN(),
+             const FunctionsOfTimeMap& functions_of_time = {}) const override {
+    if constexpr ((Maps::supports_hessian && ...)) {
+      return call_impl(std::move(source_point), time, functions_of_time,
+                       std::make_index_sequence<sizeof...(Maps)>{});
+    } else {
+      ERROR("At least one of the Maps does not support autodiff: "
+            << CoordinateMap_detail::get_unsupported_autodiff_maps_error<
+                   Maps...>());
+    }
+  }
+  /// @}
+#endif  // SPECTRE_AUTODIFF
 
   /// @{
   /// Apply the inverse `Maps...` to the point(s) `target_point`
@@ -329,7 +448,90 @@ class CoordinateMap
       const FunctionsOfTimeMap& functions_of_time = {}) const override {
     return inv_jacobian_impl(std::move(source_point), time, functions_of_time);
   }
+#ifdef SPECTRE_AUTODIFF
+  InverseJacobian<autodiff::HigherOrderDual<2, double>, dim, SourceFrame,
+                  TargetFrame>
+  inv_jacobian(
+      tnsr::I<autodiff::HigherOrderDual<2, double>, dim, SourceFrame>
+          source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
+    if constexpr ((Maps::supports_hessian && ...)) {
+      return inv_jacobian_impl(std::move(source_point), time,
+                               functions_of_time);
+    } else {
+      ERROR("At least one of the Maps does not support autodiff: "
+            << CoordinateMap_detail::get_unsupported_autodiff_maps_error<
+                   Maps...>());
+    }
+  }
+#endif  // SPECTRE_AUTODIFF
   /// @}
+
+#ifdef SPECTRE_AUTODIFF
+  /// @{
+  /*!
+   * Compute the inverse Hessian of the `Maps...` at the point(s)
+   * `source_point` by computing the Hessian of the `Maps...` and
+   * compose it with inverse Jacobians of the `Maps...`.
+   *
+   * This function propagates autodiff dual types
+   * through the `call_impl` function to automatically get the
+   * Hessian \f$ \frac{\partial^2 x^i}{\partial\xi^j \partial\xi^k} \f$
+   * where \f$ x^i \f$ are the target coordinates and \f$ \xi^i \f$ are the
+   * source coordinates. Then the inverse Hessian is computed by the
+   * identity
+   * \f[\frac{\partial^2 \xi^i}{\partial x^m \partial x^n} =
+   * -\frac{\partial \xi^i}{\partial x^j} \frac{\partial \xi^k}{\partial x^m}
+   * \frac{\partial \xi^l}{\partial x^n} \frac{\partial^2 x^j}{\partial \xi^k
+   * \partial \xi^l}, \f] where the inverse Jacobian is passed in as a function
+   * argument.
+   *
+   * See Test_CoordinateMap.cpp for a different implementation. The current
+   * implementation is chosen in production as it is faster when we have
+   * the inverse Jacobian already, and in most cases we do.
+   *
+   * We use forward mode autodiff here as it is simpler to implement and
+   * has better optimization than the reverse mode. Reverse mode in
+   * the [Autodiff](https://github.com/autodiff/autodiff) library
+   * has higher cost per propagation and does not support taping.
+   * Also see this
+   * [github issue](https://github.com/autodiff/autodiff/issues/332).
+   *
+   * \note Require SPECTRE_AUTODIFF=ON.
+   */
+  InverseHessian<double, dim, SourceFrame, TargetFrame> inv_hessian(
+      tnsr::I<double, dim, SourceFrame> source_point,
+      const ::InverseJacobian<double, dim, SourceFrame, TargetFrame>&
+          inverse_jac,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
+    if constexpr ((Maps::supports_hessian && ...)) {
+      return inv_hessian_impl(std::move(source_point), inverse_jac, time,
+                              functions_of_time);
+    } else {
+      ERROR("At least one of the Maps does not support autodiff: "
+            << CoordinateMap_detail::get_unsupported_autodiff_maps_error<
+                   Maps...>());
+    }
+  }
+  InverseHessian<DataVector, dim, SourceFrame, TargetFrame> inv_hessian(
+      tnsr::I<DataVector, dim, SourceFrame> source_point,
+      const ::InverseJacobian<DataVector, dim, SourceFrame, TargetFrame>&
+          inverse_jac,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const FunctionsOfTimeMap& functions_of_time = {}) const override {
+    if constexpr ((Maps::supports_hessian && ...)) {
+      return inv_hessian_impl(std::move(source_point), inverse_jac, time,
+                              functions_of_time);
+    } else {
+      ERROR("At least one of the Maps does not support autodiff: "
+            << CoordinateMap_detail::get_unsupported_autodiff_maps_error<
+                   Maps...>());
+    }
+  }
+  /// @}
+#endif  // SPECTRE_AUTODIFF
 
   /// @{
   /// Compute the Jacobian of the `Maps...` at the point(s) `source_point`
@@ -462,6 +664,12 @@ class CoordinateMap
   InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jacobian_impl(
       tnsr::I<T, dim, SourceFrame>&& source_point, double time,
       const FunctionsOfTimeMap& functions_of_time) const;
+
+  template <typename T>
+  InverseHessian<T, dim, SourceFrame, TargetFrame> inv_hessian_impl(
+      tnsr::I<T, dim, SourceFrame>&& source_point,
+      const ::InverseJacobian<T, dim, SourceFrame, TargetFrame>& inverse_jac,
+      double time, const FunctionsOfTimeMap& functions_of_time) const;
 
   template <typename T>
   Jacobian<T, dim, SourceFrame, TargetFrame> jacobian_impl(

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -261,22 +261,22 @@ class CoordinateMapBase : public PUP::able {
   /// @{
   /// Compute the mapped coordinates, frame velocity, Jacobian, and inverse
   /// Jacobian
-  virtual std::tuple<tnsr::I<double, Dim, TargetFrame>,
-                     InverseJacobian<double, Dim, SourceFrame, TargetFrame>,
-                     Jacobian<double, Dim, SourceFrame, TargetFrame>,
-                     tnsr::I<double, Dim, TargetFrame>>
-  coords_frame_velocity_jacobians(
+  virtual auto coords_frame_velocity_jacobians(
       tnsr::I<double, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
-  virtual std::tuple<tnsr::I<DataVector, Dim, TargetFrame>,
-                     InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>,
-                     Jacobian<DataVector, Dim, SourceFrame, TargetFrame>,
-                     tnsr::I<DataVector, Dim, TargetFrame>>
-  coords_frame_velocity_jacobians(
+      const FunctionsOfTimeMap& functions_of_time = {}) const
+      -> std::tuple<tnsr::I<double, Dim, TargetFrame>,
+                    InverseJacobian<double, Dim, SourceFrame, TargetFrame>,
+                    Jacobian<double, Dim, SourceFrame, TargetFrame>,
+                    tnsr::I<double, Dim, TargetFrame>> = 0;
+  virtual auto coords_frame_velocity_jacobians(
       tnsr::I<DataVector, Dim, SourceFrame> source_point,
       double time = std::numeric_limits<double>::signaling_NaN(),
-      const FunctionsOfTimeMap& functions_of_time = {}) const = 0;
+      const FunctionsOfTimeMap& functions_of_time = {}) const
+      -> std::tuple<tnsr::I<DataVector, Dim, TargetFrame>,
+                    InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>,
+                    Jacobian<DataVector, Dim, SourceFrame, TargetFrame>,
+                    tnsr::I<DataVector, Dim, TargetFrame>> = 0;
   /// @}
 
  private:
@@ -554,25 +554,25 @@ class CoordinateMap
   /// Jacobian. The inverse Jacobian is computed by numerically inverting the
   /// Jacobian as this was measured to be quicker than computing it directly for
   /// more complex map concatenations.
-  std::tuple<tnsr::I<double, dim, TargetFrame>,
-             InverseJacobian<double, dim, SourceFrame, TargetFrame>,
-             Jacobian<double, dim, SourceFrame, TargetFrame>,
-             tnsr::I<double, dim, TargetFrame>>
-  coords_frame_velocity_jacobians(
+  auto coords_frame_velocity_jacobians(
       tnsr::I<double, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const FunctionsOfTimeMap& functions_of_time = {}) const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const
+      -> std::tuple<tnsr::I<double, dim, TargetFrame>,
+                    InverseJacobian<double, dim, SourceFrame, TargetFrame>,
+                    Jacobian<double, dim, SourceFrame, TargetFrame>,
+                    tnsr::I<double, dim, TargetFrame>> override {
     return coords_frame_velocity_jacobians_impl(std::move(source_point), time,
                                                 functions_of_time);
   }
-  std::tuple<tnsr::I<DataVector, dim, TargetFrame>,
-             InverseJacobian<DataVector, dim, SourceFrame, TargetFrame>,
-             Jacobian<DataVector, dim, SourceFrame, TargetFrame>,
-             tnsr::I<DataVector, dim, TargetFrame>>
-  coords_frame_velocity_jacobians(
+  auto coords_frame_velocity_jacobians(
       tnsr::I<DataVector, dim, SourceFrame> source_point,
       const double time = std::numeric_limits<double>::signaling_NaN(),
-      const FunctionsOfTimeMap& functions_of_time = {}) const override {
+      const FunctionsOfTimeMap& functions_of_time = {}) const
+      -> std::tuple<tnsr::I<DataVector, dim, TargetFrame>,
+                    InverseJacobian<DataVector, dim, SourceFrame, TargetFrame>,
+                    Jacobian<DataVector, dim, SourceFrame, TargetFrame>,
+                    tnsr::I<DataVector, dim, TargetFrame>> override {
     return coords_frame_velocity_jacobians_impl(std::move(source_point), time,
                                                 functions_of_time);
   }

--- a/src/Domain/CoordinateMaps/CoordinateMap.tpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.tpp
@@ -318,6 +318,110 @@ auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
   return inv_jac;
 }
 
+#ifdef SPECTRE_AUTODIFF
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+template <typename T>
+auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_hessian_impl(
+    tnsr::I<T, dim, SourceFrame>&& source_point,
+    const ::InverseJacobian<T, dim, SourceFrame, TargetFrame>& inverse_jac,
+    const double time, const FunctionsOfTimeMap& functions_of_time) const
+    -> InverseHessian<T, dim, SourceFrame, TargetFrame> {
+  // first compute hessian
+  using BatchType = simd::batch<double>;
+  using SecondOrderDual = autodiff::HigherOrderDual<2, BatchType>;
+  using SecondOrderDualNum = autodiff::HigherOrderDual<2, double>;
+
+  size_t num_pts = 1;
+  size_t vec_end = 0;
+  if constexpr (std::is_same_v<T, DataVector>) {
+    num_pts = get<0>(source_point).size();
+    vec_end = (num_pts / BatchType::size) * BatchType::size;
+  }
+  ::Hessian<T, dim, SourceFrame, TargetFrame> hessian{num_pts};
+  ::InverseHessian<T, dim, SourceFrame, TargetFrame> inverse_hessian{num_pts};
+
+  // manual vectorization with xsimd
+  if constexpr (std::is_same_v<T, DataVector>) {
+    for (size_t pts_index = 0; pts_index < vec_end;
+         pts_index += BatchType::size) {
+      tnsr::I<SecondOrderDual, dim, SourceFrame> dual_source_coords;
+
+      for (size_t i = 0; i < dim; ++i) {
+        for (size_t j = i; j < dim; ++j) {
+          [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            ((get<Is>(dual_source_coords) =
+                  BatchType::load_unaligned(
+                    &(get<Is>(source_point))[pts_index])),
+             ...);
+          }(std::make_index_sequence<dim>{});
+
+          // In forward mode, we use seed to initialize the variable
+          // w.r.t. to which we want to differentiate. Seeding
+          // both first and second order duals computes
+          // second derivatives, which can be extracted by derivative<2>.
+          // For minimal examples, see Test_Autodiff.cpp.
+          autodiff::seed<1>(dual_source_coords.get(i), 1.0);
+          autodiff::seed<2>(dual_source_coords.get(j), 1.0);
+
+          const auto dual_target_coords =
+              call_impl(std::move(dual_source_coords), time, functions_of_time,
+                        std::make_index_sequence<sizeof...(Maps)>{});
+          for (size_t k = 0; k < dim; ++k) {
+            const auto deriv_kij =
+                autodiff::derivative<2>(dual_target_coords.get(k));
+            deriv_kij.store_unaligned(&hessian.get(k, i, j)[pts_index]);
+          }
+        }
+      }
+    }
+  }
+  // dealing with the tail
+  for (size_t pts_index = vec_end; pts_index < num_pts; ++pts_index) {
+    tnsr::I<SecondOrderDualNum, dim, SourceFrame> dual_source_coords;
+
+    for (size_t i = 0; i < dim; ++i) {
+      for (size_t j = i; j < dim; ++j) {
+        if constexpr (std::is_same_v<T, double>) {
+          [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            ((get<Is>(dual_source_coords) = get<Is>(source_point)), ...);
+          }(std::make_index_sequence<dim>{});
+        } else {
+          [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            ((get<Is>(dual_source_coords) =
+                  gsl::at(get<Is>(source_point), pts_index)),
+             ...);
+          }(std::make_index_sequence<dim>{});
+        }
+
+        autodiff::seed<1>(dual_source_coords.get(i), 1.0);
+        autodiff::seed<2>(dual_source_coords.get(j), 1.0);
+
+        const auto dual_target_coords =
+            call_impl(std::move(dual_source_coords), time, functions_of_time,
+                      std::make_index_sequence<sizeof...(Maps)>{});
+        for (size_t k = 0; k < dim; ++k) {
+          if constexpr (std::is_same_v<T, double>) {
+            hessian.get(k, i, j) =
+                autodiff::derivative<2>(dual_target_coords.get(k));
+          } else {
+            hessian.get(k, i, j)[pts_index] =
+                autodiff::derivative<2>(dual_target_coords.get(k));
+          }
+        }
+      }
+    }
+  }
+
+  // piece together the inverse hessian from hessian and inverse jacobian
+  ::tenex::evaluate<ti::I, ti::m, ti::n>(
+      make_not_null(&inverse_hessian),
+      -1.0 * inverse_jac(ti::I, ti::j) * inverse_jac(ti::K, ti::m) *
+          inverse_jac(ti::L, ti::n) * hessian(ti::J, ti::k, ti::l));
+
+  return inverse_hessian;
+}
+#endif  // SPECTRE_AUTODIFF
+
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 template <typename T>
 auto CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(

--- a/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalEndcap.hpp
@@ -171,6 +171,8 @@ class CylindricalEndcap {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const CylindricalEndcap& lhs,
                          const CylindricalEndcap& rhs);

--- a/src/Domain/CoordinateMaps/CylindricalFlatEndcap.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatEndcap.hpp
@@ -114,6 +114,8 @@ class CylindricalFlatEndcap {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const CylindricalFlatEndcap& lhs,
                          const CylindricalFlatEndcap& rhs);

--- a/src/Domain/CoordinateMaps/CylindricalFlatSide.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatSide.hpp
@@ -122,6 +122,8 @@ class CylindricalFlatSide {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const CylindricalFlatSide& lhs,
                          const CylindricalFlatSide& rhs);

--- a/src/Domain/CoordinateMaps/CylindricalSide.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalSide.hpp
@@ -123,6 +123,8 @@ class CylindricalSide {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const CylindricalSide& lhs,
                          const CylindricalSide& rhs);

--- a/src/Domain/CoordinateMaps/DiscreteRotation.cpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.cpp
@@ -5,9 +5,11 @@
 
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -112,10 +114,13 @@ template class DiscreteRotation<3>;
   DiscreteRotation<DIM(data)>::inv_jacobian(                           \
       const std::array<DTYPE(data), DIM(data)>& source_coords) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
-                        (double, DataVector,
-                         std::reference_wrapper<const double>,
-                         std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (1, 2, 3),
+    (double, DataVector,
+     std::reference_wrapper<const double>,
+     std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), MAP_AUTODIFF_TYPES)
 
 #undef DTYPE
 #undef INSTANTIATE

--- a/src/Domain/CoordinateMaps/DiscreteRotation.hpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.hpp
@@ -65,6 +65,8 @@ class DiscreteRotation {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   friend bool operator==(const DiscreteRotation& lhs,
                          const DiscreteRotation& rhs) {

--- a/src/Domain/CoordinateMaps/EquatorialCompression.hpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.hpp
@@ -94,6 +94,8 @@ class EquatorialCompression {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> angular_distortion(

--- a/src/Domain/CoordinateMaps/Equiangular.cpp
+++ b/src/Domain/CoordinateMaps/Equiangular.cpp
@@ -8,6 +8,8 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -123,9 +125,12 @@ bool operator==(const CoordinateMaps::Equiangular& lhs,
   Equiangular::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) \
       const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (double, DataVector,
+                  std::reference_wrapper<const double>,
+                  std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, MAP_AUTODIFF_TYPES)
 
 #undef DTYPE
 #undef INSTANTIATE

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -87,6 +87,8 @@ class Equiangular {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   friend bool operator==(const Equiangular& lhs, const Equiangular& rhs);
 

--- a/src/Domain/CoordinateMaps/FlatOffsetSphericalWedge.hpp
+++ b/src/Domain/CoordinateMaps/FlatOffsetSphericalWedge.hpp
@@ -276,6 +276,8 @@ class FlatOffsetSphericalWedge {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const FlatOffsetSphericalWedge& lhs,
                          const FlatOffsetSphericalWedge& rhs);

--- a/src/Domain/CoordinateMaps/FlatOffsetWedge.hpp
+++ b/src/Domain/CoordinateMaps/FlatOffsetWedge.hpp
@@ -272,6 +272,8 @@ class FlatOffsetWedge {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const FlatOffsetWedge& lhs,
                          const FlatOffsetWedge& rhs);

--- a/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedEndcap.hpp
@@ -440,6 +440,8 @@ class Endcap {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const Endcap& lhs, const Endcap& rhs);
   std::array<double, 3> center_{};

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp
@@ -216,6 +216,8 @@ class FlatEndcap {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const FlatEndcap& lhs, const FlatEndcap& rhs);
   std::array<double, 3> center_{};

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatSide.hpp
@@ -265,6 +265,8 @@ class FlatSide {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const FlatSide& lhs, const FlatSide& rhs);
   std::array<double, 3> center_{};

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.hpp
@@ -348,6 +348,8 @@ class FocallyLiftedMap {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==<InnerMap>(const FocallyLiftedMap<InnerMap>& lhs,
                                    const FocallyLiftedMap<InnerMap>& rhs);

--- a/src/Domain/CoordinateMaps/FocallyLiftedSide.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedSide.hpp
@@ -301,6 +301,8 @@ class Side {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const Side& lhs, const Side& rhs);
   std::array<double, 3> center_{

--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -11,12 +11,14 @@
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/RootFinding/GslMultiRoot.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -706,9 +708,13 @@ bool operator!=(const Frustum& lhs, const Frustum& rhs) {
   Frustum::inv_jacobian(const std::array<DTYPE(data), 3>& source_coords)      \
       const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (double, DataVector,
+                  std::reference_wrapper<const double>,
+                  std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, MAP_AUTODIFF_TYPES)
+
 #undef DTYPE
 #undef INSTANTIATE
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -333,6 +333,8 @@ class Frustum {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   friend bool operator==(const Frustum& lhs, const Frustum& rhs);
 

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -4,6 +4,8 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 
 #include "DataStructures/Tensor/Identity.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -58,10 +60,13 @@ template class Identity<3>;
   Identity<DIM(data)>::inv_jacobian(                                   \
       const std::array<DTYPE(data), DIM(data)>& source_coords) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
-                        (double, DataVector,
-                         std::reference_wrapper<const double>,
-                         std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (1, 2, 3),
+    (double, DataVector,
+     std::reference_wrapper<const double>,
+     std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), MAP_AUTODIFF_TYPES)
 
 #undef DIM
 #undef DTYPE

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -59,6 +59,8 @@ class Identity {
   void pup(PUP::er& /*p*/) {}
 
   bool is_identity() const { return true; }
+
+  static constexpr bool supports_hessian{true};
 };
 
 template <size_t Dim>

--- a/src/Domain/CoordinateMaps/Interval.cpp
+++ b/src/Domain/CoordinateMaps/Interval.cpp
@@ -9,7 +9,9 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -262,9 +264,13 @@ bool operator==(const CoordinateMaps::Interval& lhs,
   Interval::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords)      \
       const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (double, DataVector,
+                  std::reference_wrapper<const double>,
+                  std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, MAP_AUTODIFF_TYPES)
+
 #undef DTYPE
 #undef INSTANTIATE
 }  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/Interval.hpp
+++ b/src/Domain/CoordinateMaps/Interval.hpp
@@ -108,6 +108,8 @@ class Interval {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   friend bool operator==(const Interval& lhs, const Interval& rhs);
 

--- a/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
+++ b/src/Domain/CoordinateMaps/KerrHorizonConforming.hpp
@@ -103,6 +103,8 @@ class KerrHorizonConforming {
     return spin_parameter_ == std::array<double, 3>{0., 0., 0.};
   }
 
+  static constexpr bool supports_hessian{false};
+
   friend bool operator==(const KerrHorizonConforming& lhs,
                          const KerrHorizonConforming& rhs);
 

--- a/src/Domain/CoordinateMaps/PolarToCartesian.hpp
+++ b/src/Domain/CoordinateMaps/PolarToCartesian.hpp
@@ -61,6 +61,8 @@ class PolarToCartesian {
   void pup(PUP::er& p);
 
   static constexpr bool is_identity() { return false; }
+
+  static constexpr bool supports_hessian{false};
 };
 
 bool operator==(const PolarToCartesian& lhs, const PolarToCartesian& rhs);

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -68,6 +68,9 @@ class ProductOf2Maps {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{Map1::supports_hessian and
+                                          Map2::supports_hessian};
+
  private:
   friend bool operator==(const ProductOf2Maps& lhs, const ProductOf2Maps& rhs) {
     return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_ and
@@ -116,6 +119,10 @@ class ProductOf3Maps {
   void pup(PUP::er& p);
 
   bool is_identity() const { return is_identity_; }
+
+  static constexpr bool supports_hessian{Map1::supports_hessian and
+                                          Map2::supports_hessian and
+                                          Map3::supports_hessian};
 
  private:
   friend bool operator==(const ProductOf3Maps& lhs, const ProductOf3Maps& rhs) {

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -6,6 +6,8 @@
 #include <cmath>
 #include <pup.h>
 
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -219,10 +221,14 @@ bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) {
   Rotation<DIM(data)>::inv_jacobian(                                   \
       const std::array<DTYPE(data), DIM(data)>& source_coords) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
-                        (double, DataVector,
-                         std::reference_wrapper<const double>,
-                         std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (2, 3),
+    (double, DataVector,
+     std::reference_wrapper<const double>,
+     std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), MAP_AUTODIFF_TYPES)
+
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -83,6 +83,8 @@ class Rotation<2> {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   friend bool operator==(const Rotation<2>& lhs, const Rotation<2>& rhs);
 
@@ -156,6 +158,8 @@ class Rotation<3> {
   void pup(PUP::er& p);
 
   bool is_identity() const { return is_identity_; }
+
+  static constexpr bool supports_hessian{true};
 
  private:
   friend bool operator==(const Rotation<3>& lhs, const Rotation<3>& rhs);

--- a/src/Domain/CoordinateMaps/SpecialMobius.cpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.cpp
@@ -8,6 +8,8 @@
 #include <pup.h>
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -138,9 +140,12 @@ bool operator!=(const SpecialMobius& lhs, const SpecialMobius& rhs) {
   SpecialMobius::inv_jacobian(const std::array<DTYPE(data), 3>& source_coords) \
       const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
-                                      std::reference_wrapper<const double>,
-                                      std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (double, DataVector,
+                  std::reference_wrapper<const double>,
+                  std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, MAP_AUTODIFF_TYPES)
 
 #undef DTYPE
 #undef INSTANTIATE

--- a/src/Domain/CoordinateMaps/SpecialMobius.hpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.hpp
@@ -119,6 +119,8 @@ class SpecialMobius {
 
   bool is_identity() const { return is_identity_; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> mobius_distortion(

--- a/src/Domain/CoordinateMaps/SphericalToCartesianPfaffian.hpp
+++ b/src/Domain/CoordinateMaps/SphericalToCartesianPfaffian.hpp
@@ -77,6 +77,8 @@ class SphericalToCartesianPfaffian {
   void pup(PUP::er& p);
 
   static constexpr bool is_identity() { return false; }
+
+  static constexpr bool supports_hessian{false};
 };
 
 bool operator==(const SphericalToCartesianPfaffian& lhs,

--- a/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/CubicScale.hpp
@@ -155,6 +155,8 @@ class CubicScale {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;
   }

--- a/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
@@ -104,6 +104,9 @@ class ProductOf2Maps {
     return map1_.is_identity() and map2_.is_identity();
   }
 
+  static constexpr bool supports_hessian{Map1::supports_hessian and
+                                          Map2::supports_hessian};
+
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;
   }
@@ -188,6 +191,10 @@ class ProductOf3Maps {
   bool is_identity() const {
     return map1_.is_identity() and map2_.is_identity() and map3_.is_identity();
   }
+
+  static constexpr bool supports_hessian{Map1::supports_hessian and
+                                            Map2::supports_hessian and
+                                            Map3::supports_hessian};
 
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;

--- a/src/Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/RotScaleTrans.hpp
@@ -334,6 +334,9 @@ class RotScaleTrans {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
+
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;
   }

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.cpp
@@ -13,8 +13,10 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/RotationMatrixHelpers.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -215,10 +217,13 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3))
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&        \
           functions_of_time) const;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
-                        (double, DataVector,
-                         std::reference_wrapper<const double>,
-                         std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE, (2, 3),
+    (double, DataVector,
+     std::reference_wrapper<const double>,
+     std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3), MAP_AUTODIFF_TYPES)
 
 #undef DIM
 #undef DTYPE

--- a/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Rotation.hpp
@@ -215,6 +215,8 @@ class Rotation {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{true};
+
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;
   }

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -273,6 +273,7 @@ class Shape {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
   static bool is_identity() { return false; }
+  static constexpr bool supports_hessian{false};
   static constexpr size_t dim = 3;
 
   const std::unordered_set<std::string>& function_of_time_names() const {

--- a/src/Domain/CoordinateMaps/TimeDependent/Skew.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Skew.hpp
@@ -207,6 +207,8 @@ class Skew {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;
   }

--- a/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/SphericalCompression.hpp
@@ -315,6 +315,8 @@ class SphericalCompression {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;
   }

--- a/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Translation.hpp
@@ -220,6 +220,8 @@ class Translation {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
   const std::unordered_set<std::string>& function_of_time_names() const {
     return f_of_t_names_;
   }

--- a/src/Domain/CoordinateMaps/UniformCylindricalEndcap.hpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalEndcap.hpp
@@ -547,6 +547,8 @@ class UniformCylindricalEndcap {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const UniformCylindricalEndcap& lhs,
                          const UniformCylindricalEndcap& rhs);

--- a/src/Domain/CoordinateMaps/UniformCylindricalFlatEndcap.hpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalFlatEndcap.hpp
@@ -496,6 +496,8 @@ class UniformCylindricalFlatEndcap {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const UniformCylindricalFlatEndcap& lhs,
                          const UniformCylindricalFlatEndcap& rhs);

--- a/src/Domain/CoordinateMaps/UniformCylindricalSide.hpp
+++ b/src/Domain/CoordinateMaps/UniformCylindricalSide.hpp
@@ -686,6 +686,8 @@ class UniformCylindricalSide {
 
   static bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{false};
+
  private:
   friend bool operator==(const UniformCylindricalSide& lhs,
                          const UniformCylindricalSide& rhs);

--- a/src/Domain/CoordinateMaps/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/Wedge.cpp
@@ -11,9 +11,11 @@
 
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Utilities/Algorithm.hpp"
+#include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -1031,10 +1033,14 @@ bool operator!=(const Wedge<Dim>& lhs, const Wedge<Dim>& rhs) {
       const std::array<DTYPE(data), DIM(data)>& source_coords) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_DIM, (2, 3))
-GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE, (2, 3),
-                        (double, DataVector,
-                         std::reference_wrapper<const double>,
-                         std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE_DTYPE, (2, 3),
+    (double, DataVector,
+     std::reference_wrapper<const double>,
+     std::reference_wrapper<const DataVector>))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_DTYPE, (2, 3), MAP_AUTODIFF_TYPES)
 
 #undef DIM
 #undef DTYPE

--- a/src/Domain/CoordinateMaps/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/Wedge.hpp
@@ -966,6 +966,8 @@ class Wedge {
 
   static constexpr bool is_identity() { return false; }
 
+  static constexpr bool supports_hessian{true};
+
  private:
   // maps between 2D and 3D choices for coordinate axis orientations
   static constexpr size_t radial_coord =

--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -69,6 +69,7 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  Autodiff
   Boost::boost
   PUBLIC
   DataStructures

--- a/src/Domain/Structure/OrientationMap.cpp
+++ b/src/Domain/Structure/OrientationMap.cpp
@@ -13,6 +13,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/SegmentId.hpp"
 #include "Utilities/Algorithm.hpp"
+#ifdef SPECTRE_AUTODIFF
+#include "Utilities/Autodiff/Autodiff.hpp"
+#endif
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -310,16 +313,31 @@ GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
       const OrientationMap<DIM(data)>& rotation,                       \
       std::array<DTYPE(data), DIM(data)> source_coords);
 
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
-                        (double, DataVector, const double, const DataVector,
-                         std::reference_wrapper<double>,
-                         std::reference_wrapper<DataVector>,
-                         std::reference_wrapper<const double>,
-                         std::reference_wrapper<const DataVector>,
-                         std::reference_wrapper<double> const,
-                         std::reference_wrapper<DataVector> const,
-                         std::reference_wrapper<const double> const,
-                         std::reference_wrapper<const DataVector> const))
+GENERATE_INSTANTIATIONS(
+    INSTANTIATION, (1, 2, 3),
+    (double, DataVector, const double, const DataVector,
+     std::reference_wrapper<double>, std::reference_wrapper<DataVector>,
+     std::reference_wrapper<const double>,
+     std::reference_wrapper<const DataVector>,
+     std::reference_wrapper<double> const,
+     std::reference_wrapper<DataVector> const,
+     std::reference_wrapper<const double> const,
+     std::reference_wrapper<const DataVector> const))
+
+#ifdef SPECTRE_AUTODIFF
+GENERATE_INSTANTIATIONS(
+    INSTANTIATION, (1, 2, 3),
+    (autodiff::SecondOrderDual, autodiff::SecondOrderDualNum,
+     const autodiff::SecondOrderDual, const autodiff::SecondOrderDualNum,
+     std::reference_wrapper<autodiff::SecondOrderDual>,
+     std::reference_wrapper<autodiff::SecondOrderDualNum>,
+     std::reference_wrapper<const autodiff::SecondOrderDual>,
+     std::reference_wrapper<const autodiff::SecondOrderDualNum>,
+     std::reference_wrapper<autodiff::SecondOrderDual> const,
+     std::reference_wrapper<autodiff::SecondOrderDualNum> const,
+     std::reference_wrapper<const autodiff::SecondOrderDual> const,
+     std::reference_wrapper<const autodiff::SecondOrderDualNum> const))
+#endif  // SPECTRE_AUTODIFF
 
 #undef INSTANTIATION
 #undef DTYPE

--- a/src/Utilities/Autodiff/Autodiff.hpp
+++ b/src/Utilities/Autodiff/Autodiff.hpp
@@ -3,17 +3,48 @@
 
 #pragma once
 
+#ifdef SPECTRE_AUTODIFF
+
 #include <autodiff/common/numbertraits.hpp>
 #include <autodiff/forward/dual.hpp>
 #include <autodiff/reverse/var.hpp>
 
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Simd/Simd.hpp"
 
-namespace autodiff::detail {
+namespace autodiff {
+using BatchType = simd::batch<double>;
+using SecondOrderDual = autodiff::HigherOrderDual<2, BatchType>;
+using SecondOrderDualNum = autodiff::HigherOrderDual<2, double>;
+
+namespace detail {
 /// Template specialization for simd::batch<double> to treat it as arithmetic.
+// The major difficulty we have with DataVector working with autodiff is
+// DataVector does not have a scalar broadcast constructor, which is expected
+// in the seed function for autodiff dual type.
 template <>
 struct ArithmeticTraits<simd::batch<double>> {
   static constexpr bool isArithmetic = true;
 };
+}  // namespace detail
+}  // namespace autodiff
 
-}  // namespace autodiff::detail
+namespace MakeWithValueImpls {
+template <typename T>
+struct MakeWithValueImpl<autodiff::HigherOrderDual<2, double>, T> {
+  static SPECTRE_ALWAYS_INLINE autodiff::HigherOrderDual<2, double> apply(
+      const T& /* input */, const double value) {
+    return {value};
+  }
+};
+
+template <typename T>
+struct MakeWithValueImpl<autodiff::HigherOrderDual<2, simd::batch<double>>, T> {
+  static SPECTRE_ALWAYS_INLINE autodiff::HigherOrderDual<2, simd::batch<double>>
+  apply(const T& /* input */, const double value) {
+    return {simd::batch<double>::broadcast(value)};
+  }
+};
+}  // namespace MakeWithValueImpls
+
+#endif  // SPECTRE_AUTODIFF

--- a/src/Utilities/Autodiff/CMakeLists.txt
+++ b/src/Utilities/Autodiff/CMakeLists.txt
@@ -15,11 +15,19 @@ spectre_target_headers(
   Autodiff.hpp
   )
 
-target_link_libraries(
-  ${LIBRARY}
-  INTERFACE
-  autodiff::autodiff
-  Simd
-  )
+if (SPECTRE_AUTODIFF)
+  target_link_libraries(
+    ${LIBRARY}
+    INTERFACE
+    autodiff::autodiff
+    Simd
+    )
 
-message(STATUS "Enabling autodiff support")
+  target_compile_definitions(
+    ${LIBRARY}
+    INTERFACE
+    SPECTRE_AUTODIFF
+    )
+
+  message(STATUS "Enabling autodiff support")
+endif()

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -1,9 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-if (SPECTRE_AUTODIFF)
-  add_subdirectory(Autodiff)
-endif()
+
+add_subdirectory(Autodiff)
 add_subdirectory(Kokkos)
 add_subdirectory(Simd)
 
@@ -97,6 +96,7 @@ spectre_target_headers(
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  Autodiff
   BLAS::BLAS
   Blaze
   Boost::boost

--- a/src/Utilities/Simd/CMakeLists.txt
+++ b/src/Utilities/Simd/CMakeLists.txt
@@ -16,12 +16,10 @@ spectre_target_headers(
   Simd.hpp
   )
 
-if (TARGET xsimd)
-  target_link_libraries(
-    ${LIBRARY}
-    INTERFACE
-    xsimd
-    )
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE
+  xsimd
+  )
 
   message(STATUS "Enabling simd support")
-endif()

--- a/tests/Unit/Domain/CoordinateMaps/Test_Composition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Composition.cpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/Composition.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
@@ -27,6 +28,76 @@
 namespace domain::CoordinateMaps {
 
 namespace {
+#ifdef SPECTRE_AUTODIFF
+// This test helper function computes the inverse Hessian by
+// auto-differentiating through the inv_jacobian function, which gives the
+// derivatives of inv_jacobian with respect to the source coordinates, i.e.
+// \frac{\partial}{\partial\xi^k}\left(\frac{\partial\xi^i}{\partial
+// x^j}\right). The inverse Hessian is then given by the chain rule
+// \frac{\partial^2\xi^i}{\partial x^j \partial x^k} =
+// \frac{\partial\xi^l}{\partial x^k} *
+// \frac{\partial}{\partial\xi^l}\left(\frac{\partial\xi^i}{\partial
+// x^j}\right).
+template <typename DataType, typename Map, size_t Dim>
+InverseHessian<DataType, Dim, Frame::ElementLogical, Frame::Inertial>
+inv_hessian_helper(
+    const Map& coordinate_map,
+    const tnsr::I<DataType, Dim, Frame::ElementLogical>& source_point) {
+  using SecondOrderDualNum = autodiff::HigherOrderDual<2, double>;
+
+  const size_t num_pts = get<0>(source_point).size();
+  ::InverseHessian<DataType, Dim, Frame::ElementLogical, Frame::Inertial>
+      inverse_hessian{num_pts};
+
+  for (size_t pts_index = 0; pts_index < num_pts; ++pts_index) {
+    tnsr::I<SecondOrderDualNum, Dim, Frame::ElementLogical> dual_source_coords;
+
+    if constexpr (std::is_same_v<DataType, double>) {
+      [&]<std::size_t... Ins>(std::index_sequence<Ins...>) {
+        ((get<Ins>(dual_source_coords) = get<Ins>(source_point)), ...);
+      }
+      (std::make_index_sequence<Dim>{});
+    } else {
+      [&]<std::size_t... Ins>(std::index_sequence<Ins...>) {
+        ((get<Ins>(dual_source_coords) =
+              gsl::at(get<Ins>(source_point), pts_index)),
+         ...);
+      }
+      (std::make_index_sequence<Dim>{});
+    }
+
+    for (size_t k = 0; k < Dim; ++k) {
+      for (size_t i = 0; i < Dim; ++i) {
+        for (size_t j = i; j < Dim; ++j) {
+          double inv_hessian_kij{0.0};
+
+          for (size_t l = 0; l < Dim; ++l) {
+            autodiff::seed<1>(dual_source_coords.get(l), 1.0);
+            for (size_t n = 1; n < Dim; ++n) {
+              autodiff::seed<1>(dual_source_coords.get((l + n) % Dim), 0.0);
+            }
+
+            const auto dual_inverse_jac =
+                coordinate_map.inv_jacobian(dual_source_coords);
+            const auto inv_jac_lj = autodiff::val(dual_inverse_jac.get(l, j));
+            const auto deriv_kli =
+                autodiff::derivative<1>(dual_inverse_jac.get(k, i));
+            inv_hessian_kij += inv_jac_lj * deriv_kli;
+          }
+
+          if constexpr (std::is_same_v<DataType, double>) {
+            inverse_hessian.get(k, i, j) = inv_hessian_kij;
+          } else {
+            inverse_hessian.get(k, i, j)[pts_index] = inv_hessian_kij;
+          }
+        }
+      }
+    }
+  }
+  return inverse_hessian;
+}
+#endif  // SPECTRE_AUTODIFF
+
 void test_composition() {
   INFO("Composition");
 
@@ -76,6 +147,9 @@ void test_composition() {
   const auto x = map(xi);
   const auto jacobian = map.jacobian(xi);
   const auto inv_jacobian = map.inv_jacobian(xi);
+#ifdef SPECTRE_AUTODIFF
+  const auto inv_hessian = map.inv_hessian(xi, inv_jacobian);
+#endif  // SPECTRE_AUTODIFF
   CHECK_ITERABLE_APPROX(get<0>(x), (get<0>(xi) + 1.) * 0.25);
   CHECK_ITERABLE_APPROX(get<1>(x), (get<1>(xi) + 2.));
   CHECK_ITERABLE_APPROX((get<0, 0>(jacobian)), DataVector(5, 0.25));
@@ -84,6 +158,11 @@ void test_composition() {
   CHECK_ITERABLE_APPROX((get<1, 1>(inv_jacobian)), DataVector(5, 1.));
   CHECK_ITERABLE_APPROX((get<1, 0>(jacobian)), DataVector(5, 0.));
   CHECK_ITERABLE_APPROX((get<1, 0>(inv_jacobian)), DataVector(5, 0.));
+#ifdef SPECTRE_AUTODIFF
+  for (const auto& component : inv_hessian) {
+    CHECK_ITERABLE_APPROX(component, DataVector(5, 0.0));
+  }
+#endif  // SPECTRE_AUTODIFF
   const auto x_target = tnsr::I<double, 2, Frame::Inertial>{{{0.5, 1.}}};
   const auto inv = map.inverse(x_target);
   REQUIRE(inv.has_value());
@@ -122,6 +201,9 @@ void test_identity() {
   const auto x = map(xi);
   const auto jacobian = map.jacobian(xi);
   const auto inv_jacobian = map.inv_jacobian(xi);
+#ifdef SPECTRE_AUTODIFF
+  const auto inv_hessian = map.inv_hessian(xi, inv_jacobian);
+#endif  // SPECTRE_AUTODIFF
   CHECK_ITERABLE_APPROX(get<0>(x), get<0>(xi));
   CHECK_ITERABLE_APPROX(get<1>(x), get<1>(xi));
   CHECK_ITERABLE_APPROX(get<2>(x), get<2>(xi));
@@ -137,6 +219,11 @@ void test_identity() {
   CHECK_ITERABLE_APPROX((get<2, 0>(inv_jacobian)), DataVector(5, 0.));
   CHECK_ITERABLE_APPROX((get<2, 1>(jacobian)), DataVector(5, 0.));
   CHECK_ITERABLE_APPROX((get<2, 1>(inv_jacobian)), DataVector(5, 0.));
+#ifdef SPECTRE_AUTODIFF
+  for (const auto& component : inv_hessian) {
+    CHECK_ITERABLE_APPROX(component, DataVector(5, 0.0));
+  }
+#endif  // SPECTRE_AUTODIFF
   const auto x_target = tnsr::I<double, 3, Frame::Inertial>{{{0.5, 1., 0.}}};
   const auto inv = map.inverse(x_target);
   REQUIRE(inv.has_value());
@@ -184,6 +271,58 @@ void test_3d() {
   CHECK_ITERABLE_APPROX((get<1, 0>(identity)), DataVector(5, 0.));
   CHECK_ITERABLE_APPROX((get<2, 0>(identity)), DataVector(5, 0.));
   CHECK_ITERABLE_APPROX((get<2, 1>(identity)), DataVector(5, 0.));
+
+#ifdef SPECTRE_AUTODIFF
+  const auto inv_hessian = map.inv_hessian(xi, inv_jacobian);
+  const auto alt_inv_hessian = inv_hessian_helper(map, xi);
+  CHECK_ITERABLE_APPROX(inv_hessian, alt_inv_hessian);
+#endif  // SPECTRE_AUTODIFF
+}
+
+void test_unsupported_autodiff() {
+  INFO("Unsupported autodiff");
+
+#ifdef SPECTRE_AUTODIFF
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<double> logical_dist{-1., 1.};
+
+  const ElementId<3> element_id{0, {{{0, 0}, {0, 0}, {0, 0}}}};
+  // EquatorialCompression does not support autodiff
+  const Composition map{
+      element_to_block_logical_map(element_id),
+      std::make_unique<CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                                     EquatorialCompression>>(
+          EquatorialCompression{1.5, 2})};
+
+  // Check that supports_hessian() correctly returns false
+  CHECK_FALSE(map.supports_hessian());
+
+  const auto xi =
+      make_with_random_values<tnsr::I<double, 3, Frame::ElementLogical>>(
+          make_not_null(&generator), make_not_null(&logical_dist),
+          0.0);
+
+  // Calling inv_hessian should trigger an error
+  const auto inv_jacobian = map.inv_jacobian(xi);
+  CHECK_THROWS_WITH(
+      map.inv_hessian(xi, inv_jacobian),
+      Catch::Matchers::ContainsSubstring(
+          "At least one of the Maps does not support autodiff") &&
+          Catch::Matchers::ContainsSubstring("EquatorialCompression"));
+
+  // Also test with DataVector
+  const auto xi_dv =
+      make_with_random_values<tnsr::I<DataVector, 3, Frame::ElementLogical>>(
+          make_not_null(&generator), make_not_null(&logical_dist),
+          DataVector(5));
+
+  const auto inv_jacobian_dv = map.inv_jacobian(xi_dv);
+  CHECK_THROWS_WITH(
+      map.inv_hessian(xi_dv, inv_jacobian_dv),
+      Catch::Matchers::ContainsSubstring(
+          "At least one of the Maps does not support autodiff") &&
+          Catch::Matchers::ContainsSubstring("EquatorialCompression"));
+#endif  // SPECTRE_AUTODIFF
 }
 }  // namespace
 
@@ -191,6 +330,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Composition", "[Domain][Unit]") {
   test_composition();
   test_identity();
   test_3d();
+  test_unsupported_autodiff();
 }
 
 }  // namespace domain::CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -31,6 +31,7 @@
 #include "Domain/CoordinateMaps/TimeDependent/CubicScale.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/TimeDependent/Rotation.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Shape.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
@@ -47,6 +48,64 @@
 
 namespace domain {
 namespace {
+#ifdef SPECTRE_AUTODIFF
+// This test helper function computes the inverse Hessian by
+// auto-differentiating through the inv_jacobian function, which gives the
+// derivatives of inv_jacobian with respect to the source coordinates, i.e.
+// \frac{\partial}{\partial\xi^k}\left(\frac{\partial\xi^i}{\partial
+// x^j}\right). The inverse Hessian is then given by the chain rule
+// \frac{\partial^2\xi^i}{\partial x^j \partial x^k} =
+// \frac{\partial\xi^l}{\partial x^k} *
+// \frac{\partial}{\partial\xi^l}\left(\frac{\partial\xi^i}{\partial
+// x^j}\right).
+template <size_t Dim, typename SourceFrame, typename TargetFrame = Frame::Grid,
+          typename Map>
+auto inv_hessian_helper(const Map& coordinate_map,
+                        const tnsr::I<double, Dim, SourceFrame>& source_point)
+    -> InverseHessian<double, Dim, SourceFrame, TargetFrame> {
+  using SecondOrderDualNum = autodiff::HigherOrderDual<2, double>;
+
+  const size_t num_pts = 1;
+
+  InverseHessian<double, Dim, SourceFrame, TargetFrame> inverse_hessian{
+      num_pts};
+
+  for (size_t pts_index = 0; pts_index < num_pts; ++pts_index) {
+    tnsr::I<SecondOrderDualNum, Dim, SourceFrame> dual_source_coords;
+
+    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+      ((get<Is>(dual_source_coords) = get<Is>(source_point)), ...);
+    }
+    (std::make_index_sequence<Dim>{});
+
+    for (size_t k = 0; k < Dim; ++k) {
+      for (size_t i = 0; i < Dim; ++i) {
+        for (size_t j = i; j < Dim; ++j) {
+          double inv_hessian_kij{0.0};
+
+          for (size_t l = 0; l < Dim; ++l) {
+            autodiff::seed<1>(dual_source_coords.get(l), 1.0);
+            for (size_t n = 1; n < Dim; ++n) {
+              autodiff::seed<1>(dual_source_coords.get((l + n) % Dim), 0.0);
+            }
+
+            const auto dual_inverse_jac =
+                coordinate_map.inv_jacobian(dual_source_coords);
+            const auto inv_jac_lj = autodiff::val(dual_inverse_jac.get(l, j));
+            const auto deriv_kli =
+                autodiff::derivative<1>(dual_inverse_jac.get(k, i));
+            inv_hessian_kij += inv_jac_lj * deriv_kli;
+            inverse_hessian.get(k, i, j) = inv_hessian_kij;
+          }
+        }
+      }
+    }
+  }
+
+  return inverse_hessian;
+}
+#endif  // SPECTRE_AUTODIFF
+
 template <typename Map1, typename Map2, typename DataType, size_t Dim>
 auto compose_jacobians(const Map1& map1, const Map2& map2,
                        const std::array<DataType, Dim>& point) {
@@ -139,6 +198,16 @@ void test_single_coordinate_map() {
     }
     CHECK_ITERABLE_APPROX(map_base->inv_jacobian(local_source_points),
                           local_expected_inv_jac);
+
+#ifdef SPECTRE_AUTODIFF
+    const auto local_expected_inv_hessian = make_with_value<
+        InverseHessian<double, dim, Frame::BlockLogical, Frame::Grid>>(
+        get<0>(local_source_points), 0.0);
+    CHECK_ITERABLE_APPROX(
+        map_base->inv_hessian(local_source_points,
+                              map_base->inv_jacobian(local_source_points)),
+        local_expected_inv_hessian);
+#endif  // SPECTRE_AUTODIFF
 
     const auto coords_jacs_velocity =
         map_base->coords_frame_velocity_jacobians(local_source_points);
@@ -346,8 +415,12 @@ void test_coordinate_map_with_affine_map() {
           approx(map.inverse(tnsr::I<double, 1, Frame::Grid>{1.0 / i + -0.5})
                      .value()[0]));
 
-    CHECK(approx(map.inv_jacobian(source_points).get(0, 0)) == 2.0);
+    const auto inv_jac = map.inv_jacobian(source_points);
+    CHECK(approx(inv_jac.get(0, 0)) == 2.0);
     CHECK(approx(map.jacobian(source_points).get(0, 0)) == 0.5);
+#ifdef SPECTRE_AUTODIFF
+    CHECK(approx(map.inv_hessian(source_points, inv_jac).get(0, 0, 0)) == 0.0);
+#endif  // SPECTRE_AUTODIFF
 
     const auto coords_jacs_velocity =
         map.coords_frame_velocity_jacobians(source_points);
@@ -398,6 +471,13 @@ void test_coordinate_map_with_affine_map() {
     CHECK(0.0 == approx(get<1, 0>(jac)));
     CHECK(0.0 == approx(get<0, 1>(jac)));
     CHECK(4.0 == approx(get<1, 1>(jac)));
+
+#ifdef SPECTRE_AUTODIFF
+    auto inv_hessian = prod_map2d.inv_hessian(source_points, inv_jac);
+    for (auto& component : inv_hessian) {
+      CHECK(0.0 == approx(component));
+    }
+#endif  // SPECTRE_AUTODIFF
 
     const auto coords_jacs_velocity =
         prod_map2d.coords_frame_velocity_jacobians(source_points);
@@ -466,6 +546,13 @@ void test_coordinate_map_with_affine_map() {
     CHECK(0.0 == approx(get<2, 1>(jac)));
     CHECK(10.0 == approx(get<2, 2>(jac)));
 
+#ifdef SPECTRE_AUTODIFF
+    auto inv_hessian = prod_map3d.inv_hessian(source_points, inv_jac);
+    for (auto& component : inv_hessian) {
+      CHECK(0.0 == approx(component));
+    }
+#endif  // SPECTRE_AUTODIFF
+
     const auto coords_jacs_velocity =
         prod_map3d.coords_frame_velocity_jacobians(source_points);
     CHECK_ITERABLE_APPROX(std::get<0>(coords_jacs_velocity),
@@ -521,6 +608,13 @@ void test_coordinate_map_with_rotation_map() {
         first_rotated2d, second_rotated2d, gsl::at(coords2d, i));
     CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
 
+#ifdef SPECTRE_AUTODIFF
+    auto inv_hessian = double_rotated2d.inv_hessian(source_points, inv_jac);
+    for (auto& component : inv_hessian) {
+      CHECK(0.0 == approx(component));
+    }
+#endif  // SPECTRE_AUTODIFF
+
     const auto coords_jacs_velocity =
         double_rotated2d.coords_frame_velocity_jacobians(source_points);
     CHECK_ITERABLE_APPROX(std::get<0>(coords_jacs_velocity),
@@ -569,6 +663,13 @@ void test_coordinate_map_with_rotation_map() {
     const auto expected_inv_jac = compose_inv_jacobians(
         first_rotated3d, second_rotated3d, gsl::at(coords3d, i));
     CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
+
+#ifdef SPECTRE_AUTODIFF
+    auto inv_hessian = double_rotated3d.inv_hessian(source_points, inv_jac);
+    for (auto& component : inv_hessian) {
+      CHECK(0.0 == approx(component));
+    }
+#endif  // SPECTRE_AUTODIFF
 
     const auto coords_jacs_velocity =
         double_rotated3d.coords_frame_velocity_jacobians(source_points);
@@ -620,6 +721,14 @@ void test_coordinate_map_with_rotation_map_datavector() {
     const auto expected_inv_jac = compose_inv_jacobians(
         first_rotated2d, second_rotated2d, coords2d_array);
     CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
+
+#ifdef SPECTRE_AUTODIFF
+    const DataVector expected_zero{get<0>(coords2d).size(), 0.0};
+    auto inv_hessian = double_rotated2d.inv_hessian(coords2d, inv_jac);
+    for (auto& component : inv_hessian) {
+      CHECK_ITERABLE_APPROX(component, expected_zero);
+    }
+#endif  // SPECTRE_AUTODIFF
 
     const auto coords_jacs_velocity =
         double_rotated2d.coords_frame_velocity_jacobians(coords2d);
@@ -675,6 +784,14 @@ void test_coordinate_map_with_rotation_map_datavector() {
         first_rotated3d, second_rotated3d, coords3d_array);
     CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
 
+#ifdef SPECTRE_AUTODIFF
+    const DataVector expected_zero{get<0>(coords3d).size(), 0.0};
+    auto inv_hessian = double_rotated3d.inv_hessian(coords3d, inv_jac);
+    for (auto& component : inv_hessian) {
+      CHECK_ITERABLE_APPROX(component, expected_zero);
+    }
+#endif  // SPECTRE_AUTODIFF
+
     // Check inequivalence operator
     CHECK_FALSE(double_rotated3d_full != double_rotated3d_full);
     test_serialization(double_rotated3d_full);
@@ -726,6 +843,18 @@ void test_coordinate_map_with_rotation_wedge() {
   const auto expected_inv_jac =
       compose_inv_jacobians(first_map, second_map, test_point_array);
   CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
+
+#ifdef SPECTRE_AUTODIFF
+  const auto inv_hessian = composed_map.inv_hessian(test_point_vector, inv_jac);
+
+  const auto alt_inv_hessian =
+      inv_hessian_helper(composed_map, test_point_vector);
+
+  CHECK_ITERABLE_APPROX(inv_hessian, alt_inv_hessian);
+  for (auto& component : inv_hessian) {
+    CHECK_FALSE(0.0 == approx(component));
+  }
+#endif  // SPECTRE_AUTODIFF
 
   const auto coords_jacs_velocity =
       composed_map.coords_frame_velocity_jacobians(test_point_vector);
@@ -1180,19 +1309,18 @@ void test_time_dependent_map() {
   CHECK(time_dependent_map_first
             .jacobian(tnsr_double_logical, final_time, functions_of_time)
             .get(0, 0) == 1.5);
-  CHECK(time_dependent_map_first
-            .inv_jacobian(tnsr_double_logical, final_time, functions_of_time)
-            .get(0, 0) == 2. / 3.);
+  const auto inv_jac_double = time_dependent_map_first.inv_jacobian(
+      tnsr_double_logical, final_time, functions_of_time);
+  CHECK(inv_jac_double.get(0, 0) == 2. / 3.);
   CHECK_ITERABLE_APPROX(
       time_dependent_map_first
           .jacobian(tnsr_datavector_logical, final_time, functions_of_time)
           .get(0, 0),
       (DataVector{1.5, 1.5, 1.5}));
-  CHECK_ITERABLE_APPROX(
-      time_dependent_map_first
-          .inv_jacobian(tnsr_datavector_logical, final_time, functions_of_time)
-          .get(0, 0),
-      (DataVector{2. / 3., 2. / 3., 2. / 3.}));
+  const auto inv_jac_datavector = time_dependent_map_first.inv_jacobian(
+      tnsr_datavector_logical, final_time, functions_of_time);
+  CHECK_ITERABLE_APPROX(inv_jac_datavector.get(0, 0),
+                        (DataVector{2. / 3., 2. / 3., 2. / 3.}));
 
   test_serialization(time_dependent_map_first);
 
@@ -1272,6 +1400,77 @@ void test_time_dependent_map() {
                               1.5 * velocity[velocity.size() - 1]}}));
   }
 }
+
+#ifdef SPECTRE_AUTODIFF
+void test_time_dependent_map_for_hessian() {
+  INFO("Time dependent CoordinateMap for hessian");
+  // define vars for FunctionOfTime::PiecewisePolynomial f(t) = t**2.
+  const double initial_time = -1.;
+  const double final_time = 4.4;
+  constexpr size_t deriv_order = 3;
+
+  const std::array<DataVector, deriv_order + 1> init_func{
+      {{1.0}, {-2.0}, {2.0}, {0.0}}};
+  using Polynomial = domain::FunctionsOfTime::PiecewisePolynomial<deriv_order>;
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+  functions_of_time["Rotation"] =
+      std::make_unique<Polynomial>(initial_time, init_func, final_time);
+
+  const CoordinateMaps::TimeDependent::Rotation<2> rot_map{"Rotation"};
+
+  // affine(x) = x, affine(y) = y + 1
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                  CoordinateMaps::Affine>;
+  const auto affine_map =
+      Affine2D{Affine{-1.0, 1.0, -1.0, 1.0}, Affine{-1.0, 1.0, 0.0, 2.0}};
+
+  const auto time_dependent_map_first =
+      make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(rot_map,
+                                                                affine_map);
+
+  const tnsr::I<double, 2, Frame::BlockLogical> tnsr_double_logical{
+      {{3.2, -4.3}}};
+  const tnsr::I<DataVector, 2, Frame::BlockLogical> tnsr_datavector_logical{
+      {{{0.1, -4.3, 10.0}, {1.2, 10.1, -3.5}}}};
+
+  const auto inv_jac_double = time_dependent_map_first.inv_jacobian(
+      tnsr_double_logical, final_time, functions_of_time);
+  const auto inv_jac_datavector = time_dependent_map_first.inv_jacobian(
+      tnsr_datavector_logical, final_time, functions_of_time);
+
+  auto inv_hessian_double = time_dependent_map_first.inv_hessian(
+      tnsr_double_logical, inv_jac_double, final_time, functions_of_time);
+  for (const auto& component : inv_hessian_double) {
+    CHECK(component == 0.0);
+  }
+  auto inv_hessian_datavector = time_dependent_map_first.inv_hessian(
+      tnsr_datavector_logical, inv_jac_datavector, final_time,
+      functions_of_time);
+  for (const auto& component : inv_hessian_datavector) {
+    CHECK_ITERABLE_APPROX(component, (DataVector{0.0, 0.0, 0.0}));
+  }
+
+  test_serialization(time_dependent_map_first);
+
+  const auto serialized_map =
+      serialize_and_deserialize(time_dependent_map_first);
+
+  inv_hessian_double = serialized_map.inv_hessian(
+      tnsr_double_logical, inv_jac_double, final_time, functions_of_time);
+  for (const auto& component : inv_hessian_double) {
+    CHECK(component == 0.0);
+  }
+  inv_hessian_datavector =
+      serialized_map.inv_hessian(tnsr_datavector_logical, inv_jac_datavector,
+                                 final_time, functions_of_time);
+  for (const auto& component : inv_hessian_datavector) {
+    CHECK_ITERABLE_APPROX(component, (DataVector{0.0, 0.0, 0.0}));
+  }
+}
+#endif // SPECTRE_AUTODIFF
 
 void test_push_back() {
   INFO("Coordinate map with affine map");
@@ -1522,6 +1721,9 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMap", "[Domain][Unit]") {
   test_make_vector_coordinate_map_base();
   test_coordinate_maps_are_identity();
   test_time_dependent_map();
+  #ifdef SPECTRE_AUTODIFF
+  test_time_dependent_map_for_hessian();
+  #endif
   test_push_back();
   test_jacobian_is_time_dependent();
   test_coords_frame_velocity_jacobians();

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/Rectilinear.hpp"

--- a/tests/Unit/Utilities/Autodiff/CMakeLists.txt
+++ b/tests/Unit/Utilities/Autodiff/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+if (NOT SPECTRE_AUTODIFF)
+  return()
+endif()
+
 set(LIBRARY "Test_Autodiff")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -55,9 +55,7 @@ set(LIBRARY_SOURCES
   Test_WrapText.cpp
   )
 
-if (SPECTRE_AUTODIFF)
-  add_subdirectory(Autodiff)
-endif()
+add_subdirectory(Autodiff)
 add_subdirectory(ErrorHandling)
 add_subdirectory(Kokkos)
 add_subdirectory(Protocols)


### PR DESCRIPTION
## Proposed changes
Add inverse Hessian member functions to `CoordinateMap` and `Composition` classes and update the unit tests. Appropriate compile guards have been added to avoid compiling the changed code if `autodiff` is not found. Note that `autodiff` is likely to be required in the near future. We also add a `bool` member in each concrete map to indicate if it supports `autodiff`. The inverse Hessian functions implemented will only work for those maps supporting `autodiff`. This `bool` may be promoted to an `enum` in the future to support analytic Hessians for time-dependent maps.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
