### PR TITLE
Fix compiling auto-fetched dependencies with PIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
 else()
   set(SPECTRE_FETCHCONTENT_BASE_ARGS "")
 endif()
+# Enable position independent code when fetching dependencies because some of
+# them build static libs and these may be linked into shared libs
+if (SPECTRE_FETCH_MISSING_DEPS)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL
+      "Enable position independent code for all targets" FORCE)
+endif()
 
 # Define standard installation directories
 include(GNUInstallDirs)


### PR DESCRIPTION
## Proposed changes

Enable position independent code when fetching dependencies because some of them build static libs and these may be linked into shared libs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
