### PR TITLE
Modify handling of CCE prefix tag and move CCE objects to the global cache

### DIFF
--- a/src/DataStructures/DataBox/TagTraits.hpp
+++ b/src/DataStructures/DataBox/TagTraits.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <type_traits>
 
 /// \cond
@@ -130,4 +131,59 @@ struct is_tag
 /// \brief True if `Tag` is a DataBox tag.
 template <typename Tag>
 constexpr bool is_tag_v = is_tag<Tag>::value;
+
+/*!
+ * \ingroup DataBoxGroup
+ * Concept for a SimpleTag.
+ *
+ * \see is_simple_tag
+ */
+template <typename Tag>
+concept simple_tag = is_simple_tag_v<Tag>;
+
+/*!
+ * \ingroup DataBoxGroup
+ * Concept for a ComputeTag.
+ *
+ * \see is_compute_tag
+ */
+template <typename Tag>
+concept compute_tag = is_compute_tag_v<Tag>;
+
+/*!
+ * \ingroup DataBoxGroup
+ * Concept for a ReferenceTag.
+ *
+ * \see is_reference_tag
+ */
+template <typename Tag>
+concept reference_tag = is_reference_tag_v<Tag>;
+
+/*!
+ * \ingroup DataBoxGroup
+ * Concept for an immutable item tag.
+ *
+ * \see is_immutable_item_tag
+ */
+template <typename Tag>
+concept immutable_item_tag = reference_tag<Tag> or compute_tag<Tag>;
+
+/*!
+ * \ingroup DataBoxGroup
+ * Concept for a mutable item tag.
+ *
+ * \see is_mutable_item_tag
+ */
+template <typename Tag>
+concept mutable_item_tag = simple_tag<Tag>;
+
+/*!
+ * \ingroup DataBoxGroup
+ * Concept for a DataBox tag.
+ *
+ * \see is_tag
+ */
+template <typename Tag>
+concept tag = immutable_item_tag<Tag> or mutable_item_tag<Tag> or
+              std::same_as<Tag, Parallel::Tags::Metavariables>;
 }  // namespace db

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -369,7 +369,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -351,7 +351,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -357,7 +357,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -290,7 +290,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, dg_step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -669,7 +669,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -92,7 +92,7 @@ struct EvolutionMetavars
                   ::evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -283,7 +283,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -950,7 +950,7 @@ struct GhValenciaDivCleanTemplateBase<
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>,
 
           tmpl::conditional_t<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -628,7 +628,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -428,7 +428,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -286,7 +286,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration

