### PR TITLE
Add CleanFunctionsOfTime event

### DIFF
--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Averager.cpp
   CalculateMeasurementTimescales.cpp
+  CleanFunctionsOfTime.cpp
   Controller.cpp
   ExpirationTimes.cpp
   FutureMeasurements.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   HEADERS
   Averager.hpp
   CalculateMeasurementTimescales.hpp
+  CleanFunctionsOfTime.hpp
   CombinedName.hpp
   Component.hpp
   Controller.hpp

--- a/src/ControlSystem/CleanFunctionsOfTime.cpp
+++ b/src/ControlSystem/CleanFunctionsOfTime.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/CleanFunctionsOfTime.hpp"
+
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace control_system {
+void CleanFunctionsOfTimeAction::CleanFunc::apply(
+    const gsl::not_null<std::unordered_map<
+        std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+        functions,
+    const double time) {
+  for (auto& function : *functions) {
+    function.second->truncate_at_time(time);
+  }
+}
+
+CleanFunctionsOfTime::CleanFunctionsOfTime(CkMigrateMessage* const m)
+    : Event(m) {}
+
+bool CleanFunctionsOfTime::needs_evolved_variables() const { return false; }
+
+PUP::able::PUP_ID CleanFunctionsOfTime::my_PUP_ID = 0;  // NOLINT
+}  // namespace control_system

--- a/src/ControlSystem/CleanFunctionsOfTime.hpp
+++ b/src/ControlSystem/CleanFunctionsOfTime.hpp
@@ -1,0 +1,141 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+
+#include "IO/Observer/ObserverComponent.hpp"
+#include "Options/String.hpp"
+#include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Tags {
+struct Time;
+}  // namespace Tags
+namespace control_system::Tags {
+struct MeasurementTimescales;
+}  // namespace control_system::Tags
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace domain::FunctionsOfTime {
+class FunctionOfTime;
+}  // namespace domain::FunctionsOfTime
+namespace domain::Tags {
+struct FunctionsOfTime;
+}  // namespace domain::Tags
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace control_system {
+/// \ingroup ControlSystemGroup
+/// Reduction action that deletes function-of-time data from before
+/// the passed time.
+///
+/// \see CleanFunctionsOfTime
+struct CleanFunctionsOfTimeAction {
+ private:
+  struct CleanFunc {
+    static void apply(
+        gsl::not_null<std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>*>
+            functions,
+        double time);
+  };
+
+ public:
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, const double time) {
+    Parallel::mutate<domain::Tags::FunctionsOfTime, CleanFunc>(cache, time);
+    Parallel::mutate<Tags::MeasurementTimescales, CleanFunc>(cache, time);
+  }
+};
+
+/// \ingroup ControlSystemGroup
+/// Delete old function-of-time data to save memory.
+///
+/// \warning Running this event will make the
+/// `global_functions_of_time` data stored in the output files
+/// useless.
+class CleanFunctionsOfTime : public Event {
+  using ReductionData = Parallel::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
+
+ public:
+  /// \cond
+  explicit CleanFunctionsOfTime(CkMigrateMessage* m);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(CleanFunctionsOfTime);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr Options::String help =
+      "Delete old function-of-time data to save memory.\n"
+      "\n"
+      "WARNING: Running this event will make the global_functions_of_time\n"
+      "data stored in the output files useless.";
+
+  CleanFunctionsOfTime() = default;
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<::Tags::Time>;
+
+  template <typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  void operator()(const double time,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const ParallelComponent* const /*meta*/,
+                  const ObservationValue& /*observation_value*/) const {
+    if constexpr (Parallel::is_dg_element_collection_v<ParallelComponent>) {
+      (void)cache;
+      (void)array_index;
+      (void)time;
+      ERROR("Reductions not implemented with DgElementCollection.");
+    } else {
+      // It doesn't matter what individual component the target is.
+      // We use ObserverWriter[0] because it must exist and is easy to
+      // name here.
+      const auto& writer0_proxy = Parallel::get_parallel_component<
+          observers::ObserverWriter<Metavariables>>(cache)[0];
+      const auto& self_proxy =
+          Parallel::get_parallel_component<ParallelComponent>(
+              cache)[array_index];
+      Parallel::contribute_to_reduction<CleanFunctionsOfTimeAction>(
+          ReductionData(time), self_proxy, writer0_proxy);
+    }
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override;
+};
+}  // namespace control_system

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -9,6 +9,7 @@
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
 #include "ControlSystem/Actions/LimitTimeStep.hpp"
