### PR TITLE
Add Psi4Imag computation

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -174,6 +174,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
@@ -446,7 +447,8 @@ struct EvolutionMetavars {
                                                   Frame::Inertial>,
               gr::Tags::WeylTypeD1Compute<DataVector, 3, Frame::Inertial>,
               gr::Tags::WeylTypeD1ScalarCompute<DataVector, 3, Frame::Inertial>,
-              gr::Tags::Psi4RealCompute<Frame::Inertial>>,
+              gr::Tags::Psi4RealCompute<Frame::Inertial>,
+              gr::Tags::Psi4ImagCompute<Frame::Inertial>>,
           tmpl::list<>>>;
   using non_tensor_compute_tags = tmpl::list<
       ::Events::Tags::ObserverMeshCompute<volume_dim>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -116,6 +116,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
@@ -259,7 +260,8 @@ struct ObserverTags {
                                                   Frame::Inertial>,
               gr::Tags::WeylTypeD1Compute<DataVector, 3, Frame::Inertial>,
               gr::Tags::WeylTypeD1ScalarCompute<DataVector, 3, Frame::Inertial>,
-              gr::Tags::Psi4RealCompute<Frame::Inertial>>,
+              gr::Tags::Psi4RealCompute<Frame::Inertial>,
+              gr::Tags::Psi4ImagCompute<Frame::Inertial>>,
           tmpl::list<>>>;
   using non_tensor_compute_tags = tmpl::list<
       ::Events::Tags::ObserverMeshCompute<volume_dim>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -204,6 +204,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
@@ -513,6 +514,7 @@ struct GhValenciaDivCleanTemplateBase<
               ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
           gr::Tags::WeylElectricCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::Psi4RealCompute<Frame::Inertial>,
+          gr::Tags::Psi4ImagCompute<Frame::Inertial>,
           ::Events::Tags::ObserverMeshVelocity<3>>,
       tmpl::conditional_t<
           use_dg_subcell,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -111,6 +111,7 @@
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintDampingTags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
@@ -282,7 +283,8 @@ struct ObserverTags {
           gr::Tags::WeylElectric<DataVector, volume_dim, Frame::Inertial>,
           gr::Tags::WeylElectricScalar<DataVector>,
           gr::Tags::WeylMagneticScalar<DataVector>,
-          gr::Tags::Psi4RealCompute<Frame::Inertial>>>;
+          gr::Tags::Psi4RealCompute<Frame::Inertial>,
+          gr::Tags::Psi4ImagCompute<Frame::Inertial>>>;
   using non_tensor_compute_tags = tmpl::list<
       ::Events::Tags::ObserverMeshCompute<volume_dim>,
       ::Events::Tags::ObserverCoordinatesCompute<volume_dim, Frame::Inertial>,

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -24,6 +24,7 @@ spectre_target_sources(
   MomentumConstraint.cpp
   ProjectionOperators.cpp
   Psi4.cpp
+  Psi4Imag.cpp
   Psi4Real.cpp
   QuadraticCurvatureScalars.cpp
   Ricci.cpp
@@ -64,6 +65,7 @@ spectre_target_headers(
   ProjectionOperators.hpp
   Ricci.hpp
   Psi4.hpp
+  Psi4Imag.hpp
   Psi4Real.hpp
   QuadraticCurvatureScalars.hpp
   Shift.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/Psi4Imag.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Psi4Imag.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace gr {
+
+template <typename Frame>
+void psi_4_imag(
+    const gsl::not_null<Scalar<DataVector>*> psi_4_imag_result,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords) {
+  get(*psi_4_imag_result) = imag(get(
+      psi_4(spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
+            spatial_metric, inverse_spatial_metric, inertial_coords)));
+}
+
+template <typename Frame>
+Scalar<DataVector> psi_4_imag(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords) {
+  auto psi_4_imag_result = make_with_value<Scalar<DataVector>>(
+      get<0, 0>(inverse_spatial_metric),
+      std::numeric_limits<double>::signaling_NaN());
+  psi_4_imag(make_not_null(&psi_4_imag_result), spatial_ricci,
+             extrinsic_curvature, cov_deriv_extrinsic_curvature, spatial_metric,
+             inverse_spatial_metric, inertial_coords);
+  return psi_4_imag_result;
+}
+}  // namespace gr
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template Scalar<DataVector> gr::psi_4_imag(                             \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci,          \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,    \
+      const tnsr::ijj<DataVector, 3, FRAME(data)>&                        \
+          cov_deriv_extrinsic_curvature,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric, \
+      const tnsr::I<DataVector, 3, FRAME(data)>& inertial_coords);        \
+  template void gr::psi_4_imag(                                           \
+      const gsl::not_null<Scalar<DataVector>*> psi_4_imag_result,         \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_ricci,          \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& extrinsic_curvature,    \
+      const tnsr::ijj<DataVector, 3, FRAME(data)>&                        \
+          cov_deriv_extrinsic_curvature,                                  \
+      const tnsr::ii<DataVector, 3, FRAME(data)>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric, \
+      const tnsr::I<DataVector, 3, FRAME(data)>& inertial_coords);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+/// \cond
+namespace domain::Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+}  // namespace domain::Tags
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace gr {
+
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the imaginary part of the Newman Penrose quantity
+ * \f$\Psi_4\f$ using  \f$\Psi_4[Imag] = -0.5*U^{8+}_{ij}*(x^ix^j - y^iy^j)\f$.
+ */
+template <typename Frame>
+void psi_4_imag(
+    gsl::not_null<Scalar<DataVector>*> psi_4_imag_result,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords);
+
+template <typename Frame>
+Scalar<DataVector> psi_4_imag(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::ijj<DataVector, 3, Frame>& cov_deriv_extrinsic_curvature,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric,
+    const tnsr::I<DataVector, 3, Frame>& inertial_coords);
+
+namespace Tags {
+/// Computes the imaginary part of the Newman Penrose quantity \f$\Psi_4\f$
+/// using \f$\Psi_4[Imag] = -0.5*U^{8+}_{ij}*(x^ix^j - y^iy^j)\f$.
+///
+/// Can be retrieved using `gr::Tags::Psi4Imag`
+template <typename Frame>
+struct Psi4ImagCompute : Psi4Imag<DataVector>, db::ComputeTag {
+  using argument_tags = tmpl::list<
+      gr::Tags::SpatialRicci<DataVector, 3, Frame>,
+      gr::Tags::ExtrinsicCurvature<DataVector, 3, Frame>,
+      ::Tags::deriv<gr::Tags::ExtrinsicCurvature<DataVector, 3, Frame>,
+                    tmpl::size_t<3>, Frame>,
+      gr::Tags::SpatialMetric<DataVector, 3, Frame>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3, Frame>,
+      domain::Tags::Coordinates<3, Frame>>;
+
+  using return_type = Scalar<DataVector>;
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataVector>*>, const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::ijj<DataVector, 3, Frame>&,
+      const tnsr::ii<DataVector, 3, Frame>&,
+      const tnsr::II<DataVector, 3, Frame>&,
+      const tnsr::I<DataVector, 3, Frame>&)>(&psi_4_imag<Frame>);
+  using base = Psi4Imag<DataVector>;
+};
+}  // namespace Tags
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
@@ -295,6 +296,15 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
             const tnsr::ijj<DataVector, 3>&, const tnsr::ii<DataVector, 3>&,
             const tnsr::II<DataVector, 3>&, const tnsr::I<DataVector, 3>&)>(
             &::gr::psi_4_real),
+        py::arg("spatial_ricci"), py::arg("extrinsic_curvature"),
+        py::arg("cov_deriv_extrinsic_curvature"), py::arg("spatial_metric"),
+        py::arg("inverse_spatial_metric"), py::arg("inertial_coords"));
+  m.def("psi4imag",
+        static_cast<Scalar<DataVector> (*)(
+            const tnsr::ii<DataVector, 3>&, const tnsr::ii<DataVector, 3>&,
+            const tnsr::ijj<DataVector, 3>&, const tnsr::ii<DataVector, 3>&,
+            const tnsr::II<DataVector, 3>&, const tnsr::I<DataVector, 3>&)>(
+            &::gr::psi_4_imag),
         py::arg("spatial_ricci"), py::arg("extrinsic_curvature"),
         py::arg("cov_deriv_extrinsic_curvature"), py::arg("spatial_metric"),
         py::arg("inverse_spatial_metric"), py::arg("inertial_coords"));

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -192,6 +192,14 @@ struct Psi4Real : db::SimpleTag {
 };
 
 /*!
+ * \brief Computes the imaginary part of \f$\Psi_4\f$
+ */
+template <typename DataType>
+struct Psi4Imag : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
  * \brief The energy density \f$E=n_a n_b T^{ab}\f$, where \f$n_a\f$ denotes the
  * normal to the spatial hypersurface
  */

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -70,6 +70,8 @@ struct SpatialRicciScalar;
 template <typename DataType>
 struct Psi4Real;
 template <typename DataType>
+struct Psi4Imag;
+template <typename DataType>
 struct EnergyDensity;
 template <typename DataType>
 struct StressTrace;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -142,6 +142,15 @@ class TestBindings(unittest.TestCase):
             inertial_coords,
         )
         npt.assert_allclose(psi_4_real, 0)
+        psi_4_imag = psi4imag(
+            spatial_ricci,
+            extrinsic_curvature,
+            cov_deriv_extrinsic_curvature,
+            flat_metric,
+            inverse_metric,
+            inertial_coords,
+        )
+        npt.assert_allclose(psi_4_imag, 0)
 
     def test_ricci(self):
         christoffel_second_kind = tnsr.Abb[DataVector, 3](

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Psi4.cpp
@@ -18,6 +18,7 @@
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Psi4Imag.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Psi4Real.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
@@ -27,6 +28,8 @@ template <typename RealDataType>
 void test_compute_item_in_databox(const RealDataType& used_for_size_real) {
   TestHelpers::db::test_compute_tag<gr::Tags::Psi4RealCompute<Frame::Inertial>>(
       "Psi4Real");
+  TestHelpers::db::test_compute_tag<gr::Tags::Psi4ImagCompute<Frame::Inertial>>(
+      "Psi4Imag");
 
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> distribution(0.1, 3.0);
@@ -60,14 +63,20 @@ void test_compute_item_in_databox(const RealDataType& used_for_size_real) {
           gr::Tags::SpatialMetric<RealDataType, 3>,
           gr::Tags::InverseSpatialMetric<RealDataType, 3>,
           domain::Tags::Coordinates<3, Frame::Inertial>>,
-      db::AddComputeTags<gr::Tags::Psi4RealCompute<Frame::Inertial>>>(
+      db::AddComputeTags<gr::Tags::Psi4RealCompute<Frame::Inertial>,
+                         gr::Tags::Psi4ImagCompute<Frame::Inertial>>>(
       spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
       spatial_metric, inv_spatial_metric, inertial_coords);
-  const auto expected = gr::psi_4_real(
+  const auto psi_4_real_expected = gr::psi_4_real(
       spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
       spatial_metric, inv_spatial_metric, inertial_coords);
   CHECK_ITERABLE_APPROX((db::get<gr::Tags::Psi4Real<RealDataType>>(box)),
-                        expected);
+                        psi_4_real_expected);
+  const auto psi_4_imag_expected = gr::psi_4_imag(
+      spatial_ricci, extrinsic_curvature, cov_deriv_extrinsic_curvature,
+      spatial_metric, inv_spatial_metric, inertial_coords);
+  CHECK_ITERABLE_APPROX((db::get<gr::Tags::Psi4Imag<RealDataType>>(box)),
+                        psi_4_imag_expected);
 }
 
 template <typename RealDataType, typename ComplexDataType>


### PR DESCRIPTION
## Proposed changes

Add a Psi4Imag computation and compute tag. To the greatest extent copied from Psi4Real

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
