### PR TITLE
Make lower bound below upper in trumpet test

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_TrumpetSchwarzschild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_TrumpetSchwarzschild.cpp
@@ -184,7 +184,7 @@ SPECTRE_TEST_CASE(
       // random grid pts check
       test_trumpet_schwarzschild_random(
           solution, std::numeric_limits<double>::signaling_NaN(),
-          make_not_null(&generator), -1.e-4 * mass, -1.e-1 * mass, mass, n);
+          make_not_null(&generator), -1.e-1 * mass, -1.e-4 * mass, mass, n);
       test_trumpet_schwarzschild_random(
           solution, DataVector{1, std::numeric_limits<double>::signaling_NaN()},
           make_not_null(&generator), 1.e-1 * mass, 1. * mass, mass, n);


### PR DESCRIPTION
Started being enforced by libstdc++ 15.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
