### PR TITLE
Worldtube: add BH spin tag

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -68,6 +68,16 @@ struct Charge {
 };
 
 /*!
+ * \brief The dimensionless spin vector of the central black hole.
+ */
+struct Spin {
+  using type = std::array<double, 3>;
+  static constexpr Options::String help{
+      "The value of the scalar charge in units of the black hole mass M."};
+  using group = Worldtube;
+};
+
+/*!
  * \brief Options for the scalar self-force. Select `None` for a purely geodesic
  * evolution
  *
@@ -292,6 +302,19 @@ struct Charge : db::SimpleTag {
   using option_tags = tmpl::list<OptionTags::Charge>;
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double charge) { return charge; };
+};
+
+/*!
+ * \brief The dimensionless spin vector of the central black hole.
+ */
+struct Spin : db::SimpleTag {
+  using type = std::array<double, 3>;
+  using option_tags = tmpl::list<OptionTags::Spin>;
+  static constexpr bool pass_metavariables = false;
+  static std::array<double, 3> create_from_options(
+      const std::array<double, 3> spin) {
+    return spin;
+  };
 };
 
 /*!

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -731,11 +731,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
             CurvedScalarWave::Worldtube::OptionTags::ExpansionOrder>("0") == 0);
   CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Charge>("1.") == 1.);
+  CHECK(TestHelpers::test_option_tag<
+            CurvedScalarWave::Worldtube::OptionTags::Spin>("[0., 0., 0.5]") ==
+        std::array<double, 3>{0., 0., 0.5});
   TestHelpers::db::test_simple_tag<Tags::ExcisionSphere<3>>("ExcisionSphere");
+
   TestHelpers::db::test_simple_tag<
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Charge>(
       "Charge");
+  TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Spin>(
+      "Spin");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Mass>(
       "Mass");
   TestHelpers::db::test_simple_tag<


### PR DESCRIPTION
## Proposed changes

Added the black hole dimensionless spin vector to the scope of options and simple tags.

Inclusive is updates to the input file and unit test to reflect the new options and simple tag.