### PR TITLE
Add custom launch command for machines in login node.

### DIFF
--- a/support/Machines/CaltechHpc.yaml
+++ b/support/Machines/CaltechHpc.yaml
@@ -13,3 +13,4 @@ Machine:
   DefaultQueue: "expansion"
   DefaultTimeLimit: "1-00:00:00"
   LaunchCommandSingleNode: ["mpirun", "-n", "1"]
+  LaunchCommandLoginNode: []

--- a/support/Machines/Mbot.yaml
+++ b/support/Machines/Mbot.yaml
@@ -12,3 +12,4 @@ Machine:
   DefaultQueue: "normal"
   DefaultTimeLimit: "1-00:00:00"
   LaunchCommandSingleNode: ["mpirun", "-n", "1"]
+  LaunchCommandLoginNode: ["mpirun", "-n", "1"]

--- a/support/Machines/Ocean2.yaml
+++ b/support/Machines/Ocean2.yaml
@@ -12,3 +12,4 @@ Machine:
   DefaultQueue: "normal"
   DefaultTimeLimit: "01-00:00:00"
   LaunchCommandSingleNode: []
+  LaunchCommandLoginNode: []

--- a/support/Machines/Ocean2_orca1.yaml
+++ b/support/Machines/Ocean2_orca1.yaml
@@ -13,3 +13,4 @@ Machine:
   DefaultQueue: "orca-1"
   DefaultTimeLimit: "01-00:00:00"
   LaunchCommandSingleNode: []
+  LaunchCommandLoginNode: []

--- a/support/Machines/Oscar.yaml
+++ b/support/Machines/Oscar.yaml
@@ -13,3 +13,4 @@ Machine:
   DefaultQueue: "batch"
   DefaultTimeLimit: "1-00:00:00"
   LaunchCommandSingleNode: ["mpirun", "-n", "1"]
+  LaunchCommandLoginNode: []

--- a/support/Machines/Perlmutter.yaml
+++ b/support/Machines/Perlmutter.yaml
@@ -11,3 +11,5 @@ Machine:
   DefaultProcsPerTask: 32
   DefaultQueue: "regular"
   DefaultTimeLimit: "1-00:00:00"
+  LaunchCommandSingleNode: []
+  LaunchCommandLoginNode: []

--- a/support/Machines/Sonic.yaml
+++ b/support/Machines/Sonic.yaml
@@ -12,3 +12,4 @@ Machine:
   DefaultQueue: "long"
   DefaultTimeLimit: "1-00:00:00"
   LaunchCommandSingleNode: ["mpirun", "-n", "1"]
+  LaunchCommandLoginNode: []

--- a/support/Machines/Urania.yaml
+++ b/support/Machines/Urania.yaml
@@ -9,3 +9,4 @@ Machine:
   DefaultQueue: "p.urania"
   DefaultTimeLimit: "1-00:00:00"
   LaunchCommandSingleNode: ["srun", "-n", "1"]
+  LaunchCommandLoginNode: []

--- a/support/Machines/Viper.yaml
+++ b/support/Machines/Viper.yaml
@@ -9,3 +9,4 @@ Machine:
   DefaultQueue: "p.general"
   DefaultTimeLimit: "1-00:00:00"
   LaunchCommandSingleNode: ["srun", "-n", "1"]
+  LaunchCommandLoginNode: []

--- a/support/Python/Machines.py
+++ b/support/Python/Machines.py
@@ -57,6 +57,9 @@ class Machine(yaml.YAMLObject):
         to launch an executable in scheduled jobs, which can be found in the
         submit script instead. This is also not used on non-compute (login)
         nodes.
+      LaunchCommandLoginNode: Command to launch an executable on a the
+        login node. This is the counterpart to `LaunchCommandSingleNode` which
+        is to be used as a prefix for commands run on non-compute (login) nodes.
     """
 
     yaml_tag = "!Machine"
@@ -69,6 +72,7 @@ class Machine(yaml.YAMLObject):
     DefaultQueue: str
     DefaultTimeLimit: str
     LaunchCommandSingleNode: List[str]
+    LaunchCommandLoginNode: List[str]
 
     def on_compute_node(self) -> bool:
         """Determines whether or not we are running on a compute node."""
@@ -83,7 +87,7 @@ class Machine(yaml.YAMLObject):
         if self.on_compute_node():
             return self.LaunchCommandSingleNode
         else:
-            return []
+            return self.LaunchCommandLoginNode
 
 
 # Parse YAML machine files as Machine objects

--- a/tests/support/Python/Test_Machines.py
+++ b/tests/support/Python/Test_Machines.py
@@ -25,7 +25,8 @@ class TestMachines(unittest.TestCase):
                         DefaultProcsPerTask=15,
                         DefaultQueue="production",
                         DefaultTimeLimit="1-00:00:00",
-                        LaunchCommandSingleNode=["mpirun", "-n", "1"],
+                        LaunchCommandSingleNode=["mpirun", "-n", "2"],
+                        LaunchCommandLoginNode=["mpirun", "-n", "1"],
                     )
                 ),
                 open_machinefile,
@@ -45,10 +46,15 @@ class TestMachines(unittest.TestCase):
         self.assertEqual(machine.DefaultProcsPerTask, 15)
         self.assertEqual(machine.DefaultQueue, "production")
         self.assertEqual(machine.DefaultTimeLimit, "1-00:00:00")
-        self.assertEqual(machine.LaunchCommandSingleNode, ["mpirun", "-n", "1"])
+        self.assertEqual(machine.LaunchCommandSingleNode, ["mpirun", "-n", "2"])
+        self.assertEqual(machine.LaunchCommandLoginNode, ["mpirun", "-n", "1"])
         self.assertEqual(
             machine.launch_command,
-            ["mpirun", "-n", "1"] if machine.on_compute_node() else [],
+            (
+                ["mpirun", "-n", "2"]
+                if machine.on_compute_node()
+                else ["mpirun", "-n", "1"]
+            ),
         )
 
 


### PR DESCRIPTION
## Proposed changes

Adds the option to use custom launch commands for login nodes in the SpECTRE Python interface. The Python interface sometimes needs to use specific launch commands to run executables to run properly on certain machines (_e.g._ adding `mpirun -n 1` in front of the executable). This was implemented for compute nodes, but not for login nodes. Due to a recent strange issue on mbot, this is now necessary for login nodes as well.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
