### PR TITLE
Fix symmetric tensor multi-index reordering in canonicalization

### DIFF
--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -12,12 +12,14 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Array.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Numeric.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -105,29 +107,74 @@ constexpr size_t index_to_swap_with(
   // constructing very large Tensor's. If you are sure Tensor is
   // the correct data structure you can extend the compiler limit
   // by passing the flag -fconstexpr-steps=<SOME LARGER VALUE>
-  while (true) {  // See source code comment on line above this one for fix
-    if (Rank == index_to_swap_with) {
-      return current_index;
-    } else if (tensor_index[current_index] <
-                   tensor_index[index_to_swap_with] and
-               sym[current_index] == sym[index_to_swap_with]) {
+  while (index_to_swap_with < Rank) {  // See comment on line above for fix
+    if (tensor_index[current_index] > tensor_index[index_to_swap_with] and
+        sym[current_index] == sym[index_to_swap_with]) {
       return index_to_swap_with;
     }
-    index_to_swap_with++;
+    index_to_swap_with--;
   }
+  return current_index;
 }
 
-template <size_t Size, size_t SymmSize>
-constexpr cpp20::array<size_t, Size> canonicalize_tensor_index(
-    cpp20::array<size_t, Size> tensor_index,
-    const cpp20::array<int, SymmSize>& symm) {
-  for (size_t i = 0; i < Size; ++i) {
-    const size_t temp = tensor_index[i];
-    const size_t swap = index_to_swap_with(tensor_index, symm, i, i);
-    tensor_index[i] = tensor_index[swap];
-    tensor_index[swap] = temp;
+// \brief Reorders a tensor multi-index to a canonical form based on its
+// symmetries
+//
+// \details Reorders the values of the symmetric indices of a multi-index such
+// that each symmetric subset has values descending from left to right in the
+// multi-index. For example, if `tensor_index` is `[1, 2, 3, 4]` and `symm` is
+// `[2, 2, 1, 1]`, the returned canonical multi-index is `[2, 1, 4, 3]`.
+//
+// \param tensor_index the multi-index to canonicalize
+// \tparam symm the canonical symmetry of the tensor
+// (see `Symmetry` for the form of canonical symmetries)
+// \return the reordered, canonical form of `tensor_index`
+template <size_t Rank>
+constexpr cpp20::array<size_t, Rank> canonicalize_tensor_index(
+    cpp20::array<size_t, Rank> tensor_index,
+    const cpp20::array<int, Rank>& symm) {
+  for (size_t i = 1; i < Rank; ++i) {
+    for (size_t j = i; j < Rank; --j) {
+      const size_t temp = tensor_index[j];
+      const size_t swap = index_to_swap_with(tensor_index, symm, j, j);
+      tensor_index[j] = tensor_index[swap];
+      tensor_index[swap] = temp;
+    }
   }
   return tensor_index;
+}
+
+// \brief Reorders a tensor multi-index to a canonical form based on its
+// symmetries
+//
+// \details See other overload for detaiils
+//
+// \tparam Symm the symmetry of the tensor
+// \param tensor_index the multi-index to canonicalize
+// \return the reordered, canonical form of `tensor_index`
+template <typename Symm, size_t Rank>
+constexpr cpp20::array<size_t, Rank> canonicalize_tensor_index(
+    cpp20::array<size_t, Rank> tensor_index) {
+  static_assert(tmpl::size<Symm>::value == Rank,
+                "Symm and tensor_index have different ranks");
+
+  if constexpr (Rank < 2) {
+    return tensor_index;
+  } else {
+    constexpr auto symm = make_cpp20_array_from_list<Symm>();
+    constexpr auto max_symm_value = *alg::max_element(symm);
+    static_assert(*alg::min_element(symm) > 0,
+                  "canonicalize_tensor_index assumes symmetry values are > 0");
+    static_assert(
+        max_symm_value <= Rank,
+        "canonicalize_tensor_index assumes symmetry values are <= Rank");
+
+    if constexpr (max_symm_value == Rank) {
+      return tensor_index;
+    } else {
+      return canonicalize_tensor_index(tensor_index, symm);
+    }
+  }
 }
 
 template <size_t Rank>
@@ -162,31 +209,47 @@ template <typename Symm, size_t NumberOfComponents>
 constexpr auto compute_collapsed_to_storage(
     const cpp20::array<size_t, tmpl::size<Symm>::value>& index_dimensions) {
   if constexpr (tmpl::size<Symm>::value != 0) {
-    cpp20::array<size_t, NumberOfComponents> collapsed_to_storage{};
-    auto tensor_index =
-        convert_to_cpp20_array(make_array<tmpl::size<Symm>::value>(size_t{0}));
-    size_t count{0};
-    for (auto& current_storage_index : collapsed_to_storage) {
-      // Compute canonical tensor_index, which, for symmetric get_tensor_index
-      // is in decreasing numerical order, e.g. (3,2) rather than (2,3).
-      const auto canonical_tensor_index = canonicalize_tensor_index(
-          tensor_index, make_cpp20_array_from_list<Symm>());
-      // If the tensor_index was already in the canonical form, then it must be
-      // a new unique entry  and we add it to collapsed_to_storage_ as a new
-      // integer, thus increasing the size_. Else, the StorageIndex has already
-      // been determined so we look it up in the existing collapsed_to_storage
-      // table.
-      if (tensor_index == canonical_tensor_index) {
-        current_storage_index = count;
-        ++count;
-      } else {
-        current_storage_index = collapsed_to_storage[compute_collapsed_index(
-            canonical_tensor_index, index_dimensions)];
+    constexpr size_t rank = tmpl::size<Symm>::value;
+    constexpr auto symm = make_cpp20_array_from_list<Symm>();
+    constexpr std::int32_t max_symm_value = *alg::max_element(symm);
+    static_assert(
+        *alg::min_element(symm) > 0,
+        "compute_collapsed_to_storage assumes symmetry values are > 0");
+    static_assert(
+        max_symm_value <= rank,
+        "compute_collapsed_to_storage assumes symmetry values are <= rank");
+
+    if constexpr (max_symm_value == rank) {
+      const size_t first_storage_index{0};
+      cpp20::array<size_t, NumberOfComponents> collapsed_to_storage{};
+      return alg::iota(collapsed_to_storage, first_storage_index);
+    } else {
+      cpp20::array<size_t, NumberOfComponents> collapsed_to_storage{};
+      auto tensor_index = convert_to_cpp20_array(
+          make_array<tmpl::size<Symm>::value>(size_t{0}));
+      size_t count{0};
+      for (auto& current_storage_index : collapsed_to_storage) {
+        // Compute canonical tensor_index, which, for symmetric get_tensor_index
+        // is in decreasing numerical order, e.g. (3,2) rather than (2,3).
+        const auto canonical_tensor_index =
+            canonicalize_tensor_index<Symm>(tensor_index);
+        // If the tensor_index was already in the canonical form, then it must
+        // be a new unique entry  and we add it to collapsed_to_storage_ as a
+        // new integer, thus increasing the size_. Else, the StorageIndex has
+        // already been determined so we look it up in the existing
+        // collapsed_to_storage table.
+        if (tensor_index == canonical_tensor_index) {
+          current_storage_index = count;
+          ++count;
+        } else {
+          current_storage_index = collapsed_to_storage[compute_collapsed_index(
+              canonical_tensor_index, index_dimensions)];
+        }
+        // Move to the next tensor_index.
+        increment_tensor_index(tensor_index, index_dimensions);
       }
-      // Move to the next tensor_index.
-      increment_tensor_index(tensor_index, index_dimensions);
+      return collapsed_to_storage;
     }
-    return collapsed_to_storage;
   } else {
     (void)index_dimensions;
 
@@ -218,14 +281,14 @@ template <typename Symm, size_t NumIndComps, size_t NumComps>
 constexpr auto compute_storage_to_tensor(
     const cpp20::array<size_t, NumComps>& collapsed_to_storage,
     const cpp20::array<size_t, tmpl::size<Symm>::value>& index_dimensions) {
-  if constexpr (tmpl::size<Symm>::value > 0) {
+  if constexpr (tmpl::size<Symm>::value != 0) {
     constexpr size_t rank = tmpl::size<Symm>::value;
     cpp20::array<cpp20::array<size_t, rank>, NumIndComps> storage_to_tensor{};
     cpp20::array<size_t, rank> tensor_index =
         convert_to_cpp20_array(make_array<rank>(size_t{0}));
     for (const auto& current_storage_index : collapsed_to_storage) {
-      storage_to_tensor[current_storage_index] = canonicalize_tensor_index(
-          tensor_index, make_cpp20_array_from_list<Symm>());
+      storage_to_tensor[current_storage_index] =
+          canonicalize_tensor_index<Symm>(tensor_index);
       increment_tensor_index(tensor_index, index_dimensions);
     }
     return storage_to_tensor;

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Utilities/Array.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
@@ -1100,23 +1101,172 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.StreamStructure",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Structure.Indices",
-                  "[DataStructures][Unit]") {
-  const int dim = 3;
-  Tensor_detail::Structure<Symmetry<2, 1, 1>,
-                           SpatialIndex<dim, UpLo::Lo, Frame::Grid>,
-                           SpatialIndex<dim, UpLo::Lo, Frame::Grid>,
-                           SpatialIndex<dim, UpLo::Lo, Frame::Grid>>
-      tensor;
-  for (size_t j = 0; j < dim; ++j) {
-    for (size_t k = j; k < dim; ++k) {
-      for (size_t i = 0; i < dim; ++i) {
-        CHECK(tensor.get_storage_index(std::array<size_t, 3>{{i, j, k}}) ==
-              tensor.get_storage_index(tensor.get_canonical_tensor_index(
-                  tensor.get_storage_index(std::array<size_t, 3>{{i, j, k}}))));
+namespace {
+// Helper for calculating the flattened 1D index of a multi-dimensional index
+template <size_t Rank>
+size_t get_flattened_index(const cpp20::array<size_t, Rank>& tensor_index,
+                           const std::array<size_t, Rank>& index_dims) {
+  if constexpr (Rank == 0) {
+    return 0;
+  } else if constexpr (Rank == 1) {
+    return tensor_index[0];
+  } else {
+    size_t flattened_index = gsl::at(tensor_index, Rank - 1);
+    for (size_t i = Rank - 2; i < Rank; i--) {
+      flattened_index =
+          gsl::at(tensor_index, i) + gsl::at(index_dims, i) * flattened_index;
+    }
+    return flattened_index;
+  }
+}
+
+// Checks that:
+// (1) `get_storage_index` and `get_canonical_tensor_index` are inverses
+// (2) `canonicalize_tensor_index` yields the same canonical multi-index for
+//     components with symmetric indices
+//
+// (1) tests `Structure`'s interface while (2) tests its internal logic
+template <typename S>
+void check_tensor_index_canonicalization(const S& structure) {
+  constexpr size_t rank = S::rank();
+  static_assert(
+      rank > 0 and rank <= 4,
+      "check_tensor_index_canonicalization only implemented for ranks 1 - 4");
+
+  using symmetry = typename S::symmetry;
+  constexpr auto index_dims = S::dims();
+  constexpr size_t num_ind_components = S::size();
+  constexpr size_t num_total_components =
+      Tensor_detail::number_of_components(index_dims);
+  std::array<bool, num_total_components> index_hit{};
+  std::fill(index_hit.begin(), index_hit.end(), false);
+
+  size_t num_unique_canon_indices = 0;
+  if constexpr (rank == 1) {
+    for (size_t i = 0; i < index_dims[0]; i++) {
+      const auto canon_multi_index =
+          Tensor_detail::canonicalize_tensor_index<symmetry>(
+              cpp20::array<size_t, rank>{{i}});
+      const size_t flattened_index =
+          get_flattened_index(canon_multi_index, index_dims);
+      if (not gsl::at(index_hit, flattened_index)) {
+        num_unique_canon_indices++;
+      }
+      gsl::at(index_hit, flattened_index) = true;
+
+      CHECK(structure.get_storage_index(std::array<size_t, rank>{{i}}) ==
+            structure.get_storage_index(structure.get_canonical_tensor_index(
+                structure.get_storage_index(std::array<size_t, rank>{{i}}))));
+    }
+  } else if constexpr (rank == 2) {
+    for (size_t i = 0; i < index_dims[0]; i++) {
+      for (size_t j = 0; j < index_dims[1]; j++) {
+        const auto canon_multi_index =
+            Tensor_detail::canonicalize_tensor_index<symmetry>(
+                cpp20::array<size_t, rank>{{i, j}});
+        const size_t flattened_index =
+            get_flattened_index(canon_multi_index, index_dims);
+        if (not gsl::at(index_hit, flattened_index)) {
+          num_unique_canon_indices++;
+        }
+        gsl::at(index_hit, flattened_index) = true;
+
+        CHECK(structure.get_storage_index(std::array<size_t, rank>{{i, j}}) ==
+              structure.get_storage_index(structure.get_canonical_tensor_index(
+                  structure.get_storage_index(
+                      std::array<size_t, rank>{{i, j}}))));
+      }
+    }
+  } else if constexpr (rank == 3) {
+    for (size_t i = 0; i < index_dims[0]; i++) {
+      for (size_t j = 0; j < index_dims[1]; j++) {
+        for (size_t k = 0; k < index_dims[2]; k++) {
+          const auto canon_multi_index =
+              Tensor_detail::canonicalize_tensor_index<symmetry>(
+                  cpp20::array<size_t, rank>{{i, j, k}});
+          const size_t flattened_index =
+              get_flattened_index(canon_multi_index, index_dims);
+          if (not gsl::at(index_hit, flattened_index)) {
+            num_unique_canon_indices++;
+          }
+          gsl::at(index_hit, flattened_index) = true;
+
+          CHECK(
+              structure.get_storage_index(
+                  std::array<size_t, rank>{{i, j, k}}) ==
+              structure.get_storage_index(structure.get_canonical_tensor_index(
+                  structure.get_storage_index(
+                      std::array<size_t, rank>{{i, j, k}}))));
+        }
+      }
+    }
+  } else {
+    for (size_t i = 0; i < index_dims[0]; i++) {
+      for (size_t j = 0; j < index_dims[1]; j++) {
+        for (size_t k = 0; k < index_dims[2]; k++) {
+          for (size_t l = 0; l < index_dims[3]; l++) {
+            const auto canon_multi_index =
+                Tensor_detail::canonicalize_tensor_index<symmetry>(
+                    cpp20::array<size_t, rank>{{i, j, k, l}});
+            const size_t flattened_index =
+                get_flattened_index(canon_multi_index, index_dims);
+            if (not gsl::at(index_hit, flattened_index)) {
+              num_unique_canon_indices++;
+            }
+            gsl::at(index_hit, flattened_index) = true;
+
+            CHECK(structure.get_storage_index(
+                      std::array<size_t, rank>{{i, j, k, l}}) ==
+                  structure.get_storage_index(
+                      structure.get_canonical_tensor_index(
+                          structure.get_storage_index(
+                              std::array<size_t, rank>{{i, j, k, l}}))));
+          }
+        }
       }
     }
   }
+
+  CHECK(num_unique_canon_indices == num_ind_components);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Structure.Indices",
+                  "[DataStructures][Unit]") {
+  const int spatial_dim1 = 3;
+  const Tensor_detail::Structure<
+      Symmetry<2, 1, 1>, SpatialIndex<spatial_dim1, UpLo::Lo, Frame::Grid>,
+      SpatialIndex<spatial_dim1, UpLo::Lo, Frame::Grid>,
+      SpatialIndex<spatial_dim1, UpLo::Lo, Frame::Grid>>
+      structure1;
+
+  constexpr size_t spatial_dim2 = 1;
+  const Tensor_detail::Structure<
+      Symmetry<1, 2, 1>, SpacetimeIndex<spatial_dim2, UpLo::Lo, Frame::Grid>,
+      SpatialIndex<spatial_dim2, UpLo::Lo, Frame::Grid>,
+      SpacetimeIndex<spatial_dim2, UpLo::Lo, Frame::Grid>>
+      structure2;
+
+  constexpr size_t spatial_dim3 = 3;
+  const Tensor_detail::Structure<
+      Symmetry<1, 1, 1>, SpatialIndex<spatial_dim3, UpLo::Up, Frame::Inertial>,
+      SpatialIndex<spatial_dim3, UpLo::Up, Frame::Inertial>,
+      SpatialIndex<spatial_dim3, UpLo::Up, Frame::Inertial>>
+      structure3;
+
+  constexpr size_t spatial_dim4 = 3;
+  const Tensor_detail::Structure<
+      Symmetry<1, 2, 2, 1>,
+      SpatialIndex<spatial_dim4, UpLo::Lo, Frame::Inertial>,
+      SpacetimeIndex<spatial_dim4, UpLo::Up, Frame::Inertial>,
+      SpacetimeIndex<spatial_dim4, UpLo::Up, Frame::Inertial>,
+      SpatialIndex<spatial_dim4, UpLo::Lo, Frame::Inertial>>
+      structure4;
+
+  check_tensor_index_canonicalization(structure1);
+  check_tensor_index_canonicalization(structure2);
+  check_tensor_index_canonicalization(structure3);
+  check_tensor_index_canonicalization(structure4);
 }
 
 SPECTRE_TEST_CASE("Unit.Serialization.Tensor",


### PR DESCRIPTION
This fixes a bug where not all multi-indices that are equivalent under symmetry were being sorted to the same canonical form. It also updates the creation of the mapping of storage indices to/from multi-indices to elide canonicalizing multi-indices of non-symmetric tensors because it's unnecessary.

An example of the bug before this commit:
Given a tensor with `Symmetry<1, 1, 1>`, `canonicalize_tensor_index()` would return the the canonical multi-index `[2, 1, 0]` for the following multi-indices that are equivalent under symmetry: `[0, 2, 1]`, `[1, 0, 2]`, `[1, 2, 0]`, `[2, 0, 1]`, and `[2, 1, 0]`. However, it would return a different multi-index, `[1, 2, 0]`, when the input multi-index was `[0, 1, 2]`.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
