### PR TITLE
Enable adaptive ah with shape

### DIFF
--- a/src/ControlSystem/ControlErrors/Shape.hpp
+++ b/src/ControlSystem/ControlErrors/Shape.hpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <functional>
 #include <pup.h>
 #include <string>
 
@@ -13,6 +14,7 @@
 #include "ControlSystem/Tags/SystemTags.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -119,17 +121,42 @@ struct Shape : tt::ConformsTo<protocols::ControlError> {
     const double lambda_00_coef =
         functions_of_time.at(detail::size_name<Object>())->func(time)[0][0];
 
+    const size_t spectral_size = lambda_lm_coefs.size();
+    // Note: l_max == m_max for the shape map, so the spectral size is
+    // always 2 * (l_max + 1) * (l_max + 1).
+    ASSERT(spectral_size % 2 == 0, "Spectral size "
+                                       << spectral_size << " should be even "
+                                       << " for shape map coefficients.");
+    const auto l_max_plus_one = static_cast<size_t>(
+        sqrt(static_cast<double>(spectral_size / 2)));  // NOLINT
+    ASSERT(2 * l_max_plus_one * l_max_plus_one == spectral_size,
+           "Shape map spectral size " << spectral_size
+                                      << " cannot be represented by a "
+                                      << "Spherepack with l_max == m_max.");
+    const size_t l_max = l_max_plus_one - 1;
+
     const auto& ah =
         get<control_system::QueueTags::Horizon<Frame::Distorted, Object>>(
             measurements);
+    if (UNLIKELY(ah.l_max() > l_max)) {
+      ERROR("Horizon " << ::domain::name(Object)
+                       << " has l_max = " << ah.l_max()
+                       << " but the shape map has l_max = " << l_max
+                       << ". The horizon l_max must be less than or equal to "
+                          "the shape map l_max.");
+    }
     const auto& ah_coefs = ah.coefficients();
 
-    ASSERT(lambda_lm_coefs.size() == ah_coefs.size(),
-           "Number of coefficients for shape map '"
-               << function_of_time_name << "' (" << lambda_lm_coefs.size()
-               << ") does not match the number of coefficients in the AH "
-                  "Strahlkorper ("
-               << ah_coefs.size() << ").");
+    const DataVector ah_coefs_ref{};
+    if (lambda_lm_coefs.size() != ah_coefs.size()) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      const_cast<DataVector&>(ah_coefs_ref) =
+          ylm::Spherepack::prolong_or_restrict(ah_coefs, ah.l_max(), ah.m_max(),
+                                               l_max, l_max);
+    } else {
+      make_const_view(make_not_null(&ah_coefs_ref), ah_coefs, 0,
+                      ah_coefs.size());
+    }
 
     const auto& excision_spheres = domain.excision_spheres();
 
