### PR TITLE
PlotPowerMonitors: warn if not double precision

### DIFF
--- a/src/IO/H5/Python/IterElements.py
+++ b/src/IO/H5/Python/IterElements.py
@@ -221,12 +221,16 @@ def iter_elements(
             # Pre-load the tensor data because it's stored contiguously for all
             # grids in the file
             if tensor_components:
-                tensor_data = np.asarray(
-                    [
-                        volfile.get_tensor_component(obs_id, component).data
-                        for component in tensor_components
-                    ]
-                )
+                component_data = [
+                    volfile.get_tensor_component(obs_id, component).data
+                    for component in tensor_components
+                ]
+                # Ensure that all components have the same data type
+                for data in component_data:
+                    assert (
+                        data.dtype == component_data[0].dtype
+                    ), "Tensor components have different data types"
+                tensor_data = np.asarray(component_data)
             # Iterate elements in this file
             for grid_name, element_id, mesh in zip(
                 grid_names, element_ids, meshes

--- a/src/IO/H5/Python/TensorData.cpp
+++ b/src/IO/H5/Python/TensorData.cpp
@@ -3,6 +3,7 @@
 
 #include "IO/H5/Python/TensorData.hpp"
 
+#include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -27,7 +28,21 @@ void bind_tensordata(py::module& m) {
       .def(py::init<std::string, DataVector>(), py::arg("name"),
            py::arg("data"))
       .def_readwrite("name", &TensorComponent::name)
-      .def_readwrite("data", &TensorComponent::data)
+      .def_property_readonly(
+          "data",
+          [](TensorComponent& self) {
+            // Return a numpy array view of the data with the correct dtype
+            // (float32 for std::vector<float> and float64 for DataVector)
+            return std::visit(
+                [&self](auto& storage) -> py::array {
+                  using ValueType =
+                      typename std::decay_t<decltype(storage)>::value_type;
+                  return py::array_t<ValueType>(
+                      {static_cast<py::ssize_t>(storage.size())},
+                      storage.data(), py::cast(&self));
+                },
+                self.data);
+          })
       .def("__str__", get_output<TensorComponent>)
       .def("__repr__", get_output<TensorComponent>)
       // NOLINTNEXTLINE(misc-redundant-expression)

--- a/src/Visualization/Python/PlotPowerMonitors.py
+++ b/src/Visualization/Python/PlotPowerMonitors.py
@@ -91,6 +91,7 @@ def plot_power_monitors(
         num_elements = np.zeros(num_cols, dtype=int)
         max_error = np.zeros((num_cols, domain.dim))
 
+    shown_dtype_warning_once = False
     for element, tensor_data in iter_elements(
         volfiles, obs_id, tensor_components, element_patterns=element_patterns
     ):
@@ -113,6 +114,14 @@ def plot_power_monitors(
             np.zeros(element.mesh.extents(d) - skip_filtered_modes)
             for d in range(element.dim)
         ]
+        if tensor_data.dtype != np.float64:
+            if not shown_dtype_warning_once:
+                logger.warning(
+                    "Tensor data is not double precision. Power monitors"
+                    " will be inaccurate below the precision of the data."
+                )
+                shown_dtype_warning_once = True
+            tensor_data = tensor_data.astype(np.float64)
         for component in tensor_data:
             modes = power_monitors(DataVector(component), element.mesh)
             for d, modes_dim in enumerate(modes):

--- a/tests/Unit/IO/H5/Test_CombineH5.py
+++ b/tests/Unit/IO/H5/Test_CombineH5.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 import numpy as np
+import numpy.testing as npt
 from click.testing import CliRunner
 
 import spectre.IO.H5 as spectre_h5
@@ -235,13 +236,12 @@ class TestCombineH5(unittest.TestCase):
             ]
         )
         for i in range(len(expected_tensor_components)):
-            value = (
+            npt.assert_equal(
                 output_vol.get_tensor_component(
                     i, actual_tensor_component_names[i]
-                ).data
-                == expected_tensor_components[i]
+                ).data,
+                expected_tensor_components[i],
             )
-            self.assertEqual(value, True)
 
     def test_cli(self):
         # Checks if the CLI for CombineH5 runs properly

--- a/tests/Unit/IO/H5/Test_TensorData.py
+++ b/tests/Unit/IO/H5/Test_TensorData.py
@@ -17,7 +17,7 @@ class TestTensorData(unittest.TestCase):
     def test_tensor_component(self):
         # Set up Tensor Component
         tensor_component = TensorComponent(
-            "tensor component", DataVector([1.5, 1.1])
+            "tensor component", DataVector([6.7, 3.2])
         )
         # Test name
         self.assertEqual(tensor_component.name, "tensor component")
@@ -25,12 +25,9 @@ class TestTensorData(unittest.TestCase):
         self.assertEqual(tensor_component.name, "new tensor component")
         # Test data
         npt.assert_array_almost_equal(
-            np.array(tensor_component.data), np.array([1.5, 1.1])
+            tensor_component.data, np.array([6.7, 3.2])
         )
-        tensor_component.data = DataVector([6.7, 3.2])
-        npt.assert_array_almost_equal(
-            np.array(tensor_component.data), np.array([6.7, 3.2])
-        )
+        self.assertEqual(tensor_component.data.dtype, np.float64)
         # Test str, repr
         self.assertEqual(
             str(tensor_component), "(new tensor component, (6.7,3.2))"


### PR DESCRIPTION
## Proposed changes

Power monitors are truncated and possibly misleading if volume data is single precision.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
