### PR TITLE
Add `GhostZoneInverseJacobian` tag and mutator to DgSubcell

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -26,6 +26,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Tags/InitialTciData.hpp"
 #include "Evolution/DgSubcell/Tags/Interpolators.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
@@ -81,6 +82,7 @@ namespace evolution::dg::subcell::Actions {
  *   - `subcell::Tags::TciGridHistory`
  *   - `subcell::Tags::TciCallsSinceRollback`
  *   - `subcell::Tags::GhostDataForReconstruction<Dim>`
+ *   - `subcell::Tags::GhostZoneInverseJacobian<Dim>`
  *   - `subcell::Tags::TciDecision`
  *   - `subcell::Tags::DataForRdmpTci`
  *   - `subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>`
@@ -103,7 +105,8 @@ struct SetSubcellGrid {
       Tags::ActiveGrid, Tags::DidRollback, Tags::TciGridHistory,
       Tags::TciCallsSinceRollback, Tags::StepsSinceTciCall,
       evolution::dg::subcell::Tags::MeshForGhostData<Dim>,
-      Tags::GhostDataForReconstruction<Dim>, Tags::TciDecision,
+      Tags::GhostDataForReconstruction<Dim>,
+      Tags::GhostZoneInverseJacobian<Dim>, Tags::TciDecision,
       Tags::NeighborTciDecisions<Dim>, Tags::DataForRdmpTci,
       subcell::Tags::CellCenteredFlux<typename System::flux_variables, Dim>,
       subcell::Tags::ReconstructionOrder<Dim>,

--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_headers(
   GetActiveTag.hpp
   GetTciDecision.hpp
   GhostData.hpp
+  GhostZoneInverseJacobian.hpp
   GhostZoneLogicalCoordinates.hpp
   InitialTciData.hpp
   Matrices.hpp

--- a/src/Evolution/DgSubcell/GhostZoneInverseJacobian.hpp
+++ b/src/Evolution/DgSubcell/GhostZoneInverseJacobian.hpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+
+/// \brief Mutator that stores the grid coordinates and inverse Jacobians of the
+/// ghost zone.
+///
+/// \details Mutator that stores the grid coordinates and inverse Jacobians of
+/// the ghost zone. This is run in the initialization phase since this
+/// information is time-independent. The full Jacobian to inertial coordinates
+/// may be applied at each time step.
+
+template <size_t Dim, typename ReconstructorTag>
+struct GhostZoneInverseJacobian {
+  /// Tags for constant items added to the GlobalCache.  These items are
+  /// initialized from input file options.
+  using const_global_cache_tags = tmpl::list<>;
+
+  /// Tags for mutable items added to the GlobalCache.  These items are
+  /// initialized from input file options.
+  using mutable_global_cache_tags = tmpl::list<>;
+
+  /// Tags for simple DataBox items that are initialized from input file options
+  using simple_tags_from_options = tmpl::list<>;
+
+  /// Tags for simple DataBox items that are default initialized.
+  using default_initialized_simple_tags = tmpl::list<>;
+
+  /// Tags for items fetched by the DataBox and passed to the apply function
+  using argument_tags =
+      tmpl::list<Tags::Mesh<Dim>, ::domain::Tags::ElementMap<Dim, Frame::Grid>,
+                 ReconstructorTag>;
+
+  /// Tags for items in the DataBox that are mutated by the apply function
+  using return_tags = tmpl::list<Tags::GhostZoneInverseJacobian<Dim>>;
+
+  /// Tags for mutable DataBox items that are either default initialized or
+  /// initialized by the apply function
+  using simple_tags = return_tags;
+
+  /// Tags for immutable DataBox items (compute items or reference items) added
+  /// to the DataBox.
+  using compute_tags = tmpl::list<>;
+
+  /// Given the items fetched from a DataBox by the argument_tags, mutate
+  /// the items in the DataBox corresponding to return_tags
+  template <typename ReconstructorType>
+  static void apply(
+      const gsl::not_null<DirectionMap<
+          Dim, Variables<tmpl::list<
+                   evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>,
+                   evolution::dg::subcell::fd::Tags::
+                       InverseJacobianLogicalToGrid<Dim>>>>*>
+          ghost_zone_inverse_jacobian,
+      const Mesh<Dim>& subcell_mesh,
+      const ElementMap<Dim, Frame::Grid>& element_map,
+      const ReconstructorType& reconstructor) {
+    using neighbor_tags = tmpl::list<
+        evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>,
+        evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>;
+
+    for (const auto& direction : Direction<Dim>::all_directions()) {
+      const auto logical_coords = fd::ghost_zone_logical_coordinates(
+          subcell_mesh, reconstructor.ghost_zone_size(), direction);
+      const auto inv_jacobian = element_map.inv_jacobian(logical_coords);
+      const auto grid_coords = element_map(logical_coords);
+
+      Variables<neighbor_tags> ghost_coords_and_inv_jacobian{
+          logical_coords.get(0).size()};
+      get<evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>>(
+          ghost_coords_and_inv_jacobian) = grid_coords;
+      get<evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>(
+          ghost_coords_and_inv_jacobian) = inv_jacobian;
+
+      ghost_zone_inverse_jacobian->insert_or_assign(
+          direction, ghost_coords_and_inv_jacobian);
+    }
+  }
+};
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/Tags/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/Tags/CMakeLists.txt
@@ -13,6 +13,7 @@ spectre_target_headers(
   DataForRdmpTci.hpp
   DidRollback.hpp
   GhostDataForReconstruction.hpp
+  GhostZoneInverseJacobian.hpp
   Inactive.hpp
   InitialTciData.hpp
   Interpolators.hpp

--- a/src/Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp
+++ b/src/Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
+
+namespace evolution::dg::subcell::Tags {
+/// Inverse Jacobian data stored in the ghost zone.
+///
+/// The `DirectionalIdMap` stores the grid coordinates and logical to grid
+/// inverse Jacobians in the ghost zone to avoid recomputing these data when
+/// full Jacobians are needed. We store the grid coordinates to be able to
+/// compute the grid to inertial Jacobian at each time step.
+template <size_t Dim>
+struct GhostZoneInverseJacobian : db::SimpleTag {
+  using type = DirectionMap<
+      Dim, Variables<tmpl::list<Coordinates<Dim, Frame::Grid>,
+                                evolution::dg::subcell::fd::Tags::
+                                    InverseJacobianLogicalToGrid<Dim>>>>;
+};
+}  // namespace evolution::dg::subcell::Tags

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -39,6 +39,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/ReconstructionOrder.hpp"
@@ -530,6 +531,9 @@ void test(const bool always_use_subcell, const bool interior_element,
         comp, evolution::dg::subcell::Tags::TciGridHistory>(runner, self_id));
   CHECK(ActionTesting::tag_is_retrievable<
         comp, evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
+      runner, self_id));
+  CHECK(ActionTesting::tag_is_retrievable<
+        comp, evolution::dg::subcell::Tags::GhostZoneInverseJacobian<Dim>>(
       runner, self_id));
   CHECK(ActionTesting::tag_is_retrievable<
         comp, evolution::dg::subcell::Tags::DataForRdmpTci>(runner, self_id));

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_GetActiveTag.cpp
   Test_GetTciDecision.cpp
   Test_GhostData.cpp
+  Test_GhostZoneInverseJacobian.cpp
   Test_GhostZoneLogicalCoordinates.cpp
   Test_InitialTciData.cpp
   Test_JacobianCompute.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_GhostZoneInverseJacobian.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_GhostZoneInverseJacobian.cpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Frustum.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/GhostZoneInverseJacobian.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
+#include "Evolution/DgSubcell/Tags/Jacobians.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace {
+
+template <size_t Dim>
+using CoordinateMap =
+    tmpl::conditional_t<Dim == 3, domain::CoordinateMaps::Frustum,
+                        domain::CoordinateMaps::Identity<Dim>>;
+
+class DummyReconstructor {
+ public:
+  static size_t ghost_zone_size() { return 3; }
+};
+
+namespace Tags {
+struct Reconstructor : db::SimpleTag {
+  using type = std::unique_ptr<DummyReconstructor>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+void test() {
+  // Since the mutator relies on already tested functions to compute each of the
+  // quantities stored in the tag, we just test to make sure that they were
+  // properly stored in the `GhostZoneInverseJacobian` tag upon its mutation
+  CAPTURE(Dim);
+
+  // Assemble an Element and its ElementMap
+  const Mesh<Dim> dg_mesh{3, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+  const Mesh<Dim> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  using neighbor_tags = tmpl::list<
+      evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>,
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>;
+
+  const ElementId<Dim> element_id{0};
+  const Element<Dim> element{element_id, {}};
+
+  CoordinateMap<Dim> coordinate_map;
+  if constexpr (Dim == 3) {
+    const std::array<std::array<double, 2>, 4> face_vertices{
+        {{{-5., -5.}}, {{5., 5.}}, {{-3., -3.}}, {{3., 3.}}}};
+    coordinate_map = domain::CoordinateMaps::Frustum(
+        face_vertices, -4., 4., OrientationMap<3>::create_aligned());
+  } else {
+    coordinate_map = domain::CoordinateMaps::Identity<Dim>();
+  }
+  auto element_map = ElementMap<Dim, Frame::Grid>(
+      element_id,
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+          coordinate_map));
+
+  // Mutate the tag using the mutator
+  auto box = db::create<db::AddSimpleTags<
+      evolution::dg::subcell::Tags::GhostZoneInverseJacobian<Dim>,
+      ::domain::Tags::Element<Dim>, evolution::dg::subcell::Tags::Mesh<Dim>,
+      ::domain::Tags::ElementMap<Dim, Frame::Grid>, Tags::Reconstructor>>(
+      typename evolution::dg::subcell::Tags::GhostZoneInverseJacobian<
+          Dim>::type{},
+      element, subcell_mesh, std::move(element_map),
+      std::make_unique<DummyReconstructor>());
+  db::mutate_apply<evolution::dg::subcell::GhostZoneInverseJacobian<
+      Dim, Tags::Reconstructor>>(make_not_null(&box));
+
+  // Compare to computed outcome direction-wise
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    const auto logical_coords =
+        evolution::dg::subcell::fd::ghost_zone_logical_coordinates(
+            subcell_mesh, DummyReconstructor::ghost_zone_size(), direction);
+    const auto grid_coords =
+        db::get<::domain::Tags::ElementMap<Dim, Frame::Grid>>(box)(
+            logical_coords);
+    const auto inv_jacobian =
+        db::get<::domain::Tags::ElementMap<Dim, Frame::Grid>>(box).inv_jacobian(
+            logical_coords);
+
+    const Variables<neighbor_tags> ghost_zone_inverse_jacobian =
+        db::get<evolution::dg::subcell::Tags::GhostZoneInverseJacobian<Dim>>(
+            box)
+            .at(direction);
+    const auto test_grid_coords =
+        get<evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>>(
+            ghost_zone_inverse_jacobian);
+    const auto test_inv_jacobian = get<
+        evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>(
+        ghost_zone_inverse_jacobian);
+
+    CHECK_ITERABLE_APPROX(grid_coords, test_grid_coords);
+    CHECK_ITERABLE_APPROX(inv_jacobian, test_inv_jacobian);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.GhostZoneInverseJacobian",
+                  "[Parallel][Unit]") {
+  test<1>();
+  test<2>();
+  test<3>();
+}
+}  // namespace

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -27,6 +27,7 @@
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/GhostZoneInverseJacobian.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Interpolators.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
@@ -72,6 +73,8 @@ void test(const bool moving_mesh) {
   TestHelpers::db::test_simple_tag<
       subcell::Tags::GhostDataForReconstruction<Dim>>(
       "GhostDataForReconstruction");
+  TestHelpers::db::test_simple_tag<
+      subcell::Tags::GhostZoneInverseJacobian<Dim>>("GhostZoneInverseJacobian");
   TestHelpers::db::test_simple_tag<subcell::Tags::NeighborTciDecisions<Dim>>(
       "NeighborTciDecisions");
   TestHelpers::db::test_simple_tag<subcell::Tags::DataForRdmpTci>(


### PR DESCRIPTION
## Proposed changes

Adds a tag `GhostZoneInverseJacobian` to DgSubcell, which stores the grid coordinates of an element's ghost zone and the ElementLogical to Grid inverse Jacobian at those coordinates. Adds a corresponding mutator which is meant to fill in this quantity at initialization, since this information is time-independent.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
