### PR TITLE
AMR: allow to enable only specific blocks

### DIFF
--- a/src/ParallelAlgorithms/Amr/Actions/Component.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/Component.hpp
@@ -41,7 +41,8 @@ struct Component {
   static constexpr bool checkpoint_data = true;
 
   using const_global_cache_tags =
-      tmpl::list<amr::Criteria::Tags::Criteria, amr::Tags::Policies,
+      tmpl::list<amr::Criteria::Tags::Criteria,
+                 amr::Tags::AmrBlocks<volume_dim>, amr::Tags::Policies,
                  logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>;
 
   using phase_dependent_action_list = tmpl::list<

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -106,36 +106,48 @@ struct EvaluateRefinementCriteria {
     constexpr size_t volume_dim = Metavariables::volume_dim;
     auto overall_decision = make_array<volume_dim>(amr::Flag::Undefined);
 
-    using compute_tags = tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
-        tmpl::at<typename Metavariables::factory_creation::factory_classes,
-                 Criterion>,
-        detail::get_tags<tmpl::_1>>>>;
-    auto observation_box =
-        make_observation_box<compute_tags>(make_not_null(&box));
+    // Evaluate criteria on blocks that have AMR enabled, and "do nothing" on
+    // the other blocks.
+    // Note that blocks that do not have AMR enabled can still be refined to
+    // satisfy 2:1 balance. When this happens, they won't coarsen back since "do
+    // nothing" has higher priority than coarsening. This behavior can be
+    // changed if needed.
+    const auto& amr_blocks = db::get<amr::Tags::AmrBlocks<volume_dim>>(box);
+    if (not amr_blocks.has_value() or
+        amr_blocks->contains(element_id.block_id())) {
+      using compute_tags =
+          tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+              tmpl::at<
+                  typename Metavariables::factory_creation::factory_classes,
+                  Criterion>,
+              detail::get_tags<tmpl::_1>>>>;
+      auto observation_box =
+          make_observation_box<compute_tags>(make_not_null(&box));
 
-    const auto& refinement_criteria =
-        db::get<amr::Criteria::Tags::Criteria>(box);
-    for (const auto& criterion : refinement_criteria) {
-      if (Metavariables::amr::p_refine_only_in_event and
-          criterion->type() == amr::Criteria::Type::p) {
-        continue;
+      const auto& refinement_criteria =
+          db::get<amr::Criteria::Tags::Criteria>(box);
+      for (const auto& criterion : refinement_criteria) {
+        if (Metavariables::amr::p_refine_only_in_event and
+            criterion->type() == amr::Criteria::Type::p) {
+          continue;
+        }
+        auto decision = criterion->evaluate(observation_box, cache, element_id);
+        if constexpr (Metavariables::amr::p_refine_only_in_event) {
+          ASSERT(alg::none_of(decision,
+                              [](amr::Flag flag) {
+                                return flag == amr::Flag::IncreaseResolution or
+                                       flag == amr::Flag::DecreaseResolution;
+                              }),
+                 "The criterion '"
+                     << typeid(*criterion).name()
+                     << "' requested p-refinement, but claims to be "
+                        "for h-refinement.");
+        }
+        for (size_t d = 0; d < volume_dim; ++d) {
+          overall_decision[d] = std::max(overall_decision[d], decision[d]);
+        }
       }
-      auto decision = criterion->evaluate(observation_box, cache, element_id);
-      if constexpr (Metavariables::amr::p_refine_only_in_event) {
-        ASSERT(alg::none_of(decision,
-                            [](amr::Flag flag) {
-                              return flag == amr::Flag::IncreaseResolution or
-                                     flag == amr::Flag::DecreaseResolution;
-                            }),
-               "The criterion '"
-                   << typeid(*criterion).name()
-                   << "' requested p-refinement, but claims to be "
-                      "for h-refinement.");
-      }
-      for (size_t d = 0; d < volume_dim; ++d) {
-        overall_decision[d] = std::max(overall_decision[d], decision[d]);
-      }
-    }
+    }  // amr_blocks.contains(element_id.block_id())
 
     // If no refinement criteria were called, then set flag to do nothing
     for (size_t d = 0; d < volume_dim; ++d) {

--- a/src/ParallelAlgorithms/Amr/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Amr/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 set(LIBRARY ParallelAmr)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  Tags.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
@@ -14,12 +20,15 @@ spectre_target_headers(
 
 target_link_libraries(
   ${LIBRARY}
+  PUBLIC
+  DataStructures
+  Domain
+  DomainStructure
   INTERFACE
   Amr
   AmrCriteria
   AmrPolicies
   AmrProjectors
-  DataStructures
   Initialization
   Logging
   Printf

--- a/src/ParallelAlgorithms/Amr/Tags.cpp
+++ b/src/ParallelAlgorithms/Amr/Tags.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/Amr/Tags.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace amr::Tags {
+
+template <size_t Dim>
+std::optional<std::unordered_set<size_t>> AmrBlocks<Dim>::create_from_options(
+    const std::optional<std::vector<std::string>>& block_names,
+    const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) {
+  if (not block_names.has_value()) {
+    return std::nullopt;
+  }
+  // Resolve block names and IDs
+  const auto all_block_names = domain_creator->block_names();
+  std::unordered_set<size_t> result{};
+  for (const auto& name : domain::expand_block_groups_to_block_names(
+           block_names.value(), all_block_names,
+           domain_creator->block_groups())) {
+    result.insert(static_cast<size_t>(std::distance(
+        all_block_names.begin(),
+        std::find(all_block_names.begin(), all_block_names.end(), name))));
+  }
+  return result;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data)                                    \
+  template std::optional<std::unordered_set<size_t>>              \
+  AmrBlocks<DIM(data)>::create_from_options(                      \
+      const std::optional<std::vector<std::string>>& block_names, \
+      const std::unique_ptr<::DomainCreator<DIM(data)>>& domain_creator);
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+#undef INSTANTIATION
+#undef DIM
+
+}  // namespace amr::Tags

--- a/src/ParallelAlgorithms/Amr/Tags.hpp
+++ b/src/ParallelAlgorithms/Amr/Tags.hpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 
 #include "DataStructures/DataBox/Tag.hpp"
+#include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "IO/Observer/Tags.hpp"
@@ -23,18 +24,33 @@
 /// Options for AMR
 namespace amr::OptionTags {
 
+/// Group for AMR options
 struct AmrGroup {
   static std::string name() { return "Amr"; }
   static constexpr Options::String help =
       "Options for adaptive mesh refinement (AMR)";
 };
 
+/// Maximum number of AMR levels to keep.
 struct MaxCoarseLevels {
   using type = Options::Auto<size_t>;
   static constexpr Options::String help =
       "Maximum number of coarser AMR levels to keep. A value of '0' means that "
       "only the finest grid is kept, and 'Auto' means the number of levels "
       "is not restricted.";
+  using group = AmrGroup;
+};
+
+/// Blocks in which AMR is enabled.
+struct AmrBlocks {
+  static std::string name() { return "EnableInBlocks"; }
+  struct All {};
+  using type = Options::Auto<std::vector<std::string>, All>;
+  static constexpr Options::String help =
+      "Blocks in which AMR is enabled. Note that blocks that do not have AMR "
+      "enabled can still be refined to satisfy 2:1 balance. When this happens, "
+      "they won't coarsen back since 'do nothing' has higher priority than "
+      "coarsening. This behavior can be changed if needed.";
   using group = AmrGroup;
 };
 
@@ -50,7 +66,20 @@ struct MaxCoarseLevels : db::SimpleTag {
   using type = std::optional<size_t>;
   static constexpr bool pass_metavariables = false;
   using option_tags = tmpl::list<OptionTags::MaxCoarseLevels>;
-  static type create_from_options(const type value) { return value; };
+  static type create_from_options(const type value) { return value; }
+};
+
+/// The set of block IDs in which AMR is enabled. If `std::nullopt`, AMR is
+/// enabled in all blocks.
+template <size_t Dim>
+struct AmrBlocks : db::SimpleTag {
+  using type = std::optional<std::unordered_set<size_t>>;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::AmrBlocks,
+                                 ::domain::OptionTags::DomainCreator<Dim>>;
+  static type create_from_options(
+      const std::optional<std::vector<std::string>>& block_names,
+      const std::unique_ptr<::DomainCreator<Dim>>& domain_creator);
 };
 
 /// All element IDs grouped by grid index are stored in this tag. The element

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -167,6 +167,7 @@ DomainCreator:
 Amr:
   Verbosity: Verbose
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -301,6 +301,7 @@ Cce:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -178,6 +178,7 @@ Observers:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -116,6 +116,7 @@ EventsAndTriggersAtIterations:
 Amr:
   Verbosity: Quiet
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -149,6 +149,7 @@ EventsAndTriggersAtIterations:
 Amr:
   Verbosity: Quiet
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -166,6 +166,7 @@ EventsAndTriggersAtIterations:
 Amr:
   Verbosity: Quiet
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -22,6 +22,7 @@ Amr:
           Split: 2
           Join: 1
           DoNothing: 1
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
@@ -22,6 +22,7 @@ Amr:
           Split: 2
           Join: 1
           DoNothing: 1
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -21,6 +21,7 @@ Amr:
           Split: 2
           Join: 1
           DoNothing: 1
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -16,6 +16,7 @@ Parallelization:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -16,6 +16,7 @@ Parallelization:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -17,6 +17,7 @@ Parallelization:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -159,6 +159,7 @@ Amr:
         Exponent: 4
         AbsoluteTolerance: 0
         CoarseningFactor: 0.1
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -28,6 +28,7 @@ Evolution:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -29,6 +29,7 @@ Evolution:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -53,6 +53,7 @@ Evolution:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -53,6 +53,7 @@ Amr:
   Verbosity: Verbose
   Criteria:
     - IncreaseResolution
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -82,6 +82,7 @@ Amr:
         # Second AMR iteration will increase num points from 4 to 5
         Target: [5]
         OscillationAtTarget: [DoNothing]
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -119,6 +119,7 @@ EventsAndTriggersAtIterations:
 Amr:
   Verbosity: Quiet
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -122,6 +122,7 @@ EventsAndTriggersAtIterations:
 Amr:
   Verbosity: Quiet
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -77,6 +77,7 @@ Amr:
     # h-refine (split) elements at the punctures, and p-refine everywhere else
     - RefineAtPunctures
     - IncreaseResolution
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -36,6 +36,7 @@ Amr:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.e-6
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -36,6 +36,7 @@ Amr:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.e-6
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -38,6 +38,7 @@ Amr:
         VariablesToMonitor: [Psi]
         AbsoluteTarget: 1.e-6
         RelativeTarget: 1.e-6
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -32,6 +32,7 @@ InitialData:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -26,6 +26,7 @@ InitialData:
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere.yaml
@@ -24,6 +24,7 @@ InitialData: &InitialData
 
 Amr:
   Criteria:
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -160,6 +160,7 @@ DomainCreator:
 Amr:
   Verbosity: Verbose
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -230,6 +230,7 @@ EventsAndTriggersAtIterations:
 Amr:
   Verbosity: Quiet
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -118,6 +118,7 @@ Amr:
   Verbosity: Verbose
   Criteria:
     - IncreaseResolution
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -164,6 +164,7 @@ EventsAndTriggersAtIterations:
 Amr:
   Verbosity: Quiet
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -485,6 +485,7 @@ struct AmrComponent {
   using component_being_mocked = ::amr::Component<Metavariables>;
   using const_global_cache_tags =
       tmpl::list<::amr::Criteria::Tags::Criteria, ::amr::Tags::Policies,
+                 ::amr::Tags::AmrBlocks<Metavariables::volume_dim>,
                  logging::Tags::Verbosity<::amr::OptionTags::AmrGroup>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
@@ -627,7 +628,8 @@ void test_subdomain_operator(
         logging::Tags::Verbosity<DummyOptionsGroup>,
         elliptic::dg::Tags::PenaltyParameter, elliptic::dg::Tags::Massive,
         elliptic::dg::Tags::Quadrature, elliptic::dg::Tags::Formulation,
-        ::amr::Criteria::Tags::Criteria, ::amr::Tags::Policies,
+        ::amr::Criteria::Tags::Criteria, ::amr::Tags::AmrBlocks<Dim>,
+        ::amr::Tags::Policies,
         logging::Tags::Verbosity<::amr::OptionTags::AmrGroup>>{
         std::move(domain), domain_creator.functions_of_time(),
         std::move(boundary_conditions),
@@ -635,6 +637,7 @@ void test_subdomain_operator(
         max_overlap.has_value() ? std::optional<size_t>(overlap) : std::nullopt,
         ::Verbosity::Verbose, penalty_parameter, use_massive_dg_operator,
         quadrature, ::dg::Formulation::StrongInertial, std::move(amr_criteria),
+        std::nullopt,
         ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true,
                         true},
         ::Verbosity::Debug}};

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -149,7 +149,9 @@ struct AmrComponent {
   using array_index = int;
   using component_being_mocked = ::amr::Component<Metavariables>;
   using const_global_cache_tags =
-      tmpl::list<::amr::Criteria::Tags::Criteria, ::amr::Tags::Policies,
+      tmpl::list<::amr::Criteria::Tags::Criteria,
+                 amr::Tags::AmrBlocks<Metavariables::volume_dim>,
+                 ::amr::Tags::Policies,
                  logging::Tags::Verbosity<amr::OptionTags::AmrGroup>>;
 
   using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
@@ -372,12 +374,13 @@ void test_dg_operator(
       ::elliptic::dg::Tags::PenaltyParameter, ::elliptic::dg::Tags::Massive,
       ::elliptic::dg::Tags::Quadrature, ::elliptic::dg::Tags::Formulation,
       ::Tags::AnalyticSolution<AnalyticSolution>,
-      ::amr::Criteria::Tags::Criteria, ::amr::Tags::Policies,
+      ::amr::Criteria::Tags::Criteria, amr::Tags::AmrBlocks<Dim>,
+      ::amr::Tags::Policies,
       logging::Tags::Verbosity<::amr::OptionTags::AmrGroup>>{
       std::move(domain), domain_creator.functions_of_time(),
       std::move(boundary_conditions), penalty_parameter,
       use_massive_dg_operator, quadrature, dg_formulation, analytic_solution,
-      std::move(amr_criteria),
+      std::move(amr_criteria), std::nullopt,
       ::amr::Policies{::amr::Isotropy::Anisotropic, ::amr::Limits{}, true,
                       true},
       ::Verbosity::Debug}};

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -102,7 +102,8 @@ struct Component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<volume_dim>;
   using const_global_cache_tags =
-      tmpl::list<amr::Criteria::Tags::Criteria, amr::Tags::Policies>;
+      tmpl::list<amr::Criteria::Tags::Criteria,
+                 amr::Tags::AmrBlocks<volume_dim>, amr::Tags::Policies>;
   using simple_tags =
       tmpl::list<domain::Tags::Element<volume_dim>,
                  domain::Tags::Mesh<volume_dim>, amr::Tags::Info<volume_dim>,
@@ -163,6 +164,7 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
   const ElementId<1> lo_id(0, {{{1, 0}}});
   const ElementId<1> up_id(1, {{{1, 0}}});
   const ElementId<1> up_sibling_id(1, {{{1, 1}}});
+  const ElementId<1> disabled_block_id(2, {{{0, 0}}});
   const Mesh<1> self_mesh{2_st, Spectral::Basis::Legendre,
                           Spectral::Quadrature::GaussLobatto};
   const Mesh<1> lo_mesh{3_st, Spectral::Basis::Legendre,
@@ -180,9 +182,10 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
 
   amr::Info<1> initial_info{std::array{amr::Flag::Undefined}, Mesh<1>{}};
   std::unordered_map<ElementId<1>, amr::Info<1>> initial_neighbor_info;
+  const std::unordered_set<size_t> amr_blocks{0, 1};
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {std::move(criteria),
+      {std::move(criteria), amr_blocks,
        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
 
   const Element<1> self(self_id,
@@ -208,11 +211,22 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
       &runner, up_id, {up, up_mesh, initial_info, initial_neighbor_info});
 
   const Element<1> up_sibling(
-      up_sibling_id, {{{Direction<1>::lower_xi(),
-                        {{up_id}, OrientationMap<1>::create_aligned()}}}});
+      up_sibling_id,
+      {{{Direction<1>::lower_xi(),
+         {{up_id}, OrientationMap<1>::create_aligned()}},
+        {Direction<1>::upper_xi(),
+         {{disabled_block_id}, OrientationMap<1>::create_aligned()}}}});
   ActionTesting::emplace_component_and_initialize<my_component>(
       &runner, up_sibling_id,
       {up_sibling, up_sibling_mesh, initial_info, initial_neighbor_info});
+
+  const Element<1> disabled_block(
+      disabled_block_id,
+      {{{Direction<1>::lower_xi(),
+         {{up_sibling_id}, OrientationMap<1>::create_aligned()}}}});
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, disabled_block_id,
+      {disabled_block, up_sibling_mesh, initial_info, initial_neighbor_info});
 
   runner.set_phase(Parallel::Phase::Testing);
 
@@ -297,6 +311,22 @@ void evaluate_criteria(std::vector<std::unique_ptr<amr::Criterion>> criteria,
     CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
               runner, id) == (id == self_id ? 2 : (id == lo_id ? 1 : 0)));
   }
+
+  // disabled block runs EvaluateAmrCriteria, which queues nothing
+  ActionTesting::simple_action<my_component,
+                               amr::Actions::EvaluateRefinementCriteria>(
+      make_not_null(&runner), disabled_block_id);
+  const amr::Info<1> disabled_block_info{
+      std::array<amr::Flag, 1>{amr::Flag::DoNothing}, up_sibling_mesh};
+  for (const auto& id : {disabled_block_id}) {
+    CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Info<1>>(
+              runner, id) == disabled_block_info);
+    CHECK(ActionTesting::get_databox_tag<my_component,
+                                         amr::Tags::NeighborInfo<1>>(
+              runner, id) == initial_neighbor_info);
+    CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+              runner, id) == 0);
+  }
 }
 
 void check_split_while_join_is_avoided() {
@@ -332,7 +362,7 @@ void check_split_while_join_is_avoided() {
   // But we do not allow an Element to simultaneously split and join so the
   // action should change the flags to (DoNothing, Split)
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {std::move(criteria),
+      {std::move(criteria), std::nullopt,
        amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
 
   const Element<2> self(self_id, {});

--- a/tests/Unit/ParallelAlgorithms/Amr/Test_Tags.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Test_Tags.cpp
@@ -8,6 +8,7 @@
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Tags",
                   "[ParallelAlgorithms][Unit]") {
+  TestHelpers::db::test_simple_tag<amr::Tags::AmrBlocks<1>>("AmrBlocks");
   TestHelpers::db::test_simple_tag<amr::Tags::AllElementIds<1>>(
       "AllElementIds");
   TestHelpers::db::test_simple_tag<amr::Tags::ParentId<1>>("ParentId");

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -86,6 +86,7 @@ RichardsonSmoother:
 Amr:
   Verbosity: Verbose
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -77,6 +77,7 @@ RichardsonSmoother:
 Amr:
   Verbosity: Verbose
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -93,6 +93,7 @@ RichardsonSmoother:
 Amr:
   Verbosity: Verbose
   Criteria: []
+  EnableInBlocks: All
   Policies:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic


### PR DESCRIPTION
## Proposed changes

Useful to enable AMR only on some blocks, e.g. the blocks around the excisions in a BBH, while keeping other blocks to "do nothing" during AMR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Add the option `Amr.EnableInBlocks: All` to keep the current behavior.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
