### PR TITLE
Add EnforceConstrainedEvolution mutator to SoCcz4

### DIFF
--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   ApplyFilter.cpp
   Derivatives.cpp
   DummyReconstructor.cpp
+  EnforceConstrainedEvolution.cpp
   Filter.cpp
   Reconstructor.cpp
   )
@@ -23,6 +24,7 @@ spectre_target_headers(
   BoundaryConditionGhostData.hpp
   Derivatives.hpp
   DummyReconstructor.hpp
+  EnforceConstrainedEvolution.hpp
   Filter.hpp
   Reconstructor.hpp
   SoTimeDerivative.hpp

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/EnforceConstrainedEvolution.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/EnforceConstrainedEvolution.cpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/EnforceConstrainedEvolution.hpp"
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Ccz4/TempTags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+
+void EnforceConstrainedEvolution::apply(
+    const gsl::not_null<tnsr::ii<DataVector, dim>*> conformal_spatial_metric,
+    const gsl::not_null<tnsr::ii<DataVector, dim>*> a_tilde,
+    const bool constrained_evolution) {
+  if (constrained_evolution) {
+    // Allocate shared storage for temporaries in one block using existing tags
+    Variables<tmpl::list<Ccz4::Tags::DetConformalSpatialMetric<DataVector>,
+                         Ccz4::Tags::TraceATilde<DataVector>,
+                         Ccz4::Tags::InverseConformalMetric<DataVector, dim>>>
+        temporaries((conformal_spatial_metric->get(0, 0)).size());
+
+    auto& det_conformal_spatial_metric =
+        get<Ccz4::Tags::DetConformalSpatialMetric<DataVector>>(temporaries);
+    auto& trace_a_tilde = get<Ccz4::Tags::TraceATilde<DataVector>>(temporaries);
+    auto& inv_conformal_spatial_metric =
+        get<Ccz4::Tags::InverseConformalMetric<DataVector, dim>>(temporaries);
+
+    determinant(make_not_null(&det_conformal_spatial_metric),
+                *conformal_spatial_metric);
+    ASSERT(min(get(det_conformal_spatial_metric)) > 0.0,
+           "The determinant of the conformal spatial metric is non-positive: "
+               << get(det_conformal_spatial_metric));
+    get(det_conformal_spatial_metric) =
+        pow(get(det_conformal_spatial_metric), -1.0 / 3.0);
+    ::tenex::update<ti::i, ti::j>(
+        conformal_spatial_metric,
+        det_conformal_spatial_metric() *
+            (*conformal_spatial_metric)(ti::i, ti::j));
+
+    determinant_and_inverse(make_not_null(&det_conformal_spatial_metric),
+                            make_not_null(&inv_conformal_spatial_metric),
+                            *conformal_spatial_metric);
+    ::tenex::evaluate(make_not_null(&trace_a_tilde),
+                      (inv_conformal_spatial_metric)(ti::I, ti::J) *
+                          (*a_tilde)(ti::i, ti::j));
+    ::tenex::update<ti::i, ti::j>(
+        a_tilde,
+        (*a_tilde)(ti::i, ti::j) -
+            trace_a_tilde() * (*conformal_spatial_metric)(ti::i, ti::j) / 3.);
+  }
+}
+
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/EnforceConstrainedEvolution.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/EnforceConstrainedEvolution.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+/*!
+ * \brief Mutator to enforce constrained evolution after every time step
+ *
+ * Togglable option in input file via option tag defined in Ccz4::fd::Tags.
+ * If constrained_evolution is true, enforce
+ * the unit determinant constraint on the conformal spatial metric
+ * and traceless constraint on the ATilde
+ */
+struct EnforceConstrainedEvolution : tt::ConformsTo<db::protocols::Mutator> {
+  static constexpr size_t dim = System::volume_dim;
+  using return_tags = tmpl::list<::Ccz4::Tags::ConformalMetric<DataVector, dim>,
+                                 ::Ccz4::Tags::ATilde<DataVector, dim>>;
+  using argument_tags = tmpl::list<::Ccz4::fd::Tags::ConstrainedEvolution>;
+
+  static void apply(
+      gsl::not_null<tnsr::ii<DataVector, dim>*> conformal_spatial_metric,
+      gsl::not_null<tnsr::ii<DataVector, dim>*> a_tilde,
+      bool constrained_evolution);
+};
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
@@ -194,9 +194,9 @@ static void apply(
                        (*inv_conformal_spatial_metric)(ti::I, ti::K) *
                        (*inv_conformal_spatial_metric)(ti::J, ti::L));
 
-  if (min(get(lapse)) <= 0.0) {
-    ERROR("The lapse must be positive when using 1+log slicing.");
-  }
+  ASSERT(min(get(lapse)) > 0.0,
+         "The lapse must be positive when using 1+log slicing but is: "
+             << get(lapse));
 
   // slicing_condition and d_slicing_condition is not used in SO-CCZ4
   // \alpha g(\alpha)  == 2

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   FiniteDifference/Test_BoundaryConditionGhostData.cpp
   FiniteDifference/Test_Derivatives.cpp
   FiniteDifference/Test_DummyReconstructor.cpp
+  FiniteDifference/Test_EnforceConstrainedEvolution.cpp
   FiniteDifference/Test_Filter.cpp
   FiniteDifference/Test_SoTimeDerivative.cpp
   FiniteDifference/Test_Tags.cpp

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_EnforceConstrainedEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_EnforceConstrainedEvolution.cpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/EnforceConstrainedEvolution.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Ccz4::fd {
+namespace {
+
+void test(bool constrained_evolution) {
+  constexpr size_t dim = System::volume_dim;
+  const size_t num_pts = 5;
+  auto conformal_spatial_metric =
+      make_with_value<tnsr::ii<DataVector, dim>>(num_pts, 0.);
+  auto a_tilde = make_with_value<tnsr::ii<DataVector, dim>>(num_pts, 0.);
+
+  for (size_t i = 0; i < dim; ++i) {
+    conformal_spatial_metric.get(i, i) = DataVector{num_pts, 2.};
+    a_tilde.get(i, i) = DataVector{num_pts, 1.};
+  }
+
+  auto box = db::create<
+      db::AddSimpleTags<::Ccz4::fd::Tags::ConstrainedEvolution,
+                        ::Ccz4::Tags::ConformalMetric<DataVector, dim>,
+                        ::Ccz4::Tags::ATilde<DataVector, dim>>>(
+      constrained_evolution, conformal_spatial_metric, a_tilde);
+
+  for (size_t i = 0; i < dim; ++i) {
+    for (size_t j = i; j < dim; ++j) {
+      if (i == j) {
+        CHECK_ITERABLE_APPROX(
+            (get<::Ccz4::Tags::ConformalMetric<DataVector, dim>>(box))
+                .get(i, j),
+            (DataVector{num_pts, 2.}));
+        CHECK_ITERABLE_APPROX(
+            (get<::Ccz4::Tags::ATilde<DataVector, dim>>(box)).get(i, j),
+            (DataVector{num_pts, 1.}));
+      } else {
+        CHECK_ITERABLE_APPROX(
+            (get<::Ccz4::Tags::ConformalMetric<DataVector, dim>>(box))
+                .get(i, j),
+            (DataVector{num_pts, 0.}));
+        CHECK_ITERABLE_APPROX(
+            (get<::Ccz4::Tags::ATilde<DataVector, dim>>(box)).get(i, j),
+            (DataVector{num_pts, 0.}));
+      }
+    }
+  }
+
+  db::mutate_apply<EnforceConstrainedEvolution>(make_not_null(&box));
+
+  for (size_t i = 0; i < dim; ++i) {
+    if (get<::Ccz4::fd::Tags::ConstrainedEvolution>(box)) {
+      conformal_spatial_metric.get(i, i) = DataVector{num_pts, 1.};
+      a_tilde.get(i, i) = DataVector{num_pts, 0.};
+    } else {
+      conformal_spatial_metric.get(i, i) = DataVector{num_pts, 2.};
+      a_tilde.get(i, i) = DataVector{num_pts, 1.};
+    }
+  }
+  for (size_t i = 0; i < dim; ++i) {
+    for (size_t j = i; j < dim; ++j) {
+      CHECK_ITERABLE_APPROX(
+          (get<::Ccz4::Tags::ConformalMetric<DataVector, dim>>(box)).get(i, j),
+          conformal_spatial_metric.get(i, j));
+      CHECK_ITERABLE_APPROX(
+          (get<::Ccz4::Tags::ATilde<DataVector, dim>>(box)).get(i, j),
+          a_tilde.get(i, j));
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Fd.ECE", "[Unit][Evolution]") {
+  test(true);
+  test(false);
+}
+}  // namespace
+}  // namespace Ccz4::fd


### PR DESCRIPTION
## Proposed changes
Add EnforceConstrainedEvolution mutator to SoCcz4. This mutator is used to rescale the conformal spatial metric to unit determinant and remove trace from ATilde after each time step.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
