### PR TITLE
ScalarSelfForce: add h-refinement criterion

### DIFF
--- a/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/CMakeLists.txt
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/CMakeLists.txt
@@ -1,34 +1,37 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY ScalarSelfForce)
+set(LIBRARY ScalarSelfForceAmrCriteria)
 
 add_spectre_library(${LIBRARY})
 
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
-  Equations.cpp
+  RefineAtPuncture.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Equations.hpp
-  FirstOrderSystem.hpp
-  Tags.hpp
+  RefineAtPuncture.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  Amr
+  AmrCriteria
   DataStructures
   DomainStructure
-  ErrorHandling
+  Elliptic
+  InitialDataUtilities
+  Options
+  Parallel
+  Serialization
   Utilities
+  PRIVATE
+  Domain
+  ScalarSelfForceAnalyticData
   )
-
-add_subdirectory(AmrCriteria)
-add_subdirectory(BoundaryConditions)
-add_subdirectory(Events)

--- a/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.cpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace ScalarSelfForce::AmrCriteria {
+
+std::array<amr::Flag, 2> RefineAtPuncture::impl(
+    const elliptic::analytic_data::Background& background,
+    const Domain<2>& domain, const ElementId<2>& element_id) {
+  const auto circular_orbit_ptr =
+      dynamic_cast<const ScalarSelfForce::AnalyticData::CircularOrbit*>(
+          &background);
+  if (circular_orbit_ptr == nullptr) {
+    ERROR(
+        "RefineAtPuncture only works with 'CircularOrbit'. "
+        "See ScalarSelfForce::AmrCriteria::RefineAtPuncture for details.");
+  }
+  const auto puncture_position = circular_orbit_ptr->puncture_position();
+  // Split (h-refine) the element if it contains the puncture
+  const auto& block = domain.blocks()[element_id.block_id()];
+  // Check if the puncture is in the block
+  const auto block_logical_coords =
+      block_logical_coordinates_single_point(puncture_position, block);
+  if (not block_logical_coords.has_value()) {
+    return make_array<2>(amr::Flag::DoNothing);
+  }
+  if (not element_logical_coordinates(*block_logical_coords, element_id)) {
+    return make_array<2>(amr::Flag::DoNothing);
+  }
+  return make_array<2>(amr::Flag::Split);
+}
+
+PUP::able::PUP_ID RefineAtPuncture::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace ScalarSelfForce::AmrCriteria

--- a/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Tags.hpp"
+#include "Options/String.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarSelfForce::AmrCriteria {
+
+/*!
+ * \brief h-refine (split) elements containing a puncture
+ *
+ * This refinement scheme is expected to yield exponential convergence, despite
+ * the presence of the non-smooth punctures.
+ *
+ * Currently only works with ScalarSelfForce::AnalyticData::CircularOrbit.
+ * For more generic orbits, the refinement needs to happen not only at a single
+ * point but along the trajectory of the puncture.
+ */
+class RefineAtPuncture : public amr::Criterion {
+ public:
+  using options = tmpl::list<>;
+
+  static constexpr Options::String help = {
+      "h-refine (split) elements containing a puncture."};
+
+  RefineAtPuncture() = default;
+
+  /// \cond
+  explicit RefineAtPuncture(CkMigrateMessage* msg) : Criterion(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(RefineAtPuncture);  // NOLINT
+  /// \endcond
+
+  amr::Criteria::Type type() override { return amr::Criteria::Type::h; }
+
+  std::string observation_name() override { return "RefineAtPuncture"; }
+
+  using argument_tags = tmpl::list<
+      elliptic::Tags::Background<elliptic::analytic_data::Background>,
+      domain::Tags::Domain<2>>;
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  template <typename Metavariables>
+  std::array<amr::Flag, 2> operator()(
+      const elliptic::analytic_data::Background& background,
+      const Domain<2>& domain, Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<2>& element_id) const {
+    return impl(background, domain, element_id);
+  }
+
+ private:
+  static std::array<amr::Flag, 2> impl(
+      const elliptic::analytic_data::Background& background,
+      const Domain<2>& domain, const ElementId<2>& element_id);
+};
+
+}  // namespace ScalarSelfForce::AmrCriteria

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_ScalarSelfForceAmrCriteria")
+
+set(LIBRARY_SOURCES
+  Test_RefineAtPunctures.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Amr
+  AmrCriteria
+  DataStructures
+  DomainCreators
+  DomainStructure
+  Options
+  Parallel
+  ScalarSelfForceAmrCriteria
+  ScalarSelfForceAnalyticData
+  Utilities
+  )

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/Test_RefineAtPunctures.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/Test_RefineAtPunctures.cpp
@@ -1,0 +1,117 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Creators/Rectilinear.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "PointwiseFunctions/AnalyticData/SelfForce/Scalar/CircularOrbit.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarSelfForce::AmrCriteria {
+
+namespace {
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 2;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion,
+                   tmpl::list<ScalarSelfForce::AmrCriteria::RefineAtPuncture>>>;
+  };
+};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+struct OtherBackground : elliptic::analytic_data::Background,
+                         elliptic::analytic_data::InitialGuess {
+  OtherBackground() = default;
+  explicit OtherBackground(CkMigrateMessage* /*m*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(OtherBackground);
+};
+
+PUP::able::PUP_ID OtherBackground::my_PUP_ID = 0;  // NOLINT
+#pragma GCC diagnostic pop
+
+void test_criterion(
+    std::unique_ptr<elliptic::analytic_data::Background> background) {
+  const auto created =
+      TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
+                                 Metavariables>("RefineAtPuncture");
+  REQUIRE(dynamic_cast<const RefineAtPuncture*>(created.get()) != nullptr);
+  const auto& criterion = serialize_and_deserialize(
+      dynamic_cast<const RefineAtPuncture&>(*created));
+
+  {
+    INFO("Evaluate");
+    using background_tag =
+        elliptic::Tags::Background<elliptic::analytic_data::Background>;
+
+    const domain::creators::Rectangle domain_creator{
+        {{10., 0.}}, {{15., 1.}}, {{2, 2}}, {{3, 3}}, {{false, false}}};
+    auto databox =
+        db::create<tmpl::list<background_tag, domain::Tags::Domain<2>>>(
+            std::move(background), domain_creator.create_domain());
+    const ObservationBox<
+        tmpl::list<>,
+        db::DataBox<tmpl::list<background_tag, domain::Tags::Domain<2>>>>
+        box{make_not_null(&databox)};
+    Parallel::GlobalCache<Metavariables> empty_cache{};
+
+    {
+      INFO("Element with puncture within");
+      const ElementId<2> element_id{0, {{{2, 2}, {2, 0}}}};
+      const auto expected_flags = make_array<2>(amr::Flag::Split);
+      auto flags = criterion.evaluate(box, empty_cache, element_id);
+      CHECK(flags == expected_flags);
+    }
+    {
+      INFO("Elements without puncture");
+      const auto expected_flags = make_array<2>(amr::Flag::DoNothing);
+      for (const auto& element_id : {ElementId<2>{0, {{{2, 1}, {2, 0}}}},
+                                     ElementId<2>{0, {{{2, 3}, {2, 3}}}},
+                                     ElementId<2>{0, {{{2, 3}, {2, 0}}}},
+                                     ElementId<2>{0, {{{2, 0}, {2, 3}}}}}) {
+        auto flags = criterion.evaluate(box, empty_cache, element_id);
+        CHECK(flags == expected_flags);
+      }
+    }
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ScalarSelfForce.AmrCriteria.RefineAtPuncture",
+                  "[Unit][ParallelAlgorithms]") {
+  register_factory_classes_with_charm<Metavariables>();
+  test_criterion(std::make_unique<ScalarSelfForce::AnalyticData::CircularOrbit>(
+      // Only orbital radius is relevant for the test
+      1.0, 0.5, /* orbital radius */ 10.0, 2, std::nullopt));
+  CHECK_THROWS_WITH(test_criterion(std::make_unique<OtherBackground>()),
+                    Catch::Matchers::ContainsSubstring(
+                        "RefineAtPuncture only works with 'CircularOrbit'."));
+}
+
+}  // namespace ScalarSelfForce::AmrCriteria

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(AmrCriteria)
 add_subdirectory(BoundaryConditions)
 add_subdirectory(Events)


### PR DESCRIPTION
## Proposed changes

h-refine at the position of the puncture.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