+#include "ControlSystem/CleanFunctionsOfTime.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/ControlErrors/Size/Factory.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
@@ -502,6 +503,7 @@ struct EvolutionMetavars {
                            volume_dim, observe_fields, non_tensor_compute_tags>,
                        control_system::metafunctions::control_system_events<
                            control_systems>,
+                       control_system::CleanFunctionsOfTime,
                        Events::time_events<system>,
                        dg::Events::ObserveTimeStepVolume<system>,
                        amr::Events::RefineMesh,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
+#include "ControlSystem/CleanFunctionsOfTime.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/ControlErrors/Size/Factory.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
@@ -204,6 +205,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
                        ah::Events::FindApparentHorizon<ApparentHorizon>,
                        control_system::metafunctions::control_system_events<
                            control_systems>,
+                       control_system::CleanFunctionsOfTime,
                        intrp::Events::InterpolateWithoutInterpComponent<
                            3, BondiSachs, source_vars_no_deriv>,
                        intrp::Events::InterpolateWithoutInterpComponent<

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -9,6 +9,7 @@
 #include "ControlSystem/Actions/GridCenters.hpp"
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
 #include "ControlSystem/Actions/LimitTimeStep.hpp"
+#include "ControlSystem/CleanFunctionsOfTime.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/Measurements/BNSCenterOfMass.hpp"
 #include "ControlSystem/Metafunctions.hpp"
@@ -641,6 +642,9 @@ struct GhValenciaDivCleanTemplateBase<
                        dg::Events::ObserveTimeStepVolume<system>,
                        control_system::metafunctions::control_system_events<
                            control_systems>,
+                       tmpl::conditional_t<use_control_systems,
+                                           control_system::CleanFunctionsOfTime,
+                                           tmpl::list<>>,
                        intrp::Events::InterpolateWithoutInterpComponent<
                            volume_dim, InterpolationTargetTags,
                            interpolator_source_vars>...>>>,

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "ControlSystem/Actions/InitializeMeasurements.hpp"
+#include "ControlSystem/CleanFunctionsOfTime.hpp"
 #include "ControlSystem/Component.hpp"
 #include "ControlSystem/ControlErrors/Size/Factory.hpp"
 #include "ControlSystem/ControlErrors/Size/State.hpp"
@@ -217,6 +218,7 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
                     3, BondiSachs, source_vars_no_deriv>,
                 control_system::metafunctions::control_system_events<
                     control_systems>,
+                control_system::CleanFunctionsOfTime,
                 intrp::Events::InterpolateWithoutInterpComponent<
                     volume_dim, ExcisionBoundaryA, ah::source_vars<volume_dim>>,
                 intrp::Events::InterpolateWithoutInterpComponent<

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -477,6 +477,10 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 {% endif %}
+  # Discard old data to reduce memory use
+  - Trigger: Always
+    Events:
+      - CleanFunctionsOfTime
 
 EventsAndTriggersAtSteps:
 

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -295,6 +295,10 @@ EventsAndTriggersAtSlabs:
         Value: {{ FinalTime }}
     Events:
       - Completion
+  # Discard old data to reduce memory use
+  - Trigger: Always
+    Events:
+      - CleanFunctionsOfTime
 
 EventsAndTriggersAtSteps:
 

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ControlSystem")
 
 set(LIBRARY_SOURCES
   Test_Averager.cpp
+  Test_CleanFunctionsOfTime.cpp
   Test_CombinedName.cpp
   Test_Controller.cpp
   Test_EventTriggerMetafunctions.cpp

--- a/tests/Unit/ControlSystem/Test_CleanFunctionsOfTime.cpp
+++ b/tests/Unit/ControlSystem/Test_CleanFunctionsOfTime.cpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "ControlSystem/CleanFunctionsOfTime.hpp"
+#include "ControlSystem/Tags/MeasurementTimescales.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
+#include "Domain/FunctionsOfTime/RegisterDerivedWithCharm.hpp"
+#include "Domain/FunctionsOfTime/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename Metavariables>
+struct Component {
+  using chare_type = ActionTesting::MockNodeGroupChare;
+  using array_index = size_t;
+  using metavariables = Metavariables;
+  using const_global_cache_tags = tmpl::list<>;
+  using mutable_global_cache_tags =
+      tmpl::list<domain::Tags::FunctionsOfTime,
+                 control_system::Tags::MeasurementTimescales>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+};
+
+struct Metavars {
+  using component_list = tmpl::list<Component<Metavars>>;
+};
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.CleanFunctionsOfTime",
+                  "[Unit][ControlSystem]") {
+  // ActionTesting doesn't support reductions, so this just tests the
+  // reduction action as a simple action.
+
+  domain::FunctionsOfTime::register_derived_with_charm();
+  using component = Component<Metavars>;
+
+  const std::initializer_list<std::string> names{"A", "B", "C"};
+
+  domain::FunctionsOfTime::PiecewisePolynomial<0> fot_template(
+      0.0, std::array{DataVector{1.0}}, 1.7);
+  fot_template.update(1.7, DataVector{1.0}, 2.9);
+  fot_template.update(2.9, DataVector{1.0}, 5.8);
+  fot_template.update(5.8, DataVector{1.0}, 7.2);
+  fot_template.update(7.2, DataVector{1.0}, 10.1);
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      init_functions_of_time{};
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      init_measurement_timescales{};
+
+  for (const auto& name : names) {
+    init_functions_of_time[name] = fot_template.get_clone();
+    init_measurement_timescales[name] = fot_template.get_clone();
+  }
+
+  ActionTesting::MockRuntimeSystem<Metavars> runner{
+      {},
+      {std::move(init_functions_of_time),
+       std::move(init_measurement_timescales)}};
+  ActionTesting::emplace_nodegroup_component<component>(make_not_null(&runner));
+
+  ActionTesting::simple_action<component,
+                               control_system::CleanFunctionsOfTimeAction>(
+      make_not_null(&runner), 0_st, 5.0);
+
+  const auto& cache = ActionTesting::cache<component>(runner, 0_st);
+  const auto& functions_of_time =
+      Parallel::get<domain::Tags::FunctionsOfTime>(cache);
+  const auto& measurement_timescales =
+      Parallel::get<control_system::Tags::MeasurementTimescales>(cache);
+
+  for (const auto& name : names) {
+    CHECK(functions_of_time.at(name)->time_bounds()[0] > 1.0);
+    CHECK(functions_of_time.at(name)->time_bounds()[0] <= 5.0);
+    CHECK(measurement_timescales.at(name)->time_bounds()[0] > 1.0);
+    CHECK(measurement_timescales.at(name)->time_bounds()[0] <= 5.0);
+  }
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Adds and enables an event to delete old function-of-time data when it is no longer needed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
This PR enables discarding of old function-of-time data in the BBH pipeline.  If you are using the `global_functions_of_time` data and the pipeline input files, you will need to remove the `CleanFunctionsOfTime` event.  The `global_functions_of_time` data is typically used for things like "replaying" evolutions and spacetime interpolation in postprocessing.  It is not used by normal volume visualization.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
