### PR TITLE
Fix DefaultProcsPerTask on Ocean2

### DIFF
--- a/support/Machines/Ocean2.yaml
+++ b/support/Machines/Ocean2.yaml
@@ -8,7 +8,7 @@ Machine:
     More information:
     Contact Geoffrey Lovelace for more information.
   DefaultTasksPerNode: 6
-  DefaultProcsPerTasks: 32
+  DefaultProcsPerTask: 32
   DefaultQueue: "normal"
   DefaultTimeLimit: "01-00:00:00"
   LaunchCommandSingleNode: []

--- a/support/Machines/Ocean2_orca1.yaml
+++ b/support/Machines/Ocean2_orca1.yaml
@@ -9,7 +9,7 @@ Machine:
     More information:
     Contact Geoffrey Lovelace for more information.
   DefaultTasksPerNode: 1
-  DefaultProcsPerTasks: 20
+  DefaultProcsPerTask: 20
   DefaultQueue: "orca-1"
   DefaultTimeLimit: "01-00:00:00"
   LaunchCommandSingleNode: []


### PR DESCRIPTION
## Proposed changes

Schedule.py expects the variable in the machines yaml file to be DefaultProcsPerTask not DefaultProcsPerTasks which caused the scheduler to not work correctly on Ocean2.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
