### PR TITLE
Add GhostData mutator for SoCcz4

### DIFF
--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_sources(
   DummyReconstructor.cpp
   EnforceConstrainedEvolution.cpp
   Filter.cpp
+  GhostData.cpp
   Reconstructor.cpp
   )
 
@@ -26,6 +27,7 @@ spectre_target_headers(
   DummyReconstructor.hpp
   EnforceConstrainedEvolution.hpp
   Filter.hpp
+  GhostData.hpp
   Reconstructor.hpp
   SoTimeDerivative.hpp
   System.hpp

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+DataVector GhostVariables::apply(
+    const Variables<Ccz4::fd::System::variables_tag_list>& evolved_vars,
+    const size_t rdmp_size) {
+  DataVector buffer{evolved_vars.number_of_grid_points() *
+                        Variables<Ccz4::fd::System::variables_tag_list>::
+                            number_of_independent_components +
+                    rdmp_size};
+  Variables<Ccz4::fd::System::variables_tag_list> vars_to_reconstruct(
+      buffer.data(), buffer.size() - rdmp_size);
+
+  get<Tags::ConformalMetric<DataVector, 3>>(vars_to_reconstruct) =
+      get<Tags::ConformalMetric<DataVector, 3>>(evolved_vars);
+  get<gr::Tags::Lapse<DataVector>>(vars_to_reconstruct) =
+      get<gr::Tags::Lapse<DataVector>>(evolved_vars);
+  get<gr::Tags::Shift<DataVector, 3>>(vars_to_reconstruct) =
+      get<gr::Tags::Shift<DataVector, 3>>(evolved_vars);
+  get<Tags::ConformalFactor<DataVector>>(vars_to_reconstruct) =
+      get<Tags::ConformalFactor<DataVector>>(evolved_vars);
+  get<Tags::ATilde<DataVector, 3>>(vars_to_reconstruct) =
+      get<Tags::ATilde<DataVector, 3>>(evolved_vars);
+  get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(vars_to_reconstruct) =
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(evolved_vars);
+  get<Tags::Theta<DataVector>>(vars_to_reconstruct) =
+      get<Tags::Theta<DataVector>>(evolved_vars);
+  get<Tags::GammaHat<DataVector, 3>>(vars_to_reconstruct) =
+      get<Tags::GammaHat<DataVector, 3>>(evolved_vars);
+  get<Tags::AuxiliaryShiftB<DataVector, 3>>(vars_to_reconstruct) =
+      get<Tags::AuxiliaryShiftB<DataVector, 3>>(evolved_vars);
+
+  return buffer;
+}
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <typename T>
+class Variables;
+/// \endcond
+
+namespace Ccz4::fd {
+/*!
+ * \brief Get the Ccz4 evolution variables for ghost
+ *
+ * This mutator is passed to
+ * `evolution::dg::subcell::Actions::SendDataForReconstruction`.
+ */
+class GhostVariables {
+ public:
+  using return_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<::Tags::Variables<Ccz4::fd::System::variables_tag_list>>;
+
+  static DataVector apply(
+      const Variables<Ccz4::fd::System::variables_tag_list>& evolved_vars,
+      size_t rdmp_size);
+};
+}  // namespace Ccz4::fd

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   FiniteDifference/Test_DummyReconstructor.cpp
   FiniteDifference/Test_EnforceConstrainedEvolution.cpp
   FiniteDifference/Test_Filter.cpp
+  FiniteDifference/Test_GhostData.cpp
   FiniteDifference/Test_SoTimeDerivative.cpp
   FiniteDifference/Test_Tags.cpp
   Test_ATilde.cpp

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_GhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_GhostData.cpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/Projection.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Fd.GhostData",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+
+  const size_t points_per_dimension = 5;
+  const Mesh<3> subcell_mesh{points_per_dimension,
+                             Spectral::Basis::FiniteDifference,
+                             Spectral::Quadrature::CellCentered};
+  const auto random_vars_subcell = make_with_random_values<
+      Variables<::Ccz4::fd::System::variables_tag_list>>(
+      make_not_null(&gen), dist, subcell_mesh.number_of_grid_points());
+  auto box_subcell =
+      db::create<db::AddSimpleTags<::Ccz4::fd::System::variables_tag>>(
+          random_vars_subcell);
+
+  DataVector retrieved_vars_subcell =
+      db::mutate_apply<::Ccz4::fd::GhostVariables>(make_not_null(&box_subcell),
+                                                   2_st);
+
+  const Variables<::Ccz4::fd::System::variables_tag_list> retrieved_vars{
+      retrieved_vars_subcell.data(), retrieved_vars_subcell.size() - 2};
+  tmpl::for_each<::Ccz4::fd::System::variables_tag_list>(
+      [&random_vars_subcell, &retrieved_vars](auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CHECK_ITERABLE_APPROX(get<tag>(random_vars_subcell),
+                              get<tag>(retrieved_vars));
+      });
+}
+}  // namespace

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_GhostData.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_GhostData.cpp
@@ -24,7 +24,7 @@ namespace {
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Fd.GhostData",
                   "[Unit][Evolution]") {
   MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<> dist(-1.0, 1.0);
+  const std::uniform_real_distribution<> dist(-1.0, 1.0);
 
   const size_t points_per_dimension = 5;
   const Mesh<3> subcell_mesh{points_per_dimension,


### PR DESCRIPTION
## Proposed changes
Add `GhostData` mutator to `SoCcz4`, which is used in `evolution::dg::subcell::Actions::SendDataForReconstruction` to communicate ghost data across neighbors.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
