### PR TITLE
Fix continue with ringdown

### DIFF
--- a/support/Pipelines/Bbh/Ringdown.py
+++ b/support/Pipelines/Bbh/Ringdown.py
@@ -72,13 +72,13 @@ def ringdown_parameters(
 
 def start_ringdown(
     inspiral_run_dir: Union[str, Path],
-    number_of_ahc_finds_for_fit: int,
-    match_time: float,
-    settling_timescale: float,
-    zero_coefs_eps: float,
-    lev: Optional[int],
-    refinement_level: Optional[int],
-    polynomial_order: Optional[int],
+    lev: Optional[int] = None,
+    refinement_level: Optional[int] = None,
+    polynomial_order: Optional[int] = None,
+    number_of_ahc_finds_for_fit: int = 10,
+    match_time: float = None,
+    settling_timescale: float = 10.0,
+    zero_coefs_eps: float = None,
     inspiral_input_file: Optional[Union[str, Path]] = None,
     ahc_reductions_path: Optional[Union[str, Path]] = None,
     ahc_subfile: str = "ObservationAhC_Ylm",
@@ -146,6 +146,7 @@ def start_ringdown(
     )
     # Determine ringdown parameters from inspiral
     # Resolve and set correct files/paths.
+    inspiral_run_dir = Path(inspiral_run_dir).resolve()
     if inspiral_input_file is None:
         inspiral_input_file = inspiral_run_dir / "Inspiral.yaml"
 


### PR DESCRIPTION
## Proposed changes

Fixes some paths not being resolved and default arguments that needed to be set due to changes in `support/Pipelines/Bbh/Ringdown.py`. Currently there isn't a good way to catch these errors in a test because this depends on the Next section in yamls generated by the pipeline which only get called at the end of a simulation. I've tested this on quite a few inspirals now and it does continue with ringdown successfully :)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