--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -235,7 +235,7 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::list<
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   // Monte-Carlo is only triggered at the end of a full time

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -389,7 +389,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -288,7 +288,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>,
           Parallel::PhaseActions<
               Parallel::Phase::PostFailureCleanup,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -326,7 +326,7 @@ struct EvolutionMetavars {
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -30,7 +30,6 @@
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
-#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/StepNumberWithinSlab.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStep.hpp"
@@ -107,11 +106,8 @@ template <typename Metavariables, typename TimeStepperBase>
 struct TimeStepping {
   /// Tags for constant items added to the GlobalCache.  These items are
   /// initialized from input file options.
-  using const_global_cache_tags = tmpl::conditional_t<
-      TimeStepperBase::local_time_stepping,
-      tmpl::list<::Tags::ConcreteTimeStepper<TimeStepperBase>,
-                 ::Tags::StepChoosers>,
-      tmpl::list<::Tags::ConcreteTimeStepper<TimeStepperBase>>>;
+  using const_global_cache_tags =
+      tmpl::list<::Tags::ConcreteTimeStepper<TimeStepperBase>>;
 
   /// Tags for mutable items added to the GlobalCache.  These items are
   /// initialized from input file options.

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -70,13 +70,13 @@ namespace Actions {
 template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag,
           bool local_time_stepping>
 struct InitializeCharacteristicEvolutionTime {
-  using simple_tags_from_options = tmpl::flatten<tmpl::list<
-      Initialization::Tags::InitialSlabSize<local_time_stepping>,
-      Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<LtsTimeStepper>>,
-      Tags::CceEvolutionPrefix<::Tags::StepChoosers>,
-      ::Initialization::Tags::InitialTimeDelta>>;
+  using simple_tags_from_options =
+      tmpl::list<Initialization::Tags::InitialSlabSize<local_time_stepping>,
+                 ::Initialization::Tags::InitialTimeDelta>;
 
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<
+      Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<LtsTimeStepper>>,
+      Tags::CceEvolutionPrefix<::Tags::StepChoosers>>;
 
   using evolved_swsh_variables_tag = ::Tags::Variables<EvolvedSwshTag>;
   using simple_tags = tmpl::list<

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -18,7 +18,6 @@
 #include "Time/Slab.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
-#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/StepNumberWithinSlab.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStep.hpp"
@@ -75,8 +74,7 @@ struct InitializeCharacteristicEvolutionTime {
                  ::Initialization::Tags::InitialTimeDelta>;
 
   using const_global_cache_tags = tmpl::list<
-      Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<LtsTimeStepper>>,
-      Tags::CceEvolutionPrefix<::Tags::StepChoosers>>;
+      Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<LtsTimeStepper>>>;
 
   using evolved_swsh_variables_tag = ::Tags::Variables<EvolvedSwshTag>;
   using simple_tags = tmpl::list<

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -85,7 +85,9 @@ struct InitializeCharacteristicEvolutionTime {
       ::Tags::AdaptiveSteppingDiagnostics,
       ::Tags::HistoryEvolvedVariables<EvolvedCoordinatesVariablesTag>,
       ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>>;
-  using compute_tags = time_stepper_ref_tags<LtsTimeStepper>;
+  using compute_tags =
+      tmpl::transform<time_stepper_ref_tags<LtsTimeStepper>,
+                      tmpl::bind<Tags::CceEvolutionPrefix, tmpl::_1>>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -115,7 +117,9 @@ struct InitializeCharacteristicEvolutionTime {
       initial_time_step = initial_time.slab().duration();
     }
 
-    const auto& time_stepper = db::get<::Tags::TimeStepper<TimeStepper>>(box);
+    const auto& time_stepper =
+        db::get<Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>(
+            box);
 
     const size_t starting_order =
         visit(

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -69,7 +69,8 @@ struct InitializeWorldtubeBoundaryBase {
       if (dynamic_cast<const Solutions::RobinsonTrautman*>(
               &(db::get<Tags::AnalyticBoundaryDataManager>(box)
                     .get_generator())) != nullptr) {
-        if (db::get<::Tags::TimeStepper<TimeStepper>>(box)
+        if (db::get<Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>(
+                box)
                 .number_of_substeps() != 1) {
           ERROR(
               "Do not use RobinsonTrautman analytic solution with a "
@@ -254,7 +255,9 @@ struct InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>
       typename Metavariables::cce_boundary_communication_tags>;
   using base_type::apply;
   using typename base_type::simple_tags;
-  using compute_tags = time_stepper_ref_tags<TimeStepperType>;
+  using compute_tags =
+      tmpl::transform<time_stepper_ref_tags<TimeStepperType>,
+                      tmpl::bind<Tags::CceEvolutionPrefix, tmpl::_1>>;
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::ExtractionRadiusSimple,
                  Tags::SpecifiedEndTime, Tags::SpecifiedStartTime>;

--- a/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeWorldtubeBoundary.hpp
@@ -69,8 +69,8 @@ struct InitializeWorldtubeBoundaryBase {
       if (dynamic_cast<const Solutions::RobinsonTrautman*>(
               &(db::get<Tags::AnalyticBoundaryDataManager>(box)
                     .get_generator())) != nullptr) {
-        if (db::get<Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>(
-                box)
+        if (db::get<Tags::CceEvolutionPrefix<
+                ::Tags::ConcreteTimeStepper<LtsTimeStepper>>>(box)
                 .number_of_substeps() != 1) {
           ERROR(
               "Do not use RobinsonTrautman analytic solution with a "
@@ -239,25 +239,15 @@ template <typename Metavariables>
 struct InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>
     : public detail::InitializeWorldtubeBoundaryBase<
           InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>,
-          tmpl::list<Tags::AnalyticBoundaryDataManager,
-                     Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<
-                         tmpl::conditional_t<Metavariables::local_time_stepping,
-                                             LtsTimeStepper, TimeStepper>>>>,
+          tmpl::list<Tags::AnalyticBoundaryDataManager>,
           typename Metavariables::cce_boundary_communication_tags> {
-  using TimeStepperType =
-      tmpl::conditional_t<Metavariables::local_time_stepping, LtsTimeStepper,
-                          TimeStepper>;
   using base_type = detail::InitializeWorldtubeBoundaryBase<
       InitializeWorldtubeBoundary<AnalyticWorldtubeBoundary<Metavariables>>,
-      tmpl::list<Tags::AnalyticBoundaryDataManager,
-                 Tags::CceEvolutionPrefix<
-                     ::Tags::ConcreteTimeStepper<TimeStepperType>>>,
+      tmpl::list<Tags::AnalyticBoundaryDataManager>,
       typename Metavariables::cce_boundary_communication_tags>;
   using base_type::apply;
   using typename base_type::simple_tags;
-  using compute_tags =
-      tmpl::transform<time_stepper_ref_tags<TimeStepperType>,
-                      tmpl::bind<Tags::CceEvolutionPrefix, tmpl::_1>>;
+  using compute_tags = tmpl::list<>;
   using const_global_cache_tags =
       tmpl::list<Tags::LMax, Tags::ExtractionRadiusSimple,
                  Tags::SpecifiedEndTime, Tags::SpecifiedStartTime>;

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -198,8 +198,10 @@ struct CharacteristicEvolution {
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
       ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping>>,
-      ::Actions::MutateApply<CleanHistory<cce_system>>>;
+          UpdateU<cce_system, Metavariables::local_time_stepping,
+                  Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<
+          CleanHistory<cce_system, Tags::CceEvolutionPrefix>>>;
 
   using extract_action_list = tmpl::list<
       Actions::RequestBoundaryData<
@@ -232,27 +234,31 @@ struct CharacteristicEvolution {
               evolution::Actions::RunEventsAndTriggers<
                   Triggers::WhenToCheck::AtSlabs>>>>,
       compute_scri_quantities_and_observe,
-      ::Actions::MutateApply<
-          ChangeStepSize<typename Metavariables::cce_step_choosers>>,
+      ::Actions::MutateApply<ChangeStepSize<
+          typename Metavariables::cce_step_choosers, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
       ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping>>,
-      ::Actions::MutateApply<ChangeTimeStepperOrder<cce_system>>,
-      ::Actions::MutateApply<CleanHistory<cce_system>>,
+          UpdateU<cce_system, Metavariables::local_time_stepping,
+                  Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<
+          ChangeTimeStepperOrder<cce_system, Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<
+          CleanHistory<cce_system, Tags::CceEvolutionPrefix>>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<
           typename Metavariables::cce_boundary_component,
           CharacteristicEvolution<Metavariables>>,
-      ::Actions::MutateApply<AdvanceTime>, Actions::ExitIfEndTimeReached,
-      ::Actions::Goto<CceEvolutionLabelTag>>;
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
+      Actions::ExitIfEndTimeReached, ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<Parallel::Phase::InitializeTimeStepperHistory,
                              SelfStart::self_start_procedure<
-                                 self_start_extract_action_list, cce_system>>,
+                                 self_start_extract_action_list, cce_system,
+                                 Tags::CceEvolutionPrefix>>,
       Parallel::PhaseActions<Parallel::Phase::Evolve, extract_action_list>>;
 
   static void initialize(

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -122,7 +122,8 @@ struct KleinGordonCharacteristicEvolution
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
       ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping>>>;
+          UpdateU<cce_system, Metavariables::local_time_stepping,
+                  Tags::CceEvolutionPrefix>>>;
 
   using extract_action_list = tmpl::list<
       Actions::RequestBoundaryData<
@@ -166,27 +167,31 @@ struct KleinGordonCharacteristicEvolution
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
       Actions::FilterSwshVolumeQuantity<Tags::KleinGordonPi>,
       compute_scri_quantities_and_observe,
-      ::Actions::MutateApply<
-          ChangeStepSize<typename Metavariables::cce_step_choosers>>,
+      ::Actions::MutateApply<ChangeStepSize<
+          typename Metavariables::cce_step_choosers, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
       ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping>>,
-      ::Actions::MutateApply<ChangeTimeStepperOrder<cce_system>>,
-      ::Actions::MutateApply<CleanHistory<cce_system>>,
+          UpdateU<cce_system, Metavariables::local_time_stepping,
+                  Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<
+          ChangeTimeStepperOrder<cce_system, Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<
+          CleanHistory<cce_system, Tags::CceEvolutionPrefix>>,
       // We cannot know our next step for certain until after we've performed
       // step size selection, as we may need to reject a step.
       Actions::RequestNextBoundaryData<
           typename Metavariables::cce_boundary_component,
           KleinGordonCharacteristicEvolution<Metavariables>>,
-      ::Actions::MutateApply<AdvanceTime>, Actions::ExitIfEndTimeReached,
-      ::Actions::Goto<CceEvolutionLabelTag>>;
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
+      Actions::ExitIfEndTimeReached, ::Actions::Goto<CceEvolutionLabelTag>>;
 
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              initialize_action_list>,
       Parallel::PhaseActions<Parallel::Phase::InitializeTimeStepperHistory,
                              SelfStart::self_start_procedure<
-                                 self_start_extract_action_list, cce_system>>,
+                                 self_start_extract_action_list, cce_system,
+                                 Tags::CceEvolutionPrefix>>,
       Parallel::PhaseActions<Parallel::Phase::Evolve, extract_action_list>>;
 
   static void initialize(

--- a/src/Evolution/Systems/Cce/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/Cce/Instantiations/TimeStepping.cpp
@@ -2,6 +2,7 @@
 // See LICENSE.txt for details.
 
 #include "Evolution/Systems/Cce/KleinGordonSystem.hpp"
+#include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/System.hpp"
 #include "Time/ChangeTimeStepperOrder.tpp"
 #include "Time/CleanHistory.tpp"
@@ -11,19 +12,27 @@
 
 #define EVOLVE_CCM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                                             \
-  template class ChangeTimeStepperOrder<                                   \
-      Cce::KleinGordonSystem<EVOLVE_CCM(data)>>;                           \
-  template class CleanHistory<Cce::KleinGordonSystem<EVOLVE_CCM(data)>>;   \
-  template class RecordTimeStepperData<                                    \
-      Cce::KleinGordonSystem<EVOLVE_CCM(data)>>;                           \
-  template class UpdateU<Cce::KleinGordonSystem<EVOLVE_CCM(data)>, false>; \
-  template class UpdateU<Cce::KleinGordonSystem<EVOLVE_CCM(data)>, true>;  \
-  template class ChangeTimeStepperOrder<Cce::System<EVOLVE_CCM(data)>>;    \
-  template class CleanHistory<Cce::System<EVOLVE_CCM(data)>>;              \
-  template class RecordTimeStepperData<Cce::System<EVOLVE_CCM(data)>>;     \
-  template class UpdateU<Cce::System<EVOLVE_CCM(data)>, false>;            \
-  template class UpdateU<Cce::System<EVOLVE_CCM(data)>, true>;
+#define INSTANTIATION(r, data)                                            \
+  template class ChangeTimeStepperOrder<                                  \
+      Cce::KleinGordonSystem<EVOLVE_CCM(data)>,                           \
+      Cce::Tags::CceEvolutionPrefix>;                                     \
+  template class CleanHistory<Cce::KleinGordonSystem<EVOLVE_CCM(data)>,   \
+                              Cce::Tags::CceEvolutionPrefix>;             \
+  template class RecordTimeStepperData<                                   \
+      Cce::KleinGordonSystem<EVOLVE_CCM(data)>>;                          \
+  template class UpdateU<Cce::KleinGordonSystem<EVOLVE_CCM(data)>, false, \
+                         Cce::Tags::CceEvolutionPrefix>;                  \
+  template class UpdateU<Cce::KleinGordonSystem<EVOLVE_CCM(data)>, true,  \
+                         Cce::Tags::CceEvolutionPrefix>;                  \
+  template class ChangeTimeStepperOrder<Cce::System<EVOLVE_CCM(data)>,    \
+                                        Cce::Tags::CceEvolutionPrefix>;   \
+  template class CleanHistory<Cce::System<EVOLVE_CCM(data)>,              \
+                              Cce::Tags::CceEvolutionPrefix>;             \
+  template class RecordTimeStepperData<Cce::System<EVOLVE_CCM(data)>>;    \
+  template class UpdateU<Cce::System<EVOLVE_CCM(data)>, false,            \
+                         Cce::Tags::CceEvolutionPrefix>;                  \
+  template class UpdateU<Cce::System<EVOLVE_CCM(data)>, true,             \
+                         Cce::Tags::CceEvolutionPrefix>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (false, true))
 

--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -11,6 +11,8 @@
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataBox/TagTraits.hpp"
 #include "Evolution/Systems/Cce/AnalyticBoundaryDataManager.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
 #include "Evolution/Systems/Cce/ExtractionRadius.hpp"
@@ -22,8 +24,10 @@
 #include "NumericalAlgorithms/Interpolation/SpanInterpolator.hpp"
 #include "Options/Auto.hpp"
 #include "Options/String.hpp"
+#include "Parallel/InitializationTag.hpp"
 #include "Parallel/Printf/Printf.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace Cce {
 /// \brief %Option tags for CCE
@@ -257,25 +261,59 @@ struct FilePrefix : db::SimpleTag {
 
 /// Tag for duplicating functionality of another tag, but allows creation from
 /// options in the Cce::Evolution option group.
+/// @{
 template <typename Tag>
-struct CceEvolutionPrefix : Tag {
-  using base = Tag;
+struct CceEvolutionPrefix;
+
+template <db::simple_tag Tag>
+struct CceEvolutionPrefix<Tag> : db::SimpleTag {
+  using type = typename Tag::type;
+  static std::string name() { return db::tag_name<Tag>(); }
+};
+
+template <Parallel::untemplated_initialization_tag Tag>
+struct CceEvolutionPrefix<Tag> : db::SimpleTag {
   using type = typename Tag::type;
   using option_tags = db::wrap_tags_in<OptionTags::CceEvolutionPrefix,
                                        typename Tag::option_tags>;
-  static std::string name() { return pretty_type::name<Tag>(); }
+  static std::string name() { return db::tag_name<Tag>(); }
+
+  static constexpr bool pass_metavariables = Tag::pass_metavariables;
+  template <typename... Args>
+  static type create_from_options(const Args&... args) {
+    return Tag::create_from_options(args...);
+  }
+};
+
+template <Parallel::templated_initialization_tag Tag>
+struct CceEvolutionPrefix<Tag> : db::SimpleTag {
+  using type = typename Tag::type;
+  template <typename Metavariables>
+  using option_tags =
+      db::wrap_tags_in<OptionTags::CceEvolutionPrefix,
+                       typename Tag::template option_tags<Metavariables>>;
+  static std::string name() { return db::tag_name<Tag>(); }
 
   static constexpr bool pass_metavariables = Tag::pass_metavariables;
   template <typename Metavariables, typename... Args>
   static type create_from_options(const Args&... args) {
     return Tag::template create_from_options<Metavariables>(args...);
   }
+};
 
+template <db::reference_tag Tag>
+struct CceEvolutionPrefix<Tag> : CceEvolutionPrefix<typename Tag::base>,
+                                 db::ReferenceTag {
+  using base = CceEvolutionPrefix<typename Tag::base>;
+  using argument_tags =
+      tmpl::transform<typename Tag::argument_tags,
+                      tmpl::bind<CceEvolutionPrefix, tmpl::_1>>;
   template <typename... Args>
-  static type create_from_options(const Args&... args) {
-    return Tag::create_from_options(args...);
+  static const auto& get(const Args&... args) {
+    return Tag::get(args...);
   }
 };
+/// @}
 
 /// A tag that constructs a `MetricWorldtubeDataManager` or
 /// `BondiWorldtubeDataManager` from options

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -116,7 +116,7 @@ struct WorldtubeSingleton {
       Parallel::PhaseActions<
           Parallel::Phase::Evolve,
           tmpl::list<Actions::ObserveWorldtubeSolution, step_actions,
-                     ::Actions::MutateApply<AdvanceTime>,
+                     ::Actions::MutateApply<AdvanceTime<>>,
                      PhaseControl::Actions::ExecutePhaseChange>>>;
 
   using simple_tags_from_options = Parallel::get_simple_tags_from_options<

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -365,7 +365,7 @@ struct Metavariables {
           Parallel::PhaseActions<
               Parallel::Phase::Execute,
               tmpl::flatten<tmpl::list<
-                  Actions::MutateApply<AdvanceTime>,
+                  Actions::MutateApply<AdvanceTime<>>,
                   Actions::ExportCoordinates<Dim>,
                   Actions::FindGlobalMinimumGridSpacing,
                   std::conditional_t<local_time_stepping,

--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -43,6 +43,7 @@ spectre_target_headers(
   InboxInserters.hpp
   Info.hpp
   InitializationFunctions.hpp
+  InitializationTag.hpp
   Invoke.hpp
   Local.hpp
   Main.hpp

--- a/src/Parallel/CreateFromOptions.hpp
+++ b/src/Parallel/CreateFromOptions.hpp
@@ -3,14 +3,15 @@
 
 #pragma once
 
+#include "Parallel/InitializationTag.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace Parallel {
 namespace detail {
-template <typename Metavariables, typename Tag, typename... OptionTags,
-          Requires<Tag::pass_metavariables> = nullptr>
+template <typename Metavariables, templated_initialization_tag Tag,
+          typename... OptionTags>
 typename Tag::type create_initialization_item_from_options(
     const tuples::TaggedTuple<OptionTags...>& options) {
   return tuples::apply<typename Tag::template option_tags<Metavariables>>(
@@ -20,8 +21,8 @@ typename Tag::type create_initialization_item_from_options(
       options);
 }
 
-template <typename Metavariables, typename Tag, typename... OptionTags,
-          Requires<not Tag::pass_metavariables> = nullptr>
+template <typename Metavariables, untemplated_initialization_tag Tag,
+          typename... OptionTags>
 typename Tag::type create_initialization_item_from_options(
     const tuples::TaggedTuple<OptionTags...>& options) {
   return tuples::apply<typename Tag::option_tags>(
@@ -34,7 +35,8 @@ typename Tag::type create_initialization_item_from_options(
 /// \brief Given a list of tags and a tagged tuple containing items
 /// created from input options, return a tagged tuple of items constructed
 /// by calls to create_from_options for each tag in the list.
-template <typename Metavariables, typename... Tags, typename... OptionTags>
+template <typename Metavariables, initialization_tag... Tags,
+          typename... OptionTags>
 tuples::TaggedTuple<Tags...> create_from_options(
     const tuples::TaggedTuple<OptionTags...>& options,
     tmpl::list<Tags...> /*meta*/) {

--- a/src/Parallel/InitializationTag.hpp
+++ b/src/Parallel/InitializationTag.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+
+#include "DataStructures/DataBox/TagTraits.hpp"
+
+namespace Parallel {
+namespace initialization_tag_detail {
+template <template <typename> typename>
+constexpr bool is_templated() {
+  return true;
+}
+}  // namespace initialization_tag_detail
+
+/*!
+ * \ingroup ParallelGroup
+ * Concept for an initialization tag with `pass_metavariables` true.
+ */
+template <typename Tag>
+concept templated_initialization_tag =
+    db::simple_tag<Tag> and Tag::pass_metavariables and
+    initialization_tag_detail::is_templated<Tag::template option_tags>();
+
+/*!
+ * \ingroup ParallelGroup
+ * Concept for an initialization tag with `pass_metavariables` false.
+ */
+template <typename Tag>
+concept untemplated_initialization_tag =
+    db::simple_tag<Tag> and not Tag::pass_metavariables and
+    requires { typename Tag::option_tags; };
+
+/*!
+ * \ingroup ParallelGroup
+ * Concept for an initialization tag.
+ */
+template <typename Tag>
+concept initialization_tag =
+    templated_initialization_tag<Tag> or untemplated_initialization_tag<Tag>;
+}  // namespace Parallel

--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <tuple>
+#include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -182,7 +183,8 @@ using vars_to_save = typename vars_to_save_impl<
 ///     has primitives
 /// - Removes: nothing
 /// - Modifies: Tags::TimeStep
-template <typename System>
+template <typename System,
+          template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct Initialize {
  private:
   template <typename TagsToSave>
@@ -223,7 +225,8 @@ struct Initialize {
         db::get<::Tags::Next<::Tags::TimeStepId>>(box).slab_number() == 0
             ? 0
             : get<TimeSteppers::Tags::FixedOrder>(
-                  db::get<::Tags::TimeStepper<TimeStepper>>(box).order()) -
+                  db::get<CacheTagPrefix<::Tags::TimeStepper<TimeStepper>>>(box)
+                      .order()) -
                   1;
 
     // Decrease the step so that the generated history will be
@@ -450,19 +453,20 @@ struct PhaseEnd;
 /// time).
 ///
 /// \see SelfStart
-template <typename StepActions, typename System>
+template <typename StepActions, typename System,
+          template <typename> typename CacheTagPrefix = std::type_identity_t>
 using self_start_procedure = tmpl::flatten<tmpl::list<
 // clang-format off
-    SelfStart::Actions::Initialize<System>,
+    SelfStart::Actions::Initialize<System, CacheTagPrefix>,
     ::Actions::Label<detail::PhaseStart>,
     SelfStart::Actions::CheckForCompletion<detail::PhaseEnd, System>,
-    ::Actions::MutateApply<AdvanceTime>,
+    ::Actions::MutateApply<AdvanceTime<CacheTagPrefix>>,
     SelfStart::Actions::CheckForOrderIncrease,
     StepActions,
     ::Actions::Goto<detail::PhaseStart>,
     ::Actions::Label<detail::PhaseEnd>,
     SelfStart::Actions::Cleanup,
-    ::Actions::MutateApply<AdvanceTime>,
+    ::Actions::MutateApply<AdvanceTime<CacheTagPrefix>>,
     Parallel::Actions::TerminatePhase>>;
 // clang-format on
 }  // namespace SelfStart

--- a/src/Time/AdvanceTime.cpp
+++ b/src/Time/AdvanceTime.cpp
@@ -11,14 +11,14 @@
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
 
-void AdvanceTime::apply(const gsl::not_null<TimeStepId*> time_id,
-                        const gsl::not_null<TimeStepId*> next_time_id,
-                        const gsl::not_null<TimeDelta*> time_step,
-                        const gsl::not_null<double*> time,
-                        const gsl::not_null<uint64_t*> step_number_within_slab,
-                        const gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
-                        const TimeStepper& time_stepper,
-                        const bool using_error_control) {
+namespace AdvanceTime_detail {
+void apply(const gsl::not_null<TimeStepId*> time_id,
+           const gsl::not_null<TimeStepId*> next_time_id,
+           const gsl::not_null<TimeDelta*> time_step,
+           const gsl::not_null<double*> time,
+           const gsl::not_null<uint64_t*> step_number_within_slab,
+           const gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
+           const TimeStepper& time_stepper, const bool using_error_control) {
   const bool new_step = next_time_id->substep() == 0;
   if (time_id->slab_number() != next_time_id->slab_number()) {
     *step_number_within_slab = 0;
@@ -43,3 +43,4 @@ void AdvanceTime::apply(const gsl::not_null<TimeStepId*> time_id,
   }
   *time = time_id->substep_time();
 }
+}  // namespace AdvanceTime_detail

--- a/src/Time/AdvanceTime.hpp
+++ b/src/Time/AdvanceTime.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
 #include "Utilities/TMPL.hpp"
 
@@ -30,24 +31,29 @@ class not_null;
 }  // namespace gsl
 /// \endcond
 
+namespace AdvanceTime_detail {
+void apply(gsl::not_null<TimeStepId*> time_id,
+           gsl::not_null<TimeStepId*> next_time_id,
+           gsl::not_null<TimeDelta*> time_step, gsl::not_null<double*> time,
+           gsl::not_null<uint64_t*> step_number_within_slab,
+           gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
+           const TimeStepper& time_stepper, bool using_error_control);
+}  // namespace AdvanceTime_detail
+
 /// \ingroup TimeGroup
 /// \brief Advance time one substep
 ///
 /// Replaces the time state with the `Tags::Next` values, advances the
 /// `Tags::Next` values, and sets `Tags::Time` to the new substep time.
+template <template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct AdvanceTime {
   using return_tags =
       tmpl::list<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
                  Tags::Time, Tags::StepNumberWithinSlab,
                  Tags::AdaptiveSteppingDiagnostics>;
-  using argument_tags = tmpl::list<Tags::TimeStepper<TimeStepper>,
-                                   Tags::StepperErrorEstimatesEnabled>;
+  using argument_tags =
+      tmpl::list<CacheTagPrefix<Tags::TimeStepper<TimeStepper>>,
+                 Tags::StepperErrorEstimatesEnabled>;
 
-  static void apply(gsl::not_null<TimeStepId*> time_id,
-                    gsl::not_null<TimeStepId*> next_time_id,
-                    gsl::not_null<TimeDelta*> time_step,
-                    gsl::not_null<double*> time,
-                    gsl::not_null<uint64_t*> step_number_within_slab,
-                    gsl::not_null<AdaptiveSteppingDiagnostics*> diags,
-                    const TimeStepper& time_stepper, bool using_error_control);
+  static constexpr auto apply = &AdvanceTime_detail::apply;
 };

--- a/src/Time/ChangeStepSize.hpp
+++ b/src/Time/ChangeStepSize.hpp
@@ -64,7 +64,8 @@ template <typename StepChoosersToUse = AllStepChoosers,
           template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct ChangeStepSize {
   using const_global_cache_tags =
-      tmpl::list<Tags::MinimumTimeStep, CacheTagPrefix<Tags::StepChoosers>>;
+      tmpl::list<CacheTagPrefix<Tags::MinimumTimeStep>,
+                 CacheTagPrefix<Tags::StepChoosers>>;
 
   using return_tags = tmpl::list<Tags::DataBox>;
   using argument_tags = tmpl::list<>;
@@ -129,13 +130,16 @@ struct ChangeStepSize {
     const double desired_step = step_requests.step_size(
         time_step_id.step_time().value(), current_step.value());
 
+    const auto& minimum_time_step =
+        db::get<CacheTagPrefix<::Tags::MinimumTimeStep>>(*box);
+
     // We do this check twice, first on the desired value, and then on
     // the actual chosen value, which is probably slightly smaller.
-    if (std::abs(desired_step) < db::get<::Tags::MinimumTimeStep>(*box)) {
+    if (std::abs(desired_step) < minimum_time_step) {
       ERROR_NO_TRACE(
           "Chosen step size "
           << desired_step << " is smaller than the MinimumTimeStep of "
-          << db::get<::Tags::MinimumTimeStep>(*box)
+          << minimum_time_step
           << ".\n"
              "\n"
              "This can indicate a flaw in the step chooser, the grid, or a "
@@ -154,11 +158,11 @@ struct ChangeStepSize {
       return;
     }
 
-    if (std::abs(new_step.value()) < db::get<::Tags::MinimumTimeStep>(*box)) {
+    if (std::abs(new_step.value()) < minimum_time_step) {
       ERROR_NO_TRACE(
           "Chosen step size after conversion to a fraction of a slab "
           << new_step << " is smaller than the MinimumTimeStep of "
-          << db::get<::Tags::MinimumTimeStep>(*box)
+          << minimum_time_step
           << ".\n"
              "\n"
              "This can indicate a flaw in the step chooser, the grid, or a "

--- a/src/Time/ChangeStepSize.hpp
+++ b/src/Time/ChangeStepSize.hpp
@@ -14,6 +14,7 @@
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/Tags/MinimumTimeStep.hpp"
+#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeStepRequest.hpp"
@@ -32,7 +33,6 @@ struct DataBox;
 struct FixedLtsRatio;
 template <typename Tag>
 struct Next;
-struct StepChoosers;
 struct TimeStep;
 struct TimeStepId;
 template <typename StepperInterface>
@@ -63,7 +63,8 @@ struct TimeStepper;
 template <typename StepChoosersToUse = AllStepChoosers,
           template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct ChangeStepSize {
-  using const_global_cache_tags = tmpl::list<Tags::MinimumTimeStep>;
+  using const_global_cache_tags =
+      tmpl::list<Tags::MinimumTimeStep, CacheTagPrefix<Tags::StepChoosers>>;
 
   using return_tags = tmpl::list<Tags::DataBox>;
   using argument_tags = tmpl::list<>;

--- a/src/Time/ChangeStepSize.hpp
+++ b/src/Time/ChangeStepSize.hpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstddef>
 #include <optional>
+#include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Time/AdaptiveSteppingDiagnostics.hpp"
@@ -59,7 +60,8 @@ struct TimeStepper;
 /// indicates that any constructible step chooser may be used. This option is
 /// used when multiple components need to invoke `ChangeStepSize` with step
 /// choosers that may not be compatible with all components.
-template <typename StepChoosersToUse = AllStepChoosers>
+template <typename StepChoosersToUse = AllStepChoosers,
+          template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct ChangeStepSize {
   using const_global_cache_tags = tmpl::list<Tags::MinimumTimeStep>;
 
@@ -74,8 +76,9 @@ struct ChangeStepSize {
     }
 
     const LtsTimeStepper& time_stepper =
-        db::get<Tags::TimeStepper<LtsTimeStepper>>(*box);
-    const auto& step_choosers = db::get<Tags::StepChoosers>(*box);
+        db::get<CacheTagPrefix<Tags::TimeStepper<LtsTimeStepper>>>(*box);
+    const auto& step_choosers =
+        db::get<CacheTagPrefix<Tags::StepChoosers>>(*box);
 
     using history_tags = ::Tags::get_all_history_tags<DbTags>;
     bool can_change_step_size = true;

--- a/src/Time/ChangeTimeStepperOrder.hpp
+++ b/src/Time/ChangeTimeStepperOrder.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <optional>
+#include <type_traits>
 
 #include "Time/Tags/VariableOrderAlgorithm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -46,20 +47,23 @@ class not_null;
  */
 /// @{
 template <typename System,
+          template <typename> typename CacheTagPrefix = std::type_identity_t,
           typename = tmpl::conditional_t<
               tt::is_a_v<tmpl::list, typename System::variables_tag>,
               typename System::variables_tag,
               tmpl::list<typename System::variables_tag>>>
 struct ChangeTimeStepperOrder;
 
-template <typename System, typename... VariablesTags>
-struct ChangeTimeStepperOrder<System, tmpl::list<VariablesTags...>> {
+template <typename System, template <typename> typename CacheTagPrefix,
+          typename... VariablesTags>
+struct ChangeTimeStepperOrder<System, CacheTagPrefix,
+                              tmpl::list<VariablesTags...>> {
   using const_global_cache_tags = tmpl::list<Tags::VariableOrderAlgorithm>;
   using return_tags =
       tmpl::list<Tags::HistoryEvolvedVariables<VariablesTags>...>;
   using argument_tags =
-      tmpl::list<Tags::TimeStepper<TimeStepper>, Tags::VariableOrderAlgorithm,
-                 Tags::Next<Tags::TimeStepId>,
+      tmpl::list<CacheTagPrefix<Tags::TimeStepper<TimeStepper>>,
+                 Tags::VariableOrderAlgorithm, Tags::Next<Tags::TimeStepId>,
                  Tags::StepperErrors<VariablesTags>...>;
 
   static void apply(

--- a/src/Time/ChangeTimeStepperOrder.hpp
+++ b/src/Time/ChangeTimeStepperOrder.hpp
@@ -58,12 +58,14 @@ template <typename System, template <typename> typename CacheTagPrefix,
           typename... VariablesTags>
 struct ChangeTimeStepperOrder<System, CacheTagPrefix,
                               tmpl::list<VariablesTags...>> {
-  using const_global_cache_tags = tmpl::list<Tags::VariableOrderAlgorithm>;
+  using const_global_cache_tags =
+      tmpl::list<CacheTagPrefix<Tags::VariableOrderAlgorithm>>;
   using return_tags =
       tmpl::list<Tags::HistoryEvolvedVariables<VariablesTags>...>;
   using argument_tags =
       tmpl::list<CacheTagPrefix<Tags::TimeStepper<TimeStepper>>,
-                 Tags::VariableOrderAlgorithm, Tags::Next<Tags::TimeStepId>,
+                 CacheTagPrefix<Tags::VariableOrderAlgorithm>,
+                 Tags::Next<Tags::TimeStepId>,
                  Tags::StepperErrors<VariablesTags>...>;
 
   static void apply(

--- a/src/Time/ChangeTimeStepperOrder.tpp
+++ b/src/Time/ChangeTimeStepperOrder.tpp
@@ -19,16 +19,19 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <typename System, typename... VariablesTags>
-void ChangeTimeStepperOrder<System, tmpl::list<VariablesTags...>>::apply(
-    const gsl::not_null<
-        TimeSteppers::History<typename VariablesTags::type>*>... histories,
-    const TimeStepper& time_stepper,
-    const VariableOrderAlgorithm& order_algorithm,
-    const TimeStepId& next_time_step_id,
-    const typename tmpl::has_type<
-        VariablesTags,
-        std::array<std::optional<StepperErrorEstimate>, 2>>::type&... errors) {
+template <typename System, template <typename> typename CacheTagPrefix,
+          typename... VariablesTags>
+void ChangeTimeStepperOrder<System, CacheTagPrefix,
+                            tmpl::list<VariablesTags...>>::
+    apply(
+        const gsl::not_null<
+            TimeSteppers::History<typename VariablesTags::type>*>... histories,
+        const TimeStepper& time_stepper,
+        const VariableOrderAlgorithm& order_algorithm,
+        const TimeStepId& next_time_step_id,
+        const typename tmpl::has_type<
+            VariablesTags, std::array<std::optional<StepperErrorEstimate>,
+                                      2>>::type&... errors) {
   if (next_time_step_id.substep() != 0) {
     return;
   }

--- a/src/Time/CleanHistory.hpp
+++ b/src/Time/CleanHistory.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
 
@@ -28,17 +30,20 @@ class not_null;
 /// \brief Clean time stepper history after a substep
 /// @{
 template <typename System,
+          template <typename> typename CacheTagPrefix = std::type_identity_t,
           typename = tmpl::conditional_t<
               tt::is_a_v<tmpl::list, typename System::variables_tag>,
               typename System::variables_tag,
               tmpl::list<typename System::variables_tag>>>
 struct CleanHistory;
 
-template <typename System, typename... VariablesTags>
-struct CleanHistory<System, tmpl::list<VariablesTags...>> {
+template <typename System, template <typename> typename CacheTagPrefix,
+          typename... VariablesTags>
+struct CleanHistory<System, CacheTagPrefix, tmpl::list<VariablesTags...>> {
   using return_tags =
       tmpl::list<Tags::HistoryEvolvedVariables<VariablesTags>...>;
-  using argument_tags = tmpl::list<Tags::TimeStepper<TimeStepper>>;
+  using argument_tags =
+      tmpl::list<CacheTagPrefix<Tags::TimeStepper<TimeStepper>>>;
 
   static void apply(
       const gsl::not_null<

--- a/src/Time/CleanHistory.tpp
+++ b/src/Time/CleanHistory.tpp
@@ -10,8 +10,9 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <typename System, typename... VariablesTags>
-void CleanHistory<System, tmpl::list<VariablesTags...>>::apply(
+template <typename System, template <typename> typename CacheTagPrefix,
+          typename... VariablesTags>
+void CleanHistory<System, CacheTagPrefix, tmpl::list<VariablesTags...>>::apply(
     const gsl::not_null<
         TimeSteppers::History<typename VariablesTags::type>*>... histories,
     const TimeStepper& time_stepper) {

--- a/src/Time/Tags/StepperErrorTolerancesCompute.cpp
+++ b/src/Time/Tags/StepperErrorTolerancesCompute.cpp
@@ -33,8 +33,8 @@ bool requests_any_tolerances(const StepChooser<StepChooserUse>& step_chooser) {
 }
 }  // namespace
 
-template <>
-void StepperErrorEstimatesEnabledCompute<true>::function(
+namespace StepperErrorEstimatesEnabledCompute_detail {
+void lts_function(
     const gsl::not_null<bool*> error_estimates_enabled,
     const ::EventsAndTriggers& events_and_triggers,
     const std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
@@ -79,10 +79,8 @@ void StepperErrorEstimatesEnabledCompute<true>::function(
   }
 }
 
-template <>
-void StepperErrorEstimatesEnabledCompute<false>::function(
-    const gsl::not_null<bool*> error_estimates_enabled,
-    const ::EventsAndTriggers& events_and_triggers) {
+void gts_function(const gsl::not_null<bool*> error_estimates_enabled,
+                  const ::EventsAndTriggers& events_and_triggers) {
   // In principle the slab size could be changed based on a dense
   // trigger, but it's not clear that there is ever a good reason to
   // do so, and it wouldn't make sense to use error control in that
@@ -106,6 +104,7 @@ void StepperErrorEstimatesEnabledCompute<false>::function(
     }
   });
 }
+}  // namespace StepperErrorEstimatesEnabledCompute_detail
 
 namespace StepperErrorTolerancesCompute_detail {
 namespace {

--- a/src/Time/Tags/StepperErrorTolerancesCompute.hpp
+++ b/src/Time/Tags/StepperErrorTolerancesCompute.hpp
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <typeindex>
 #include <vector>
 
@@ -37,9 +38,21 @@ struct VariableOrderAlgorithm;
 /// \endcond
 
 namespace Tags {
+namespace StepperErrorEstimatesEnabledCompute_detail {
+void lts_function(
+    gsl::not_null<bool*> error_estimates_enabled,
+    const ::EventsAndTriggers& events_and_triggers,
+    const std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
+        step_choosers);
+
+void gts_function(gsl::not_null<bool*> error_estimates_enabled,
+                  const ::EventsAndTriggers& events_and_triggers);
+}  // namespace StepperErrorEstimatesEnabledCompute_detail
+
 /// \ingroup TimeGroup
 /// \brief Searches the StepChoosers for any requesting error estimates.
-template <bool LocalTimeStepping>
+template <bool LocalTimeStepping,
+          template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct StepperErrorEstimatesEnabledCompute : db::ComputeTag,
                                              StepperErrorEstimatesEnabled {
   using base = StepperErrorEstimatesEnabled;
@@ -47,20 +60,16 @@ struct StepperErrorEstimatesEnabledCompute : db::ComputeTag,
   using argument_tags = tmpl::conditional_t<
       LocalTimeStepping,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
-                 ::Tags::StepChoosers>,
+                 CacheTagPrefix<::Tags::StepChoosers>>,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 
-  // local time stepping
-  static void function(
-      gsl::not_null<bool*> error_estimates_enabled,
-      const ::EventsAndTriggers& events_and_triggers,
-      const std::vector<
-          std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
-          step_choosers);
-
-  // global time stepping
-  static void function(gsl::not_null<bool*> error_estimates_enabled,
-                       const ::EventsAndTriggers& events_and_triggers);
+  static constexpr auto function = []() {
+    if constexpr (LocalTimeStepping) {
+      return &StepperErrorEstimatesEnabledCompute_detail::lts_function;
+    } else {
+      return &StepperErrorEstimatesEnabledCompute_detail::gts_function;
+    }
+  }();
 };
 
 namespace StepperErrorTolerancesCompute_detail {
@@ -81,7 +90,8 @@ void gts_impl(gsl::not_null<::StepperErrorTolerances*> tolerances,
 /// \ingroup TimeGroup
 /// \brief A tag that contains the error tolerances if any StepChooser
 /// requests an error estimate for the variable.
-template <typename EvolvedVariableTag, bool LocalTimeStepping>
+template <typename EvolvedVariableTag, bool LocalTimeStepping,
+          template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct StepperErrorTolerancesCompute
     : db::ComputeTag,
       StepperErrorTolerances<EvolvedVariableTag> {
@@ -90,7 +100,8 @@ struct StepperErrorTolerancesCompute
   using argument_tags = tmpl::conditional_t<
       LocalTimeStepping,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
-                 ::Tags::StepChoosers, ::Tags::TimeStepper<::TimeStepper>,
+                 CacheTagPrefix<::Tags::StepChoosers>,
+                 CacheTagPrefix<::Tags::TimeStepper<::TimeStepper>>,
                  ::Tags::VariableOrderAlgorithm>,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 

--- a/src/Time/Tags/StepperErrorTolerancesCompute.hpp
+++ b/src/Time/Tags/StepperErrorTolerancesCompute.hpp
@@ -102,7 +102,7 @@ struct StepperErrorTolerancesCompute
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
                  CacheTagPrefix<::Tags::StepChoosers>,
                  CacheTagPrefix<::Tags::TimeStepper<::TimeStepper>>,
-                 ::Tags::VariableOrderAlgorithm>,
+                 CacheTagPrefix<::Tags::VariableOrderAlgorithm>>,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 
   // local time stepping

--- a/src/Time/UpdateU.hpp
+++ b/src/Time/UpdateU.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <optional>
+#include <type_traits>
 
 #include "Time/Tags/StepperErrorTolerancesCompute.hpp"
 #include "Time/Tags/StepperErrors.hpp"
@@ -44,24 +45,30 @@ class not_null;
 /// \brief Perform variable updates for one substep
 /// @{
 template <typename System, bool LocalTimeStepping,
+          template <typename> typename CacheTagPrefix = std::type_identity_t,
           typename = tmpl::conditional_t<
               tt::is_a_v<tmpl::list, typename System::variables_tag>,
               typename System::variables_tag,
               tmpl::list<typename System::variables_tag>>>
 struct UpdateU;
 
-template <typename System, bool LocalTimeStepping, typename... VariablesTags>
-struct UpdateU<System, LocalTimeStepping, tmpl::list<VariablesTags...>> {
+template <typename System, bool LocalTimeStepping,
+          template <typename> typename CacheTagPrefix,
+          typename... VariablesTags>
+struct UpdateU<System, LocalTimeStepping, CacheTagPrefix,
+               tmpl::list<VariablesTags...>> {
   using simple_tags = tmpl::list<::Tags::StepperErrors<VariablesTags>...>;
-  using compute_tags = tmpl::list<
-      Tags::StepperErrorEstimatesEnabledCompute<LocalTimeStepping>,
-      Tags::StepperErrorTolerancesCompute<VariablesTags, LocalTimeStepping>...>;
+  using compute_tags =
+      tmpl::list<Tags::StepperErrorEstimatesEnabledCompute<LocalTimeStepping,
+                                                           CacheTagPrefix>,
+                 Tags::StepperErrorTolerancesCompute<
+                     VariablesTags, LocalTimeStepping, CacheTagPrefix>...>;
 
   using return_tags =
       tmpl::list<VariablesTags..., Tags::StepperErrors<VariablesTags>...>;
   using argument_tags =
-      tmpl::list<Tags::TimeStepper<TimeStepper>, Tags::TimeStepId,
-                 Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+      tmpl::list<CacheTagPrefix<Tags::TimeStepper<TimeStepper>>,
+                 Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
                  Tags::StepperErrorEstimatesEnabled,
                  Tags::HistoryEvolvedVariables<VariablesTags>...,
                  Tags::StepperErrorTolerances<VariablesTags>...>;

--- a/src/Time/UpdateU.tpp
+++ b/src/Time/UpdateU.tpp
@@ -19,19 +19,23 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <typename System, bool LocalTimeStepping, typename... VariablesTags>
-void UpdateU<System, LocalTimeStepping, tmpl::list<VariablesTags...>>::apply(
-    const gsl::not_null<typename VariablesTags::type*>... vars,
-    const typename tmpl::has_type<
-        VariablesTags,
-        gsl::not_null<std::array<std::optional<StepperErrorEstimate>, 2>*>>::
-        type... errors,
-    const TimeStepper& time_stepper, const TimeStepId& time_step_id,
-    const TimeStepId& next_time_step_id, const TimeDelta& time_step,
-    const bool error_estimates_enabled,
-    const TimeSteppers::History<typename VariablesTags::type>&... histories,
-    const typename tmpl::has_type<
-        VariablesTags, StepperErrorTolerances>::type&... tolerances) {
+template <typename System, bool LocalTimeStepping,
+          template <typename> typename CacheTagPrefix,
+          typename... VariablesTags>
+void UpdateU<System, LocalTimeStepping, CacheTagPrefix,
+             tmpl::list<VariablesTags...>>::
+    apply(
+        const gsl::not_null<typename VariablesTags::type*>... vars,
+        const typename tmpl::has_type<
+            VariablesTags,
+            gsl::not_null<std::array<std::optional<StepperErrorEstimate>,
+                                     2>*>>::type... errors,
+        const TimeStepper& time_stepper, const TimeStepId& time_step_id,
+        const TimeStepId& next_time_step_id, const TimeDelta& time_step,
+        const bool error_estimates_enabled,
+        const TimeSteppers::History<typename VariablesTags::type>&... histories,
+        const typename tmpl::has_type<
+            VariablesTags, StepperErrorTolerances>::type&... tolerances) {
   if (::SelfStart::step_unused(time_step_id, next_time_step_id)) {
     return;
   }

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -20,8 +20,6 @@ OutputFileChecks:
 Evolution:
   InitialTimeStep: 0.01
   InitialSlabSize: 0.8
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -55,6 +53,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -19,7 +19,6 @@ OutputFileChecks:
 
 Evolution:
   InitialTimeStep: 0.01
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -56,6 +55,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -20,8 +20,6 @@ OutputFileChecks:
 Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.8
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -55,6 +53,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.4

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -19,7 +19,6 @@ OutputFileChecks:
 
 Evolution:
   InitialTimeStep: 0.1
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -56,6 +55,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.4
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -20,8 +20,6 @@ OutputFileChecks:
 Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.8
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -55,6 +53,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.4

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -19,7 +19,6 @@ OutputFileChecks:
 
 Evolution:
   InitialTimeStep: 0.1
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -56,6 +55,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.4
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -19,7 +19,6 @@ OutputFileChecks:
 
 Evolution:
   InitialTimeStep: 0.1
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 0.6
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -56,6 +55,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -20,8 +20,6 @@ OutputFileChecks:
 Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.6
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -55,6 +53,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -19,7 +19,6 @@ OutputFileChecks:
 
 Evolution:
   InitialTimeStep: 0.1
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -56,6 +55,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.2
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -20,8 +20,6 @@ OutputFileChecks:
 Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 0.8
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -55,6 +53,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.2

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -20,8 +20,6 @@ OutputFileChecks:
 Evolution:
   InitialTimeStep: 0.1
   InitialSlabSize: 1.0
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -55,6 +53,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.5

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -19,7 +19,6 @@ OutputFileChecks:
 
 Evolution:
   InitialTimeStep: 0.1
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 1.0
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -56,6 +55,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.5
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
@@ -65,8 +65,6 @@ ExtraFileCheckExecs:
 Evolution:
   InitialTimeStep: 0.01
   InitialSlabSize: 0.8
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -117,6 +115,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1

--- a/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
@@ -64,7 +64,6 @@ ExtraFileCheckExecs:
 
 Evolution:
   InitialTimeStep: 0.01
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -118,6 +117,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -28,7 +28,6 @@ ExtraFileCheckExecs:
 
 Evolution:
   InitialTimeStep: 0.01
-  MinimumTimeStep: 1e-7
   InitialSlabSize: 0.8
   VariableOrderAlgorithm:
     GoalOrder: 3
@@ -73,6 +72,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1
       - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -29,8 +29,6 @@ ExtraFileCheckExecs:
 Evolution:
   InitialTimeStep: 0.01
   InitialSlabSize: 0.8
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   AvoidGlobalProc0: false
@@ -72,6 +70,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -14,7 +14,6 @@ Evolution:
   # The initial step sizes isn't super important because we use error-based
   # adaptive time stepping to adjust the step size.
   InitialTimeStep: 0.25
-  MinimumTimeStep: 1e-7
   # The initial Slab size controls how often the EventsAndTriggers are run. They
   # are run once per Slab.
   InitialSlabSize: 10.0
@@ -76,6 +75,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3 # Going to higher order doesn't seem necessary for CCE
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1 # Don't take steps bigger than 0.1M
       - LimitIncrease:

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -17,8 +17,6 @@ Evolution:
   # The initial Slab size controls how often the EventsAndTriggers are run. They
   # are run once per Slab.
   InitialSlabSize: 10.0
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   # Can ignore this section since CCE performs best on a single core.
@@ -75,6 +73,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3 # Going to higher order doesn't seem necessary for CCE
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1 # Don't take steps bigger than 0.1M

--- a/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
@@ -14,7 +14,6 @@ Evolution:
   # The initial step sizes isn't super important because we use error-based
   # adaptive time stepping to adjust the step size.
   InitialTimeStep: 0.25
-  MinimumTimeStep: 1e-7
   # The initial Slab size controls how often the EventsAndTriggers are run. They
   # are run once per Slab.
   InitialSlabSize: 10.0
@@ -55,6 +54,7 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3 # Going to higher order doesn't seem necessary for CCE
+    MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1 # Don't take steps bigger than 0.1M
       - LimitIncrease:

--- a/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
@@ -17,8 +17,6 @@ Evolution:
   # The initial Slab size controls how often the EventsAndTriggers are run. They
   # are run once per Slab.
   InitialSlabSize: 10.0
-  VariableOrderAlgorithm:
-    GoalOrder: 3
 
 ResourceInfo:
   # Can ignore this section since CCE performs best on a single core.
@@ -54,6 +52,8 @@ Cce:
     TimeStepper:
       AdamsBashforth:
         Order: 3 # Going to higher order doesn't seem necessary for CCE
+    VariableOrderAlgorithm:
+      GoalOrder: 3
     MinimumTimeStep: 1e-7
     StepChoosers:
       - Constant: 0.1 # Don't take steps bigger than 0.1M

--- a/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_TagTraits.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "DataStructures/DataBox/MetavariablesTag.hpp"
 #include "DataStructures/DataBox/TagTraits.hpp"
 #include "Helpers/DataStructures/DataBox/TestTags.hpp"
 
@@ -11,11 +12,25 @@ static_assert(not db::is_compute_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(not db::is_compute_tag_v<
               TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
+static_assert(not db::compute_tag<TestHelpers::db::Tags::Bad>);
+static_assert(not db::compute_tag<TestHelpers::db::Tags::Simple>);
+static_assert(db::compute_tag<TestHelpers::db::Tags::SimpleCompute>);
+static_assert(not db::compute_tag<TestHelpers::db::Tags::SimpleReference>);
+static_assert(not db::compute_tag<
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
+
 static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Bad>);
 static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::Simple>);
 static_assert(not db::is_reference_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(db::is_reference_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(not db::is_reference_tag_v<
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
+
+static_assert(not db::reference_tag<TestHelpers::db::Tags::Bad>);
+static_assert(not db::reference_tag<TestHelpers::db::Tags::Simple>);
+static_assert(not db::reference_tag<TestHelpers::db::Tags::SimpleCompute>);
+static_assert(db::reference_tag<TestHelpers::db::Tags::SimpleReference>);
+static_assert(not db::reference_tag<
               TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
 static_assert(not db::is_immutable_item_tag_v<TestHelpers::db::Tags::Bad>);
@@ -27,6 +42,13 @@ static_assert(
 static_assert(not db::is_immutable_item_tag_v<
               TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
+static_assert(not db::immutable_item_tag<TestHelpers::db::Tags::Bad>);
+static_assert(not db::immutable_item_tag<TestHelpers::db::Tags::Simple>);
+static_assert(db::immutable_item_tag<TestHelpers::db::Tags::SimpleCompute>);
+static_assert(db::immutable_item_tag<TestHelpers::db::Tags::SimpleReference>);
+static_assert(not db::immutable_item_tag<
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
+
 static_assert(not db::is_mutable_item_tag_v<TestHelpers::db::Tags::Bad>);
 static_assert(db::is_mutable_item_tag_v<TestHelpers::db::Tags::Simple>);
 static_assert(
@@ -36,11 +58,25 @@ static_assert(
 static_assert(db::is_mutable_item_tag_v<
               TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
+static_assert(not db::mutable_item_tag<TestHelpers::db::Tags::Bad>);
+static_assert(db::mutable_item_tag<TestHelpers::db::Tags::Simple>);
+static_assert(not db::mutable_item_tag<TestHelpers::db::Tags::SimpleCompute>);
+static_assert(not db::mutable_item_tag<TestHelpers::db::Tags::SimpleReference>);
+static_assert(db::mutable_item_tag<
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
+
 static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::Bad>);
 static_assert(db::is_simple_tag_v<TestHelpers::db::Tags::Simple>);
 static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(not db::is_simple_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(db::is_simple_tag_v<
+              TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
+
+static_assert(not db::simple_tag<TestHelpers::db::Tags::Bad>);
+static_assert(db::simple_tag<TestHelpers::db::Tags::Simple>);
+static_assert(not db::simple_tag<TestHelpers::db::Tags::SimpleCompute>);
+static_assert(not db::simple_tag<TestHelpers::db::Tags::SimpleReference>);
+static_assert(db::simple_tag<
               TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
 
 static_assert(not db::is_creation_tag_v<TestHelpers::db::Tags::Bad>);
@@ -56,3 +92,69 @@ static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleCompute>);
 static_assert(db::is_tag_v<TestHelpers::db::Tags::SimpleReference>);
 static_assert(
     db::is_tag_v<TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
+
+static_assert(not db::tag<TestHelpers::db::Tags::Bad>);
+static_assert(db::tag<TestHelpers::db::Tags::Simple>);
+static_assert(db::tag<TestHelpers::db::Tags::SimpleCompute>);
+static_assert(db::tag<TestHelpers::db::Tags::SimpleReference>);
+static_assert(
+    db::tag<TestHelpers::db::Tags::Label<TestHelpers::db::Tags::Simple>>);
+
+namespace {
+enum class TagType1 { Simple, Compute, Reference, Other };
+
+template <db::tag Tag>
+struct ConceptTest1 {
+  static constexpr TagType1 value = TagType1::Other;
+};
+
+template <db::simple_tag Tag>
+struct ConceptTest1<Tag> {
+  static constexpr TagType1 value = TagType1::Simple;
+};
+
+template <db::compute_tag Tag>
+struct ConceptTest1<Tag> {
+  static constexpr TagType1 value = TagType1::Compute;
+};
+
+template <db::reference_tag Tag>
+struct ConceptTest1<Tag> {
+  static constexpr TagType1 value = TagType1::Reference;
+};
+
+static_assert(ConceptTest1<TestHelpers::db::Tags::Simple>::value ==
+              TagType1::Simple);
+static_assert(ConceptTest1<TestHelpers::db::Tags::SimpleCompute>::value ==
+              TagType1::Compute);
+static_assert(ConceptTest1<TestHelpers::db::Tags::SimpleReference>::value ==
+              TagType1::Reference);
+static_assert(ConceptTest1<Parallel::Tags::Metavariables>::value ==
+              TagType1::Other);
+
+enum class TagType2 { Compute, Immutable, Tag };
+
+template <db::tag Tag>
+struct ConceptTest2 {
+  static constexpr TagType2 value = TagType2::Tag;
+};
+
+template <db::immutable_item_tag Tag>
+struct ConceptTest2<Tag> {
+  static constexpr TagType2 value = TagType2::Immutable;
+};
+
+template <db::compute_tag Tag>
+struct ConceptTest2<Tag> {
+  static constexpr TagType2 value = TagType2::Compute;
+};
+
+static_assert(ConceptTest2<TestHelpers::db::Tags::Simple>::value ==
+              TagType2::Tag);
+static_assert(ConceptTest2<TestHelpers::db::Tags::SimpleCompute>::value ==
+              TagType2::Compute);
+static_assert(ConceptTest2<TestHelpers::db::Tags::SimpleReference>::value ==
+              TagType2::Immutable);
+static_assert(ConceptTest2<Parallel::Tags::Metavariables>::value ==
+              TagType2::Tag);
+}  // namespace

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -35,7 +35,6 @@
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
-#include "Time/TimeSteppers/DormandPrince5.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
@@ -112,7 +111,6 @@ struct mock_characteristic_evolution {
 
 struct test_metavariables {
   using evolved_swsh_tags = tmpl::list<Tags::BondiJ>;
-  static constexpr bool local_time_stepping = false;
   using evolved_swsh_dt_tags = tmpl::list<Tags::BondiH>;
   using cce_step_choosers = tmpl::list<>;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
@@ -170,7 +168,7 @@ SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.AnalyticBoundaryCommunication",
     "[Unit][Cce]") {
   register_classes_with_charm<Cce::Solutions::RotatingSchwarzschild>();
-  register_classes_with_charm<TimeSteppers::DormandPrince5>();
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component =
       mock_analytic_worldtube_boundary<test_metavariables>;
@@ -191,7 +189,11 @@ SPECTRE_TEST_CASE(
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<test_metavariables>>{
           false, l_max, extraction_radius, end_time, start_time,
-          number_of_radial_points}};
+          number_of_radial_points,
+          static_cast<std::unique_ptr<LtsTimeStepper>>(
+              std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+          make_vector<
+              std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   const AnalyticBoundaryDataManager analytic_manager{
       l_max, extraction_radius,
@@ -199,18 +201,13 @@ SPECTRE_TEST_CASE(
                                                               1.0, frequency)};
   runner.set_phase(Parallel::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size, scri_plus_interpolation_order,
+      &runner, 0, target_step_size, target_step_size,
+      scri_plus_interpolation_order,
       serialize_and_deserialize(analytic_manager));
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.
   ActionTesting::emplace_component<worldtube_component>(
-      &runner, 0, serialize_and_deserialize(analytic_manager),
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::DormandPrince5>()));
+      &runner, 0, serialize_and_deserialize(analytic_manager));
 
   // Run the initializations
   for (size_t i = 0; i < 6; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -82,7 +82,7 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>,
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -191,9 +191,7 @@ SPECTRE_TEST_CASE(
           false, l_max, extraction_radius, end_time, start_time,
           number_of_radial_points,
           static_cast<std::unique_ptr<LtsTimeStepper>>(
-              std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-          make_vector<
-              std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+              std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   const AnalyticBoundaryDataManager analytic_manager{
       l_max, extraction_radius,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -243,8 +243,7 @@ SPECTRE_TEST_CASE(
       {start_time, std::make_unique<InitializeJ::InverseCubic<false>>(), false,
        l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -211,6 +211,7 @@ SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.CharacteristicBondiCalculations",
     "[Unit][Cce]") {
   register_derived_classes_with_charm<InitializeJ::InitializeJ<false>>();
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   using component = mock_characteristic_evolution<metavariables>;
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
@@ -240,18 +241,17 @@ SPECTRE_TEST_CASE(
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {start_time, std::make_unique<InitializeJ::InverseCubic<false>>(), false,
-       l_max, number_of_radial_points}};
+       l_max, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_component_and_initialize<
       mock_observer_writer<metavariables>>(&runner, 0, {Parallel::NodeLock{}});
-  ActionTesting::emplace_component<component>(
-      &runner, 0, target_step_size,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size);
+  ActionTesting::emplace_component<component>(&runner, 0, target_step_size,
+                                              target_step_size);
 
   // this should run the initialization
   for(size_t i = 0; i < 2; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -96,7 +96,7 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>,
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
       Actions::ReceiveWorldtubeData<
           Metavariables,
           typename Metavariables::cce_boundary_communication_tags>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -54,6 +54,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -187,6 +188,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
                   "[Unit][Cce]") {
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component = mock_gh_worldtube_boundary<test_metavariables>;
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
   const double extraction_radius = 100.0;
@@ -205,7 +207,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
       tuples::tagged_tuple_from_typelist<
           Parallel::get_const_global_cache_tags<test_metavariables>>{
           false, l_max, extraction_radius, end_time, start_time,
-          number_of_radial_points}};
+          number_of_radial_points,
+          static_cast<std::unique_ptr<LtsTimeStepper>>(
+              std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+          make_vector<
+              std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   // first prepare the input for the modal version
   const double mass = value_dist(gen);
@@ -221,11 +227,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
 
   runner.set_phase(Parallel::Phase::Initialization);
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size, scri_plus_interpolation_order);
+      &runner, 0, target_step_size, target_step_size,
+      scri_plus_interpolation_order);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       InterfaceManagers::GhLocalTimeStepping{

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -209,9 +209,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
           false, l_max, extraction_radius, end_time, start_time,
           number_of_radial_points,
           static_cast<std::unique_ptr<LtsTimeStepper>>(
-              std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-          make_vector<
-              std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+              std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   // first prepare the input for the modal version
   const double mass = value_dist(gen);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -97,7 +97,7 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>,
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -239,8 +239,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   // create the test file, because on initialization the manager will need
   // to get basic data out of the file

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -112,7 +112,8 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>, Parallel::Actions::TerminatePhase>;
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
+      Parallel::Actions::TerminatePhase>;
   using simple_tags_from_options =
       Parallel::get_simple_tags_from_options<initialize_action_list>;
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -49,6 +49,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -202,6 +203,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component = mock_h5_worldtube_boundary<test_metavariables>;
   using writer_component = mock_observer_writer<test_metavariables>;
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
 
@@ -235,7 +237,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {false, l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
-       start_time, number_of_radial_points}};
+       start_time, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   // create the test file, because on initialization the manager will need
   // to get basic data out of the file
@@ -246,11 +251,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
   ActionTesting::emplace_component_and_initialize<writer_component>(
       &runner, 0, {Parallel::NodeLock{}});
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size);
+      &runner, 0, target_step_size, target_step_size);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -68,7 +68,7 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>,
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe, NoSuchType>,
       Parallel::Actions::TerminatePhase>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -43,6 +43,7 @@
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -152,6 +153,7 @@ SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.Cce.Actions.InitializeCharacteristicEvolution",
     "[Unit][Cce]") {
   using component = mock_characteristic_evolution<metavariables>;
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
 
@@ -186,16 +188,16 @@ SPECTRE_TEST_CASE(
   const double target_step_size = 0.01 * value_dist(gen);
   const size_t scri_plus_interpolation_order = 3;
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {start_time, false, l_max, number_of_radial_points}};
+      {start_time, false, l_max, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_component<component>(
-      &runner, 0, target_step_size * 0.75,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size, scri_plus_interpolation_order);
+      &runner, 0, target_step_size * 0.75, target_step_size,
+      scri_plus_interpolation_order);
 
   // this should run the initialization
   for (size_t i = 0; i < 6; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -190,8 +190,7 @@ SPECTRE_TEST_CASE(
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {start_time, false, l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
@@ -17,6 +17,7 @@
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Utilities/MakeVector.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace Cce {
 namespace {
@@ -139,6 +140,7 @@ struct metavariables : CharacteristicExtractDefaults<false> {
 template <typename Generator>
 void test_klein_gordon_cce_initialization(const gsl::not_null<Generator*> gen) {
   using component = mock_klein_gordon_characteristic_evolution<metavariables>;
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
 
@@ -173,16 +175,16 @@ void test_klein_gordon_cce_initialization(const gsl::not_null<Generator*> gen) {
 
   // tests start here
   ActionTesting::MockRuntimeSystem<metavariables> runner{
-      {start_time, false, l_max, number_of_radial_points}};
+      {start_time, false, l_max, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
   ActionTesting::emplace_component<component>(
-      &runner, 0, target_step_size * 0.75,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size, scri_plus_interpolation_order);
+      &runner, 0, target_step_size * 0.75, target_step_size,
+      scri_plus_interpolation_order);
 
   // go through the action list
   for (size_t i = 0; i < 7; ++i) {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
@@ -36,7 +36,7 @@ struct mock_klein_gordon_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>,
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe, NoSuchType>,
       Parallel::Actions::TerminatePhase>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
@@ -177,8 +177,7 @@ void test_klein_gordon_cce_initialization(const gsl::not_null<Generator*> gen) {
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {start_time, false, l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeWorldtubeBoundary.cpp
@@ -30,7 +30,7 @@
 #include "Parallel/Phase.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
-#include "Time/TimeSteppers/Rk3HesthavenSsp.hpp"
+#include "Time/TimeSteppers/AdamsMoultonPc.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
@@ -57,9 +57,8 @@ struct mock_analytic_worldtube_boundary {
       tmpl::list<Parallel::PhaseActions<Parallel::Phase::Initialization,
                                         initialize_action_list>,
                  Parallel::PhaseActions<Parallel::Phase::Evolve, tmpl::list<>>>;
-  using const_global_cache_tags =
-      Parallel::get_const_global_cache_tags_from_actions<
-    phase_dependent_action_list>;
+  using const_global_cache_tags = tmpl::list<
+      Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<LtsTimeStepper>>>;
 };
 
 struct H5Metavariables {
@@ -79,7 +78,6 @@ struct GhMetavariables {
 };
 
 struct AnalyticMetavariables {
-  static constexpr bool local_time_stepping = false;
   using cce_boundary_communication_tags =
       Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>;
   using component_list =
@@ -198,17 +196,17 @@ void test_analytic_initialization() {
   using component = mock_analytic_worldtube_boundary<AnalyticMetavariables>;
   const size_t l_max = 8;
   const double extraction_radius = 20.0;
-  register_classes_with_charm<TimeSteppers::Rk3HesthavenSsp>();
+  register_classes_with_charm<TimeSteppers::AdamsMoultonPc<false>>();
   ActionTesting::MockRuntimeSystem<AnalyticMetavariables> runner{
-      {l_max, extraction_radius, 100.0, 0.0}};
+      {static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsMoultonPc<false>>(3)),
+       l_max, extraction_radius, 100.0, 0.0}};
 
   runner.set_phase(Parallel::Phase::Initialization);
   ActionTesting::emplace_component<component>(
       &runner, 0,
       AnalyticBoundaryDataManager{12_st, extraction_radius,
-                                  std::make_unique<SolutionType>()},
-      static_cast<std::unique_ptr<TimeStepper>>(
-          std::make_unique<::TimeSteppers::Rk3HesthavenSsp>()));
+                                  std::make_unique<SolutionType>()});
   // this should run the initialization
   for (size_t i = 0; i < 3; ++i) {
     ActionTesting::next_action<component>(make_not_null(&runner), 0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -186,7 +186,6 @@ struct test_metavariables {
   using evolved_swsh_tags = tmpl::list<Tags::BondiJ>;
   using evolved_swsh_dt_tags = tmpl::list<Tags::BondiH>;
   using cce_step_choosers = tmpl::list<>;
-  static constexpr bool local_time_stepping = false;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
   using cce_boundary_communication_tags =
@@ -259,6 +258,7 @@ SPECTRE_TEST_CASE(
     "[Unit][Cce]") {
   register_classes_with_charm<Cce::Solutions::RotatingSchwarzschild>();
   register_classes_with_charm<RotatingSchwarzschildWithNoninertialNews>();
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   using evolution_component = MockCharacteristicEvolution<test_metavariables>;
   using observation_component = MockObserver<test_metavariables>;
   MAKE_GENERATOR(gen);
@@ -279,16 +279,15 @@ SPECTRE_TEST_CASE(
       l_max, extraction_radius, analytic_solution.get_clone()};
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {start_time, false, l_max, l_max, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
        scri_output_density, true}};
   runner.set_phase(Parallel::Phase::Initialization);
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size, buffer_size,
+      &runner, 0, target_step_size, target_step_size, buffer_size,
       serialize_and_deserialize(analytic_manager));
   ActionTesting::emplace_component<MockObserver<test_metavariables>>(&runner,
                                                                      0);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -155,7 +155,7 @@ struct MockCharacteristicEvolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>,
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -281,7 +281,6 @@ SPECTRE_TEST_CASE(
       {start_time, false, l_max, l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
            std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
        scri_output_density, true}};
   runner.set_phase(Parallel::Phase::Initialization);
   // Serialize and deserialize to get around the lack of implicit copy

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -22,6 +22,7 @@
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace Cce {
 
@@ -177,6 +178,7 @@ void test_klein_gordon_h5_boundary_communication(
   using worldtube_component =
       mock_klein_gordon_h5_worldtube_boundary<test_metavariables>;
   using writer_component = mock_observer_writer<test_metavariables>;
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
 
@@ -214,7 +216,10 @@ void test_klein_gordon_h5_boundary_communication(
       {false, l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(std::nullopt, filename,
                                                   false),
-       start_time, number_of_radial_points}};
+       start_time, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   const size_t buffer_size = 5;
   ActionTesting::set_phase(make_not_null(&runner),
@@ -222,11 +227,7 @@ void test_klein_gordon_h5_boundary_communication(
   ActionTesting::emplace_component_and_initialize<writer_component>(
       &runner, 0, {Parallel::NodeLock{}});
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size);
+      &runner, 0, target_step_size, target_step_size);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -218,8 +218,7 @@ void test_klein_gordon_h5_boundary_communication(
                                                   false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   const size_t buffer_size = 5;
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -89,7 +89,8 @@ struct mock_klein_gordon_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>, Parallel::Actions::TerminatePhase>;
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
+      Parallel::Actions::TerminatePhase>;
   using simple_tags_from_options =
       Parallel::get_simple_tags_from_options<initialize_action_list>;
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -206,8 +206,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -79,7 +79,8 @@ struct mock_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>, Parallel::Actions::TerminatePhase>;
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
+      Parallel::Actions::TerminatePhase>;
   using simple_tags_from_options =
       Parallel::get_simple_tags_from_options<initialize_action_list>;
 

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -40,6 +40,7 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Cce {
@@ -165,6 +166,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
                   "[Unit][Cce]") {
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using worldtube_component = mock_h5_worldtube_boundary<test_metavariables>;
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
 
@@ -202,7 +204,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {false, l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
-       start_time, number_of_radial_points}};
+       start_time, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
@@ -210,11 +215,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
   // chosen step is a predictable value (not subject to roundoff
   // fluctuations in the generated value)
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size * 0.75,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size);
+      &runner, 0, target_step_size * 0.75, target_step_size);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -66,7 +66,8 @@ struct mock_kg_characteristic_evolution {
           typename Metavariables::evolved_swsh_tags, false>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
-      ::Actions::MutateApply<AdvanceTime>, Parallel::Actions::TerminatePhase>;
+      ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,
+      Parallel::Actions::TerminatePhase>;
 
   using simple_tags_from_options =
       Parallel::get_simple_tags_from_options<initialize_action_list>;

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -22,6 +22,7 @@
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
 namespace Cce {
 namespace Actions {
@@ -143,6 +144,7 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
       mock_kg_characteristic_evolution<test_metavariables>;
   using worldtube_component =
       mock_klein_gordon_h5_worldtube_boundary<test_metavariables>;
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   const size_t number_of_radial_points = 10;
   const size_t l_max = 8;
 
@@ -181,7 +183,10 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {false, l_max, extraction_radius,
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
-       start_time, number_of_radial_points}};
+       start_time, number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);
@@ -189,11 +194,7 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
   // chosen step is a predictable value (not subject to roundoff
   // fluctuations in the generated value)
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size * 0.75,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size);
+      &runner, 0, target_step_size * 0.75, target_step_size);
   ActionTesting::emplace_component<worldtube_component>(
       &runner, 0,
       Tags::H5WorldtubeBoundaryDataManager::create_from_options(

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -185,8 +185,7 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>()}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -153,7 +153,7 @@ struct mock_characteristic_evolution {
               Actions::ScriObserveInterpolated<
                   mock_observer<Metavariables>,
                   typename Metavariables::cce_boundary_component, false>,
-              ::Actions::MutateApply<AdvanceTime>>>>;
+              ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>>>>;
 };
 
 struct test_metavariables {

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -279,7 +279,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
        number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
            std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
        scri_output_density, false}};
 
   runner.set_phase(Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -160,7 +160,6 @@ struct test_metavariables {
   using evolved_swsh_tags = tmpl::list<Tags::BondiJ>;
   using evolved_swsh_dt_tags = tmpl::list<Tags::BondiH>;
   using cce_step_choosers = tmpl::list<>;
-  static constexpr bool local_time_stepping = false;
   using evolved_coordinates_variables_tag = ::Tags::Variables<
       tmpl::list<Tags::CauchyCartesianCoords, Tags::InertialRetardedTime>>;
   using cce_boundary_communication_tags =
@@ -249,6 +248,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
                   "[Unit][Cce]") {
   register_classes_with_charm<Cce::Solutions::RotatingSchwarzschild>();
   register_classes_with_charm<Cce::Solutions::TeukolskyWave>();
+  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   using evolution_component = mock_characteristic_evolution<test_metavariables>;
   using observation_component = mock_observer<test_metavariables>;
   pypp::SetupLocalPythonEnvironment local_python_env{
@@ -276,17 +276,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
 
   ActionTesting::MockRuntimeSystem<test_metavariables> runner{
       {start_time, extraction_radius, false, filename, l_max, l_max,
-       number_of_radial_points, scri_output_density, false}};
+       number_of_radial_points,
+       static_cast<std::unique_ptr<LtsTimeStepper>>(
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
+       scri_output_density, false}};
 
   runner.set_phase(Parallel::Phase::Initialization);
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.
   ActionTesting::emplace_component<evolution_component>(
-      &runner, 0, target_step_size,
-      static_cast<std::unique_ptr<LtsTimeStepper>>(
-          std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-      make_vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>(),
-      target_step_size, scri_interpolation_size,
+      &runner, 0, target_step_size, target_step_size, scri_interpolation_size,
       serialize_and_deserialize(analytic_manager));
   if (file_system::check_if_file_exists(filename + ".h5")) {
     file_system::rm(filename + ".h5", true);

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -914,8 +914,7 @@ struct component {
       domain::Tags::ElementMap<Metavariables::volume_dim, Frame::Grid>,
       tmpl::conditional_t<
           Metavariables::local_time_stepping,
-          tmpl::list<::Tags::StepChoosers,
-                     ::Tags::ConcreteTimeStepper<LtsTimeStepper>>,
+          tmpl::list<::Tags::ConcreteTimeStepper<LtsTimeStepper>>,
           tmpl::list<::Tags::ConcreteTimeStepper<TimeStepper>>>>>;
   using common_compute_tags = tmpl::list<
       domain::Tags::JacobianCompute<Metavariables::volume_dim,
@@ -1116,8 +1115,13 @@ void test_impl(const Spectral::Quadrature quadrature,
     }
   }
 
+  const Slab time_slab{0.2, 3.4};
+  const TimeDelta time_step{time_slab, {1, 128}};
+  const TimeStepId time_step_id{true, 3, Time{time_slab, {3, 128}}};
+  const TimeStepId next_time_step_id = time_step_id.next_step(time_step);
+
   MockRuntimeSystem runner = [&dg_formulation, &extents, &south_orientation,
-                              &grid_to_inertial_map]() {
+                              &grid_to_inertial_map, &time_step]() {
     std::vector<DirectionMap<
         Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
         boundary_conditions{2};
@@ -1163,13 +1167,18 @@ void test_impl(const Spectral::Quadrature quadrature,
         1, grid_to_inertial_map->get_clone());
 
     if constexpr (LocalTimeStepping) {
+      std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>
+          step_choosers;
+      step_choosers.emplace_back(
+          std::make_unique<StepChoosers::Constant>(time_step.value()));
       return MockRuntimeSystem{
           {std::vector<std::array<size_t, Dim>>{extents, extents},
            typename metavars::normal_dot_numerical_flux::type{},
            std::move(domain), dg_formulation,
            std::make_unique<BoundaryTerms<Dim, HasPrims>>(),
-           std::move(boundary_conditions), 1e-8}};
+           std::move(boundary_conditions), 1e-8, std::move(step_choosers)}};
     } else {
+      (void)time_step;
       return MockRuntimeSystem{
           {std::vector<std::array<size_t, Dim>>{extents, extents},
            typename metavars::normal_dot_numerical_flux::type{},
@@ -1306,10 +1315,6 @@ void test_impl(const Spectral::Quadrature quadrature,
     return fluxes;
   }();
 
-  const Slab time_slab{0.2, 3.4};
-  const TimeDelta time_step{time_slab, {1, 128}};
-  const TimeStepId time_step_id{true, 3, Time{time_slab, {3, 128}}};
-  const TimeStepId next_time_step_id = time_step_id.next_step(time_step);
   // Our moving mesh map doesn't actually move (we set a mesh velocity, etc.
   // separately), but we need the FunctionsOfTime tag for boundary conditions.
   // When checking boundary conditions we just test that the boundary condition
@@ -1320,133 +1325,62 @@ void test_impl(const Spectral::Quadrature quadrature,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
 
-  if constexpr (metavars::local_time_stepping) {
-    std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>
-        step_choosers;
-    step_choosers.emplace_back(std::make_unique<StepChoosers::Constant>(
-        time_step.value()));
-    ActionTesting::emplace_component_and_initialize<component<metavars>>(
-        &runner, self_id,
-        {time_step_id,
-         next_time_step_id,
-         time_step,
-         time_step_id.step_time().value(),
-         AdaptiveSteppingDiagnostics{},
-         quadrature,
-         evolved_vars,
-         dt_evolved_vars,
-         history,
-         var3,
-         mesh,
-         clone_unique_ptrs(functions_of_time),
-         grid_to_inertial_map->get_clone(),
-         element,
-         neighbor_mesh,
-         inertial_coords,
-         inv_jac,
-         mesh_velocity,
-         div_mesh_velocity,
-         ElementMap<Dim, Frame::Grid>{
-             self_id,
-             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
-                 domain::CoordinateMaps::Identity<Dim>{})},
-         std::move(step_choosers),
-         static_cast<std::unique_ptr<LtsTimeStepper>>(
-             std::make_unique<TimeSteppers::AdamsBashforth>(5))});
-    for (const auto& [direction, neighbor_ids] : neighbors) {
-      (void)direction;
-      for (const auto& neighbor_id : neighbor_ids) {
-        ActionTesting::emplace_component_and_initialize<component<metavars>>(
-            &runner, neighbor_id,
-            {time_step_id,
-             next_time_step_id,
-             time_step,
-             time_step_id.step_time().value(),
-             AdaptiveSteppingDiagnostics{},
-             quadrature,
-             evolved_vars,
-             dt_evolved_vars,
-             history,
-             var3,
-             mesh,
-             clone_unique_ptrs(functions_of_time),
-             grid_to_inertial_map->get_clone(),
-             element,
-             neighbor_mesh,
-             inertial_coords,
-             inv_jac,
-             mesh_velocity,
-             div_mesh_velocity,
-             ElementMap<Dim, Frame::Grid>{
-                 neighbor_id,
-                 domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                  Frame::Grid>(
-                     domain::CoordinateMaps::Identity<Dim>{})},
-             std::move(step_choosers),
-             static_cast<std::unique_ptr<LtsTimeStepper>>(
-                 std::make_unique<TimeSteppers::AdamsBashforth>(5))});
-      }
-    }
-  } else {
-    ActionTesting::emplace_component_and_initialize<component<metavars>>(
-        &runner, self_id,
-        {time_step_id,
-         next_time_step_id,
-         time_step,
-         time_step_id.step_time().value(),
-         AdaptiveSteppingDiagnostics{},
-         quadrature,
-         evolved_vars,
-         dt_evolved_vars,
-         history,
-         var3,
-         mesh,
-         clone_unique_ptrs(functions_of_time),
-         grid_to_inertial_map->get_clone(),
-         element,
-         neighbor_mesh,
-         inertial_coords,
-         inv_jac,
-         mesh_velocity,
-         div_mesh_velocity,
-         ElementMap<Dim, Frame::Grid>{
-             self_id,
-             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
-                 domain::CoordinateMaps::Identity<Dim>{})},
-         static_cast<std::unique_ptr<LtsTimeStepper>>(
-             std::make_unique<TimeSteppers::AdamsBashforth>(5))});
-    for (const auto& [direction, neighbor_ids] : neighbors) {
-      (void)direction;
-      for (const auto& neighbor_id : neighbor_ids) {
-        ActionTesting::emplace_component_and_initialize<component<metavars>>(
-            &runner, neighbor_id,
-            {time_step_id,
-             next_time_step_id,
-             time_step,
-             time_step_id.step_time().value(),
-             AdaptiveSteppingDiagnostics{},
-             quadrature,
-             evolved_vars,
-             dt_evolved_vars,
-             history,
-             var3,
-             mesh,
-             clone_unique_ptrs(functions_of_time),
-             grid_to_inertial_map->get_clone(),
-             element,
-             neighbor_mesh,
-             inertial_coords,
-             inv_jac,
-             mesh_velocity,
-             div_mesh_velocity,
-             ElementMap<Dim, Frame::Grid>{
-                 neighbor_id,
-                 domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                  Frame::Grid>(
-                     domain::CoordinateMaps::Identity<Dim>{})},
-             static_cast<std::unique_ptr<LtsTimeStepper>>(
-                 std::make_unique<TimeSteppers::AdamsBashforth>(5))});
-      }
+  ActionTesting::emplace_component_and_initialize<component<metavars>>(
+      &runner, self_id,
+      {time_step_id,
+       next_time_step_id,
+       time_step,
+       time_step_id.step_time().value(),
+       AdaptiveSteppingDiagnostics{},
+       quadrature,
+       evolved_vars,
+       dt_evolved_vars,
+       history,
+       var3,
+       mesh,
+       clone_unique_ptrs(functions_of_time),
+       grid_to_inertial_map->get_clone(),
+       element,
+       neighbor_mesh,
+       inertial_coords,
+       inv_jac,
+       mesh_velocity,
+       div_mesh_velocity,
+       ElementMap<Dim, Frame::Grid>{
+           self_id,
+           domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+               domain::CoordinateMaps::Identity<Dim>{})},
+       std::make_unique<TimeSteppers::AdamsBashforth>(5)});
+  for (const auto& [direction, neighbor_ids] : neighbors) {
+    (void)direction;
+    for (const auto& neighbor_id : neighbor_ids) {
+      ActionTesting::emplace_component_and_initialize<component<metavars>>(
+          &runner, neighbor_id,
+          {time_step_id,
+           next_time_step_id,
+           time_step,
+           time_step_id.step_time().value(),
+           AdaptiveSteppingDiagnostics{},
+           quadrature,
+           evolved_vars,
+           dt_evolved_vars,
+           history,
+           var3,
+           mesh,
+           clone_unique_ptrs(functions_of_time),
+           grid_to_inertial_map->get_clone(),
+           element,
+           neighbor_mesh,
+           inertial_coords,
+           inv_jac,
+           mesh_velocity,
+           div_mesh_velocity,
+           ElementMap<Dim, Frame::Grid>{
+               neighbor_id,
+               domain::make_coordinate_map_base<Frame::BlockLogical,
+                                                Frame::Grid>(
+                   domain::CoordinateMaps::Identity<Dim>{})},
+           std::make_unique<TimeSteppers::AdamsBashforth>(5)});
     }
   }
 

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -166,6 +166,7 @@ set(LIBRARY_SOURCES
   Test_ExitCode.cpp
   Test_GlobalCacheDataBox.cpp
   Test_InboxInserters.cpp
+  Test_InitializationTag.cpp
   Test_MemoryMonitor.cpp
   Test_MultiReaderSpinlock.cpp
   Test_NodeLock.cpp

--- a/tests/Unit/Parallel/Test_InitializationTag.cpp
+++ b/tests/Unit/Parallel/Test_InitializationTag.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagTraits.hpp"
+#include "Parallel/InitializationTag.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct NormalTag : db::SimpleTag {
+  using type = int;
+};
+
+struct InitTag1 : db::SimpleTag {
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<>;
+};
+
+struct InitTag2 : db::SimpleTag {
+  static constexpr bool pass_metavariables = true;
+  template <typename Metavariables>
+  using option_tags =
+      tmpl::conditional_t<Metavariables::something, tmpl::list<>, tmpl::list<>>;
+};
+
+struct BadInitTag1 : db::SimpleTag {
+  static constexpr bool pass_metavariables = false;
+};
+
+struct BadInitTag2 : db::SimpleTag {
+  using option_tags = tmpl::list<>;
+};
+
+struct BadInitTag3 : db::SimpleTag {
+  static constexpr bool pass_metavariables = true;
+  using option_tags = tmpl::list<>;
+};
+
+struct BadInitTag4 : db::SimpleTag {
+  static constexpr bool pass_metavariables = false;
+  template <typename Metavariables>
+  using option_tags =
+      tmpl::conditional_t<Metavariables::something, tmpl::list<>, tmpl::list<>>;
+};
+
+static_assert(not Parallel::initialization_tag<NormalTag>);
+static_assert(Parallel::initialization_tag<InitTag1>);
+static_assert(Parallel::initialization_tag<InitTag2>);
+
+static_assert(not Parallel::templated_initialization_tag<NormalTag>);
+static_assert(not Parallel::templated_initialization_tag<InitTag1>);
+static_assert(Parallel::templated_initialization_tag<InitTag2>);
+
+static_assert(not Parallel::untemplated_initialization_tag<NormalTag>);
+static_assert(Parallel::untemplated_initialization_tag<InitTag1>);
+static_assert(not Parallel::untemplated_initialization_tag<InitTag2>);
+
+static_assert(not Parallel::initialization_tag<BadInitTag1>);
+static_assert(not Parallel::initialization_tag<BadInitTag2>);
+static_assert(not Parallel::initialization_tag<BadInitTag3>);
+static_assert(not Parallel::initialization_tag<BadInitTag4>);
+}  // namespace

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include "DataStructures/DataBox/Tag.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Options/String.hpp"
 #include "Parallel/CreateFromOptions.hpp"
@@ -260,21 +261,21 @@ namespace Initialization {
 struct MetavariablesGreeting {};
 
 namespace Tags {
-struct Yards {
+struct Yards : db::SimpleTag {
   using option_tags = tmpl::list<OptionTags::Yards>;
   using type = double;
 
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double yards) { return yards; }
 };
-struct Feet {
+struct Feet : db::SimpleTag {
   using option_tags = tmpl::list<OptionTags::Yards>;
   using type = double;
 
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double yards) { return 3.0 * yards; }
 };
-struct Sides {
+struct Sides : db::SimpleTag {
   using option_tags = tmpl::list<OptionTags::Yards, OptionTags::Dim>;
   using type = std::vector<double>;
 
@@ -284,7 +285,7 @@ struct Sides {
     return std::vector<double>(dim, yards);
   }
 };
-struct FullGreeting {
+struct FullGreeting : db::SimpleTag {
   using type = std::string;
 
   static constexpr bool pass_metavariables = true;

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -252,8 +252,15 @@ void emplace_component_and_initialize<true, true>(
        uint64_t{0}, Tags::AdaptiveSteppingDiagnostics::type{}});
 }
 
+template <typename T>
+struct is_initialize : std::false_type {};
+
+template <typename System, template <typename> typename CacheTagPrefix>
+struct is_initialize<SelfStart::Actions::Initialize<System, CacheTagPrefix>>
+    : std::true_type {};
+
 using not_self_start_action = std::negation<std::disjunction<
-    tt::is_a<SelfStart::Actions::Initialize, tmpl::_1>,
+    is_initialize<tmpl::_1>,
     tt::is_a<SelfStart::Actions::CheckForCompletion, tmpl::_1>,
     std::is_same<SelfStart::Actions::CheckForOrderIncrease, tmpl::_1>,
     std::is_same<SelfStart::Actions::Cleanup, tmpl::_1>>>;
@@ -315,8 +322,8 @@ void test_actions(const size_t order, const int step_denominator) {
   {
     INFO("Initialize");
     const bool jumped =
-        run_past<tt::is_a<SelfStart::Actions::Initialize, tmpl::_1>,
-                 not_self_start_action>(make_not_null(&runner));
+        run_past<is_initialize<tmpl::_1>, not_self_start_action>(
+            make_not_null(&runner));
     CHECK(not jumped);
     CHECK(ActionTesting::get_databox_tag<Component<Metavariables<>>,
                                          Tags::StepNumberWithinSlab>(runner,

--- a/tests/Unit/Time/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Test_AdvanceTime.cpp
@@ -71,7 +71,7 @@ void check(std::unique_ptr<TimeStepper> time_stepper,
             db::get<Tags::TimeStepId>(box).substep_time());
       CHECK(db::get<Tags::StepNumberWithinSlab>(box) ==
             step_number_within_slab);
-      db::mutate_apply<AdvanceTime>(make_not_null(&box));
+      db::mutate_apply<AdvanceTime<>>(make_not_null(&box));
     }
     if (current_slab_number ==
         db::get<Tags::AdaptiveSteppingDiagnostics>(box).number_of_slabs) {


### PR DESCRIPTION
This makes the CCE code more similar to the other evolution systems.  It resolves a DataBox conflict that we would hit if we try to create a new combined GH/CCE executable, and allows some tags to be added in more specific places, rather than general initialization actions.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
When running a CCE evolution, the input file options `MinimumTimeStep` and `VariableOrderAlgorithm` have moved from the top-level `Evolution` section to the `Evolution` section under `Cce`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