@@ -143,17 +170,17 @@ struct Shape : tt::ConformsTo<protocols::ControlError> {
         excision_spheres.at(detail::excision_sphere_name<Object>()).radius();
 
     const double Y00 = sqrt(0.25 / M_PI);
-    ylm::SpherepackIterator iter{ah.l_max(), ah.m_max()};
+    ylm::SpherepackIterator iter{l_max, l_max};
     // See above docs for why we have the sqrt(pi/2) in the denominator
     const double relative_size_factor =
         (radius_excision_sphere_grid_frame / Y00 - lambda_00_coef) /
-        (sqrt(0.5 * M_PI) * ah_coefs[iter.set(0, 0)()]);
+        (sqrt(0.5 * M_PI) * ah_coefs_ref[iter.set(0, 0)()]);
 
     // The map parameters are in terms of SPHEREPACK coefficients (just like
     // strahlkorper coefficients), *not* spherical harmonic coefficients, thus
     // the control error for each l,m is in terms of SPHEREPACK coefficients
     // and no extra factors of sqrt(2/pi) are needed
-    DataVector Q = -relative_size_factor * ah_coefs - lambda_lm_coefs;
+    DataVector Q = -relative_size_factor * ah_coefs_ref - lambda_lm_coefs;
 
     // Shape control is only for l > 1 so enforce that Q=0 for l=0,l=1. These
     // components of the control error won't be 0 automatically because the AH

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -25,6 +25,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/AreaElement.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/SurfaceIntegralOfScalar.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -189,6 +190,17 @@ ErrorDiagnostics control_error(
       min(get(deriv_comoving_char_speed)) > 0.0;
 
   // Difference between horizon and excision boundary.
+  if (UNLIKELY(apparent_horizon.l_max() > excision_boundary.l_max() or
+               (apparent_horizon.l_max() == excision_boundary.l_max() and
+                apparent_horizon.m_max() > excision_boundary.m_max()))) {
+    ERROR(
+        "Size control assumes the excision boundary resolution is at least "
+        "as high as the horizon resolution, but the horizon has l_max = "
+        << apparent_horizon.l_max() << " and m_max = "
+        << apparent_horizon.m_max() << " while the excision boundary has "
+        << "l_max = " << excision_boundary.l_max()
+        << " and m_max = " << excision_boundary.m_max() << ".");
+  }
   gr::surfaces::radial_distance(make_not_null(&radial_distance),
                                 apparent_horizon, excision_boundary);
 

--- a/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.cpp
@@ -892,12 +892,23 @@ void Spherepack::fill_scalar_work_arrays() {
 }
 
 DataVector Spherepack::prolong_or_restrict(const DataVector& spectral_coefs,
-                                           const Spherepack& target) const {
-  ASSERT(spectral_coefs.size() == spectral_size(),
-         "Expecting " << spectral_size() << ", got " << spectral_coefs.size());
-  DataVector result(target.spectral_size(), 0.0);
-  SpherepackIterator src_it(l_max_, m_max_);
-  SpherepackIterator dest_it(target.l_max_, target.m_max_);
+                                           const size_t l_max_coefs,
+                                           const size_t m_max_coefs,
+                                           const size_t l_max_target,
+                                           const size_t m_max_target) {
+  if (l_max_coefs == l_max_target and m_max_coefs == m_max_target) {
+    return spectral_coefs;
+  }
+
+  ASSERT(spectral_coefs.size() ==
+             Spherepack::spectral_size(l_max_coefs, m_max_coefs),
+         "Expecting " << Spherepack::spectral_size(l_max_coefs, m_max_coefs)
+                      << ", got " << spectral_coefs.size());
+  const size_t spectral_size_target =
+      Spherepack::spectral_size(l_max_target, m_max_target);
+  DataVector result{spectral_size_target, 0.0};
+  SpherepackIterator src_it(l_max_coefs, m_max_coefs);
+  SpherepackIterator dest_it(l_max_target, m_max_target);
   for (; dest_it; ++dest_it) {
     if (dest_it.l() <= src_it.l_max() and dest_it.m() <= src_it.m_max()) {
       src_it.set(dest_it.l(), dest_it.m(), dest_it.coefficient_array());
@@ -905,6 +916,12 @@ DataVector Spherepack::prolong_or_restrict(const DataVector& spectral_coefs,
     }
   }
   return result;
+}
+
+DataVector Spherepack::prolong_or_restrict(const DataVector& spectral_coefs,
+                                           const Spherepack& target) const {
+  return prolong_or_restrict(spectral_coefs, l_max_, m_max_, target.l_max_,
+                             target.m_max_);
 }
 
 bool operator==(const Spherepack& lhs, const Spherepack& rhs) {

--- a/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp
@@ -468,6 +468,16 @@ class Spherepack {
   T interpolate_from_coefs(const DataVector& spectral_coefs,
                            const std::array<T, 2>& target_points) const;
 
+  /// Takes spectral coefficients compatible with a resolution given by
+  /// `l_max_coefs` and `m_max_coefs` and either prolongs them or restricts
+  /// them to be compatible with a resolution given by `l_max_target` and
+  /// `m_max_target`. This is done by truncation (restriction) or padding
+  /// with zeros (prolongation).
+  static DataVector prolong_or_restrict(const DataVector& spectral_coefs,
+                                        size_t l_max_coefs, size_t m_max_coefs,
+                                        size_t l_max_target,
+                                        size_t m_max_target);
+
   /// Takes spectral coefficients compatible with `*this`, and either
   /// prolongs them or restricts them to be compatible with `target`.
   /// This is done by truncation (restriction) or padding with zeros

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.cpp
@@ -22,20 +22,40 @@ void radial_distance(const gsl::not_null<Scalar<DataVector>*> radial_distance,
         << strahlkorper_a.expansion_center() << " and "
         << strahlkorper_b.expansion_center());
   }
-  get(*radial_distance)
-      .destructive_resize(strahlkorper_a.ylm_spherepack().physical_size());
+  const auto physical_size_a = strahlkorper_a.ylm_spherepack().physical_size();
+  const auto physical_size_b = strahlkorper_b.ylm_spherepack().physical_size();
   if (strahlkorper_a.l_max() == strahlkorper_b.l_max() and
       strahlkorper_a.m_max() == strahlkorper_b.m_max()) {
+    if (UNLIKELY(get(*radial_distance).size() != physical_size_a)) {
+      ERROR("radial_distance has size "
+            << get(*radial_distance).size()
+            << " but both Strahlkorpers have physical_size " << physical_size_a
+            << ". Provide an output of the correct size.");
+    }
     get(*radial_distance) =
         get(ylm::radius(strahlkorper_a)) - get(ylm::radius(strahlkorper_b));
   } else if (strahlkorper_a.l_max() > strahlkorper_b.l_max() or
              (strahlkorper_a.l_max() == strahlkorper_b.l_max() and
               strahlkorper_a.m_max() > strahlkorper_b.m_max())) {
+    if (UNLIKELY(get(*radial_distance).size() != physical_size_a)) {
+      ERROR("radial_distance has size "
+            << get(*radial_distance).size()
+            << " but Strahlkorper a has higher resolution with physical_size "
+            << physical_size_a
+            << ". Provide an output matching the higher-resolution surface.");
+    }
     get(*radial_distance) =
         get(ylm::radius(strahlkorper_a)) -
         get(ylm::radius(ylm::Strahlkorper<Frame>(
             strahlkorper_a.l_max(), strahlkorper_a.m_max(), strahlkorper_b)));
   } else {
+    if (UNLIKELY(get(*radial_distance).size() != physical_size_b)) {
+      ERROR("radial_distance has size "
+            << get(*radial_distance).size()
+            << " but Strahlkorper b has higher resolution with physical_size "
+            << physical_size_b
+            << ". Provide an output matching the higher-resolution surface.");
+    }
     get(*radial_distance) =
         -get(ylm::radius(strahlkorper_b)) +
         get(ylm::radius(ylm::Strahlkorper<Frame>(

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/RadialDistance.hpp
@@ -24,9 +24,11 @@ namespace gr::surfaces {
  *
  * \details Computes the pointwise radial distance \f$r_a-r_b\f$ between two
  * Strahlkorpers `strahlkorper_a` and `strahlkorper_b` that have the same
- * center, first (if the Strahlkorpers' resolutions are unequal) prolonging the
- * lower-resolution Strahlkorper to the same resolution as the higher-resolution
- * Strahlkorper.
+ * center. If the Strahlkorpers' resolutions are unequal, the lower-resolution
+ * Strahlkorper is internally prolonged to match the higher-resolution
+ * Strahlkorper. The `radial_distance` DataVector must already have size
+ * consistent with the higher-resolution Strahlkorper's resolution (or the
+ * common size when the resolutions match); a mismatch triggers an error.
  */
 template <typename Frame>
 void radial_distance(gsl::not_null<Scalar<DataVector>*> radial_distance,

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Shape.cpp
@@ -36,6 +36,7 @@
 #include "Framework/ActionTesting.hpp"
 #include "Helpers/ControlSystem/SystemHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Parallel/Phase.hpp"
@@ -56,30 +57,32 @@ using FoTMap = std::unordered_map<
     std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
 using Strahlkorper = ylm::Strahlkorper<Frame::Distorted>;
 
-void test_shape_control_error() {
-  constexpr size_t deriv_order = 2;
+constexpr size_t deriv_order = 2;
+
+void check_shape_control_error(const size_t ah_l_max, const size_t lambda_l_max,
+                               std::mt19937& generator) {
   using metavars =
       TestHelpers::control_system::MockMetavars<0, 0, 0, deriv_order>;
   using system = typename metavars::shape_system;
   using ControlError = system::control_error;
   using element_component = typename metavars::element_component;
 
-  MAKE_GENERATOR(generator);
-  domain::FunctionsOfTime::register_derived_with_charm();
-
   const tnsr::I<double, 3, Frame::Grid> origin{0.0};
   const double ah_radius = 1.5;
   const double initial_time = 0.0;
-  Strahlkorper fake_ah{10, 10, make_array<double, 3>(origin)};
+  Strahlkorper fake_ah{ah_l_max, ah_l_max, ah_radius,
+                       make_array<double, 3>(origin)};
   auto& fake_ah_coefs = fake_ah.coefficients();
+
+  const ylm::Spherepack lambda_spherepack{lambda_l_max, lambda_l_max};
 
   // Setup initial shape map coefficients. In the map the coefficients are
   // stored as the negative of the actual spherical harmonic coefficients
   // because that's just how the map is defined. But since these are random
   // numbers it doesn't matter for initial data
   auto initial_shape_func = make_array<deriv_order + 1, DataVector>(
-      DataVector{fake_ah_coefs.size(), 0.0});
-  ylm::SpherepackIterator iter{fake_ah.l_max(), fake_ah.m_max()};
+      DataVector{lambda_spherepack.spectral_size(), 0.0});
+  ylm::SpherepackIterator iter{lambda_l_max, lambda_l_max};
   std::uniform_real_distribution<double> coef_dist{-1.0, 1.0};
   for (size_t i = 0; i < initial_shape_func.size(); i++) {
     for (iter.reset(); iter; ++iter) {
@@ -187,10 +190,16 @@ void test_shape_control_error() {
   const auto lambda_lm_coefs =
       functions_of_time.at(shape_name)->func(check_time)[0];
 
+  const DataVector ah_coefs_for_expected =
+      lambda_lm_coefs.size() == measurement_coefs.size()
+          ? measurement_coefs
+          : fake_ah.ylm_spherepack().prolong_or_restrict(measurement_coefs,
+                                                         lambda_spherepack);
+
   DataVector expected_control_error =
       -(excision_radius / Y00 - lambda_00_coef) /
-          (sqrt(0.5 * M_PI) * measurement_coefs[iter.set(0, 0)()]) *
-          measurement_coefs -
+          (sqrt(0.5 * M_PI) * ah_coefs_for_expected[iter.set(0, 0)()]) *
+          ah_coefs_for_expected -
       lambda_lm_coefs;
   // We don't control l=0 or l=1 modes
   for (iter.reset(); iter; ++iter) {
@@ -204,7 +213,17 @@ void test_shape_control_error() {
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.Shape",
                   "[ControlSystem][Unit]") {
-  test_shape_control_error();
+  MAKE_GENERATOR(generator);
+  domain::FunctionsOfTime::register_derived_with_charm();
+
+  // ah_l_max < lambda_l_max (prolong), equal, and ah_l_max > lambda_l_max
+  check_shape_control_error(8, 10, generator);
+  check_shape_control_error(10, 10, generator);
+  CHECK_THROWS_WITH(
+      check_shape_control_error(12, 10, generator),
+      Catch::Matchers::ContainsSubstring(
+          "Horizon A has l_max = 12 but the shape map has l_max = 10. The "
+          "horizon l_max must be less than or equal to the shape map l_max."));
 }
 }  // namespace
 }  // namespace control_system

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -90,6 +90,59 @@ void test_control_error_delta_r() {
   CHECK(control_error_delta_r == approx(-2.5));
 }
 
+void test_size_error_horizon_higher_res_than_excision() {
+  control_system::size::Info info{
+      std::make_unique<control_system::size::States::Initial>(),
+      0.1,
+      0.0,
+      0.0,
+      std::nullopt,
+      false};
+
+  intrp::ZeroCrossingPredictor predictor_char_speed;
+  intrp::ZeroCrossingPredictor predictor_comoving_char_speed;
+  intrp::ZeroCrossingPredictor predictor_delta_radius;
+  intrp::ZeroCrossingPredictor predictor_drift_limit_char_speed;
+  intrp::ZeroCrossingPredictor predictor_drift_limit_delta_radius;
+
+  const size_t horizon_l_max = 3;
+  const size_t excision_l_max = 2;
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  const ylm::Strahlkorper<Frame::Distorted> horizon(horizon_l_max, 1.0, center);
+  const ylm::Strahlkorper<Frame::Distorted> excision_boundary(excision_l_max,
+                                                              0.9, center);
+
+  const size_t excision_size =
+      excision_boundary.ylm_spherepack().physical_size();
+
+  const Scalar<DataVector> lapse{DataVector(excision_size, 1.0)};
+  const tnsr::I<DataVector, 3, Frame::Distorted> frame_components_of_grid_shift{
+      excision_size, 0.0};
+  tnsr::ii<DataVector, 3, Frame::Distorted> spatial_metric{excision_size, 0.0};
+  tnsr::II<DataVector, 3, Frame::Distorted> inverse_spatial_metric{
+      excision_size, 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    spatial_metric.get(i, i) = DataVector(excision_size, 1.0);
+    inverse_spatial_metric.get(i, i) = DataVector(excision_size, 1.0);
+  }
+  const Scalar<DataVector> deriv_comoving_char_speed{
+      DataVector(excision_size, 0.0)};
+
+  CHECK_THROWS_WITH(
+      control_system::size::control_error(
+          make_not_null(&info), make_not_null(&predictor_char_speed),
+          make_not_null(&predictor_comoving_char_speed),
+          make_not_null(&predictor_delta_radius),
+          make_not_null(&predictor_drift_limit_char_speed),
+          make_not_null(&predictor_drift_limit_delta_radius), 0.0, 0.0,
+          std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+          horizon.coefficients()[0], 0.0, horizon, excision_boundary, lapse,
+          frame_components_of_grid_shift, spatial_metric,
+          inverse_spatial_metric, deriv_comoving_char_speed),
+      Catch::Matchers::ContainsSubstring(
+          "excision boundary resolution is at least as high"));
+}
+
 template <typename InitialState, typename FinalState>
 void test_size_error_one_step(
     const gsl::not_null<intrp::ZeroCrossingPredictor*> predictor_char_speed,
@@ -422,6 +475,7 @@ void test_size_error(const double grid_excision_boundary_radius,
 SPECTRE_TEST_CASE("Unit.ControlSystem.SizeError", "[Domain][Unit]") {
   control_system::size::register_derived_with_charm();
   test_control_error_delta_r();
+  test_size_error_horizon_higher_res_than_excision();
   // Should go to DeltaR state with error of zero, since ComovingMinCharSpeed
   // will be positive.
   test_size_error<control_system::size::States::Initial,

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Spherepack.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Spherepack.cpp
@@ -537,6 +537,10 @@ void test_prolong_restrict() {
     const auto u_coef_a2b2a = ylm_b.prolong_or_restrict(u_coef_a2b, ylm_a);
     const auto u_b_test = ylm_a.spec_to_phys(u_coef_a2b2a);
     CHECK_ITERABLE_APPROX(u_b, u_b_test);
+
+    const auto u_coef_a2b_direct = Spherepack::prolong_or_restrict(
+        u_coef_a, ylm_a.l_max(), ylm_a.m_max(), ylm_b.l_max(), ylm_b.m_max());
+    CHECK_ITERABLE_APPROX(u_coef_a2b, u_coef_a2b_direct);
   }
 
   {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
@@ -1286,6 +1286,34 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.RadialDistance",
       strahlkorper_a);
   CHECK_ITERABLE_APPROX(radial_dist, expected_radial_dist_b_minus_a);
 
+  Scalar<DataVector> wrong_size_radial_dist{
+      DataVector{strahlkorper_a.ylm_spherepack().physical_size() + 1}};
+  CHECK_THROWS_WITH(
+      (gr::surfaces::radial_distance(make_not_null(&wrong_size_radial_dist),
+                                     strahlkorper_a, strahlkorper_b)),
+      Catch::Matchers::ContainsSubstring(
+          "both Strahlkorpers have physical_size"));
+
+  Scalar<DataVector> too_small_for_a{
+      DataVector{strahlkorper_b.ylm_spherepack().physical_size() / 2}};
+  const ylm::Strahlkorper<Frame::Inertial> lower_res_b(
+      strahlkorper_b.l_max() - 1, strahlkorper_b.m_max() - 1, strahlkorper_b);
+  CHECK_THROWS_WITH(
+      (gr::surfaces::radial_distance(make_not_null(&too_small_for_a),
+                                     strahlkorper_a, lower_res_b)),
+      Catch::Matchers::ContainsSubstring(
+          "Strahlkorper a has higher resolution with physical_size"));
+
+  Scalar<DataVector> too_small_for_b{
+      DataVector{strahlkorper_a.ylm_spherepack().physical_size()}};
+  const ylm::Strahlkorper<Frame::Inertial> higher_res_b(
+      strahlkorper_b.l_max() + 1, strahlkorper_b.m_max() + 1, strahlkorper_b);
+  CHECK_THROWS_WITH(
+      (gr::surfaces::radial_distance(make_not_null(&too_small_for_b),
+                                     strahlkorper_a, higher_res_b)),
+      Catch::Matchers::ContainsSubstring(
+          "Strahlkorper b has higher resolution with physical_size"));
+
   CHECK_THROWS_WITH(
       ([&strahlkorper_a, &y11_amplitude, &radius, &radial_dist]() {
         const std::array<double, 3> different_center{{0.1, 0.4, 0.3}};


### PR DESCRIPTION
## Proposed changes

This PR enables apparent-horizon adaptivity in simulations with shape and size control.

Previously, shape control assumed the horizon resolution never changed and always agreed with the resolution of the shape functions of time. Now, the horizon is prolonged or extended if needed to match the shape control resolution.

Size control already prolongs whichever has lower resolution, the excision surface or the horizon, when computing their radial separation. The excision resolution is fixed. So as long as the horizon resolution never exceeds the excision surface resolution, the DataVectors passed to zero crossing predictors will always have the same size. To make sure this is always the case, size control now ERRORs if the excision surface resolution is less than the horizon resolution.

A future PR will turn on apparent horizon adaptivity in the binary-black-hole pipeline, but I don't want to do that until I've tested adaptive horizon finding out on a full evolution. For this PR, I just tried a brief evolution (to make sure it didn't throw any errors) as well as the unit tests.

Note: OpenAI Codex and Cursor tab conmpletion assisted in generating this PR.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Adaptive horizon finding should now work in binary-black-hole evolutions, but it is still experimental. If you turn on adaptivity by adding criteria to the horizon finders, ensure that the excision resolution is never smaller than the apparent horizon resolutions. You can do this, e.g., by setting the maximum allowed resolution `LMax` for the apparent horizons to the same L as `LMax` in `ControlSystemCharSpeedExcision`s in the evolution input file.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
