### PR TITLE
Change some ASSERTs to PARSE_ERROR in domain code

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -21,6 +21,51 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"
 
+namespace {
+template <typename Map>
+std::unique_ptr<Map> clone_map(const std::unique_ptr<Map>& map) {
+  return map == nullptr ? nullptr : map->get_clone();
+}
+}  // namespace
+
+template <size_t VolumeDim>
+Block<VolumeDim>::Block(const Block<VolumeDim>& rhs)
+    : stationary_map_(clone_map(rhs.stationary_map_)),
+      moving_mesh_logical_to_grid_map_(
+          clone_map(rhs.moving_mesh_logical_to_grid_map_)),
+      moving_mesh_grid_to_inertial_map_(
+          clone_map(rhs.moving_mesh_grid_to_inertial_map_)),
+      moving_mesh_grid_to_distorted_map_(
+          clone_map(rhs.moving_mesh_grid_to_distorted_map_)),
+      moving_mesh_distorted_to_inertial_map_(
+          clone_map(rhs.moving_mesh_distorted_to_inertial_map_)),
+      id_(rhs.id_),
+      neighbors_(rhs.neighbors_),
+      external_boundaries_(rhs.external_boundaries_),
+      name_(rhs.name_),
+      topologies_(rhs.topologies_) {}
+
+template <size_t VolumeDim>
+Block<VolumeDim>& Block<VolumeDim>::operator=(const Block<VolumeDim>& rhs) {
+  if (this != &rhs) {
+    stationary_map_ = clone_map(rhs.stationary_map_);
+    moving_mesh_logical_to_grid_map_ =
+        clone_map(rhs.moving_mesh_logical_to_grid_map_);
+    moving_mesh_grid_to_inertial_map_ =
+        clone_map(rhs.moving_mesh_grid_to_inertial_map_);
+    moving_mesh_grid_to_distorted_map_ =
+        clone_map(rhs.moving_mesh_grid_to_distorted_map_);
+    moving_mesh_distorted_to_inertial_map_ =
+        clone_map(rhs.moving_mesh_distorted_to_inertial_map_);
+    id_ = rhs.id_;
+    neighbors_ = rhs.neighbors_;
+    external_boundaries_ = rhs.external_boundaries_;
+    name_ = rhs.name_;
+    topologies_ = rhs.topologies_;
+  }
+  return *this;
+}
+
 template <size_t VolumeDim>
 Block<VolumeDim>::Block(
     std::unique_ptr<domain::CoordinateMapBase<

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -63,9 +63,9 @@ class Block {
 
   Block() = default;
   ~Block() = default;
-  Block(const Block&) = delete;
+  Block(const Block& rhs);
   Block(Block&&) = default;
-  Block& operator=(const Block&) = delete;
+  Block& operator=(const Block& rhs);
   Block& operator=(Block&&) = default;
 
   /// \brief The map used when the coordinate map is time-independent.

--- a/src/Domain/CoordinateMaps/Wedge.cpp
+++ b/src/Domain/CoordinateMaps/Wedge.cpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
+#include "Options/ParseError.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -33,36 +34,50 @@ void run_shared_asserts(const double radius_inner,
                         const double sphericity_outer,
                         const Distribution radial_distribution,
                         const OrientationMap<Dim>& orientation_of_wedge,
-                        const std::array<double, Dim>& focal_offset) {
+                        const std::array<double, Dim>& focal_offset,
+                        const Options::Context& context) {
   const double sqrt_dim = sqrt(Dim);
   const bool zero_offset = (focal_offset == make_array<Dim, double>(0.0));
 
-  ASSERT(radius_inner > 0.0,
-         "The radius of the inner surface must be greater than zero.");
+  if (radius_inner <= 0.0) {
+    PARSE_ERROR(context,
+                "The radius of the inner surface must be greater than zero.");
+  }
   if (radius_outer.has_value()) {
     // radius_outer should have a value
-    ASSERT(radius_outer.value() > radius_inner,
-           "The radius of the outer surface must be greater than the radius of "
-           "the inner surface.");
+    if (radius_outer.value() <= radius_inner) {
+      PARSE_ERROR(
+          context,
+          "The radius of the outer surface must be greater than the radius of "
+          "the inner surface.");
+    }
   }
-  ASSERT(radial_distribution == Distribution::Linear or
-             (sphericity_inner == 1.0 and sphericity_outer == 1.0),
-         "Only the 'Linear' radial distribution is supported for non-spherical "
-         "wedges.");
+  if (radial_distribution != Distribution::Linear and
+      (sphericity_inner != 1.0 or sphericity_outer != 1.0)) {
+    PARSE_ERROR(context,
+                "Only the 'Linear' radial distribution is supported for "
+                "non-spherical wedges.");
+  }
   if (zero_offset) {
     // radius_outer should have a value
-    ASSERT(radius_outer.value() *
-                   ((1.0 - sphericity_outer) / sqrt_dim + sphericity_outer) >
-               radius_inner *
-                   ((1.0 - sphericity_inner) / sqrt_dim + sphericity_inner),
-           "The arguments passed into the constructor for Wedge result in an "
-           "object where the outer surface is pierced by the inner surface.");
+    if (radius_outer.value() *
+            ((1.0 - sphericity_outer) / sqrt_dim + sphericity_outer) <=
+        radius_inner *
+            ((1.0 - sphericity_inner) / sqrt_dim + sphericity_inner)) {
+      PARSE_ERROR(
+          context,
+          "The arguments passed into the constructor for Wedge result in an "
+          "object where the outer surface is pierced by the inner surface.");
+    }
   }
-  ASSERT(
-      get(determinant(discrete_rotation_jacobian(orientation_of_wedge))) > 0.0,
-      "Wedge rotations must be done in such a manner that the sign of "
-      "the determinant of the discrete rotation is positive. This is to "
-      "preserve handedness of the coordinates.");
+  if (get(determinant(discrete_rotation_jacobian(orientation_of_wedge))) <=
+      0.0) {
+    PARSE_ERROR(
+        context,
+        "Wedge rotations must be done in such a manner that the sign of "
+        "the determinant of the discrete rotation is positive. This is to "
+        "preserve handedness of the coordinates.");
+  }
 }
 }  // namespace
 
@@ -74,7 +89,8 @@ Wedge<Dim>::Wedge(const double radius_inner, const double radius_outer,
                   const WedgeHalves halves_to_use,
                   const Distribution radial_distribution,
                   const std::array<double, Dim - 1>& opening_angles,
-                  const bool with_adapted_equiangular_map)
+                  const bool with_adapted_equiangular_map,
+                  const Options::Context& context)
     : radius_inner_(radius_inner),
       radius_outer_(radius_outer),
       sphericity_inner_(sphericity_inner),
