### PR TITLE
Fix electron fraction bounds in primitive recovery

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -124,7 +124,10 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
   // work because everything will get reset to atmosphere.
   if (max(get(tilde_d)) < cutoffD) {
     get(*rest_mass_density) = floorD;
-    get(*electron_fraction) = min(0.5, max(get(tilde_ye) / get(tilde_d), 0.));
+    get(*electron_fraction) =
+        min(equation_of_state.electron_fraction_upper_bound(),
+            max(get(tilde_ye) / get(tilde_d),
+                equation_of_state.electron_fraction_lower_bound()));
     if constexpr (eos_is_barotropic) {
       // Note: default construction for T and Y_e must be okay since the EOS is
       // barotropic.
@@ -187,11 +190,11 @@ bool PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
   rest_mass_density_times_lorentz_factor =
       get(tilde_d) / get(sqrt_det_spatial_metric);
 
-  // This may need bounds
-  // limit Ye to table bounds once that is implemented
   for (size_t s = 0; s < number_of_points; ++s) {
     get(*electron_fraction)[s] =
-        std::min(0.5, std::max(get(tilde_ye)[s] / get(tilde_d)[s], 0.));
+        std::min(equation_of_state.electron_fraction_upper_bound(),
+            std::max(get(tilde_ye)[s] / get(tilde_d)[s],
+                equation_of_state.electron_fraction_lower_bound()));
 
     std::optional<PrimitiveRecoverySchemes::PrimitiveRecoveryData>
         primitive_data = std::nullopt;


### PR DESCRIPTION
## Proposed changes

In `ValenciaDivClean`'s primitive recovery, there are a few points where the value of the electron fraction is restricted to the range [0.,0.5]. The range should actually be dictated by the equation of state in use, so this change replaces the hard-coded bounds with the bounds set by the equation of state.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
