### PR TITLE
Split NaN initialization from SPECTRE_DEBUG

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -27,6 +27,14 @@ if(${SPECTRE_DEBUG})
     APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS SPECTRE_DEBUG)
 endif()
 
+option(SPECTRE_NAN_INIT "Initialize memory to NaN is various places"
+  ${SPECTRE_DEBUG})
+
+if(${SPECTRE_NAN_INIT})
+  set_property(TARGET SpectreFlags
+    APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS SPECTRE_NAN_INIT)
+endif()
+
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSPECTRE_DEBUG")
 
 if(${SPECTRE_OPTIMIZE_SIZE})
@@ -176,3 +184,9 @@ else()
     SpectreFpExceptions
     )
 endif()
+
+file(APPEND
+  "${CMAKE_BINARY_DIR}/BuildInfo.txt"
+  "SPECTRE_DEBUG: ${SPECTRE_DEBUG}\n"
+  "SPECTRE_NAN_INIT: ${SPECTRE_NAN_INIT}\n"
+  )

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -194,6 +194,10 @@ alphabetical order):
     and compiler optimizations. You cannot disable the checks in Debug builds,
     so this option has no effect in Debug builds.
     (default is `OFF` in release)
+- SPECTRE_NAN_INIT
+  - Defines `SPECTRE_NAN_INIT` macro to initialize memory to NaN in various
+    places to catch use of uninitialized values.
+    (default is the value of `SPECTRE_DEBUG`, or `ON` in Debug builds)
 - SPECTRE_OPTIMIZE_SIZE
   - Optimize for executable size instead of speed (adds the `-Oz` compiler
     flag). The default is `OFF`, unless on Apple Silicon machines, where the

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -84,8 +84,8 @@ class Variables;
  * performing one memory allocation for all the `Tensor`s. The advantage is that
  * memory allocations are quite expensive, especially in a parallel environment.
  *
- * In Debug mode, or if the macro `SPECTRE_NAN_INIT` is defined, the contents
- * are initialized with `NaN`s.
+ * If the macro `SPECTRE_NAN_INIT` is defined, the contents are
+ * initialized with `NaN`s.
  *
  * `Variables` stores the data it owns in a `std::unique_ptr<double[]>`
  * instead of a `std::vector` because `std::vector` value-initializes its
@@ -678,10 +678,10 @@ void Variables<tmpl::list<Tags...>>::initialize(
           cpp20::make_unique_for_overwrite<value_type[]>(size_);
     }
     add_reference_variable_data();
-#if defined(SPECTRE_DEBUG) || defined(SPECTRE_NAN_INIT)
+#if defined(SPECTRE_NAN_INIT)
     std::fill(variable_data_.data(), variable_data_.data() + size_,
               make_signaling_NaN<value_type>());
-#endif  // SPECTRE_DEBUG
+#endif  // SPECTRE_NAN_INIT
   }
 }
 

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -130,9 +130,9 @@ constexpr size_t default_vector_impl_static_size = 0;
  *  vector types in math expressions.
  *
  * \note
- * - If either `SPECTRE_DEBUG` or `SPECTRE_NAN_INIT` are defined, then the
- *   `VectorImpl` is default initialized to `signaling_NaN()`. Otherwise, the
- *   vector is filled with uninitialized memory for performance.
+ * - If `SPECTRE_NAN_INIT` is defined, then the `VectorImpl` is default
+ *   initialized to `signaling_NaN()`. Otherwise, the vector is filled with
+ *   uninitialized memory for performance.
  */
 template <typename T, typename VectorType,
           size_t StaticSize = default_vector_impl_static_size>
@@ -184,10 +184,10 @@ class VectorImpl
   explicit VectorImpl(size_t set_size)
       : owned_data_(heap_alloc_if_necessary(set_size)) {
     reset_pointer_vector(set_size);
-#if defined(SPECTRE_DEBUG) || defined(SPECTRE_NAN_INIT)
+#if defined(SPECTRE_NAN_INIT)
     std::fill(data(), data() + set_size,
               std::numeric_limits<value_type>::signaling_NaN());
-#endif  // SPECTRE_DEBUG
+#endif  // SPECTRE_NAN_INIT
   }
 
   /// Create with the given size and value.

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -519,7 +519,7 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping,
        DgPackagedDataVarsOnFace::number_of_independent_components) *
           num_face_temporary_grid_points;
   auto buffer = cpp20::make_unique_for_overwrite<double[]>(buffer_size);
-#ifdef SPECTRE_DEBUG
+#ifdef SPECTRE_NAN_INIT
   std::fill(&buffer[0], &buffer[buffer_size],
             std::numeric_limits<double>::signaling_NaN());
 #endif

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodImpl.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodImpl.cpp
@@ -78,11 +78,11 @@ bool minmod_limited_slopes(
 
     if (not u_needs_limiting) {
       // Skip the limiting step for this tensor component
-#ifdef SPECTRE_DEBUG
+#ifdef SPECTRE_NAN_INIT
       *u_mean = std::numeric_limits<double>::signaling_NaN();
       *u_limited_slopes =
           make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
-#endif  // ifdef SPECTRE_DEBUG
+#endif  // ifdef SPECTRE_NAN_INIT
       return false;
     }
   }  // end if LambdaPiN
@@ -162,7 +162,7 @@ bool minmod_limited_slopes(
     }
   }
 
-#ifdef SPECTRE_DEBUG
+#ifdef SPECTRE_NAN_INIT
   // Guard against incorrect use of returned (by reference) slopes in a
   // LambdaPiN limiter, by setting these to NaN when they should not be used.
   if (minmod_type == Limiters::MinmodType::LambdaPiN and
@@ -171,7 +171,7 @@ bool minmod_limited_slopes(
     *u_limited_slopes =
         make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
   }
-#endif  // ifdef SPECTRE_DEBUG
+#endif  // ifdef SPECTRE_NAN_INIT
 
   return slopes_need_reducing;
 }


### PR DESCRIPTION
Defaults to the same state as SPECTRE_DEBUG to preserve old behavior, but can be toggled separately.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
