### PR TITLE
Observe worldtube data before updating values

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -115,7 +115,7 @@ struct WorldtubeSingleton {
                      Parallel::Actions::TerminatePhase>>,
       Parallel::PhaseActions<
           Parallel::Phase::Evolve,
-          tmpl::list<step_actions, Actions::ObserveWorldtubeSolution,
+          tmpl::list<Actions::ObserveWorldtubeSolution, step_actions,
                      ::Actions::MutateApply<AdvanceTime>,
                      PhaseControl::Actions::ExecutePhaseChange>>>;
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Currently, the worldtube solution is observed after the values have been updated but before the time is incremented. This means that the observation time and the observation values are off by a time step. This PR changes the observation to happen before the values are updated to the next time step


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
