### PR TITLE
Improve remove_duplicates implementation

### DIFF
--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -476,12 +476,6 @@ using conditional_t = typename conditional<B>::template type<T, F>;
 }  // namespace brigand
 
 namespace brigand {
-template <typename List>
-using remove_duplicates =
-    fold<List, clear<List>,
-         if_<bind<none, _state, defer<std::is_same<_1, parent<_element>>>>,
-             bind<push_back, _state, _element>, _state>>;
-
 template <bool>
 struct branch_if;
 
@@ -629,6 +623,11 @@ constexpr bool list_contains_v = lazy::list_contains<Sequence, Item>::value;
 template <typename Sequence1, typename Sequence2>
 using list_difference =
     fold<Sequence2, Sequence1, lazy::remove<_state, _element>>;
+
+template <typename List>
+using remove_duplicates = fold<List, clear<List>,
+                               if_<lazy::list_contains<_state, _element>,
+                                   _state, bind<push_back, _state, _element>>>;
 
 namespace detail {
 template <typename List>


### PR DESCRIPTION
Using list_contains is faster than using none.

For GCC 15, this is about a 10x speedup.  Clang 20 seems to have worse than quadratic scaling with the new method, but the constant is improved enough that it is still better than the old algorithm for lengths that don't hit the recursion limit.  Both compilers showed comparable performance with quadratic scaling with the old implementation.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
