### PR TITLE
Select l_max automatically in the Shape map according to a truncation limit

### DIFF
--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.cpp
@@ -32,6 +32,37 @@
 
 namespace domain::CoordinateMaps::TimeDependent {
 
+using ylm::Spherepack;
+using ylm::SpherepackIterator;
+
+size_t lmax_from_coefs(const DataVector& coefs) {
+  const size_t num_coefs = coefs.size();
+  const auto l_max =
+      static_cast<size_t>(sqrt(static_cast<double>(num_coefs) / 2) - 1);
+  ASSERT(square(l_max + 1) * 2 == num_coefs,
+         "Number of shape coefficients ("
+             << num_coefs << ") is not of valid size 2(l_max+1)(l_max+1).");
+  ASSERT(l_max >= 2, "l_max must be at least 2.");
+  return l_max;
+}
+
+DataVector truncate_coefs(const DataVector& coefs, SpherepackIterator iterator,
+                          SpherepackIterator truncated_iterator) {
+  DataVector truncated_coefs(truncated_iterator.spherepack_array_size(), 0.0);
+  for (truncated_iterator.reset(); truncated_iterator; ++truncated_iterator) {
+    const size_t l = truncated_iterator.l();
+    const size_t m = truncated_iterator.m();
+    // If the requested truncation order exceeds the available coefficients,
+    // leave the entry at zero.
+    if (l > iterator.l_max() or m > iterator.m_max()) {
+      continue;
+    }
+    iterator.set(l, m, truncated_iterator.coefficient_array());
+    truncated_coefs[truncated_iterator()] = coefs[iterator()];
+  }
+  return truncated_coefs;
+}
+
 template <typename T>
 std::array<T, 2> cartesian_to_spherical(const std::array<T, 3>& cartesian) {
   const auto& [x, y, z] = cartesian;
@@ -50,17 +81,16 @@ void Shape::jacobian_helper(
     gsl::not_null<tnsr::Ij<T, 3, Frame::NoFrame>*> result,
     const ylm::Spherepack::InterpolationInfo<T>& interpolation_info,
     const DataVector& extended_coefs, const std::array<T, 3>& centered_coords,
-    const T& radial_distortion, const T& transition_func) const {
-  const auto angular_gradient =
-      extended_ylm_.gradient_from_coefs(extended_coefs);
-
+    const T& radial_distortion, const T& transition_func,
+    const Spherepack& ylm) const {
+  const auto angular_gradient = ylm.gradient_from_coefs(extended_coefs);
   tnsr::i<DataVector, 3, Frame::Inertial> cartesian_gradient(
-      extended_ylm_.physical_size());
+      ylm.physical_size());
 
   std::array<DataVector, 2> collocation_theta_phis{};
   collocation_theta_phis[0].set_data_ref(&get<2>(cartesian_gradient));
   collocation_theta_phis[1].set_data_ref(&get<1>(cartesian_gradient));
-  collocation_theta_phis = extended_ylm_.theta_phi_points();
+  collocation_theta_phis = ylm.theta_phi_points();
 
   const auto& col_thetas = collocation_theta_phis[0];
   const auto& col_phis = collocation_theta_phis[1];
@@ -92,9 +122,8 @@ void Shape::jacobian_helper(
 
     // interpolate the cartesian gradient to the thetas and phis of the
     // `source_coords`
-    extended_ylm_.interpolate(make_not_null(&gsl::at(target_gradient, i)),
-                              cartesian_gradient.get(i).data(),
-                              interpolation_info);
+    ylm.interpolate(make_not_null(&gsl::at(target_gradient, i)),
+                    cartesian_gradient.get(i).data(), interpolation_info);
   }
 
   // G / r
@@ -119,7 +148,7 @@ void Shape::jacobian_helper(
 }
 
 Shape::Shape(
-    const std::array<double, 3>& center, const size_t l_max, const size_t m_max,
+    const std::array<double, 3>& center, const double truncation_limit,
     std::unique_ptr<ShapeMapTransitionFunctions::ShapeMapTransitionFunction>
         transition_func,
     std::string shape_function_of_time_name,
@@ -127,19 +156,12 @@ Shape::Shape(
     : shape_f_of_t_name_(std::move(shape_function_of_time_name)),
       size_f_of_t_name_(std::move(size_function_of_time_name)),
       center_(center),
-      l_max_(l_max),
-      m_max_(m_max),
-      ylm_(l_max, m_max),
-      extended_ylm_(l_max + 1, m_max + 1),
+      truncation_limit_(truncation_limit),
       transition_func_(std::move(transition_func)) {
   f_of_t_names_.insert(shape_f_of_t_name_);
   if (size_f_of_t_name_.has_value()) {
     f_of_t_names_.insert(size_f_of_t_name_.value());
   }
-  ASSERT(l_max >= 2, "The shape map requires l_max >= 2 but l_max = " << l_max);
-  ASSERT(m_max >= 2, "The shape map requires m_max >= 2 but m_max = " << m_max);
-  ASSERT(l_max >= m_max, "The shape map requires l_max >= m_max but l_max = "
-                             << l_max << ", m_max = " << m_max);
 }
 
 Shape& Shape::operator=(const Shape& rhs) {
@@ -148,10 +170,7 @@ Shape& Shape::operator=(const Shape& rhs) {
     size_f_of_t_name_ = rhs.size_f_of_t_name_;
     f_of_t_names_ = rhs.f_of_t_names_;
     center_ = rhs.center_;
-    l_max_ = rhs.l_max_;
-    m_max_ = rhs.m_max_;
-    ylm_ = rhs.ylm_;
-    extended_ylm_ = rhs.extended_ylm_;
+    truncation_limit_ = rhs.truncation_limit_;
     transition_func_ = rhs.transition_func_->get_clone();
   }
   return *this;
@@ -165,15 +184,24 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::operator()(
     const FunctionsOfTimeMap& functions_of_time) const {
   const auto centered_coords = center_coordinates(source_coords);
   auto theta_phis = cartesian_to_spherical(centered_coords);
-  const auto interpolation_info = ylm_.set_up_interpolation_info(theta_phis);
-  DataVector coefs = functions_of_time.at(shape_f_of_t_name_)->func(time)[0];
-  check_size(make_not_null(&coefs), functions_of_time, time, false);
-  check_coefficients(coefs);
+  const auto [coefs, coef_derivs, coef_dderivs] =
+      functions_of_time.at(shape_f_of_t_name_)->func_and_2_derivs(time);
+  const size_t l_max = lmax_from_coefs(coefs);
+  const SpherepackIterator full_iterator{l_max, l_max};
+  const size_t truncated_l_max =
+      find_truncated_l_max(coefs, coef_derivs, coef_dderivs, full_iterator);
+  const SpherepackIterator truncated_iterator{truncated_l_max, truncated_l_max};
+  DataVector truncated_coefs =
+      truncate_coefs(coefs, full_iterator, truncated_iterator);
+  check_size(make_not_null(&truncated_coefs), functions_of_time, time, false);
+  const ylm::Spherepack ylm{truncated_l_max, truncated_l_max};
+
   // re-use allocation
   auto& radial_distortion = get<0>(theta_phis);
+  const auto interpolation_info = ylm.set_up_interpolation_info(theta_phis);
   // evaluate the spherical harmonic expansion at the angles of `source_coords`
-  ylm_.interpolate_from_coefs(make_not_null(&radial_distortion), coefs,
-                              interpolation_info);
+  ylm.interpolate_from_coefs(make_not_null(&radial_distortion), truncated_coefs,
+                             interpolation_info);
 
   // this should be taken care of by the control system but is very hard to
   // debug
@@ -204,11 +232,19 @@ std::optional<std::array<double, 3>> Shape::inverse(
       center_coordinates(target_coords);
   const std::array<double, 2> theta_phis =
       cartesian_to_spherical(centered_coords);
-  DataVector coefs = functions_of_time.at(shape_f_of_t_name_)->func(time)[0];
-  check_size(make_not_null(&coefs), functions_of_time, time, false);
-  check_coefficients(coefs);
+  const auto [coefs, coef_derivs, coef_dderivs] =
+      functions_of_time.at(shape_f_of_t_name_)->func_and_2_derivs(time);
+  const size_t l_max = lmax_from_coefs(coefs);
+  const SpherepackIterator full_iterator{l_max, l_max};
+  const size_t truncated_l_max =
+      find_truncated_l_max(coefs, coef_derivs, coef_dderivs, full_iterator);
+  const SpherepackIterator truncated_iterator{truncated_l_max, truncated_l_max};
+  DataVector truncated_coefs =
+      truncate_coefs(coefs, full_iterator, truncated_iterator);
+  check_size(make_not_null(&truncated_coefs), functions_of_time, time, false);
+  const ylm::Spherepack ylm{truncated_l_max, truncated_l_max};
   const double radial_distortion =
-      ylm_.interpolate_from_coefs(coefs, theta_phis);
+      ylm.interpolate_from_coefs(truncated_coefs, theta_phis);
   const std::optional<double> original_radius_over_radius =
       transition_func_->original_radius_over_radius(centered_coords,
                                                     radial_distortion);
@@ -224,15 +260,23 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Shape::frame_velocity(
     const FunctionsOfTimeMap& functions_of_time) const {
   const auto centered_coords = center_coordinates(source_coords);
   auto theta_phis = cartesian_to_spherical(centered_coords);
-  const auto interpolation_info = ylm_.set_up_interpolation_info(theta_phis);
-  DataVector coef_derivs =
-      functions_of_time.at(shape_f_of_t_name_)->func_and_deriv(time)[1];
-  check_size(make_not_null(&coef_derivs), functions_of_time, time, true);
-  check_coefficients(coef_derivs);
+  const auto [coefs, coef_derivs, coef_dderivs] =
+      functions_of_time.at(shape_f_of_t_name_)->func_and_2_derivs(time);
+  const size_t l_max = lmax_from_coefs(coefs);
+  const SpherepackIterator full_iterator{l_max, l_max};
+  const size_t truncated_l_max =
+      find_truncated_l_max(coefs, coef_derivs, coef_dderivs, full_iterator);
+  const SpherepackIterator truncated_iterator{truncated_l_max, truncated_l_max};
+  DataVector truncated_coef_derivs =
+      truncate_coefs(coef_derivs, full_iterator, truncated_iterator);
+  check_size(make_not_null(&truncated_coef_derivs), functions_of_time, time,
+             true);
+  const ylm::Spherepack ylm{truncated_l_max, truncated_l_max};
+  const auto interpolation_info = ylm.set_up_interpolation_info(theta_phis);
   // re-use allocation
   auto& radii_velocities = get<0>(theta_phis);
-  ylm_.interpolate_from_coefs(make_not_null(&radii_velocities), coef_derivs,
-                              interpolation_info);
+  ylm.interpolate_from_coefs(make_not_null(&radii_velocities),
+                             truncated_coef_derivs, interpolation_info);
   return -centered_coords * radii_velocities *
          transition_func_->operator()(centered_coords, std::nullopt);
 }
@@ -245,38 +289,25 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
 
   // The distorted radii are calculated analogously to the call operator
   auto theta_phis = cartesian_to_spherical(centered_coords);
-
-  // The Cartesian gradient cannot be represented exactly by `l_max_` and
-  // `m_max_` which causes an aliasing error. We need an additional order to
-  // represent it. This is in theory not needed for the radial_distortion
-  // calculation but saves calculating the `interpolation_info` twice.
-  const auto interpolation_info =
-      extended_ylm_.set_up_interpolation_info(theta_phis);
-
-  const DataVector coefs =
-      functions_of_time.at(shape_f_of_t_name_)->func(time)[0];
-  check_coefficients(coefs);
-  DataVector extended_coefs(extended_ylm_.spectral_size(), 0.);
-
-  // Copy over the coefficients. The additional coefficients of order `l_max_
-  // +1` are zero and will only have an effect in the interpolation of the
-  // cartesian gradient.
-  ylm::SpherepackIterator extended_iter(l_max_ + 1, m_max_ + 1);
-  ylm::SpherepackIterator iter(l_max_, m_max_);
-  for (size_t l = 0; l <= l_max_; ++l) {
-    const int m_max = static_cast<int>(std::min(l, m_max_));
-    for (int m = -m_max; m <= m_max; ++m) {
-      iter.set(l, m);
-      extended_iter.set(l, m);
-      extended_coefs[extended_iter()] = coefs[iter()];
-    }
-  }
-  check_size(make_not_null(&extended_coefs), functions_of_time, time, false);
+  const auto [coefs, coef_derivs, coef_dderivs] =
+      functions_of_time.at(shape_f_of_t_name_)->func_and_2_derivs(time);
+  const size_t l_max = lmax_from_coefs(coefs);
+  const SpherepackIterator full_iterator{l_max, l_max};
+  size_t truncated_l_max =
+      find_truncated_l_max(coefs, coef_derivs, coef_dderivs, full_iterator);
+  // we need an additional l_max to compute the gradient without aliasing error
+  truncated_l_max += 1;
+  const SpherepackIterator truncated_iterator{truncated_l_max, truncated_l_max};
+  DataVector truncated_coefs =
+      truncate_coefs(coefs, full_iterator, truncated_iterator);
+  check_size(make_not_null(&truncated_coefs), functions_of_time, time, false);
+  const ylm::Spherepack ylm{truncated_l_max, truncated_l_max};
+  const auto interpolation_info = ylm.set_up_interpolation_info(theta_phis);
 
   // Re-use allocation
   auto& radial_distortion = get<0>(theta_phis);
-  extended_ylm_.interpolate_from_coefs(make_not_null(&radial_distortion),
-                                       extended_coefs, interpolation_info);
+  ylm.interpolate_from_coefs(make_not_null(&radial_distortion), truncated_coefs,
+                             interpolation_info);
 
   using ReturnType = tt::remove_cvref_wrap_t<T>;
   const ReturnType transition_func =
@@ -284,8 +315,8 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::jacobian(
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> result(
       get_size(centered_coords[0]));
 
-  jacobian_helper(make_not_null(&result), interpolation_info, extended_coefs,
-                  centered_coords, radial_distortion, transition_func);
+  jacobian_helper(make_not_null(&result), interpolation_info, truncated_coefs,
+                  centered_coords, radial_distortion, transition_func, ylm);
   return result;
 }
 
@@ -320,36 +351,30 @@ void Shape::coords_frame_velocity_jacobian(
   theta_phis[0].set_data_ref(&get<0, 0>(*jac));
   theta_phis[1].set_data_ref(&get<0, 1>(*jac));
   cartesian_to_spherical(make_not_null(&theta_phis), centered_coords);
-  const auto interpolation_info =
-      extended_ylm_.set_up_interpolation_info(theta_phis);
 
-  const auto [coefs, coef_derivs] =
-      functions_of_time.at(shape_f_of_t_name_)->func_and_deriv(time);
-  DataVector extended_coefs_derivs(extended_ylm_.spectral_size(), 0.);
-  DataVector extended_coefs(extended_ylm_.spectral_size(), 0.);
-
-  // Copy over the coefficients. The additional coefficients of order `l_max_
-  // +1` are zero and will only have an effect in the interpolation of the
-  // cartesian gradient.
-  ylm::SpherepackIterator extended_iter(l_max_ + 1, m_max_ + 1);
-  ylm::SpherepackIterator iter(l_max_, m_max_);
-  for (size_t l = 0; l <= l_max_; ++l) {
-    const int m_max = static_cast<int>(std::min(l, m_max_));
-    for (int m = -m_max; m <= m_max; ++m) {
-      iter.set(l, m);
-      extended_iter.set(l, m);
-      extended_coefs[extended_iter()] = coefs[iter()];
-      extended_coefs_derivs[extended_iter()] = coef_derivs[iter()];
-    }
-  }
-  check_size(make_not_null(&extended_coefs), functions_of_time, time, false);
-  check_size(make_not_null(&extended_coefs_derivs), functions_of_time, time,
+  const auto [coefs, coef_derivs, coef_dderivs] =
+      functions_of_time.at(shape_f_of_t_name_)->func_and_2_derivs(time);
+  const size_t l_max = lmax_from_coefs(coefs);
+  const SpherepackIterator full_iterator{l_max, l_max};
+  size_t truncated_l_max =
+      find_truncated_l_max(coefs, coef_derivs, coef_dderivs, full_iterator);
+  // we need an additional l_max to compute the gradient without aliasing error
+  truncated_l_max += 1;
+  const SpherepackIterator truncated_iterator{truncated_l_max, truncated_l_max};
+  DataVector truncated_coefs =
+      truncate_coefs(coefs, full_iterator, truncated_iterator);
+  DataVector truncated_coef_derivs =
+      truncate_coefs(coef_derivs, full_iterator, truncated_iterator);
+  check_size(make_not_null(&truncated_coefs), functions_of_time, time, false);
+  check_size(make_not_null(&truncated_coef_derivs), functions_of_time, time,
              true);
+  const ylm::Spherepack ylm{truncated_l_max, truncated_l_max};
+  const auto interpolation_info = ylm.set_up_interpolation_info(theta_phis);
   auto& radial_distortion = get(get<::Tags::TempScalar<0>>(temps));
   // evaluate the spherical harmonic expansion at the angles of
   // `source_coords`
-  extended_ylm_.interpolate_from_coefs(make_not_null(&radial_distortion),
-                                       extended_coefs, interpolation_info);
+  ylm.interpolate_from_coefs(make_not_null(&radial_distortion), truncated_coefs,
+                             interpolation_info);
 
   auto& transition_func = get(get<::Tags::TempScalar<1>>(temps));
   transition_func = transition_func_->operator()(centered_coords, std::nullopt);
@@ -357,14 +382,13 @@ void Shape::coords_frame_velocity_jacobian(
       center_ + centered_coords * (1. - radial_distortion * transition_func);
 
   auto& radii_velocities = get<0, 1>(*jac);
-  extended_ylm_.interpolate_from_coefs(make_not_null(&radii_velocities),
-                                       extended_coefs_derivs,
-                                       interpolation_info);
+  ylm.interpolate_from_coefs(make_not_null(&radii_velocities),
+                             truncated_coef_derivs, interpolation_info);
   *frame_vel = -centered_coords * radii_velocities * transition_func;
 
-  jacobian_helper<DataVector>(jac, interpolation_info, extended_coefs,
+  jacobian_helper<DataVector>(jac, interpolation_info, truncated_coefs,
                               centered_coords, radial_distortion,
-                              transition_func);
+                              transition_func, ylm);
 }
 
 template <typename T>
@@ -376,16 +400,24 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Shape::inv_jacobian(
       .second;
 }
 
-void Shape::check_coefficients([[maybe_unused]] const DataVector& coefs) const {
-#ifdef SPECTRE_DEBUG
-  // The expected format of the coefficients passed from the control system can
-  // be changed depending on what turns out to be most convenient for the
-  // control system
-  ASSERT(coefs.size() == ylm_.spectral_size(),
-         "Spectral coefficients are expected to be in ylm::Spherepack format "
-         "with size 2 * (l_max + 1) * (m_max + 1) = "
-             << ylm_.spectral_size() << ", but have size " << coefs.size());
-#endif  // SPECTRE_DEBUG
+size_t Shape::find_truncated_l_max(const DataVector& coefs,
+                                   const DataVector& coef_derivs,
+                                   const DataVector& coef_dderivs,
+                                   SpherepackIterator iterator) const {
+  const size_t l_max = iterator.l_max();
+  // we require at least l=2 because l=0 is size and l=1 is translation
+  for (size_t l = l_max; l > 2; --l) {
+    for (int m = static_cast<int>(l); m >= -static_cast<int>(l); --m) {
+      iterator.set(l, m);
+      const size_t current_index = iterator();
+      if (abs(coefs[current_index]) > truncation_limit_ or
+          abs(coef_derivs[current_index]) > truncation_limit_ or
+          abs(coef_dderivs[current_index]) > truncation_limit_) {
+        return l;
+      }
+    }
+  }
+  return 2;
 }
 
 void Shape::check_size(const gsl::not_null<DataVector*>& coefs,
@@ -420,8 +452,8 @@ void Shape::check_size(const gsl::not_null<DataVector*>& coefs,
 bool operator==(const Shape& lhs, const Shape& rhs) {
   return lhs.shape_f_of_t_name_ == rhs.shape_f_of_t_name_ and
          lhs.size_f_of_t_name_ == rhs.size_f_of_t_name_ and
-         lhs.center_ == rhs.center_ and lhs.l_max_ == rhs.l_max_ and
-         lhs.m_max_ == rhs.m_max_ and
+         lhs.center_ == rhs.center_ and
+         lhs.truncation_limit_ == rhs.truncation_limit_ and
          (lhs.transition_func_ == nullptr) ==
              (rhs.transition_func_ == nullptr) and
          ((lhs.transition_func_ == nullptr and
@@ -432,24 +464,31 @@ bool operator==(const Shape& lhs, const Shape& rhs) {
 bool operator!=(const Shape& lhs, const Shape& rhs) { return not(lhs == rhs); }
 
 void Shape::pup(PUP::er& p) {
-  size_t version = 0;
+  size_t version = 1;
   p | version;
   // Remember to increment the version number when making changes to this
   // function. Retain support for unpacking data written by previous versions
   // whenever possible. See `Domain` docs for details.
-  if (version >= 0) {
-    p | l_max_;
-    p | m_max_;
-    p | center_;
-    p | shape_f_of_t_name_;
-    p | size_f_of_t_name_;
-    p | transition_func_;
+  if (version == 0) {
+    size_t old_l_max = 0;
+    size_t old_m_max = 0;
+    p | old_l_max;
+    p | old_m_max;
+  }
+  p | center_;
+  p | shape_f_of_t_name_;
+  p | size_f_of_t_name_;
+  p | transition_func_;
+
+  if (version >= 1) {
+    p | truncation_limit_;
   }
 
   // No need to pup these because they are uniquely determined by other members
   if (p.isUnpacking()) {
-    ylm_ = ylm::Spherepack(l_max_, m_max_);
-    extended_ylm_ = ylm::Spherepack(l_max_ + 1, m_max_ + 1);
+    if (version == 0) {
+      truncation_limit_ = 0.;
+    }
     f_of_t_names_.clear();
     f_of_t_names_.insert(shape_f_of_t_name_);
     if (size_f_of_t_name_.has_value()) {

--- a/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/Shape.hpp
@@ -4,14 +4,17 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_set>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/ShapeMapTransitionFunction.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
@@ -25,6 +28,12 @@ class er;
 /// \endcond
 
 namespace domain::CoordinateMaps::TimeDependent {
+
+size_t lmax_from_coefs(const DataVector& coefs);
+
+DataVector truncate_coefs(const DataVector& coefs,
+                          ylm::SpherepackIterator iterator,
+                          ylm::SpherepackIterator truncated_iterator);
 
 /*!
  * \ingroup CoordMapsTimeDependentGroup
@@ -210,7 +219,7 @@ class Shape {
       std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>;
 
   explicit Shape(
-      const std::array<double, 3>& center, size_t l_max, size_t m_max,
+      const std::array<double, 3>& center, double truncation_limit,
       std::unique_ptr<ShapeMapTransitionFunctions::ShapeMapTransitionFunction>
           transition_func,
       std::string shape_function_of_time_name,
@@ -275,10 +284,7 @@ class Shape {
   std::optional<std::string> size_f_of_t_name_;
   std::unordered_set<std::string> f_of_t_names_;
   std::array<double, 3> center_{};
-  size_t l_max_ = 2;
-  size_t m_max_ = 2;
-  ylm::Spherepack ylm_{2, 2};
-  ylm::Spherepack extended_ylm_{3, 3};
+  double truncation_limit_{0.};
   std::unique_ptr<ShapeMapTransitionFunctions::ShapeMapTransitionFunction>
       transition_func_;
 
@@ -303,15 +309,17 @@ class Shape {
       gsl::not_null<tnsr::Ij<T, 3, Frame::NoFrame>*> result,
       const ylm::Spherepack::InterpolationInfo<T>& interpolation_info,
       const DataVector& extended_coefs, const std::array<T, 3>& centered_coords,
-      const T& radial_distortion, const T& transition_func) const;
+      const T& radial_distortion, const T& transition_func,
+      const ylm::Spherepack& ylm) const;
 
   void check_size(const gsl::not_null<DataVector*>& coefs,
                   const FunctionsOfTimeMap& functions_of_time, double time,
                   bool use_deriv) const;
 
-  // Checks that the vector of coefficients has the right size and that the
-  // monopole and dipole coefficients are zero.
-  void check_coefficients(const DataVector& coefs) const;
+  size_t find_truncated_l_max(const DataVector& coefs,
+                              const DataVector& coef_derivs,
+                              const DataVector& coef_dderivs,
+                              ylm::SpherepackIterator iterator) const;
 
   friend bool operator==(const Shape& lhs, const Shape& rhs);
 };

--- a/src/Domain/Creators/TimeDependence/Shape.cpp
+++ b/src/Domain/Creators/TimeDependence/Shape.cpp
@@ -41,6 +41,7 @@ template <domain::ObjectLabel Label>
 Shape<Label>::Shape(const double initial_time, const size_t l_max,
                     const double mass, const std::array<double, 3> spin,
                     const std::array<double, 3> center,
+                    const double coefficient_truncation_limit,
                     const double inner_radius, const double outer_radius,
                     const Options::Context& context)
     : initial_time_(initial_time),
@@ -48,6 +49,7 @@ Shape<Label>::Shape(const double initial_time, const size_t l_max,
       mass_(mass),
       spin_(spin),
       center_(center),
+      coefficient_truncation_limit_(coefficient_truncation_limit),
       inner_radius_(inner_radius),
       outer_radius_(outer_radius),
       transition_func_(std::make_unique<SphereTransition>(
@@ -65,6 +67,11 @@ Shape<Label>::Shape(const double initial_time, const size_t l_max,
                 "the magnitude of the spin ("
                     << spin << ") is greater than one.");
   }
+  if (coefficient_truncation_limit_ < 0.0) {
+    PARSE_ERROR(context,
+                "CoefficientTruncationLimit must be non-negative, but is "
+                    << coefficient_truncation_limit_ << ".");
+  }
   // There is no PARSE_ERROR for the `inner_radius` < `outer_radius` condition
   // because the SphereTransition already checks for this condition.
 }
@@ -73,7 +80,8 @@ template <domain::ObjectLabel Label>
 std::unique_ptr<TimeDependence<Shape<Label>::mesh_dim>>
 Shape<Label>::get_clone() const {
   return std::make_unique<Shape<Label>>(initial_time_, l_max_, mass_, spin_,
-                                        center_, inner_radius_, outer_radius_);
+                                        center_, coefficient_truncation_limit_,
+                                        inner_radius_, outer_radius_);
 }
 
 template <domain::ObjectLabel Label>
@@ -189,14 +197,14 @@ Shape<Label>::functions_of_time(const std::unordered_map<std::string, double>&
 
 template <domain::ObjectLabel Label>
 auto Shape<Label>::grid_to_inertial_map() const -> GridToInertialMap {
-  return GridToInertialMap{ShapeMap{center_, l_max_, l_max_,
+  return GridToInertialMap{ShapeMap{center_, coefficient_truncation_limit_,
                                     transition_func_->get_clone(),
                                     function_of_time_name_}};
 }
 
 template <domain::ObjectLabel Label>
 auto Shape<Label>::grid_to_distorted_map() const -> GridToDistortedMap {
-  return GridToDistortedMap{ShapeMap{center_, l_max_, l_max_,
+  return GridToDistortedMap{ShapeMap{center_, coefficient_truncation_limit_,
                                      transition_func_->get_clone(),
                                      function_of_time_name_}};
 }
@@ -211,6 +219,8 @@ bool operator==(const Shape<Label>& lhs, const Shape<Label>& rhs) {
   return lhs.initial_time_ == rhs.initial_time_ and lhs.l_max_ == rhs.l_max_ and
          lhs.mass_ == rhs.mass_ and lhs.spin_ == rhs.spin_ and
          lhs.center_ == rhs.center_ and
+         lhs.coefficient_truncation_limit_ ==
+             rhs.coefficient_truncation_limit_ and
          lhs.inner_radius_ == rhs.inner_radius_ and
          lhs.outer_radius_ == rhs.outer_radius_;
 }

--- a/src/Domain/Creators/TimeDependence/Shape.hpp
+++ b/src/Domain/Creators/TimeDependence/Shape.hpp
@@ -135,6 +135,15 @@ class Shape final : public TimeDependence<3> {
     using type = std::array<double, 3>;
     static constexpr Options::String help = {"Center for the Shape map."};
   };
+  /// \brief Coefficients below this absolute value will be truncated from the
+  /// Shape map.
+  struct CoefficientTruncationLimit {
+    using type = double;
+    static constexpr Options::String help = {
+        "Coefficients below this absolute value will be truncated from the "
+        "Shape map. Set to 0.0 to disable truncation."};
+    static constexpr type default_value = 0.0;
+  };
   /// \brief The inner radius of the Shape map, the radius at which
   /// to begin applying the map.
   struct InnerRadius {
@@ -150,8 +159,9 @@ class Shape final : public TimeDependence<3> {
         "The outer radius of the Shape map."};
   };
 
-  using options = tmpl::list<InitialTime, LMax, Mass, Spin, Center, InnerRadius,
-                             OuterRadius>;
+  using options =
+      tmpl::list<InitialTime, LMax, Mass, Spin, Center,
+                 CoefficientTruncationLimit, InnerRadius, OuterRadius>;
 
   static constexpr Options::String help = {
       "Creates a Shape that conforms to a Kerr horizon of given mass and "
@@ -166,8 +176,8 @@ class Shape final : public TimeDependence<3> {
 
   Shape(double initial_time, size_t l_max, double mass,
         std::array<double, 3> spin, std::array<double, 3> center,
-        double inner_radius, double outer_radius,
-        const Options::Context& context = {});
+        double coefficient_truncation_limit, double inner_radius,
+        double outer_radius, const Options::Context& context = {});
 
   auto get_clone() const -> std::unique_ptr<TimeDependence<mesh_dim>> override;
 
@@ -211,6 +221,7 @@ class Shape final : public TimeDependence<3> {
       make_array<3>(std::numeric_limits<double>::signaling_NaN())};
   inline static const std::string function_of_time_name_{"Shape" +
                                                          get_output(Label)};
+  double coefficient_truncation_limit_{0.0};
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
   double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
   std::unique_ptr<TransitionFunction> transition_func_;

--- a/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/BinaryCompactObject.cpp
@@ -353,15 +353,16 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
     // Store the inner radii for creating functions of time
     gsl::at(deformed_radii_, i) = filled ? radii[1] : radii[0];
 
-    const size_t initial_l_max =
-        i == 0 ? time_dependent_options::l_max_from_shape_options(
-                     shape_options_A_.value())
-               : time_dependent_options::l_max_from_shape_options(
-                     shape_options_B_.value());
-
     std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                         ShapeMapTransitionFunction>
         transition_func{};
+    const double coefficient_truncation_limit =
+        i == 0 ? time_dependent_options::
+                     coefficient_truncation_limit_from_shape_options(
+                         shape_options_A_.value())
+               : time_dependent_options::
+                     coefficient_truncation_limit_from_shape_options(
+                         shape_options_B_.value());
 
     // Currently, we don't support different transition functions for the
     // cylindrical domain
@@ -375,12 +376,10 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
           std::make_unique<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                                SphereTransition>(radii[0], radii[1]);
 
-      gsl::at(shape_maps_, i) = Shape{gsl::at(object_centers, i),
-                                      initial_l_max,
-                                      initial_l_max,
-                                      std::move(transition_func),
-                                      gsl::at(shape_names, i),
-                                      gsl::at(size_names, i)};
+      gsl::at(shape_maps_, i) =
+          Shape{gsl::at(object_centers, i), coefficient_truncation_limit,
+                std::move(transition_func), gsl::at(shape_names, i),
+                gsl::at(size_names, i)};
 
       transition_func =
           std::make_unique<domain::CoordinateMaps::ShapeMapTransitionFunctions::
@@ -389,11 +388,8 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
 
       // Last two are the interior maps
       gsl::at(shape_maps_, shape_maps_.size() - 2 + i) =
-          Shape{gsl::at(object_centers, i),
-                initial_l_max,
-                initial_l_max,
-                std::move(transition_func),
-                gsl::at(shape_names, i),
+          Shape{gsl::at(object_centers, i), coefficient_truncation_limit,
+                std::move(transition_func), gsl::at(shape_names, i),
                 gsl::at(size_names, i)};
     } else {
       // These must match the order of orientations_for_sphere_wrappings() in
@@ -454,12 +450,10 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
 
         // The shape map should be given the center of the excision always,
         // regardless of if it is offset or not
-        gsl::at(gsl::at(shape_maps_, i), j) = Shape{inner_center,
-                                                    initial_l_max,
-                                                    initial_l_max,
-                                                    std::move(transition_func),
-                                                    gsl::at(shape_names, i),
-                                                    gsl::at(size_names, i)};
+        gsl::at(gsl::at(shape_maps_, i), j) =
+            Shape{inner_center, coefficient_truncation_limit,
+                  std::move(transition_func), gsl::at(shape_names, i),
+                  gsl::at(size_names, i)};
       }
 
       // Add the interior maps if we are excised (aka not filled)
@@ -469,11 +463,8 @@ void TimeDependentMapOptions<IsCylindrical>::build_maps(
             outer_radius, outer_sphericity, Wedge::Axis::Interior);
 
         gsl::at(gsl::at(shape_maps_, i), gsl::at(shape_maps_, i).size() - 1) =
-            Shape{inner_center,
-                  initial_l_max,
-                  initial_l_max,
-                  std::move(transition_func),
-                  gsl::at(shape_names, i),
+            Shape{inner_center, coefficient_truncation_limit,
+                  std::move(transition_func), gsl::at(shape_names, i),
                   gsl::at(size_names, i)};
       }
     }

--- a/src/Domain/Creators/TimeDependentOptions/Python/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Python/ShapeMap.cpp
@@ -52,9 +52,10 @@ void bind_shape_map_impl(py::module& m) {
                            KerrSchildFromBoyerLindquist,
                        domain::creators::time_dependent_options::YlmsFromFile,
                        domain::creators::time_dependent_options::YlmsFromSpEC>>,
-                   std::optional<std::array<double, 3>>, bool>(),
+                   std::optional<std::array<double, 3>>, double, bool>(),
           py::arg("l_max"), py::arg("initial_values"),
           py::arg("initial_size_values") = std::nullopt,
+          py::arg("coefficient_truncation_limit") = 0.0,
           py::arg("transition_ends_at_cube") = true);
 }
 }  // namespace

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.cpp
@@ -65,6 +65,7 @@ YlmsFromSpEC::YlmsFromSpEC(std::string dat_filename_in,
 template <ObjectLabel Object>
 FromVolumeFileShapeSize<Object>::FromVolumeFileShapeSize(
     const std::optional<size_t>& l_max_in,
+    const double coefficient_truncation_limit_in,
     const bool transition_ends_at_cube_in, std::string h5_filename,
     std::string subfile_name, const Options::Context& context)
     : FromVolumeFile(std::move(h5_filename), std::move(subfile_name)),
@@ -89,6 +90,13 @@ FromVolumeFileShapeSize<Object>::FromVolumeFileShapeSize(
     // worrying about odd numbers or non-perfect squares
     l_max = -1 + sqrt(function[0].size() / 2);  // NOLINT
   }
+
+  if (coefficient_truncation_limit_in < 0.0) {
+    PARSE_ERROR(context,
+                "CoefficientTruncationLimit must be non-negative, but is "
+                    << coefficient_truncation_limit_in << ".");
+  }
+  coefficient_truncation_limit = coefficient_truncation_limit_in;
 }
 
 template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
@@ -97,6 +105,15 @@ size_t l_max_from_shape_options(
                        FromVolumeFileShapeSize<Object>>& shape_map_options) {
   return std::visit([](auto variant) { return variant.l_max; },
                     shape_map_options);
+}
+
+template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
+double coefficient_truncation_limit_from_shape_options(
+    const std::variant<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>,
+                       FromVolumeFileShapeSize<Object>>& shape_map_options) {
+  return std::visit(
+      [](auto variant) { return variant.coefficient_truncation_limit; },
+      shape_map_options);
 }
 
 template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
@@ -390,6 +407,10 @@ FunctionsOfTimeMap get_shape_and_size(
 
 #define INSTANTIATE(_, data)                                          \
   template size_t l_max_from_shape_options(                           \
+      const std::variant<                                             \
+          ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>,     \
+          FromVolumeFileShapeSize<OBJECT(data)>>& shape_map_options); \
+  template double coefficient_truncation_limit_from_shape_options(    \
       const std::variant<                                             \
           ShapeMapOptions<INCLUDETRANSITION(data), OBJECT(data)>,     \
           FromVolumeFileShapeSize<OBJECT(data)>>& shape_map_options); \

--- a/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/ShapeMap.hpp
@@ -198,6 +198,13 @@ struct TransitionEndsAtCube {
 template <ObjectLabel Object>
 struct FromVolumeFileShapeSize : public FromVolumeFile {
  public:
+  struct CoefficientTruncationLimit {
+    using type = double;
+    static constexpr Options::String help = {
+        "Coefficients below this absolute value will be truncated from the "
+        "Shape map. Set to 0.0 to disable truncation."};
+    static constexpr type default_value = 0.0;
+  };
   struct LMax {
     using type = Options::Auto<size_t>;
     static constexpr Options::String help = {
@@ -206,15 +213,18 @@ struct FromVolumeFileShapeSize : public FromVolumeFile {
         "function of time in the volume file."};
   };
   using options = tmpl::push_front<FromVolumeFile::options, LMax,
+                                   CoefficientTruncationLimit,
                                    detail::TransitionEndsAtCube>;
 
   FromVolumeFileShapeSize() = default;
   FromVolumeFileShapeSize(const std::optional<size_t>& l_max_in,
+                          double coefficient_truncation_limit_in,
                           bool transition_ends_at_cube_in,
                           std::string h5_filename, std::string subfile_name,
                           const Options::Context& context = {});
 
   size_t l_max{};
+  double coefficient_truncation_limit{0.0};
   bool transition_ends_at_cube{};
 
  private:
@@ -236,6 +246,13 @@ struct FromVolumeFileShapeSize : public FromVolumeFile {
  */
 template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
 struct ShapeMapOptions {
+  struct CoefficientTruncationLimit {
+    using type = double;
+    static constexpr Options::String help = {
+        "Coefficients below this absolute value will be truncated from the "
+        "Shape map. Set to 0.0 to disable truncation."};
+    static constexpr type default_value = 0.0;
+  };
   using type = Options::Auto<
       std::variant<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>,
                    FromVolumeFileShapeSize<Object>>,
@@ -271,7 +288,8 @@ struct ShapeMapOptions {
         "set the radius of the sphere in the grid frame (before deformation)."};
   };
 
-  using common_options = tmpl::list<LMax, InitialValues, SizeInitialValues>;
+  using common_options = tmpl::list<LMax, InitialValues, SizeInitialValues,
+                                    CoefficientTruncationLimit>;
 
   using options = tmpl::conditional_t<
       IncludeTransitionEndsAtCube,
@@ -284,10 +302,12 @@ struct ShapeMapOptions {
                       initial_values_in,
                   std::optional<std::array<double, 3>> initial_size_values_in =
                       std::nullopt,
+                  double coefficient_truncation_limit_in = 0.0,
                   bool transition_ends_at_cube_in = false)
       : l_max(l_max_in),
         initial_values(std::move(initial_values_in)),
         initial_size_values(initial_size_values_in),
+        coefficient_truncation_limit(coefficient_truncation_limit_in),
         transition_ends_at_cube(transition_ends_at_cube_in) {}
 
   size_t l_max{};
@@ -295,6 +315,7 @@ struct ShapeMapOptions {
       std::variant<KerrSchildFromBoyerLindquist, YlmsFromFile, YlmsFromSpEC>>
       initial_values;
   std::optional<std::array<double, 3>> initial_size_values;
+  double coefficient_truncation_limit{0.0};
   bool transition_ends_at_cube{false};
 };
 
@@ -304,6 +325,15 @@ struct ShapeMapOptions {
  */
 template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
 size_t l_max_from_shape_options(
+    const std::variant<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>,
+                       FromVolumeFileShapeSize<Object>>& shape_map_options);
+
+/*!
+ * \brief Helper function to get the coefficient truncation limit from the
+ * different variants that the shape map options could be.
+ */
+template <bool IncludeTransitionEndsAtCube, domain::ObjectLabel Object>
+double coefficient_truncation_limit_from_shape_options(
     const std::variant<ShapeMapOptions<IncludeTransitionEndsAtCube, Object>,
                        FromVolumeFileShapeSize<Object>>& shape_map_options);
 

--- a/src/Domain/Creators/TimeDependentOptions/Sphere.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Sphere.cpp
@@ -108,8 +108,9 @@ void TimeDependentMapOptions::build_maps(
     const double outer_radius) {
   filled_ = filled;
   if (shape_map_options_.has_value()) {
-    const size_t l_max = time_dependent_options::l_max_from_shape_options(
-        shape_map_options_.value());
+    const double coefficient_truncation_limit =
+        time_dependent_options::coefficient_truncation_limit_from_shape_options(
+            shape_map_options_.value());
     std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                         ShapeMapTransitionFunction>
         transition_func;
@@ -151,8 +152,8 @@ void TimeDependentMapOptions::build_maps(
               static_cast<WedgeTransition::Axis>(gsl::at(axes, j % 6)));
         }
         gsl::at(shape_maps_, j) =
-            ShapeMap{center,     l_max,    l_max, std::move(transition_func),
-                     shape_name, size_name};
+            ShapeMap{center, coefficient_truncation_limit,
+                     std::move(transition_func), shape_name, size_name};
       }
     } else {
       // Shape map transitions from 1 to 0 from the inner radius to the first
@@ -165,8 +166,8 @@ void TimeDependentMapOptions::build_maps(
                                SphereTransition>(inner_radius,
                                                  shape_outer_radius);
       shape_maps_[0] =
-          ShapeMap{center,     l_max,    l_max, std::move(transition_func),
-                   shape_name, size_name};
+          ShapeMap{center, coefficient_truncation_limit,
+                   std::move(transition_func), shape_name, size_name};
 
       // Interior map
       transition_func =
@@ -174,8 +175,8 @@ void TimeDependentMapOptions::build_maps(
                                SphereTransition>(
               inner_radius, shape_outer_radius, false, true);
       shape_maps_[1] =
-          ShapeMap{center,     l_max,    l_max, std::move(transition_func),
-                   shape_name, size_name};
+          ShapeMap{center, coefficient_truncation_limit,
+                   std::move(transition_func), shape_name, size_name};
     }
   }
 

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -148,12 +148,14 @@ DomainCreator:
       SkewMap: None
       ShapeMapA:
         LMax: {{ HorizonLMax }}
+        CoefficientTruncationLimit: 0.
         InitialValues:
           Mass: *mass_right
           Spin: *spin_right
         SizeInitialValues: Auto
         TransitionEndsAtCube: False
       ShapeMapB:
+        CoefficientTruncationLimit: 0.
         LMax: {{ HorizonLMax }}
         InitialValues:
           Mass: *mass_left

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -148,11 +148,13 @@ DomainCreator:
         H5Filename: "{{ FotFilename }}"
         SubfileName: "{{ IdSubfile }}"
       ShapeMapA:
+        CoefficientTruncationLimit: 1e-16
         H5Filename: "{{ FotFilename }}"
         SubfileName: "{{ IdSubfile }}"
         LMax: Auto
         TransitionEndsAtCube: True
       ShapeMapB:
+        CoefficientTruncationLimit: 1e-16
         H5Filename: "{{ FotFilename }}"
         SubfileName: "{{ IdSubfile }}"
         LMax: Auto
@@ -174,6 +176,7 @@ DomainCreator:
         InitialValuesZ: [0.0, 0.0, 0.0]
       ShapeMapA:
         LMax: &ShapeLMax 10
+        CoefficientTruncationLimit: 1e-16
   {% if SpecDataDirectory is defined %}
         InitialValues: Spherical
   {% else %}
@@ -188,6 +191,7 @@ DomainCreator:
         TransitionEndsAtCube: true
       ShapeMapB:
         LMax: *ShapeLMax
+        CoefficientTruncationLimit: 1e-16
   {% if SpecDataDirectory is defined %}
         InitialValues: Spherical
   {% else %}

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -51,6 +51,7 @@ DomainCreator:
       InitialTime: *InitialTime
       ShapeMap:
         LMax: &MaximumL {{ ShapeMapLMax }}
+        CoefficientTruncationLimit: 1e-12
         InitialValues:
           H5Filename: "{{ PathToAhCCoefsH5File }}"
           SubfileNames: ["{{ AhCCoefsSubfilePrefix }}AhC_Ylm",

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -79,11 +79,13 @@ DomainCreator:
       SkewMap: None
       ShapeMapA:
         LMax: 8
+        CoefficientTruncationLimit: 0.
         InitialValues: Spherical
         SizeInitialValues: [0., 0., 0.]
         TransitionEndsAtCube: false
       ShapeMapB:
         LMax: 8
+        CoefficientTruncationLimit: 0.
         InitialValues: Spherical
         SizeInitialValues: [0., 0., 0.]
         TransitionEndsAtCube: false

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -82,11 +82,13 @@ DomainCreator:
         InitialValuesY: [-0.4, 0.0, 0.0]
         InitialValuesZ: [-0.4, 0.0, 0.0]
       ShapeMapA:
+        CoefficientTruncationLimit: 0.
         LMax: 8
         InitialValues: Spherical
         SizeInitialValues: [0.0, 0.0, 0.0]
         TransitionEndsAtCube: true
       ShapeMapB:
+        CoefficientTruncationLimit: 0.
         LMax: 8
         InitialValues: Spherical
         SizeInitialValues: [0.0, 0.0, 0.0]

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -70,10 +70,12 @@ DomainCreator:
         InitialValues: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
       SkewMap: None
       ShapeMapA:
+        CoefficientTruncationLimit: 0.
         LMax: &LMax 10
         InitialValues: Spherical
         SizeInitialValues: [0.0, 0.0, 0.0]
       ShapeMapB:
+        CoefficientTruncationLimit: 0.
         LMax: *LMax
         InitialValues: Spherical
         SizeInitialValues: [0.0, 0.0, 0.0]

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -101,6 +101,7 @@ DomainCreator:
       Shape:
         InitialTime: 0.
         LMax: 18
+        CoefficientTruncationLimit: 0.
         Mass: *KerrMass
         Spin: *KerrSpin
         Center: *KerrCenter

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_SphereTransition.cpp
@@ -47,10 +47,10 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
     sphere_transition_interior =
         serialize_and_deserialize(sphere_transition_interior);
     const domain::CoordinateMaps::TimeDependent::Shape shape_map{
-        std::array{0.0, 0.0, 0.0}, l_max, l_max,
+        std::array{0.0, 0.0, 0.0}, 0.0,
         std::make_unique<SphereTransition>(sphere_transition), "Shape"};
     const domain::CoordinateMaps::TimeDependent::Shape shape_map_interior{
-        std::array{0.0, 0.0, 0.0}, l_max, l_max,
+        std::array{0.0, 0.0, 0.0}, 0.0,
         std::make_unique<SphereTransition>(sphere_transition_interior),
         "Shape"};
 
@@ -91,7 +91,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Shape.SphereTransition",
     sphere_transition = serialize_and_deserialize(sphere_transition);
 
     const domain::CoordinateMaps::TimeDependent::Shape shape_map{
-        std::array{0.0, 0.0, 0.0}, 4, 4,
+        std::array{0.0, 0.0, 0.0}, 0.0,
         std::make_unique<SphereTransition>(sphere_transition), "Shape"};
 
     const std::vector<double> function_values{0.0, 0.0, 0.5 / 3.0, 0.25, 0.25};

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
@@ -416,7 +416,7 @@ void test_points_shape_map(
       inner_center, inner_radius, inner_sphericity, outer_center, outer_radius,
       outer_sphericity, static_cast<Wedge::Axis>(axis), reverse);
 
-  const TimeDependent::Shape shape{inner_center, l_max, l_max, std::move(wedge),
+  const TimeDependent::Shape shape{inner_center, 0.0, std::move(wedge),
                                    fot_name};
 
   // test_coordinate_map_argument_types creates its own DataVectors and we only

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_Shape.cpp
@@ -31,6 +31,7 @@ namespace domain {
 namespace {
 
 const std::complex<double> imag(0, 1);
+constexpr double truncation_limit = 1e-14;
 
 std::complex<double> Y00(double /*theta*/, double /*phi*/) {
   return 0.5 * sqrt(1. / M_PI);
@@ -124,8 +125,7 @@ auto dphi = [](size_t l, size_t m) {
 auto evaluate_harmonic_expansion =
     [](auto function, double theta, double phi,
        const std::vector<std::vector<std::complex<double>>>& coefs,
-       const std::optional<double>& lambda_00_coef, size_t l_max,
-       size_t m_max) {
+       const std::optional<double>& lambda_00_coef, size_t l_max) {
       std::complex<double> res = 0.;
       for (size_t l = 0; l <= l_max; ++l) {
         if (l == 0 and lambda_00_coef.has_value()) {
@@ -134,7 +134,7 @@ auto evaluate_harmonic_expansion =
         } else {
           res += gsl::at(gsl::at(coefs, l), 0) * function(l, 0)(theta, phi);
         }
-        for (size_t m = 1; m <= std::min(l, m_max); ++m) {
+        for (size_t m = 1; m <= l; ++m) {
           res += 2. * (std::real(gsl::at(gsl::at(coefs, l), m)) *
                            std::real(function(l, m)(theta, phi)) -
                        std::imag(gsl::at(gsl::at(coefs, l), m)) *
@@ -151,7 +151,7 @@ using FunctionsOfTimeMap =
                        std::unique_ptr<FunctionsOfTime::FunctionOfTime>>;
 
 std::vector<std::vector<std::complex<double>>> generate_random_coefs(
-    size_t l_max, size_t m_max, gsl::not_null<std::mt19937*> generator) {
+    size_t l_max, gsl::not_null<std::mt19937*> generator) {
   std::vector<std::vector<std::complex<double>>> coefs{};
   // if the coefficients are made too large, the map has a good chance of
   // mapping through the center, causing the test to fail which is why we limit
@@ -162,7 +162,7 @@ std::vector<std::vector<std::complex<double>>> generate_random_coefs(
     // m=0 is real
     std::vector<std::complex<double>> tmp{
         make_with_random_values<double>(generator, coef_dist, 1)};
-    for (size_t m = 1; m <= std::min(l, m_max); ++m) {
+    for (size_t m = 1; m <= l; ++m) {
       tmp.emplace_back(make_with_random_values<std::complex<double>>(
           generator, coef_dist, 2));
     }
@@ -179,9 +179,8 @@ double generate_random_00_coef(const gsl::not_null<std::mt19937*> generator) {
 
 // converts complex coefficients to format expected by spherepack
 DataVector convert_coefs_to_spherepack(
-    const std::vector<std::vector<std::complex<double>>>& coefs, size_t l_max,
-    size_t m_max) {
-  ylm::SpherepackIterator iter(l_max, m_max);
+    const std::vector<std::vector<std::complex<double>>>& coefs, size_t l_max) {
+  ylm::SpherepackIterator iter(l_max, l_max);
   auto spherepack_coefs =
       make_with_value<DataVector>(iter.spherepack_array_size(), 0.);
 
@@ -190,7 +189,7 @@ DataVector convert_coefs_to_spherepack(
     iter.set(l, 0);
     spherepack_coefs[iter()] =
         sqrt_2_by_pi * std::real(gsl::at(gsl::at(coefs, l), 0));
-    for (size_t m = 1; m <= std::min(l, m_max); ++m) {
+    for (size_t m = 1; m <= l; ++m) {
       iter.set(l, m);
       spherepack_coefs[iter()] =
           pow(-1, m) * sqrt_2_by_pi * std::real(gsl::at(gsl::at(coefs, l), m));
@@ -202,6 +201,30 @@ DataVector convert_coefs_to_spherepack(
   return spherepack_coefs;
 }
 
+DataVector pad_spherepack_coefs_with_truncation_values(
+    const DataVector& coefs, const size_t original_l_max,
+    const size_t target_l_max) {
+  CHECK(target_l_max >= original_l_max);
+
+  ylm::SpherepackIterator original_iter{original_l_max, original_l_max};
+  ylm::SpherepackIterator target_iter{target_l_max, target_l_max};
+  DataVector padded_coefs(target_iter.spherepack_array_size(), 0.0);
+
+  for (original_iter.reset(); original_iter; ++original_iter) {
+    target_iter.set(original_iter.l(), original_iter.m(),
+                    original_iter.coefficient_array());
+    padded_coefs[target_iter()] = coefs[original_iter()];
+  }
+
+  const double tiny_value = 0.5 * truncation_limit;
+  for (target_iter.reset(); target_iter; ++target_iter) {
+    if (target_iter.l() > original_l_max) {
+      padded_coefs[target_iter()] = tiny_value;
+    }
+  }
+  return padded_coefs;
+}
+
 // Generates the map, time, and a FunctionOfTime. `const_f_of_t` decides whether
 // the function of time will be constant which is needed for the analytical
 // comparisons.
@@ -210,15 +233,20 @@ void generate_random_map_time_and_f_of_time(
     const gsl::not_null<CoordinateMaps::TimeDependent::Shape*> map,
     const gsl::not_null<double*> time,
     const gsl::not_null<FunctionsOfTimeMap*> functions_of_time,
-    const size_t l_max, const size_t m_max, const std::array<double, 3>& center,
+    const size_t l_max, const std::array<double, 3>& center,
     const TransitionFunction& transition_func, const DataVector& ylm_coefs,
     const std::optional<double>& lambda_00_coef, const bool const_f_of_t,
-    gsl::not_null<std::mt19937*> generator) {
+    gsl::not_null<std::mt19937*> generator,
+    const std::optional<size_t> functions_of_time_l_max = std::nullopt) {
   const std::string shape_f_of_t_name{"Shape"};
   const std::optional<std::string> size_f_of_t_name{"Size"};
 
+  const size_t function_of_time_l_max = functions_of_time_l_max.value_or(l_max);
+  CHECK(function_of_time_l_max >= l_max);
+  const ylm::SpherepackIterator function_of_time_iterator{
+      function_of_time_l_max, function_of_time_l_max};
   *map = CoordinateMaps::TimeDependent::Shape(
-      center, l_max, m_max,
+      center, truncation_limit,
       std::make_unique<TransitionFunction>(transition_func), shape_f_of_t_name,
       lambda_00_coef.has_value() ? size_f_of_t_name : std::nullopt);
   const auto& function_of_time_names = map->function_of_time_names();
@@ -236,16 +264,20 @@ void generate_random_map_time_and_f_of_time(
   const double initial_time{*time - dt_dis(*generator)};
   const double expiration_time{*time + dt_dis(*generator)};
 
-  DataVector shape_dtcoefs{ylm_coefs.size(), 0.};
-  DataVector shape_ddtcoefs{ylm_coefs.size(), 0.};
+  DataVector shape_dtcoefs{function_of_time_iterator.spherepack_array_size(),
+                           0.};
+  DataVector shape_ddtcoefs{function_of_time_iterator.spherepack_array_size(),
+                            0.};
 
   if (not const_f_of_t) {
-    const auto dt_random_coefs = generate_random_coefs(l_max, m_max, generator);
-    shape_dtcoefs = convert_coefs_to_spherepack(dt_random_coefs, l_max, m_max);
-    const auto ddt_random_coefs =
-        generate_random_coefs(l_max, m_max, generator);
-    shape_ddtcoefs =
-        convert_coefs_to_spherepack(ddt_random_coefs, l_max, m_max);
+    const auto dt_random_coefs = generate_random_coefs(l_max, generator);
+    shape_dtcoefs = pad_spherepack_coefs_with_truncation_values(
+        convert_coefs_to_spherepack(dt_random_coefs, l_max), l_max,
+        function_of_time_l_max);
+    const auto ddt_random_coefs = generate_random_coefs(l_max, generator);
+    shape_ddtcoefs = pad_spherepack_coefs_with_truncation_values(
+        convert_coefs_to_spherepack(ddt_random_coefs, l_max), l_max,
+        function_of_time_l_max);
   }
 
   if (lambda_00_coef.has_value()) {
@@ -265,8 +297,10 @@ void generate_random_map_time_and_f_of_time(
     shape_ddtcoefs[0] = 0.0;
   }
 
+  const DataVector shape_coefs = pad_spherepack_coefs_with_truncation_values(
+      ylm_coefs, l_max, function_of_time_l_max);
   const std::array<DataVector, 3> initial_shape_coefficients = {
-      ylm_coefs, shape_dtcoefs, shape_ddtcoefs};
+      shape_coefs, shape_dtcoefs, shape_ddtcoefs};
 
   (*functions_of_time)[shape_f_of_t_name] =
       std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
@@ -275,7 +309,7 @@ void generate_random_map_time_and_f_of_time(
 
 template <typename TransitionFunction>
 void test_map_helpers(const TransitionFunction& transition_func, size_t l_max,
-                      size_t m_max, const bool include_size,
+                      const bool include_size,
                       gsl::not_null<std::mt19937*> generator) {
   std::uniform_real_distribution dist{-10., 10.};
   const auto center =
@@ -284,9 +318,9 @@ void test_map_helpers(const TransitionFunction& transition_func, size_t l_max,
   FunctionsOfTimeMap functions_of_time{};
   double time{};
   auto map = CoordinateMaps::TimeDependent::Shape{};
-  auto random_coefs = generate_random_coefs(l_max, m_max, generator);
+  auto random_coefs = generate_random_coefs(l_max, generator);
   DataVector spherepack_coefs =
-      convert_coefs_to_spherepack(random_coefs, l_max, m_max);
+      convert_coefs_to_spherepack(random_coefs, l_max);
   std::optional<double> random_00_coef{};
   if (include_size) {
     spherepack_coefs[0] = 0.0;
@@ -295,8 +329,8 @@ void test_map_helpers(const TransitionFunction& transition_func, size_t l_max,
 
   generate_random_map_time_and_f_of_time(
       make_not_null(&map), make_not_null(&time),
-      make_not_null(&functions_of_time), l_max, m_max, center, transition_func,
-      spherepack_coefs, random_00_coef, false, generator);
+      make_not_null(&functions_of_time), l_max, center, transition_func,
+      spherepack_coefs, random_00_coef, false, generator, l_max + 2);
 
   const auto random_point =
       make_with_random_values<std::array<double, 3>>(generator, dist, 3);
@@ -317,8 +351,7 @@ void test_map_helpers(const TransitionFunction& transition_func, size_t l_max,
 // duplicates map but calculates spherical harmonics expansion directly.
 std::array<DataVector, 3> calculate_analytical_map(
     std::array<DataVector, 3> target_points, std::array<double, 3> center,
-    size_t l_max, size_t m_max,
-    const std::vector<std::vector<std::complex<double>>>& coefs,
+    size_t l_max, const std::vector<std::vector<std::complex<double>>>& coefs,
     const std::optional<double>& lambda_00_coef,
     const CoordinateMaps::ShapeMapTransitionFunctions::
         ShapeMapTransitionFunction& transition_func) {
@@ -335,7 +368,7 @@ std::array<DataVector, 3> calculate_analytical_map(
   for (size_t i = 0; i < num_points; ++i) {
     angular_part[i] = evaluate_harmonic_expansion(
         identity, gsl::at(target_thetas, i), gsl::at(target_phis, i), coefs,
-        lambda_00_coef, l_max, m_max);
+        lambda_00_coef, l_max);
   }
   const DataVector spatial_part =
       transition_func(centered_coords, std::nullopt);
@@ -344,8 +377,8 @@ std::array<DataVector, 3> calculate_analytical_map(
 
 template <typename TransitionFunction>
 void test_analytical_solution(const TransitionFunction& transition_func,
-                              size_t l_max, size_t m_max,
-                              const bool include_size, size_t num_points,
+                              size_t l_max, const bool include_size,
+                              size_t num_points,
                               gsl::not_null<std::mt19937*> generator) {
   std::uniform_real_distribution dist{-10., 10.};
   const auto center =
@@ -353,14 +386,14 @@ void test_analytical_solution(const TransitionFunction& transition_func,
   const auto target_data = make_with_random_values<std::array<DataVector, 3>>(
       generator, dist, num_points);
 
-  auto random_coefs = generate_random_coefs(l_max, m_max, generator);
+  auto random_coefs = generate_random_coefs(l_max, generator);
 
   FunctionsOfTimeMap functions_of_time{};
   double time{};
   auto map = CoordinateMaps::TimeDependent::Shape{};
 
   DataVector spherepack_coefs =
-      convert_coefs_to_spherepack(random_coefs, l_max, m_max);
+      convert_coefs_to_spherepack(random_coefs, l_max);
   std::optional<double> random_00_coef{};
   if (include_size) {
     random_coefs[0][0] = 0.0;
@@ -370,11 +403,11 @@ void test_analytical_solution(const TransitionFunction& transition_func,
 
   generate_random_map_time_and_f_of_time(
       make_not_null(&map), make_not_null(&time),
-      make_not_null(&functions_of_time), l_max, m_max, center, transition_func,
-      spherepack_coefs, random_00_coef, true, generator);
+      make_not_null(&functions_of_time), l_max, center, transition_func,
+      spherepack_coefs, random_00_coef, true, generator, l_max + 2);
   const auto mapped_result = map(target_data, time, functions_of_time);
   const auto analytical_result =
-      calculate_analytical_map(target_data, center, l_max, m_max, random_coefs,
+      calculate_analytical_map(target_data, center, l_max, random_coefs,
                                random_00_coef, transition_func);
   CHECK_ITERABLE_APPROX(mapped_result, analytical_result);
 }
@@ -382,7 +415,7 @@ void test_analytical_solution(const TransitionFunction& transition_func,
 // calculate the Jacobian using spherical harmonics directly
 tnsr::Ij<DataVector, 3, Frame::NoFrame> calculate_analytical_jacobian(
     const std::array<DataVector, 3>& target_points,
-    const std::array<double, 3>& center, size_t l_max, size_t m_max,
+    const std::array<double, 3>& center, size_t l_max,
     const std::vector<std::vector<std::complex<double>>>& coefs,
     const std::optional<double>& lambda_00_coef,
     const CoordinateMaps::ShapeMapTransitionFunctions::
@@ -398,13 +431,13 @@ tnsr::Ij<DataVector, 3, Frame::NoFrame> calculate_analytical_jacobian(
   for (size_t i = 0; i < num_points; ++i) {
     angular_part.at(i) = evaluate_harmonic_expansion(
         identity, gsl::at(target_thetas, i), gsl::at(target_phis, i), coefs,
-        lambda_00_coef, l_max, m_max);
+        lambda_00_coef, l_max);
     theta_gradient.at(i) = evaluate_harmonic_expansion(
         dtheta, gsl::at(target_thetas, i), gsl::at(target_phis, i), coefs,
-        lambda_00_coef, l_max, m_max);
+        lambda_00_coef, l_max);
     phi_gradient.at(i) = evaluate_harmonic_expansion(
         dphi, gsl::at(target_thetas, i), gsl::at(target_phis, i), coefs,
-        lambda_00_coef, l_max, m_max);
+        lambda_00_coef, l_max);
   }
   // multiply angular gradient by inverse jacobian to get cartesian gradient
   std::array<DataVector, 3> cartesian_gradient{};
@@ -439,8 +472,8 @@ tnsr::Ij<DataVector, 3, Frame::NoFrame> calculate_analytical_jacobian(
 
 template <typename TransitionFunction>
 void test_analytical_jacobian(const TransitionFunction& transition_func,
-                              size_t l_max, size_t m_max,
-                              const bool include_size, size_t num_points,
+                              size_t l_max, const bool include_size,
+                              size_t num_points,
                               gsl::not_null<std::mt19937*> generator) {
   std::uniform_real_distribution dist{-10., 10.};
   const auto center =
@@ -461,14 +494,14 @@ void test_analytical_jacobian(const TransitionFunction& transition_func,
     }
   }
 
-  auto random_coefs = generate_random_coefs(l_max, m_max, generator);
+  auto random_coefs = generate_random_coefs(l_max, generator);
 
   FunctionsOfTimeMap functions_of_time{};
   double time{};
   auto map = CoordinateMaps::TimeDependent::Shape{};
 
   DataVector spherepack_coefs =
-      convert_coefs_to_spherepack(random_coefs, l_max, m_max);
+      convert_coefs_to_spherepack(random_coefs, l_max);
   std::optional<double> random_00_coef{};
   if (include_size) {
     random_coefs[0][0] = 0.0;
@@ -478,14 +511,16 @@ void test_analytical_jacobian(const TransitionFunction& transition_func,
 
   generate_random_map_time_and_f_of_time(
       make_not_null(&map), make_not_null(&time),
-      make_not_null(&functions_of_time), l_max, m_max, center, transition_func,
-      spherepack_coefs, random_00_coef, true, generator);
+      make_not_null(&functions_of_time), l_max, center, transition_func,
+      spherepack_coefs, random_00_coef, true, generator, l_max + 2);
   const auto mapped_jacobian =
       map.jacobian(target_data, time, functions_of_time);
-  const auto analytical_jacobian = calculate_analytical_jacobian(
-      target_data, center, l_max, m_max, random_coefs, random_00_coef,
-      transition_func);
-  CHECK_ITERABLE_APPROX(mapped_jacobian, analytical_jacobian);
+  const auto analytical_jacobian =
+      calculate_analytical_jacobian(target_data, center, l_max, random_coefs,
+                                    random_00_coef, transition_func);
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(mapped_jacobian, analytical_jacobian,
+                               custom_approx);
 }
 
 template <typename Generator>
@@ -495,7 +530,7 @@ void test_inverse(const gsl::not_null<Generator*> generator) {
   const double time = 1.0;
   const TransitionFunc sphere_transition{1.0, 1.5};
   CoordinateMaps::TimeDependent::Shape shape{
-      std::array{0.0, 0.0, 0.0}, 10, 10,
+      std::array{0.0, 0.0, 0.0}, 0.0,
       std::make_unique<TransitionFunc>(sphere_transition), "Shape"};
 
   DataVector coefs{ylm::Spherepack::spectral_size(10, 10), 0.0};
@@ -540,7 +575,7 @@ void test_inverse(const gsl::not_null<Generator*> generator) {
 
 template <typename TransitionFunction>
 void test_combined_call(const TransitionFunction& transition_func, size_t l_max,
-                        size_t m_max, size_t num_points,
+                        size_t num_points,
                         gsl::not_null<std::mt19937*> generator) {
   const std::uniform_real_distribution dist{-10., 10.};
   const auto center =
@@ -548,22 +583,22 @@ void test_combined_call(const TransitionFunction& transition_func, size_t l_max,
   auto target_data = make_with_random_values<std::array<DataVector, 3>>(
       generator, dist, num_points);
 
-  auto random_coefs = generate_random_coefs(l_max, m_max, generator);
+  auto random_coefs = generate_random_coefs(l_max, generator);
 
   FunctionsOfTimeMap functions_of_time{};
   double time{};
   auto map = CoordinateMaps::TimeDependent::Shape{};
 
   DataVector spherepack_coefs =
-      convert_coefs_to_spherepack(random_coefs, l_max, m_max);
+      convert_coefs_to_spherepack(random_coefs, l_max);
   std::optional<double> random_00_coef{};
   random_coefs[0][0] = 0.0;
   spherepack_coefs[0] = 0.0;
   random_00_coef = generate_random_00_coef(generator);
   generate_random_map_time_and_f_of_time(
       make_not_null(&map), make_not_null(&time),
-      make_not_null(&functions_of_time), l_max, m_max, center, transition_func,
-      spherepack_coefs, random_00_coef, true, generator);
+      make_not_null(&functions_of_time), l_max, center, transition_func,
+      spherepack_coefs, random_00_coef, true, generator, l_max + 2);
   const auto single_coords = map(target_data, time, functions_of_time);
   const auto single_frame_velocity =
       map.frame_velocity(target_data, time, functions_of_time);
@@ -594,44 +629,38 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.TimeDependent.Shape",
 
   test_inverse(make_not_null(&generator));
 
+  const size_t num_points = 1000;
+
   for (const auto include_size : make_array(false, true)) {
     CAPTURE(include_size);
     {
       INFO("Testing MapHelpers");
       for (size_t l_max = 2; l_max < 12; ++l_max) {
-        for (size_t m_max = 2; m_max <= l_max; ++m_max) {
-          CAPTURE(l_max, m_max);
-          test_map_helpers(sphere_transition, l_max, m_max, include_size,
-                           make_not_null(&generator));
-        }
+        CAPTURE(l_max);
+        test_map_helpers(sphere_transition, l_max, include_size,
+                         make_not_null(&generator));
       }
     }
     {
       INFO("Testing analytical solution");
       for (size_t l_max = 2; l_max <= 3; ++l_max) {
-        for (size_t m_max = 2; m_max <= l_max; ++m_max) {
-          CAPTURE(l_max, m_max);
-          test_analytical_solution(sphere_transition, l_max, m_max,
-                                   include_size, 1000,
-                                   make_not_null(&generator));
-        }
+        CAPTURE(l_max);
+        test_analytical_solution(sphere_transition, l_max, include_size,
+                                 num_points, make_not_null(&generator));
       }
     }
     {
       INFO("Testing analytical gradient");
       const size_t l_max = 2;
-      const size_t m_max = 2;
-      test_analytical_jacobian(sphere_transition, l_max, m_max, include_size,
-                               1000, make_not_null(&generator));
+      test_analytical_jacobian(sphere_transition, l_max, include_size, 1000,
+                               make_not_null(&generator));
     }
     {
       INFO("Testing combined call");
       for (size_t l_max = 2; l_max <= 3; ++l_max) {
-        for (size_t m_max = 2; m_max <= l_max; ++m_max) {
-          CAPTURE(l_max, m_max);
-          test_combined_call(sphere_transition, l_max, m_max, 1000,
-                             make_not_null(&generator));
-        }
+        CAPTURE(l_max);
+        test_combined_call(sphere_transition, l_max, num_points,
+                           make_not_null(&generator));
       }
     }
   }

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -460,12 +460,14 @@ std::string create_option_string(
              "      InitialValuesZ: [0.0, -0.01, 0.0]\n" +
              (excise_A ? "    ShapeMapA:\n"
                          "      LMax: 8\n"
+                         "      CoefficientTruncationLimit: 0.\n"
                          "      InitialValues: Spherical\n"
                          "      SizeInitialValues: [0.0, -0.1, 0.01]\n"
                          "      TransitionEndsAtCube: false\n"s
                        : "    ShapeMapA: None\n"s) +
              (excise_B ? "    ShapeMapB:\n"
                          "      LMax: 8\n"
+                         "      CoefficientTruncationLimit: 0.\n"
                          "      InitialValues: Spherical\n"
                          "      SizeInitialValues: [0.0, -0.2, 0.02]\n"
                          "      TransitionEndsAtCube: true"s

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -258,10 +258,12 @@ std::string create_option_string(
                              "    SkewMap: None\n"
                              "    ShapeMapA:\n"
                              "      LMax: 8\n"
+                             "      CoefficientTruncationLimit: 0.\n"
                              "      InitialValues: Spherical\n"
                              "      SizeInitialValues: [1.1, 0.0, 0.0]\n"
                              "    ShapeMapB:\n"
                              "      LMax: 8\n"
+                             "      CoefficientTruncationLimit: 0.\n"
                              "      InitialValues: Spherical\n"
                              "      SizeInitialValues: [1.2, 0.0, 0.0]\n")
                           : "  TimeDependentMaps: None\n"};

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -149,6 +149,7 @@ std::string option_string(
                               "    InitialTime: 1.0\n"
                               "    ShapeMap:\n"
                               "      LMax: 10\n"
+                              "      CoefficientTruncationLimit: 0.\n"
                               "      InitialValues: Spherical\n"
                               "      SizeInitialValues: Auto\n"
                               "    RotationMap: None\n"
@@ -708,7 +709,7 @@ void test_shape_distortion() {
     // Time dependence
     time_dependent_options = std::make_unique<
         domain::creators::time_dependence::Shape<domain::ObjectLabel::None>>(
-        time, l_max, mass, spin, std::array<double, 3>{{0., 0., 0.}},
+        time, l_max, mass, spin, std::array<double, 3>{{0., 0., 0.}}, 0.0,
         inner_radius, 4.);
 
     test_shape_distortion_general(time, std::move(time_dependent_options),

--- a/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
@@ -71,6 +71,7 @@ std::string option_string(
                               "    ShapeMap:\n"
                               "      LMax: 10\n"
                               "      InitialValues: Spherical\n"
+                              "      CoefficientTruncationLimit: 0.0\n"
                               "      SizeInitialValues: Auto\n"
                               "    RotationMap: None\n"
                               "    ExpansionMap: None\n"
@@ -517,7 +518,7 @@ void test_shape_distortion() {
     // Time dependence
     time_dependent_options = std::make_unique<
         domain::creators::time_dependence::Shape<domain::ObjectLabel::None>>(
-        time, l_max, mass, spin, std::array<double, 3>{{0., 0., 0.}},
+        time, l_max, mass, spin, std::array<double, 3>{{0., 0., 0.}}, 0.0,
         inner_radius, 4.);
 
     test_shape_distortion_general(time, std::move(time_dependent_options),

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_Shape.cpp
@@ -57,16 +57,20 @@ template <typename SourceFrame, typename TargetFrame>
 ConcreteMapSimple<SourceFrame, TargetFrame> create_coord_map(
     const std::string& f_of_t_name, const size_t l_max,
     const std::array<double, 3>& center,
+    const double coefficient_truncation_limit,
     std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                         ShapeMapTransitionFunction>
         transition_func) {
+  (void)l_max;
   if constexpr (std::is_same_v<SourceFrame, Frame::Grid>) {
-    return ConcreteMapSimple<SourceFrame, TargetFrame>{{ShapeMap{
-        center, l_max, l_max, transition_func->get_clone(), f_of_t_name}}};
+    return ConcreteMapSimple<SourceFrame, TargetFrame>{
+        {ShapeMap{center, coefficient_truncation_limit,
+                  transition_func->get_clone(), f_of_t_name}}};
   } else {
     (void)f_of_t_name;
     (void)l_max;
     (void)center;
+    (void)coefficient_truncation_limit;
     (void)transition_func;
     return ConcreteMapSimple<SourceFrame, TargetFrame>{Identity{}};
   }
@@ -75,11 +79,14 @@ ConcreteMapSimple<SourceFrame, TargetFrame> create_coord_map(
 ConcreteMapCombined create_coord_map_combined(
     const std::string& f_of_t_name, const size_t l_max,
     const std::array<double, 3>& center,
+    const double coefficient_truncation_limit,
     std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                         ShapeMapTransitionFunction>
         transition_func) {
-  return ConcreteMapCombined{ShapeMap{
-      center, l_max, l_max, transition_func->get_clone(), f_of_t_name}};
+  (void)l_max;
+  return ConcreteMapCombined{ShapeMap{center, coefficient_truncation_limit,
+                                      transition_func->get_clone(),
+                                      f_of_t_name}};
 }
 
 template <typename Frame>
@@ -122,8 +129,7 @@ void test_r_theta_phi(const tnsr::I<double, 3, SourceFrame>& input,
   const double radius = magnitude(input_centered).get();
   const double transition_factor =
       std::make_unique<Transition>(Transition{inner_radius, outer_radius})
-          ->
-          operator()(std::array{radius, 0.0, 0.0}, std::nullopt);
+          ->operator()(std::array{radius, 0.0, 0.0}, std::nullopt);
   const double expected_output_centered_spherical =
       input_centered_spherical[0] *
       (1.0 + transition_factor * (kerr_schild_radius - inner_radius));
@@ -235,8 +241,9 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
           std::unique_ptr<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                               ShapeMapTransitionFunction>
               transition_func,
-          const double inner_radius, const double outer_radius,
-          const double mass, const std::array<double, 3>& spin,
+          const double coefficient_truncation_limit, const double inner_radius,
+          const double outer_radius, const double mass,
+          const std::array<double, 3>& spin,
           const std::array<double, 3>& center) {
   MAKE_GENERATOR(gen);
   CAPTURE(initial_time);
@@ -259,7 +266,8 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
   const size_t num_blocks = dist_size_t(gen);
   CAPTURE(num_blocks);
   const auto expected_block_map_grid_to_inertial = create_coord_map_combined(
-      f_of_t_name, l_max, center, transition_func->get_clone());
+      f_of_t_name, l_max, center, coefficient_truncation_limit,
+      transition_func->get_clone());
   const auto block_maps_grid_to_inertial =
       time_dep_unique_ptr->block_maps_grid_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps_grid_to_inertial) {
@@ -276,7 +284,8 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
 
   const auto expected_block_map_grid_to_distorted =
       create_coord_map<Frame::Grid, Frame::Distorted>(
-          f_of_t_name, l_max, center, transition_func->get_clone());
+          f_of_t_name, l_max, center, coefficient_truncation_limit,
+          transition_func->get_clone());
   const auto block_maps_grid_to_distorted =
       time_dep_unique_ptr->block_maps_grid_to_distorted(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps_grid_to_distorted) {
@@ -294,7 +303,8 @@ void test(const std::unique_ptr<TimeDependence<3>>& time_dep_unique_ptr,
 
   const auto expected_block_map_distorted_to_inertial =
       create_coord_map<Frame::Distorted, Frame::Inertial>(
-          f_of_t_name, l_max, center, transition_func->get_clone());
+          f_of_t_name, l_max, center, coefficient_truncation_limit,
+          transition_func->get_clone());
   const auto block_maps_distorted_to_inertial =
       time_dep_unique_ptr->block_maps_distorted_to_inertial(num_blocks);
   for (const auto& block_map_unique_ptr : block_maps_distorted_to_inertial) {
@@ -340,6 +350,7 @@ void test_all() {
   // compare ylm output with analytic solution.
   constexpr size_t l_max{16};
   constexpr double mass{1.0};
+  constexpr double coefficient_truncation_limit{0.0};
   const std::array<double, 3> spin{{0.1, 0.4, -0.5}};
   const std::array<double, 3> center{{-0.02, 0.013, 0.024}};
   const double inner_radius = 2.0;
@@ -350,13 +361,16 @@ void test_all() {
 
   const std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dep = std::make_unique<Shape>(initial_time, l_max, mass, spin,
-                                         center, inner_radius, outer_radius);
+                                         center, coefficient_truncation_limit,
+                                         inner_radius, outer_radius);
   test(time_dep, initial_time, f_of_t_name, l_max,
-       std::make_unique<Transition>(sphere_transition), inner_radius,
-       outer_radius, mass, spin, center);
+       std::make_unique<Transition>(sphere_transition),
+       coefficient_truncation_limit, inner_radius, outer_radius, mass, spin,
+       center);
   test(time_dep->get_clone(), initial_time, f_of_t_name, l_max,
-       std::make_unique<Transition>(sphere_transition), inner_radius,
-       outer_radius, mass, spin, center);
+       std::make_unique<Transition>(sphere_transition),
+       coefficient_truncation_limit, inner_radius, outer_radius, mass, spin,
+       center);
 
   test(TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
            "Shape:\n"
@@ -365,11 +379,13 @@ void test_all() {
            "  Mass: 1.0\n"
            "  Spin: [0.1, 0.4, -0.5]\n"
            "  Center: [-0.02, 0.013, 0.024]\n"
+           "  CoefficientTruncationLimit: 0.0\n"
            "  InnerRadius: 2.0\n"
            "  OuterRadius: 100.0\n"),
        initial_time, f_of_t_name, l_max,
-       std::make_unique<Transition>(sphere_transition), inner_radius,
-       outer_radius, mass, spin, center);
+       std::make_unique<Transition>(sphere_transition),
+       coefficient_truncation_limit, inner_radius, outer_radius, mass, spin,
+       center);
 }
 
 void test_equivalence() {
@@ -381,15 +397,41 @@ void test_equivalence() {
   const double inner_radius = 1.0;
   const double outer_radius1 = 10.0;
   const double outer_radius2 = 20.0;
+  const double coefficient_truncation_limit1 = 0.0;
+  const double coefficient_truncation_limit2 = 1.0e-4;
 
-  Shape sc0{1.0, 4, mass, spin1, center1, inner_radius, outer_radius1};
-  Shape sc1{1.0, 4, mass, spin1, center1, inner_radius, outer_radius1};
-  Shape sc2{1.0, 4, mass, spin2, center1, inner_radius, outer_radius1};
-  Shape sc3{1.0, 4, mass, spin2, center1, inner_radius, outer_radius1};
-  Shape sc4{1.0, 4, mass, spin1, center2, inner_radius, outer_radius2};
-  Shape sc5{1.0, 4, mass, spin1, center2, inner_radius, outer_radius2};
-  Shape sc6{1.0, 4, mass, spin2, center2, inner_radius, outer_radius2};
-  Shape sc7{1.0, 4, mass, spin2, center2, inner_radius, outer_radius2};
+  Shape sc0{1.0,          4,
+            mass,         spin1,
+            center1,      coefficient_truncation_limit1,
+            inner_radius, outer_radius1};
+  Shape sc1{1.0,          4,
+            mass,         spin1,
+            center1,      coefficient_truncation_limit1,
+            inner_radius, outer_radius1};
+  Shape sc2{1.0,          4,
+            mass,         spin2,
+            center1,      coefficient_truncation_limit1,
+            inner_radius, outer_radius1};
+  Shape sc3{1.0,          4,
+            mass,         spin2,
+            center1,      coefficient_truncation_limit1,
+            inner_radius, outer_radius1};
+  Shape sc4{1.0,          4,
+            mass,         spin1,
+            center2,      coefficient_truncation_limit2,
+            inner_radius, outer_radius2};
+  Shape sc5{1.0,          4,
+            mass,         spin1,
+            center2,      coefficient_truncation_limit2,
+            inner_radius, outer_radius2};
+  Shape sc6{1.0,          4,
+            mass,         spin2,
+            center2,      coefficient_truncation_limit2,
+            inner_radius, outer_radius2};
+  Shape sc7{1.0,          4,
+            mass,         spin2,
+            center2,      coefficient_truncation_limit2,
+            inner_radius, outer_radius2};
 
   CHECK(sc0 == sc0);
   CHECK_FALSE(sc0 != sc0);
@@ -415,6 +457,7 @@ void test_errors() {
           "Shape:\n"
           "  InitialTime: 1.3\n"
           "  LMax: 4\n"
+          "  CoefficientTruncationLimit: 0.0\n"
           "  Mass: 1.0\n"
           "  Spin: [0.0, 1.0, 0.1]\n"
           "  Center: [-0.01, 0.02, 0.01]\n"
@@ -429,6 +472,7 @@ void test_errors() {
           "Shape:\n"
           "  InitialTime: 1.3\n"
           "  LMax: 4\n"
+          "  CoefficientTruncationLimit: 0.0\n"
           "  Mass: 1.0\n"
           "  Spin: [0.0, 1.0, 0.1]\n"
           "  Center: [-0.01, 0.02, 0.01]\n"
@@ -441,6 +485,7 @@ void test_errors() {
       TestHelpers::test_creation<std::unique_ptr<TimeDependence<3>>>(
           "Shape:\n"
           "  InitialTime: 1.3\n"
+          "  CoefficientTruncationLimit: 0.0\n"
           "  LMax: 4\n"
           "  Mass: -1.0\n"
           "  Spin: [0.0, 1.0, 0.1]\n"

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_BinaryCompactObject.cpp
@@ -184,7 +184,7 @@ void test(const bool include_expansion, const bool include_rotation,
                                                              size_A_values}
             : time_dependent_options::ShapeMapOptions<not IsCylindrical,
                                                       domain::ObjectLabel::A>{
-                  l_max_A, std::nullopt, size_A_values,
+                  l_max_A, std::nullopt, size_A_values, 0.,
                   transition_ends_at_cube_A};
   }
 
@@ -199,7 +199,7 @@ void test(const bool include_expansion, const bool include_rotation,
                                                              size_B_values}
             : time_dependent_options::ShapeMapOptions<not IsCylindrical,
                                                       domain::ObjectLabel::B>{
-                  l_max_B, std::nullopt, size_B_values,
+                  l_max_B, std::nullopt, size_B_values, 0.,
                   transition_ends_at_cube_B};
   }
 

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ShapeMap.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_ShapeMap.cpp
@@ -84,6 +84,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
     const auto shape_map_options = TestHelpers::test_option_tag<
         ShapeMapOptions<false, domain::ObjectLabel::None>>(
         "LMax: 8\n"
+        "CoefficientTruncationLimit: 0.0\n"
         "InitialValues: Spherical\n"
         "SizeInitialValues: Auto\n");
 
@@ -111,6 +112,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
         domain::creators::time_dependent_options::ShapeMapOptions<
             false, domain::ObjectLabel::None>>(
         "LMax: 8\n"
+        "CoefficientTruncationLimit: 0.0\n"
         "InitialValues:\n"
         "  Mass: 1.0\n"
         "  Spin: [0.0, 0.0, 0.0]\n"
@@ -191,6 +193,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
           domain::creators::time_dependent_options::ShapeMapOptions<
               true, domain::ObjectLabel::B>>(
           "LMax: 8\n"
+          "CoefficientTruncationLimit: 0.0\n"
           "InitialValues:\n"
           "  H5Filename: TotalEclipseOfTheHeart.h5\n"
           "  SubfileNames:\n"
@@ -262,6 +265,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
           domain::creators::time_dependent_options::ShapeMapOptions<
               true, domain::ObjectLabel::B>>(
           "LMax: 8\n"
+          "CoefficientTruncationLimit: 0.0\n"
           "InitialValues:\n"
           "  H5Filename: TotalEclipseOfTheHeart.h5\n"
           "  SubfileNames:\n"
@@ -300,6 +304,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
           domain::creators::time_dependent_options::ShapeMapOptions<
               false, domain::ObjectLabel::B>>(
           "LMax: 6\n"
+          "CoefficientTruncationLimit: 0.0\n"
           "TransitionEndsAtCube: false\n"
           "H5Filename: TotalEclipseOfTheHeart.h5\n"
           "SubfileName: VolumeData\n");
@@ -421,6 +426,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
           domain::creators::time_dependent_options::ShapeMapOptions<
               false, domain::ObjectLabel::None>>(
           "LMax: 8\n"
+          "CoefficientTruncationLimit: 0.0\n"
           "InitialValues:\n"
           "  DatFilename: PartialEclipseOfTheHeart.dat\n"
           "  MatchTime: 2.7\n"
@@ -477,6 +483,7 @@ void test_funcs(const gsl::not_null<Generator*> generator) {
           domain::creators::time_dependent_options::ShapeMapOptions<
               false, domain::ObjectLabel::None>>(
           "LMax: 8\n"
+          "CoefficientTruncationLimit: 0.0\n"
           "InitialValues:\n"
           "  DatFilename: PartialEclipseOfTheHeart.dat\n"
           "  MatchTime: 10000.0\n"

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_Sphere.cpp
@@ -36,6 +36,7 @@ std::string create_option_string(const std::optional<bool> use_non_zero_shape) {
          (use_non_zero_shape.has_value()
               ? "\n"
                 "  LMax: 8\n"
+                "  CoefficientTruncationLimit: 0.\n"
                 "  SizeInitialValues: Auto\n"
                 "  InitialValues:" +
                     (use_non_zero_shape.value() ? "\n"

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -852,8 +852,7 @@ struct TestTimeDependentMapOptions {
         // Store the inner radii for creating functions of time
         gsl::at(inner_radii_, i) = radii[0];
 
-        const size_t initial_l_max = i == 0 ? shape_options_A_.value().l_max
-                                            : shape_options_B_.value().l_max;
+        const double coefficient_truncation_limit = 0.;
 
         std::unique_ptr<CoordinateMaps::ShapeMapTransitionFunctions::
                             ShapeMapTransitionFunction>
@@ -867,9 +866,9 @@ struct TestTimeDependentMapOptions {
               radii[0], radii[1]);
 
           gsl::at(shape_maps_, i) =
-              Shape{gsl::at(centers, i),     initial_l_max,
-                    initial_l_max,           std::move(transition_func),
-                    gsl::at(shape_names, i), gsl::at(size_names, i)};
+              Shape{gsl::at(centers, i), coefficient_truncation_limit,
+                    std::move(transition_func), gsl::at(shape_names, i),
+                    gsl::at(size_names, i)};
         } else {
           // These must match the order of orientations_for_sphere_wrappings()
           // in DomainHelpers.hpp
@@ -893,9 +892,9 @@ struct TestTimeDependentMapOptions {
                 gsl::at(axes, j));
 
             gsl::at(gsl::at(shape_maps_, i), j) =
-                Shape{gsl::at(centers, i),     initial_l_max,
-                      initial_l_max,           std::move(transition_func),
-                      gsl::at(shape_names, i), gsl::at(size_names, i)};
+                Shape{gsl::at(centers, i), coefficient_truncation_limit,
+                      std::move(transition_func), gsl::at(shape_names, i),
+                      gsl::at(size_names, i)};
           }
         }
 

--- a/tests/Unit/Domain/Test_StrahlkorperTransformations.cpp
+++ b/tests/Unit/Domain/Test_StrahlkorperTransformations.cpp
@@ -54,9 +54,9 @@ void test_strahlkorper_in_different_frame() {
         radial_distribution, ShellWedges::All,
         // Choose time dependence to be centered at the strahlkorper center.
         std::make_unique<domain::creators::time_dependence::Shape<
-            domain::ObjectLabel::None>>(0.0, l_max, 1.0,
-                                        std::array<double, 3>{{0.1, 0.2, 0.3}},
-                                        strahlkorper_src_center, 2.0, 12.0)));
+            domain::ObjectLabel::None>>(
+            0.0, l_max, 1.0, std::array<double, 3>{{0.1, 0.2, 0.3}},
+            strahlkorper_src_center, 0., 2.0, 12.0)));
   } else {
     domain_creator.reset(new domain::creators::Sphere(
         1.9, 2.9, domain::creators::Sphere::Excision{}, 1_st,

--- a/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/CurvedScalarWave/Worldtube/TestHelpers.cpp
@@ -78,11 +78,13 @@ std::unique_ptr<DomainCreator<3>> worldtube_binary_compact_object(
       "    SkewMap: None\n"
       "    ShapeMapA:\n"
       "      LMax: 2\n"
+      "      CoefficientTruncationLimit: 0.\n"
       "      InitialValues: Spherical\n"
       "      SizeInitialValues: [0.0, 0.0, 0.0]\n"
       "      TransitionEndsAtCube: false\n"
       "    ShapeMapB:\n"
       "      LMax: 2\n"
+      "      CoefficientTruncationLimit: 0.\n"
       "      InitialValues: Spherical\n"
       "      SizeInitialValues: [0.0, 0.0, 0.0]\n"
       "      TransitionEndsAtCube: false\n";

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ApparentHorizonFinder.cpp
@@ -410,8 +410,8 @@ void test_apparent_horizon(
       // excision is still inside the horizon but isn't spherical
       time_dependence = std::make_unique<
           domain::creators::time_dependence::Shape<domain::ObjectLabel::None>>(
-          0.0, l_max, mass, dimensionless_spin, std::array{0.0, 0.0, 0.0}, 1.9,
-          2.9);
+          0.0, l_max, mass, dimensionless_spin, std::array{0.0, 0.0, 0.0}, 0.,
+          1.9, 2.9);
     } else {
       time_dependence = std::make_unique<
           domain::creators::time_dependence::UniformTranslation<3>>(


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Changes the shape map to no longer store l_max but infer it from the functions of time. This is needed for the adaptive apparent horizon finder. In the future, we probably want to cache the Spherepack object somehow and update it only when the l_max changes.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
All InputFiles that use the Shape map need to add the CoefficientTruncationLimit option. For Spec, the choice is 1e-20 for the inspiral and 1e-12 for the ringdown

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
