### PR TITLE
Add higher order fd interpolants

### DIFF
--- a/src/Evolution/DgSubcell/SetInterpolators.hpp
+++ b/src/Evolution/DgSubcell/SetInterpolators.hpp
@@ -285,14 +285,16 @@ struct SetInterpolators {
           const Mesh<Dim> new_mesh{new_extents, new_basis, new_quads};
           (*interpolators_fd_to_neighbor_fd_ptr)[DirectionalId<Dim>{
               direction, neighbor_id}] = intrp::Irregular<Dim>{
-              new_mesh, new_neighbor_logical_ghost_zone_coords};
+              new_mesh, new_neighbor_logical_ghost_zone_coords,
+              subcell_options.get_fd_to_fd_interp_order()};
           (*extension_direction_ptr)[direction] =
               interpolators_detail::ExtensionDirection<Dim>{
                   direction_to_extend.value()};
         } else {
           (*interpolators_fd_to_neighbor_fd_ptr)[DirectionalId<Dim>{
               direction, neighbor_id}] = intrp::Irregular<Dim>{
-              my_fd_mesh, neighbor_logical_ghost_zone_coords};
+              my_fd_mesh, neighbor_logical_ghost_zone_coords,
+              subcell_options.get_fd_to_fd_interp_order()};
         }
         // Set up interpolators for our local element to our neighbor's
         // ghost zones.

--- a/src/Evolution/DgSubcell/SubcellOptions.cpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.cpp
@@ -31,7 +31,7 @@ SubcellOptions::SubcellOptions(
     ::fd::DerivativeOrder finite_difference_derivative_order,
     const size_t number_of_steps_between_tci_calls,
     const size_t min_tci_calls_after_rollback,
-    const size_t min_clear_tci_before_dg)
+    const size_t min_clear_tci_before_dg, const size_t fd_to_fd_interp_order)
     : persson_exponent_(persson_exponent),
       persson_num_highest_modes_(persson_num_highest_modes),
       rdmp_delta0_(rdmp_delta0),
