### PR TITLE
Fix bug when setting ringdown L1 coeffs to zero

### DIFF
--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
@@ -254,7 +254,9 @@ FunctionsOfTimeMap get_shape_and_size(
             deformed_radius * 2.0 * sqrt(M_PI);
         // Set l=0 for shape map to 0 because size control will adjust l=0
         gsl::at(shape_funcs, i)[0] = 0.0;
-        if (set_l1_coefs_to_zero) {
+        // Always set l=1 derivatives to zero because shape control does not
+        // control adjust these components
+        if (i >= (set_l1_coefs_to_zero ? 0 : 1)){
           for (int m = -1; m <= 1; m++) {
             gsl::at(shape_funcs, i)[iter.set(1_st, m)()] = 0.0;
           }


### PR DESCRIPTION
## Proposed changes

Always set l=1 derivatives to zero because shape control does not control adjust these components and will cause a linear drift during the evolution if we set ` SetL1CoefsToZero: False` in the ringdown input file.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
