### PR TITLE
Solve hydro+Ye characteristics numerically

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
@@ -3,9 +3,18 @@
 
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
+#include <gsl/gsl_complex.h>
+#include <gsl/gsl_complex_math.h>
+#include <gsl/gsl_eigen.h>
+#include <gsl/gsl_math.h>
+#include <gsl/gsl_matrix.h>
+#include <gsl/gsl_vector.h>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
@@ -99,6 +108,7 @@ void compute_characteristic_speeds_approximate_mhd(
 }  // namespace
 
 namespace grmhd::ValenciaDivClean {
+
 template <size_t ThermodynamicDim>
 void characteristic_speeds_approximate_mhd(
     const gsl::not_null<std::array<DataVector, 9>*> char_speeds,
@@ -231,26 +241,29 @@ std::array<DataVector, 9> characteristic_speeds_approximate_mhd(
 
 template <size_t ThermodynamicDim>
 void characteristic_speeds_hydro(
-    const gsl::not_null<std::array<DataVector, 3>*> char_speeds,
+    const gsl::not_null<tnsr::i<DataVector, 3>*> characteristic_speeds,
+    /* primitive variables */
     const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
     const Scalar<DataVector>& rest_mass_density,
     const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& specific_enthalpy,
     const Scalar<DataVector>& electron_fraction,
+    /* other helpful quantities */
     const Scalar<DataVector>& lorentz_factor,
-    const tnsr::i<DataVector, 3>& unit_normal,
+    const Scalar<DataVector>& specific_enthalpy,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) {
   const size_t num_grid_points = get(lorentz_factor).size();
-  if ((*char_speeds)[0].size() != num_grid_points) {
-    for (auto& cs : (*char_speeds)) {
-      cs = DataVector(num_grid_points, 0.0);
+  if (characteristic_speeds->get(0).size() != num_grid_points) {
+    for (size_t i = 0; i < 3; ++i) {
+      characteristic_speeds->get(i) = DataVector(num_grid_points, 0.0);
     }
   }
 
   Variables<tmpl::list<hydro::Tags::SpatialVelocityOneForm<DataVector, 3>,
                        hydro::Tags::SpatialVelocitySquared<DataVector>,
+                       hydro::Tags::Temperature<DataVector>,
                        hydro::Tags::SoundSpeedSquared<DataVector>,
                        ::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
                        ::Tags::TempScalar<2>, ::Tags::TempScalar<3>>>
@@ -291,9 +304,11 @@ void characteristic_speeds_hydro(
                     rest_mass_density, specific_internal_energy));
     get(sound_speed_squared) /= get(specific_enthalpy);
   } else if constexpr (ThermodynamicDim == 3) {
-    const auto temperature =
-        equation_of_state.temperature_from_density_and_energy(
-            rest_mass_density, specific_internal_energy, electron_fraction);
+    Scalar<DataVector>& temperature =
+        get<hydro::Tags::Temperature<DataVector>>(temp_tensors);
+    get(temperature) =
+        get(equation_of_state.temperature_from_density_and_energy(
+            rest_mass_density, specific_internal_energy, electron_fraction));
     get(sound_speed_squared) =
         get(equation_of_state.sound_speed_squared_from_density_and_temperature(
             rest_mass_density, temperature, electron_fraction));
@@ -314,36 +329,516 @@ void characteristic_speeds_hydro(
                             (1 - get(sound_speed_squared))) /
       (get(lorentz_factor) * get(denom));
 
-  enum HydroSpeed : uint32_t {
-    NormalDotVelocity = 0,
-    LambdaPlus = 1,
-    LambdaMinus = 2
-  };
-  // Degenerate eigenvalue (normal dot velocity)
-  (*char_speeds)[HydroSpeed::NormalDotVelocity] = get(normal_velocity);
-  (*char_speeds)[HydroSpeed::LambdaPlus] = get(first_term) + get(second_term);
-  (*char_speeds)[HydroSpeed::LambdaMinus] = get(first_term) - get(second_term);
+  // Degenerate characteristic speed (normal dot velocity)
+  characteristic_speeds->get(HydroSpeed::NormalDotVelocity) =
+      get(normal_velocity);
+  characteristic_speeds->get(HydroSpeed::LambdaPlus) =
+      get(first_term) + get(second_term);
+  characteristic_speeds->get(HydroSpeed::LambdaMinus) =
+      get(first_term) - get(second_term);
 }
 
 
 template <size_t ThermodynamicDim>
-std::array<DataVector, 3> characteristic_speeds_hydro(
+tnsr::i<DataVector, 3> characteristic_speeds_hydro(
     const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
     const Scalar<DataVector>& rest_mass_density,
     const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& specific_enthalpy,
     const Scalar<DataVector>& electron_fraction,
     const Scalar<DataVector>& lorentz_factor,
-    const tnsr::i<DataVector, 3>& unit_normal,
+    const Scalar<DataVector>& specific_enthalpy,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) {
-  std::array<DataVector, 3> char_speeds{};
-  characteristic_speeds_hydro(
-      make_not_null(&char_speeds), spatial_velocity, rest_mass_density,
-      specific_internal_energy, specific_enthalpy, electron_fraction,
-      lorentz_factor, unit_normal, spatial_metric, equation_of_state);
-  return char_speeds;
+  tnsr::i<DataVector, 3> characteristic_speeds{};
+  characteristic_speeds_hydro(make_not_null(&characteristic_speeds),
+                              spatial_velocity, rest_mass_density,
+                              specific_internal_energy, electron_fraction,
+                              lorentz_factor, specific_enthalpy, spatial_metric,
+                              unit_normal, equation_of_state);
+  return characteristic_speeds;
+}
+
+template <size_t ThermodynamicDim>
+void flux_jacobian_hydro(
+    const gsl::not_null<tnsr::iJ<DataVector, 6>*> characteristic_matrix,
+    /* primitive variables */
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& electron_fraction,
+    /* other helpful quantities */
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) {
+  Variables<tmpl::list<hydro::Tags::SoundSpeedSquared<DataVector>,
+                       hydro::Tags::Pressure<DataVector>,
+                       ::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
+                       ::Tags::TempScalar<2>, ::Tags::TempScalar<3>,
+                       ::Tags::TempScalar<4>, ::Tags::TempScalar<5>,
+                       ::Tags::TempScalar<6>, ::Tags::TempScalar<7>,
+                       ::Tags::TempScalar<8>, ::Tags::TempI<0, 3>,
+                       ::Tags::Tempi<0, 3>, ::Tags::TempIj<0, 3>,
+                       ::Tags::TempI<1, 3>>>
+      temp_tensors{get<0, 0>(spatial_metric).size()};
+
+  Scalar<DataVector>& sound_speed_squared =
+      get<hydro::Tags::SoundSpeedSquared<DataVector>>(temp_tensors);
+  // We define kappa as the partial derivative of pressure with respect to
+  // specific internal energy
+  Scalar<DataVector>& kappa = get<::Tags::TempScalar<0>>(temp_tensors);
+  // We define zeta as the partial derivative of pressure with respect to
+  // electron fraction
+  Scalar<DataVector>& zeta = get<::Tags::TempScalar<1>>(temp_tensors);
+  Scalar<DataVector>& kappa_times_p_over_rho_squared =
+      get<::Tags::TempScalar<2>>(temp_tensors);
+  Scalar<DataVector>& pressure =
+      get<hydro::Tags::Pressure<DataVector>>(temp_tensors);
+  if constexpr (ThermodynamicDim == 1) {
+    get(sound_speed_squared) =
+        get(equation_of_state.chi_from_density(rest_mass_density)) +
+        get(equation_of_state.kappa_times_p_over_rho_squared_from_density(
+            rest_mass_density));
+    get(sound_speed_squared) /= get(specific_enthalpy);
+    get(kappa) = 0.0;
+    get(zeta) = 0.0;
+  } else if constexpr (ThermodynamicDim == 2) {
+    get(kappa_times_p_over_rho_squared) =
+        get(equation_of_state
+                .kappa_times_p_over_rho_squared_from_density_and_energy(
+                    rest_mass_density, specific_internal_energy));
+    get(sound_speed_squared) =
+        (get(equation_of_state.chi_from_density_and_energy(
+             rest_mass_density, specific_internal_energy)) +
+         get(kappa_times_p_over_rho_squared)) /
+        get(specific_enthalpy);
+    get(pressure) = get(equation_of_state.pressure_from_density_and_energy(
+        rest_mass_density, specific_internal_energy));
+    get(kappa) = get(kappa_times_p_over_rho_squared) / get(pressure) *
+                 square(get(rest_mass_density));
+    get(zeta) = 0.0;
+  } else if constexpr (ThermodynamicDim == 3) {
+    const Scalar<DataVector> temperature =
+        equation_of_state.temperature_from_density_and_energy(
+            rest_mass_density, specific_internal_energy, electron_fraction);
+    get(sound_speed_squared) =
+        get(equation_of_state.sound_speed_squared_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction));
+    get(pressure) = get(equation_of_state.pressure_from_density_and_temperature(
+        rest_mass_density, temperature, electron_fraction));
+    get(kappa) = get(equation_of_state.kappa_from_density_and_temperature(
+        rest_mass_density, temperature, electron_fraction));
+    get(zeta) = get(equation_of_state.zeta_from_density_and_temperature(
+        rest_mass_density, temperature, electron_fraction));
+  }
+
+  // Intermediate variables
+  Scalar<DataVector>& Z = get<::Tags::TempScalar<3>>(temp_tensors);
+  tenex::evaluate(make_not_null(&Z),
+                  rest_mass_density() * specific_enthalpy() *
+                      square(lorentz_factor()));
+  Scalar<DataVector>& D = get<::Tags::TempScalar<4>>(temp_tensors);
+  tenex::evaluate(make_not_null(&D), rest_mass_density() * lorentz_factor());
+  Scalar<DataVector>& normal_velocity = get<::Tags::TempScalar<5>>(temp_tensors);
+  tenex::evaluate(make_not_null(&normal_velocity),
+                  spatial_velocity(ti::I) * unit_normal(ti::i));
+  tnsr::I<DataVector, 3>& unit_vector = get<::Tags::TempI<0, 3>>(temp_tensors);
+  tenex::evaluate<ti::I>(make_not_null(&unit_vector),
+                         inv_spatial_metric(ti::I, ti::J) * unit_normal(ti::j));
+  tnsr::i<DataVector, 3>& spatial_velocity_one_form =
+      get<::Tags::Tempi<0, 3>>(temp_tensors);
+  tenex::evaluate<ti::i>(make_not_null(&spatial_velocity_one_form),
+                         spatial_metric(ti::i, ti::j) *
+                             spatial_velocity(ti::J));
+  tnsr::Ij<DataVector, 3>& mixed_spatial_metric =
+      get<::Tags::TempIj<0, 3>>(temp_tensors);
+  tenex::evaluate<ti::I, ti::j>(make_not_null(&mixed_spatial_metric),
+                                inv_spatial_metric(ti::I, ti::K) *
+                                    spatial_metric(ti::k, ti::j));
+
+  // Derivatives of Z
+  Scalar<DataVector>& dzdD = get<::Tags::TempScalar<6>>(temp_tensors);
+  tenex::evaluate(
+      make_not_null(&dzdD),
+      -((lorentz_factor() *
+         (kappa() * (-specific_enthalpy() + lorentz_factor()) -
+          zeta() * electron_fraction() +
+          (sound_speed_squared() * specific_enthalpy() + lorentz_factor()) *
+              rest_mass_density())) /
+        ((-square(lorentz_factor()) +
+          sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+         rest_mass_density())));
+  tnsr::I<DataVector, 3>& dzds = get<::Tags::TempI<1, 3>>(temp_tensors);
+  tenex::evaluate<ti::I>(
+      make_not_null(&dzds),
+      (spatial_velocity(ti::I) * square(lorentz_factor()) *
+       (kappa() + sound_speed_squared() * rest_mass_density())) /
+      ((-square(lorentz_factor()) +
+        sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+       rest_mass_density()));
+  Scalar<DataVector>& dzdtau = get<::Tags::TempScalar<7>>(temp_tensors);
+  tenex::evaluate(
+      make_not_null(&dzdtau),
+      -((square(lorentz_factor()) * (kappa() + rest_mass_density())) /
+        ((-square(lorentz_factor()) +
+          sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+         rest_mass_density())));
+  Scalar<DataVector>& dzdye = get<::Tags::TempScalar<8>>(temp_tensors);
+  tenex::evaluate(
+      make_not_null(&dzdye),
+      (zeta() * lorentz_factor()) /
+      ((square(lorentz_factor()) -
+        sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+       rest_mass_density()));
+
+  // Put analytic expressions into characteristic matrix
+  characteristic_matrix->get(0, 0) =
+      ((get(Z) - get(D) * get(dzdD)) * get(normal_velocity)) / get(Z);
+  for (size_t B = 0; B < 3; ++B) {
+    characteristic_matrix->get(0, B + 1) =
+        (get(D) * (unit_vector.get(B) - dzds.get(B) * get(normal_velocity))) /
+        get(Z);
+  }
+  characteristic_matrix->get(0, 4) =
+      -((get(D) * get(dzdtau) * get(normal_velocity)) / get(Z));
+  characteristic_matrix->get(0, 5) =
+      -((get(D) * get(dzdye) * get(normal_velocity)) / get(Z));
+  for (size_t c = 0; c < 3; ++c) {
+    characteristic_matrix->get(c + 1, 0) =
+        (-1.0 + get(dzdD)) * unit_normal.get(c) -
+        get(dzdD) * get(normal_velocity) * spatial_velocity_one_form.get(c);
+    for (size_t B = 0; B < 3; ++B) {
+      characteristic_matrix->get(c + 1, B + 1) =
+          mixed_spatial_metric.get(B, c) * get(normal_velocity) +
+          unit_vector.get(B) * spatial_velocity_one_form.get(c) +
+          dzds.get(B) *
+              (unit_normal.get(c) -
+               get(normal_velocity) * spatial_velocity_one_form.get(c));
+    }
+    characteristic_matrix->get(c + 1, 4) =
+        (-1.0 + get(dzdtau)) * unit_normal.get(c) -
+        get(dzdtau) * get(normal_velocity) * spatial_velocity_one_form.get(c);
+    characteristic_matrix->get(c + 1, 5) =
+        get(dzdye) * (unit_normal.get(c) -
+                      get(normal_velocity) * spatial_velocity_one_form.get(c));
+  }
+  characteristic_matrix->get(4, 0) =
+      -(((get(Z) - get(D) * get(dzdD)) * get(normal_velocity)) / get(Z));
+  for (size_t B = 0; B < 3; ++B) {
+    characteristic_matrix->get(4, B + 1) =
+        ((get(Z) - get(D)) * unit_vector.get(B) +
+         get(D) * dzds.get(B) * get(normal_velocity)) /
+        get(Z);
+  }
+  characteristic_matrix->get(4, 4) =
+      (get(D) * get(dzdtau) * get(normal_velocity)) / get(Z);
+  characteristic_matrix->get(4, 5) =
+      (get(D) * get(dzdye) * get(normal_velocity)) / get(Z);
+  characteristic_matrix->get(5, 0) =
+      -((get(D) * get(electron_fraction) * get(dzdD) * get(normal_velocity)) /
+        get(Z));
+  for (size_t B = 0; B < 3; ++B) {
+    characteristic_matrix->get(5, B + 1) =
+        (get(D) * get(electron_fraction) *
+         (unit_vector.get(B) - dzds.get(B) * get(normal_velocity))) /
+        get(Z);
+  }
+  characteristic_matrix->get(5, 4) =
+      -((get(D) * get(electron_fraction) * get(dzdtau) * get(normal_velocity)) /
+        get(Z));
+  characteristic_matrix->get(5, 5) =
+      ((get(Z) - get(D) * get(electron_fraction) * get(dzdye)) *
+       get(normal_velocity)) /
+      get(Z);
+}
+
+template <size_t ThermodynamicDim>
+void numerical_characteristics(
+    const gsl::not_null<tnsr::i<DataVector, 6>*> characteristic_speeds,
+    const gsl::not_null<tnsr::ij<DataVector, 6>*> characteristic_modes,
+    const gsl::not_null<tnsr::IJ<DataVector, 6>*> characteristic_projectors,
+    /* primitive variables */
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& electron_fraction,
+    /* other helpful quantities */
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) {
+  // Build characteristic matrix
+  Variables<tmpl::list<::Tags::TempiJ<0, 6>>> temp_tensors{
+      get<0, 0>(spatial_metric).size()};
+  tnsr::iJ<DataVector, 6>& characteristic_matrix =
+      get<::Tags::TempiJ<0, 6>>(temp_tensors);
+  flux_jacobian_hydro(make_not_null(&characteristic_matrix), spatial_velocity,
+                      rest_mass_density, specific_internal_energy,
+                      electron_fraction,
+                      /* other helpful quantities */
+                      lorentz_factor, specific_enthalpy, spatial_metric,
+                      inv_spatial_metric, unit_normal, equation_of_state);
+
+  // Allocate memory to work with blaze::geev (outside of loop to save
+  // time/memory)
+  constexpr size_t matrix_size = 6;
+  blaze::StaticMatrix<double, matrix_size, matrix_size> blaze_point_matrix{};
+  blaze::StaticVector<blaze::complex<double>, matrix_size>
+      blaze_complex_eigenvalues{};
+  blaze::StaticMatrix<blaze::complex<double>, matrix_size, matrix_size>
+      blaze_complex_L{};
+  blaze::StaticMatrix<blaze::complex<double>, matrix_size, matrix_size>
+      blaze_complex_R{};
+  std::array<double, matrix_size> blaze_real_eigenvalues{};
+
+  // Loop over each grid point
+  const size_t num_points = get<0, 0>(spatial_metric).size();
+  for (size_t point = 0; point < num_points; ++point) {
+    // Build matrix at this grid point
+    for (size_t row = 0; row < matrix_size; ++row) {
+      for (size_t col = 0; col < matrix_size; ++col) {
+        blaze_point_matrix(row, col) =
+            characteristic_matrix.get(row, col)[point];
+      }
+    }
+
+    // Solve eigensystem using blaze:geev
+    blaze::geev(blaze_point_matrix, blaze_complex_L, blaze_complex_eigenvalues,
+                blaze_complex_R);
+    const double tolerance = 1.0e-12;
+    for (size_t i = 0; i < matrix_size; ++i) {
+      ASSERT(std::abs(blaze_complex_eigenvalues[i].imag()) < tolerance,
+             "Complex eigenvalue: "
+                 << blaze_complex_eigenvalues[i].real() << " + "
+                 << blaze_complex_eigenvalues[i].imag() << " i.");
+      blaze_real_eigenvalues[i] = blaze_complex_eigenvalues[i].real();
+    }
+
+// We found cases in which blaze::geev returns a wrong eigenvalue. As a sanity
+// check, we use GSL to compute the eigenvalues for the same matrix and check
+// that they are the same.
+#ifdef SPECTRE_DEBUG
+    // Allocate memory to work with GSL:
+    // Workspace for computing eigenvalues and eigenvectors
+    gsl_eigen_nonsymm_workspace* gsl_workspace =
+        gsl_eigen_nonsymm_alloc(matrix_size);
+    // Containers for the right eigensystem (A * R = lambda * R)
+    gsl_matrix* gsl_point_matrix = gsl_matrix_alloc(matrix_size, matrix_size);
+    gsl_vector_complex* gsl_complex_eigenvalues =
+        gsl_vector_complex_alloc(matrix_size);
+    gsl_matrix_complex* gsl_complex_right_eigenvectors =
+        gsl_matrix_complex_alloc(matrix_size, matrix_size);
+    std::array<double, matrix_size> gsl_real_eigenvalues{};
+
+    // Build matrix at this grid point
+    for (size_t row = 0; row < matrix_size; ++row) {
+      for (size_t col = 0; col < matrix_size; ++col) {
+        const double entry = characteristic_matrix.get(row, col)[point];
+        gsl_matrix_set(gsl_point_matrix, row, col, entry);
+      }
+    }
+
+    // Solve for eigenvalues using GSL
+    gsl_eigen_nonsymm(gsl_point_matrix, gsl_complex_eigenvalues, gsl_workspace);
+    for (size_t i = 0; i < matrix_size; ++i) {
+      gsl_real_eigenvalues[i] =
+          GSL_REAL(gsl_vector_complex_get(gsl_complex_eigenvalues, i));
+    }
+
+    // Sort both blaze's and GSL's eigenvalues to facilitate comparison
+    std::array<double, matrix_size> sorted_blaze_real_eigenvalues =
+        blaze_real_eigenvalues;
+    std::sort(sorted_blaze_real_eigenvalues.begin(),
+              sorted_blaze_real_eigenvalues.end());
+    std::sort(gsl_real_eigenvalues.begin(), gsl_real_eigenvalues.end());
+
+    // Compare eigenvalues
+    for (size_t i = 0; i < matrix_size; ++i) {
+      if (UNLIKELY(std::abs(sorted_blaze_real_eigenvalues[i] -
+                            gsl_real_eigenvalues[i]) > 1.e-6)) {
+        std::ostringstream matrix_stream;
+        matrix_stream << "Point matrix:\n";
+        for (size_t row = 0; row < matrix_size; ++row) {
+          for (size_t col = 0; col < matrix_size; ++col) {
+            matrix_stream << blaze_point_matrix(row, col) << " ";
+          }
+          matrix_stream << "\n";
+        }
+        matrix_stream << "Blaze eigenvalue: "
+                      << sorted_blaze_real_eigenvalues[i]
+                      << ", GSL eigenvalue: " << gsl_real_eigenvalues[i]
+                      << "\n";
+
+        ERROR(
+            "The eigensolvers from blaze and GSL found different eigenvalues "
+            "for the same matrix.\n"
+            << matrix_stream.str());
+      }
+    }
+
+    // Free GSL allocations
+    gsl_eigen_nonsymm_free(gsl_workspace);
+    gsl_matrix_free(gsl_point_matrix);
+    gsl_vector_complex_free(gsl_complex_eigenvalues);
+    gsl_matrix_complex_free(gsl_complex_right_eigenvectors);
+#endif
+
+    // Check and save results
+    // Track which indices have been processed to avoid double-counting partners
+    std::array<bool, matrix_size> processed_right_eigenvectors{};
+    std::array<bool, matrix_size> processed_left_eigenvectors{};
+    // Note: we're looping through the ith eigenvalue/vectors, not the ith row!
+    for (size_t i = 0; i < matrix_size; ++i) {
+      // Store eigenvalue
+      characteristic_speeds->get(i)[point] = blaze_real_eigenvalues[i];
+
+      // For each PAIR of degenerate eigenvalues, it is possible that GSL
+      // returns a PAIR of complex eigenvectors that are complex conjugates of
+      // each other. Here, we check if the ith right/left eigenvector is
+      // complex.
+      bool right_eigenvector_is_complex = false;
+      bool left_eigenvector_is_complex = false;
+      for (size_t k = 0; k < matrix_size; ++k) {
+        if (std::abs(blaze_complex_R(k, i).imag()) > tolerance) {
+          right_eigenvector_is_complex = true;
+        }
+
+        if (std::abs(blaze_complex_L(k, i).imag()) > tolerance) {
+          left_eigenvector_is_complex = true;
+        }
+      }
+
+      // If either eigenvector is complex, then we know that the vectors formed
+      // by their real and imaginary parts are also linearly-independent
+      // eigenvectors. Here, we use this fact to build real-valued left and
+      // right eigenvectors.
+      if (not processed_right_eigenvectors[i]) {
+        // If needed, find index of complex conjugate eigenvector
+        // Note: most time this will be i+1, but not always.
+        size_t conjugate_i = 0;
+        if (right_eigenvector_is_complex) {
+          for (conjugate_i = i + 1; conjugate_i < matrix_size; ++conjugate_i) {
+            // Assume that this eigenvector is the conjugate until we find
+            // otherwise by checking each component
+            bool is_conjugate = true;
+            for (size_t k = 0; k < matrix_size; ++k) {
+              const auto component = blaze_complex_R(k, i);
+              const auto conjugate_component = blaze_complex_R(k, conjugate_i);
+              if (std::abs(component.real() - conjugate_component.real()) >
+                      tolerance or
+                  std::abs(component.imag() + conjugate_component.imag()) >
+                      tolerance) {
+                is_conjugate = false;
+                break;
+              }
+            }
+            // If we made it through all components, then we've found the
+            // conjugate eigenvector
+            if (is_conjugate) {
+              break;
+            }
+          }
+        }
+        ASSERT(not right_eigenvector_is_complex or
+                   (conjugate_i > i and conjugate_i < matrix_size),
+               "Found complex right eigenvector without identifying its "
+               "conjugate partner.");
+        // If the eigenvector is complex, then its respective eigenvalue must
+        // be degenerate
+        if (right_eigenvector_is_complex) {
+          ASSERT(
+              blaze_real_eigenvalues[i] - blaze_real_eigenvalues[conjugate_i] <
+                  1.e-8,
+              "Expected degenerate eigenvalues for complex eigenvectors, but "
+              "eigenvalues differ by "
+                  << blaze_real_eigenvalues[i] -
+                         blaze_real_eigenvalues[conjugate_i]
+                  << ".");
+        }
+        // Process the ith right eigenvector (and its complex conjugate if
+        // needed)
+        for (size_t k = 0; k < matrix_size; ++k) {
+          characteristic_modes->get(i, k)[point] = blaze_complex_R(k, i).real();
+          if (right_eigenvector_is_complex) {
+            characteristic_modes->get(conjugate_i, k)[point] =
+                blaze_complex_R(k, i).imag();
+          }
+        }
+        processed_right_eigenvectors[i] = true;
+        if (right_eigenvector_is_complex) {
+          processed_right_eigenvectors[conjugate_i] = true;
+        }
+      }
+
+      // Same as above, but for left eigenvectors
+      if (not processed_left_eigenvectors[i]) {
+        // If needed, find index of complex conjugate eigenvector
+        // Note: most time this will be i+1, but not always.
+        size_t conjugate_i = 0;
+        if (left_eigenvector_is_complex) {
+          for (conjugate_i = i + 1; conjugate_i < matrix_size; ++conjugate_i) {
+            // Assume that this eigenvector is the conjugate until we find
+            // otherwise by checking each component
+            bool is_conjugate = true;
+            for (size_t k = 0; k < matrix_size; ++k) {
+              const auto component = blaze_complex_L(k, i);
+              const auto conjugate_component = blaze_complex_L(k, conjugate_i);
+              if (std::abs(component.real() - conjugate_component.real()) >
+                      tolerance or
+                  std::abs(component.imag() + conjugate_component.imag()) >
+                      tolerance) {
+                is_conjugate = false;
+                break;
+              }
+            }
+            // If we made it through all components, then we've found the
+            // conjugate eigenvector
+            if (is_conjugate) {
+              break;
+            }
+          }
+        }
+        ASSERT(not left_eigenvector_is_complex or
+                   (conjugate_i > i and conjugate_i < matrix_size),
+               "Found complex left eigenvector without identifying its "
+               "conjugate partner.");
+        // If the eigenvector is complex, then its respective eigenvalue must
+        // be degenerate
+        if (left_eigenvector_is_complex) {
+          ASSERT(
+              blaze_real_eigenvalues[i] - blaze_real_eigenvalues[conjugate_i] <
+                  1.e-8,
+              "Expected degenerate eigenvalues for complex eigenvectors, but "
+              "eigenvalues differ by "
+                  << blaze_real_eigenvalues[i] -
+                         blaze_real_eigenvalues[conjugate_i]
+                  << ".");
+        }
+        // Process the ith left eigenvector (and its complex conjugate if
+        // needed)
+        for (size_t k = 0; k < matrix_size; ++k) {
+          characteristic_projectors->get(i, k)[point] =
+              blaze_complex_L(k, i).real();
+          if (left_eigenvector_is_complex) {
+            characteristic_projectors->get(conjugate_i, k)[point] =
+                blaze_complex_L(k, i).imag();
+          }
+        }
+        processed_left_eigenvectors[i] = true;
+        if (left_eigenvector_is_complex) {
+          processed_left_eigenvectors[conjugate_i] = true;
+        }
+      }
+    }
+  }
 }
 
 namespace Tags {
@@ -395,58 +890,85 @@ GENERATE_INSTANTIATIONS(FUNCTION_INSTANTIATION, (1, 2, 3))
 
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                                              \
-  template std::array<DataVector, 9>                                        \
-  characteristic_speeds_approximate_mhd<GET_DIM(data)>(                     \
-      const Scalar<DataVector>& rest_mass_density,                          \
-      const Scalar<DataVector>& electron_fraction,                          \
-      const Scalar<DataVector>& specific_internal_energy,                   \
-      const Scalar<DataVector>& specific_enthalpy,                          \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,      \
-      const Scalar<DataVector>& lorentz_factor,                             \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,        \
-      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift, \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
-      const tnsr::i<DataVector, 3>& unit_normal,                            \
-      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
-          equation_of_state);                                               \
-  template void characteristic_speeds_approximate_mhd<GET_DIM(data)>(       \
-      const gsl::not_null<std::array<DataVector, 9>*> char_speeds,          \
-      const Scalar<DataVector>& rest_mass_density,                          \
-      const Scalar<DataVector>& electron_fraction,                          \
-      const Scalar<DataVector>& specific_internal_energy,                   \
-      const Scalar<DataVector>& specific_enthalpy,                          \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,      \
-      const Scalar<DataVector>& lorentz_factor,                             \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,        \
-      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift, \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
-      const tnsr::i<DataVector, 3>& unit_normal,                            \
-      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
-          equation_of_state);                                               \
-  template std::array<DataVector, 3>                                        \
-  characteristic_speeds_hydro<GET_DIM(data)>(                               \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,      \
-      const Scalar<DataVector>& rest_mass_density,                          \
-      const Scalar<DataVector>& specific_internal_energy,                   \
-      const Scalar<DataVector>& specific_enthalpy,                          \
-      const Scalar<DataVector>& electron_fraction,                          \
-      const Scalar<DataVector>& lorentz_factor,                             \
-      const tnsr::i<DataVector, 3>& unit_normal,                            \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
-      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
-          equation_of_state);                                               \
-  template void characteristic_speeds_hydro<GET_DIM(data)>(                 \
-      const gsl::not_null<std::array<DataVector, 3>*> char_speeds,          \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,      \
-      const Scalar<DataVector>& rest_mass_density,                          \
-      const Scalar<DataVector>& specific_internal_energy,                   \
-      const Scalar<DataVector>& specific_enthalpy,                          \
-      const Scalar<DataVector>& electron_fraction,                          \
-      const Scalar<DataVector>& lorentz_factor,                             \
-      const tnsr::i<DataVector, 3>& unit_normal,                            \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
-      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
+#define INSTANTIATION(r, data)                                                 \
+  template std::array<DataVector, 9>                                           \
+  characteristic_speeds_approximate_mhd<GET_DIM(data)>(                        \
+      const Scalar<DataVector>& rest_mass_density,                             \
+      const Scalar<DataVector>& electron_fraction,                             \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+      const Scalar<DataVector>& specific_enthalpy,                             \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,         \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,           \
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,    \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,          \
+      const tnsr::i<DataVector, 3>& unit_normal,                               \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&            \
+          equation_of_state);                                                  \
+  template void characteristic_speeds_approximate_mhd<GET_DIM(data)>(          \
+      const gsl::not_null<std::array<DataVector, 9>*> char_speeds,             \
+      const Scalar<DataVector>& rest_mass_density,                             \
+      const Scalar<DataVector>& electron_fraction,                             \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+      const Scalar<DataVector>& specific_enthalpy,                             \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,         \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,           \
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,    \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,          \
+      const tnsr::i<DataVector, 3>& unit_normal,                               \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&            \
+          equation_of_state);                                                  \
+  template tnsr::i<DataVector, 3> characteristic_speeds_hydro<GET_DIM(data)>(  \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,         \
+      const Scalar<DataVector>& rest_mass_density,                             \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+      const Scalar<DataVector>& electron_fraction,                             \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const Scalar<DataVector>& specific_enthalpy,                             \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,          \
+      const tnsr::i<DataVector, 3>& unit_normal,                               \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&            \
+          equation_of_state);                                                  \
+  template void characteristic_speeds_hydro<GET_DIM(data)>(                    \
+      const gsl::not_null<tnsr::i<DataVector, 3>*> characteristic_speeds,      \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,         \
+      const Scalar<DataVector>& rest_mass_density,                             \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+      const Scalar<DataVector>& electron_fraction,                             \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const Scalar<DataVector>& specific_enthalpy,                             \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,          \
+      const tnsr::i<DataVector, 3>& unit_normal,                               \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&            \
+          equation_of_state);                                                  \
+  template void flux_jacobian_hydro<GET_DIM(data)>(                            \
+      const gsl::not_null<tnsr::iJ<DataVector, 6>*> characteristic_matrix,     \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,         \
+      const Scalar<DataVector>& rest_mass_density,                             \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+      const Scalar<DataVector>& electron_fraction,                             \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const Scalar<DataVector>& specific_enthalpy,                             \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,          \
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,      \
+      const tnsr::i<DataVector, 3>& unit_normal,                               \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&            \
+          equation_of_state);                                                  \
+  template void numerical_characteristics<GET_DIM(data)>(                      \
+      const gsl::not_null<tnsr::i<DataVector, 6>*> characteristic_speeds,      \
+      const gsl::not_null<tnsr::ij<DataVector, 6>*> characteristic_modes,      \
+      const gsl::not_null<tnsr::IJ<DataVector, 6>*> characteristic_projectors, \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,         \
+      const Scalar<DataVector>& rest_mass_density,                             \
+      const Scalar<DataVector>& specific_internal_energy,                      \
+      const Scalar<DataVector>& electron_fraction,                             \
+      const Scalar<DataVector>& lorentz_factor,                                \
+      const Scalar<DataVector>& specific_enthalpy,                             \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,          \
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,      \
+      const tnsr::i<DataVector, 3>& unit_normal,                               \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&            \
           equation_of_state);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
@@ -376,15 +376,16 @@ void flux_jacobian_hydro(
     const tnsr::i<DataVector, 3>& unit_normal,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) {
-  Variables<tmpl::list<hydro::Tags::SoundSpeedSquared<DataVector>,
-                       hydro::Tags::Pressure<DataVector>,
-                       ::Tags::TempScalar<0>, ::Tags::TempScalar<1>,
-                       ::Tags::TempScalar<2>, ::Tags::TempScalar<3>,
-                       ::Tags::TempScalar<4>, ::Tags::TempScalar<5>,
-                       ::Tags::TempScalar<6>, ::Tags::TempScalar<7>,
-                       ::Tags::TempScalar<8>, ::Tags::TempI<0, 3>,
-                       ::Tags::Tempi<0, 3>, ::Tags::TempIj<0, 3>,
-                       ::Tags::TempI<1, 3>>>
+  // Use Variables to reduce total number of allocations
+  Variables<tmpl::list<
+      hydro::Tags::SoundSpeedSquared<DataVector>,
+      hydro::Tags::Pressure<DataVector>, ::Tags::TempScalar<0>,
+      ::Tags::TempScalar<1>, ::Tags::TempScalar<2>, ::Tags::TempScalar<3>,
+      ::Tags::TempScalar<4>, ::Tags::TempScalar<5>, ::Tags::TempScalar<6>,
+      ::Tags::TempScalar<7>, ::Tags::TempScalar<8>, ::Tags::TempScalar<9>,
+      ::Tags::TempScalar<10>, ::Tags::TempScalar<11>, ::Tags::TempScalar<12>,
+      ::Tags::TempScalar<13>, ::Tags::TempI<0, 3>, ::Tags::Tempi<0, 3>,
+      ::Tags::TempI<1, 3>>>
       temp_tensors{get<0, 0>(spatial_metric).size()};
 
   Scalar<DataVector>& sound_speed_squared =
@@ -395,8 +396,6 @@ void flux_jacobian_hydro(
   // We define zeta as the partial derivative of pressure with respect to
   // electron fraction
   Scalar<DataVector>& zeta = get<::Tags::TempScalar<1>>(temp_tensors);
-  Scalar<DataVector>& kappa_times_p_over_rho_squared =
-      get<::Tags::TempScalar<2>>(temp_tensors);
   Scalar<DataVector>& pressure =
       get<hydro::Tags::Pressure<DataVector>>(temp_tensors);
   if constexpr (ThermodynamicDim == 1) {
@@ -408,6 +407,8 @@ void flux_jacobian_hydro(
     get(kappa) = 0.0;
     get(zeta) = 0.0;
   } else if constexpr (ThermodynamicDim == 2) {
+    Scalar<DataVector>& kappa_times_p_over_rho_squared =
+        get<::Tags::TempScalar<2>>(temp_tensors);
     get(kappa_times_p_over_rho_squared) =
         get(equation_of_state
                 .kappa_times_p_over_rho_squared_from_density_and_energy(
@@ -423,9 +424,10 @@ void flux_jacobian_hydro(
                  square(get(rest_mass_density));
     get(zeta) = 0.0;
   } else if constexpr (ThermodynamicDim == 3) {
-    const Scalar<DataVector> temperature =
-        equation_of_state.temperature_from_density_and_energy(
-            rest_mass_density, specific_internal_energy, electron_fraction);
+    Scalar<DataVector>& temperature = get<::Tags::TempScalar<2>>(temp_tensors);
+    get(temperature) =
+        get(equation_of_state.temperature_from_density_and_energy(
+            rest_mass_density, specific_internal_energy, electron_fraction));
     get(sound_speed_squared) =
         get(equation_of_state.sound_speed_squared_from_density_and_temperature(
             rest_mass_density, temperature, electron_fraction));
@@ -437,14 +439,18 @@ void flux_jacobian_hydro(
         rest_mass_density, temperature, electron_fraction));
   }
 
+  // The expressions in this function have been iteratively optimized by Codex
+  // with 3 main goals:
+  //   1. Avoid catastrophic cancellations by rewriting terms like W-1 to, e.g.,
+  //      v^2 W^2 / (W + 1). Known tricks were listed in a skill used by Codex.
+  //   2. Avoid repeated calculations by storing intermediate results in
+  //      temporary variables and reusing previous allocations when possible.
+  //   3. Try different rearrangements and run benchmark to find the best
+  //      optimization.
+
   // Intermediate variables
-  Scalar<DataVector>& Z = get<::Tags::TempScalar<3>>(temp_tensors);
-  tenex::evaluate(make_not_null(&Z),
-                  rest_mass_density() * specific_enthalpy() *
-                      square(lorentz_factor()));
-  Scalar<DataVector>& D = get<::Tags::TempScalar<4>>(temp_tensors);
-  tenex::evaluate(make_not_null(&D), rest_mass_density() * lorentz_factor());
-  Scalar<DataVector>& normal_velocity = get<::Tags::TempScalar<5>>(temp_tensors);
+  Scalar<DataVector>& normal_velocity =
+      get<::Tags::TempScalar<3>>(temp_tensors);
   tenex::evaluate(make_not_null(&normal_velocity),
                   spatial_velocity(ti::I) * unit_normal(ti::i));
   tnsr::I<DataVector, 3>& unit_vector = get<::Tags::TempI<0, 3>>(temp_tensors);
@@ -452,109 +458,166 @@ void flux_jacobian_hydro(
                          inv_spatial_metric(ti::I, ti::J) * unit_normal(ti::j));
   tnsr::i<DataVector, 3>& spatial_velocity_one_form =
       get<::Tags::Tempi<0, 3>>(temp_tensors);
-  tenex::evaluate<ti::i>(make_not_null(&spatial_velocity_one_form),
-                         spatial_metric(ti::i, ti::j) *
-                             spatial_velocity(ti::J));
-  tnsr::Ij<DataVector, 3>& mixed_spatial_metric =
-      get<::Tags::TempIj<0, 3>>(temp_tensors);
-  tenex::evaluate<ti::I, ti::j>(make_not_null(&mixed_spatial_metric),
-                                inv_spatial_metric(ti::I, ti::K) *
-                                    spatial_metric(ti::k, ti::j));
+  tenex::evaluate<ti::i>(
+      make_not_null(&spatial_velocity_one_form),
+      spatial_metric(ti::i, ti::j) * spatial_velocity(ti::J));
+
+  // Cancellation-safe thermodynamic / kinematic differences
+  Scalar<DataVector>& h_minus_1 = get<::Tags::TempScalar<9>>(temp_tensors);
+  get(h_minus_1) =
+      get(specific_internal_energy) + get(pressure) / get(rest_mass_density);
+  Scalar<DataVector>& velocity_squared =
+      get<::Tags::TempScalar<10>>(temp_tensors);
+  tenex::evaluate(make_not_null(&velocity_squared),
+                  spatial_velocity(ti::I) * spatial_velocity_one_form(ti::i));
+  Scalar<DataVector>& lorentz_factor_squared =
+      get<::Tags::TempScalar<11>>(temp_tensors);
+  get(lorentz_factor_squared) = square(get(lorentz_factor));
+  Scalar<DataVector>& W_minus_1 = get<::Tags::TempScalar<12>>(temp_tensors);
+  get(W_minus_1) = get(velocity_squared) * get(lorentz_factor_squared) /
+                   (get(lorentz_factor) + 1.0);
+  Scalar<DataVector>& h_minus_W = get<::Tags::TempScalar<13>>(temp_tensors);
+  get(h_minus_W) = get(h_minus_1) - get(W_minus_1);
 
   // Derivatives of Z
-  Scalar<DataVector>& dzdD = get<::Tags::TempScalar<6>>(temp_tensors);
+  Scalar<DataVector>& inv_derivative_denom =
+      get<::Tags::TempScalar<7>>(temp_tensors);
+  get(inv_derivative_denom) =
+      1.0 / ((-get(lorentz_factor_squared) + get(sound_speed_squared) *
+                                                 get(velocity_squared) *
+                                                 get(lorentz_factor_squared)) *
+             get(rest_mass_density));
+  Scalar<DataVector>& dzdD = get<::Tags::TempScalar<4>>(temp_tensors);
   tenex::evaluate(
       make_not_null(&dzdD),
-      -((lorentz_factor() *
-         (kappa() * (-specific_enthalpy() + lorentz_factor()) -
-          zeta() * electron_fraction() +
-          (sound_speed_squared() * specific_enthalpy() + lorentz_factor()) *
-              rest_mass_density())) /
-        ((-square(lorentz_factor()) +
-          sound_speed_squared() * (-1. + square(lorentz_factor()))) *
-         rest_mass_density())));
+      -(lorentz_factor() *
+        (-kappa() * h_minus_W() - zeta() * electron_fraction() +
+         (sound_speed_squared() * specific_enthalpy() + lorentz_factor()) *
+             rest_mass_density()) *
+        inv_derivative_denom()));
   tnsr::I<DataVector, 3>& dzds = get<::Tags::TempI<1, 3>>(temp_tensors);
   tenex::evaluate<ti::I>(
       make_not_null(&dzds),
-      (spatial_velocity(ti::I) * square(lorentz_factor()) *
-       (kappa() + sound_speed_squared() * rest_mass_density())) /
-      ((-square(lorentz_factor()) +
-        sound_speed_squared() * (-1. + square(lorentz_factor()))) *
-       rest_mass_density()));
-  Scalar<DataVector>& dzdtau = get<::Tags::TempScalar<7>>(temp_tensors);
-  tenex::evaluate(
-      make_not_null(&dzdtau),
-      -((square(lorentz_factor()) * (kappa() + rest_mass_density())) /
-        ((-square(lorentz_factor()) +
-          sound_speed_squared() * (-1. + square(lorentz_factor()))) *
-         rest_mass_density())));
-  Scalar<DataVector>& dzdye = get<::Tags::TempScalar<8>>(temp_tensors);
-  tenex::evaluate(
-      make_not_null(&dzdye),
-      (zeta() * lorentz_factor()) /
-      ((square(lorentz_factor()) -
-        sound_speed_squared() * (-1. + square(lorentz_factor()))) *
-       rest_mass_density()));
+      (spatial_velocity(ti::I) * lorentz_factor_squared() *
+       (kappa() + sound_speed_squared() * rest_mass_density()) *
+       inv_derivative_denom()));
+  Scalar<DataVector>& dzdtau = get<::Tags::TempScalar<5>>(temp_tensors);
+  tenex::evaluate(make_not_null(&dzdtau),
+                  -(lorentz_factor_squared() * (kappa() + rest_mass_density()) *
+                    inv_derivative_denom()));
+  Scalar<DataVector>& dzdye = get<::Tags::TempScalar<6>>(temp_tensors);
+  tenex::evaluate(make_not_null(&dzdye),
+                  -(zeta() * lorentz_factor() * inv_derivative_denom()));
 
+  // Common factors used repeatedly in the characteristic matrix entries
+  Scalar<DataVector>& D_over_Z = get<::Tags::TempScalar<8>>(temp_tensors);
+  get(D_over_Z) = 1.0 / (get(specific_enthalpy) * get(lorentz_factor));
   // Put analytic expressions into characteristic matrix
   characteristic_matrix->get(0, 0) =
-      ((get(Z) - get(D) * get(dzdD)) * get(normal_velocity)) / get(Z);
-  for (size_t B = 0; B < 3; ++B) {
-    characteristic_matrix->get(0, B + 1) =
-        (get(D) * (unit_vector.get(B) - dzds.get(B) * get(normal_velocity))) /
-        get(Z);
-  }
+      (1.0 - get(D_over_Z) * get(dzdD)) * get(normal_velocity);
+  characteristic_matrix->get(0, 1) =
+      get(D_over_Z) * (unit_vector.get(0) - dzds.get(0) * get(normal_velocity));
+  characteristic_matrix->get(0, 2) =
+      get(D_over_Z) * (unit_vector.get(1) - dzds.get(1) * get(normal_velocity));
+  characteristic_matrix->get(0, 3) =
+      get(D_over_Z) * (unit_vector.get(2) - dzds.get(2) * get(normal_velocity));
+  characteristic_matrix->get(4, 1) =
+      unit_vector.get(0) - characteristic_matrix->get(0, 1);
+  characteristic_matrix->get(4, 2) =
+      unit_vector.get(1) - characteristic_matrix->get(0, 2);
+  characteristic_matrix->get(4, 3) =
+      unit_vector.get(2) - characteristic_matrix->get(0, 3);
+  characteristic_matrix->get(5, 1) =
+      get(electron_fraction) * characteristic_matrix->get(0, 1);
+  characteristic_matrix->get(5, 2) =
+      get(electron_fraction) * characteristic_matrix->get(0, 2);
+  characteristic_matrix->get(5, 3) =
+      get(electron_fraction) * characteristic_matrix->get(0, 3);
   characteristic_matrix->get(0, 4) =
-      -((get(D) * get(dzdtau) * get(normal_velocity)) / get(Z));
+      -(get(D_over_Z) * get(dzdtau) * get(normal_velocity));
   characteristic_matrix->get(0, 5) =
-      -((get(D) * get(dzdye) * get(normal_velocity)) / get(Z));
-  for (size_t c = 0; c < 3; ++c) {
-    characteristic_matrix->get(c + 1, 0) =
-        (-1.0 + get(dzdD)) * unit_normal.get(c) -
-        get(dzdD) * get(normal_velocity) * spatial_velocity_one_form.get(c);
-    for (size_t B = 0; B < 3; ++B) {
-      characteristic_matrix->get(c + 1, B + 1) =
-          mixed_spatial_metric.get(B, c) * get(normal_velocity) +
-          unit_vector.get(B) * spatial_velocity_one_form.get(c) +
-          dzds.get(B) *
-              (unit_normal.get(c) -
-               get(normal_velocity) * spatial_velocity_one_form.get(c));
-    }
-    characteristic_matrix->get(c + 1, 4) =
-        (-1.0 + get(dzdtau)) * unit_normal.get(c) -
-        get(dzdtau) * get(normal_velocity) * spatial_velocity_one_form.get(c);
-    characteristic_matrix->get(c + 1, 5) =
-        get(dzdye) * (unit_normal.get(c) -
-                      get(normal_velocity) * spatial_velocity_one_form.get(c));
-  }
-  characteristic_matrix->get(4, 0) =
-      -(((get(Z) - get(D) * get(dzdD)) * get(normal_velocity)) / get(Z));
-  for (size_t B = 0; B < 3; ++B) {
-    characteristic_matrix->get(4, B + 1) =
-        ((get(Z) - get(D)) * unit_vector.get(B) +
-         get(D) * dzds.get(B) * get(normal_velocity)) /
-        get(Z);
-  }
-  characteristic_matrix->get(4, 4) =
-      (get(D) * get(dzdtau) * get(normal_velocity)) / get(Z);
-  characteristic_matrix->get(4, 5) =
-      (get(D) * get(dzdye) * get(normal_velocity)) / get(Z);
-  characteristic_matrix->get(5, 0) =
-      -((get(D) * get(electron_fraction) * get(dzdD) * get(normal_velocity)) /
-        get(Z));
-  for (size_t B = 0; B < 3; ++B) {
-    characteristic_matrix->get(5, B + 1) =
-        (get(D) * get(electron_fraction) *
-         (unit_vector.get(B) - dzds.get(B) * get(normal_velocity))) /
-        get(Z);
-  }
+      -(get(D_over_Z) * get(dzdye) * get(normal_velocity));
+  characteristic_matrix->get(1, 0) =
+      (-1.0 + get(dzdD)) * unit_normal.get(0) -
+      get(dzdD) * get(normal_velocity) * spatial_velocity_one_form.get(0);
+  characteristic_matrix->get(2, 0) =
+      (-1.0 + get(dzdD)) * unit_normal.get(1) -
+      get(dzdD) * get(normal_velocity) * spatial_velocity_one_form.get(1);
+  characteristic_matrix->get(3, 0) =
+      (-1.0 + get(dzdD)) * unit_normal.get(2) -
+      get(dzdD) * get(normal_velocity) * spatial_velocity_one_form.get(2);
+
+  characteristic_matrix->get(1, 1) =
+      get(normal_velocity) +
+      unit_vector.get(0) * spatial_velocity_one_form.get(0) +
+      dzds.get(0) * (unit_normal.get(0) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(0));
+  characteristic_matrix->get(1, 2) =
+      unit_vector.get(1) * spatial_velocity_one_form.get(0) +
+      dzds.get(1) * (unit_normal.get(0) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(0));
+  characteristic_matrix->get(1, 3) =
+      unit_vector.get(2) * spatial_velocity_one_form.get(0) +
+      dzds.get(2) * (unit_normal.get(0) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(0));
+  characteristic_matrix->get(2, 1) =
+      unit_vector.get(0) * spatial_velocity_one_form.get(1) +
+      dzds.get(0) * (unit_normal.get(1) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(1));
+  characteristic_matrix->get(2, 2) =
+      get(normal_velocity) +
+      unit_vector.get(1) * spatial_velocity_one_form.get(1) +
+      dzds.get(1) * (unit_normal.get(1) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(1));
+  characteristic_matrix->get(2, 3) =
+      unit_vector.get(2) * spatial_velocity_one_form.get(1) +
+      dzds.get(2) * (unit_normal.get(1) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(1));
+  characteristic_matrix->get(3, 1) =
+      unit_vector.get(0) * spatial_velocity_one_form.get(2) +
+      dzds.get(0) * (unit_normal.get(2) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(2));
+  characteristic_matrix->get(3, 2) =
+      unit_vector.get(1) * spatial_velocity_one_form.get(2) +
+      dzds.get(1) * (unit_normal.get(2) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(2));
+  characteristic_matrix->get(3, 3) =
+      get(normal_velocity) +
+      unit_vector.get(2) * spatial_velocity_one_form.get(2) +
+      dzds.get(2) * (unit_normal.get(2) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(2));
+
+  characteristic_matrix->get(1, 4) =
+      -unit_normal.get(0) +
+      get(dzdtau) * (unit_normal.get(0) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(0));
+  characteristic_matrix->get(2, 4) =
+      -unit_normal.get(1) +
+      get(dzdtau) * (unit_normal.get(1) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(1));
+  characteristic_matrix->get(3, 4) =
+      -unit_normal.get(2) +
+      get(dzdtau) * (unit_normal.get(2) -
+                     get(normal_velocity) * spatial_velocity_one_form.get(2));
+  characteristic_matrix->get(1, 5) =
+      get(dzdye) * (unit_normal.get(0) -
+                    get(normal_velocity) * spatial_velocity_one_form.get(0));
+  characteristic_matrix->get(2, 5) =
+      get(dzdye) * (unit_normal.get(1) -
+                    get(normal_velocity) * spatial_velocity_one_form.get(1));
+  characteristic_matrix->get(3, 5) =
+      get(dzdye) * (unit_normal.get(2) -
+                    get(normal_velocity) * spatial_velocity_one_form.get(2));
+  characteristic_matrix->get(4, 0) = -characteristic_matrix->get(0, 0);
+  characteristic_matrix->get(4, 4) = -characteristic_matrix->get(0, 4);
+  characteristic_matrix->get(4, 5) = -characteristic_matrix->get(0, 5);
+  characteristic_matrix->get(5, 0) = -get(electron_fraction) * get(D_over_Z) *
+                                     get(dzdD) * get(normal_velocity);
   characteristic_matrix->get(5, 4) =
-      -((get(D) * get(electron_fraction) * get(dzdtau) * get(normal_velocity)) /
-        get(Z));
+      get(electron_fraction) * characteristic_matrix->get(0, 4);
   characteristic_matrix->get(5, 5) =
-      ((get(Z) - get(D) * get(electron_fraction) * get(dzdye)) *
-       get(normal_velocity)) /
-      get(Z);
+      (1.0 - get(electron_fraction) * get(D_over_Z) * get(dzdye)) *
+      get(normal_velocity);
 }
 
 template <size_t ThermodynamicDim>
@@ -615,11 +678,12 @@ void numerical_characteristics(
                 blaze_complex_R);
     const double tolerance = 1.0e-12;
     for (size_t i = 0; i < matrix_size; ++i) {
-      ASSERT(std::abs(blaze_complex_eigenvalues[i].imag()) < tolerance,
+      ASSERT(std::abs(blaze_complex_eigenvalues.at(i).imag()) < tolerance,
              "Complex eigenvalue: "
-                 << blaze_complex_eigenvalues[i].real() << " + "
-                 << blaze_complex_eigenvalues[i].imag() << " i.");
-      blaze_real_eigenvalues[i] = blaze_complex_eigenvalues[i].real();
+                 << blaze_complex_eigenvalues.at(i).real() << " + "
+                 << blaze_complex_eigenvalues.at(i).imag() << " i.");
+      gsl::at(blaze_real_eigenvalues, i) =
+          blaze_complex_eigenvalues.at(i).real();
     }
 
 // We found cases in which blaze::geev returns a wrong eigenvalue. As a sanity
@@ -649,7 +713,7 @@ void numerical_characteristics(
     // Solve for eigenvalues using GSL
     gsl_eigen_nonsymm(gsl_point_matrix, gsl_complex_eigenvalues, gsl_workspace);
     for (size_t i = 0; i < matrix_size; ++i) {
-      gsl_real_eigenvalues[i] =
+      gsl::at(gsl_real_eigenvalues, i) =
           GSL_REAL(gsl_vector_complex_get(gsl_complex_eigenvalues, i));
     }
 
@@ -662,8 +726,8 @@ void numerical_characteristics(
 
     // Compare eigenvalues
     for (size_t i = 0; i < matrix_size; ++i) {
-      if (UNLIKELY(std::abs(sorted_blaze_real_eigenvalues[i] -
-                            gsl_real_eigenvalues[i]) > 1.e-6)) {
+      if (UNLIKELY(std::abs(gsl::at(sorted_blaze_real_eigenvalues, i) -
+                            gsl::at(gsl_real_eigenvalues, i)) > 1.e-6)) {
         std::ostringstream matrix_stream;
         matrix_stream << "Point matrix:\n";
         for (size_t row = 0; row < matrix_size; ++row) {
@@ -673,9 +737,9 @@ void numerical_characteristics(
           matrix_stream << "\n";
         }
         matrix_stream << "Blaze eigenvalue: "
-                      << sorted_blaze_real_eigenvalues[i]
-                      << ", GSL eigenvalue: " << gsl_real_eigenvalues[i]
-                      << "\n";
+                      << gsl::at(sorted_blaze_real_eigenvalues, i)
+                      << ", GSL eigenvalue: "
+                      << gsl::at(gsl_real_eigenvalues, i) << "\n";
 
         ERROR(
             "The eigensolvers from blaze and GSL found different eigenvalues "
@@ -698,7 +762,7 @@ void numerical_characteristics(
     // Note: we're looping through the ith eigenvalue/vectors, not the ith row!
     for (size_t i = 0; i < matrix_size; ++i) {
       // Store eigenvalue
-      characteristic_speeds->get(i)[point] = blaze_real_eigenvalues[i];
+      characteristic_speeds->get(i)[point] = gsl::at(blaze_real_eigenvalues, i);
 
       // For each PAIR of degenerate eigenvalues, it is possible that GSL
       // returns a PAIR of complex eigenvectors that are complex conjugates of
@@ -720,7 +784,7 @@ void numerical_characteristics(
       // by their real and imaginary parts are also linearly-independent
       // eigenvectors. Here, we use this fact to build real-valued left and
       // right eigenvectors.
-      if (not processed_right_eigenvectors[i]) {
+      if (not gsl::at(processed_right_eigenvectors, i)) {
         // If needed, find index of complex conjugate eigenvector
         // Note: most time this will be i+1, but not always.
         size_t conjugate_i = 0;
@@ -755,12 +819,13 @@ void numerical_characteristics(
         // be degenerate
         if (right_eigenvector_is_complex) {
           ASSERT(
-              blaze_real_eigenvalues[i] - blaze_real_eigenvalues[conjugate_i] <
+              gsl::at(blaze_real_eigenvalues, i) -
+                      gsl::at(blaze_real_eigenvalues, conjugate_i) <
                   1.e-8,
               "Expected degenerate eigenvalues for complex eigenvectors, but "
               "eigenvalues differ by "
-                  << blaze_real_eigenvalues[i] -
-                         blaze_real_eigenvalues[conjugate_i]
+                  << gsl::at(blaze_real_eigenvalues, i) -
+                         gsl::at(blaze_real_eigenvalues, conjugate_i)
                   << ".");
         }
         // Process the ith right eigenvector (and its complex conjugate if
@@ -772,14 +837,14 @@ void numerical_characteristics(
                 blaze_complex_R(k, i).imag();
           }
         }
-        processed_right_eigenvectors[i] = true;
+        gsl::at(processed_right_eigenvectors, i) = true;
         if (right_eigenvector_is_complex) {
-          processed_right_eigenvectors[conjugate_i] = true;
+          gsl::at(processed_right_eigenvectors, conjugate_i) = true;
         }
       }
 
       // Same as above, but for left eigenvectors
-      if (not processed_left_eigenvectors[i]) {
+      if (not gsl::at(processed_left_eigenvectors, i)) {
         // If needed, find index of complex conjugate eigenvector
         // Note: most time this will be i+1, but not always.
         size_t conjugate_i = 0;
@@ -814,12 +879,13 @@ void numerical_characteristics(
         // be degenerate
         if (left_eigenvector_is_complex) {
           ASSERT(
-              blaze_real_eigenvalues[i] - blaze_real_eigenvalues[conjugate_i] <
+              gsl::at(blaze_real_eigenvalues, i) -
+                      gsl::at(blaze_real_eigenvalues, conjugate_i) <
                   1.e-8,
               "Expected degenerate eigenvalues for complex eigenvectors, but "
               "eigenvalues differ by "
-                  << blaze_real_eigenvalues[i] -
-                         blaze_real_eigenvalues[conjugate_i]
+                  << gsl::at(blaze_real_eigenvalues, i) -
+                         gsl::at(blaze_real_eigenvalues, conjugate_i)
                   << ".");
         }
         // Process the ith left eigenvector (and its complex conjugate if
@@ -832,9 +898,9 @@ void numerical_characteristics(
                 blaze_complex_L(k, i).imag();
           }
         }
-        processed_left_eigenvectors[i] = true;
+        gsl::at(processed_left_eigenvectors, i) = true;
         if (left_eigenvector_is_complex) {
-          processed_left_eigenvectors[conjugate_i] = true;
+          gsl::at(processed_left_eigenvectors, conjugate_i) = true;
         }
       }
     }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -120,6 +120,20 @@ void characteristic_speeds_approximate_mhd(
 
 /// @{
 /*!
+ * \brief Labels for the characteristic speeds of the relativistic hydrodynamics
+ * system.
+ *
+ * \see `grmhd::ValenciaDivClean::characteristic_speeds_hydro`
+ */
+enum HydroSpeed : uint32_t {
+  NormalDotVelocity = 0,
+  LambdaPlus = 1,
+  LambdaMinus = 2
+};
+/// @}
+
+/// @{
+/*!
  * \brief Compute the characteristic speeds for the relativistic hydrodynamics
  * system in the Eulerian frame.
  *
@@ -151,37 +165,144 @@ void characteristic_speeds_approximate_mhd(
  * c_s^2 &= \frac{1}{h}\left(\chi + \kappa \frac{p}{\rho^2}\right) ,
  * \f}
  *
- * The returned array has size 3 and contains the unique characteristic speeds:
- *  - `char_speeds[0]`: \f$v_n\f$ (degenerate eigenvalue, multiplicity 4 if the
- * electron fraction is included),
- *  - `char_speeds[1]`: \f$\lambda_+\f$ (right-propagating acoustic mode),
- *  - `char_speeds[2]`: \f$\lambda_-\f$ (left-propagating acoustic mode).
+ * The returned tensor has index 0..2:
+ * - `characteristic_speeds.get(0)`: degenerate speed \f$v_n\f$
+ * - `characteristic_speeds.get(1)`: acoustic speed \f$\lambda_+\f$
+ * - `characteristic_speeds.get(2)`: acoustic speed \f$\lambda_-\f$
+ *
+ * \see `grmhd::ValenciaDivClean::numerical_characteristics` for how these
+ * speeds are paired with characteristic modes and characteristic projectors.
  */
 
 template <size_t ThermodynamicDim>
 void characteristic_speeds_hydro(
-    gsl::not_null<std::array<DataVector, 3>*> pchar_speeds,
+    gsl::not_null<tnsr::i<DataVector, 3>*> characteristic_speeds,
+
+    /* primitive variables */
     const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
     const Scalar<DataVector>& rest_mass_density,
     const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& specific_enthalpy,
     const Scalar<DataVector>& electron_fraction,
+
+    /* other helpful quantities */
     const Scalar<DataVector>& lorentz_factor,
-    const tnsr::i<DataVector, 3>& unit_normal,
+    const Scalar<DataVector>& specific_enthalpy,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state);
 
 template <size_t ThermodynamicDim>
-std::array<DataVector, 3> characteristic_speeds_hydro(
+tnsr::i<DataVector, 3> characteristic_speeds_hydro(
     const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
     const Scalar<DataVector>& rest_mass_density,
     const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& specific_enthalpy,
     const Scalar<DataVector>& electron_fraction,
     const Scalar<DataVector>& lorentz_factor,
-    const tnsr::i<DataVector, 3>& unit_normal,
+    const Scalar<DataVector>& specific_enthalpy,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state);
+/// @}
+
+/// @{
+/**
+ * \brief Compute the characteristic matrix for relativistic hydrodynamics +
+ * composition ($Y_e$), in a given direction.
+ *
+ * \see `grmhd::ValenciaDivClean::numerical_characteristics` for the
+ * conventions relating this matrix to characteristic speeds, modes, and
+ * projectors.
+ */
+template <size_t ThermodynamicDim>
+void flux_jacobian_hydro(
+    gsl::not_null<tnsr::iJ<DataVector, 6>*> characteristic_matrix,
+
+    /* primitive variables */
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& electron_fraction,
+
+    /* other helpful quantities */
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state);
+/// @}
+
+/// @{
+/**
+ * \brief Compute numerical characteristic speeds, characteristic projectors
+ * (left eigenvectors), and characteristic modes (right eigenvectors) for
+ * a given characterisitc matrix.
+ *
+ * \note Currently, this function only supports building the eigensystem for
+ * relativistic hydrodynamics (no magnetic field) with composition dependence
+ * ($Y_e$).
+ *
+ * We label the characteristic matrix in a given direction, $A_{m}{}^{n}$, such
+ * that the index $m$ labels rows and the index $n$ labels columns.
+ *
+ * With this choice of indices, the $i$th left eigensystem is given by
+ * \begin{equation}
+ *   \sum_m L^{im} A_{m}{}^{n} = \lambda_{(i)} L^{in},
+ * \end{equation}
+ * where $\lambda_{(i)}$ is the $i$th eigenvalue / characteristic speed.
+ * Similarly, the $i$th right eigensystem is given by
+ * \begin{equation}
+ *   \sum_n R_{in} A_{m}{}^{n} = \lambda_{(i)} R_{im}.
+ * \end{equation}
+ *
+ * We provide the characteristics in the following types:
+ * - Eigenvalues $\lambda_{(i)}$: `tnsr::i<DataVector, 6> characteristic_speeds`
+ * - Right eigenvectors $R_{in}$: `tnsr::ij<DataVector, 6> characteristic_modes`
+ * - Left eigenvectors $L^{im}$: `tnsr::IJ<DataVector, 6>
+ *   characteristic_projectors`
+ *
+ * Note that the indices $i$, $m$, and $n$ are not tensorial. They simply label
+ * the eigensystem, rows of the matrix, and columns of the matrix, respectively.
+ * We make the conventions (raised or lowered) presented above to clearly
+ * distinguish which indices (first or second) of the matrix get contracted
+ * with which eigenvectors (left or right).
+ *
+ * We refer to the left eigenvectors as "projectors" because they are used to
+ * project a state into the characteristic basis. Similarly, we refer to the
+ * right eigenvectors as "modes" because they are used to reconstruct the state.
+ * For example, consider a state vector $U_{m}$ that can be represented in the
+ * characteristic basis as
+ * \begin{equation}
+ *   U_{m} = \sum_i w^{i} R_{im}.
+ * \end{equation}
+ * Then, the characteristic fields $w^{i}$ can be obtained by projecting the
+ * state vector $U_{m}$ into the characteristic basis using the left
+ * eigenvectors:
+ * \begin{equation}
+ *   w^{i} = \sum_m L^{im} U_{m}.
+ * \end{equation}
+ */
+template <size_t ThermodynamicDim>
+void numerical_characteristics(
+    gsl::not_null<tnsr::i<DataVector, 6>*> characteristic_speeds,
+    gsl::not_null<tnsr::ij<DataVector, 6>*> characteristic_modes,
+    gsl::not_null<tnsr::IJ<DataVector, 6>*> characteristic_projectors,
+
+    /* primitive variables */
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& electron_fraction,
+
+    /* other helpful quantities */
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state);
 /// @}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CharacteristicSpeeds.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CharacteristicSpeeds.py
@@ -61,8 +61,10 @@ def characteristic_speeds_hydro(
     y_plus = (factor + cs * d / (lorentz_factor * lorentz_factor)) / denom
     y_minus = (factor - cs * d / (lorentz_factor * lorentz_factor)) / denom
 
-    return [
-        normal_velocity,
-        float(y_plus),
-        float(y_minus),
-    ]
+    return np.array(
+        [
+            normal_velocity,
+            float(y_plus),
+            float(y_minus),
+        ]
+    )

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
@@ -15,6 +15,7 @@
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 #include "Helpers/PointwiseFunctions/Hydro/TestHelpers.hpp"
@@ -154,13 +155,169 @@ void test_hydro_characteristic_speed(const DataVector& used_for_size) {
     CHECK_ITERABLE_CUSTOM_APPROX(
         grmhd::ValenciaDivClean::characteristic_speeds_hydro<3>(
             spatial_velocity, rest_mass_density, specific_internal_energy,
-            specific_enthalpy, electron_fraction, lorentz_factor, unit_normal,
-            spatial_metric, *eos_3d),
-        (pypp::call<std::array<DataVector, 3>>(
+            electron_fraction, lorentz_factor, specific_enthalpy,
+            spatial_metric, unit_normal, *eos_3d),
+        (pypp::call<tnsr::i<DataVector, 3>>(
             "CharacteristicSpeeds", "characteristic_speeds_hydro",
             spatial_velocity, spatial_velocity_squared, sound_speed_squared,
             lorentz_factor, unit_normal)),
         custom_approx);
+  }
+}
+
+void test_hydro_numerical_characteristics(const DataVector& used_for_size) {
+  // Initialize number generator
+  MAKE_GENERATOR(generator);
+  const auto nn_gen = make_not_null(&generator);
+
+  // Generate random quantities
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<3>(nn_gen, used_for_size);
+  const auto lorentz_factor =
+      TestHelpers::hydro::random_lorentz_factor(nn_gen, used_for_size);
+  const auto spatial_velocity = TestHelpers::hydro::random_velocity(
+      nn_gen, lorentz_factor, spatial_metric);
+  const auto rest_mass_density =
+      TestHelpers::hydro::random_density(nn_gen, used_for_size);
+  const auto specific_internal_energy =
+      TestHelpers::hydro::random_specific_internal_energy(nn_gen,
+                                                          used_for_size);
+  const auto electron_fraction =
+      TestHelpers::hydro::random_electron_fraction(nn_gen, used_for_size);
+
+  // Define equation of state
+  const auto equation_of_state_2d =
+      EquationsOfState::IdealFluid<true>(1.5, 0.0);
+  const auto equation_of_state_3d = equation_of_state_2d.promote_to_3d_eos();
+
+  // Compute derived quantities
+  const auto pressure = equation_of_state_3d->pressure_from_density_and_energy(
+      rest_mass_density, specific_internal_energy, electron_fraction);
+  const auto specific_enthalpy = hydro::relativistic_specific_enthalpy(
+      rest_mass_density, specific_internal_energy, pressure);
+  const auto& inv_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+
+  // Initialize containers for all eigenvalues and eigenvectors
+  constexpr size_t matrix_size = 6;
+  const size_t num_points = used_for_size.size();
+  tnsr::i<DataVector, matrix_size> eigenvalues{num_points};
+  tnsr::ij<DataVector, matrix_size> right_eigenvectors{num_points};
+  tnsr::IJ<DataVector, matrix_size> left_eigenvectors{num_points};
+
+  // Loop over directions
+  for (const auto& direction : Direction<3>::all_directions()) {
+    // Get unit normal and normal velocity in this direction
+    const auto unit_normal = unit_basis_form(direction, inv_spatial_metric);
+    const auto normal_velocity =
+        tenex::evaluate(spatial_velocity(ti::I) * unit_normal(ti::i));
+
+    // Solve numerical eigensystem
+    grmhd::ValenciaDivClean::numerical_characteristics(
+        make_not_null(&eigenvalues), make_not_null(&right_eigenvectors),
+        make_not_null(&left_eigenvectors), spatial_velocity, rest_mass_density,
+        specific_internal_energy, electron_fraction, lorentz_factor,
+        specific_enthalpy, spatial_metric, inv_spatial_metric, unit_normal,
+        *equation_of_state_3d);
+
+    // Get analytic characteristic speeds to check the numeric eigenvalues
+    const tnsr::i<DataVector, 3> analytic_speeds =
+        grmhd::ValenciaDivClean::characteristic_speeds_hydro<3>(
+            spatial_velocity, rest_mass_density, specific_internal_energy,
+            electron_fraction, lorentz_factor, specific_enthalpy,
+            spatial_metric, unit_normal, *equation_of_state_3d);
+
+    // Count degenerate eigenvalues and check the other speeds
+    // Note 1: We expect 4 degenerate eigenvalues equal to the normal velocity.
+    // Note 2: The characteristic matrix becomes more defective for larger
+    //         Lorentz boosts. With the default random Lorentz factor generator,
+    //         the largest Lorentz factor is ~20, which leads to an eigenvalue
+    //         error of ~1e-10.
+    constexpr double eigenvalue_tolerance = 1e-9;
+    for (size_t point = 0; point < num_points; ++point) {
+      int number_of_degenerate_eigenvalues = 0;
+      bool found_lambda_plus = false;
+      bool found_lambda_minus = false;
+      for (size_t i = 0; i < 6; ++i) {
+        const DataVector& eigenvalue = eigenvalues.get(i);
+        const double diff_with_normal_velocity =
+            std::abs(eigenvalue[point] - get(normal_velocity)[point]);
+        const double diff_with_lambda_plus = std::abs(
+            eigenvalue[point] -
+            analytic_speeds.get(
+                grmhd::ValenciaDivClean::HydroSpeed::LambdaPlus)[point]);
+        const double diff_with_lambda_minus = std::abs(
+            eigenvalue[point] -
+            analytic_speeds.get(
+                grmhd::ValenciaDivClean::HydroSpeed::LambdaMinus)[point]);
+        if (diff_with_normal_velocity < eigenvalue_tolerance) {
+          number_of_degenerate_eigenvalues += 1;
+        } else if (diff_with_lambda_plus < eigenvalue_tolerance) {
+          CHECK_FALSE(found_lambda_plus);
+          found_lambda_plus = true;
+        } else if (diff_with_lambda_minus < eigenvalue_tolerance) {
+          CHECK_FALSE(found_lambda_minus);
+          found_lambda_minus = true;
+        } else {
+          FAIL(
+              "Found an eigenvalue that does not match any expected "
+              "characteristic speed.\n"
+              "Lorentz factor: "
+              << get(lorentz_factor)[point]
+              << "\n"
+                 "Differences with analytic eigenvalues: "
+              << diff_with_normal_velocity << ", " << diff_with_lambda_plus
+              << ", " << diff_with_lambda_minus);
+        }
+      }
+      CHECK(number_of_degenerate_eigenvalues == 4);
+      CHECK(found_lambda_plus);
+      CHECK(found_lambda_minus);
+    }
+
+    // Get characteristic matrix to check eigensystem relations
+    tnsr::iJ<DataVector, 6> characteristic_matrix{num_points};
+    grmhd::ValenciaDivClean::flux_jacobian_hydro(
+        make_not_null(&characteristic_matrix), spatial_velocity,
+        rest_mass_density, specific_internal_energy, electron_fraction,
+        lorentz_factor, specific_enthalpy, spatial_metric, inv_spatial_metric,
+        unit_normal, *equation_of_state_3d);
+
+    // Check eigensystem relation for each eigenvalue/eigenvector
+    constexpr double numeric_tolerance = 1e-12;
+    for (size_t i = 0; i < 6; ++i) {
+      // Use non-owning DataVector views to avoid copying data
+      const Scalar<DataVector> eigenvalue{};
+      const tnsr::i<DataVector, 6> right_eigenvector{};
+      const tnsr::I<DataVector, 6> left_eigenvector{};
+      make_const_view(make_not_null(&get(eigenvalue)), eigenvalues.get(i), 0,
+                      num_points);
+      for (size_t k = 0; k < 6; ++k) {
+        make_const_view(make_not_null(&right_eigenvector.get(k)),
+                        right_eigenvectors.get(i, k), 0, num_points);
+        make_const_view(make_not_null(&left_eigenvector.get(k)),
+                        left_eigenvectors.get(i, k), 0, num_points);
+      }
+
+      const Scalar<DataVector> right_eigensystem_error =
+          magnitude(tenex::evaluate<ti::k>(
+              characteristic_matrix(ti::k, ti::J) * right_eigenvector(ti::j) -
+              eigenvalue() * right_eigenvector(ti::k)));
+
+      const Scalar<DataVector> left_eigensystem_error =
+          magnitude(tenex::evaluate<ti::K>(
+              left_eigenvector(ti::J) * characteristic_matrix(ti::j, ti::K) -
+              eigenvalue() * left_eigenvector(ti::K)));
+
+      double eigensystem_error = 0.0;
+      for (size_t point = 0; point < used_for_size.size(); ++point) {
+        eigensystem_error = std::max(
+            eigensystem_error, std::abs(get(right_eigensystem_error)[point]));
+        eigensystem_error = std::max(
+            eigensystem_error, std::abs(get(left_eigensystem_error)[point]));
+      }
+      CHECK(eigensystem_error < numeric_tolerance);
+    }
   }
 }
 }  // namespace
@@ -176,6 +333,7 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Characteristics",
   // with vector components being 0.
   test_with_normal_along_coordinate_axes(dv);
   test_hydro_characteristic_speed(dv);
+  test_hydro_numerical_characteristics(dv);
 
   TestHelpers::db::test_compute_tag<
       grmhd::ValenciaDivClean::Tags::CharacteristicSpeedsCompute>(

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
@@ -4,11 +4,18 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <cmath>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/EagerMath/OrthonormalOneform.hpp"
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/Expressions/AddSubtract.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
 #include "Framework/Pypp.hpp"
@@ -24,10 +31,216 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
+
+// This namespace is meant to hold straightforward implementations of the
+// expressions used in the GRMHD characteristics that are not optimized for
+// performance. We keep them here to compare against the optimized versions in
+// Characteristics.cpp to ensure the optimized versions are correct.
+namespace unoptimized {
+
+template <size_t ThermodynamicDim>
+void flux_jacobian_hydro(
+    const gsl::not_null<tnsr::iJ<DataVector, 6>*> characteristic_matrix,
+    /* primitive variables */
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& electron_fraction,
+    /* other helpful quantities */
+    const Scalar<DataVector>& lorentz_factor,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) {
+  Variables<tmpl::list<
+      hydro::Tags::SoundSpeedSquared<DataVector>,
+      hydro::Tags::Pressure<DataVector>, ::Tags::TempScalar<0>,
+      ::Tags::TempScalar<1>, ::Tags::TempScalar<2>, ::Tags::TempScalar<3>,
+      ::Tags::TempScalar<4>, ::Tags::TempScalar<5>, ::Tags::TempScalar<6>,
+      ::Tags::TempScalar<7>, ::Tags::TempScalar<8>, ::Tags::TempI<0, 3>,
+      ::Tags::Tempi<0, 3>, ::Tags::TempIj<0, 3>, ::Tags::TempI<1, 3>>>
+      temp_tensors{get<0, 0>(spatial_metric).size()};
+
+  Scalar<DataVector>& sound_speed_squared =
+      get<hydro::Tags::SoundSpeedSquared<DataVector>>(temp_tensors);
+  // We define kappa as the partial derivative of pressure with respect to
+  // specific internal energy
+  Scalar<DataVector>& kappa = get<::Tags::TempScalar<0>>(temp_tensors);
+  // We define zeta as the partial derivative of pressure with respect to
+  // electron fraction
+  Scalar<DataVector>& zeta = get<::Tags::TempScalar<1>>(temp_tensors);
+  Scalar<DataVector>& pressure =
+      get<hydro::Tags::Pressure<DataVector>>(temp_tensors);
+  if constexpr (ThermodynamicDim == 1) {
+    get(sound_speed_squared) =
+        get(equation_of_state.chi_from_density(rest_mass_density)) +
+        get(equation_of_state.kappa_times_p_over_rho_squared_from_density(
+            rest_mass_density));
+    get(sound_speed_squared) /= get(specific_enthalpy);
+    get(kappa) = 0.0;
+    get(zeta) = 0.0;
+  } else if constexpr (ThermodynamicDim == 2) {
+    Scalar<DataVector>& kappa_times_p_over_rho_squared =
+        get<::Tags::TempScalar<2>>(temp_tensors);
+    get(kappa_times_p_over_rho_squared) =
+        get(equation_of_state
+                .kappa_times_p_over_rho_squared_from_density_and_energy(
+                    rest_mass_density, specific_internal_energy));
+    get(sound_speed_squared) =
+        (get(equation_of_state.chi_from_density_and_energy(
+             rest_mass_density, specific_internal_energy)) +
+         get(kappa_times_p_over_rho_squared)) /
+        get(specific_enthalpy);
+    get(pressure) = get(equation_of_state.pressure_from_density_and_energy(
+        rest_mass_density, specific_internal_energy));
+    get(kappa) = get(kappa_times_p_over_rho_squared) / get(pressure) *
+                 square(get(rest_mass_density));
+    get(zeta) = 0.0;
+  } else if constexpr (ThermodynamicDim == 3) {
+    Scalar<DataVector>& temperature = get<::Tags::TempScalar<2>>(temp_tensors);
+    get(temperature) =
+        get(equation_of_state.temperature_from_density_and_energy(
+            rest_mass_density, specific_internal_energy, electron_fraction));
+    get(sound_speed_squared) =
+        get(equation_of_state.sound_speed_squared_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction));
+    get(pressure) = get(equation_of_state.pressure_from_density_and_temperature(
+        rest_mass_density, temperature, electron_fraction));
+    get(kappa) = get(equation_of_state.kappa_from_density_and_temperature(
+        rest_mass_density, temperature, electron_fraction));
+    get(zeta) = get(equation_of_state.zeta_from_density_and_temperature(
+        rest_mass_density, temperature, electron_fraction));
+  }
+
+  // Intermediate variables
+  Scalar<DataVector>& Z = get<::Tags::TempScalar<3>>(temp_tensors);
+  tenex::evaluate(make_not_null(&Z), rest_mass_density() * specific_enthalpy() *
+                                         square(lorentz_factor()));
+  Scalar<DataVector>& D = get<::Tags::TempScalar<4>>(temp_tensors);
+  tenex::evaluate(make_not_null(&D), rest_mass_density() * lorentz_factor());
+  Scalar<DataVector>& normal_velocity =
+      get<::Tags::TempScalar<5>>(temp_tensors);
+  tenex::evaluate(make_not_null(&normal_velocity),
+                  spatial_velocity(ti::I) * unit_normal(ti::i));
+  tnsr::I<DataVector, 3>& unit_vector = get<::Tags::TempI<0, 3>>(temp_tensors);
+  tenex::evaluate<ti::I>(make_not_null(&unit_vector),
+                         inv_spatial_metric(ti::I, ti::J) * unit_normal(ti::j));
+  tnsr::i<DataVector, 3>& spatial_velocity_one_form =
+      get<::Tags::Tempi<0, 3>>(temp_tensors);
+  tenex::evaluate<ti::i>(
+      make_not_null(&spatial_velocity_one_form),
+      spatial_metric(ti::i, ti::j) * spatial_velocity(ti::J));
+  tnsr::Ij<DataVector, 3>& mixed_spatial_metric =
+      get<::Tags::TempIj<0, 3>>(temp_tensors);
+  tenex::evaluate<ti::I, ti::j>(
+      make_not_null(&mixed_spatial_metric),
+      inv_spatial_metric(ti::I, ti::K) * spatial_metric(ti::k, ti::j));
+
+  // Derivatives of Z
+  Scalar<DataVector>& dzdD = get<::Tags::TempScalar<6>>(temp_tensors);
+  tenex::evaluate(
+      make_not_null(&dzdD),
+      -((lorentz_factor() *
+         (kappa() * (-specific_enthalpy() + lorentz_factor()) -
+          zeta() * electron_fraction() +
+          (sound_speed_squared() * specific_enthalpy() + lorentz_factor()) *
+              rest_mass_density())) /
+        ((-square(lorentz_factor()) +
+          sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+         rest_mass_density())));
+  tnsr::I<DataVector, 3>& dzds = get<::Tags::TempI<1, 3>>(temp_tensors);
+  tenex::evaluate<ti::I>(
+      make_not_null(&dzds),
+      (spatial_velocity(ti::I) * square(lorentz_factor()) *
+       (kappa() + sound_speed_squared() * rest_mass_density())) /
+          ((-square(lorentz_factor()) +
+            sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+           rest_mass_density()));
+  Scalar<DataVector>& dzdtau = get<::Tags::TempScalar<7>>(temp_tensors);
+  tenex::evaluate(
+      make_not_null(&dzdtau),
+      -((square(lorentz_factor()) * (kappa() + rest_mass_density())) /
+        ((-square(lorentz_factor()) +
+          sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+         rest_mass_density())));
+  Scalar<DataVector>& dzdye = get<::Tags::TempScalar<8>>(temp_tensors);
+  tenex::evaluate(
+      make_not_null(&dzdye),
+      (zeta() * lorentz_factor()) /
+          ((square(lorentz_factor()) -
+            sound_speed_squared() * (-1. + square(lorentz_factor()))) *
+           rest_mass_density()));
+
+  // Put analytic expressions into characteristic matrix
+  characteristic_matrix->get(0, 0) =
+      ((get(Z) - get(D) * get(dzdD)) * get(normal_velocity)) / get(Z);
+  for (size_t B = 0; B < 3; ++B) {
+    characteristic_matrix->get(0, B + 1) =
+        (get(D) * (unit_vector.get(B) - dzds.get(B) * get(normal_velocity))) /
+        get(Z);
+  }
+  characteristic_matrix->get(0, 4) =
+      -((get(D) * get(dzdtau) * get(normal_velocity)) / get(Z));
+  characteristic_matrix->get(0, 5) =
+      -((get(D) * get(dzdye) * get(normal_velocity)) / get(Z));
+  for (size_t c = 0; c < 3; ++c) {
+    characteristic_matrix->get(c + 1, 0) =
+        (-1.0 + get(dzdD)) * unit_normal.get(c) -
+        get(dzdD) * get(normal_velocity) * spatial_velocity_one_form.get(c);
+    for (size_t B = 0; B < 3; ++B) {
+      characteristic_matrix->get(c + 1, B + 1) =
+          mixed_spatial_metric.get(B, c) * get(normal_velocity) +
+          unit_vector.get(B) * spatial_velocity_one_form.get(c) +
+          dzds.get(B) *
+              (unit_normal.get(c) -
+               get(normal_velocity) * spatial_velocity_one_form.get(c));
+    }
+    characteristic_matrix->get(c + 1, 4) =
+        (-1.0 + get(dzdtau)) * unit_normal.get(c) -
+        get(dzdtau) * get(normal_velocity) * spatial_velocity_one_form.get(c);
+    characteristic_matrix->get(c + 1, 5) =
+        get(dzdye) * (unit_normal.get(c) -
+                      get(normal_velocity) * spatial_velocity_one_form.get(c));
+  }
+  characteristic_matrix->get(4, 0) =
+      -(((get(Z) - get(D) * get(dzdD)) * get(normal_velocity)) / get(Z));
+  for (size_t B = 0; B < 3; ++B) {
+    characteristic_matrix->get(4, B + 1) =
+        ((get(Z) - get(D)) * unit_vector.get(B) +
+         get(D) * dzds.get(B) * get(normal_velocity)) /
+        get(Z);
+  }
+  characteristic_matrix->get(4, 4) =
+      (get(D) * get(dzdtau) * get(normal_velocity)) / get(Z);
+  characteristic_matrix->get(4, 5) =
+      (get(D) * get(dzdye) * get(normal_velocity)) / get(Z);
+  characteristic_matrix->get(5, 0) =
+      -((get(D) * get(electron_fraction) * get(dzdD) * get(normal_velocity)) /
+        get(Z));
+  for (size_t B = 0; B < 3; ++B) {
+    characteristic_matrix->get(5, B + 1) =
+        (get(D) * get(electron_fraction) *
+         (unit_vector.get(B) - dzds.get(B) * get(normal_velocity))) /
+        get(Z);
+  }
+  characteristic_matrix->get(5, 4) =
+      -((get(D) * get(electron_fraction) * get(dzdtau) * get(normal_velocity)) /
+        get(Z));
+  characteristic_matrix->get(5, 5) =
+      ((get(Z) - get(D) * get(electron_fraction) * get(dzdye)) *
+       get(normal_velocity)) /
+      get(Z);
+}
+
+}  // namespace unoptimized
 
 void test_characteristic_speeds(const DataVector& /*used_for_size*/) {
   //  Arbitrary random numbers can produce a negative radicand in Lambda^\pm.
@@ -320,6 +533,120 @@ void test_hydro_numerical_characteristics(const DataVector& used_for_size) {
     }
   }
 }
+
+void test_hydro_characteristics_match_unoptimized_version(
+    const DataVector& used_for_size) {
+  MAKE_GENERATOR(generator);
+  namespace helper = TestHelpers::hydro;
+  namespace gr_helper = TestHelpers::gr;
+  const auto nn_gen = make_not_null(&generator);
+
+  const auto rest_mass_density = helper::random_density(nn_gen, used_for_size);
+  const auto specific_internal_energy =
+      helper::random_specific_internal_energy(nn_gen, used_for_size);
+  const auto electron_fraction =
+      helper::random_electron_fraction(nn_gen, used_for_size);
+  const auto lorentz_factor =
+      helper::random_lorentz_factor(nn_gen, used_for_size);
+  const auto spatial_metric =
+      gr_helper::random_spatial_metric<3>(nn_gen, used_for_size);
+  const auto spatial_velocity =
+      helper::random_velocity(nn_gen, lorentz_factor, spatial_metric);
+  const auto& inv_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+
+  const EquationsOfState::IdealFluid<true> base_eos(1.5, 0.0);
+  const auto eos_3d = base_eos.promote_to_3d_eos();
+
+  const auto pressure = eos_3d->pressure_from_density_and_energy(
+      rest_mass_density, specific_internal_energy, electron_fraction);
+  const auto specific_enthalpy = hydro::relativistic_specific_enthalpy(
+      rest_mass_density, specific_internal_energy, pressure);
+
+  constexpr size_t matrix_size = 6;
+  const size_t num_points = used_for_size.size();
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const auto unit_normal = unit_basis_form(direction, inv_spatial_metric);
+
+    tnsr::iJ<DataVector, matrix_size> optimized_matrix{num_points};
+    tnsr::iJ<DataVector, matrix_size> unoptimized_matrix{num_points};
+    grmhd::ValenciaDivClean::flux_jacobian_hydro<3>(
+        make_not_null(&optimized_matrix), spatial_velocity, rest_mass_density,
+        specific_internal_energy, electron_fraction, lorentz_factor,
+        specific_enthalpy, spatial_metric, inv_spatial_metric, unit_normal,
+        *eos_3d);
+    unoptimized::flux_jacobian_hydro<3>(
+        make_not_null(&unoptimized_matrix), spatial_velocity, rest_mass_density,
+        specific_internal_energy, electron_fraction, lorentz_factor,
+        specific_enthalpy, spatial_metric, inv_spatial_metric, unit_normal,
+        *eos_3d);
+    CHECK_ITERABLE_CUSTOM_APPROX(optimized_matrix, unoptimized_matrix,
+                                 custom_approx);
+  }
+}
+
+void run_hydro_characteristic_benchmarks(const bool enable) {
+  if (not enable) {
+    return;
+  }
+
+  MAKE_GENERATOR(generator);
+  namespace helper = TestHelpers::hydro;
+  namespace gr_helper = TestHelpers::gr;
+  const auto nn_gen = make_not_null(&generator);
+
+  constexpr size_t num_points = 1000000;
+  const DataVector used_for_size(num_points);
+
+  const auto rest_mass_density = helper::random_density(nn_gen, used_for_size);
+  const auto specific_internal_energy =
+      helper::random_specific_internal_energy(nn_gen, used_for_size);
+  const auto electron_fraction =
+      helper::random_electron_fraction(nn_gen, used_for_size);
+  const auto lorentz_factor =
+      helper::random_lorentz_factor(nn_gen, used_for_size);
+  const auto spatial_metric =
+      gr_helper::random_spatial_metric<3>(nn_gen, used_for_size);
+  const auto spatial_velocity =
+      helper::random_velocity(nn_gen, lorentz_factor, spatial_metric);
+  const auto& inv_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+
+  const EquationsOfState::IdealFluid<true> base_eos(1.5, 0.0);
+  const auto eos_3d = base_eos.promote_to_3d_eos();
+
+  const auto pressure = eos_3d->pressure_from_density_and_energy(
+      rest_mass_density, specific_internal_energy, electron_fraction);
+  const auto specific_enthalpy = hydro::relativistic_specific_enthalpy(
+      rest_mass_density, specific_internal_energy, pressure);
+
+  const auto unit_normal =
+      unit_basis_form(Direction<3>::lower_xi(), inv_spatial_metric);
+
+  // Benchmark ran on mbot (Iago Mendes, April 2026):
+  // - flux_jacobian_hydro (optimized): ~134 ms
+  // - flux_jacobian_hydro (unoptimized): ~159 ms
+  // - optimization result: ~1.2x speedup (~20% faster)
+  constexpr size_t matrix_size = 6;
+  tnsr::iJ<DataVector, matrix_size> optimized_matrix{num_points};
+  tnsr::iJ<DataVector, matrix_size> unoptimized_matrix{num_points};
+  BENCHMARK("flux_jacobian_hydro (optimized)") {
+    grmhd::ValenciaDivClean::flux_jacobian_hydro<3>(
+        make_not_null(&optimized_matrix), spatial_velocity, rest_mass_density,
+        specific_internal_energy, electron_fraction, lorentz_factor,
+        specific_enthalpy, spatial_metric, inv_spatial_metric, unit_normal,
+        *eos_3d);
+  };
+  BENCHMARK("flux_jacobian_hydro (unoptimized)") {
+    unoptimized::flux_jacobian_hydro<3>(
+        make_not_null(&unoptimized_matrix), spatial_velocity, rest_mass_density,
+        specific_internal_energy, electron_fraction, lorentz_factor,
+        specific_enthalpy, spatial_metric, inv_spatial_metric, unit_normal,
+        *eos_3d);
+  };
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Characteristics",
@@ -334,6 +661,10 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Characteristics",
   test_with_normal_along_coordinate_axes(dv);
   test_hydro_characteristic_speed(dv);
   test_hydro_numerical_characteristics(dv);
+  test_hydro_characteristics_match_unoptimized_version(dv);
+
+  // Disable benchmark by default
+  run_hydro_characteristic_benchmarks(false);
 
   TestHelpers::db::test_compute_tag<
       grmhd::ValenciaDivClean::Tags::CharacteristicSpeedsCompute>(


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

This PR adds a way to numerically find the characteristic speeds and fields for relativistic hydrodynamics with composition dependence (electron fraction).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