@@ -44,7 +44,8 @@ SubcellOptions::SubcellOptions(
       finite_difference_derivative_order_(finite_difference_derivative_order),
       number_of_steps_between_tci_calls_(number_of_steps_between_tci_calls),
       min_tci_calls_after_rollback_(min_tci_calls_after_rollback),
-      min_clear_tci_before_dg_(min_clear_tci_before_dg) {
+      min_clear_tci_before_dg_(min_clear_tci_before_dg),
+      fd_to_fd_interp_order_(fd_to_fd_interp_order) {
   if (not only_dg_block_and_group_names_.has_value()) {
     only_dg_block_ids_ = std::vector<size_t>{};
   }
@@ -96,6 +97,7 @@ void SubcellOptions::pup(PUP::er& p) {
   p | use_halo_;
   p | only_dg_block_and_group_names_;
   p | only_dg_block_ids_;
+  p | fd_to_fd_interp_order_;
   p | finite_difference_derivative_order_;
   p | number_of_steps_between_tci_calls_;
   p | min_tci_calls_after_rollback_;
@@ -121,7 +123,8 @@ bool operator==(const SubcellOptions& lhs, const SubcellOptions& rhs) {
              rhs.number_of_steps_between_tci_calls_ and
          lhs.min_tci_calls_after_rollback_ ==
              rhs.min_tci_calls_after_rollback_ and
-         lhs.min_clear_tci_before_dg_ == rhs.min_clear_tci_before_dg_;
+         lhs.min_clear_tci_before_dg_ == rhs.min_clear_tci_before_dg_ and
+         lhs.fd_to_fd_interp_order_ == rhs.fd_to_fd_interp_order_;
 }
 
 bool operator!=(const SubcellOptions& lhs, const SubcellOptions& rhs) {

--- a/src/Evolution/DgSubcell/SubcellOptions.hpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.hpp
@@ -200,13 +200,24 @@ class SubcellOptions {
     using group = FdToDgTci;
   };
 
+  /// \brief FD to FD interpolation order.
+  ///
+  struct FdInterpolationOrder {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "The interpolation order to use when interpolating from FD block to FD "
+        "block."};
+    static constexpr type lower_bound() { return 1; }
+    static constexpr type upper_bound() { return 3; }
+  };
+
   using options =
       tmpl::list<PerssonExponent, PerssonNumHighestModes, RdmpDelta0,
                  RdmpEpsilon, AlwaysUseSubcells, EnableExtensionDirections,
                  SubcellToDgReconstructionMethod, UseHalo,
                  OnlyDgBlocksAndGroups, FiniteDifferenceDerivativeOrder,
                  NumberOfStepsBetweenTciCalls, MinTciCallsAfterRollback,
-                 MinimumClearTcis>;
+                 MinimumClearTcis, FdInterpolationOrder>;
 
   static constexpr Options::String help{
       "System-agnostic options for the DG-subcell method."};
@@ -220,7 +231,8 @@ class SubcellOptions {
       std::optional<std::vector<std::string>> only_dg_block_and_group_names,
       ::fd::DerivativeOrder finite_difference_derivative_order,
       size_t number_of_steps_between_tci_calls,
-      size_t min_tci_calls_after_rollback, size_t min_clear_tci_before_dg);
+      size_t min_tci_calls_after_rollback, size_t min_clear_tci_before_dg,
+      size_t fd_to_fd_interp_order = 1_st);
 
   /// \brief Given an existing SubcellOptions that was created from block and
   /// group names, create one that stores block IDs.
@@ -266,6 +278,8 @@ class SubcellOptions {
            "set.");
     return only_dg_block_ids_.value();
   }
+
+  size_t get_fd_to_fd_interp_order() const { return fd_to_fd_interp_order_; }
 
   ::fd::DerivativeOrder finite_difference_derivative_order() const {
     return finite_difference_derivative_order_;
@@ -313,6 +327,7 @@ class SubcellOptions {
   size_t number_of_steps_between_tci_calls_{1};
   size_t min_tci_calls_after_rollback_{1};
   size_t min_clear_tci_before_dg_{0};
+  size_t fd_to_fd_interp_order_{};
 };
 
 bool operator!=(const SubcellOptions& lhs, const SubcellOptions& rhs);

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <array>
 #include <iterator>
+#include <limits>
+#include <optional>
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
@@ -17,12 +19,18 @@
 #include "Utilities/ContainerHelpers.hpp"
 
 namespace {
+template <size_t Order>
+std::vector<double> fd_stencil(const DataVector& xi_source,
+                               double xi_target);
+
+// potential future optimization: use the barycentric formula
 
 // Just linear for now, can be extended to higher order...
 // Future optimization: it might be more efficient to use Blaze's sparse
 // matrices since the interpolation matrix is mostly zeros
-std::vector<double> fd_stencil(const DataVector& xi_source,
-                               const double xi_target) {
+template <>
+std::vector<double> fd_stencil<1>(const DataVector& xi_source,
+                                  const double xi_target) {
   ASSERT(std::is_sorted(std::begin(xi_source), std::end(xi_source)),
          "xi_source = " << xi_source);
   auto xi_u =
@@ -43,6 +51,165 @@ std::vector<double> fd_stencil(const DataVector& xi_source,
   return result;
 }
 
+// Quadratic (three-point) finite-difference interpolation stencil.
+// Returns a weight vector with exactly three non-zero entries corresponding
+// to a chosen triplet of consecutive grid points. For interior targets we pick
+// the more centered of the two possible triplets bracketing the target.
+// Edge targets (or outside) use the first or last 3 points, yielding
+// one-sided quadratic extrapolation.
+template <>
+std::vector<double> fd_stencil<2>(const DataVector& xi_source,
+                                  const double xi_target) {
+  ASSERT(std::is_sorted(std::begin(xi_source), std::end(xi_source)),
+         "xi_source = " << xi_source);
+  const size_t num_of_pts = xi_source.size();
+  ASSERT(num_of_pts >= 3,
+         "Need at least 3 points for quadratic interpolation (got "
+             << num_of_pts << ")");
+
+  auto xi_u =
+      std::upper_bound(std::begin(xi_source), std::end(xi_source), xi_target);
+
+  // Determine the three indices to use.
+  size_t i0{0};
+  size_t i1{0};
+  size_t i2{0};
+
+  if (xi_u == std::begin(xi_source)) {
+    // Target at/below first point
+    i0 = 0;
+    i1 = 1;
+    i2 = 2;
+  } else if (xi_u == std::end(xi_source)) {
+    // Target above last point
+    i0 = num_of_pts - 3;
+    i1 = num_of_pts - 2;
+    i2 = num_of_pts - 1;
+  } else {
+    const auto iu =
+        static_cast<size_t>(std::distance(std::begin(xi_source), xi_u));
+    const size_t il = iu - 1;  // lower bracket index
+
+    if (il == 0) {
+      // Near lower boundary
+      i0 = 0;
+      i1 = 1;
+      i2 = 2;
+    } else if (iu == num_of_pts - 1) {
+      // Near upper boundary (target between last two points)
+      i0 = num_of_pts - 3;
+      i1 = num_of_pts - 2;
+      i2 = num_of_pts - 1;
+    } else {
+      // Interior: choose centered triplet
+      // Option A: (il-1, il, iu)
+      // Option B: (il, iu, iu+1)
+      const double x_il = xi_source[il];
+      const double x_iu = xi_source[iu];
+      // Compare proximity to pick more centered set
+      if (xi_target - x_il < x_iu - xi_target) {
+        i0 = il - 1;
+        i1 = il;
+        i2 = iu;
+      } else {
+        i0 = il;
+        i1 = iu;
+        i2 = iu + 1;
+      }
+    }
+  }
+
+  // Compute Lagrange weights for the selected three nodes.
+  const double x0 = xi_source[i0];
+  const double x1 = xi_source[i1];
+  const double x2 = xi_source[i2];
+
+  const double denom0 = (x0 - x1) * (x0 - x2);
+  const double denom1 = (x1 - x0) * (x1 - x2);
+  const double denom2 = (x2 - x0) * (x2 - x1);
+
+  std::vector<double> w(num_of_pts, 0.0);
+  w[i0] = (xi_target - x1) * (xi_target - x2) / denom0;
+  w[i1] = (xi_target - x0) * (xi_target - x2) / denom1;
+  w[i2] = (xi_target - x0) * (xi_target - x1) / denom2;
+
+  return w;
+}
+
+// Cubic (four-point) finite-difference interpolation stencil.
+// Uses four consecutive grid points to build a degree-3 Lagrange interpolant.
+// Boundary/out-of-domain targets use the first/last 4 points (one-sided cubic
+// extrapolation). Interior targets: choose among candidate 4-point windows that
+// contain the bracketing pair to best center the target (minimizing distance to
+// the window's midpoint).
+template <>
+std::vector<double> fd_stencil<3>(const DataVector& xi_source,
+                                  const double xi_target) {
+  ASSERT(std::is_sorted(std::begin(xi_source), std::end(xi_source)),
+         "xi_source = " << xi_source);
+  const size_t num_of_pts = xi_source.size();
+  ASSERT(num_of_pts >= 4, "Need at least 4 points for cubic interpolation (got "
+                              << num_of_pts << ")");
+  auto xi_u =
+      std::upper_bound(std::begin(xi_source), std::end(xi_source), xi_target);
+
+  size_t start{0};  // start index of the 4-point window
+  if (xi_u == std::begin(xi_source)) {
+    // Below first point
+    start = 0;
+  } else if (xi_u == std::end(xi_source)) {
+    // Above last point
+    start = num_of_pts - 4;
+  } else {
+    const auto iu =
+        static_cast<size_t>(std::distance(std::begin(xi_source), xi_u));
+    const size_t il = iu - 1;  // lower bracket index
+    // Determine candidate window starts ensuring il >= s and iu <= s+3
+    const size_t min_start = (il >= 2 ? il - 2 : 0);
+    const size_t max_start = std::min(il, num_of_pts - 4);
+    // Collect candidates
+    double best_dist = std::numeric_limits<double>::max();
+    size_t best_start = min_start;
+    for (size_t s = min_start; s <= max_start; ++s) {
+      // Midpoint of inner two nodes (s+1, s+2) gives a reasonable center
+      const double mid = 0.5 * (xi_source[s + 1] + xi_source[s + 2]);
+      const double dist = std::abs(xi_target - mid);
+      if (dist < best_dist) {
+        best_dist = dist;
+        best_start = s;
+      }
+    }
+    start = best_start;
+  }
+
+  const size_t i0 = start;
+  const size_t i1 = start + 1;
+  const size_t i2 = start + 2;
+  const size_t i3 = start + 3;
+  const double x0 = xi_source[i0];
+  const double x1 = xi_source[i1];
+  const double x2 = xi_source[i2];
+  const double x3 = xi_source[i3];
+
+  // Compute Lagrange weights for 4 points.
+  auto lagrange_weight = [&](double xj, const std::array<double, 3>& others) {
+    double num = 1.0;
+    double denom = 1.0;
+    for (const double xo : others) {
+      num *= (xi_target - xo);
+      denom *= (xj - xo);
+    }
+    return num / denom;
+  };
+
+  std::vector<double> w(num_of_pts, 0.0);
+  w[i0] = lagrange_weight(x0, {x1, x2, x3});
+  w[i1] = lagrange_weight(x1, {x0, x2, x3});
+  w[i2] = lagrange_weight(x2, {x0, x1, x3});
+  w[i3] = lagrange_weight(x3, {x0, x1, x2});
+  return w;
+}
+
 template <size_t Dim, typename DataType>
 Matrix interpolation_matrix(
     const Mesh<Dim>& mesh,
@@ -51,7 +218,8 @@ Matrix interpolation_matrix(
 template <typename DataType>
 Matrix interpolation_matrix(
     const Mesh<1>& mesh,
-    const tnsr::I<DataType, 1, Frame::ElementLogical>& points) {
+    const tnsr::I<DataType, 1, Frame::ElementLogical>& points,
+    const std::optional<size_t>& fd_to_fd_interp_order) {
   if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
     auto source_xi = logical_coordinates(mesh);
     const auto number_of_source_points = mesh.number_of_grid_points();
@@ -59,9 +227,28 @@ Matrix interpolation_matrix(
                                number_of_source_points);
     const size_t number_of_target_points = get_size(get<0>(points));
     Matrix result(number_of_target_points, number_of_source_points);
+    constexpr size_t default_order = 1;  // linear interpolation by default
     for (size_t p = 0; p < number_of_target_points; ++p) {
       const double xi_target = get_element(get<0>(points), p);
-      const auto stencil = fd_stencil(xi_source, xi_target);
+      std::vector<double> stencil;
+      switch (fd_to_fd_interp_order.value_or(default_order)) {
+        case 1: {
+          stencil = fd_stencil<1>(xi_source, xi_target);
+          break;
+        }
+        case 2: {
+          stencil = fd_stencil<2>(xi_source, xi_target);
+          break;
+        }
+        case 3: {
+          stencil = fd_stencil<3>(xi_source, xi_target);
+          break;
+        }
+        default:
+          ERROR("Unsupported fd_to_fd_interp_order: "
+            << fd_to_fd_interp_order.value_or(default_order)
+            << "; expected 1, 2, or 3.");
+      }
       for (size_t i = 0; i < number_of_source_points; ++i) {
         result(p, i) = stencil[i];
       }
@@ -70,13 +257,17 @@ Matrix interpolation_matrix(
   }
 
   // Not FD, so use spectral interpolation
+  ASSERT(
+      fd_to_fd_interp_order == std::nullopt,
+      "fd_to_fd_interp_order only applies to FD meshes. But Mesh is " << mesh);
   return Spectral::interpolation_matrix(mesh, get<0>(points));
 }
 
 template <typename DataType>
 Matrix interpolation_matrix(
     const Mesh<2>& mesh,
-    const tnsr::I<DataType, 2, Frame::ElementLogical>& points) {
+    const tnsr::I<DataType, 2, Frame::ElementLogical>& points,
+    const std::optional<size_t>& fd_to_fd_interp_order) {
   const auto number_of_target_points = get_size(get<0>(points));
   Matrix result(number_of_target_points, mesh.number_of_grid_points());
 
@@ -94,11 +285,33 @@ Matrix interpolation_matrix(
         eta_source[j] = get<1>(source_xi)[j * mesh.extents(0)];
       }
     }
+    constexpr size_t default_order = 1;  // linear interpolation by default
     for (size_t p = 0; p < number_of_target_points; ++p) {
       const double xi_target = get_element(get<0>(points), p);
       const double eta_target = get_element(get<1>(points), p);
-      const auto xi_stencil = fd_stencil(xi_source, xi_target);
-      const auto eta_stencil = fd_stencil(eta_source, eta_target);
+      std::vector<double> xi_stencil;
+      std::vector<double> eta_stencil;
+      switch (fd_to_fd_interp_order.value_or(default_order)) {
+        case 1: {
+          xi_stencil = fd_stencil<1>(xi_source, xi_target);
+          eta_stencil = fd_stencil<1>(eta_source, eta_target);
+          break;
+        }
+        case 2: {
+          xi_stencil = fd_stencil<2>(xi_source, xi_target);
+          eta_stencil = fd_stencil<2>(eta_source, eta_target);
+          break;
+        }
+        case 3: {
+          xi_stencil = fd_stencil<3>(xi_source, xi_target);
+          eta_stencil = fd_stencil<3>(eta_source, eta_target);
+          break;
+        }
+        default:
+          ERROR("Unsupported fd_to_fd_interp_order: "
+            << fd_to_fd_interp_order.value_or(default_order)
+            << "; expected 1, 2, or 3.");
+      }
       for (size_t j = 0, s = 0; j < mesh.extents(1); ++j) {
         for (size_t i = 0; i < mesh.extents(0); ++i) {
           result(p, s) = xi_stencil[i] * eta_stencil[j];
@@ -110,6 +323,9 @@ Matrix interpolation_matrix(
   } else if (mesh.basis()[0] == Spectral::Basis::SphericalHarmonic) {
     ASSERT(mesh.basis()[1] == Spectral::Basis::SphericalHarmonic,
            "Expected both dimensions to have spherical harmonic basis. Mesh = "
+               << mesh);
+    ASSERT(fd_to_fd_interp_order == std::nullopt,
+           "fd_to_fd_interp_order only applies to FD meshes. But Mesh is "
                << mesh);
     const intrp::Cardinal cardinal_interpolator(mesh, points);
     const auto [n_th, n_ph] = mesh.extents().indices();
@@ -127,6 +343,9 @@ Matrix interpolation_matrix(
   }
 
   // Not FD or special basis, so use 1D spectral interpolation matrices
+  ASSERT(
+      fd_to_fd_interp_order == std::nullopt,
+      "fd_to_fd_interp_order only applies to FD meshes. But Mesh is " << mesh);
   const std::array<Matrix, 2> matrices{
       {Spectral::interpolation_matrix(mesh.slice_through(0), get<0>(points)),
        Spectral::interpolation_matrix(mesh.slice_through(1), get<1>(points))}};
@@ -146,7 +365,8 @@ Matrix interpolation_matrix(
 template <typename DataType>
 Matrix interpolation_matrix(
     const Mesh<3>& mesh,
-    const tnsr::I<DataType, 3, Frame::ElementLogical>& points) {
+    const tnsr::I<DataType, 3, Frame::ElementLogical>& points,
+    const std::optional<size_t>& fd_to_fd_interp_order) {
   const auto number_of_target_points = get_size(get<0>(points));
   Matrix result(number_of_target_points, mesh.number_of_grid_points());
 
@@ -177,13 +397,38 @@ Matrix interpolation_matrix(
             get<2>(source_xi)[k * mesh.extents(0) * mesh.extents(1)];
       }
     }
+    constexpr size_t default_order = 1;  // linear interpolation by default
     for (size_t p = 0; p < number_of_target_points; ++p) {
       const double xi_target = get_element(get<0>(points), p);
       const double eta_target = get_element(get<1>(points), p);
       const double zeta_target = get_element(get<2>(points), p);
-      const auto xi_stencil = fd_stencil(xi_source, xi_target);
-      const auto eta_stencil = fd_stencil(eta_source, eta_target);
-      const auto zeta_stencil = fd_stencil(zeta_source, zeta_target);
+      std::vector<double> xi_stencil;
+      std::vector<double> eta_stencil;
+      std::vector<double> zeta_stencil;
+      switch (fd_to_fd_interp_order.value_or(default_order)) {
+        case 1: {
+          xi_stencil = fd_stencil<1>(xi_source, xi_target);
+          eta_stencil = fd_stencil<1>(eta_source, eta_target);
+          zeta_stencil = fd_stencil<1>(zeta_source, zeta_target);
+          break;
+        }
+        case 2: {
+          xi_stencil = fd_stencil<2>(xi_source, xi_target);
+          eta_stencil = fd_stencil<2>(eta_source, eta_target);
+          zeta_stencil = fd_stencil<2>(zeta_source, zeta_target);
+          break;
+        }
+        case 3: {
+          xi_stencil = fd_stencil<3>(xi_source, xi_target);
+          eta_stencil = fd_stencil<3>(eta_source, eta_target);
+          zeta_stencil = fd_stencil<3>(zeta_source, zeta_target);
+          break;
+        }
+        default:
+          ERROR("Unsupported fd_to_fd_interp_order: "
+            << fd_to_fd_interp_order.value_or(default_order)
+            << "; expected 1, 2, or 3.");
+      }
       for (size_t k = 0, s = 0; k < mesh.extents(2); ++k) {
         for (size_t j = 0; j < mesh.extents(1); ++j) {
           for (size_t i = 0; i < mesh.extents(0); ++i) {
@@ -195,6 +440,9 @@ Matrix interpolation_matrix(
     }
     return result;
   } else if (mesh.basis()[1] == Spectral::Basis::SphericalHarmonic) {
+    ASSERT(fd_to_fd_interp_order == std::nullopt,
+           "fd_to_fd_interp_order only applies to FD meshes. But Mesh is "
+               << mesh);
     ASSERT(mesh.basis()[2] == Spectral::Basis::SphericalHarmonic,
            "Expected last two dimensions to each have spherical harmonic "
            "basis. Mesh = "
@@ -219,6 +467,9 @@ Matrix interpolation_matrix(
   }
 
   // Not FD or special basis, so use 1D spectral interpolation matrices
+  ASSERT(
+      fd_to_fd_interp_order == std::nullopt,
+      "fd_to_fd_interp_order only applies to FD meshes. But Mesh is " << mesh);
   const std::array<Matrix, 3> matrices{
       {Spectral::interpolation_matrix(mesh.slice_through(0), get<0>(points)),
        Spectral::interpolation_matrix(mesh.slice_through(1), get<1>(points)),
@@ -248,14 +499,18 @@ Irregular<Dim>::Irregular() = default;
 template <size_t Dim>
 Irregular<Dim>::Irregular(
     const Mesh<Dim>& source_mesh,
-    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points)
-    : interpolation_matrix_(interpolation_matrix(source_mesh, target_points)) {}
+    const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points,
+    const std::optional<size_t>& fd_to_fd_interp_order)
+    : interpolation_matrix_(interpolation_matrix(source_mesh, target_points,
+                                                 fd_to_fd_interp_order)) {}
 
 template <size_t Dim>
 Irregular<Dim>::Irregular(
     const Mesh<Dim>& source_mesh,
-    const tnsr::I<double, Dim, Frame::ElementLogical>& target_point)
-    : interpolation_matrix_(interpolation_matrix(source_mesh, target_point)) {}
+    const tnsr::I<double, Dim, Frame::ElementLogical>& target_point,
+    const std::optional<size_t>& fd_to_fd_interp_order)
+    : interpolation_matrix_(interpolation_matrix(source_mesh, target_point,
+                                                 fd_to_fd_interp_order)) {}
 
 template <size_t Dim>
 void Irregular<Dim>::pup(PUP::er& p) {

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -38,10 +38,11 @@ class Irregular {
  public:
   Irregular(
       const Mesh<Dim>& source_mesh,
-      const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points);
-  Irregular(
-      const Mesh<Dim>& source_mesh,
-      const tnsr::I<double, Dim, Frame::ElementLogical>& target_point);
+      const tnsr::I<DataVector, Dim, Frame::ElementLogical>& target_points,
+      const std::optional<size_t>& fd_to_fd_interp_order = std::nullopt);
+  Irregular(const Mesh<Dim>& source_mesh,
+            const tnsr::I<double, Dim, Frame::ElementLogical>& target_point,
+            const std::optional<size_t>& fd_to_fd_interp_order = std::nullopt);
   Irregular();
 
   /// Serialization for Charm++

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -67,6 +67,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
   SubcellSolver:
     Reconstructor: MonotonisedCentral
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -242,6 +242,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: [Envelope, OuterShell0, OuterShell1, OuterShell2]
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfYe: 1.0e-20

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -165,6 +165,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 6
+      FdInterpolationOrder: 1
     TciOptions:
       MinimumValueOfD: 1.0e-15
       MinimumValueOfYe: 1.0e-20

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -162,6 +162,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfYe: 1.0e-20

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -66,6 +66,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfYe: 1.0e-20

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -101,6 +101,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
     TciOptions:
       MinimumValueOfD: 1.0e-20
       MinimumValueOfYe: 1.0e-20

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -76,6 +76,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
   SubcellSolver:
     Reconstructor:
       MonotonisedCentralPrim:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -79,6 +79,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
   SubcellSolver:
     Reconstructor:
       MonotonisedCentralPrim:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -82,6 +82,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
   SubcellSolver:
     Reconstructor:
       MonotonisedCentralPrim:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -57,6 +57,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
     TciOptions:
       UCutoff: 1.0e-10
   SubcellSolver:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -58,6 +58,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
     TciOptions:
       UCutoff: 1.0e-10
   SubcellSolver:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -57,6 +57,7 @@ SpatialDiscretization:
         OnlyDgBlocksAndGroups: None
       SubcellToDgReconstructionMethod: DimByDim
       FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
     TciOptions:
       UCutoff: 1.0e-10
   SubcellSolver:

--- a/tests/Unit/Evolution/DgSubcell/Test_SetInterpolators.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SetInterpolators.cpp
@@ -4,6 +4,7 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <optional>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -65,17 +66,17 @@ struct Reconstructor : db::SimpleTag {
 }  // namespace Tags
 
 template <size_t Dim>
-void test(const bool enable_extension) {
+void test(const bool enable_extension, const size_t fd_to_fd_interp_order) {
   // Domain setup:
   //   | lower_xi | element |
   //
   // No neighbors in upper xi or in eta/zeta.
   // We currently can only use enable_extension =true
   // with always_use_subcell = true.
-  const evolution::dg::subcell::SubcellOptions subcell_options(
+  evolution::dg::subcell::SubcellOptions subcell_options(
       4.0, 1, 2.0e-3, 2.0e-4, enable_extension, enable_extension,
       evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-      std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1);
+      std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1, fd_to_fd_interp_order);
 
   const ::Mesh<Dim> dg_mesh{6, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto};
@@ -307,8 +308,10 @@ void test(const bool enable_extension) {
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SetInterpolators",
                   "[Evolution][Unit]") {
   for (const bool enable_extension : {false, true}) {
-    test<1>(enable_extension);
-    test<2>(enable_extension);
-    test<3>(enable_extension);
+    for (size_t fd_interp_order = 1; fd_interp_order <= 3; ++fd_interp_order) {
+      test<1>(enable_extension, fd_interp_order);
+      test<2>(enable_extension, fd_interp_order);
+      test<3>(enable_extension, fd_interp_order);
+    }
   }
 }

--- a/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
@@ -132,11 +132,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
     test_impl(expected_values, i);
   }
 
-  const SubcellOptions options(
-      expected_values[0], static_cast<size_t>(expected_values[1]),
-      expected_values[2], expected_values[3], true, true,
-      fd::ReconstructionMethod::DimByDim, true, std::nullopt,
-      ::fd::DerivativeOrder::Four, 1, 1, 1);
+  SubcellOptions options(expected_values[0],
+                         static_cast<size_t>(expected_values[1]),
+                         expected_values[2], expected_values[3], true, true,
+                         fd::ReconstructionMethod::DimByDim, true, std::nullopt,
+                         ::fd::DerivativeOrder::Four, 1, 1, 1, 2);
   const SubcellOptions deserialized_options =
       serialize_and_deserialize(options);
   CHECK(options == deserialized_options);
@@ -158,7 +158,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
                        "  UseHalo: true\n"
                        "  OnlyDgBlocksAndGroups: None\n"
                        "SubcellToDgReconstructionMethod: DimByDim\n"
-                       "FiniteDifferenceDerivativeOrder: 4\n"));
+                       "FiniteDifferenceDerivativeOrder: 4\n"
+                       "FdInterpolationOrder: 2\n"));
 
   INFO("Test with block names and groups");
   const domain::creators::Cylinder cylinder{2.0,   10.0, 1.0,  8.0,
@@ -180,7 +181,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
       "  UseHalo: true\n";
   const std::string opts_end =
       "SubcellToDgReconstructionMethod: DimByDim\n"
-      "FiniteDifferenceDerivativeOrder: 4\n";
+      "FiniteDifferenceDerivativeOrder: 4\n"
+      "FdInterpolationOrder: 2\n";
   CHECK_THROWS_WITH(
       SubcellOptions(
           TestHelpers::test_option_tag<OptionTags::SubcellOptions>(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -399,11 +399,13 @@ Variables<var_tags> polynomial(
   return result;
 }
 
-template <size_t Dim, size_t MaxDegree>
-void test_polynomial_interpolant(const std::array<size_t, Dim>& extents) {
+template <size_t Dim>
+void test_polynomial_interpolant(const std::array<size_t, Dim>& extents,
+                                 const size_t max_degree) {
   const size_t n_random_target_points = 10;
-
-  const auto domain = create_domain<Dim>(20.0 / 3.0, extents);
+  // use a small domain to avoid huge polynomial values for large max_degree
+  // which results in large absolute errors
+  const auto domain = create_domain<Dim>(1.3, extents);
   const auto& block = domain.blocks()[0];
   const ElementMap<Dim, Frame::Inertial> element_map{
       ElementId<Dim>{0}, block.stationary_map().get_clone()};
@@ -414,18 +416,22 @@ void test_polynomial_interpolant(const std::array<size_t, Dim>& extents) {
   const auto source_x = element_map(source_xi);
   const auto target_xi = create_target_points<Dim>(n_random_target_points);
   const auto target_x = element_map(target_xi);
-  intrp::Irregular irregular_interp{mesh, target_xi};
+  const intrp::Irregular irregular_interp{mesh, target_xi,
+                                    std::optional<size_t>{max_degree}};
 
-  for (size_t degree = 0; degree <= MaxDegree; ++degree) {
+  for (size_t degree = 0; degree <= max_degree; ++degree) {
     const auto source_vars = polynomial<Dim>(source_x, degree);
     const auto target_vars = irregular_interp.interpolate(source_vars);
     const auto expected_vars = polynomial<Dim>(target_x, degree);
+    CAPTURE(Dim);
+    CAPTURE(max_degree);
+    CAPTURE(degree);
     CHECK_VARIABLES_APPROX(target_vars, expected_vars);
   }
 }
 
-void test_tov() {
-  const std::array<size_t, 3> isotropic_extents{{11, 11, 11}};
+void test_tov(const size_t max_degree, const bool specified_interp_order) {
+  const std::array<size_t, 3> isotropic_extents{{15, 15, 15}};
   constexpr size_t n_resolutions = 4;
   auto errors =
       make_array<n_resolutions>(std::numeric_limits<double>::signaling_NaN());
@@ -450,8 +456,11 @@ void test_tov() {
         tov_star.variables(x, 0.0, tmpl::list<rho_tag>{}));
 
     const tnsr::I<DataVector, 3, Frame::ElementLogical> xi_target{1_st, -1.0};
-
     intrp::Irregular irregular_interp{mesh, xi_target};
+    if (specified_interp_order) {
+      irregular_interp =
+          intrp::Irregular{mesh, xi_target, std::optional<size_t>{max_degree}};
+    }
 
     const auto target_vars = irregular_interp.interpolate(vars);
     gsl::at(errors, i) =
@@ -466,7 +475,13 @@ void test_tov() {
 
   Approx custom_approx = Approx::custom().epsilon(1.e-2).scale(1.);
   for (size_t i = 1; i < n_resolutions; ++i) {
-    CHECK(4.0 == custom_approx(gsl::at(ratio_of_errors, i)));
+    CAPTURE(max_degree);
+    CAPTURE(i);
+    // since \rho is a symmetric function across the center, quadratic
+    // extrapolation has one order higher convergence rate at the center
+    CHECK((specified_interp_order
+               ? (max_degree == 2 ? 16.0 : two_to_the(max_degree + 1))
+               : 4.0) == custom_approx(gsl::at(ratio_of_errors, i)));
   }
 }
 
@@ -614,15 +629,19 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
   test_irregular_interpolant<Spectral::Basis::Legendre,
                              Spectral::Quadrature::Gauss>();
   test_irregular_interpolant_mixed_quadrature();
-  test_polynomial_interpolant<1, 1>({{11}});
-  test_polynomial_interpolant<2, 1>({{11, 11}});
-  test_polynomial_interpolant<2, 1>({{11, 9}});
-  test_polynomial_interpolant<3, 1>({{11, 11, 11}});
-  test_polynomial_interpolant<3, 1>({{11, 9, 11}});
-  test_polynomial_interpolant<3, 1>({{11, 11, 9}});
-  test_polynomial_interpolant<3, 1>({{11, 9, 9}});
-  test_polynomial_interpolant<3, 1>({{11, 9, 13}});
-  test_tov();
+  for (size_t max_degree = 1; max_degree <= 3; ++max_degree) {
+    test_polynomial_interpolant<1>({{11}}, max_degree);
+    test_polynomial_interpolant<2>({{11, 11}}, max_degree);
+    test_polynomial_interpolant<2>({{11, 9}}, max_degree);
+    test_polynomial_interpolant<3>({{11, 11, 11}}, max_degree);
+    test_polynomial_interpolant<3>({{11, 9, 11}}, max_degree);
+    test_polynomial_interpolant<3>({{11, 11, 9}}, max_degree);
+    test_polynomial_interpolant<3>({{11, 9, 9}}, max_degree);
+    test_polynomial_interpolant<3>({{11, 9, 13}}, max_degree);
+    for (const bool specified_interp_order : {false, true}) {
+      test_tov(max_degree, specified_interp_order);
+    }
+  }
   MAKE_GENERATOR(generator);
   test_2d_spherical(make_not_null(&generator));
   test_3d_spherical(make_not_null(&generator));


### PR DESCRIPTION
## Proposed changes

Add higher order fd interpolants. SpECTRE currently only does linear interpolation/extrapolation between blocks doing finite difference, which ruins the higher order finite difference convergence. We now add the quadratic and cubic interpolation using the canonical Lagrange interpolation formula, which will have formally the same order as the higher order finite difference.  Potential future optimization: use the barycentric formula.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