@@ -86,17 +102,23 @@ Wedge<Dim>::Wedge(const double radius_inner, const double radius_outer,
       halves_to_use_(halves_to_use),
       radial_distribution_(radial_distribution),
       opening_angles_(opening_angles) {
-  ASSERT(sphericity_inner >= 0.0 and sphericity_inner <= 1.0,
-         "Sphericity of the inner surface must be between 0 and 1");
-  ASSERT(sphericity_outer >= 0.0 and sphericity_outer <= 1.0,
-         "Sphericity of the outer surface must be between 0 and 1");
+  if (sphericity_inner < 0.0 or sphericity_inner > 1.0) {
+    PARSE_ERROR(context,
+                "Sphericity of the inner surface must be between 0 and 1");
+  }
+  if (sphericity_outer < 0.0 or sphericity_outer > 1.0) {
+    PARSE_ERROR(context,
+                "Sphericity of the outer surface must be between 0 and 1");
+  }
   run_shared_asserts(radius_inner_, radius_outer_, sphericity_inner_,
                      sphericity_outer_, radial_distribution_,
-                     orientation_of_wedge_, focal_offset_);
-  ASSERT(opening_angles_ != make_array<Dim - 1>(M_PI_2) ? with_equiangular_map
-                                                        : true,
-         "If using opening angles other than pi/2, then the "
-         "equiangular map option must be turned on.");
+                     orientation_of_wedge_, focal_offset_, context);
+  if (opening_angles_ != make_array<Dim - 1>(M_PI_2) and
+      not with_equiangular_map_) {
+    PARSE_ERROR(context,
+                "If using opening angles other than pi/2, then the "
+                "equiangular map option must be turned on.");
+  }
 
   if (radial_distribution_ == Distribution::Linear) {
     const double sqrt_dim = sqrt(double{Dim});
@@ -140,7 +162,8 @@ Wedge<Dim>::Wedge(
     const double radius_inner, const std::optional<double> radius_outer,
     const double cube_half_length, const std::array<double, Dim> focal_offset,
     OrientationMap<Dim> orientation_of_wedge, const bool with_equiangular_map,
-    const WedgeHalves halves_to_use, const Distribution radial_distribution)
+    const WedgeHalves halves_to_use, const Distribution radial_distribution,
+    const Options::Context& context)
     : radius_inner_(radius_inner),
       radius_outer_((focal_offset == make_array<Dim>(0.0))
                         ? radius_outer.value_or(sqrt(Dim) * cube_half_length)
@@ -166,16 +189,21 @@ Wedge<Dim>::Wedge(
               : std::nullopt) {
   run_shared_asserts(radius_inner_, radius_outer_, sphericity_inner_,
                      sphericity_outer_, radial_distribution_,
-                     orientation_of_wedge_, focal_offset_);
+                     orientation_of_wedge_, focal_offset_, context);
 
   const bool zero_offset = (focal_offset_ == make_array<Dim, double>(0.0));
   if (not zero_offset) {
     // Do checks specific to an offset Wedge
-    ASSERT(sphericity_inner_ == 1.0,
-           "Focal offsets are not supported for inner sphericity < 1.0");
-    ASSERT(sphericity_outer_ == 0.0 or sphericity_outer_ == 1.0,  // NOLINT
-           "Focal offsets are only supported for wedges with outer sphericity "
-           "of 1.0 or 0.0");
+    if (sphericity_inner_ != 1.0) {
+      PARSE_ERROR(context,
+                  "Focal offsets are not supported for inner sphericity < 1.0");
+    }
+    if (sphericity_outer_ != 0.0 and sphericity_outer_ != 1.0) {
+      PARSE_ERROR(
+          context,
+          "Focal offsets are only supported for wedges with outer sphericity "
+          "of 1.0 or 0.0");
+    }
 
     // coord of focal_offset_ with largest magnitude
     const double max_abs_focal_offset_coord = *alg::max_element(
@@ -185,28 +213,33 @@ Wedge<Dim>::Wedge(
     if (radius_outer_.has_value()) {
       // note: this assert may be more restrictive than we need, can be revisted
       // if needed
-      ASSERT(
-          max_abs_focal_offset_coord + radius_outer_.value() < cube_half_length,
-          "For a spherical focally offset Wedge, the sum of the outer radius "
-          "and the coordinate of the focal offset with the largest magnitude "
-          "must be less than the cube half length. In other words, the "
-          "spherical surface at the given outer radius centered at the focal "
-          "offset must not pierce the cube of length 2 * cube_half_length_ "
-          "centered at the origin. See the Wedge class documentation for a "
-          "visual representation of this sphere and cube.");
+      if (max_abs_focal_offset_coord + radius_outer_.value() >=
+          cube_half_length) {
+        PARSE_ERROR(
+            context,
+            "For a spherical focally offset Wedge, the sum of the outer radius "
+            "and the coordinate of the focal offset with the largest magnitude "
+            "must be less than the cube half length. In other words, the "
+            "spherical surface at the given outer radius centered at the focal "
+            "offset must not pierce the cube of length 2 * cube_half_length_ "
+            "centered at the origin. See the Wedge class documentation for a "
+            "visual representation of this sphere and cube.");
+      }
 
     } else {
       // if sphericity_outer_= 0.0, the outer surface of the Wedge is the parent
       // surface
-      ASSERT(
-          max_abs_focal_offset_coord + radius_inner_ < cube_half_length,
-          "For a cubical focally offset Wedge, the sum of the inner radius "
-          "and the coordinate of the focal offset with the largest magnitude "
-          "must be less than the cube half length. In other words, the "
-          "spherical surface at the given inner radius centered at the focal "
-          "offset must not pierce the cube of length 2 * cube_half_length_ "
-          "centered at the origin. See the Wedge class documentation for a "
-          "visual representation of this sphere and cube.");
+      if (max_abs_focal_offset_coord + radius_inner_ >= cube_half_length) {
+        PARSE_ERROR(
+            context,
+            "For a cubical focally offset Wedge, the sum of the inner radius "
+            "and the coordinate of the focal offset with the largest magnitude "
+            "must be less than the cube half length. In other words, the "
+            "spherical surface at the given inner radius centered at the focal "
+            "offset must not pierce the cube of length 2 * cube_half_length_ "
+            "centered at the origin. See the Wedge class documentation for a "
+            "visual representation of this sphere and cube.");
+      }
     }
   }
 

--- a/src/Domain/CoordinateMaps/Wedge.hpp
+++ b/src/Domain/CoordinateMaps/Wedge.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
+#include "Options/Context.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 /// \cond
@@ -852,6 +853,7 @@ class Wedge {
    * `true`, angular distances are proportional to logical distances. Note
    * that it is not possible to use adapted maps in every Wedge of a Sphere
    * unless each Wedge has the same size along both angular directions.
+   * \param context Used by the input file parser.
    */
   Wedge(double radius_inner, double radius_outer, double sphericity_inner,
         double sphericity_outer, OrientationMap<Dim> orientation_of_wedge,
@@ -860,7 +862,8 @@ class Wedge {
         Distribution radial_distribution = Distribution::Linear,
         const std::array<double, Dim - 1>& opening_angles =
             make_array<Dim - 1>(M_PI_2),
-        bool with_adapted_equiangular_map = true);
+        bool with_adapted_equiangular_map = true,
+        const Options::Context& context = {});
 
   /*!
    * \brief Constructs a wedge with a focal offset
@@ -920,12 +923,14 @@ class Wedge {
    * \param radial_distribution Determines how to distribute gridpoints along
    * the radial direction. For wedges that are not exactly spherical, only
    * `Distribution::Linear` is currently supported.
+   * \param context Used by the input file parser.
    */
   Wedge(double radius_inner, std::optional<double> radius_outer,
         double cube_half_length, std::array<double, Dim> focal_offset,
         OrientationMap<Dim> orientation_of_wedge, bool with_equiangular_map,
         WedgeHalves halves_to_use = WedgeHalves::Both,
-        Distribution radial_distribution = Distribution::Linear);
+        Distribution radial_distribution = Distribution::Linear,
+        const Options::Context& context = {});
 
   Wedge() = default;
   ~Wedge() = default;

--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -149,12 +149,18 @@ AlignedLattice<Dim>::AlignedLattice(
 }
 
 template <size_t Dim>
-Domain<Dim> AlignedLattice<Dim>::create_domain() const {
+Domain<Dim> AlignedLattice<Dim>::create_domain(
+    const Options::Context& /*context*/) const {
   return rectilinear_domain<Dim>(
       number_of_blocks_by_dim_, block_bounds_,
       {std::vector<Index<Dim>>(blocks_to_exclude_.begin(),
                                blocks_to_exclude_.end())},
       {}, is_periodic_in_, {}, false);
+}
+
+template <size_t Dim>
+Domain<Dim> AlignedLattice<Dim>::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -150,7 +150,7 @@ AlignedLattice<Dim>::AlignedLattice(
 }
 
 template <size_t Dim>
-Domain<Dim> AlignedLattice<Dim>::create_domain(
+Domain<Dim> AlignedLattice<Dim>::build_domain(
     const Options::Context& /*context*/) const {
   return rectilinear_domain<Dim>(
       number_of_blocks_by_dim_, block_bounds_,
@@ -160,7 +160,7 @@ Domain<Dim> AlignedLattice<Dim>::create_domain(
 }
 
 template <size_t Dim>
-Domain<Dim> AlignedLattice<Dim>::create_domain() const {
+const Domain<Dim>& AlignedLattice<Dim>::domain() const {
   return domain_;
 }
 
@@ -180,7 +180,7 @@ AlignedLattice<Dim>::external_boundary_conditions() const {
   }
   // Set boundary conditions by using the computed domain's external
   // boundaries
-  const auto domain = create_domain();
+  const auto& domain = domain_;
   const auto& blocks = domain.blocks();
   std::vector<DirectionMap<
       Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -76,6 +76,11 @@ AlignedLattice<Dim>::AlignedLattice(
       }
     }
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -79,7 +79,7 @@ AlignedLattice<Dim>::AlignedLattice(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -165,7 +165,7 @@ Domain<Dim> AlignedLattice<Dim>::create_domain(
 
 template <size_t Dim>
 Domain<Dim> AlignedLattice<Dim>::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -76,11 +76,7 @@ AlignedLattice<Dim>::AlignedLattice(
       }
     }
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 template <size_t Dim>
@@ -165,7 +161,7 @@ Domain<Dim> AlignedLattice<Dim>::create_domain(
 
 template <size_t Dim>
 Domain<Dim> AlignedLattice<Dim>::create_domain() const {
-  return build_domain(Options::Context{});
+  return domain_;
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -241,6 +241,7 @@ class AlignedLattice final : public DomainCreator<Dim> {
       const override;
 
  private:
+  Domain<Dim> create_domain(const Options::Context& context) const;
   std::array<std::vector<double>, Dim> block_bounds_{
       make_array<Dim, std::vector<double>>({})};
   std::array<bool, Dim> is_periodic_in_{make_array<Dim>(false)};

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -241,7 +241,7 @@ class AlignedLattice final : public DomainCreator<Dim> {
       const override;
 
  private:
-  Domain<Dim> create_domain(const Options::Context& context) const;
+  Domain<Dim> build_domain(const Options::Context& context) const;
   std::array<std::vector<double>, Dim> block_bounds_{
       make_array<Dim, std::vector<double>>({})};
   std::array<bool, Dim> is_periodic_in_{make_array<Dim>(false)};

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -242,6 +242,7 @@ class AlignedLattice final : public DomainCreator<Dim> {
 
  private:
   Domain<Dim> build_domain(const Options::Context& context) const;
+  Domain<Dim> domain_{};
   std::array<std::vector<double>, Dim> block_bounds_{
       make_array<Dim, std::vector<double>>({})};
   std::array<bool, Dim> is_periodic_in_{make_array<Dim>(false)};

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -227,7 +227,7 @@ class AlignedLattice final : public DomainCreator<Dim> {
   AlignedLattice& operator=(AlignedLattice&&) = default;
   ~AlignedLattice() override = default;
 
-  Domain<Dim> create_domain() const override;
+  const Domain<Dim>& domain() const override;
 
   std::vector<DirectionMap<
       Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -95,7 +95,7 @@ template <size_t Dim>
 /// number of Block%s that your problem needs.  More initial Element%s can be
 /// created by specifying a larger `InitialRefinement`.
 template <size_t Dim>
-class AlignedLattice : public DomainCreator<Dim> {
+class AlignedLattice final : public DomainCreator<Dim> {
  public:
   using maps_list = tmpl::list<
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,

--- a/src/Domain/Creators/AngularCylinder.cpp
+++ b/src/Domain/Creators/AngularCylinder.cpp
@@ -443,7 +443,7 @@ Domain<3> AngularCylinder::build_domain(
   return domain;
 }
 
-Domain<3> AngularCylinder::create_domain() const { return domain_; }
+const Domain<3>& AngularCylinder::domain() const { return domain_; }
 
 std::vector<DirectionMap<
     3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AngularCylinder.cpp
+++ b/src/Domain/Creators/AngularCylinder.cpp
@@ -227,6 +227,7 @@ AngularCylinder::AngularCylinder(
                       << initial_refinement_in_z_.size() << ".");
     }
   }
+  domain_ = build_domain(context);
 }
 
 AngularCylinder::AngularCylinder(
@@ -318,6 +319,7 @@ AngularCylinder::AngularCylinder(
                   "is probably a mistake");
     }
   }
+  domain_ = build_domain(context);
 }
 
 Domain<3> AngularCylinder::build_domain(
@@ -441,9 +443,7 @@ Domain<3> AngularCylinder::build_domain(
   return domain;
 }
 
-Domain<3> AngularCylinder::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> AngularCylinder::create_domain() const { return domain_; }
 
 std::vector<DirectionMap<
     3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AngularCylinder.cpp
+++ b/src/Domain/Creators/AngularCylinder.cpp
@@ -320,7 +320,8 @@ AngularCylinder::AngularCylinder(
   }
 }
 
-Domain<3> AngularCylinder::create_domain() const {
+Domain<3> AngularCylinder::build_domain(
+    const Options::Context& /*context*/) const {
   using Affine = CoordinateMaps::Affine;
   using Identity1D = CoordinateMaps::Identity<1>;
   using Interval = CoordinateMaps::Interval;
@@ -438,6 +439,10 @@ Domain<3> AngularCylinder::create_domain() const {
     }
   }
   return domain;
+}
+
+Domain<3> AngularCylinder::create_domain() const {
+  return build_domain(Options::Context{});
 }
 
 std::vector<DirectionMap<

--- a/src/Domain/Creators/AngularCylinder.hpp
+++ b/src/Domain/Creators/AngularCylinder.hpp
@@ -329,6 +329,7 @@ class AngularCylinder final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   typename OuterRadius::type outer_radius_{};
   typename LowerZBound::type lower_z_bound_{};
   typename UpperZBound::type upper_z_bound_{};

--- a/src/Domain/Creators/AngularCylinder.hpp
+++ b/src/Domain/Creators/AngularCylinder.hpp
@@ -49,7 +49,7 @@ namespace domain::creators {
  * B2/I1 filled cylinder at the center and Fourier hollow cylinders surrounding
  * it.
  */
-class AngularCylinder : public DomainCreator<3> {
+class AngularCylinder final : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
       Frame::BlockLogical, Frame::Inertial,
@@ -328,6 +328,7 @@ class AngularCylinder : public DomainCreator<3> {
   }
 
  private:
+  Domain<3> build_domain(const Options::Context& context) const;
   typename OuterRadius::type outer_radius_{};
   typename LowerZBound::type lower_z_bound_{};
   typename UpperZBound::type upper_z_bound_{};

--- a/src/Domain/Creators/AngularCylinder.hpp
+++ b/src/Domain/Creators/AngularCylinder.hpp
@@ -310,7 +310,7 @@ class AngularCylinder final : public DomainCreator<3> {
   AngularCylinder& operator=(AngularCylinder&&) = default;
   ~AngularCylinder() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AngularDisk.cpp
+++ b/src/Domain/Creators/AngularDisk.cpp
@@ -141,6 +141,7 @@ AngularDisk::AngularDisk(
       block_groups_["Shells"].insert(shell);
     }
   }
+  domain_ = build_domain(context);
 }
 
 Domain<2> AngularDisk::build_domain(const Options::Context& /*context*/) const {
@@ -205,9 +206,7 @@ Domain<2> AngularDisk::build_domain(const Options::Context& /*context*/) const {
   return domain;
 }
 
-Domain<2> AngularDisk::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<2> AngularDisk::create_domain() const { return domain_; }
 
 std::vector<DirectionMap<
     2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AngularDisk.cpp
+++ b/src/Domain/Creators/AngularDisk.cpp
@@ -143,7 +143,7 @@ AngularDisk::AngularDisk(
   }
 }
 
-Domain<2> AngularDisk::create_domain() const {
+Domain<2> AngularDisk::build_domain(const Options::Context& /*context*/) const {
   using Identity = CoordinateMaps::Identity<1>;
   using Affine = CoordinateMaps::Affine;
   const auto aligned = OrientationMap<2>::create_aligned();
@@ -203,6 +203,10 @@ Domain<2> AngularDisk::create_domain() const {
     }
   }
   return domain;
+}
+
+Domain<2> AngularDisk::create_domain() const {
+  return build_domain(Options::Context{});
 }
 
 std::vector<DirectionMap<

--- a/src/Domain/Creators/AngularDisk.cpp
+++ b/src/Domain/Creators/AngularDisk.cpp
@@ -206,7 +206,7 @@ Domain<2> AngularDisk::build_domain(const Options::Context& /*context*/) const {
   return domain;
 }
 
-Domain<2> AngularDisk::create_domain() const { return domain_; }
+const Domain<2>& AngularDisk::domain() const { return domain_; }
 
 std::vector<DirectionMap<
     2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AngularDisk.hpp
+++ b/src/Domain/Creators/AngularDisk.hpp
@@ -44,7 +44,7 @@ namespace domain::creators {
  * \brief Create a 2D filled disk domain with radial partitioning using a B2
  * filled disk at the center and Fourier hollow disks surrounding it.
  */
-class AngularDisk : public DomainCreator<2> {
+class AngularDisk final : public DomainCreator<2> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
       Frame::BlockLogical, Frame::Inertial,
@@ -172,6 +172,7 @@ class AngularDisk : public DomainCreator<2> {
   }
 
  private:
+  Domain<2> build_domain(const Options::Context& context) const;
   typename OuterRadius::type outer_radius_{};
   typename RadialPartitioning::type radial_partitioning_{};
   typename InitialDiskThetaGridPoints::type initial_disk_grid_points_{};

--- a/src/Domain/Creators/AngularDisk.hpp
+++ b/src/Domain/Creators/AngularDisk.hpp
@@ -154,7 +154,7 @@ class AngularDisk final : public DomainCreator<2> {
   AngularDisk& operator=(AngularDisk&&) = default;
   ~AngularDisk() override = default;
 
-  Domain<2> create_domain() const override;
+  const Domain<2>& domain() const override;
 
   std::vector<DirectionMap<
       2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/AngularDisk.hpp
+++ b/src/Domain/Creators/AngularDisk.hpp
@@ -173,6 +173,7 @@ class AngularDisk final : public DomainCreator<2> {
 
  private:
   Domain<2> build_domain(const Options::Context& context) const;
+  Domain<2> domain_{};
   typename OuterRadius::type outer_radius_{};
   typename RadialPartitioning::type radial_partitioning_{};
   typename InitialDiskThetaGridPoints::type initial_disk_grid_points_{};

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -428,7 +428,7 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -905,7 +905,7 @@ BinaryCompactObject<UseWorldtube>::functions_of_time(
 
 template <bool UseWorldtube>
 Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 template class BinaryCompactObject<true>;

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -429,7 +429,7 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
 }
 
 template <bool UseWorldtube>
-Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
+Domain<3> BinaryCompactObject<UseWorldtube>::build_domain(
     const Options::Context& context) const {
   const double inner_sphericity_A = is_excised_a_ ? 1.0 : 0.0;
   const double inner_sphericity_B = is_excised_b_ ? 1.0 : 0.0;
@@ -900,7 +900,7 @@ BinaryCompactObject<UseWorldtube>::functions_of_time(
 }
 
 template <bool UseWorldtube>
-Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
+const Domain<3>& BinaryCompactObject<UseWorldtube>::domain() const {
   return domain_;
 }
 

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -425,6 +425,11 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
         radii_A, radii_B, not is_excised_a_, not is_excised_b_,
         envelope_radius_, outer_radius_);
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 template <bool UseWorldtube>

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -428,7 +428,8 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
 }
 
 template <bool UseWorldtube>
-Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
+Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
+    const Options::Context& /*context*/) const {
   const double inner_sphericity_A = is_excised_a_ ? 1.0 : 0.0;
   const double inner_sphericity_B = is_excised_b_ ? 1.0 : 0.0;
 
@@ -895,6 +896,11 @@ BinaryCompactObject<UseWorldtube>::functions_of_time(
              : std::unordered_map<
                    std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{};
+}
+
+template <bool UseWorldtube>
+Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 template class BinaryCompactObject<true>;

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -434,7 +434,7 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
 
 template <bool UseWorldtube>
 Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
-    const Options::Context& /*context*/) const {
+    const Options::Context& context) const {
   const double inner_sphericity_A = is_excised_a_ ? 1.0 : 0.0;
   const double inner_sphericity_B = is_excised_b_ ? 1.0 : 0.0;
 
@@ -503,7 +503,7 @@ Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
                                                 Frame::Inertial, 3>(
             sph_wedge_coordinate_maps(
                 object_a.inner_radius, object_a.outer_radius,
-                inner_sphericity_A, 1.0, use_equiangular_map_,
+                inner_sphericity_A, 1.0, use_equiangular_map_, context,
                 offset_a_optional, false, {}, object_A_radial_distribution),
             translation_A);
     Maps maps_cube_A =
@@ -511,7 +511,7 @@ Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
                                                 Frame::Inertial, 3>(
             sph_wedge_coordinate_maps(
                 object_a.outer_radius, sqrt(3.0) * 0.5 * length_inner_cube_,
-                1.0, 0.0, use_equiangular_map_, offset_a_optional),
+                1.0, 0.0, use_equiangular_map_, context, offset_a_optional),
             translation_A);
     std::move(maps_center_A.begin(), maps_center_A.end(),
               std::back_inserter(maps));
@@ -546,7 +546,7 @@ Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
                                                 Frame::Inertial, 3>(
             sph_wedge_coordinate_maps(
                 object_b.inner_radius, object_b.outer_radius,
-                inner_sphericity_B, 1.0, use_equiangular_map_,
+                inner_sphericity_B, 1.0, use_equiangular_map_, context,
                 offset_b_optional, false, {}, object_B_radial_distribution),
             translation_B);
     Maps maps_cube_B =
@@ -554,7 +554,7 @@ Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
                                                 Frame::Inertial, 3>(
             sph_wedge_coordinate_maps(
                 object_b.outer_radius, sqrt(3.0) * 0.5 * length_inner_cube_,
-                1.0, 0.0, use_equiangular_map_, offset_b_optional),
+                1.0, 0.0, use_equiangular_map_, context, offset_b_optional),
             translation_B);
     std::move(maps_center_B.begin(), maps_center_B.end(),
               std::back_inserter(maps));
@@ -586,7 +586,7 @@ Domain<3> BinaryCompactObject<UseWorldtube>::create_domain(
   // --- Outer spherical shell (10*num_outer_shells blocks) ---
   Maps maps_outer_shell = domain::make_vector_coordinate_map_base<
       Frame::BlockLogical, Frame::Inertial, 3>(sph_wedge_coordinate_maps(
-      envelope_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_,
+      envelope_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, context,
       std::nullopt, true, radial_partitioning_outer_shell_,
       radial_distribution_outer_shell_, ShellWedges::All, opening_angle_));
   std::move(maps_outer_shell.begin(), maps_outer_shell.end(),

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -425,11 +425,7 @@ BinaryCompactObject<UseWorldtube>::BinaryCompactObject(
         radii_A, radii_B, not is_excised_a_, not is_excised_b_,
         envelope_radius_, outer_radius_);
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 template <bool UseWorldtube>
@@ -905,7 +901,7 @@ BinaryCompactObject<UseWorldtube>::functions_of_time(
 
 template <bool UseWorldtube>
 Domain<3> BinaryCompactObject<UseWorldtube>::create_domain() const {
-  return build_domain(Options::Context{});
+  return domain_;
 }
 
 template class BinaryCompactObject<true>;

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -574,6 +574,7 @@ class BinaryCompactObject final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   typename ObjectA::type object_A_{};
   typename ObjectB::type object_B_{};
   std::array<double, 2> center_of_mass_offset_{};

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -156,7 +156,7 @@ create_grid_anchors(const std::array<double, 3>& center_a,
  * to control the orbit of the worldtube.
  */
 template <bool UseWorldtube = false>
-class BinaryCompactObject : public DomainCreator<3> {
+class BinaryCompactObject final : public DomainCreator<3> {
  private:
   // Time-independent maps
   using Affine = CoordinateMaps::Affine;

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -573,6 +573,7 @@ class BinaryCompactObject final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   typename ObjectA::type object_A_{};
   typename ObjectB::type object_B_{};
   std::array<double, 2> center_of_mass_offset_{};

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -573,7 +573,7 @@ class BinaryCompactObject final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   typename ObjectA::type object_A_{};
   typename ObjectB::type object_B_{};
   std::array<double, 2> center_of_mass_offset_{};

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -539,7 +539,7 @@ class BinaryCompactObject final : public DomainCreator<3> {
   BinaryCompactObject& operator=(BinaryCompactObject&&) = default;
   ~BinaryCompactObject() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
   grid_anchors() const override {

--- a/src/Domain/Creators/CartoonCylinder.cpp
+++ b/src/Domain/Creators/CartoonCylinder.cpp
@@ -105,11 +105,7 @@ CartoonCylinder::CartoonCylinder(
       is_periodic_in_y_ = is_periodic(lower_bc);
     }
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> CartoonCylinder::create_domain(
@@ -189,9 +185,7 @@ CartoonCylinder::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> CartoonCylinder::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> CartoonCylinder::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> CartoonCylinder::initial_extents() const {
   // cartoon bases always have extents set to 1

--- a/src/Domain/Creators/CartoonCylinder.cpp
+++ b/src/Domain/Creators/CartoonCylinder.cpp
@@ -108,7 +108,7 @@ CartoonCylinder::CartoonCylinder(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -190,7 +190,7 @@ CartoonCylinder::external_boundary_conditions() const {
 }
 
 Domain<3> CartoonCylinder::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> CartoonCylinder::initial_extents() const {

--- a/src/Domain/Creators/CartoonCylinder.cpp
+++ b/src/Domain/Creators/CartoonCylinder.cpp
@@ -105,6 +105,11 @@ CartoonCylinder::CartoonCylinder(
       is_periodic_in_y_ = is_periodic(lower_bc);
     }
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> CartoonCylinder::create_domain(

--- a/src/Domain/Creators/CartoonCylinder.cpp
+++ b/src/Domain/Creators/CartoonCylinder.cpp
@@ -107,7 +107,8 @@ CartoonCylinder::CartoonCylinder(
   }
 }
 
-Domain<3> CartoonCylinder::create_domain() const {
+Domain<3> CartoonCylinder::create_domain(
+    const Options::Context& /*context*/) const {
   using Interval = CoordinateMaps::Interval;
   using Identity1D = CoordinateMaps::Identity<1>;
   using cartoon_cylinder_map =
@@ -181,6 +182,10 @@ CartoonCylinder::external_boundary_conditions() const {
     }
   }
   return boundary_conditions;
+}
+
+Domain<3> CartoonCylinder::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> CartoonCylinder::initial_extents() const {

--- a/src/Domain/Creators/CartoonCylinder.cpp
+++ b/src/Domain/Creators/CartoonCylinder.cpp
@@ -108,7 +108,7 @@ CartoonCylinder::CartoonCylinder(
   domain_ = build_domain(context);
 }
 
-Domain<3> CartoonCylinder::create_domain(
+Domain<3> CartoonCylinder::build_domain(
     const Options::Context& /*context*/) const {
   using Interval = CoordinateMaps::Interval;
   using Identity1D = CoordinateMaps::Identity<1>;
@@ -185,7 +185,7 @@ CartoonCylinder::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> CartoonCylinder::create_domain() const { return domain_; }
+const Domain<3>& CartoonCylinder::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> CartoonCylinder::initial_extents() const {
   // cartoon bases always have extents set to 1

--- a/src/Domain/Creators/CartoonCylinder.hpp
+++ b/src/Domain/Creators/CartoonCylinder.hpp
@@ -38,7 +38,7 @@ namespace domain::creators {
 /// Create a 3D Domain with its computational domain being the\f$x-y\f$
 /// plane. The third dimension uses a Cartoon basis with Killing vector along
 /// the \f$\phi\f$ direction.
-class CartoonCylinder : public DomainCreator<3> {
+class CartoonCylinder final : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
       Frame::BlockLogical, Frame::Inertial,

--- a/src/Domain/Creators/CartoonCylinder.hpp
+++ b/src/Domain/Creators/CartoonCylinder.hpp
@@ -223,6 +223,7 @@ class CartoonCylinder final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   std::array<double, 2> lower_bounds_{};
   std::array<double, 2> upper_bounds_{};
   std::array<size_t, 2> initial_refinement_levels_{};

--- a/src/Domain/Creators/CartoonCylinder.hpp
+++ b/src/Domain/Creators/CartoonCylinder.hpp
@@ -183,7 +183,7 @@ class CartoonCylinder final : public DomainCreator<3> {
   CartoonCylinder& operator=(CartoonCylinder&&) = default;
   ~CartoonCylinder() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/CartoonCylinder.hpp
+++ b/src/Domain/Creators/CartoonCylinder.hpp
@@ -222,7 +222,7 @@ class CartoonCylinder final : public DomainCreator<3> {
           2>;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   std::array<double, 2> lower_bounds_{};
   std::array<double, 2> upper_bounds_{};
   std::array<size_t, 2> initial_refinement_levels_{};

--- a/src/Domain/Creators/CartoonCylinder.hpp
+++ b/src/Domain/Creators/CartoonCylinder.hpp
@@ -222,6 +222,7 @@ class CartoonCylinder final : public DomainCreator<3> {
           2>;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   std::array<double, 2> lower_bounds_{};
   std::array<double, 2> upper_bounds_{};
   std::array<size_t, 2> initial_refinement_levels_{};

--- a/src/Domain/Creators/CartoonSphere1D.cpp
+++ b/src/Domain/Creators/CartoonSphere1D.cpp
@@ -125,7 +125,7 @@ CartoonSphere1D::CartoonSphere1D(
   domain_ = build_domain(context);
 }
 
-Domain<3> CartoonSphere1D::create_domain(
+Domain<3> CartoonSphere1D::build_domain(
     const Options::Context& /*context*/) const {
   using Interval = CoordinateMaps::Interval;
   using Identity1D = CoordinateMaps::Identity<1>;
@@ -200,7 +200,7 @@ CartoonSphere1D::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> CartoonSphere1D::create_domain() const { return domain_; }
+const Domain<3>& CartoonSphere1D::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> CartoonSphere1D::initial_extents() const {
   std::vector<std::array<size_t, 3>> output;

--- a/src/Domain/Creators/CartoonSphere1D.cpp
+++ b/src/Domain/Creators/CartoonSphere1D.cpp
@@ -124,7 +124,8 @@ CartoonSphere1D::CartoonSphere1D(
   }
 }
 
-Domain<3> CartoonSphere1D::create_domain() const {
+Domain<3> CartoonSphere1D::create_domain(
+    const Options::Context& /*context*/) const {
   using Interval = CoordinateMaps::Interval;
   using Identity1D = CoordinateMaps::Identity<1>;
   using cartoon_sphere_map =
@@ -196,6 +197,10 @@ CartoonSphere1D::external_boundary_conditions() const {
   boundary_conditions[num_blocks_ - 1][Direction<3>::upper_xi()] =
       outer_boundary_condition_->get_clone();
   return boundary_conditions;
+}
+
+Domain<3> CartoonSphere1D::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> CartoonSphere1D::initial_extents() const {

--- a/src/Domain/Creators/CartoonSphere1D.cpp
+++ b/src/Domain/Creators/CartoonSphere1D.cpp
@@ -122,11 +122,7 @@ CartoonSphere1D::CartoonSphere1D(
     block_names_.emplace_back(block_name);
     block_groups_[block_name].insert(block_name);
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> CartoonSphere1D::create_domain(
@@ -204,9 +200,7 @@ CartoonSphere1D::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> CartoonSphere1D::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> CartoonSphere1D::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> CartoonSphere1D::initial_extents() const {
   std::vector<std::array<size_t, 3>> output;

--- a/src/Domain/Creators/CartoonSphere1D.cpp
+++ b/src/Domain/Creators/CartoonSphere1D.cpp
@@ -122,6 +122,11 @@ CartoonSphere1D::CartoonSphere1D(
     block_names_.emplace_back(block_name);
     block_groups_[block_name].insert(block_name);
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> CartoonSphere1D::create_domain(

--- a/src/Domain/Creators/CartoonSphere1D.cpp
+++ b/src/Domain/Creators/CartoonSphere1D.cpp
@@ -125,7 +125,7 @@ CartoonSphere1D::CartoonSphere1D(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -205,7 +205,7 @@ CartoonSphere1D::external_boundary_conditions() const {
 }
 
 Domain<3> CartoonSphere1D::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> CartoonSphere1D::initial_extents() const {

--- a/src/Domain/Creators/CartoonSphere1D.hpp
+++ b/src/Domain/Creators/CartoonSphere1D.hpp
@@ -163,7 +163,7 @@ class CartoonSphere1D final : public DomainCreator<3> {
   CartoonSphere1D& operator=(CartoonSphere1D&&) = default;
   ~CartoonSphere1D() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/CartoonSphere1D.hpp
+++ b/src/Domain/Creators/CartoonSphere1D.hpp
@@ -38,7 +38,7 @@ namespace domain::creators {
 /// Create a 3D Domain that is topologically a line. The 2nd and 3rd
 /// dimensions use Cartoon bases with Killing vectors along the \f$\theta\f$ and
 /// \f$\phi\f$ directions.
-class CartoonSphere1D : public DomainCreator<3> {
+class CartoonSphere1D final : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
       Frame::BlockLogical, Frame::Inertial,

--- a/src/Domain/Creators/CartoonSphere1D.hpp
+++ b/src/Domain/Creators/CartoonSphere1D.hpp
@@ -189,6 +189,7 @@ class CartoonSphere1D final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   double inner_bound_{};
   double outer_bound_{};
   std::vector<size_t> initial_refinement_levels_{};

--- a/src/Domain/Creators/CartoonSphere1D.hpp
+++ b/src/Domain/Creators/CartoonSphere1D.hpp
@@ -190,6 +190,7 @@ class CartoonSphere1D final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   double inner_bound_{};
   double outer_bound_{};
   std::vector<size_t> initial_refinement_levels_{};

--- a/src/Domain/Creators/CartoonSphere1D.hpp
+++ b/src/Domain/Creators/CartoonSphere1D.hpp
@@ -189,7 +189,7 @@ class CartoonSphere1D final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   double inner_bound_{};
   double outer_bound_{};
   std::vector<size_t> initial_refinement_levels_{};

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -170,7 +170,8 @@ CartoonSphere2D::CartoonSphere2D(
   }
 }
 
-Domain<3> CartoonSphere2D::create_domain() const {
+Domain<3> CartoonSphere2D::create_domain(
+    const Options::Context& /*context*/) const {
   using Affine = CoordinateMaps::Affine;
   using Equiangular = CoordinateMaps::Equiangular;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
@@ -405,6 +406,10 @@ CartoonSphere2D::external_boundary_conditions() const {
         excision_boundary_condition->get_clone();
   }
   return boundary_conditions;
+}
+
+Domain<3> CartoonSphere2D::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> CartoonSphere2D::initial_extents() const {

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -191,8 +191,9 @@ Domain<3> CartoonSphere2D::build_domain(const Options::Context& context) const {
       fill_interior_ ? std::get<InnerSquare>(interior_).sphericity
                      : std::numeric_limits<double>::signaling_NaN();
   if (fill_interior_ and inner_square_sphericity != 0.0) {
-    ERROR("CartoonSphere2D cannot have a non-zero inner sphericity, "
-          << "got " << inner_square_sphericity << ".");
+    PARSE_ERROR(context,
+                "CartoonSphere2D cannot have a non-zero inner sphericity, "
+                    << "got " << inner_square_sphericity << ".");
   }
 
   const auto aligned = OrientationMap<3>::create_aligned();

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -168,6 +168,11 @@ CartoonSphere2D::CartoonSphere2D(
     block_names_.emplace_back(shell + "_HalfSquare");
     block_groups_[shell].insert(shell + "_HalfSquare");
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> CartoonSphere2D::create_domain(

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -169,11 +169,7 @@ CartoonSphere2D::CartoonSphere2D(
     block_names_.emplace_back(shell + "_HalfSquare");
     block_groups_[shell].insert(shell + "_HalfSquare");
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> CartoonSphere2D::create_domain(
@@ -418,9 +414,7 @@ CartoonSphere2D::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> CartoonSphere2D::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> CartoonSphere2D::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> CartoonSphere2D::initial_extents() const {
   std::vector<std::array<size_t, 3>> extended;

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -172,7 +172,7 @@ CartoonSphere2D::CartoonSphere2D(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -419,7 +419,7 @@ CartoonSphere2D::external_boundary_conditions() const {
 }
 
 Domain<3> CartoonSphere2D::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> CartoonSphere2D::initial_extents() const {

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -172,8 +172,7 @@ CartoonSphere2D::CartoonSphere2D(
   domain_ = build_domain(context);
 }
 
-Domain<3> CartoonSphere2D::create_domain(
-    const Options::Context& context) const {
+Domain<3> CartoonSphere2D::build_domain(const Options::Context& context) const {
   using Affine = CoordinateMaps::Affine;
   using Equiangular = CoordinateMaps::Equiangular;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
@@ -414,7 +413,7 @@ CartoonSphere2D::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> CartoonSphere2D::create_domain() const { return domain_; }
+const Domain<3>& CartoonSphere2D::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> CartoonSphere2D::initial_extents() const {
   std::vector<std::array<size_t, 3>> extended;

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -3,6 +3,7 @@
 
 #include "Domain/Creators/CartoonSphere2D.hpp"
 
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <iterator>
@@ -176,7 +177,7 @@ CartoonSphere2D::CartoonSphere2D(
 }
 
 Domain<3> CartoonSphere2D::create_domain(
-    const Options::Context& /*context*/) const {
+    const Options::Context& context) const {
   using Affine = CoordinateMaps::Affine;
   using Equiangular = CoordinateMaps::Equiangular;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
@@ -222,40 +223,44 @@ Domain<3> CartoonSphere2D::create_domain(
         i == 0 ? outer_radius_
                : radial_partitioning_[radial_partitioning_.size() - i];
     const double inner_sphericity = has_square ? inner_square_sphericity : 1.0;
+    const std::array<double, 1> opening_angles{M_PI_2};
+    const auto make_wedge = [&](const OrientationMap<2>& orientation,
+                                Wedge2DMap::WedgeHalves halves =
+                                    Wedge2DMap::WedgeHalves::Both) {
+      return Wedge2DMap{
+          inner_radius,     outer_radius,
+          inner_sphericity, 1.0,
+          orientation,      use_equiangular_map_,
+          halves,           domain::CoordinateMaps::Distribution::Linear,
+          opening_angles,   true,
+          context};
+    };
     // this is a half-wedge, -y
     auto coord_maps = make_vector_coordinate_map_base<Frame::BlockLogical,
                                                       Frame::Inertial, 3>(
         std::vector<Rotation3D>{Rotation3D{turn_ccw}},
-        Wedge3DPrism{
-            Wedge2DMap{
-                inner_radius, outer_radius, inner_sphericity, 1.0,
-                OrientationMap<2>{std::array<Direction<2>, 2>{
-                    {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
-                use_equiangular_map_,
-                domain::CoordinateMaps::Wedge<2>::WedgeHalves::UpperOnly},
-            Identity1D{}});
+        Wedge3DPrism{make_wedge(OrientationMap<2>{std::array<Direction<2>, 2>{
+                                    {Direction<2>::upper_eta(),
+                                     Direction<2>::lower_xi()}}},
+                                Wedge2DMap::WedgeHalves::UpperOnly),
+                     Identity1D{}});
     // this is a full wedge, +x
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Rotation3D{turn_cw},
             Wedge3DPrism{
-                Wedge2DMap{
-                    inner_radius, outer_radius, inner_sphericity, 1.0,
-                    OrientationMap<2>{std::array<Direction<2>, 2>{
-                        {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
-                    use_equiangular_map_},
+                make_wedge(OrientationMap<2>{std::array<Direction<2>, 2>{
+                    {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}}),
                 Identity1D{}}));
     // this is a half-wedge, +y
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
             Rotation3D{turn_cw},
             Wedge3DPrism{
-                Wedge2DMap{
-                    inner_radius, outer_radius, inner_sphericity, 1.0,
+                make_wedge(
                     OrientationMap<2>{std::array<Direction<2>, 2>{
                         {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
-                    use_equiangular_map_,
-                    domain::CoordinateMaps::Wedge<2>::WedgeHalves::LowerOnly},
+                    Wedge2DMap::WedgeHalves::LowerOnly),
                 Identity1D{}}));
     if (has_square) {
       if (use_equiangular_map_) {

--- a/src/Domain/Creators/CartoonSphere2D.hpp
+++ b/src/Domain/Creators/CartoonSphere2D.hpp
@@ -251,6 +251,7 @@ class CartoonSphere2D final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   double inner_radius_{};
   double outer_radius_{};
   std::vector<std::array<size_t, 2>> initial_refinement_{};

--- a/src/Domain/Creators/CartoonSphere2D.hpp
+++ b/src/Domain/Creators/CartoonSphere2D.hpp
@@ -252,6 +252,7 @@ class CartoonSphere2D final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   double inner_radius_{};
   double outer_radius_{};
   std::vector<std::array<size_t, 2>> initial_refinement_{};

--- a/src/Domain/Creators/CartoonSphere2D.hpp
+++ b/src/Domain/Creators/CartoonSphere2D.hpp
@@ -251,7 +251,7 @@ class CartoonSphere2D final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   double inner_radius_{};
   double outer_radius_{};
   std::vector<std::array<size_t, 2>> initial_refinement_{};

--- a/src/Domain/Creators/CartoonSphere2D.hpp
+++ b/src/Domain/Creators/CartoonSphere2D.hpp
@@ -227,7 +227,7 @@ class CartoonSphere2D final : public DomainCreator<3> {
   CartoonSphere2D& operator=(CartoonSphere2D&&) = default;
   ~CartoonSphere2D() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/CartoonSphere2D.hpp
+++ b/src/Domain/Creators/CartoonSphere2D.hpp
@@ -70,7 +70,7 @@ namespace domain::creators {
 /// Create a 3D Domain with a half-disk computational domain employing axial
 /// symmetry. The third dimension uses a Cartoon basis with Killing vector
 /// along the $\phi$ direction.
-class CartoonSphere2D : public DomainCreator<3> {
+class CartoonSphere2D final : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
       domain::CoordinateMap<

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -260,6 +260,11 @@ Cylinder::Cylinder(
                 "constructor to specify 'is_periodic_in_z' instead of boundary "
                 "conditions.");
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> Cylinder::create_domain(const Options::Context& /*context*/) const {

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -198,6 +198,7 @@ Cylinder::Cylinder(
     central_cube_refinement[0] = central_cube_refinement[1];
     central_cube_grid_points[0] = central_cube_grid_points[1];
   }
+  domain_ = build_domain(context);
 }
 
 Cylinder::Cylinder(
@@ -260,11 +261,7 @@ Cylinder::Cylinder(
                 "constructor to specify 'is_periodic_in_z' instead of boundary "
                 "conditions.");
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> Cylinder::build_domain(const Options::Context& context) const {
@@ -352,9 +349,7 @@ Cylinder::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> Cylinder::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> Cylinder::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> Cylinder::initial_extents() const {
   return initial_number_of_grid_points_;

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -267,7 +267,7 @@ Cylinder::Cylinder(
   }
 }
 
-Domain<3> Cylinder::create_domain(const Options::Context& /*context*/) const {
+Domain<3> Cylinder::create_domain(const Options::Context& context) const {
   const size_t number_of_shells = 1 + radial_partitioning_.size();
   const size_t number_of_layers = 1 + partitioning_in_z_.size();
   std::vector<PairOfFaces> pairs_of_faces{};
@@ -302,8 +302,8 @@ Domain<3> Cylinder::create_domain(const Options::Context& /*context*/) const {
   return Domain<3>{
       cyl_wedge_coordinate_maps<Frame::Inertial>(
           inner_radius_, outer_radius_, lower_z_bound_, upper_z_bound_,
-          use_equiangular_map_, radial_partitioning_, partitioning_in_z_,
-          radial_distribution_, distribution_in_z_),
+          use_equiangular_map_, context, radial_partitioning_,
+          partitioning_in_z_, radial_distribution_, distribution_in_z_),
       corners_for_cylindrical_layered_domains(number_of_shells,
                                               number_of_layers),
       pairs_of_faces,

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -262,7 +262,7 @@ Cylinder::Cylinder(
   }
 }
 
-Domain<3> Cylinder::create_domain() const {
+Domain<3> Cylinder::create_domain(const Options::Context& /*context*/) const {
   const size_t number_of_shells = 1 + radial_partitioning_.size();
   const size_t number_of_layers = 1 + partitioning_in_z_.size();
   std::vector<PairOfFaces> pairs_of_faces{};
@@ -345,6 +345,10 @@ Cylinder::external_boundary_conditions() const {
         mantle_boundary_condition_->get_clone();
   }
   return boundary_conditions;
+}
+
+Domain<3> Cylinder::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> Cylinder::initial_extents() const {

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -349,7 +349,7 @@ Cylinder::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> Cylinder::create_domain() const { return domain_; }
+const Domain<3>& Cylinder::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> Cylinder::initial_extents() const {
   return initial_number_of_grid_points_;

--- a/src/Domain/Creators/Cylinder.cpp
+++ b/src/Domain/Creators/Cylinder.cpp
@@ -263,11 +263,11 @@ Cylinder::Cylinder(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
-Domain<3> Cylinder::create_domain(const Options::Context& context) const {
+Domain<3> Cylinder::build_domain(const Options::Context& context) const {
   const size_t number_of_shells = 1 + radial_partitioning_.size();
   const size_t number_of_layers = 1 + partitioning_in_z_.size();
   std::vector<PairOfFaces> pairs_of_faces{};
@@ -353,7 +353,7 @@ Cylinder::external_boundary_conditions() const {
 }
 
 Domain<3> Cylinder::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> Cylinder::initial_extents() const {

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -293,7 +293,7 @@ class Cylinder final : public DomainCreator<3> {
   }
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   double lower_z_bound_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -49,7 +49,7 @@ namespace domain::creators {
 /// then repeats this pattern for all layers bottom to top.
 ///
 /// \image html Cylinder.png "The Cylinder Domain."
-class Cylinder : public DomainCreator<3> {
+class Cylinder final : public DomainCreator<3> {
  public:
   using maps_list =
       tmpl::list<domain::CoordinateMap<

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -293,6 +293,7 @@ class Cylinder final : public DomainCreator<3> {
   }
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   double lower_z_bound_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -275,7 +275,7 @@ class Cylinder final : public DomainCreator<3> {
   Cylinder& operator=(Cylinder&&) = default;
   ~Cylinder() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/Cylinder.hpp
+++ b/src/Domain/Creators/Cylinder.hpp
@@ -294,6 +294,7 @@ class Cylinder final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   double lower_z_bound_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -896,9 +896,11 @@ Domain<3> CylindricalBinaryCompactObject::build_domain(
                    block_names_, block_groups_};
 
   if (time_dependent_options_.has_value()) {
-    ASSERT(include_inner_sphere_A_ and include_inner_sphere_B_,
-           "When using time dependent maps for the CylindricalBBH domain, you "
-           "must include both inner spheres.");
+    if (not(include_inner_sphere_A_ and include_inner_sphere_B_)) {
+      PARSE_ERROR(context,
+                  "When using time dependent maps for the CylindricalBBH "
+                  "domain, you must include both inner spheres.");
+    }
     // Default initialize everything to nullptr so that we only need to set the
     // appropriate block maps for the specific frames
     std::vector<std::unique_ptr<

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -426,6 +426,11 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
         std::array{radius_B_, outer_radius_B_}, false, false,
         inner_common_radius, outer_radius_);
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> CylindricalBinaryCompactObject::create_domain(

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -428,7 +428,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   }
 }
 
-Domain<3> CylindricalBinaryCompactObject::create_domain() const {
+Domain<3> CylindricalBinaryCompactObject::create_domain(
+    const Options::Context& /*context*/) const {
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coordinate_maps{};
@@ -1110,6 +1111,10 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
     }
   }
   return boundary_conditions;
+}
+
+Domain<3> CylindricalBinaryCompactObject::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>>

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -429,7 +429,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -1119,7 +1119,7 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
 }
 
 Domain<3> CylindricalBinaryCompactObject::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>>

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -429,7 +429,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   domain_ = build_domain(context);
 }
 
-Domain<3> CylindricalBinaryCompactObject::create_domain(
+Domain<3> CylindricalBinaryCompactObject::build_domain(
     const Options::Context& context) const {
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
@@ -1114,7 +1114,7 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> CylindricalBinaryCompactObject::create_domain() const {
+const Domain<3>& CylindricalBinaryCompactObject::domain() const {
   return domain_;
 }
 

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -434,7 +434,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
 }
 
 Domain<3> CylindricalBinaryCompactObject::create_domain(
-    const Options::Context& /*context*/) const {
+    const Options::Context& context) const {
   std::vector<std::unique_ptr<
       domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coordinate_maps{};
@@ -491,7 +491,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain(
   const auto logical_to_cylinder_surrounding_maps =
       cyl_wedge_coord_map_surrounding_blocks(
           cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,
-          cylinder_upper_bound_z, use_equiangular_map_, 0.0);
+          cylinder_upper_bound_z, use_equiangular_map_, context, 0.0);
 
   // Lambda that takes a UniformCylindricalEndcap map and a
   // DiscreteRotation map, composes it with the logical-to-cylinder
@@ -567,7 +567,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain(
       cyl_wedge_coord_map_surrounding_blocks(
           cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
           cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z,
-          use_equiangular_map_, 1.0);
+          use_equiangular_map_, context, 1.0);
 
   // Lambda that takes a UniformCylindricalSide map and a DiscreteRotation
   // map, composes it with the logical-to-cylinder maps, and adds it

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -426,11 +426,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
         std::array{radius_B_, outer_radius_B_}, false, false,
         inner_common_radius, outer_radius_);
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> CylindricalBinaryCompactObject::create_domain(
@@ -1119,7 +1115,7 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
 }
 
 Domain<3> CylindricalBinaryCompactObject::create_domain() const {
-  return build_domain(Options::Context{});
+  return domain_;
 }
 
 std::vector<std::array<size_t, 3>>

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -336,7 +336,7 @@ class CylindricalBinaryCompactObject final : public DomainCreator<3> {
       default;
   ~CylindricalBinaryCompactObject() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
   grid_anchors() const override {

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -150,7 +150,7 @@ namespace domain::creators {
  * template parameter of `true` to
  * `domain::creators::bco::TimeDependentMapOptions`.
  */
-class CylindricalBinaryCompactObject : public DomainCreator<3> {
+class CylindricalBinaryCompactObject final : public DomainCreator<3> {
  public:
   using maps_list = tmpl::flatten<
       tmpl::list<domain::CoordinateMap<

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -365,6 +365,7 @@ class CylindricalBinaryCompactObject final : public DomainCreator<3> {
   }
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   // Note that center_A_ and center_B_ are rotated with respect to the
   // input centers (which are in the grid frame), so that we can
   // construct the map in a frame where the centers are offset in the

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -365,7 +365,7 @@ class CylindricalBinaryCompactObject final : public DomainCreator<3> {
   }
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   // Note that center_A_ and center_B_ are rotated with respect to the
   // input centers (which are in the grid frame), so that we can
   // construct the map in a frame where the centers are offset in the

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -366,6 +366,7 @@ class CylindricalBinaryCompactObject final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   // Note that center_A_ and center_B_ are rotated with respect to the
   // input centers (which are in the grid frame), so that we can
   // construct the map in a frame where the centers are offset in the

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -71,6 +71,11 @@ Disk::Disk(typename InnerRadius::type inner_radius,
   }
   block_names_.emplace_back("CenterSquare");
   block_groups_["CenterSquare"].insert("CenterSquare");
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<2> Disk::create_domain(const Options::Context& /*context*/) const {

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -71,11 +71,7 @@ Disk::Disk(typename InnerRadius::type inner_radius,
   }
   block_names_.emplace_back("CenterSquare");
   block_groups_["CenterSquare"].insert("CenterSquare");
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<2> Disk::build_domain(const Options::Context& context) const {
@@ -175,9 +171,7 @@ Disk::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<2> Disk::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<2> Disk::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 2>> Disk::initial_extents() const {
   return {

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -74,11 +74,11 @@ Disk::Disk(typename InnerRadius::type inner_radius,
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
-Domain<2> Disk::create_domain(const Options::Context& context) const {
+Domain<2> Disk::build_domain(const Options::Context& context) const {
   using Wedge2DMap = CoordinateMaps::Wedge<2>;
   using Affine = CoordinateMaps::Affine;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
@@ -176,7 +176,7 @@ Disk::external_boundary_conditions() const {
 }
 
 Domain<2> Disk::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 2>> Disk::initial_extents() const {

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -78,13 +78,29 @@ Disk::Disk(typename InnerRadius::type inner_radius,
   }
 }
 
-Domain<2> Disk::create_domain(const Options::Context& /*context*/) const {
+Domain<2> Disk::create_domain(const Options::Context& context) const {
   using Wedge2DMap = CoordinateMaps::Wedge<2>;
   using Affine = CoordinateMaps::Affine;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular2D =
       CoordinateMaps::ProductOf2Maps<Equiangular, Equiangular>;
+  const std::array<double, 1> opening_angles{M_PI_2};
+  const auto make_wedge = [&](OrientationMap<2> orientation,
+                              Wedge2DMap::WedgeHalves halves =
+                                  Wedge2DMap::WedgeHalves::Both) {
+    return Wedge2DMap{inner_radius_,
+                      outer_radius_,
+                      0.0,
+                      1.0,
+                      orientation,
+                      use_equiangular_map_,
+                      halves,
+                      domain::CoordinateMaps::Distribution::Linear,
+                      opening_angles,
+                      true,
+                      context};
+  };
 
   std::array<size_t, 4> block0_corners{{1, 5, 3, 7}};  //+x wedge
   std::array<size_t, 4> block1_corners{{3, 7, 2, 6}};  //+y wedge
@@ -96,24 +112,16 @@ Domain<2> Disk::create_domain(const Options::Context& /*context*/) const {
                                              block2_corners, block3_corners,
                                              block4_corners};
 
-  auto coord_maps = make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial>(
-      Wedge2DMap{inner_radius_, outer_radius_, 0.0, 1.0,
-                 OrientationMap<2>{std::array<Direction<2>, 2>{
-                     {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
-                 use_equiangular_map_},
-      Wedge2DMap{inner_radius_, outer_radius_, 0.0, 1.0,
-                 OrientationMap<2>{std::array<Direction<2>, 2>{
-                     {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
-                 use_equiangular_map_},
-      Wedge2DMap{inner_radius_, outer_radius_, 0.0, 1.0,
-                 OrientationMap<2>{std::array<Direction<2>, 2>{
-                     {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
-                 use_equiangular_map_},
-      Wedge2DMap{inner_radius_, outer_radius_, 0.0, 1.0,
-                 OrientationMap<2>{std::array<Direction<2>, 2>{
-                     {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
-                 use_equiangular_map_});
+  auto coord_maps =
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          make_wedge(OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}}),
+          make_wedge(OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}),
+          make_wedge(OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}}),
+          make_wedge(OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}));
 
   if (use_equiangular_map_) {
     coord_maps.emplace_back(

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -171,7 +171,7 @@ Disk::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<2> Disk::create_domain() const { return domain_; }
+const Domain<2>& Disk::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 2>> Disk::initial_extents() const {
   return {

--- a/src/Domain/Creators/Disk.cpp
+++ b/src/Domain/Creators/Disk.cpp
@@ -73,7 +73,7 @@ Disk::Disk(typename InnerRadius::type inner_radius,
   block_groups_["CenterSquare"].insert("CenterSquare");
 }
 
-Domain<2> Disk::create_domain() const {
+Domain<2> Disk::create_domain(const Options::Context& /*context*/) const {
   using Wedge2DMap = CoordinateMaps::Wedge<2>;
   using Affine = CoordinateMaps::Affine;
   using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
@@ -160,6 +160,10 @@ Disk::external_boundary_conditions() const {
         boundary_condition_->get_clone();
   }
   return boundary_conditions;
+}
+
+Domain<2> Disk::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 2>> Disk::initial_extents() const {

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -149,6 +149,7 @@ class Disk final : public DomainCreator<2> {
   }
 
  private:
+  Domain<2> create_domain(const Options::Context& context) const;
   typename InnerRadius::type inner_radius_{};
   typename OuterRadius::type outer_radius_{};
   typename InitialRefinement::type initial_refinement_{};

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -149,7 +149,7 @@ class Disk final : public DomainCreator<2> {
   }
 
  private:
-  Domain<2> create_domain(const Options::Context& context) const;
+  Domain<2> build_domain(const Options::Context& context) const;
   typename InnerRadius::type inner_radius_{};
   typename OuterRadius::type outer_radius_{};
   typename InitialRefinement::type initial_refinement_{};

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -131,7 +131,7 @@ class Disk final : public DomainCreator<2> {
   Disk& operator=(Disk&&) = default;
   ~Disk() override = default;
 
-  Domain<2> create_domain() const override;
+  const Domain<2>& domain() const override;
 
   std::vector<DirectionMap<
       2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -40,7 +40,7 @@ namespace domain {
 namespace creators {
 /// Create a 2D Domain in the shape of a disk from a square surrounded by four
 /// wedges.
-class Disk : public DomainCreator<2> {
+class Disk final : public DomainCreator<2> {
  public:
   using maps_list =
       tmpl::list<domain::CoordinateMap<

--- a/src/Domain/Creators/Disk.hpp
+++ b/src/Domain/Creators/Disk.hpp
@@ -150,6 +150,7 @@ class Disk final : public DomainCreator<2> {
 
  private:
   Domain<2> build_domain(const Options::Context& context) const;
+  Domain<2> domain_{};
   typename InnerRadius::type inner_radius_{};
   typename OuterRadius::type outer_radius_{};
   typename InitialRefinement::type initial_refinement_{};

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -49,7 +49,7 @@ class DomainCreator {
   DomainCreator<VolumeDim>& operator=(DomainCreator<VolumeDim>&&) = default;
   virtual ~DomainCreator() = default;
 
-  virtual Domain<VolumeDim> create_domain() const = 0;
+  virtual const Domain<VolumeDim>& domain() const = 0;
 
   /// A set of named coordinates in the grid frame, like the center of the
   /// domain or the positions of specific objects in a domain

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -71,7 +71,7 @@ FrustalCloak::FrustalCloak(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -110,7 +110,7 @@ FrustalCloak::external_boundary_conditions() const {
 }
 
 Domain<3> FrustalCloak::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> FrustalCloak::initial_extents() const {

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -68,11 +68,7 @@ FrustalCloak::FrustalCloak(
         context,
         "Cannot have periodic boundary conditions with a frustal cloak");
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> FrustalCloak::create_domain(
@@ -109,9 +105,7 @@ FrustalCloak::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> FrustalCloak::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> FrustalCloak::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> FrustalCloak::initial_extents() const {
   return {

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -70,7 +70,8 @@ FrustalCloak::FrustalCloak(
   }
 }
 
-Domain<3> FrustalCloak::create_domain() const {
+Domain<3> FrustalCloak::create_domain(
+    const Options::Context& /*context*/) const {
   std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
       coord_maps = domain::make_vector_coordinate_map_base<Frame::BlockLogical,
@@ -101,6 +102,10 @@ FrustalCloak::external_boundary_conditions() const {
         boundary_condition_->get_clone();
   }
   return boundary_conditions;
+}
+
+Domain<3> FrustalCloak::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> FrustalCloak::initial_extents() const {

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -71,7 +71,7 @@ FrustalCloak::FrustalCloak(
   domain_ = build_domain(context);
 }
 
-Domain<3> FrustalCloak::create_domain(
+Domain<3> FrustalCloak::build_domain(
     const Options::Context& /*context*/) const {
   std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
@@ -105,7 +105,7 @@ FrustalCloak::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> FrustalCloak::create_domain() const { return domain_; }
+const Domain<3>& FrustalCloak::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> FrustalCloak::initial_extents() const {
   return {

--- a/src/Domain/Creators/FrustalCloak.cpp
+++ b/src/Domain/Creators/FrustalCloak.cpp
@@ -68,6 +68,11 @@ FrustalCloak::FrustalCloak(
         context,
         "Cannot have periodic boundary conditions with a frustal cloak");
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> FrustalCloak::create_domain(

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -145,7 +145,7 @@ class FrustalCloak final : public DomainCreator<3> {
   FrustalCloak& operator=(FrustalCloak&&) = default;
   ~FrustalCloak() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -39,7 +39,7 @@ namespace creators {
  *
  * \image html FrustalCloak.png "A slice through the frustal cloak."
  */
-class FrustalCloak : public DomainCreator<3> {
+class FrustalCloak final : public DomainCreator<3> {
  public:
   using maps_list =
       tmpl::list<domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -156,6 +156,7 @@ class FrustalCloak final : public DomainCreator<3> {
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   typename InitialRefinement::type initial_refinement_level_{};
   typename InitialGridPoints::type initial_number_of_grid_points_{};
   typename UseEquiangularMap::type use_equiangular_map_ = false;

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -157,6 +157,7 @@ class FrustalCloak final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   typename InitialRefinement::type initial_refinement_level_{};
   typename InitialGridPoints::type initial_number_of_grid_points_{};
   typename UseEquiangularMap::type use_equiangular_map_ = false;

--- a/src/Domain/Creators/FrustalCloak.hpp
+++ b/src/Domain/Creators/FrustalCloak.hpp
@@ -156,7 +156,7 @@ class FrustalCloak final : public DomainCreator<3> {
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   typename InitialRefinement::type initial_refinement_level_{};
   typename InitialGridPoints::type initial_number_of_grid_points_{};
   typename UseEquiangularMap::type use_equiangular_map_ = false;

--- a/src/Domain/Creators/NonconformingSphericalShells.cpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.cpp
@@ -122,6 +122,11 @@ NonconformingSphericalShells::NonconformingSphericalShells(
                                         initial_spherical_harmonic_l_ + 1,
                                         2 * initial_spherical_harmonic_l_ + 1}};
   initial_refinement_levels_[6] = {{initial_radial_refinement_, 0_st, 0_st}};
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> NonconformingSphericalShells::create_domain(

--- a/src/Domain/Creators/NonconformingSphericalShells.cpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.cpp
@@ -122,11 +122,7 @@ NonconformingSphericalShells::NonconformingSphericalShells(
                                         initial_spherical_harmonic_l_ + 1,
                                         2 * initial_spherical_harmonic_l_ + 1}};
   initial_refinement_levels_[6] = {{initial_radial_refinement_, 0_st, 0_st}};
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> NonconformingSphericalShells::create_domain(
@@ -181,7 +177,7 @@ Domain<3> NonconformingSphericalShells::create_domain(
 }
 
 Domain<3> NonconformingSphericalShells::create_domain() const {
-  return build_domain(Options::Context{});
+  return domain_;
 }
 
 std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>

--- a/src/Domain/Creators/NonconformingSphericalShells.cpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.cpp
@@ -125,7 +125,7 @@ NonconformingSphericalShells::NonconformingSphericalShells(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -181,7 +181,7 @@ Domain<3> NonconformingSphericalShells::create_domain(
 }
 
 Domain<3> NonconformingSphericalShells::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>

--- a/src/Domain/Creators/NonconformingSphericalShells.cpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.cpp
@@ -124,7 +124,8 @@ NonconformingSphericalShells::NonconformingSphericalShells(
   initial_refinement_levels_[6] = {{initial_radial_refinement_, 0_st, 0_st}};
 }
 
-Domain<3> NonconformingSphericalShells::create_domain() const {
+Domain<3> NonconformingSphericalShells::create_domain(
+    const Options::Context& /*context*/) const {
   std::vector<Block<3>> blocks;
   blocks.reserve(7);
   const std::vector<std::array<size_t, 8>> corners_of_wedges =
@@ -172,6 +173,10 @@ Domain<3> NonconformingSphericalShells::create_domain() const {
                       std::move(neighbors_of_shell), "Shell",
                       domain::topologies::spherical_shell);
   return Domain(std::move(blocks));
+}
+
+Domain<3> NonconformingSphericalShells::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>

--- a/src/Domain/Creators/NonconformingSphericalShells.cpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.cpp
@@ -125,7 +125,7 @@ NonconformingSphericalShells::NonconformingSphericalShells(
   domain_ = build_domain(context);
 }
 
-Domain<3> NonconformingSphericalShells::create_domain(
+Domain<3> NonconformingSphericalShells::build_domain(
     const Options::Context& context) const {
   std::vector<Block<3>> blocks;
   blocks.reserve(7);
@@ -176,7 +176,7 @@ Domain<3> NonconformingSphericalShells::create_domain(
   return Domain(std::move(blocks));
 }
 
-Domain<3> NonconformingSphericalShells::create_domain() const {
+const Domain<3>& NonconformingSphericalShells::domain() const {
   return domain_;
 }
 

--- a/src/Domain/Creators/NonconformingSphericalShells.cpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.cpp
@@ -130,7 +130,7 @@ NonconformingSphericalShells::NonconformingSphericalShells(
 }
 
 Domain<3> NonconformingSphericalShells::create_domain(
-    const Options::Context& /*context*/) const {
+    const Options::Context& context) const {
   std::vector<Block<3>> blocks;
   blocks.reserve(7);
   const std::vector<std::array<size_t, 8>> corners_of_wedges =
@@ -160,7 +160,7 @@ Domain<3> NonconformingSphericalShells::create_domain(
   auto wedge_coord_maps =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
           sph_wedge_coordinate_maps(inner_radius_, interface_radius_, 1.0, 1.0,
-                                    true));
+                                    true, context));
   auto sphere_map =
       make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,

--- a/src/Domain/Creators/NonconformingSphericalShells.hpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.hpp
@@ -189,6 +189,7 @@ class NonconformingSphericalShells final : public DomainCreator<3> {
 
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   double inner_radius_{};
   double interface_radius_{};
   double outer_radius_{};

--- a/src/Domain/Creators/NonconformingSphericalShells.hpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.hpp
@@ -173,7 +173,7 @@ class NonconformingSphericalShells final : public DomainCreator<3> {
       default;
   ~NonconformingSphericalShells() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
   grid_anchors() const override;

--- a/src/Domain/Creators/NonconformingSphericalShells.hpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.hpp
@@ -13,6 +13,7 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
@@ -20,8 +21,6 @@
 /// \cond
 template <size_t Dim, typename T>
 class DirectionMap;
-template <size_t Dim>
-class Domain;
 namespace domain {
 namespace CoordinateMaps {
 class Affine;
@@ -190,6 +189,7 @@ class NonconformingSphericalShells final : public DomainCreator<3> {
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   double inner_radius_{};
   double interface_radius_{};
   double outer_radius_{};

--- a/src/Domain/Creators/NonconformingSphericalShells.hpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.hpp
@@ -189,7 +189,7 @@ class NonconformingSphericalShells final : public DomainCreator<3> {
 
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   double inner_radius_{};
   double interface_radius_{};
   double outer_radius_{};

--- a/src/Domain/Creators/NonconformingSphericalShells.hpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.hpp
@@ -51,7 +51,7 @@ namespace domain::creators {
  * This domain creator offers one grid anchor "Center" at the origin.
  *
  */
-class NonconformingSphericalShells : public DomainCreator<3> {
+class NonconformingSphericalShells final : public DomainCreator<3> {
  public:
   using maps_list =
       tmpl::list<domain::CoordinateMap<

--- a/src/Domain/Creators/Python/DomainCreator.cpp
+++ b/src/Domain/Creators/Python/DomainCreator.cpp
@@ -23,7 +23,7 @@ template <size_t Dim>
 void bind_domain_creator_impl(py::module& m) {  // NOLINT
   py::class_<DomainCreator<Dim>>(
       m, ("DomainCreator" + get_output(Dim) + "D").c_str())
-      .def("create_domain", &DomainCreator<Dim>::create_domain)
+      .def("domain", &DomainCreator<Dim>::domain)
       .def("block_names", &DomainCreator<Dim>::block_names)
       .def("block_groups", &DomainCreator<Dim>::block_groups)
       .def("initial_extents", &DomainCreator<Dim>::initial_extents)

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -72,6 +72,11 @@ Rectilinear<Dim>::Rectilinear(
                                << gsl::at(upper_bounds_, d) << "].");
     }
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -119,7 +119,7 @@ Rectilinear<Dim>::Rectilinear(
 }
 
 template <size_t Dim>
-Domain<Dim> Rectilinear<Dim>::create_domain(
+Domain<Dim> Rectilinear<Dim>::build_domain(
     const Options::Context& /*context*/) const {
   // Handle periodicity by identifying faces
   std::vector<PairOfFaces> identifications{};
@@ -225,7 +225,7 @@ Rectilinear<Dim>::external_boundary_conditions() const {
 }
 
 template <size_t Dim>
-Domain<Dim> Rectilinear<Dim>::create_domain() const {
+const Domain<Dim>& Rectilinear<Dim>::domain() const {
   return domain_;
 }
 

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -75,7 +75,7 @@ Rectilinear<Dim>::Rectilinear(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -229,7 +229,7 @@ Rectilinear<Dim>::external_boundary_conditions() const {
 
 template <size_t Dim>
 Domain<Dim> Rectilinear<Dim>::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -72,11 +72,7 @@ Rectilinear<Dim>::Rectilinear(
                                << gsl::at(upper_bounds_, d) << "].");
     }
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 template <size_t Dim>
@@ -119,6 +115,7 @@ Rectilinear<Dim>::Rectilinear(
       gsl::at(is_periodic_, d) = true;
     }
   }
+  domain_ = build_domain(context);
 }
 
 template <size_t Dim>
@@ -229,7 +226,7 @@ Rectilinear<Dim>::external_boundary_conditions() const {
 
 template <size_t Dim>
 Domain<Dim> Rectilinear<Dim>::create_domain() const {
-  return build_domain(Options::Context{});
+  return domain_;
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -117,7 +117,8 @@ Rectilinear<Dim>::Rectilinear(
 }
 
 template <size_t Dim>
-Domain<Dim> Rectilinear<Dim>::create_domain() const {
+Domain<Dim> Rectilinear<Dim>::create_domain(
+    const Options::Context& /*context*/) const {
   // Handle periodicity by identifying faces
   std::vector<PairOfFaces> identifications{};
   if constexpr (Dim == 1) {
@@ -219,6 +220,11 @@ Rectilinear<Dim>::external_boundary_conditions() const {
     }
   }
   return boundary_conditions;
+}
+
+template <size_t Dim>
+Domain<Dim> Rectilinear<Dim>::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -43,7 +43,7 @@ namespace domain::creators {
 
 /// Create a domain consisting of a single Block in `Dim` dimensions.
 template <size_t Dim>
-class Rectilinear : public DomainCreator<Dim> {
+class Rectilinear final : public DomainCreator<Dim> {
  private:
   static_assert(Dim == 1 or Dim == 2 or Dim == 3,
                 "Rectilinear domain is only implemented in 1, 2, or 3 "

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -270,6 +270,7 @@ class Rectilinear final : public DomainCreator<Dim> {
 
  private:
   Domain<Dim> build_domain(const Options::Context& context) const;
+  Domain<Dim> domain_{};
   std::array<double, Dim> lower_bounds_{};
   std::array<double, Dim> upper_bounds_{};
   std::array<CoordinateMaps::DistributionAndSingularityPosition, Dim>

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -269,7 +269,7 @@ class Rectilinear final : public DomainCreator<Dim> {
           Dim>;
 
  private:
-  Domain<Dim> create_domain(const Options::Context& context) const;
+  Domain<Dim> build_domain(const Options::Context& context) const;
   std::array<double, Dim> lower_bounds_{};
   std::array<double, Dim> upper_bounds_{};
   std::array<CoordinateMaps::DistributionAndSingularityPosition, Dim>

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -229,7 +229,7 @@ class Rectilinear final : public DomainCreator<Dim> {
   Rectilinear& operator=(Rectilinear&&) = default;
   ~Rectilinear() override = default;
 
-  Domain<Dim> create_domain() const override;
+  const Domain<Dim>& domain() const override;
 
   std::vector<DirectionMap<
       Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/Rectilinear.hpp
+++ b/src/Domain/Creators/Rectilinear.hpp
@@ -269,6 +269,7 @@ class Rectilinear final : public DomainCreator<Dim> {
           Dim>;
 
  private:
+  Domain<Dim> create_domain(const Options::Context& context) const;
   std::array<double, Dim> lower_bounds_{};
   std::array<double, Dim> upper_bounds_{};
   std::array<CoordinateMaps::DistributionAndSingularityPosition, Dim>

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -72,7 +72,8 @@ RotatedBricks::RotatedBricks(
   }
 }
 
-Domain<3> RotatedBricks::create_domain() const {
+Domain<3> RotatedBricks::create_domain(
+    const Options::Context& /*context*/) const {
   return rectilinear_domain<3>(
       Index<3>{2, 2, 2},
       std::array<std::vector<double>, 3>{
@@ -146,6 +147,10 @@ RotatedBricks::external_boundary_conditions() const {
 
 std::vector<std::string> RotatedBricks::block_names() const {
   return block_names_for_rectilinear_domains(Index<3>{2, 2, 2});
+}
+
+Domain<3> RotatedBricks::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> RotatedBricks::initial_extents() const {

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -75,7 +75,7 @@ RotatedBricks::RotatedBricks(
   domain_ = build_domain(context);
 }
 
-Domain<3> RotatedBricks::create_domain(
+Domain<3> RotatedBricks::build_domain(
     const Options::Context& /*context*/) const {
   return rectilinear_domain<3>(
       Index<3>{2, 2, 2},
@@ -152,7 +152,7 @@ std::vector<std::string> RotatedBricks::block_names() const {
   return block_names_for_rectilinear_domains(Index<3>{2, 2, 2});
 }
 
-Domain<3> RotatedBricks::create_domain() const { return domain_; }
+const Domain<3>& RotatedBricks::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> RotatedBricks::initial_extents() const {
   const size_t& x_0 = initial_number_of_grid_points_in_xyz_[0][0];

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -70,6 +70,11 @@ RotatedBricks::RotatedBricks(
     is_periodic_in_[1] = true;
     is_periodic_in_[2] = true;
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> RotatedBricks::create_domain(

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -36,7 +36,9 @@ RotatedBricks::RotatedBricks(
           std::move(initial_refinement_level_xyz)),          // NOLINT
       initial_number_of_grid_points_in_xyz_(                 // NOLINT
           std::move(initial_number_of_grid_points_in_xyz)),  // NOLINT
-      boundary_condition_(nullptr) {}
+      boundary_condition_(nullptr) {
+  domain_ = build_domain({});
+}
 
 RotatedBricks::RotatedBricks(
     const typename LowerBound::type lower_xyz,
@@ -70,11 +72,7 @@ RotatedBricks::RotatedBricks(
     is_periodic_in_[1] = true;
     is_periodic_in_[2] = true;
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> RotatedBricks::create_domain(
@@ -154,9 +152,7 @@ std::vector<std::string> RotatedBricks::block_names() const {
   return block_names_for_rectilinear_domains(Index<3>{2, 2, 2});
 }
 
-Domain<3> RotatedBricks::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> RotatedBricks::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> RotatedBricks::initial_extents() const {
   const size_t& x_0 = initial_number_of_grid_points_in_xyz_[0][0];

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -73,7 +73,7 @@ RotatedBricks::RotatedBricks(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -155,7 +155,7 @@ std::vector<std::string> RotatedBricks::block_names() const {
 }
 
 Domain<3> RotatedBricks::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> RotatedBricks::initial_extents() const {

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -214,6 +214,7 @@ class RotatedBricks final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   typename LowerBound::type lower_xyz_{
       {std::numeric_limits<double>::signaling_NaN()}};
   typename Midpoint::type midpoint_xyz_{

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -213,7 +213,7 @@ class RotatedBricks final : public DomainCreator<3> {
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   typename LowerBound::type lower_xyz_{
       {std::numeric_limits<double>::signaling_NaN()}};
   typename Midpoint::type midpoint_xyz_{

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -200,7 +200,7 @@ class RotatedBricks final : public DomainCreator<3> {
   RotatedBricks& operator=(RotatedBricks&&) = default;
   ~RotatedBricks() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -213,6 +213,7 @@ class RotatedBricks final : public DomainCreator<3> {
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   typename LowerBound::type lower_xyz_{
       {std::numeric_limits<double>::signaling_NaN()}};
   typename Midpoint::type midpoint_xyz_{

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -98,7 +98,7 @@ namespace creators {
 ///
 /// This DomainCreator is useful for testing code that deals with
 /// unaligned blocks.
-class RotatedBricks : public DomainCreator<3> {
+class RotatedBricks final : public DomainCreator<3> {
  public:
   using maps_list = tmpl::list<
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -102,7 +102,8 @@ RotatedIntervals::RotatedIntervals(
   }
 }
 
-Domain<1> RotatedIntervals::create_domain() const {
+Domain<1> RotatedIntervals::create_domain(
+    const Options::Context& /*context*/) const {
   std::vector<DirectionMap<
       1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions_all_blocks{};
@@ -151,6 +152,10 @@ RotatedIntervals::external_boundary_conditions() const {
 
 std::vector<std::string> RotatedIntervals::block_names() const {
   return block_names_for_rectilinear_domains(Index<1>{2});
+}
+
+Domain<1> RotatedIntervals::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 1>> RotatedIntervals::initial_extents() const {

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -103,7 +103,7 @@ RotatedIntervals::RotatedIntervals(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -160,7 +160,7 @@ std::vector<std::string> RotatedIntervals::block_names() const {
 }
 
 Domain<1> RotatedIntervals::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 1>> RotatedIntervals::initial_extents() const {

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -104,7 +104,7 @@ RotatedIntervals::RotatedIntervals(
   domain_ = build_domain(context);
 }
 
-Domain<1> RotatedIntervals::create_domain(
+Domain<1> RotatedIntervals::build_domain(
     const Options::Context& /*context*/) const {
   std::vector<DirectionMap<
       1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
@@ -156,7 +156,7 @@ std::vector<std::string> RotatedIntervals::block_names() const {
   return block_names_for_rectilinear_domains(Index<1>{2});
 }
 
-Domain<1> RotatedIntervals::create_domain() const { return domain_; }
+const Domain<1>& RotatedIntervals::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 1>> RotatedIntervals::initial_extents() const {
   return {{{initial_number_of_grid_points_in_x_[0][0]}},

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -46,6 +46,7 @@ RotatedIntervals::RotatedIntervals(
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<1>>();
   }
+  domain_ = build_domain({});
 }
 
 RotatedIntervals::RotatedIntervals(
@@ -100,11 +101,7 @@ RotatedIntervals::RotatedIntervals(
   if (is_periodic(lower_boundary_condition_)) {
     is_periodic_in_[0] = true;
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<1> RotatedIntervals::create_domain(
@@ -159,9 +156,7 @@ std::vector<std::string> RotatedIntervals::block_names() const {
   return block_names_for_rectilinear_domains(Index<1>{2});
 }
 
-Domain<1> RotatedIntervals::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<1> RotatedIntervals::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 1>> RotatedIntervals::initial_extents() const {
   return {{{initial_number_of_grid_points_in_x_[0][0]}},

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -100,6 +100,11 @@ RotatedIntervals::RotatedIntervals(
   if (is_periodic(lower_boundary_condition_)) {
     is_periodic_in_[0] = true;
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<1> RotatedIntervals::create_domain(

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -40,7 +40,7 @@ namespace creators {
 /// The left block has its logical \f$\xi\f$-axis aligned with the grid x-axis.
 /// The right block has its logical \f$\xi\f$-axis opposite to the grid x-axis.
 /// This is useful for testing code that deals with unaligned blocks.
-class RotatedIntervals : public DomainCreator<1> {
+class RotatedIntervals final : public DomainCreator<1> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
       Frame::BlockLogical, Frame::Inertial,

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -165,7 +165,7 @@ class RotatedIntervals final : public DomainCreator<1> {
   RotatedIntervals& operator=(RotatedIntervals&&) = default;
   ~RotatedIntervals() override = default;
 
-  Domain<1> create_domain() const override;
+  const Domain<1>& domain() const override;
 
   std::vector<DirectionMap<
       1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -184,6 +184,7 @@ class RotatedIntervals final : public DomainCreator<1> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
+  Domain<1> create_domain(const Options::Context& context) const;
   std::array<double, 1> lower_x_{
       {std::numeric_limits<double>::signaling_NaN()}};
   std::array<double, 1> midpoint_x_{

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -184,7 +184,7 @@ class RotatedIntervals final : public DomainCreator<1> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
-  Domain<1> create_domain(const Options::Context& context) const;
+  Domain<1> build_domain(const Options::Context& context) const;
   std::array<double, 1> lower_x_{
       {std::numeric_limits<double>::signaling_NaN()}};
   std::array<double, 1> midpoint_x_{

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -185,6 +185,7 @@ class RotatedIntervals final : public DomainCreator<1> {
 
  private:
   Domain<1> build_domain(const Options::Context& context) const;
+  Domain<1> domain_{};
   std::array<double, 1> lower_x_{
       {std::numeric_limits<double>::signaling_NaN()}};
   std::array<double, 1> midpoint_x_{

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -72,7 +72,7 @@ RotatedRectangles::RotatedRectangles(
   domain_ = build_domain(context);
 }
 
-Domain<2> RotatedRectangles::create_domain(
+Domain<2> RotatedRectangles::build_domain(
     const Options::Context& /*context*/) const {
   return rectilinear_domain<2>(
       Index<2>{2, 2},
@@ -126,7 +126,7 @@ std::vector<std::string> RotatedRectangles::block_names() const {
   return block_names_for_rectilinear_domains(Index<2>{2, 2});
 }
 
-Domain<2> RotatedRectangles::create_domain() const { return domain_; }
+const Domain<2>& RotatedRectangles::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 2>> RotatedRectangles::initial_extents() const {
   const size_t& x_0 = initial_number_of_grid_points_in_xy_[0][0];

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -37,7 +37,9 @@ RotatedRectangles::RotatedRectangles(
           std::move(initial_refinement_level_xy)),          // NOLINT
       initial_number_of_grid_points_in_xy_(                 // NOLINT
           std::move(initial_number_of_grid_points_in_xy)),  // NOLINT
-      boundary_condition_(nullptr) {}
+      boundary_condition_(nullptr) {
+  domain_ = build_domain({});
+}
 
 RotatedRectangles::RotatedRectangles(
     const typename LowerBound::type lower_xy,
@@ -67,11 +69,7 @@ RotatedRectangles::RotatedRectangles(
     is_periodic_in_[0] = true;
     is_periodic_in_[1] = true;
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<2> RotatedRectangles::create_domain(
@@ -128,9 +126,7 @@ std::vector<std::string> RotatedRectangles::block_names() const {
   return block_names_for_rectilinear_domains(Index<2>{2, 2});
 }
 
-Domain<2> RotatedRectangles::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<2> RotatedRectangles::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 2>> RotatedRectangles::initial_extents() const {
   const size_t& x_0 = initial_number_of_grid_points_in_xy_[0][0];

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -70,7 +70,7 @@ RotatedRectangles::RotatedRectangles(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -129,7 +129,7 @@ std::vector<std::string> RotatedRectangles::block_names() const {
 }
 
 Domain<2> RotatedRectangles::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 2>> RotatedRectangles::initial_extents() const {

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -67,6 +67,11 @@ RotatedRectangles::RotatedRectangles(
     is_periodic_in_[0] = true;
     is_periodic_in_[1] = true;
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<2> RotatedRectangles::create_domain(

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -69,7 +69,8 @@ RotatedRectangles::RotatedRectangles(
   }
 }
 
-Domain<2> RotatedRectangles::create_domain() const {
+Domain<2> RotatedRectangles::create_domain(
+    const Options::Context& /*context*/) const {
   return rectilinear_domain<2>(
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{
@@ -120,6 +121,10 @@ RotatedRectangles::external_boundary_conditions() const {
 
 std::vector<std::string> RotatedRectangles::block_names() const {
   return block_names_for_rectilinear_domains(Index<2>{2, 2});
+}
+
+Domain<2> RotatedRectangles::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 2>> RotatedRectangles::initial_extents() const {

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -165,6 +165,7 @@ class RotatedRectangles final : public DomainCreator<2> {
   std::vector<std::array<size_t, 2>> initial_refinement_levels() const override;
 
  private:
+  Domain<2> create_domain(const Options::Context& context) const;
   typename LowerBound::type lower_xy_{
       {std::numeric_limits<double>::signaling_NaN()}};
   typename Midpoint::type midpoint_xy_{

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -165,7 +165,7 @@ class RotatedRectangles final : public DomainCreator<2> {
   std::vector<std::array<size_t, 2>> initial_refinement_levels() const override;
 
  private:
-  Domain<2> create_domain(const Options::Context& context) const;
+  Domain<2> build_domain(const Options::Context& context) const;
   typename LowerBound::type lower_xy_{
       {std::numeric_limits<double>::signaling_NaN()}};
   typename Midpoint::type midpoint_xy_{

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -50,7 +50,7 @@ namespace creators {
 ///
 /// This DomainCreator is useful for testing code that deals with
 /// unaligned blocks.
-class RotatedRectangles : public DomainCreator<2> {
+class RotatedRectangles final : public DomainCreator<2> {
  public:
   using maps_list =
       tmpl::list<domain::CoordinateMap<

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -166,6 +166,7 @@ class RotatedRectangles final : public DomainCreator<2> {
 
  private:
   Domain<2> build_domain(const Options::Context& context) const;
+  Domain<2> domain_{};
   typename LowerBound::type lower_xy_{
       {std::numeric_limits<double>::signaling_NaN()}};
   typename Midpoint::type midpoint_xy_{

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -152,7 +152,7 @@ class RotatedRectangles final : public DomainCreator<2> {
   RotatedRectangles& operator=(RotatedRectangles&&) = default;
   ~RotatedRectangles() override = default;
 
-  Domain<2> create_domain() const override;
+  const Domain<2>& domain() const override;
 
   std::vector<DirectionMap<
       2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -290,10 +290,11 @@ Domain<3> Sphere::build_domain(const Options::Context& context) const {
 
   Domain<3> domain{std::move(coord_maps),       corners,      {},
                    std::move(excision_spheres), block_names_, block_groups_};
-  ASSERT(domain.blocks().size() == num_blocks_,
-         "Unexpected number of blocks. Expected "
-             << num_blocks_ << " but created " << domain.blocks().size()
-             << ".");
+  if (domain.blocks().size() != num_blocks_) {
+    PARSE_ERROR(context, "Unexpected number of blocks. Expected "
+                             << num_blocks_ << " but created "
+                             << domain.blocks().size() << ".");
+  }
 
   if (time_dependent_options_.has_value()) {
     std::vector<std::unique_ptr<

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -403,7 +403,7 @@ Sphere::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> Sphere::create_domain() const { return domain_; }
+const Domain<3>& Sphere::domain() const { return domain_; }
 
 std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -213,11 +213,11 @@ Sphere::Sphere(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
-Domain<3> Sphere::create_domain(const Options::Context& context) const {
+Domain<3> Sphere::build_domain(const Options::Context& context) const {
   std::vector<std::array<size_t, 8>> corners =
       corners_for_radially_layered_domains(num_shells_, fill_interior_,
                                            {{1, 2, 3, 4, 5, 6, 7, 8}},
@@ -408,7 +408,7 @@ Sphere::external_boundary_conditions() const {
 }
 
 Domain<3> Sphere::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::unordered_map<std::string,

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -210,6 +210,11 @@ Sphere::Sphere(
                       radial_partitioning_, outer_radius_);
     }
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> Sphere::create_domain(const Options::Context& /*context*/) const {

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -212,7 +212,7 @@ Sphere::Sphere(
   }
 }
 
-Domain<3> Sphere::create_domain() const {
+Domain<3> Sphere::create_domain(const Options::Context& /*context*/) const {
   std::vector<std::array<size_t, 8>> corners =
       corners_for_radially_layered_domains(num_shells_, fill_interior_,
                                            {{1, 2, 3, 4, 5, 6, 7, 8}},
@@ -400,6 +400,10 @@ Sphere::external_boundary_conditions() const {
     }
   }
   return boundary_conditions;
+}
+
+Domain<3> Sphere::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::unordered_map<std::string,

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -217,7 +217,7 @@ Sphere::Sphere(
   }
 }
 
-Domain<3> Sphere::create_domain(const Options::Context& /*context*/) const {
+Domain<3> Sphere::create_domain(const Options::Context& context) const {
   std::vector<std::array<size_t, 8>> corners =
       corners_for_radially_layered_domains(num_shells_, fill_interior_,
                                            {{1, 2, 3, 4, 5, 6, 7, 8}},
@@ -236,8 +236,8 @@ Domain<3> Sphere::create_domain(const Options::Context& /*context*/) const {
       sph_wedge_coordinate_maps(
           inner_radius_, outer_radius_,
           fill_interior_ ? std::get<InnerCube>(interior_).sphericity : 1.0, 1.0,
-          use_equiangular_map_, std::nullopt, false, radial_partitioning_,
-          radial_distribution_, which_wedges_),
+          use_equiangular_map_, context, std::nullopt, false,
+          radial_partitioning_, radial_distribution_, which_wedges_),
       compression);
 
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};

--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -210,11 +210,7 @@ Sphere::Sphere(
                       radial_partitioning_, outer_radius_);
     }
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> Sphere::build_domain(const Options::Context& context) const {
@@ -407,9 +403,7 @@ Sphere::external_boundary_conditions() const {
   return boundary_conditions;
 }
 
-Domain<3> Sphere::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> Sphere::create_domain() const { return domain_; }
 
 std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -419,6 +419,7 @@ class Sphere final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   double inner_radius_{};
   double outer_radius_{};
   std::variant<Excision, InnerCube> interior_{};

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -418,6 +418,7 @@ class Sphere final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   double inner_radius_{};
   double outer_radius_{};
   std::variant<Excision, InnerCube> interior_{};

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -384,7 +384,7 @@ class Sphere final : public DomainCreator<3> {
   Sphere& operator=(Sphere&&) = default;
   ~Sphere() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
   grid_anchors() const override {

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -418,7 +418,7 @@ class Sphere final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   double inner_radius_{};
   double outer_radius_{};
   std::variant<Excision, InnerCube> interior_{};

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -170,7 +170,7 @@ namespace domain::creators {
  * `TimeDependentMaps: None`.
  *
  */
-class Sphere : public DomainCreator<3> {
+class Sphere final : public DomainCreator<3> {
  private:
   using Affine = CoordinateMaps::Affine;
   using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;

--- a/src/Domain/Creators/SphericalShells.cpp
+++ b/src/Domain/Creators/SphericalShells.cpp
@@ -116,7 +116,7 @@ SphericalShells::SphericalShells(
   if (context != Options::Context{}) {
     // Run create_domain for non-default contexts to validate the constructed
     // domain.
-    (void)create_domain(context);
+    (void)build_domain(context);
   }
 }
 
@@ -245,7 +245,7 @@ std::vector<std::array<size_t, 3>> SphericalShells::initial_extents() const {
 }
 
 Domain<3> SphericalShells::create_domain() const {
-  return create_domain(Options::Context{});
+  return build_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> SphericalShells::initial_refinement_levels()

--- a/src/Domain/Creators/SphericalShells.cpp
+++ b/src/Domain/Creators/SphericalShells.cpp
@@ -116,7 +116,7 @@ SphericalShells::SphericalShells(
   domain_ = build_domain(context);
 }
 
-Domain<3> SphericalShells::create_domain(
+Domain<3> SphericalShells::build_domain(
     const Options::Context& /*context*/) const {
   std::vector<Block<3>> blocks;
   blocks.reserve(num_blocks_);
@@ -240,7 +240,7 @@ std::vector<std::array<size_t, 3>> SphericalShells::initial_extents() const {
                                 2 * initial_spherical_harmonic_l_ + 1}};
 }
 
-Domain<3> SphericalShells::create_domain() const { return domain_; }
+const Domain<3>& SphericalShells::domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> SphericalShells::initial_refinement_levels()
     const {

--- a/src/Domain/Creators/SphericalShells.cpp
+++ b/src/Domain/Creators/SphericalShells.cpp
@@ -115,7 +115,8 @@ SphericalShells::SphericalShells(
   }
 }
 
-Domain<3> SphericalShells::create_domain() const {
+Domain<3> SphericalShells::create_domain(
+    const Options::Context& /*context*/) const {
   std::vector<Block<3>> blocks;
   blocks.reserve(num_blocks_);
   const auto aligned = OrientationMap<3>::create_aligned();
@@ -236,6 +237,10 @@ std::vector<std::array<size_t, 3>> SphericalShells::initial_extents() const {
                      std::array{initial_number_of_radial_grid_points_,
                                 initial_spherical_harmonic_l_ + 1,
                                 2 * initial_spherical_harmonic_l_ + 1}};
+}
+
+Domain<3> SphericalShells::create_domain() const {
+  return create_domain(Options::Context{});
 }
 
 std::vector<std::array<size_t, 3>> SphericalShells::initial_refinement_levels()

--- a/src/Domain/Creators/SphericalShells.cpp
+++ b/src/Domain/Creators/SphericalShells.cpp
@@ -113,11 +113,7 @@ SphericalShells::SphericalShells(
                       radial_partitioning_, outer_radius_);
     }
   }
-  if (context != Options::Context{}) {
-    // Run create_domain for non-default contexts to validate the constructed
-    // domain.
-    (void)build_domain(context);
-  }
+  domain_ = build_domain(context);
 }
 
 Domain<3> SphericalShells::create_domain(
@@ -244,9 +240,7 @@ std::vector<std::array<size_t, 3>> SphericalShells::initial_extents() const {
                                 2 * initial_spherical_harmonic_l_ + 1}};
 }
 
-Domain<3> SphericalShells::create_domain() const {
-  return build_domain(Options::Context{});
-}
+Domain<3> SphericalShells::create_domain() const { return domain_; }
 
 std::vector<std::array<size_t, 3>> SphericalShells::initial_refinement_levels()
     const {

--- a/src/Domain/Creators/SphericalShells.cpp
+++ b/src/Domain/Creators/SphericalShells.cpp
@@ -113,6 +113,11 @@ SphericalShells::SphericalShells(
                       radial_partitioning_, outer_radius_);
     }
   }
+  if (context != Options::Context{}) {
+    // Run create_domain for non-default contexts to validate the constructed
+    // domain.
+    (void)create_domain(context);
+  }
 }
 
 Domain<3> SphericalShells::create_domain(

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -18,6 +18,7 @@
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
 #include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
+#include "Domain/Domain.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
@@ -26,8 +27,6 @@
 /// \cond
 template <size_t Dim, typename T>
 class DirectionMap;
-template <size_t Dim>
-class Domain;
 namespace domain {
 namespace CoordinateMaps {
 template <size_t Dim>
@@ -244,6 +243,7 @@ class SphericalShells final : public DomainCreator<3> {
 
  private:
   Domain<3> build_domain(const Options::Context& context) const;
+  Domain<3> domain_{};
   double inner_radius_{};
   double outer_radius_{};
   size_t initial_radial_refinement_{};

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -212,7 +212,7 @@ class SphericalShells final : public DomainCreator<3> {
   SphericalShells& operator=(SphericalShells&&) = default;
   ~SphericalShells() override = default;
 
-  Domain<3> create_domain() const override;
+  const Domain<3>& domain() const override;
 
   /// A single grid anchor "Center" at the origin.
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -243,7 +243,7 @@ class SphericalShells final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
-  Domain<3> create_domain(const Options::Context& context) const;
+  Domain<3> build_domain(const Options::Context& context) const;
   double inner_radius_{};
   double outer_radius_{};
   size_t initial_radial_refinement_{};

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -243,6 +243,7 @@ class SphericalShells final : public DomainCreator<3> {
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
 
  private:
+  Domain<3> create_domain(const Options::Context& context) const;
   double inner_radius_{};
   double outer_radius_{};
   size_t initial_radial_refinement_{};

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -78,7 +78,7 @@ namespace domain::creators {
 /// To not have any time dependent maps, pass a `std::nullopt` as the
 /// appropriate argument in the constructor. In the input file, simply have
 /// `TimeDependentMaps: None`.
-class SphericalShells : public DomainCreator<3> {
+class SphericalShells final : public DomainCreator<3> {
  public:
   using maps_list =
       tmpl::append<tmpl::list<domain::CoordinateMap<

--- a/src/Domain/Creators/Tags/Domain.cpp
+++ b/src/Domain/Creators/Tags/Domain.cpp
@@ -14,7 +14,7 @@ namespace domain::Tags {
 template <size_t VolumeDim>
 ::Domain<VolumeDim> Domain<VolumeDim>::create_from_options(
     const std::unique_ptr<::DomainCreator<VolumeDim>>& domain_creator) {
-  return domain_creator->create_domain();
+  return domain_creator->domain();
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -90,6 +90,22 @@ Domain<VolumeDim>::Domain(
 }
 
 template <size_t VolumeDim>
+Domain<VolumeDim>::Domain(const Domain<VolumeDim>& rhs)
+    : blocks_(rhs.blocks_),
+      excision_spheres_(rhs.excision_spheres_),
+      block_groups_(rhs.block_groups_) {}
+
+template <size_t VolumeDim>
+Domain<VolumeDim>& Domain<VolumeDim>::operator=(const Domain<VolumeDim>& rhs) {
+  if (this != &rhs) {
+    blocks_ = rhs.blocks_;
+    excision_spheres_ = rhs.excision_spheres_;
+    block_groups_ = rhs.block_groups_;
+  }
+  return *this;
+}
+
+template <size_t VolumeDim>
 void Domain<VolumeDim>::inject_time_dependent_map_for_block(
     const size_t block_id,
     std::unique_ptr<

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -179,9 +179,9 @@ class Domain {
 
   Domain() = default;
   ~Domain() = default;
-  Domain(const Domain&) = delete;
+  Domain(const Domain&);
   Domain(Domain&&) = default;
-  Domain<VolumeDim>& operator=(const Domain<VolumeDim>&) = delete;
+  Domain<VolumeDim>& operator=(const Domain<VolumeDim>&);
   Domain<VolumeDim>& operator=(Domain<VolumeDim>&&) = default;
 
   void inject_time_dependent_map_for_block(

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -1070,15 +1070,20 @@ cyl_wedge_coord_map_surrounding_blocks(
   using Wedge2D = domain::CoordinateMaps::Wedge<2>;
   using Wedge3DPrism =
       domain::CoordinateMaps::ProductOf2Maps<Wedge2D, Interval>;
-  ASSERT(radial_distribution.size() == 1 + radial_partitioning.size(),
-         "Specify a radial distribution for every cylindrical shell. You "
-         "specified "
-             << radial_distribution.size() << " items, but the domain has "
-             << 1 + radial_partitioning.size() << " shells.");
-  ASSERT(radial_distribution.front() ==
-             domain::CoordinateMaps::Distribution::Linear,
-         "The innermost shell must have a 'Linear' radial distribution because "
-         "it changes in circularity.");
+  if (radial_distribution.size() != 1 + radial_partitioning.size()) {
+    PARSE_ERROR(
+        options_context,
+        "Specify a radial distribution for every cylindrical shell. You "
+        "specified "
+            << radial_distribution.size() << " items, but the domain has "
+            << 1 + radial_partitioning.size() << " shells.");
+  }
+  if (radial_distribution.front() !=
+      domain::CoordinateMaps::Distribution::Linear) {
+    PARSE_ERROR(options_context,
+                "The innermost shell must have a 'Linear' radial distribution "
+                "because it changes in circularity.");
+  }
   std::vector<Wedge3DPrism> maps{};
   double temp_inner_circularity{};
   double temp_inner_radius{};

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -33,6 +33,7 @@
 #include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Options/Context.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Utilities/Algorithm.hpp"
@@ -600,7 +601,7 @@ size_t which_wedge_index(const ShellWedges& which_wedges) {
 std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double inner_sphericity, const double outer_sphericity,
-    const bool use_equiangular_map,
+    const bool use_equiangular_map, const Options::Context& options_context,
     const std::optional<std::pair<double, std::array<double, 3>>>&
         offset_options,
     const bool use_half_wedges, const std::vector<double>& radial_partitioning,
@@ -647,7 +648,7 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
               temp_inner_radius, optional_outer_radius,
               offset_options.value().first, offset_options.value().second,
               gsl::at(wedge_orientations, face_j), use_equiangular_map,
-              Halves::Both, radial_distribution_this_layer);
+              Halves::Both, radial_distribution_this_layer, options_context);
         }
       } else {
         for (size_t i = 0; i < 4; i++) {
@@ -655,23 +656,25 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
               temp_inner_radius, optional_outer_radius,
               offset_options.value().first, offset_options.value().second,
               gsl::at(wedge_orientations, i), use_equiangular_map,
-              Halves::LowerOnly, radial_distribution_this_layer);
+              Halves::LowerOnly, radial_distribution_this_layer,
+              options_context);
           wedges_for_this_layer.emplace_back(
               temp_inner_radius, optional_outer_radius,
               offset_options.value().first, offset_options.value().second,
               gsl::at(wedge_orientations, i), use_equiangular_map,
-              Halves::UpperOnly, radial_distribution_this_layer);
+              Halves::UpperOnly, radial_distribution_this_layer,
+              options_context);
         }
         wedges_for_this_layer.emplace_back(
             temp_inner_radius, optional_outer_radius,
             offset_options.value().first, offset_options.value().second,
             gsl::at(wedge_orientations, 4), use_equiangular_map, Halves::Both,
-            radial_distribution_this_layer);
+            radial_distribution_this_layer, options_context);
         wedges_for_this_layer.emplace_back(
             temp_inner_radius, optional_outer_radius,
             offset_options.value().first, offset_options.value().second,
             gsl::at(wedge_orientations, 5), use_equiangular_map, Halves::Both,
-            radial_distribution_this_layer);
+            radial_distribution_this_layer, options_context);
       }
       for (const auto& wedge : wedges_for_this_layer) {
         wedges_for_all_layers.push_back(wedge);
@@ -696,7 +699,7 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
               temp_inner_radius, temp_outer_radius, temp_inner_sphericity,
               outer_sphericity, gsl::at(wedge_orientations, face_j),
               use_equiangular_map, Halves::Both, radial_distribution_this_layer,
-              std::array<double, 2>({{M_PI_2, M_PI_2}}));
+              std::array<double, 2>({{M_PI_2, M_PI_2}}), true, options_context);
         }
       } else {
         for (size_t i = 0; i < 4; i++) {
@@ -705,13 +708,15 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
               outer_sphericity, gsl::at(wedge_orientations, i),
               use_equiangular_map, Halves::LowerOnly,
               radial_distribution_this_layer,
-              std::array<double, 2>({{opening_angle, M_PI_2}}));
+              std::array<double, 2>({{opening_angle, M_PI_2}}), true,
+              options_context);
           wedges_for_this_layer.emplace_back(
               temp_inner_radius, temp_outer_radius, temp_inner_sphericity,
               outer_sphericity, gsl::at(wedge_orientations, i),
               use_equiangular_map, Halves::UpperOnly,
               radial_distribution_this_layer,
-              std::array<double, 2>({{opening_angle, M_PI_2}}));
+              std::array<double, 2>({{opening_angle, M_PI_2}}), true,
+              options_context);
         }
         const double endcap_opening_angle = M_PI - opening_angle;
         const std::array<double, 2> endcap_opening_angles = {
@@ -720,12 +725,12 @@ std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
             temp_inner_radius, temp_outer_radius, temp_inner_sphericity,
             outer_sphericity, gsl::at(wedge_orientations, 4),
             use_equiangular_map, Halves::Both, radial_distribution_this_layer,
-            endcap_opening_angles, false);
+            endcap_opening_angles, false, options_context);
         wedges_for_this_layer.emplace_back(
             temp_inner_radius, temp_outer_radius, temp_inner_sphericity,
             outer_sphericity, gsl::at(wedge_orientations, 5),
             use_equiangular_map, Halves::Both, radial_distribution_this_layer,
-            endcap_opening_angles, false);
+            endcap_opening_angles, false, options_context);
       }
       for (const auto& wedge : wedges_for_this_layer) {
         wedges_for_all_layers.push_back(wedge);
@@ -1053,7 +1058,8 @@ std::vector<domain::CoordinateMaps::ProductOf2Maps<
 cyl_wedge_coord_map_surrounding_blocks(
     const double inner_radius, const double outer_radius,
     const double lower_z_bound, const double upper_z_bound,
-    const bool use_equiangular_map, const double inner_circularity,
+    const bool use_equiangular_map, const Options::Context& options_context,
+    const double inner_circularity,
     const std::vector<double>& radial_partitioning,
     const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&
@@ -1116,7 +1122,8 @@ cyl_wedge_coord_map_surrounding_blocks(
             Wedge2D{temp_inner_radius, temp_outer_radius,
                     temp_inner_circularity, 1.0, cardinal_direction,
                     use_equiangular_map, use_both_halves,
-                    radial_distribution.at(shell)},
+                    radial_distribution.at(shell),
+                    std::array<double, 1>{{M_PI_2}}, true, options_context},
             z_map});
       }
       temp_inner_circularity = 1.;
@@ -1137,7 +1144,7 @@ std::vector<std::unique_ptr<
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double lower_z_bound, const double upper_z_bound,
-    const bool use_equiangular_map,
+    const bool use_equiangular_map, const Options::Context& options_context,
     const std::vector<double>& radial_partitioning,
     const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&
@@ -1149,8 +1156,8 @@ cyl_wedge_coordinate_maps(
       cylinder_mapping;
   const auto maps_surrounding = cyl_wedge_coord_map_surrounding_blocks(
       inner_radius, outer_radius, lower_z_bound, upper_z_bound,
-      use_equiangular_map, 0.0, radial_partitioning, partitioning_in_z,
-      radial_distribution, distribution_in_z,
+      use_equiangular_map, options_context, 0.0, radial_partitioning,
+      partitioning_in_z, radial_distribution, distribution_in_z,
       CylindricalDomainParityFlip::none);
 
   // add_to_cylinder_mapping adds the maps for individual blocks in
@@ -1492,7 +1499,7 @@ template std::vector<std::unique_ptr<
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double lower_z_bound, const double upper_z_bound,
-    const bool use_equiangular_map,
+    const bool use_equiangular_map, const Options::Context& options_context,
     const std::vector<double>& radial_partitioning,
     const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&
@@ -1503,7 +1510,7 @@ template std::vector<std::unique_ptr<
 cyl_wedge_coordinate_maps(
     const double inner_radius, const double outer_radius,
     const double lower_z_bound, const double upper_z_bound,
-    const bool use_equiangular_map,
+    const bool use_equiangular_map, const Options::Context& options_context,
     const std::vector<double>& radial_partitioning,
     const std::vector<double>& partitioning_in_z,
     const std::vector<domain::CoordinateMaps::Distribution>&

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -18,6 +18,7 @@
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Options/Context.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -173,6 +174,7 @@ size_t which_wedge_index(const ShellWedges& which_wedges);
  * of the cube that would form the outer boundary and the second being the
  * offset to apply to the wedges.
  * \param use_equiangular_map Toggles the equiangular map of the Wedge map.
+ * \param options_context Used by the input file parser.
  * \param use_half_wedges When `true`, the wedges in the +z,-z,+y,-y directions
  * are cut in half along their xi-axes. The resulting ten CoordinateMaps are
  * used for the outermost Blocks of the BBH Domain.
@@ -190,6 +192,7 @@ size_t which_wedge_index(const ShellWedges& which_wedges);
 std::vector<domain::CoordinateMaps::Wedge<3>> sph_wedge_coordinate_maps(
     double inner_radius, double outer_radius, double inner_sphericity,
     double outer_sphericity, bool use_equiangular_map,
+    const Options::Context& options_context,
     const std::optional<std::pair<double, std::array<double, 3>>>&
         offset_options = std::nullopt,
     bool use_half_wedges = false,
@@ -291,6 +294,7 @@ template <typename TargetFrame>
 auto cyl_wedge_coordinate_maps(
     double inner_radius, double outer_radius, double lower_z_bound,
     double upper_z_bound, bool use_equiangular_map,
+    const Options::Context& options_context,
     const std::vector<double>& radial_partitioning = {},
     const std::vector<double>& partitioning_in_z = {},
     const std::vector<domain::CoordinateMaps::Distribution>&
@@ -342,7 +346,8 @@ auto cyl_wedge_coord_map_center_blocks(
 /// be composed with other maps later.
 auto cyl_wedge_coord_map_surrounding_blocks(
     double inner_radius, double outer_radius, double lower_z_bound,
-    double upper_z_bound, bool use_equiangular_map, double inner_circularity,
+    double upper_z_bound, bool use_equiangular_map,
+    const Options::Context& options_context, double inner_circularity,
     const std::vector<double>& radial_partitioning = {},
     const std::vector<double>& partitioning_in_z = {},
     const std::vector<domain::CoordinateMaps::Distribution>&

--- a/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.cpp
+++ b/src/Evolution/Ringdown/StrahlkorperCoefsInRingdownDistortedFrame.cpp
@@ -96,7 +96,7 @@ std::vector<DataVector> strahlkorper_coefs_in_ringdown_distorted_frame(
       ShellWedges::All,
       time_dependent_map_options};
 
-  const auto temporary_domain = domain_creator.create_domain();
+  const auto temporary_domain = domain_creator.domain();
   const auto functions_of_time = domain_creator.functions_of_time();
 
   // Loop over the selected horizons, transforming each to the

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -268,7 +268,7 @@ struct ExcisionSphere : db::SimpleTag {
   static ::ExcisionSphere<Dim> create_from_options(
       const std::unique_ptr<::DomainCreator<Dim>>& domain_creator,
       const std::string& excision_sphere) {
-    const auto domain = domain_creator->create_domain();
+    const auto domain = domain_creator->domain();
     const auto& excision_spheres = domain.excision_spheres();
     if (excision_spheres.count(excision_sphere) == 0) {
       ERROR("Specified excision sphere '"
@@ -443,7 +443,7 @@ struct InitialPositionAndVelocity : db::SimpleTag {
       const std::string& excision_sphere_name, const double initial_time) {
     // only evaluated at initial time, so expiration times don't matter
     const auto initial_fot = domain_creator->functions_of_time();
-    const auto domain = domain_creator->create_domain();
+    const auto domain = domain_creator->domain();
     const auto& excision_sphere =
         domain.excision_spheres().at(excision_sphere_name);
     ASSERT(excision_sphere.is_time_dependent(),

--- a/src/Options/Context.cpp
+++ b/src/Options/Context.cpp
@@ -13,4 +13,13 @@ std::ostream& operator<<(std::ostream& s, const Context& c) {
   }
   return s;
 }
+
+bool operator==(const Context& lhs, const Context& rhs) {
+  return lhs.top_level == rhs.top_level and lhs.context == rhs.context and
+         lhs.line == rhs.line and lhs.column == rhs.column;
+}
+
+bool operator!=(const Context& lhs, const Context& rhs) {
+  return not(lhs == rhs);
+}
 }  // namespace Options

--- a/src/Options/Context.hpp
+++ b/src/Options/Context.hpp
@@ -27,6 +27,14 @@ struct Context {
   void append(const std::string& c) { context += c + ":\n"; }
 };
 
+/// \ingroup OptionParsingGroup
+/// \brief Equivalence operator for Options::Context
+bool operator==(const Context& lhs, const Context& rhs);
+
+/// \ingroup OptionParsingGroup
+/// \brief Inequivalence operator for Options::Context
+bool operator!=(const Context& lhs, const Context& rhs);
+
 std::ostream& operator<<(std::ostream& s, const Context& c);
 
 }  // namespace Options

--- a/tests/Unit/ControlSystem/Systems/Test_GridCenters.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_GridCenters.cpp
@@ -123,7 +123,7 @@ void test_grid_centers_process_measurement() {
   using component = MockComponent<Metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   MockRuntimeSystem runner{
-      {creator.create_domain(), ::Verbosity::Silent, 4, true, false,
+      {creator.domain(), ::Verbosity::Silent, 4, true, false,
        std::unordered_map<std::string, bool>{},
        tnsr::I<double, 3, Frame::Grid>{std::array{-16.0, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{std::array{16.0, 0.0, 0.0}},

--- a/tests/Unit/ControlSystem/Systems/Test_Size.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Size.cpp
@@ -121,7 +121,7 @@ void test_size_process_measurement() {
   using component = MockComponent<Metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   MockRuntimeSystem runner{
-      {creator.create_domain(), ::Verbosity::Silent, 4, true, false,
+      {creator.domain(), ::Verbosity::Silent, 4, true, false,
        std::unordered_map<std::string, bool>{},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},

--- a/tests/Unit/ControlSystem/Systems/Test_Skew.cpp
+++ b/tests/Unit/ControlSystem/Systems/Test_Skew.cpp
@@ -118,7 +118,7 @@ void test_skew_process_measurement() {
   using component = MockComponent<Metavars>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavars>;
   MockRuntimeSystem runner{
-      {creator.create_domain(), ::Verbosity::Silent, 4, true, false,
+      {creator.domain(), ::Verbosity::Silent, 4, true, false,
        std::unordered_map<std::string, bool>{},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},
        tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}},

--- a/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
+++ b/tests/Unit/ControlSystem/Tags/Test_FunctionsOfTimeInitialize.cpp
@@ -79,7 +79,7 @@ class TestCreator : public DomainCreator<1> {
  public:
   explicit TestCreator(const bool add_controlled)
       : add_controlled_(add_controlled) {}
-  Domain<1> create_domain() const override { ERROR(""); }
+  const Domain<1>& domain() const override { return domain_; }
   std::vector<DirectionMap<
       1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override {
@@ -145,11 +145,12 @@ class TestCreator : public DomainCreator<1> {
 
  private:
   bool add_controlled_{};
+  Domain<1> domain_{};
 };
 
 class BadCreator : public DomainCreator<1> {
  public:
-  Domain<1> create_domain() const override { ERROR(""); }
+  const Domain<1>& domain() const override { return domain_; }
   std::vector<DirectionMap<
       1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override {
@@ -184,6 +185,9 @@ class BadCreator : public DomainCreator<1> {
 
     return functions_of_time;
   }
+
+ private:
+  Domain<1> domain_{};
 };
 
 template <size_t Index>

--- a/tests/Unit/ControlSystem/Test_Measurements.cpp
+++ b/tests/Unit/ControlSystem/Test_Measurements.cpp
@@ -362,7 +362,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FindTwoCenters",
   using obs_writer = MockObserverWriter<Metavariables>;
 
   MockRuntimeSystem runner{
-      {true, ::Verbosity::Silent, binary_compact_object.create_domain()},
+      {true, ::Verbosity::Silent, binary_compact_object.domain()},
       {binary_compact_object.functions_of_time()}};
   ActionTesting::emplace_singleton_component<control_system_component>(
       make_not_null(&runner), ActionTesting::NodeId{0},

--- a/tests/Unit/Domain/CoordinateMaps/Python/Test_Composition.py
+++ b/tests/Unit/Domain/CoordinateMaps/Python/Test_Composition.py
@@ -23,7 +23,7 @@ class TestComposition(unittest.TestCase):
             initial_number_of_grid_points=5,
             use_equiangular_map=True,
             excise=True,
-        ).create_domain()
+        ).domain()
         element_id = ElementId[3](0)
         element_map = ElementMap(element_id, domain)
         self.assertIsInstance(

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -422,7 +422,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Map", "[Domain][Unit]") {
   test_equality();
   CHECK(not Wedge2D{}.is_identity());
 
-#ifdef SPECTRE_DEBUG
   // centered wedge checks
   CHECK_THROWS_WITH(
       Wedge2D(-0.2, 4.0, 0.0, 1.0, OrientationMap<2>::create_aligned(), true),
@@ -509,6 +508,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Map", "[Domain][Unit]") {
           "offset must not pierce the cube of length 2 * cube_half_length_ "
           "centered at the origin. See the Wedge class documentation for a "
           "visual representation of this sphere and cube."));
-#endif
 }
 }  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -821,7 +821,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
   test_wedge3d_large_radius();
   CHECK(not Wedge3D{}.is_identity());
 
-#ifdef SPECTRE_DEBUG
   // centered wedge checks
   CHECK_THROWS_WITH(
       Wedge3D(-0.2, 4.0, 0.0, 1.0, OrientationMap<3>::create_aligned(), true),
@@ -908,6 +907,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
           "offset must not pierce the cube of length 2 * cube_half_length_ "
           "centered at the origin. See the Wedge class documentation for a "
           "visual representation of this sphere and cube."));
-#endif
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Python/Test_Brick.py
+++ b/tests/Unit/Domain/Creators/Python/Test_Brick.py
@@ -15,7 +15,7 @@ class TestBrick(unittest.TestCase):
             initial_refinement_levels=[1, 0, 1],
             initial_num_points=[3, 4, 2],
         )
-        domain = brick.create_domain()
+        domain = brick.domain()
         self.assertFalse(domain.is_time_dependent())
         self.assertEqual(brick.block_names(), ["Brick"])
         self.assertEqual(brick.block_groups(), {"Brick": {"Brick"}})

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -128,7 +128,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     TestHelpers::domain::creators::test_domain_creator(
         *aligned_blocks_creator_1d, use_boundary_condition);
     CHECK(domain_creator_1d->grid_anchors().empty());
-    check_block_names(domain_creator_1d->create_domain(),
+    check_block_names(domain_creator_1d->domain(),
                       {{{0.1, 2.6, 5.1, 5.2, 7.2}}});
 
     const auto domain_creator_2d = make_domain_creator<2>(
@@ -148,7 +148,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
             domain_creator_2d.get());
     TestHelpers::domain::creators::test_domain_creator(
         *aligned_blocks_creator_2d, use_boundary_condition);
-    check_block_names(domain_creator_2d->create_domain(),
+    check_block_names(domain_creator_2d->domain(),
                       {{{0.1, 2.6, 5.1}, {-0.4, 3.2, 6.2, 8.9}}});
 
     const auto domain_creator_3d = make_domain_creator<3>(
@@ -168,7 +168,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
             domain_creator_3d.get());
     TestHelpers::domain::creators::test_domain_creator(
         *aligned_blocks_creator_3d, use_boundary_condition);
-    check_block_names(domain_creator_3d->create_domain(),
+    check_block_names(domain_creator_3d->domain(),
                       {{{0.1, 2.6, 5.1}, {-0.4, 3.2, 6.2}, {-0.2, 3.2}}});
 
     const auto cubical_shell_domain = make_domain_creator<3>(
@@ -190,7 +190,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     TestHelpers::domain::creators::test_domain_creator(
         *cubical_shell_creator_3d, use_boundary_condition);
     check_block_names(
-        cubical_shell_domain->create_domain(),
+        cubical_shell_domain->domain(),
         {{{0.1, 2.6, 5.1, 6.0}, {-0.4, 3.2, 6.2, 7.0}, {-0.2, 3.2, 4.0, 5.2}}});
 
     const auto unit_cubical_shell_domain = make_domain_creator<3>(
@@ -211,7 +211,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
             unit_cubical_shell_domain.get());
     TestHelpers::domain::creators::test_domain_creator(
         *unit_cubical_shell_creator_3d, use_boundary_condition);
-    check_block_names(unit_cubical_shell_domain->create_domain(),
+    check_block_names(unit_cubical_shell_domain->domain(),
                       {{{-1.5, -0.5, 0.5, 1.5},
                         {-1.5, -0.5, 0.5, 1.5},
                         {-1.5, -0.5, 0.5, 1.5}}});
@@ -235,7 +235,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           domain_creator_2d_periodic.get());
   TestHelpers::domain::creators::test_domain_creator(
       *aligned_blocks_creator_2d_periodic, false, true);
-  check_block_names(domain_creator_2d_periodic->create_domain(),
+  check_block_names(domain_creator_2d_periodic->domain(),
                     {{{0.1, 2.6, 5.1}, {-0.4, 3.2, 6.2, 8.9}}});
 
   const auto domain_creator_3d_periodic = TestHelpers::test_option_tag<
@@ -256,7 +256,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           domain_creator_3d_periodic.get());
   TestHelpers::domain::creators::test_domain_creator(
       *aligned_blocks_creator_3d_periodic, false, true);
-  check_block_names(domain_creator_3d_periodic->create_domain(),
+  check_block_names(domain_creator_3d_periodic->domain(),
                     {{{0.1, 2.6, 5.1}, {-0.4, 3.2, 6.2}, {-0.2, 3.2}}});
 
   {

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -981,6 +981,36 @@ void test_parse_errors() {
           std::vector<double>{}, Distribution::Linear, 120.0, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("Invalid 'InitialGridPoints'"));
+  CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_bco = domain::creators::BinaryCompactObject(
+            Object{0.0, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+            Object{
+                0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
+            std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st,
+            true, Distribution::Projective, std::vector<double>{},
+            Distribution::Linear, 120.0, std::nullopt,
+            create_outer_boundary_condition(),
+            Options::Context{false, {}, 1, 1});
+        invalid_bco.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the inner surface must be greater than zero."));
+  CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_bco = domain::creators::BinaryCompactObject(
+            Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+            Object{
+                0.0, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
+            std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st,
+            true, Distribution::Projective, std::vector<double>{},
+            Distribution::Linear, 120.0, std::nullopt,
+            create_outer_boundary_condition(),
+            Options::Context{false, {}, 1, 1});
+        invalid_bco.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the inner surface must be greater than zero."));
   // Note: the boundary condition-related parse errors are checked in the
   // test_connectivity function.
 }

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -982,33 +982,23 @@ void test_parse_errors() {
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("Invalid 'InitialGridPoints'"));
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_bco = domain::creators::BinaryCompactObject(
-            Object{0.0, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
-            Object{
-                0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
-            std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st,
-            true, Distribution::Projective, std::vector<double>{},
-            Distribution::Linear, 120.0, std::nullopt,
-            create_outer_boundary_condition(),
-            Options::Context{false, {}, 1, 1});
-        invalid_bco.create_domain();
-      }(),
+      domain::creators::BinaryCompactObject(
+          Object{0.0, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.3, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the inner surface must be greater than zero."));
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_bco = domain::creators::BinaryCompactObject(
-            Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
-            Object{
-                0.0, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
-            std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st,
-            true, Distribution::Projective, std::vector<double>{},
-            Distribution::Linear, 120.0, std::nullopt,
-            create_outer_boundary_condition(),
-            Options::Context{false, {}, 1, 1});
-        invalid_bco.create_domain();
-      }(),
+      domain::creators::BinaryCompactObject(
+          Object{0.3, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
+          Object{0.0, 0.8, -1.0, {{create_inner_boundary_condition()}}, false},
+          std::array<double, 2>{{0.1, 0.2}}, 25.5, 32.4, 1.0, 2_st, 6_st, true,
+          Distribution::Projective, std::vector<double>{}, Distribution::Linear,
+          120.0, std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the inner surface must be greater than zero."));
   // Note: the boundary condition-related parse errors are checked in the

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -1047,7 +1047,7 @@ void test_kerr_horizon_conforming() {
               32_st, domain::creators::time_dependent_options::
                          KerrSchildFromBoyerLindquist{mass_B, spin_B}},
           std::nullopt}};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto functions_of_time = domain_creator.functions_of_time();
   // Set up coordinates on an ellipsoid of constant Boyer-Lindquist radius
   const size_t num_points = 10;

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -628,6 +628,35 @@ void test_sphere_factory() {
       time_map_vec, initial_expiration_times);
 }
 
+void test_sphere_option_wedge_errors() {
+  INFO("CartoonSphere2D option wedge errors");
+  using SphereMetavars = TestHelpers::domain::BoundaryConditions::
+      MetavariablesWithoutBoundaryConditions<3,
+                                             domain::creators::CartoonSphere2D>;
+  const auto inner_surface_error = Catch::Matchers::ContainsSubstring(
+      "The radius of the inner surface must be greater than zero.");
+  CHECK_THROWS_WITH(
+      ([&]() {
+        const auto sphere =
+            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
+                                         SphereMetavars>(
+                "CartoonSphere2D:\n"
+                "  InnerRadius: 0.0\n"
+                "  OuterRadius: 3.0\n"
+                "  InitialRefinement:\n"
+                "    - [2, 2]\n"
+                "    - [2, 2]\n"
+                "  InitialGridPoints: [2,3]\n"
+                "  RadialPartitioning: [1.5]\n"
+                "  UseEquiangularMap: true\n"
+                "  Interior:\n"
+                "    FillWithSphericity: 0.0\n"
+                "  TimeDependence: None\n");
+        dynamic_cast<const creators::CartoonSphere2D&>(*sphere).create_domain();
+      }()),
+      inner_surface_error);
+}
+
 void test_sphere_errors() {
   INFO("CartoonSphere2D testing errors");
   const double inner_radius = 1.0;
@@ -727,6 +756,7 @@ void test_sphere_errors() {
 SPECTRE_TEST_CASE("Unit.Domain.Creators.CartoonSphere2D", "[Domain][Unit]") {
   test_sphere_boundaries();
   test_sphere_factory();
+  test_sphere_option_wedge_errors();
   test_sphere_errors();
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -711,6 +711,16 @@ void test_sphere_errors() {
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot have periodic boundary conditions on a 2D sphere."));
+  CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_cartoon = creators::CartoonSphere2D(
+            0.0, outer_radius, refinement_level_vec, grid_points_vec,
+            radial_partitioning, false, fill_center, nullptr, nullptr, nullptr,
+            Options::Context{false, {}, 1, 1});
+        invalid_cartoon.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the inner surface must be greater than zero."));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -759,13 +759,10 @@ void test_sphere_errors() {
       Catch::Matchers::ContainsSubstring(
           "Cannot have periodic boundary conditions on a 2D sphere."));
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_cartoon = creators::CartoonSphere2D(
-            0.0, outer_radius, refinement_level_vec, grid_points_vec,
-            radial_partitioning, false, fill_center, nullptr, nullptr, nullptr,
-            Options::Context{false, {}, 1, 1});
-        invalid_cartoon.create_domain();
-      }(),
+      creators::CartoonSphere2D(0.0, outer_radius, refinement_level_vec,
+                                grid_points_vec, radial_partitioning, false,
+                                fill_center, nullptr, nullptr, nullptr,
+                                Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the inner surface must be greater than zero."));
 }

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -635,6 +635,8 @@ void test_sphere_option_wedge_errors() {
                                              domain::creators::CartoonSphere2D>;
   const auto inner_surface_error = Catch::Matchers::ContainsSubstring(
       "The radius of the inner surface must be greater than zero.");
+  const auto outer_surface_error = Catch::Matchers::ContainsSubstring(
+      "Inner radius must be smaller than outer radius");
   CHECK_THROWS_WITH(
       ([&]() {
         const auto sphere =
@@ -655,6 +657,26 @@ void test_sphere_option_wedge_errors() {
         dynamic_cast<const creators::CartoonSphere2D&>(*sphere).create_domain();
       }()),
       inner_surface_error);
+  CHECK_THROWS_WITH(
+      ([&]() {
+        const auto sphere =
+            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
+                                         SphereMetavars>(
+                "CartoonSphere2D:\n"
+                "  InnerRadius: 1.0\n"
+                "  OuterRadius: 1.0\n"
+                "  InitialRefinement:\n"
+                "    - [2, 2]\n"
+                "    - [2, 2]\n"
+                "  InitialGridPoints: [2,3]\n"
+                "  RadialPartitioning: [1.5]\n"
+                "  UseEquiangularMap: true\n"
+                "  Interior:\n"
+                "    FillWithSphericity: 0.0\n"
+                "  TimeDependence: None\n");
+        dynamic_cast<const creators::CartoonSphere2D&>(*sphere).create_domain();
+      }()),
+      outer_surface_error);
 }
 
 void test_sphere_errors() {

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -639,42 +639,38 @@ void test_sphere_option_wedge_errors() {
       "Inner radius must be smaller than outer radius");
   CHECK_THROWS_WITH(
       ([&]() {
-        const auto sphere =
-            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
-                                         SphereMetavars>(
-                "CartoonSphere2D:\n"
-                "  InnerRadius: 0.0\n"
-                "  OuterRadius: 3.0\n"
-                "  InitialRefinement:\n"
-                "    - [2, 2]\n"
-                "    - [2, 2]\n"
-                "  InitialGridPoints: [2,3]\n"
-                "  RadialPartitioning: [1.5]\n"
-                "  UseEquiangularMap: true\n"
-                "  Interior:\n"
-                "    FillWithSphericity: 0.0\n"
-                "  TimeDependence: None\n");
-        dynamic_cast<const creators::CartoonSphere2D&>(*sphere).create_domain();
+        TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
+                                     SphereMetavars>(
+            "CartoonSphere2D:\n"
+            "  InnerRadius: 0.0\n"
+            "  OuterRadius: 3.0\n"
+            "  InitialRefinement:\n"
+            "    - [2, 2]\n"
+            "    - [2, 2]\n"
+            "  InitialGridPoints: [2,3]\n"
+            "  RadialPartitioning: [1.5]\n"
+            "  UseEquiangularMap: true\n"
+            "  Interior:\n"
+            "    FillWithSphericity: 0.0\n"
+            "  TimeDependence: None\n");
       }()),
       inner_surface_error);
   CHECK_THROWS_WITH(
       ([&]() {
-        const auto sphere =
-            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
-                                         SphereMetavars>(
-                "CartoonSphere2D:\n"
-                "  InnerRadius: 1.0\n"
-                "  OuterRadius: 1.0\n"
-                "  InitialRefinement:\n"
-                "    - [2, 2]\n"
-                "    - [2, 2]\n"
-                "  InitialGridPoints: [2,3]\n"
-                "  RadialPartitioning: [1.5]\n"
-                "  UseEquiangularMap: true\n"
-                "  Interior:\n"
-                "    FillWithSphericity: 0.0\n"
-                "  TimeDependence: None\n");
-        dynamic_cast<const creators::CartoonSphere2D&>(*sphere).create_domain();
+        TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<3>,
+                                     SphereMetavars>(
+            "CartoonSphere2D:\n"
+            "  InnerRadius: 1.0\n"
+            "  OuterRadius: 1.0\n"
+            "  InitialRefinement:\n"
+            "    - [2, 2]\n"
+            "    - [2, 2]\n"
+            "  InitialGridPoints: [2,3]\n"
+            "  RadialPartitioning: [1.5]\n"
+            "  UseEquiangularMap: true\n"
+            "  Interior:\n"
+            "    FillWithSphericity: 0.0\n"
+            "  TimeDependence: None\n");
       }()),
       outer_surface_error);
 }

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -1232,25 +1232,19 @@ void test_cylinder_wedge_parse_errors() {
       domain::CoordinateMaps::Distribution::Linear};
 
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_cylinder = creators::Cylinder(
-            0.0, 1.0, lower_z_bound, upper_z_bound, false, refinement_level,
-            grid_points, false, radial_partitioning, partitioning_in_z,
-            radial_distribution, distribution_in_z,
-            Options::Context{false, {}, 1, 1});
-        invalid_cylinder.create_domain();
-      }(),
+      creators::Cylinder(0.0, 1.0, lower_z_bound, upper_z_bound, false,
+                         refinement_level, grid_points, false,
+                         radial_partitioning, partitioning_in_z,
+                         radial_distribution, distribution_in_z,
+                         Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the inner surface must be greater than zero."));
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_cylinder = creators::Cylinder(
-            1.0, 1.0, lower_z_bound, upper_z_bound, false, refinement_level,
-            grid_points, false, radial_partitioning, partitioning_in_z,
-            radial_distribution, distribution_in_z,
-            Options::Context{false, {}, 1, 1});
-        invalid_cylinder.create_domain();
-      }(),
+      creators::Cylinder(1.0, 1.0, lower_z_bound, upper_z_bound, false,
+                         refinement_level, grid_points, false,
+                         radial_partitioning, partitioning_in_z,
+                         radial_distribution, distribution_in_z,
+                         Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the outer surface must be greater than the radius of "
           "the inner surface."));
@@ -1264,14 +1258,11 @@ void test_cylinder_wedge_parse_errors() {
         distribution_in_z_extra_shell{
             domain::CoordinateMaps::Distribution::Linear};
     CHECK_THROWS_WITH(
-        [&]() {
-          auto invalid_cylinder = creators::Cylinder(
-              1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
-              grid_points, false, radial_partitioning_extra_shell,
-              partitioning_in_z_extra_shell, radial_distribution_missing,
-              distribution_in_z_extra_shell, Options::Context{false, {}, 1, 1});
-          invalid_cylinder.create_domain();
-        }(),
+        creators::Cylinder(
+            1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
+            grid_points, false, radial_partitioning_extra_shell,
+            partitioning_in_z_extra_shell, radial_distribution_missing,
+            distribution_in_z_extra_shell, Options::Context{false, {}, 1, 1}),
         Catch::Matchers::ContainsSubstring(
             "Specify a 'RadialDistribution' for every cylindrical shell."));
   }
@@ -1286,14 +1277,11 @@ void test_cylinder_wedge_parse_errors() {
         distribution_in_z_extra_shell{
             domain::CoordinateMaps::Distribution::Linear};
     CHECK_THROWS_WITH(
-        [&]() {
-          auto invalid_cylinder = creators::Cylinder(
-              1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
-              grid_points, false, radial_partitioning_extra_shell,
-              partitioning_in_z_extra_shell, radial_distribution_non_linear,
-              distribution_in_z_extra_shell, Options::Context{false, {}, 1, 1});
-          invalid_cylinder.create_domain();
-        }(),
+        creators::Cylinder(
+            1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
+            grid_points, false, radial_partitioning_extra_shell,
+            partitioning_in_z_extra_shell, radial_distribution_non_linear,
+            distribution_in_z_extra_shell, Options::Context{false, {}, 1, 1}),
         Catch::Matchers::ContainsSubstring(
             "The 'RadialDistribution' must be 'Linear' for the innermost "
             "shell because it changes in circularity."));

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -1254,6 +1254,48 @@ void test_cylinder_wedge_parse_errors() {
       Catch::Matchers::ContainsSubstring(
           "The radius of the outer surface must be greater than the radius of "
           "the inner surface."));
+  {
+    const std::vector<double> radial_partitioning_more{1.5};
+    const std::vector<double> partitioning_in_z_more{};
+    const std::vector<domain::CoordinateMaps::Distribution>
+        radial_distribution_missing{
+            domain::CoordinateMaps::Distribution::Linear};
+    const std::vector<domain::CoordinateMaps::Distribution>
+        distribution_in_z_more{domain::CoordinateMaps::Distribution::Linear};
+    CHECK_THROWS_WITH(
+        [&]() {
+          auto invalid_cylinder = creators::Cylinder(
+              1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
+              grid_points, false, radial_partitioning_more,
+              partitioning_in_z_more, radial_distribution_missing,
+              distribution_in_z_more, Options::Context{false, {}, 1, 1});
+          invalid_cylinder.create_domain();
+        }(),
+        Catch::Matchers::ContainsSubstring(
+            "Specify a 'RadialDistribution' for every cylindrical shell."));
+  }
+  {
+    const std::vector<double> radial_partitioning_more{1.5};
+    const std::vector<double> partitioning_in_z_more{};
+    const std::vector<domain::CoordinateMaps::Distribution>
+        radial_distribution_non_linear{
+            domain::CoordinateMaps::Distribution::Logarithmic,
+            domain::CoordinateMaps::Distribution::Linear};
+    const std::vector<domain::CoordinateMaps::Distribution>
+        distribution_in_z_more{domain::CoordinateMaps::Distribution::Linear};
+    CHECK_THROWS_WITH(
+        [&]() {
+          auto invalid_cylinder = creators::Cylinder(
+              1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
+              grid_points, false, radial_partitioning_more,
+              partitioning_in_z_more, radial_distribution_non_linear,
+              distribution_in_z_more, Options::Context{false, {}, 1, 1});
+          invalid_cylinder.create_domain();
+        }(),
+        Catch::Matchers::ContainsSubstring(
+            "The 'RadialDistribution' must be 'Linear' for the innermost "
+            "shell because it changes in circularity."));
+  }
 }
 
 }  // namespace

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -1218,6 +1218,44 @@ void test_refined_cylinder_periodic_boundaries(const bool use_equiangular_map) {
                            expected_external_boundaries, coord_maps);
 }
 
+void test_cylinder_wedge_parse_errors() {
+  INFO("Cylinder wedge parse errors");
+  const double lower_z_bound = -1.0;
+  const double upper_z_bound = 1.0;
+  const size_t refinement_level = 2;
+  const std::array<size_t, 3> grid_points{{4, 4, 4}};
+  const std::vector<double> radial_partitioning{};
+  const std::vector<double> partitioning_in_z{};
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Linear};
+  const std::vector<domain::CoordinateMaps::Distribution> distribution_in_z{
+      domain::CoordinateMaps::Distribution::Linear};
+
+  CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_cylinder = creators::Cylinder(
+            0.0, 1.0, lower_z_bound, upper_z_bound, false, refinement_level,
+            grid_points, false, radial_partitioning, partitioning_in_z,
+            radial_distribution, distribution_in_z,
+            Options::Context{false, {}, 1, 1});
+        invalid_cylinder.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the inner surface must be greater than zero."));
+  CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_cylinder = creators::Cylinder(
+            1.0, 1.0, lower_z_bound, upper_z_bound, false, refinement_level,
+            grid_points, false, radial_partitioning, partitioning_in_z,
+            radial_distribution, distribution_in_z,
+            Options::Context{false, {}, 1, 1});
+        invalid_cylinder.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the outer surface must be greater than the radius of "
+          "the inner surface."));
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder", "[Domain][Unit]") {
@@ -1264,5 +1302,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder", "[Domain][Unit]") {
     test_refined_cylinder_periodic_boundaries(true);
     test_refined_cylinder_periodic_boundaries(false);
   }
+  test_cylinder_wedge_parse_errors();
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -1255,41 +1255,43 @@ void test_cylinder_wedge_parse_errors() {
           "The radius of the outer surface must be greater than the radius of "
           "the inner surface."));
   {
-    const std::vector<double> radial_partitioning_more{1.5};
-    const std::vector<double> partitioning_in_z_more{};
+    const std::vector<double> radial_partitioning_extra_shell{1.5};
+    const std::vector<double> partitioning_in_z_extra_shell{};
     const std::vector<domain::CoordinateMaps::Distribution>
         radial_distribution_missing{
             domain::CoordinateMaps::Distribution::Linear};
     const std::vector<domain::CoordinateMaps::Distribution>
-        distribution_in_z_more{domain::CoordinateMaps::Distribution::Linear};
+        distribution_in_z_extra_shell{
+            domain::CoordinateMaps::Distribution::Linear};
     CHECK_THROWS_WITH(
         [&]() {
           auto invalid_cylinder = creators::Cylinder(
               1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
-              grid_points, false, radial_partitioning_more,
-              partitioning_in_z_more, radial_distribution_missing,
-              distribution_in_z_more, Options::Context{false, {}, 1, 1});
+              grid_points, false, radial_partitioning_extra_shell,
+              partitioning_in_z_extra_shell, radial_distribution_missing,
+              distribution_in_z_extra_shell, Options::Context{false, {}, 1, 1});
           invalid_cylinder.create_domain();
         }(),
         Catch::Matchers::ContainsSubstring(
             "Specify a 'RadialDistribution' for every cylindrical shell."));
   }
   {
-    const std::vector<double> radial_partitioning_more{1.5};
-    const std::vector<double> partitioning_in_z_more{};
+    const std::vector<double> radial_partitioning_extra_shell{1.5};
+    const std::vector<double> partitioning_in_z_extra_shell{};
     const std::vector<domain::CoordinateMaps::Distribution>
         radial_distribution_non_linear{
             domain::CoordinateMaps::Distribution::Logarithmic,
             domain::CoordinateMaps::Distribution::Linear};
     const std::vector<domain::CoordinateMaps::Distribution>
-        distribution_in_z_more{domain::CoordinateMaps::Distribution::Linear};
+        distribution_in_z_extra_shell{
+            domain::CoordinateMaps::Distribution::Linear};
     CHECK_THROWS_WITH(
         [&]() {
           auto invalid_cylinder = creators::Cylinder(
               1.0, 2.0, lower_z_bound, upper_z_bound, false, refinement_level,
-              grid_points, false, radial_partitioning_more,
-              partitioning_in_z_more, radial_distribution_non_linear,
-              distribution_in_z_more, Options::Context{false, {}, 1, 1});
+              grid_points, false, radial_partitioning_extra_shell,
+              partitioning_in_z_extra_shell, radial_distribution_non_linear,
+              distribution_in_z_extra_shell, Options::Context{false, {}, 1, 1});
           invalid_cylinder.create_domain();
         }(),
         Catch::Matchers::ContainsSubstring(

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -252,21 +252,13 @@ void test_disk_boundaries_equidistant() {
           "None boundary condition is not supported. If you would like an "
           "outflow-type boundary condition, you must use that."));
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_disk =
-            creators::Disk(0.0, outer_radius, refinement_level, grid_points,
-                           false, nullptr, Options::Context{false, {}, 1, 1});
-        invalid_disk.create_domain();
-      }(),
+      creators::Disk(0.0, outer_radius, refinement_level, grid_points, false,
+                     nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the inner surface must be greater than zero."));
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_disk = creators::Disk(
-            inner_radius, inner_radius, refinement_level, grid_points, false,
-            nullptr, Options::Context{false, {}, 1, 1});
-        invalid_disk.create_domain();
-      }(),
+      creators::Disk(inner_radius, inner_radius, refinement_level, grid_points,
+                     false, nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the outer surface must be greater than the radius of "
           "the inner surface."));
@@ -324,58 +316,50 @@ void test_disk_option_errors() {
       "the inner surface.");
   CHECK_THROWS_WITH(
       ([&]() {
-        const auto disk =
-            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
-                                         DiskMetavars>(
-                "Disk:\n"
-                "  InnerRadius: 0\n"
-                "  OuterRadius: 3\n"
-                "  InitialRefinement: 2\n"
-                "  InitialGridPoints: [2,2]\n"
-                "  UseEquiangularMap: true\n");
-        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+        TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                     DiskMetavars>(
+            "Disk:\n"
+            "  InnerRadius: 0\n"
+            "  OuterRadius: 3\n"
+            "  InitialRefinement: 2\n"
+            "  InitialGridPoints: [2,2]\n"
+            "  UseEquiangularMap: true\n");
       }()),
       inner_surface_error);
   CHECK_THROWS_WITH(
       ([&]() {
-        const auto disk =
-            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
-                                         DiskMetavars>(
-                "Disk:\n"
-                "  InnerRadius: 1\n"
-                "  OuterRadius: 1\n"
-                "  InitialRefinement: 2\n"
-                "  InitialGridPoints: [2,2]\n"
-                "  UseEquiangularMap: true\n");
-        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+        TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                     DiskMetavars>(
+            "Disk:\n"
+            "  InnerRadius: 1\n"
+            "  OuterRadius: 1\n"
+            "  InitialRefinement: 2\n"
+            "  InitialGridPoints: [2,2]\n"
+            "  UseEquiangularMap: true\n");
       }()),
       outer_surface_error);
   CHECK_THROWS_WITH(
       ([&]() {
-        const auto disk =
-            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
-                                         DiskMetavars>(
-                "Disk:\n"
-                "  InnerRadius: 0\n"
-                "  OuterRadius: 3\n"
-                "  InitialRefinement: 2\n"
-                "  InitialGridPoints: [2,2]\n"
-                "  UseEquiangularMap: false\n");
-        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+        TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                     DiskMetavars>(
+            "Disk:\n"
+            "  InnerRadius: 0\n"
+            "  OuterRadius: 3\n"
+            "  InitialRefinement: 2\n"
+            "  InitialGridPoints: [2,2]\n"
+            "  UseEquiangularMap: false\n");
       }()),
       inner_surface_error);
   CHECK_THROWS_WITH(
       ([&]() {
-        const auto disk =
-            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
-                                         DiskMetavars>(
-                "Disk:\n"
-                "  InnerRadius: 1\n"
-                "  OuterRadius: 1\n"
-                "  InitialRefinement: 2\n"
-                "  InitialGridPoints: [2,2]\n"
-                "  UseEquiangularMap: false\n");
-        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+        TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                     DiskMetavars>(
+            "Disk:\n"
+            "  InnerRadius: 1\n"
+            "  OuterRadius: 1\n"
+            "  InitialRefinement: 2\n"
+            "  InitialGridPoints: [2,2]\n"
+            "  UseEquiangularMap: false\n");
       }()),
       outer_surface_error);
 }

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -312,6 +312,45 @@ void test_disk_factory_equidistant() {
       inner_radius, outer_radius, grid_points,
       {5, make_array<2>(refinement_level)}, false, true);
 }
+
+void test_disk_option_errors() {
+  INFO("Disk option Wedge errors");
+  using DiskMetavars = TestHelpers::domain::BoundaryConditions::
+      MetavariablesWithoutBoundaryConditions<2, domain::creators::Disk>;
+  const auto inner_surface_error = Catch::Matchers::ContainsSubstring(
+      "The radius of the inner surface must be greater than zero.");
+  const auto outer_surface_error = Catch::Matchers::ContainsSubstring(
+      "The radius of the outer surface must be greater than the radius of "
+      "the inner surface.");
+  CHECK_THROWS_WITH(
+      ([&]() {
+        const auto disk =
+            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                         DiskMetavars>(
+                "Disk:\n"
+                "  InnerRadius: 0\n"
+                "  OuterRadius: 3\n"
+                "  InitialRefinement: 2\n"
+                "  InitialGridPoints: [2,2]\n"
+                "  UseEquiangularMap: true\n");
+        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+      }()),
+      inner_surface_error);
+  CHECK_THROWS_WITH(
+      ([&]() {
+        const auto disk =
+            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                         DiskMetavars>(
+                "Disk:\n"
+                "  InnerRadius: 1\n"
+                "  OuterRadius: 1\n"
+                "  InitialRefinement: 2\n"
+                "  InitialGridPoints: [2,2]\n"
+                "  UseEquiangularMap: true\n");
+        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+      }()),
+      outer_surface_error);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk", "[Domain][Unit]") {
@@ -319,5 +358,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk", "[Domain][Unit]") {
   test_disk_factory_equiangular();
   test_disk_boundaries_equidistant();
   test_disk_factory_equidistant();
+  test_disk_option_errors();
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -251,6 +251,25 @@ void test_disk_boundaries_equidistant() {
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like an "
           "outflow-type boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_disk =
+            creators::Disk(0.0, outer_radius, refinement_level, grid_points,
+                           false, nullptr, Options::Context{false, {}, 1, 1});
+        invalid_disk.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the inner surface must be greater than zero."));
+  CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_disk = creators::Disk(
+            inner_radius, inner_radius, refinement_level, grid_points, false,
+            nullptr, Options::Context{false, {}, 1, 1});
+        invalid_disk.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the outer surface must be greater than the radius of "
+          "the inner surface."));
 }
 
 void test_disk_factory_equidistant() {

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -350,6 +350,34 @@ void test_disk_option_errors() {
         dynamic_cast<const creators::Disk&>(*disk).create_domain();
       }()),
       outer_surface_error);
+  CHECK_THROWS_WITH(
+      ([&]() {
+        const auto disk =
+            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                         DiskMetavars>(
+                "Disk:\n"
+                "  InnerRadius: 0\n"
+                "  OuterRadius: 3\n"
+                "  InitialRefinement: 2\n"
+                "  InitialGridPoints: [2,2]\n"
+                "  UseEquiangularMap: false\n");
+        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+      }()),
+      inner_surface_error);
+  CHECK_THROWS_WITH(
+      ([&]() {
+        const auto disk =
+            TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                         DiskMetavars>(
+                "Disk:\n"
+                "  InnerRadius: 1\n"
+                "  OuterRadius: 1\n"
+                "  InitialRefinement: 2\n"
+                "  InitialGridPoints: [2,2]\n"
+                "  UseEquiangularMap: false\n");
+        dynamic_cast<const creators::Disk&>(*disk).create_domain();
+      }()),
+      outer_surface_error);
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Creators/Test_NonconformingSphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_NonconformingSphericalShells.cpp
@@ -154,6 +154,17 @@ void test_parse_errors() {
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like "
           "an outflow-type boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      [&]() {
+        const auto invalid_shell =
+            domain::creators::NonconformingSphericalShells(
+                0.0, interface_radius, outer_radius, radial_refinement,
+                angular_refinement, radial_extents, l, angular_extents, nullptr,
+                nullptr, Options::Context{false, {}, 1, 1});
+        invalid_shell.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the inner surface must be greater than zero."));
 }
 
 template <typename Generator>

--- a/tests/Unit/Domain/Creators/Test_NonconformingSphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_NonconformingSphericalShells.cpp
@@ -155,14 +155,10 @@ void test_parse_errors() {
           "None boundary condition is not supported. If you would like "
           "an outflow-type boundary condition, you must use that."));
   CHECK_THROWS_WITH(
-      [&]() {
-        const auto invalid_shell =
-            domain::creators::NonconformingSphericalShells(
-                0.0, interface_radius, outer_radius, radial_refinement,
-                angular_refinement, radial_extents, l, angular_extents, nullptr,
-                nullptr, Options::Context{false, {}, 1, 1});
-        invalid_shell.create_domain();
-      }(),
+      domain::creators::NonconformingSphericalShells(
+          0.0, interface_radius, outer_radius, radial_refinement,
+          angular_refinement, radial_extents, l, angular_extents, nullptr,
+          nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the inner surface must be greater than zero."));
 }

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -433,14 +433,11 @@ void test_parse_errors() {
   const ShellWedges which_wedges = ShellWedges::All;
 
   CHECK_THROWS_WITH(
-      [&]() {
-        auto invalid_sphere = creators::Sphere(
-            0.0, outer_radius, inner_cube, refinement, initial_extents,
-            use_equiangular_map, equatorial_compression, radial_partitioning,
-            radial_distribution, which_wedges, std::nullopt, nullptr,
-            Options::Context{false, {}, 1, 1});
-        invalid_sphere.create_domain();
-      }(),
+      creators::Sphere(0.0, outer_radius, inner_cube, refinement,
+                       initial_extents, use_equiangular_map,
+                       equatorial_compression, radial_partitioning,
+                       radial_distribution, which_wedges, std::nullopt, nullptr,
+                       Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The radius of the inner surface must be greater than zero."));
   CHECK_THROWS_WITH(

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -673,7 +673,7 @@ void test_shape_distortion_general(
       domain::CoordinateMaps::Distribution::Linear,
       ShellWedges::All,
       std::move(time_dependent_options)};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto functions_of_time = domain_creator.functions_of_time();
   // Map the coordinates through the domain. They should lie at the lower zeta
   // boundary of their block.

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -433,6 +433,17 @@ void test_parse_errors() {
   const ShellWedges which_wedges = ShellWedges::All;
 
   CHECK_THROWS_WITH(
+      [&]() {
+        auto invalid_sphere = creators::Sphere(
+            0.0, outer_radius, inner_cube, refinement, initial_extents,
+            use_equiangular_map, equatorial_compression, radial_partitioning,
+            radial_distribution, which_wedges, std::nullopt, nullptr,
+            Options::Context{false, {}, 1, 1});
+        invalid_sphere.create_domain();
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "The radius of the inner surface must be greater than zero."));
+  CHECK_THROWS_WITH(
       creators::Sphere(inner_radius, 0.5 * inner_radius, inner_cube, refinement,
                        initial_extents, use_equiangular_map,
                        equatorial_compression, radial_partitioning,

--- a/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
@@ -475,7 +475,7 @@ void test_shape_distortion_general(
       {4.},
       domain::CoordinateMaps::Distribution::Linear,
       std::move(time_dependent_options)};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto functions_of_time = domain_creator.functions_of_time();
   // Map the coordinates through the domain. They should lie at the lower xi
   // boundary of their block.

--- a/tests/Unit/Domain/Python/Test_Domain.py
+++ b/tests/Unit/Domain/Python/Test_Domain.py
@@ -27,7 +27,7 @@ class TestDomain(unittest.TestCase):
             initial_refinement_levels=[1],
             initial_num_points=[4],
             is_periodic=[False],
-        ).create_domain()
+        ).domain()
         self.assertEqual(
             deserialize_domain[1](serialize_domain(domain)), domain
         )

--- a/tests/Unit/Domain/Python/Test_ElementMap.py
+++ b/tests/Unit/Domain/Python/Test_ElementMap.py
@@ -32,7 +32,7 @@ class TestElementMap(unittest.TestCase):
             is_periodic=[False],
             initial_refinement_levels=[1],
             initial_num_points=[3],
-        ).create_domain()
+        ).domain()
         # Element is [0, 1]
         element_id = ElementId[1]("[B0,(L1I0)]")
         element_map = ElementMap(element_id, domain)

--- a/tests/Unit/Domain/Test_AreaElement.cpp
+++ b/tests/Unit/Domain/Test_AreaElement.cpp
@@ -117,7 +117,7 @@ void test_sphere_integral() {
     domain::creators::Sphere shell{
         inner_radius, 3.,    domain::creators::Sphere::Excision{},
         ref_level,    10_st, true};
-    const auto shell_domain = shell.create_domain();
+    const auto shell_domain = shell.domain();
     const auto& blocks = shell_domain.blocks();
     const auto& initial_ref_levels = shell.initial_refinement_levels();
     const auto element_ids = initial_element_ids(initial_ref_levels);
@@ -170,7 +170,7 @@ void test_kerr_area() {
                                    ref_level,
                                    size_t(10),
                                    true};
-    const auto shell_domain = shell.create_domain();
+    const auto shell_domain = shell.domain();
     const auto& blocks = shell_domain.blocks();
     const auto& initial_ref_levels = shell.initial_refinement_levels();
     const auto element_ids = initial_element_ids(initial_ref_levels);

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -461,7 +461,7 @@ void fuzzy_test_block_and_element_logical_coordinates_unrefined(
 
 void fuzzy_test_block_and_element_logical_coordinates_shell(
     const DomainCreator<3>& shell, const size_t n_pts) {
-  const auto domain = shell.create_domain();
+  const auto domain = shell.domain();
   fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts);
   fuzzy_test_block_and_element_logical_coordinates(
       domain, shell.initial_refinement_levels(), n_pts);
@@ -475,7 +475,7 @@ void fuzzy_test_block_and_element_logical_coordinates_time_dependent_brick(
   const domain::creators::Brick brick(
       {{-0.1, -0.2, -0.3}}, {{0.1, 0.2, 0.3}}, {{0, 0, 0}}, {{3, 3, 3}},
       {{false, false, false}}, {}, uniform_translation.get_clone());
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   const auto functions_of_time = uniform_translation.functions_of_time();
   // Test at two different times.
   fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts, 0.0,
@@ -492,7 +492,7 @@ void fuzzy_test_block_and_element_logical_coordinates_distorted_brick(
   const domain::creators::Brick brick(
       {{-0.1, -0.2, -0.3}}, {{0.1, 0.2, 0.3}}, {{0, 0, 0}}, {{3, 3, 3}},
       {{false, false, false}}, {}, uniform_translation.get_clone());
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   const auto functions_of_time = uniform_translation.functions_of_time();
   // Test at two different times.
   fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts, 0.0,
@@ -878,7 +878,7 @@ void test_element_ids_are_uniquely_determined() {
 void test_block_logical_coordinates_with_roundoff_error() {
   const auto shell = domain::creators::Sphere(
       1., 3., domain::creators::Sphere::Excision{}, 0_st, 3_st, true);
-  const auto domain = shell.create_domain();
+  const auto domain = shell.domain();
 
   // Use this as roundoff error
   const double eps = 1e-14;

--- a/tests/Unit/Domain/Test_CoordsToDifferentFrame.cpp
+++ b/tests/Unit/Domain/Test_CoordsToDifferentFrame.cpp
@@ -46,7 +46,7 @@ void test_coords_to_different_frame() {
           0.0, std::array<double, 3>({{0.0, 0.0, 0.0}}),
           std::array<double, 3>({{0.01, 0.02, 0.03}}))};
 
-  const Domain<3> domain = domain_creator.create_domain();
+  const Domain<3> domain = domain_creator.domain();
   const auto functions_of_time = domain_creator.functions_of_time();
 
   const double time = 0.5;

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -58,6 +58,7 @@
 #include "IO/H5/VolumeData.hpp"
 #include "Informer/InfoFromBuild.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "Options/Context.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeVector.hpp"
@@ -1167,19 +1168,20 @@ Domain<3> create_serialized_domain() {
       Affine{-1.0, 1.0, -1.0 + x_coord_a, 1.0 + x_coord_a}, Identity2D{}};
   const Translation translation_B{
       Affine{-1.0, 1.0, -1.0 + x_coord_b, 1.0 + x_coord_b}, Identity2D{}};
+  const Options::Context context{};
 
   Maps maps_center_A =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
-          sph_wedge_coordinate_maps(object_A.inner_radius,
-                                    object_A.outer_radius, inner_sphericity_A,
-                                    1.0, use_equiangular_map, std::nullopt,
-                                    false, {}, radial_distribution),
+          sph_wedge_coordinate_maps(
+              object_A.inner_radius, object_A.outer_radius, inner_sphericity_A,
+              1.0, use_equiangular_map, context, std::nullopt, false, {},
+              radial_distribution),
           translation_A);
   Maps maps_cube_A =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
           sph_wedge_coordinate_maps(object_A.outer_radius,
                                     sqrt(3.0) * 0.5 * length_inner_cube, 1.0,
-                                    0.0, use_equiangular_map),
+                                    0.0, use_equiangular_map, context),
           translation_A);
   std::move(maps_center_A.begin(), maps_center_A.end(),
             std::back_inserter(maps));
@@ -1187,16 +1189,16 @@ Domain<3> create_serialized_domain() {
 
   Maps maps_center_B =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
-          sph_wedge_coordinate_maps(object_B.inner_radius,
-                                    object_B.outer_radius, inner_sphericity_B,
-                                    1.0, use_equiangular_map, std::nullopt,
-                                    false, {}, radial_distribution),
+          sph_wedge_coordinate_maps(
+              object_B.inner_radius, object_B.outer_radius, inner_sphericity_B,
+              1.0, use_equiangular_map, context, std::nullopt, false, {},
+              radial_distribution),
           translation_B);
   Maps maps_cube_B =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
           sph_wedge_coordinate_maps(object_B.outer_radius,
                                     sqrt(3.0) * 0.5 * length_inner_cube, 1.0,
-                                    0.0, use_equiangular_map),
+                                    0.0, use_equiangular_map, context),
           translation_B);
   std::move(maps_center_B.begin(), maps_center_B.end(),
             std::back_inserter(maps));
@@ -1219,8 +1221,8 @@ Domain<3> create_serialized_domain() {
   Maps maps_outer_shell =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
           sph_wedge_coordinate_maps(envelope_radius, outer_radius, 1.0, 1.0,
-                                    use_equiangular_map, std::nullopt, true, {},
-                                    {radial_distribution_outer_shell},
+                                    use_equiangular_map, context, std::nullopt,
+                                    true, {}, {radial_distribution_outer_shell},
                                     ShellWedges::All, opening_angle));
   std::move(maps_outer_shell.begin(), maps_outer_shell.end(),
             std::back_inserter(maps));

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -31,6 +31,7 @@
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Options/Context.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
@@ -305,9 +306,10 @@ void test_wedge_map_generation_against_domain_helpers(
   const auto expected_coord_maps = test_wedge_map_generation(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, offset_options, use_half_wedges);
+  const Options::Context context{};
   const auto maps = sph_wedge_coordinate_maps(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, offset_options, use_half_wedges);
+      use_equiangular_map, context, offset_options, use_half_wedges);
   CHECK(maps == expected_coord_maps);
 }
 
@@ -324,9 +326,10 @@ void test_wedge_errors() {
             radial_distribution{
                 domain::CoordinateMaps::Distribution::Logarithmic};
         const ShellWedges which_wedges = ShellWedges::FourOnEquator;
+        const Options::Context context{};
         static_cast<void>(sph_wedge_coordinate_maps(
             inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-            use_equiangular_map, std::nullopt, use_half_wedges, {},
+            use_equiangular_map, context, std::nullopt, use_half_wedges, {},
             radial_distribution, which_wedges));
       }()),
       Catch::Matchers::ContainsSubstring(

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -23,6 +23,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/BlockNeighbors.hpp"
@@ -335,6 +336,57 @@ void test_wedge_errors() {
       Catch::Matchers::ContainsSubstring(
           "If we are using half wedges we must also be using "
           "ShellWedges::All."));
+}
+
+void test_cyl_wedge_surrounding_blocks_radial_distribution_size_error() {
+  INFO("cyl wedge radial distribution size parse error");
+  const Options::Context context{false, "CylWedge.CylindricalShell.DistSize"};
+  const double inner_radius = 0.4;
+  const double outer_radius = 1.2;
+  const double lower_z_bound = -0.8;
+  const double upper_z_bound = 0.8;
+  const std::vector<double> radial_partitioning{0.9};
+  const std::vector<double> partitioning_in_z{};
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Linear};
+  const std::vector<domain::CoordinateMaps::Distribution> distribution_in_z{
+      domain::CoordinateMaps::Distribution::Linear};
+  CHECK_THROWS_WITH(
+      ([&]() {
+        static_cast<void>(cyl_wedge_coord_map_surrounding_blocks(
+            inner_radius, outer_radius, lower_z_bound, upper_z_bound, false,
+            context, 0.0, radial_partitioning, partitioning_in_z,
+            radial_distribution, distribution_in_z,
+            CylindricalDomainParityFlip::none));
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "Specify a radial distribution for every cylindrical shell"));
+}
+
+void test_cyl_wedge_surrounding_blocks_radial_distribution_linear_error() {
+  INFO("cyl wedge radial distribution linear parse error");
+  const Options::Context context{false, "CylWedge.CylindricalShell.Linear"};
+  const double inner_radius = 0.4;
+  const double outer_radius = 1.2;
+  const double lower_z_bound = -0.8;
+  const double upper_z_bound = 0.8;
+  const std::vector<double> radial_partitioning{0.9};
+  const std::vector<double> partitioning_in_z{};
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Logarithmic,
+      domain::CoordinateMaps::Distribution::Linear};
+  const std::vector<domain::CoordinateMaps::Distribution> distribution_in_z{
+      domain::CoordinateMaps::Distribution::Linear};
+  CHECK_THROWS_WITH(
+      ([&]() {
+        static_cast<void>(cyl_wedge_coord_map_surrounding_blocks(
+            inner_radius, outer_radius, lower_z_bound, upper_z_bound, false,
+            context, 0.0, radial_partitioning, partitioning_in_z,
+            radial_distribution, distribution_in_z,
+            CylindricalDomainParityFlip::none));
+      }()),
+      Catch::Matchers::ContainsSubstring(
+          "The innermost shell must have a 'Linear' radial distribution"));
 }
 
 void test_six_wedge_directions_equiangular() {
@@ -1668,6 +1720,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers", "[Domain][Unit]") {
   test_periodic_different_blocks();
   test_wedge_map_generation();
   test_wedge_errors();
+  test_cyl_wedge_surrounding_blocks_radial_distribution_size_error();
+  test_cyl_wedge_surrounding_blocks_radial_distribution_linear_error();
   test_all_frustum_directions();
   test_frustrum_errors();
   test_shell_graph();

--- a/tests/Unit/Domain/Test_ElementDistribution.cpp
+++ b/tests/Unit/Domain/Test_ElementDistribution.cpp
@@ -35,7 +35,7 @@ void test_uniform_cost_function() {
       {{{{{1, 0}}, {{3, 2}}, {{3, 5}}}, {{{2, 1}}, {{3, 3}}, {{4, 6}}}}},
       {{{{{1, 0}}, {{3, 2}}, {{4, 5}}}, {{{2, 1}}, {{3, 3}}, {{6, 7}}}}}, {});
 
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& blocks = domain.blocks();
 
   const auto costs = domain::get_element_costs(
@@ -54,7 +54,7 @@ void test_weighted_cost_function(const domain::ElementWeight element_weight) {
   const auto domain_creator1 = domain::creators::AlignedLattice<3>(
       {{{{0.0, 1.0, 2.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}},
       {{4, 4, 4}}, {}, {}, {});
-  const auto domain1 = domain_creator1.create_domain();
+  const auto domain1 = domain_creator1.domain();
   const auto& blocks1 = domain1.blocks();
 
   // Block size and grid points are the same as blocks in `domain1`, but
@@ -62,7 +62,7 @@ void test_weighted_cost_function(const domain::ElementWeight element_weight) {
   const auto domain_creator2 = domain::creators::AlignedLattice<3>(
       {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 3, 2}}, {{4, 4, 4}},
       {}, {}, {});
-  const auto domain2 = domain_creator2.create_domain();
+  const auto domain2 = domain_creator2.domain();
   const auto& blocks2 = domain2.blocks();
 
   // Block size and refinement levels are the same as blocks in `domain1`, but
@@ -70,7 +70,7 @@ void test_weighted_cost_function(const domain::ElementWeight element_weight) {
   const auto domain_creator3 = domain::creators::AlignedLattice<3>(
       {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}}, {{4, 3, 2}},
       {}, {}, {});
-  const auto domain3 = domain_creator3.create_domain();
+  const auto domain3 = domain_creator3.domain();
   const auto& blocks3 = domain2.blocks();
 
   const auto costs1 = domain::get_element_costs(
@@ -148,7 +148,7 @@ void test_uniform_element_distribution_construction(
     const DomainCreator<Dim>& domain_creator,
     const size_t number_of_procs_with_elements,
     const std::unordered_set<size_t>& global_procs_to_ignore = {}) {
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& blocks = domain.blocks();
   const auto initial_refinement_levels =
       domain_creator.initial_refinement_levels();
@@ -241,7 +241,7 @@ void test_weighted_element_distribution_construction(
     const DomainCreator<Dim>& domain_creator,
     const size_t number_of_procs_with_elements,
     const std::unordered_set<size_t>& global_procs_to_ignore = {}) {
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& blocks = domain.blocks();
   const auto initial_refinement_levels =
       domain_creator.initial_refinement_levels();
@@ -430,7 +430,7 @@ void test_proc_retrieval(
     const DomainCreator<Dim>& domain_creator,
     const size_t number_of_procs_with_elements,
     const std::unordered_set<size_t>& global_procs_to_ignore = {}) {
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& blocks = domain.blocks();
   const auto initial_refinement_levels =
       domain_creator.initial_refinement_levels();

--- a/tests/Unit/Domain/Test_ExcisionSphere.cpp
+++ b/tests/Unit/Domain/Test_ExcisionSphere.cpp
@@ -113,7 +113,7 @@ void test_abutting_direction_shell() {
     shells.push_back(std::move(shell_plain));
     shells.push_back(std::move(shell_partitioned));
     for (const auto& shell : shells) {
-      const auto shell_domain = shell.create_domain();
+      const auto shell_domain = shell.domain();
       const auto& blocks = shell_domain.blocks();
       const auto& initial_ref_levels = shell.initial_refinement_levels();
       const auto element_ids = initial_element_ids(initial_ref_levels);

--- a/tests/Unit/Domain/Test_StrahlkorperTransformations.cpp
+++ b/tests/Unit/Domain/Test_StrahlkorperTransformations.cpp
@@ -67,7 +67,7 @@ void test_strahlkorper_in_different_frame() {
             0.0, std::array<double, 3>({{0.0, 0.0, 0.0}}),
             std::array<double, 3>({{0.01, 0.02, 0.03}}))));
   }
-  Domain<3> domain = domain_creator->create_domain();
+  Domain<3> domain = domain_creator->domain();
   const auto functions_of_time = domain_creator->functions_of_time();
 
   // Compute strahlkorper in the destination frame.
@@ -164,7 +164,7 @@ void test_strahlkorper_coords_in_different_frame() {
         grid_points_each_dimension, false, std::nullopt, radial_partitioning,
         radial_distribution, ShellWedges::All);
   }
-  Domain<3> domain = domain_creator->create_domain();
+  Domain<3> domain = domain_creator->domain();
   const auto functions_of_time = domain_creator->functions_of_time();
 
   // Compute strahlkorper coords in the inertial frame.

--- a/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeBackgroundFields.cpp
@@ -88,7 +88,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeBackgroundFields",
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {std::make_unique<Background>(), domain_creator.create_domain(),
+      {std::make_unique<Background>(), domain_creator.domain(),
        domain_creator.functions_of_time(), Spectral::Quadrature::GaussLobatto}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFields.cpp
@@ -116,7 +116,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFields",
 
   using element_array = ElementArray<Metavariables>;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {std::make_unique<InitialGuess>(), domain_creator.create_domain(),
+      {std::make_unique<InitialGuess>(), domain_creator.domain(),
        domain_creator.functions_of_time(), Spectral::Quadrature::GaussLobatto}};
   ActionTesting::emplace_component_and_initialize<element_array>(
       &runner, element_id,

--- a/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeFixedSources.cpp
@@ -127,7 +127,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Actions.InitializeFixedSources",
                           domain::Tags::FunctionsOfTimeInitialize,
                           elliptic::dg::Tags::Massive,
                           elliptic::dg::Tags::Quadrature>{
-          std::make_unique<Background>(), domain_creator.create_domain(),
+          std::make_unique<Background>(), domain_creator.domain(),
           domain_creator.functions_of_time(), false,
           Spectral::Quadrature::GaussLobatto}};
   ActionTesting::emplace_component_and_initialize<element_array>(

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Actions/Test_InitializeDomain.cpp
@@ -85,7 +85,7 @@ void test_initialize_domain(const Spectral::Quadrature quadrature) {
     using element_array = ElementArray<1, metavariables>;
 
     ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {domain_creator.create_domain(), domain_creator.functions_of_time(),
+        {domain_creator.domain(), domain_creator.functions_of_time(),
          quadrature}};
     ActionTesting::emplace_component_and_initialize<element_array>(
         &runner, element_id, {domain_creator.initial_refinement_levels(),
@@ -160,7 +160,7 @@ void test_initialize_domain(const Spectral::Quadrature quadrature) {
     using element_array = ElementArray<2, metavariables>;
 
     ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {domain_creator.create_domain(), domain_creator.functions_of_time(),
+        {domain_creator.domain(), domain_creator.functions_of_time(),
          quadrature}};
     ActionTesting::emplace_component_and_initialize<element_array>(
         &runner, element_id, {domain_creator.initial_refinement_levels(),
@@ -231,7 +231,7 @@ void test_initialize_domain(const Spectral::Quadrature quadrature) {
     using metavariables = Metavariables<3>;
     using element_array = ElementArray<3, metavariables>;
     ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {domain_creator.create_domain(), domain_creator.functions_of_time(),
+        {domain_creator.domain(), domain_creator.functions_of_time(),
          quadrature}};
     ActionTesting::emplace_component_and_initialize<element_array>(
         &runner, element_id, {domain_creator.initial_refinement_levels(),

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -603,7 +603,7 @@ void test_subdomain_operator(
 
     // Re-create the domain in every iteration of this loop because it's not
     // copyable
-    auto domain = domain_creator.create_domain();
+    auto domain = domain_creator.domain();
     auto boundary_conditions = domain_creator.external_boundary_conditions();
     const auto initial_ref_levs = domain_creator.initial_refinement_levels();
     const auto initial_extents = domain_creator.initial_extents();

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -345,7 +345,7 @@ void test_dg_operator(
   register_factory_classes_with_charm<Metavars>();
 
   // Get a list of all elements in the domain
-  auto domain = domain_creator.create_domain();
+  auto domain = domain_creator.domain();
   auto boundary_conditions = domain_creator.external_boundary_conditions();
   const auto initial_ref_levs = domain_creator.initial_refinement_levels();
   const auto initial_extents = domain_creator.initial_extents();

--- a/tests/Unit/Elliptic/Systems/Elasticity/Actions/Test_InitializeConstitutiveRelation.cpp
+++ b/tests/Unit/Elliptic/Systems/Elasticity/Actions/Test_InitializeConstitutiveRelation.cpp
@@ -103,7 +103,7 @@ SPECTRE_TEST_CASE("Unit.Elasticity.Actions.InitializeConstitutiveRelation",
       tuples::TaggedTuple<domain::Tags::Domain<Dim>,
                           Tags::ConstitutiveRelationPerBlock<Dim>,
                           Tags::MaterialBlockGroups<Dim>>{
-          domain_creator->create_domain(), std::move(material_per_block),
+          domain_creator->domain(), std::move(material_per_block),
           std::move(material_block_groups)}};
   for (const auto& element_id : {element_id_layer1, element_id_layer2}) {
     ActionTesting::emplace_component_and_initialize<element_array>(

--- a/tests/Unit/Elliptic/Systems/Punctures/AmrCriteria/Test_RefineAtPunctures.cpp
+++ b/tests/Unit/Elliptic/Systems/Punctures/AmrCriteria/Test_RefineAtPunctures.cpp
@@ -83,7 +83,7 @@ SPECTRE_TEST_CASE("Unit.Punctures.AmrCriteria.RefineAtPunctures",
             std::unique_ptr<elliptic::analytic_data::Background>(
                 std::make_unique<MultiplePunctures>(
                     std::vector<Puncture>{puncture_within, puncture_boundary})),
-            domain_creator.create_domain());
+            domain_creator.domain());
     ObservationBox<
         tmpl::list<>,
         db::DataBox<tmpl::list<background_tag, domain::Tags::Domain<3>>>>

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
@@ -96,8 +96,8 @@ SPECTRE_TEST_CASE("Unit.GrSelfForce.Actions.InitializeEffectiveSource",
                           elliptic::dg::Tags::Quadrature>{
           std::make_unique<GrSelfForce::AnalyticData::CircularOrbit>(1.0, 0.0,
                                                                      6.0, 1),
-          domain_creator.create_domain(), domain_creator.functions_of_time(),
-          false, Spectral::Quadrature::GaussLobatto}};
+          domain_creator.domain(), domain_creator.functions_of_time(), false,
+          Spectral::Quadrature::GaussLobatto}};
   const ::Tags::Mortars<domain::Tags::Coordinates<2, Frame::Inertial>, 2>::type
       empty_mortar_coords{};
   ActionTesting::emplace_component_and_initialize<element_array>(

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/Test_CircularOrbit.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/Test_CircularOrbit.cpp
@@ -41,7 +41,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GrSelfForce.CircularOrbit",
       {{0, 0}},
       {{npoints, npoints}},
       {{false, false}}};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& block = domain.blocks()[0];
   const ElementId<2> element_id{0};
   const ElementMap<2, Frame::Inertial> element_map{element_id, block};

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
@@ -96,8 +96,8 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.Actions.InitializeEffectiveSource",
                           elliptic::dg::Tags::Quadrature>{
           std::make_unique<ScalarSelfForce::AnalyticData::CircularOrbit>(
               1.0, 0.0, 6.0, 1, std::nullopt, false),
-          domain_creator.create_domain(), domain_creator.functions_of_time(),
-          false, Spectral::Quadrature::GaussLobatto}};
+          domain_creator.domain(), domain_creator.functions_of_time(), false,
+          Spectral::Quadrature::GaussLobatto}};
   const ::Tags::Mortars<domain::Tags::Coordinates<2, Frame::Inertial>, 2>::type
       empty_mortar_coords{};
   ActionTesting::emplace_component_and_initialize<element_array>(

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/Test_RefineAtPunctures.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/Test_RefineAtPunctures.cpp
@@ -73,7 +73,7 @@ void test_criterion(
         {{10., 0.}}, {{15., 1.}}, {{2, 2}}, {{3, 3}}, {{false, false}}};
     auto databox =
         db::create<tmpl::list<background_tag, domain::Tags::Domain<2>>>(
-            std::move(background), domain_creator.create_domain());
+            std::move(background), domain_creator.domain());
     const ObservationBox<
         tmpl::list<>,
         db::DataBox<tmpl::list<background_tag, domain::Tags::Domain<2>>>>

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
@@ -41,7 +41,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarSelfForce.CircularOrbit",
       {{0, 0}},
       {{npoints, npoints}},
       {{false, false}}};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& block = domain.blocks()[0];
   const ElementId<2> element_id{0};
   const ElementMap<2, Frame::Inertial> element_map{element_id, block};

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Events/Test_ObserveSelfForce.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Events/Test_ObserveSelfForce.cpp
@@ -142,7 +142,7 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.Events.ObserveSelfForce",
       {{puncture_r_star + 1.0, 0.5}},
       {{0, 0}},
       {{4, 4}}};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const Mesh<2> mesh{4_st, Spectral::Basis::Legendre,
                      Spectral::Quadrature::Gauss};
   const ElementId<2> element_id_a{0, {{{1, 0}, {0, 0}}}};
@@ -174,7 +174,7 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.Events.ObserveSelfForce",
         std::unique_ptr<elliptic::analytic_data::Background>(
             std::make_unique<ScalarSelfForce::AnalyticData::CircularOrbit>(
                 circular_orbit)),
-        domain_creator.create_domain(), mesh, inv_jacobian, field);
+        domain_creator.domain(), mesh, inv_jacobian, field);
     auto obs_box =
         make_observation_box<db::AddComputeTags<>>(make_not_null(&box));
     event.run(make_not_null(&obs_box),

--- a/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Events/Test_ObserveAdmIntegrals.cpp
@@ -79,7 +79,7 @@ void test_local_adm_integrals(const double& distance,
       /* equatorial_compression */ {},
       /* radial_partitioning */ prev_distances,
       /* radial_distribution */ domain::CoordinateMaps::Distribution::Inverse};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto& blocks = shell_domain.blocks();
   const auto& initial_ref_levels = shell.initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_ref_levels);

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -238,7 +238,8 @@ bool Metavariables<Dim, TciFails, SubcellEnabledOnExternalBoundary>::
 
 template <size_t Dim>
 class TestCreator : public DomainCreator<Dim> {
-  Domain<Dim> create_domain() const override { return Domain<Dim>{}; }
+  const Domain<Dim>& domain() const override { return domain_; }
+  Domain<Dim> domain_{};
   std::vector<DirectionMap<
       Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override {

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
@@ -880,14 +880,14 @@ void test_receive_and_send_data(const bool enable_extension,
                               domain::CoordinateMaps::Distribution::Linear,
                               ShellWedges::All,
                               std::nullopt};
-  auto domain = domain_creator.create_domain();
+  auto domain = domain_creator.domain();
 
   using metavars = Metavariables<Dim, UseNodegroupDgElements, true>;
   metavars::ghost_zone_size_invoked = false;
   metavars::ghost_data_mutator_invoked = false;
   using comp = component<Dim, metavars, UseNodegroupDgElements, true>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  MockRuntimeSystem runner{{std::move(domain_creator.create_domain())}};
+  MockRuntimeSystem runner{{domain_creator.domain()}};
 
   const std::vector<Block<3>>& blocks = domain.blocks();
   // Create the elements that we will use in the test.

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -237,7 +237,8 @@ Element<Dim> create_element(const bool with_neighbors) {
 
 template <size_t Dim>
 class TestCreator : public DomainCreator<Dim> {
-  Domain<Dim> create_domain() const override { return Domain<Dim>{}; }
+  const Domain<Dim>& domain() const override { return domain_; }
+  Domain<Dim> domain_{};
   std::vector<DirectionMap<
       Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override {

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndSwitchToDg.cpp
@@ -186,7 +186,8 @@ std::unique_ptr<TimeStepper> make_time_stepper(
 
 template <size_t Dim>
 class TestCreator : public DomainCreator<Dim> {
-  Domain<Dim> create_domain() const override { return Domain<Dim>{}; }
+  const Domain<Dim>& domain() const override { return domain_; }
+  Domain<Dim> domain_{};
   std::vector<DirectionMap<
       Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override {

--- a/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
@@ -160,7 +160,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const bool did_rollback) {
     }
   }();
 
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   const auto element_id = ElementId<3>{0};
   Element<3> element = domain::create_initial_element(
       element_id, domain.blocks(),
@@ -260,7 +260,7 @@ void test(const gsl::not_null<std::mt19937*> gen, const bool did_rollback) {
         subcell_face_gr_variables_tag,
         evolution::dg::subcell::Tags::DidRollback,
         evolution::initial_data::Tags::InitialData>>(
-        initial_time, brick.create_domain(), element,
+        initial_time, brick.domain(), element,
         ElementMap<3, Frame::Grid>{
             element_id,
             block.is_time_dependent()

--- a/tests/Unit/Evolution/DgSubcell/Test_DisableLts.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_DisableLts.cpp
@@ -43,7 +43,7 @@ void test(const size_t block, const size_t segment) {
   const domain::creators::AlignedLattice<Dim> domain_creator(
       make_array<Dim>(make_vector(0.0, 1.0, 2.0)), make_array<Dim>(1_st),
       make_array<Dim>(6_st), {}, {}, {});
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto element = domain::create_initial_element(
       id, domain.blocks(), domain_creator.initial_refinement_levels());
 

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -156,7 +156,8 @@ DirectionalIdMap<Dim, Mesh<Dim>> compute_neighbor_meshes(
 // TestCreator class needed for subcell options specified below
 template <size_t Dim>
 class TestCreator : public DomainCreator<Dim> {
-  Domain<Dim> create_domain() const override { return Domain<Dim>{}; }
+  const Domain<Dim>& domain() const override { return domain_; }
+  Domain<Dim> domain_{};
   std::vector<DirectionMap<
       Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -426,7 +426,7 @@ void test_nonconforming_blocks() {
   INFO("NonconformingSphericalShells");
   const auto creator = domain::creators::NonconformingSphericalShells(
       2.0, 3.0, 4.0, 0, 0, 5, 7, 11, nullptr, nullptr);
-  auto domain = creator.create_domain();
+  auto domain = creator.domain();
   const auto initial_refinement = creator.initial_refinement_levels();
   const auto initial_extents = creator.initial_extents();
   const ElementId<3> shell_id{6};
@@ -482,7 +482,7 @@ void test_nonconforming_blocks() {
   }
   {
     INFO("Test cubed sphere");
-    domain = creator.create_domain();
+    domain = creator.domain();
     const ElementId<3> element_id{2};
     const Element<3> element = domain::create_initial_element(
         element_id, domain.blocks(), initial_refinement);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BackgroundGrVars.cpp
@@ -127,7 +127,7 @@ void test(const gsl::not_null<std::mt19937*> gen) {
       return create_a_brick<false>(num_dg_pts, initial_time);
     }
   }();
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   const auto element_id = ElementId<3>{0};
   Element<3> element = domain::create_initial_element(
       element_id, domain.blocks(),
@@ -182,9 +182,8 @@ void test(const gsl::not_null<std::mt19937*> gen) {
         ::Tags::Time, domain::Tags::Domain<3>, domain::Tags::Element<3>,
         domain::Tags::Mesh<3>, domain::Tags::Coordinates<3, Frame::Inertial>,
         gr_variables_tag, evolution::initial_data::Tags::InitialData>>(
-        initial_time, brick.create_domain(), element, mesh,
-        initial_inertial_coords, typename gr_variables_tag::type{},
-        solution.get_clone());
+        initial_time, brick.domain(), element, mesh, initial_inertial_coords,
+        typename gr_variables_tag::type{}, solution.get_clone());
   }();
 
   // Apply the mutator for initialization phase, and check that it has put

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarInfo.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarInfo.cpp
@@ -60,7 +60,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.MortarInfo", "[Unit][Evolution]") {
   test<2>({{Spectral::SegmentSize::Full}}, std::nullopt);
   const auto creator = domain::creators::NonconformingSphericalShells(
       2.0, 3.0, 4.0, 0, 0, 5, 8, 11, nullptr, nullptr);
-  const auto domain = creator.create_domain();
+  const auto domain = creator.domain();
   test<3>(
       {{Spectral::SegmentSize::UpperHalf, Spectral::SegmentSize::LowerHalf}},
       ::dg::MortarInterpolator{

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -568,7 +568,7 @@ void test_nonconforming_blocks() {
 
   const auto creator = domain::creators::NonconformingSphericalShells(
       2.0, 3.0, 4.0, 0, 0, 5, 7, 11, nullptr, nullptr);
-  auto domain = creator.create_domain();
+  auto domain = creator.domain();
   const auto initial_refinement = creator.initial_refinement_levels();
   const auto initial_extents = creator.initial_extents();
   const ElementId<3> shell_id{6};

--- a/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsInRingdownDistortedFrame.cpp
+++ b/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsInRingdownDistortedFrame.cpp
@@ -127,7 +127,7 @@ SPECTRE_TEST_CASE(
       domain::CoordinateMaps::Distribution::Linear,
       ShellWedges::All,
       time_dependent_map_options};
-  const auto temporary_domain = domain_creator.create_domain();
+  const auto temporary_domain = domain_creator.domain();
   const auto functions_of_time = domain_creator.functions_of_time();
 
   // For each Strahlkorper, transform from distorted -> inertial using

--- a/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -92,7 +92,7 @@ void test(const BoundaryConditionType& boundary_condition) {
   const auto interval = domain::creators::Interval(
       lower_x, upper_x, refinement_level_x, number_of_grid_points_in_x,
       {{{{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
-  auto domain = interval.create_domain();
+  auto domain = interval.domain();
   auto boundary_conditions = interval.external_boundary_conditions();
   const auto element = domain::create_initial_element(
       ElementId<1>{0, {SegmentId{0, 0}}}, domain.blocks(),

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -113,7 +113,7 @@ void test(const BoundaryConditionType& boundary_condition,
       {{{{boundary_condition.get_clone(), boundary_condition.get_clone()}},
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}},
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
-  auto domain = brick.create_domain();
+  auto domain = brick.domain();
   auto boundary_conditions = brick.external_boundary_conditions();
   const auto element = domain::create_initial_element(
       ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
@@ -163,7 +163,7 @@ void test_iterations(const size_t max_iterations) {
                                          initial_refinement,
                                          initial_extent,
                                          true};
-    const auto shell_domain = shell.create_domain();
+    const auto shell_domain = shell.domain();
     const auto excision_sphere =
         shell_domain.excision_spheres().at("ExcisionSphere");
 
@@ -178,7 +178,7 @@ void test_iterations(const size_t max_iterations) {
         Tags::ExcisionSphere<Dim>, Tags::WorldtubeRadius, Tags::ExpansionOrder,
         Tags::MaxIterations, Tags::Charge, Tags::Mass, ::Tags::Time,
         Tags::SelfForceTurnOnTime, Tags::SelfForceTurnOnInterval>
-        tuple_of_opts{shell.create_domain(),
+        tuple_of_opts{shell.domain(),
                       kerr_schild,
                       excision_sphere,
                       excision_sphere.radius(),

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -134,7 +134,7 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.ReceiveWorldtubeData",
                                          initial_refinement,
                                          initial_extent,
                                          true};
-    const auto shell_domain = shell.create_domain();
+    const auto shell_domain = shell.domain();
     const auto excision_sphere =
         shell_domain.excision_spheres().at("ExcisionSphere");
 

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -163,7 +163,7 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
                                          initial_refinement,
                                          initial_extent,
                                          true};
-    const auto shell_domain = shell.create_domain();
+    const auto shell_domain = shell.domain();
     const auto excision_sphere =
         shell_domain.excision_spheres().at("ExcisionSphere");
 
@@ -175,7 +175,7 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
                         Tags::MaxIterations, Tags::Charge, Tags::Mass,
                         ::Tags::Time, Tags::SelfForceTurnOnTime,
                         Tags::SelfForceTurnOnInterval>
-        tuple_of_opts{shell.create_domain(),
+        tuple_of_opts{shell.domain(),
                       excision_sphere,
                       excision_sphere.radius(),
                       expansion_order,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_InitializeElementFacesGridCoordinates.cpp
@@ -36,7 +36,7 @@ void test_initialize_element_faces_coordinates_map(
     const DomainCreator<3>& domain_creator,
     const Spectral::Quadrature& quadrature) {
   static constexpr size_t Dim = 3;
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& excision_spheres = domain.excision_spheres();
   const auto& initial_refinements = domain_creator.initial_refinement_levels();
   const auto& initial_extents = domain_creator.initial_extents();
@@ -46,7 +46,7 @@ void test_initialize_element_faces_coordinates_map(
         ::domain::Tags::InitialRefinementLevels<Dim>,
         evolution::dg::Tags::Quadrature, Tags::ExcisionSphere<Dim>,
         Tags::ElementFacesGridCoordinates<Dim>>>(
-        domain_creator.create_domain(), initial_extents, initial_refinements,
+        domain_creator.domain(), initial_extents, initial_refinements,
         quadrature, excision_sphere,
         std::unordered_map<ElementId<3>,
                            tnsr::I<DataVector, Dim, Frame::Grid>>{});

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateFunctionsOfTime.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonActions/Test_UpdateFunctionsOfTime.cpp
@@ -86,7 +86,7 @@ void test_particle_motion() {
           true>(6., initial_worldtube_radius, 0.1);
   domain::FunctionsOfTime::register_derived_with_charm();
 
-  const auto domain = bco_domain_creator->create_domain();
+  const auto domain = bco_domain_creator->domain();
   const auto wt_excision_sphere =
       domain.excision_spheres().at("ExcisionSphereA");
   const auto bh_excision_sphere =
@@ -99,7 +99,7 @@ void test_particle_motion() {
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {
           wt_excision_sphere,
-          bco_domain_creator->create_domain(),
+          bco_domain_creator->domain(),
           wt_radius_options,
           bh_radius_options,
       },

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -57,7 +57,7 @@ void test_excision_sphere_tag() {
       std::make_unique<domain::creators::Sphere>(
           1., 2., domain::creators::Sphere::Excision{}, 2_st, 4_st, true);
   const auto shell_excision_sphere =
-      shell->create_domain().excision_spheres().at("ExcisionSphere");
+      shell->domain().excision_spheres().at("ExcisionSphere");
 
   CHECK(Tags::ExcisionSphere<3>::create_from_options(shell, "ExcisionSphere") ==
         shell_excision_sphere);
@@ -119,7 +119,7 @@ void test_compute_face_coordinates_grid() {
     const auto& initial_extents_1 = shell_1.initial_extents();
     const auto& initial_extents_2 = shell_2.initial_extents();
 
-    const auto domain = shell_1.create_domain();
+    const auto domain = shell_1.domain();
     const auto& blocks = domain.blocks();
     const auto& excision_sphere =
         domain.excision_spheres().at("ExcisionSphere");
@@ -201,7 +201,7 @@ void test_compute_face_coordinates() {
       TestHelpers::CurvedScalarWave::Worldtube::worldtube_binary_compact_object<
           false>(7., 0.2, pow(7, -1.5));
   const double initial_time = 0.;
-  auto domain = domain_creator->create_domain();
+  auto domain = domain_creator->domain();
   const auto excision_sphere = domain.excision_spheres().at("ExcisionSphereA");
   const auto& blocks = domain.blocks();
   const auto initial_extents = domain_creator->initial_extents();
@@ -332,7 +332,7 @@ void test_particle_position_velocity_compute() {
       TestHelpers::CurvedScalarWave::Worldtube::worldtube_binary_compact_object<
           false>(orbit_radius, 0.2, angular_velocity);
   const double initial_time = 0.;
-  auto domain = domain_creator->create_domain();
+  auto domain = domain_creator->domain();
   const auto excision_sphere = domain.excision_spheres().at("ExcisionSphereA");
   std::uniform_real_distribution<> time_dist(0., 10.);
   auto box =
@@ -544,7 +544,7 @@ void test_face_quantities_compute() {
                                        initial_refinement,
                                        initial_extent,
                                        true};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto excision_sphere =
       shell_domain.excision_spheres().at("ExcisionSphere");
   const auto& initial_refinements = shell.initial_refinement_levels();

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -108,7 +108,7 @@ void test(const BoundaryConditionType& boundary_condition,
       {{{{boundary_condition.get_clone(), boundary_condition.get_clone()}},
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}},
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
-  auto domain = brick.create_domain();
+  auto domain = brick.domain();
   auto boundary_conditions = brick.external_boundary_conditions();
   const auto element = domain::create_initial_element(
       ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ZeroTimeDerivatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_ZeroTimeDerivatives.cpp
@@ -38,8 +38,8 @@ SPECTRE_TEST_CASE(
 
   const domain::creators::Sphere sphere(
       10.0, 80.0, domain::creators::Sphere::InnerCube{0.0}, 3_st, 8_st, false);
-  REQUIRE(sphere.create_domain().blocks().size() == 7);
-  REQUIRE(sphere.create_domain().block_names().at(6) == "InnerCube");
+  REQUIRE(sphere.domain().blocks().size() == 7);
+  REQUIRE(sphere.domain().block_names().at(6) == "InnerCube");
 
   const SubcellOptions subcell_options{
       SubcellOptions{4.0, 1, 1.0e-4, 1.0e-4, false, false,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_BoundaryConditionGhostData.cpp
@@ -105,7 +105,7 @@ void test(const BoundaryConditionType& boundary_condition,
       {{{{boundary_condition.get_clone(), boundary_condition.get_clone()}},
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}},
         {{boundary_condition.get_clone(), boundary_condition.get_clone()}}}});
-  auto domain = brick.create_domain();
+  auto domain = brick.domain();
   auto boundary_conditions = brick.external_boundary_conditions();
   const auto element = domain::create_initial_element(
       ElementId<3>{0, {SegmentId{0, 0}, SegmentId{0, 0}, SegmentId{0, 0}}},

--- a/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
+++ b/tests/Unit/Helpers/ControlSystem/SystemHelpers.hpp
@@ -113,31 +113,7 @@ class FakeCreator : public DomainCreator<3> {
   FakeCreator(const std::unordered_map<std::string, size_t>& num_components_map)
       : num_components_map_(num_components_map) {}
 
-  Domain<3> create_domain() const override {
-    std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
-    excision_spheres.insert(
-        {"ExcisionSphereA",
-         ExcisionSphere<3>{1.3,
-                           tnsr::I<double, 3, Frame::Grid>{{+0.9, 0.0, 0.0}},
-                           {{0, Direction<3>::lower_zeta()},
-                            {1, Direction<3>::lower_zeta()},
-                            {2, Direction<3>::lower_zeta()},
-                            {3, Direction<3>::lower_zeta()},
-                            {4, Direction<3>::lower_zeta()},
-                            {5, Direction<3>::lower_zeta()}}}});
-    excision_spheres.insert(
-        {"ExcisionSphereB",
-         ExcisionSphere<3>{0.8,
-                           tnsr::I<double, 3, Frame::Grid>{{-1.1, 0.0, 0.0}},
-                           {{0, Direction<3>::lower_zeta()},
-                            {1, Direction<3>::lower_zeta()},
-                            {2, Direction<3>::lower_zeta()},
-                            {3, Direction<3>::lower_zeta()},
-                            {4, Direction<3>::lower_zeta()},
-                            {5, Direction<3>::lower_zeta()}}}});
-
-    return Domain<3>{std::vector<Block<3>>{}, std::move(excision_spheres)};
-  }
+  const Domain<3>& domain() const override { return domain_; }
 
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
@@ -184,6 +160,30 @@ class FakeCreator : public DomainCreator<3> {
 
  private:
   std::unordered_map<std::string, size_t> num_components_map_{};
+  Domain<3> domain_{[]() {
+    std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
+    excision_spheres.insert(
+        {"ExcisionSphereA",
+         ExcisionSphere<3>{1.3,
+                           tnsr::I<double, 3, Frame::Grid>{{+0.9, 0.0, 0.0}},
+                           {{0, Direction<3>::lower_zeta()},
+                            {1, Direction<3>::lower_zeta()},
+                            {2, Direction<3>::lower_zeta()},
+                            {3, Direction<3>::lower_zeta()},
+                            {4, Direction<3>::lower_zeta()},
+                            {5, Direction<3>::lower_zeta()}}}});
+    excision_spheres.insert(
+        {"ExcisionSphereB",
+         ExcisionSphere<3>{0.8,
+                           tnsr::I<double, 3, Frame::Grid>{{-1.1, 0.0, 0.0}},
+                           {{0, Direction<3>::lower_zeta()},
+                            {1, Direction<3>::lower_zeta()},
+                            {2, Direction<3>::lower_zeta()},
+                            {3, Direction<3>::lower_zeta()},
+                            {4, Direction<3>::lower_zeta()},
+                            {5, Direction<3>::lower_zeta()}}}});
+    return Domain<3>{std::vector<Block<3>>{}, std::move(excision_spheres)};
+  }()};
 };
 
 template <typename Metavariables, typename ControlSystem>

--- a/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
@@ -36,7 +36,7 @@ Domain<Dim> test_domain_creator(const DomainCreator<Dim>& domain_creator,
                                     std::numeric_limits<double>::quiet_NaN()}) {
   INFO("Test domain creator consistency");
   CAPTURE(Dim);
-  auto domain = domain_creator.create_domain();
+  auto domain = domain_creator.domain();
   const auto block_names = domain_creator.block_names();
   const auto block_groups = domain_creator.block_groups();
   const auto all_boundary_conditions =
@@ -172,7 +172,7 @@ void test_creation(const std::string& option_string, const Creator& rhs,
   // Check equality of domain creators by comparing the subset of properties
   // that support comparison
   const auto& lhs = *created;
-  CHECK(lhs.create_domain() == rhs.create_domain());
+  CHECK(lhs.domain() == rhs.domain());
   CHECK(lhs.initial_extents() == rhs.initial_extents());
   CHECK(lhs.initial_refinement_levels() == rhs.initial_refinement_levels());
 }

--- a/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Interpolation/InterpolateOnElementTestHelpers.hpp
@@ -299,7 +299,7 @@ void test_interpolate_on_element(
     }
   }();
   const DomainCreator<3>& domain_creator = *domain_creator_ptr;
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const double x_center = OffCenter ? -4.0 : 0.0;
 
   Slab slab(0.0, 1.0);
@@ -342,8 +342,7 @@ void test_interpolate_on_element(
       tmpl::list<domain::Tags::Domain<3>, intrp::Tags::Verbosity>>>
       init_tuple{};
 
-  tuples::get<domain::Tags::Domain<3>>(init_tuple) =
-      std::move(domain_creator.create_domain());
+  tuples::get<domain::Tags::Domain<3>>(init_tuple) = domain_creator.domain();
   tuples::get<intrp::Tags::Verbosity>(init_tuple) = ::Verbosity::Silent;
 
   if constexpr (is_sphere) {

--- a/tests/Unit/IO/Exporter/Python/Test_SpacetimeInterpolator.py
+++ b/tests/Unit/IO/Exporter/Python/Test_SpacetimeInterpolator.py
@@ -35,7 +35,7 @@ class TestSpacetimeInterpolator(unittest.TestCase):
             initial_refinement_levels=[0, 0, 0],
             initial_num_points=[4, 4, 4],
             is_periodic=[False, False, False],
-        ).create_domain()
+        ).domain()
         serialized_domain = serialize_domain(domain)
         mesh = Mesh[3](4, Basis.Legendre, Quadrature.GaussLobatto)
         with spectre_h5.H5File(self.h5_filename, "w") as open_h5file:

--- a/tests/Unit/IO/Exporter/Test_Exporter.cpp
+++ b/tests/Unit/IO/Exporter/Test_Exporter.cpp
@@ -106,7 +106,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
     INFO("Single-precision volume data");
     const domain::creators::Rectangle domain_creator{
         {{-1., -1.}}, {{1., 1.}}, {{0, 0}}, {{4, 4}}, {{false, false}}};
-    const auto domain = domain_creator.create_domain();
+    const auto domain = domain_creator.domain();
     const ElementId<2> element_id{0};
     const Mesh<2> mesh{4, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto};
@@ -170,7 +170,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter", "[Unit]") {
         std::vector<double>{},
         domain::CoordinateMaps::Distribution::Inverse,
         120.};
-    const auto domain = domain_creator.create_domain();
+    const auto domain = domain_creator.domain();
     const auto functions_of_time = domain_creator.functions_of_time();
     const double time = 1.0;
     const auto element_ids =

--- a/tests/Unit/IO/Exporter/Test_SpacetimeInterpolator.cpp
+++ b/tests/Unit/IO/Exporter/Test_SpacetimeInterpolator.cpp
@@ -49,7 +49,7 @@ void write_data_to_file(const std::string& h5_file_name) {
       domain::CoordinateMaps::Distribution::Linear,
       ShellWedges::All,
       time_dependence.get_clone()};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto functions_of_time = domain_creator.functions_of_time();
 
   // Generate some volume data in the grid frame
@@ -179,7 +179,7 @@ SPECTRE_TEST_CASE("Unit.IO.Exporter.SpacetimeInterpolator", "[Unit]") {
         {{0.0, 0.0, 0.0}},
         {{1.0, 1.0, 1.0}},
         {{0, 0, 0}},
-        {{4, 4, 4}}}.create_domain();
+        {{4, 4, 4}}}.domain();
     const Mesh<3> mesh{4, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto};
 

--- a/tests/Unit/IO/H5/Test_CombineH5.py
+++ b/tests/Unit/IO/H5/Test_CombineH5.py
@@ -61,9 +61,7 @@ class TestCombineH5(unittest.TestCase):
             initial_num_points=[2, 2, 2],
             is_periodic=[False, False, False],
         )
-        self.serialized_domain = serialize_domain(
-            domain_creator.create_domain()
-        )
+        self.serialized_domain = serialize_domain(domain_creator.domain())
 
         def make_translation_fot(fill_value, expiration):
             coefficients = [

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -270,7 +270,7 @@ void test() {
                {2, 2, 2},
                bases.back(),
                quadratures.back()}},
-          serialize(domain_creator.create_domain()),
+          serialize(domain_creator.domain()),
           serialize(domain_creator.functions_of_time()),
           serialize(domain_creator.functions_of_time()));
       // Write another tensor component separately
@@ -332,7 +332,7 @@ void test() {
                    });
     CHECK(found_observation_ids == observation_ids);
   }
-  CHECK(volume_file.get_domain() == serialize(domain_creator.create_domain()));
+  CHECK(volume_file.get_domain() == serialize(domain_creator.domain()));
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     TestHelpers::io::VolumeData::check_volume_data(
         h5_file_name, version_number, "element_data"s, observation_ids[i],
@@ -400,7 +400,7 @@ void test() {
           Spectral::Basis::Legendre},
          {Spectral::Quadrature::Gauss, Spectral::Quadrature::Gauss,
           Spectral::Quadrature::Gauss}}};
-    const auto serialized_domain = serialize(domain_creator.create_domain());
+    const auto serialized_domain = serialize(domain_creator.domain());
     const auto make_serialized_functions_of_time =
         [](const double expiration_time) {
           domain::FunctionsOfTimeMap map{};
@@ -971,7 +971,7 @@ void test_cartoon() {
                {2, 2, 1},
                bases.front(),
                quadratures.front()}},
-          serialize(domain_creator.create_domain()),
+          serialize(domain_creator.domain()),
           serialize(domain_creator.functions_of_time()));
     };
     for (size_t i = 0; i < observation_ids.size(); ++i) {
@@ -999,7 +999,7 @@ void test_cartoon() {
     CHECK(found_observation_ids == observation_ids);
   }
 
-  CHECK(volume_file.get_domain() == serialize(domain_creator.create_domain()));
+  CHECK(volume_file.get_domain() == serialize(domain_creator.domain()));
   for (size_t i = 0; i < observation_ids.size(); ++i) {
     TestHelpers::io::VolumeData::check_volume_data(
         h5_file_name, version_number, "element_data"s, observation_ids[i],

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm.hpp
@@ -136,7 +136,7 @@ struct Domain : db::SimpleTag {
   static constexpr bool pass_metavariables = false;
   static ::Domain<Dim> create_from_options(
       const std::unique_ptr<::DomainCreator<Dim>>& domain_creator) {
-    return domain_creator->create_domain();
+    return domain_creator->domain();
   }
 };
 

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -200,7 +200,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
   tuples::TaggedTuple<observers::Tags::ReductionFileName,
                       observers::Tags::VolumeFileName, domain::Tags::Domain<3>,
                       domain::Tags::FunctionsOfTimeInitialize>
-      cache_data{"", output_file_prefix, domain_creator.create_domain(),
+      cache_data{"", output_file_prefix, domain_creator.domain(),
                  domain_creator.functions_of_time(initial_expiration_times)};
   ActionTesting::MockRuntimeSystem<metavariables> runner{std::move(cache_data)};
   ActionTesting::emplace_group_component<obs_component>(&runner);

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
@@ -105,7 +105,7 @@ void insert_mortar_data(
 void test_non_conforming_spheres() {
   const auto creator = domain::creators::NonconformingSphericalShells(
       2.0, 3.0, 4.0, 0, 2, 5, 8, 11, nullptr, nullptr);
-  const auto domain = creator.create_domain();
+  const auto domain = creator.domain();
   const auto refinement_levels = creator.initial_refinement_levels();
   const ElementId<3> shell_id{6};
   const Element<3> shell = domain::create_initial_element(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -347,7 +347,7 @@ Domain<3> create_domain<3>(const double length,
                                         {{0, 0, 0}},
                                         extents,
                                         {{false, false, false}}};
-  return creator.create_domain();
+  return creator.domain();
 }
 
 template <>
@@ -355,14 +355,14 @@ Domain<2> create_domain<2>(const double length,
                            const std::array<size_t, 2>& extents) {
   const domain::creators::Rectangle creator{
       {{0.0, 0.0}}, {{length, length}}, {{0, 0}}, extents, {{false, false}}};
-  return creator.create_domain();
+  return creator.domain();
 }
 
 template <>
 Domain<1> create_domain<1>(const double length,
                            const std::array<size_t, 1>& extents) {
   const domain::creators::Interval creator{{{0.0}}, {{length}}, {{0}}, extents};
-  return creator.create_domain();
+  return creator.domain();
 }
 
 template <size_t Dim>

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -289,9 +289,9 @@ template <size_t Dim>
 class TestCreator : public DomainCreator<Dim> {
  public:
   TestCreator(const bool use_block_names = true)
-      : use_block_names_(use_block_names) {}
+      : use_block_names_(use_block_names), domain_{make_domain<Dim>()} {}
 
-  Domain<Dim> create_domain() const override { return make_domain<Dim>(); }
+  const Domain<Dim>& domain() const override { return domain_; }
   std::vector<std::string> block_names() const override {
     return use_block_names_ ? domain_block_names() : std::vector<std::string>{};
   }
@@ -325,6 +325,7 @@ class TestCreator : public DomainCreator<Dim> {
 
  private:
   bool use_block_names_;
+  Domain<Dim> domain_;
 };
 
 template <size_t Dim>

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -1024,6 +1024,32 @@ void test_options_option_context_default_stream() {
   CHECK(get_output(Options::Context{}).empty());
 }
 
+void test_options_context_comparison() {
+  Options::Context default_context{};
+  Options::Context same_context = default_context;
+  CHECK(default_context == same_context);
+  CHECK_FALSE(default_context != same_context);
+
+  Options::Context region_context = default_context;
+  region_context.context = "Region";
+  CHECK(region_context != default_context);
+
+  region_context.context = default_context.context;
+  region_context.line = 5;
+  CHECK(region_context != default_context);
+
+  region_context.line = default_context.line;
+  region_context.column = 12;
+  CHECK(region_context != default_context);
+
+  region_context.column = default_context.column;
+  region_context.top_level = false;
+  CHECK(region_context != default_context);
+
+  Options::Context copy = region_context;
+  CHECK(copy == region_context);
+}
+
 // Use formatted inner types to make sure nested formatting works
 template <typename T>
 using In = std::array<T, 0>;
@@ -1712,6 +1738,7 @@ SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
   test_options_invalid_calls();
   test_options_apply();
   test_options_option_context_default_stream();
+  test_options_context_comparison();
   test_options_format();
   test_options_explicit_constructor();
   test_options_input_source();

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_FailedHorizonFind.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_FailedHorizonFind.cpp
@@ -57,7 +57,7 @@ void run_test() {
 
   const domain::creators::Sphere sphere_creator{
       0.9, 2.0, domain::creators::Sphere::Excision{nullptr}, 0_st, 4_st, true};
-  const Domain<3> domain = sphere_creator.create_domain();
+  const Domain<3> domain = sphere_creator.domain();
 
   const size_t l_max = 6;
   const LinkedMessageId<double> time{2.0, {1.0}};

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_InvokeCallbacks.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Callbacks/Test_InvokeCallbacks.cpp
@@ -115,7 +115,7 @@ void run_test() {
       0.9, 2.0, domain::creators::Sphere::Excision{nullptr}, 0_st, 4_st, true};
 
   Parallel::GlobalCache<Metavariables<Fr>> cache{
-      {sphere_creator.create_domain()},
+      {sphere_creator.domain()},
       {sphere_creator.functions_of_time(),
        ah::Storage::LockedPreviousSurface<Fr>{}}};
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindApparentHorizon.cpp
@@ -173,7 +173,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
           std::move(time_dependence)}});
   const auto block_names = domain_creator.block_names();
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(),
+      {domain_creator.domain(),
        std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}},
       {domain_creator.functions_of_time(),
@@ -315,7 +315,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.FindApparentHorizonEvent",
         get<gh::Tags::Phi<DataVector, 3>>(vars),
         get<Tags::deriv<gh::Tags::Phi<DataVector, 3>, tmpl::size_t<3>,
                         Frame::Inertial>>(vars),
-        observation_time, domain_creator.create_domain(), mesh, element_id,
+        observation_time, domain_creator.domain(), mesh, element_id,
         functions_of_time);
     CHECK(results.vars == target_vars);
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Events/Test_FindCommonHorizon.cpp
@@ -221,7 +221,7 @@ void common_horizon_event() {
       {0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}, {0, 0, 0}, {5, 5, 5}};
   const auto block_names = brick.block_names();
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {brick.create_domain(),
+      {brick.domain(),
        std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"InterpolationTargetA", {block_names.begin(), block_names.end()}}},
        ::Verbosity::Silent}};
@@ -395,7 +395,7 @@ void common_horizon_event() {
       {0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}, {0, 0, 0}, {5, 5, 5}};
   const auto block_names = brick.block_names();
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {brick.create_domain(),
+      {brick.domain(),
        std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"MockHorizonMetavars", {block_names.begin(), block_names.end()}}}},
       {ah::Storage::LockedPreviousSurface<Frame::Grid>{}}};

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -430,7 +430,7 @@ void test_apparent_horizon(
         domain::Tags::Domain<3>, ah::Tags::BlocksForInterpolation,
         typename ::ah::Tags::ApparentHorizon<typename metavars::AhA, Frame>,
         intrp::Tags::Verbosity>
-        tuple_of_opts{std::move(domain_creator->create_domain()),
+        tuple_of_opts{domain_creator->domain(),
                       std::move(blocks_for_interpolation),
                       std::move(apparent_horizon_opts), ::Verbosity::Silent};
     runner_ptr = std::make_unique<ActionTesting::MockRuntimeSystem<metavars>>(
@@ -448,7 +448,7 @@ void test_apparent_horizon(
         domain::Tags::Domain<3>, ah::Tags::BlocksForInterpolation,
         typename ::ah::Tags::ApparentHorizon<typename metavars::AhA, Frame>,
         intrp::Tags::Verbosity>
-        tuple_of_opts{std::move(domain_creator->create_domain()),
+        tuple_of_opts{domain_creator->domain(),
                       std::move(blocks_for_interpolation),
                       std::move(apparent_horizon_opts), ::Verbosity::Silent};
 
@@ -487,7 +487,7 @@ void test_apparent_horizon(
 
   // Create element_ids.
   std::vector<ElementId<3>> element_ids{};
-  Domain<3> domain = domain_creator->create_domain();
+  Domain<3> domain = domain_creator->domain();
   for (const auto& block : domain.blocks()) {
     const auto initial_ref_levs =
         domain_creator->initial_refinement_levels()[block.id()];

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeCoords.cpp
@@ -44,7 +44,7 @@ void test_compute_points() {
       1.0,          3.0,  domain::creators::Sphere::Excision{nullptr},
       0_st,         2_st, true,
       std::nullopt, {2.0}};
-  const Domain<3> domain = sphere.create_domain();
+  const Domain<3> domain = sphere.domain();
   const domain::FunctionsOfTimeMap functions_of_time =
       sphere.functions_of_time();
 
@@ -265,7 +265,7 @@ void test_compute_points_different_resolutions() {
       1.0,          3.0,  domain::creators::Sphere::Excision{nullptr},
       0_st,         2_st, true,
       std::nullopt, {2.0}};
-  const Domain<3> domain = sphere.create_domain();
+  const Domain<3> domain = sphere.domain();
   const domain::FunctionsOfTimeMap functions_of_time =
       sphere.functions_of_time();
 

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeExcisionBoundaryVolumeQuantities.cpp
@@ -84,7 +84,7 @@ void test_compute_excision_boundary_volume_quantities() {
                               number_of_grid_points},
         std::array<bool, 3>{false, false, false});
   }
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   ASSERT(domain.blocks().size() == 1, "Expected a Domain with one block");
   const Block<3>& block = domain.blocks()[0];
   const auto functions_of_time = domain_creator.functions_of_time();

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeHorizonVolumeQuantities.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeHorizonVolumeQuantities.cpp
@@ -68,7 +68,7 @@ void test_compute_horizon_volume_quantities() {
                               number_of_grid_points},
         std::array<bool, 3>{false, false, false});
   }
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   ASSERT(domain.blocks().size() == 1, "Expected a Domain with one block");
 
   const auto element_ids = initial_element_ids(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
@@ -76,7 +76,7 @@ void test_compute_horizon_volume_quantities(const bool is_time_dependent) {
                                   std::array{0.0, 0.0, 0.0}}},
                 true}}
           : std::nullopt};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& functions_of_time = domain_creator.functions_of_time();
 
   // Just use the first block, it has all maps and all frames

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_CurrentTime.cpp
@@ -263,7 +263,7 @@ void test_check_current_time() {
   using component = MockComponent<MockMetavariables>;
 
   ActionTesting::MockRuntimeSystem<MockMetavariables> runner{
-      {domain_creator.create_domain()},
+      {domain_creator.domain()},
       {domain_creator.functions_of_time({{"Rotation", 2.0}})}};
 
   ActionTesting::emplace_array_component<component>(

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
@@ -249,8 +249,7 @@ void test_apparent_horizon(
           : std::nullopt);
 
   {
-    const Domain<3> domain_for_block_selection =
-        domain_creator->create_domain();
+    const Domain<3> domain_for_block_selection = domain_creator->domain();
     std::unordered_set<std::string> blocks_to_use{};
     for (const auto& block : domain_for_block_selection.blocks()) {
       if constexpr (std::is_same_v<Fr, ::Frame::Distorted>) {
@@ -268,7 +267,7 @@ void test_apparent_horizon(
       std::max(l_max, static_cast<size_t>(12));
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator->create_domain(), std::move(apparent_horizon_opts),
+      {domain_creator->domain(), std::move(apparent_horizon_opts),
        max_resolution_and_output_l, blocks_for_interpolation},
       {domain_creator->functions_of_time(),
        ah::Storage::LockedPreviousSurface<Fr>{}}};
@@ -294,7 +293,7 @@ void test_apparent_horizon(
 
   // Create element_ids.
   std::vector<ElementId<3>> element_ids{};
-  const Domain<3> domain = domain_creator->create_domain();
+  const Domain<3> domain = domain_creator->domain();
   const auto& blocks_to_use =
       blocks_for_interpolation.at("TestingHorizonMetavars");
   const domain::FunctionsOfTimeMap functions_of_time =

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolateVolumeVars.cpp
@@ -108,7 +108,7 @@ void test_interpolate_volume_vars() {
       0_st,
       number_of_grid_points,
       true};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto& functions_of_time = domain_creator.functions_of_time();
 
   const auto& blocks = domain.blocks();

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_InterpolationTargetApparentHorizon.cpp
@@ -121,7 +121,7 @@ SPECTRE_TEST_CASE(
         ++s;
       }
     }
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -191,8 +191,8 @@ void test_observe(
       ::Tags::Variables<typename decltype(prim_vars)::tags_list>,
       coordinates_tag, ::Tags::AnalyticSolutions<solution_variables>,
       observers::Tags::ObservationKey<ArraySectionIdTag>>>(
-      metavariables{}, rectilinear.create_domain(), element, mesh, vars,
-      prim_vars, get<coordinates_tag>(coordinate_vars),
+      metavariables{}, rectilinear.domain(), element, mesh, vars, prim_vars,
+      get<coordinates_tag>(coordinate_vars),
       [&solutions, &has_analytic_solutions]() {
         return has_analytic_solutions ? std::make_optional(solutions)
                                       : std::nullopt;

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -217,8 +217,8 @@ void test_add_temporal_ids() {
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(), ::Verbosity::Silent,
-       "UnusedVolumeFilename", "UnusedReductionFilename"}};
+      {domain_creator.domain(), ::Verbosity::Silent, "UnusedVolumeFilename",
+       "UnusedReductionFilename"}};
   ActionTesting::emplace_component<target_component>(&runner, 0);
   for (int i = 0; i < 2; ++i) {
     ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
@@ -392,8 +392,8 @@ void test_add_linked_message_id() {
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(), ::Verbosity::Silent,
-       "UnusedVolumeFileName", "UnusedReductionFilename"}};
+      {domain_creator.domain(), ::Verbosity::Silent, "UnusedVolumeFileName",
+       "UnusedReductionFilename"}};
   ActionTesting::emplace_component<target_component>(&runner, 0);
   for (int i = 0; i < 2; ++i) {
     ActionTesting::next_action<target_component>(make_not_null(&runner), 0);
@@ -656,8 +656,8 @@ void test_add_temporal_ids_time_dependent() {
   initial_expiration_times[f_of_t_name] = 0.1;
   const double new_expiration_time = 1.0;
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(), ::Verbosity::Silent,
-       "UnusedVolumeFileName", "UnusedReductionFilename"},
+      {domain_creator.domain(), ::Verbosity::Silent, "UnusedVolumeFileName",
+       "UnusedReductionFilename"},
       {domain_creator.functions_of_time(initial_expiration_times)}};
   ActionTesting::emplace_component<target_component>(&runner, 0);
   for (size_t i = 0; i < 2; ++i) {

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ComputeDestVars.cpp
@@ -128,7 +128,7 @@ void test() {
           {domain::CoordinateMaps::Distribution::Linear,
            domain::CoordinateMaps::Distribution::Linear}},
       {}, time_dep_opts);
-  const Domain<3> domain = domain_creator.create_domain();
+  const Domain<3> domain = domain_creator.domain();
 
   Parallel::GlobalCache<Metavars> cache{{domain_creator.functions_of_time()}};
 

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ElementReceiveInterpPoints.cpp
@@ -147,8 +147,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ElementReceivePoints",
                       domain::Tags::Domain<metavars::volume_dim>,
                       intrp::Tags::Verbosity>
       tuple_of_opts{std::move(line_segment_opts_a),
-                    std::move(line_segment_opts_b),
-                    domain_creator.create_domain(), ::Verbosity::Silent};
+                    std::move(line_segment_opts_b), domain_creator.domain(),
+                    ::Verbosity::Silent};
 
   // Initialization
   ActionTesting::MockRuntimeSystem<metavars> runner{std::move(tuple_of_opts)};

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -82,7 +82,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
-      {domain_creator.create_domain(), ::Verbosity::Silent}};
+      {domain_creator.domain(), ::Verbosity::Silent}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_component<component>(&runner, 0);
@@ -102,7 +102,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
 
   const auto& cache = ActionTesting::cache<component>(runner, 0_st);
   CHECK(Parallel::get<domain::Tags::Domain<3>>(cache) ==
-        domain_creator.create_domain());
+        domain_creator.domain());
 
   CHECK(ActionTesting::get_databox_tag<
             component, ::intrp::Tags::InterpolatedVars<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_Interpolate.cpp
@@ -246,7 +246,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.InterpolateEvent",
       {std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"InterpolatorTargetA", {block_names.begin(), block_names.end()}}},
        ah::OptionHolders::ApparentHorizon<Frame::Inertial>{},
-       domain_creator.create_domain(), ::Verbosity::Silent},
+       domain_creator.domain(), ::Verbosity::Silent},
       {std::move(functions_of_time)}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -150,7 +150,7 @@ void test_interpolation_target_kerr_horizon(
         }
       }
     }
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -73,7 +73,7 @@ void test() {
         points.get(d)[i] = 1.0 + 0.1 * i;  // Worked out by hand.
       }
     }
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -332,7 +332,7 @@ void test_interpolation_target_receive_vars() {
             domain::creators::time_dependence::UniformTranslation<3>>(
             0.0, std::array<double, 3>({{0.0, 0.0, 0.0}})));
     tuples::TaggedTuple<domain::Tags::Domain<3>, intrp::Tags::Verbosity>
-        const_opts{domain_creator.create_domain(), ::Verbosity::Silent};
+        const_opts{domain_creator.domain(), ::Verbosity::Silent};
     tuples::TaggedTuple<domain::Tags::FunctionsOfTimeInitialize> mutable_opts{
         domain_creator.functions_of_time(initial_expiration_times)};
     runner_ptr = std::make_unique<ActionTesting::MockRuntimeSystem<metavars>>(
@@ -341,7 +341,7 @@ void test_interpolation_target_receive_vars() {
     const auto domain_creator = domain::creators::Sphere(
         0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 5_st, false);
     tuples::TaggedTuple<domain::Tags::Domain<3>, intrp::Tags::Verbosity> opts{
-        domain_creator.create_domain(), ::Verbosity::Silent};
+        domain_creator.domain(), ::Verbosity::Silent};
     runner_ptr = std::make_unique<ActionTesting::MockRuntimeSystem<metavars>>(
         std::move(opts));
   }

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSpecifiedPoints.cpp
@@ -67,7 +67,7 @@ void test_1d() {
   const auto expected_block_coord_holders = [&domain_creator]() {
     tnsr::I<DataVector, 1, Frame::Inertial> points;
     get<0>(points) = DataVector({{1.0, 0.3}});
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   TestHelpers::db::test_simple_tag<
@@ -100,7 +100,7 @@ void test_2d() {
     tnsr::I<DataVector, 2, Frame::Inertial> points;
     get<0>(points) = DataVector({{0.0, -0.2, 0.3}});
     get<1>(points) = DataVector({{1.0, 0.1, 1.9}});
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   TestHelpers::db::test_simple_tag<
@@ -138,7 +138,7 @@ void test_3d() {
     get<0>(points) = DataVector({{0.0, 1.0, -0.8, 0.0}});
     get<1>(points) = DataVector({{0.0, -0.3, 1.6, 1.0}});
     get<2>(points) = DataVector({{0.0, 0.2, 2.4, 0.0}});
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetSphere.cpp
@@ -171,7 +171,7 @@ void test_interpolation_target_sphere(
         }
       }
     }
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   InterpTargetTestHelpers::test_interpolation_target<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetVarsFromElement.cpp
@@ -253,12 +253,12 @@ void test() {
                                                        &init_expr_times]() {
     if constexpr (UseTimeDepMaps) {
       return ActionTesting::MockRuntimeSystem<metavars>(
-          {domain_creator.create_domain(), ::Verbosity::Silent},
+          {domain_creator.domain(), ::Verbosity::Silent},
           {domain_creator.functions_of_time(init_expr_times)});
     } else {
       (void)init_expr_times;
       return ActionTesting::MockRuntimeSystem<metavars>(
-          {domain_creator.create_domain(), ::Verbosity::Silent});
+          {domain_creator.domain(), ::Verbosity::Silent});
     }
   }();
   ActionTesting::emplace_component_and_initialize<target_component>(

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -89,7 +89,7 @@ void test_r_theta_lgl() {
         }
       }
     }
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   InterpTargetTestHelpers::test_interpolation_target<
@@ -125,7 +125,7 @@ void test_r_theta_uniform() {
         }
       }
     }
-    return block_logical_coordinates(domain_creator.create_domain(), points);
+    return block_logical_coordinates(domain_creator.domain(), points);
   }();
 
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceiveAndDumpVolumeData.cpp
@@ -414,7 +414,7 @@ void test(const bool dump_vol_data) {
   // Make an InterpolatedVarsHolders containing the target points.
   const auto domain_creator = domain::creators::Sphere(
       0.9, 4.9, domain::creators::Sphere::Excision{}, 1_st, 7_st, false);
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto block_names = domain_creator.block_names();
   Slab slab(0.0, 1.0);
   TimeStepId temporal_id(true, 0, Time(slab, Rational(11, 15)));
@@ -451,8 +451,7 @@ void test(const bool dump_vol_data) {
       {std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"InterpolationTargetA", {block_names.begin(), block_names.end()}},
            {"InterpolationTargetB", {block_names.begin(), block_names.end()}}},
-       domain_creator.create_domain(), dump_vol_data, ::Verbosity::Silent,
-       filename}};
+       domain_creator.domain(), dump_vol_data, ::Verbosity::Silent, filename}};
   ActionTesting::emplace_group_component_and_initialize<interp_component>(
       &runner,
       {std::unordered_map<std::string, std::unordered_set<ElementId<3>>>{},

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -241,13 +241,13 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
       std::array{0.0, 0.0, 0.0}, std::array{1.0, 1.0, 1.0},
       std::array{1_st, 2_st, 0_st}, std::array{2_st, 2_st, 2_st},
       std::array{false, false, false}};
-  const Domain<3> domain = domain_creator.create_domain();
+  const Domain<3> domain = domain_creator.domain();
   const auto block_names = domain_creator.block_names();
 
   ActionTesting::MockRuntimeSystem<metavars> runner{
       {std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"InterpolationTargetA", {block_names.begin(), block_names.end()}}},
-       domain_creator.create_domain(), ::Verbosity::Silent},
+       domain_creator.domain(), ::Verbosity::Silent},
       {},
       std::vector<std::size_t>{2_st}};
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -107,7 +107,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
       {std::unordered_map<std::string, std::unordered_set<std::string>>{
            {"MockTargetTag", {block_names.begin(), block_names.end()}}},
        ah::OptionHolders::ApparentHorizon<Frame::Inertial>{},
-       domain_creator.create_domain(), ::Verbosity::Silent}};
+       domain_creator.domain(), ::Verbosity::Silent}};
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_group_component<interp_component>(&runner);

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveLineSegment.cpp
@@ -287,7 +287,7 @@ void run_test(gsl::not_null<Generator*> generator,
           std::unordered_map<std::string, std::unordered_set<std::string>>{
               {"LineA", {block_names.begin(), block_names.end()}},
               {"LineB", {block_names.begin(), block_names.end()}}},
-          domain_creator.create_domain()};
+          domain_creator.domain()};
 
   // Three mock nodes, with 2, 1, and 4 mock cores.
   ActionTesting::MockRuntimeSystem<metavars> runner{
@@ -323,7 +323,7 @@ void run_test(gsl::not_null<Generator*> generator,
 
   Slab slab(0.0, 1.0);
   TimeStepId temporal_id(true, 0, Time(slab, 0));
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
 
   // Create element_ids.
   std::vector<ElementId<Dim>> element_ids{};

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ObserveTimeSeriesAndSurfaceData.cpp
@@ -611,7 +611,7 @@ void run_test() {
               {"SurfaceC", {block_names.begin(), block_names.end()}},
               {"SurfaceD", {block_names.begin(), block_names.end()}},
               {"SurfaceE", {block_names.begin(), block_names.end()}}},
-          domain_creator.create_domain(),
+          domain_creator.domain(),
           kerr_horizon_opts_B,
           kerr_horizon_opts_C,
           kerr_horizon_opts_D,
@@ -667,7 +667,7 @@ void run_test() {
 
   Slab slab(0.0, 1.0);
   TimeStepId temporal_id(true, 0, Time(slab, 0));
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
 
   // Create element_ids.
   std::vector<ElementId<3>> element_ids{};

--- a/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/ParallelAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -338,7 +338,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
                {block_names.begin(), block_names.end()}},
               {"InterpolationTargetC",
                {block_names.begin(), block_names.end()}}},
-          domain_creator.create_domain(), std::move(line_segment_opts_B),
+          domain_creator.domain(), std::move(line_segment_opts_B),
           kerr_horizon_opts_C, ::Verbosity::Silent);
 
   // 3 mock nodes, with 2, 3, and 1 mocked core respectively.
@@ -372,7 +372,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
 
   Slab slab(0.0, 1.0);
   TimeStepId temporal_id(true, 0, Time(slab, 0));
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
 
   // Create Element_ids.
   std::vector<ElementId<3>> element_ids{};

--- a/tests/Unit/ParallelAlgorithms/RayTracer/BackgroundSpacetimes/Test_NumericData.cpp
+++ b/tests/Unit/ParallelAlgorithms/RayTracer/BackgroundSpacetimes/Test_NumericData.cpp
@@ -61,7 +61,7 @@ void make_test_volume_data_file(const std::string& volfile_name) {
   const domain::creators::Sphere domain_creator{
       3.0, 4.0, domain::creators::Sphere::Excision{}, 0_st, num_points_per_dim,
       true};
-  const auto domain = domain_creator.create_domain();
+  const auto domain = domain_creator.domain();
   const auto element_ids =
       initial_element_ids(domain_creator.initial_refinement_levels());
   h5::H5File<h5::AccessType::ReadWrite> h5file(volfile_name);

--- a/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_FindRadialSurface.py
+++ b/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_FindRadialSurface.py
@@ -59,7 +59,7 @@ class TestFindRadialSurface(unittest.TestCase):
             initial_refinement=0,
             initial_number_of_grid_points=8,
             use_equiangular_map=True,
-        ).create_domain()
+        ).domain()
         element_ids = [ElementId[3](block_id) for block_id in range(6)]
         elements = [
             Element(

--- a/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/SurfaceFinder/Test_SurfaceFinder.cpp
@@ -147,7 +147,7 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.SurfaceFinder.SurfaceFinder",
   static constexpr size_t dim = 3;
   const domain::creators::Sphere sphere{
       1., 5., domain::creators::Sphere::InnerCube{0.}, 0_st, 12_st, false};
-  const auto domain = sphere.create_domain();
+  const auto domain = sphere.domain();
   const auto refinement_levels = sphere.initial_refinement_levels();
   const auto extents = sphere.initial_extents();
   const ElementId<dim> id{0};

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -196,7 +196,7 @@ void test_solution() {
                                 {{false, false, false}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   verify_grmhd_solution(solution, domain.blocks()[0], mesh, 1.e-10, 1.234,
                         1.e-4);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -148,7 +148,7 @@ void test_solution() {
                                 {{false, false, false}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   verify_grmhd_solution(solution, domain.blocks()[0], mesh, 1.e-10, 1.234,
                         1.e-4);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
@@ -225,7 +225,7 @@ void test_solution() {
                                 {{false, false, false}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   verify_grmhd_solution(solution, domain.blocks()[0], mesh, 1.e-10, 1.234,
                         1.e-1);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -179,7 +179,7 @@ void test_solution() {
                                 {{false, false, false}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   verify_grmhd_solution(solution, domain.blocks()[0], mesh, 1.e-10, 1.234,
                         1.e-4);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -210,7 +210,7 @@ void test_solution() {
                                 {{false, false, false}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   verify_grmhd_solution(solution, domain.blocks()[0], mesh, 1.e-9, 1.234,
                         1.e-1);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
@@ -27,7 +27,7 @@ void verify_solution(const RelativisticEuler::Solutions::RotatingStar& solution,
                                 {{false, false, false}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
 
   verify_grmhd_solution(solution, domain.blocks()[0], mesh, error_tolerance,
                         1.234, 1.e-4);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_TovStar.cpp
@@ -40,7 +40,7 @@ void verify_solution(const TovStar& solution, const std::array<double, 3>& x) {
                                 {{false, false, false}});
   Mesh<3> mesh{brick.initial_extents()[0], Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
-  const auto domain = brick.create_domain();
+  const auto domain = brick.domain();
   verify_grmhd_solution(solution, domain.blocks()[0], mesh, 1.e-7, 1.234,
                         1.e-4);
 

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMass.cpp
@@ -46,7 +46,7 @@ void test_infinite_surface_integral(const double distance, const double mass,
       /* equatorial_compression */ {},
       /* radial_partitioning */ {},
       /* radial_distribution */ domain::CoordinateMaps::Distribution::Inverse};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto& blocks = shell_domain.blocks();
   const auto& initial_ref_levels = shell.initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_ref_levels);
@@ -172,7 +172,7 @@ void test_infinite_volume_integral(const double distance, const double mass,
       /* equatorial_compression */ {},
       /* radial_partitioning */ {},
       /* radial_distribution */ domain::CoordinateMaps::Distribution::Inverse};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto& blocks = shell_domain.blocks();
   const auto& initial_ref_levels = shell.initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_ref_levels);

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_AdmMomentum.cpp
@@ -52,7 +52,7 @@ void test_infinite_surface_integrals(const double distance, const double mass,
       /* equatorial_compression */ {},
       /* radial_partitioning */ {},
       /* radial_distribution */ domain::CoordinateMaps::Distribution::Inverse};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto& blocks = shell_domain.blocks();
   const auto& initial_ref_levels = shell.initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_ref_levels);
@@ -195,7 +195,7 @@ void test_infinite_volume_integral(const double distance, const double mass,
       /* equatorial_compression */ {},
       /* radial_partitioning */ {},
       /* radial_distribution */ domain::CoordinateMaps::Distribution::Inverse};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto& blocks = shell_domain.blocks();
   const auto& initial_ref_levels = shell.initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_ref_levels);

--- a/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
+++ b/tests/Unit/PointwiseFunctions/Xcts/Test_CenterOfMass.cpp
@@ -51,7 +51,7 @@ void test_infinite_surface_integral(const double distance,
       /* equatorial_compression */ {},
       /* radial_partitioning */ {},
       /* radial_distribution */ domain::CoordinateMaps::Distribution::Inverse};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto& blocks = shell_domain.blocks();
   const auto& initial_ref_levels = shell.initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_ref_levels);
@@ -145,7 +145,7 @@ void test_infinite_volume_integral(const double distance,
       /* equatorial_compression */ {},
       /* radial_partitioning */ {},
       /* radial_distribution */ domain::CoordinateMaps::Distribution::Inverse};
-  const auto shell_domain = shell.create_domain();
+  const auto shell_domain = shell.domain();
   const auto& blocks = shell_domain.blocks();
   const auto& initial_ref_levels = shell.initial_refinement_levels();
   const auto element_ids = initial_element_ids(initial_ref_levels);

--- a/tests/Unit/Visualization/Python/Test_PlotPowerMonitors.py
+++ b/tests/Unit/Visualization/Python/Test_PlotPowerMonitors.py
@@ -39,7 +39,7 @@ class TestPlotPowerMonitors(unittest.TestCase):
             initial_refinement=1,
             initial_number_of_grid_points=[3, 4, 5],
             use_equiangular_map=True,
-        ).create_domain()
+        ).domain()
         self.assertEqual(
             find_block_or_group(0, ["BlockyBlock", "InnerCube"], domain), 1
         )

--- a/tests/Unit/Visualization/Python/Test_Render1D.py
+++ b/tests/Unit/Visualization/Python/Test_Render1D.py
@@ -34,7 +34,7 @@ class TestRender1D(unittest.TestCase):
             initial_refinement_levels=[1],
             initial_num_points=[4],
             is_periodic=[False],
-        ).create_domain()
+        ).domain()
         serialized_domain = serialize_domain(domain)
         mesh = Mesh[1](4, Basis.Legendre, Quadrature.GaussLobatto)
         self.h5file = os.path.join(self.test_dir, "voldata.h5")

--- a/tests/support/Pipelines/Bbh/Test_FindHorizon.py
+++ b/tests/support/Pipelines/Bbh/Test_FindHorizon.py
@@ -74,7 +74,7 @@ class TestFindHorizon(unittest.TestCase):
             initial_refinement=0,
             initial_number_of_grid_points=8,
             use_equiangular_map=True,
-        ).create_domain()
+        ).domain()
         element_ids = [ElementId[3](block_id) for block_id in range(6)]
         elements = [
             Element(


### PR DESCRIPTION
## Proposed changes

Fixes #5109

This makes a number of changes towards getting errors earlier on in our input file parsing for the domain creators. I now pass the option context into various helper functions, pass it to `create_domain()`, and call `create_domain()` in the constructor of domain creators if the `Options::Context` is not default-constructed.

I'm asking for multiple people to "review", mostly because I think parts of this are applicable to different people and I would like feedback on both the general direction and overall on using LLMs to do these tedious refactors.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
