### PR TITLE
Add helper function to store neighbor spacetime data in GhValenciaDivClean

### DIFF
--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_headers(
   BoundaryConditionGhostData.hpp
   Derivatives.hpp
   Factory.hpp
+  FillNeighborSpacetimeVariables.hpp
   FilterOptions.hpp
   Filters.hpp
   FiniteDifference.hpp

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
@@ -4,25 +4,18 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp"
 
 #include <cstddef>
-#include <utility>
 
-#include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/IndexType.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
-#include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/FillNeighborSpacetimeVariables.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
 #include "Evolution/Systems/RadiationTransport/NoNeutrinos/System.hpp"
 #include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/TMPL.hpp"
 
 namespace grmhd::GhValenciaDivClean::fd {
 template <typename System>
@@ -45,50 +38,28 @@ void spacetime_derivatives(
     result->initialize(volume_evolved_variables.number_of_grid_points());
   }
 
-  using first_gh_tag = tmpl::front<
-      grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>;
   constexpr size_t number_of_gh_components = Variables<
       grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>::
       number_of_independent_components;
 
-  DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
-  for (const auto& [directional_element_id, ghost_data] : all_ghost_data) {
-    using NeighborVariables =
-        Variables<grmhd::GhValenciaDivClean::Tags::
-                      primitive_grmhd_and_spacetime_reconstruction_tags>;
-    const DataVector& neighbor_data =
-        ghost_data.neighbor_ghost_data_for_reconstruction();
-    const size_t neighbor_number_of_points =
-        neighbor_data.size() /
-        NeighborVariables::number_of_independent_components;
-    ASSERT(
-        neighbor_data.size() %
-                NeighborVariables::number_of_independent_components ==
-            0,
-        "Amount of reconstruction data sent ("
-            << neighbor_data.size() << ") from " << directional_element_id
-            << " is not a multiple of the number of reconstruction variables "
-            << NeighborVariables::number_of_independent_components);
-    // Use a Variables view to get offset into spacetime variables
-    // without having to do pointer math.
-    const NeighborVariables
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-        view{const_cast<double*>(neighbor_data.data()),
-             neighbor_number_of_points *
-                 NeighborVariables::number_of_independent_components};
-    ghost_cell_vars.insert(std::pair{
-        directional_element_id.direction(),
-        gsl::make_span(get<first_gh_tag>(view)[0].data(),
-                       number_of_gh_components * neighbor_number_of_points)});
-  }
+  DirectionMap<3, gsl::span<const double>> ghost_cell_spacetime_vars{};
+  using NeighborVariables =
+      Variables<grmhd::GhValenciaDivClean::Tags::
+                    primitive_grmhd_and_spacetime_reconstruction_tags>;
+  using FirstGhTag = tmpl::front<
+      grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>;
+
+  fill_neighbor_spacetime_variables<NeighborVariables, FirstGhTag>(
+      make_not_null(&ghost_cell_spacetime_vars), all_ghost_data,
+      number_of_gh_components);
 
   const auto volume_gh_vars =
-      gsl::make_span(get<first_gh_tag>(volume_evolved_variables)[0].data(),
+      gsl::make_span(get<FirstGhTag>(volume_evolved_variables)[0].data(),
                      number_of_gh_components *
                          volume_evolved_variables.number_of_grid_points());
 
   ::fd::partial_derivatives<gradients_tags>(
-      result, volume_gh_vars, ghost_cell_vars, volume_mesh,
+      result, volume_gh_vars, ghost_cell_spacetime_vars, volume_mesh,
       number_of_gh_components, deriv_order,
       cell_centered_logical_to_inertial_inv_jacobian);
 }

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/FillNeighborSpacetimeVariables.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/FillNeighborSpacetimeVariables.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace grmhd::GhValenciaDivClean::fd {
+/*!
+ * \brief Helper function that takes spacetime variable data from a
+ * `DirectionalIdMap` containing all neighbor data and copies them to
+ * `ghost_cell_spacetime_vars`, a separate `DirectionMap`.
+ *
+ * \tparam NeighborVariables a `Variables` type containing all tags stored in
+ * the neighbor data
+ * \tparam FirstGhTag the first spacetime variables tag in
+ * `NeighborVariables`. Note: it is assumed that the spacetime variables are
+ * consecutively stored in the `Variables`
+ * \param ghost_cell_spacetime_vars a `DirectionMap` to be filled with spans
+ * storing the spacetime data
+ * \param all_ghost_data a `DirectionalIdMap` containing all neighbor data
+ * \param number_of_gh_components the number of independent components for all
+ * spacetime variables in `NeighborVariables`
+ */
+template <typename NeighborVariables, typename FirstGhTag>
+void fill_neighbor_spacetime_variables(
+    const gsl::not_null<DirectionMap<3, gsl::span<const double>>*>
+        ghost_cell_spacetime_vars,
+    const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&
+        all_ghost_data,
+    const size_t number_of_gh_components) {
+  for (const auto& [directional_element_id, ghost_data] : all_ghost_data) {
+    const DataVector& neighbor_data =
+        ghost_data.neighbor_ghost_data_for_reconstruction();
+    const size_t neighbor_number_of_points =
+        neighbor_data.size() /
+        NeighborVariables::number_of_independent_components;
+    ASSERT(
+        neighbor_data.size() %
+                NeighborVariables::number_of_independent_components ==
+            0,
+        "Amount of reconstruction data sent ("
+            << neighbor_data.size() << ") from " << directional_element_id
+            << " is not a multiple of the number of reconstruction variables "
+            << NeighborVariables::number_of_independent_components);
+    // Use a Variables view to get offset into spacetime variables
+    // without having to do pointer math.
+    const NeighborVariables
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        view{const_cast<double*>(neighbor_data.data()),
+             neighbor_number_of_points *
+                 NeighborVariables::number_of_independent_components};
+    // Note: assumes that the spacetime tags are consecutive in
+    // `NeighborVariables`
+    ghost_cell_spacetime_vars->insert(std::pair{
+        directional_element_id.direction(),
+        gsl::make_span(get<FirstGhTag>(view)[0].data(),
+                       number_of_gh_components * neighbor_number_of_points)});
+  }
+}
+
+}  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.cpp
@@ -4,25 +4,18 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.hpp"
 
 #include <cstddef>
-#include <utility>
 
-#include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/IndexType.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
-#include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/FillNeighborSpacetimeVariables.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
 #include "Evolution/Systems/RadiationTransport/NoNeutrinos/System.hpp"
 #include "NumericalAlgorithms/FiniteDifference/Filter.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/TMPL.hpp"
 
 namespace grmhd::GhValenciaDivClean::fd {
 template <typename VariableTags>
@@ -37,54 +30,32 @@ void spacetime_kreiss_oliger_filter(
     result->initialize(volume_evolved_variables.number_of_grid_points());
   }
 
-  using first_gh_tag = tmpl::front<
-      grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>;
   constexpr size_t number_of_gh_components = Variables<
       grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>::
       number_of_independent_components;
 
-  DirectionMap<3, gsl::span<const double>> ghost_cell_vars{};
-  for (const auto& [directional_element_id, ghost_data] : all_ghost_data) {
-    using NeighborVariables =
-        Variables<grmhd::GhValenciaDivClean::Tags::
-                      primitive_grmhd_and_spacetime_reconstruction_tags>;
-    const DataVector& neighbor_data =
-        ghost_data.neighbor_ghost_data_for_reconstruction();
-    const size_t neighbor_number_of_points =
-        neighbor_data.size() /
-        NeighborVariables::number_of_independent_components;
-    ASSERT(
-        neighbor_data.size() %
-                NeighborVariables::number_of_independent_components ==
-            0,
-        "Amount of reconstruction data sent ("
-            << neighbor_data.size() << ") from " << directional_element_id
-            << " is not a multiple of the number of reconstruction variables "
-            << NeighborVariables::number_of_independent_components);
-    // Use a Variables view to get offset into spacetime variables
-    // without having to do pointer math.
-    const NeighborVariables
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-        view{const_cast<double*>(neighbor_data.data()),
-             neighbor_number_of_points *
-                 NeighborVariables::number_of_independent_components};
-    ghost_cell_vars.insert(std::pair{
-        directional_element_id.direction(),
-        gsl::make_span(get<first_gh_tag>(view)[0].data(),
-                       number_of_gh_components * neighbor_number_of_points)});
-  }
+  DirectionMap<3, gsl::span<const double>> ghost_cell_spacetime_vars{};
+  using NeighborVariables =
+      Variables<grmhd::GhValenciaDivClean::Tags::
+                    primitive_grmhd_and_spacetime_reconstruction_tags>;
+  using FirstGhTag = tmpl::front<
+      grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>;
+
+  fill_neighbor_spacetime_variables<NeighborVariables, FirstGhTag>(
+      make_not_null(&ghost_cell_spacetime_vars), all_ghost_data,
+      number_of_gh_components);
 
   const auto volume_gh_vars =
-      gsl::make_span(get<first_gh_tag>(volume_evolved_variables)[0].data(),
+      gsl::make_span(get<FirstGhTag>(volume_evolved_variables)[0].data(),
                      number_of_gh_components *
                          volume_evolved_variables.number_of_grid_points());
 
   auto filtered_gh_vars =
-      gsl::make_span(get<first_gh_tag>(*result)[0].data(),
+      gsl::make_span(get<FirstGhTag>(*result)[0].data(),
                      number_of_gh_components *
                          volume_evolved_variables.number_of_grid_points());
   ::fd::kreiss_oliger_filter(make_not_null(&filtered_gh_vars), volume_gh_vars,
-                             ghost_cell_vars, volume_mesh,
+                             ghost_cell_spacetime_vars, volume_mesh,
                              number_of_gh_components, order, epsilon);
 }
 

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   BoundaryCorrections/Test_ProductOfCorrections.cpp
   FiniteDifference/Test_BoundaryConditionGhostData.cpp
   FiniteDifference/Test_Derivatives.cpp
+  FiniteDifference/Test_FillNeighborSpacetimeVariables.cpp
   FiniteDifference/Test_FilterOptions.cpp
   FiniteDifference/Test_Filters.cpp
   FiniteDifference/Test_MonotonisedCentral.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_FillNeighborSpacetimeVariables.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_FillNeighborSpacetimeVariables.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DgSubcell/SliceData.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/FillNeighborSpacetimeVariables.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Fd."
+    "FillNeighborSpacetimeVariables",
+    "[Unit][Evolution]") {
+  const size_t points_per_dimension = 5;
+  const Mesh<3> subcell_mesh{points_per_dimension,
+                             Spectral::Basis::FiniteDifference,
+                             Spectral::Quadrature::CellCentered};
+
+  using NeighborVariables =
+      Variables<grmhd::GhValenciaDivClean::Tags::
+                    primitive_grmhd_and_spacetime_reconstruction_tags>;
+  using gh_tags =
+      grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags;
+  constexpr size_t number_of_gh_components = Variables<
+      grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>::
+      number_of_independent_components;
+
+  DirectionalIdMap<3, evolution::dg::subcell::GhostData> neighbor_data{};
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(-5.0, 5.0);
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const auto neighbor_vars = make_with_random_values<NeighborVariables>(
+        make_not_null(&gen), make_not_null(&dist),
+        subcell_mesh.number_of_grid_points());
+
+    const auto sliced_data = evolution::dg::subcell::detail::slice_data_impl(
+        gsl::make_span(neighbor_vars), subcell_mesh.extents(), 2,
+        std::unordered_set{direction.opposite()}, 0, {});
+    REQUIRE(sliced_data.size() == 1);
+    REQUIRE(sliced_data.contains(direction.opposite()));
+    const auto key = DirectionalId<3>{direction, ElementId<3>{0}};
+    neighbor_data[key] = evolution::dg::subcell::GhostData{1};
+    neighbor_data[key].neighbor_ghost_data_for_reconstruction() =
+        sliced_data.at(direction.opposite());
+  }
+
+  DirectionMap<3, gsl::span<const double>> result{};
+  grmhd::GhValenciaDivClean::fd::fill_neighbor_spacetime_variables<
+      NeighborVariables, tmpl::front<gh_tags>>(
+      make_not_null(&result), neighbor_data, number_of_gh_components);
+
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const auto key = DirectionalId<3>{direction, ElementId<3>{0}};
+    auto& result_in_dir = result[direction];
+    auto& ghost_data_in_dir =
+        (neighbor_data[key].neighbor_ghost_data_for_reconstruction());
+    const size_t neighbor_number_of_points =
+        ghost_data_in_dir.size() /
+        NeighborVariables::number_of_independent_components;
+
+    const NeighborVariables
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        view{const_cast<double*>(ghost_data_in_dir.data()),
+             neighbor_number_of_points *
+                 NeighborVariables::number_of_independent_components};
+    const auto subset_view = view.extract_subset<gh_tags>();
+    const auto compare = subset_view.data();
+    for (size_t element = 0;
+         element < number_of_gh_components * neighbor_number_of_points;
+         ++element) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      CHECK(result_in_dir[element] == *(compare + element));
+    };
+  }
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

Refactors duplicated code in the `Filters.cpp` and `Derivatives.cpp` files in `GhValenciaDivClean/FiniteDifference`. When upgrading `GhValenciaDivClean` to support higher order FD, the `NeighborVariables` in these files may include extra tags in some circumstances, so this is mostly to prevent future re-duplication of these same lines for `NeighborVariables` taking on different types.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
