### PR TITLE
Add equation of state calls for specific entropy and compute tag for observing it

### DIFF
--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -208,6 +208,7 @@
 #include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEntropy.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
@@ -496,6 +497,7 @@ struct GhValenciaDivCleanTemplateBase<
               ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
               hydro::Tags::TransportVelocity<DataVector, volume_dim,
                                              Frame::Inertial>>,
+          hydro::Tags::SpecificEntropyCompute<DataVector>,
           gh::Tags::TimeDerivLapseCompute<volume_dim, Frame::Inertial>,
           gh::Tags::TimeDerivShiftCompute<volume_dim, Frame::Inertial>,
           ::Tags::dt<gh::Tags::Phi<DataVector, volume_dim, Frame::Inertial>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -151,6 +151,7 @@
 #include "PointwiseFunctions/Hydro/InversePlasmaBeta.hpp"
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/QuadrupoleFormula.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEntropy.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
@@ -293,7 +294,8 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
           ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>,
           hydro::Tags::TransportVelocity<DataVector, volume_dim,
                                          Frame::Inertial>>,
-      hydro::Tags::InversePlasmaBetaCompute<DataVector>>;
+      hydro::Tags::InversePlasmaBetaCompute<DataVector>,
+      hydro::Tags::SpecificEntropyCompute<DataVector>>;
   using non_tensor_compute_tags = tmpl::list<
       tmpl::conditional_t<
           use_dg_subcell,

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   QuadrupoleFormula.cpp
   SoundSpeedSquared.cpp
   SpecificEnthalpy.cpp
+  SpecificEntropy.cpp
   StressEnergy.cpp
   TransportVelocity.cpp
   )
@@ -36,6 +37,7 @@ spectre_target_headers(
   QuadrupoleFormula.hpp
   SoundSpeedSquared.hpp
   SpecificEnthalpy.hpp
+  SpecificEntropy.hpp
   StressEnergy.hpp
   Tags.hpp
   TagsDeclarations.hpp

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic2D.cpp
@@ -80,6 +80,24 @@ Scalar<DataType> Barotropic2D<ColdEos>::pressure_from_density_and_enthalpy_impl(
 template <typename ColdEos>
 template <class DataType>
 Scalar<DataType>
+Barotropic2D<ColdEos>::specific_entropy_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_internal_energy*/) const {
+  return underlying_eos_.specific_entropy_from_density(rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic2D<ColdEos>::specific_entropy_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*temperature*/) const {
+  return underlying_eos_.specific_entropy_from_density(rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType>
 Barotropic2D<ColdEos>::specific_internal_energy_from_density_and_pressure_impl(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& /*pressure*/) const {

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Barotropic3D.cpp
@@ -84,6 +84,26 @@ Barotropic3D<ColdEquilEos>::temperature_from_density_and_energy_impl(
   return make_with_value<Scalar<DataType>>(rest_mass_density, 0.0);
 }
 
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic3D<ColdEos>::specific_entropy_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*specific_internal_energy*/,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.specific_entropy_from_density(rest_mass_density);
+}
+
+template <typename ColdEos>
+template <class DataType>
+Scalar<DataType>
+Barotropic3D<ColdEos>::specific_entropy_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& /*temperature*/,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.specific_entropy_from_density(rest_mass_density);
+}
+
 template <typename ColdEquilEos>
 template <class DataType>
 Scalar<DataType> Barotropic3D<ColdEquilEos>::

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.cpp
@@ -92,6 +92,44 @@ DarkEnergyFluid<IsRelativistic>::pressure_from_density_and_enthalpy_impl(
 
 template <bool IsRelativistic>
 template <class DataType>
+Scalar<DataType>
+DarkEnergyFluid<IsRelativistic>::specific_entropy_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{specific_entropy_from_density_and_energy(
+        get(rest_mass_density), get(specific_internal_energy))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = specific_entropy_from_density_and_energy(
+          get(rest_mass_density)[i], get(specific_internal_energy)[i]);
+    }
+    return result;
+  }
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType> DarkEnergyFluid<IsRelativistic>::
+    specific_entropy_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& temperature) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{specific_entropy_from_density_and_energy(
+        get(rest_mass_density), get(temperature) / parameter_w_)};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = specific_entropy_from_density_and_energy(
+          get(rest_mass_density)[i], get(temperature)[i] / parameter_w_);
+    }
+    return result;
+  }
+}
+
+template <bool IsRelativistic>
+template <class DataType>
 Scalar<DataType> DarkEnergyFluid<IsRelativistic>::
     specific_internal_energy_from_density_and_pressure_impl(
         const Scalar<DataType>& rest_mass_density,
@@ -135,6 +173,23 @@ Scalar<DataType> DarkEnergyFluid<IsRelativistic>::
         const Scalar<DataType>& specific_internal_energy) const {
   return Scalar<DataType>{square(parameter_w_) *
                           (1.0 + get(specific_internal_energy))};
+}
+
+template <bool IsRelativistic>
+double
+DarkEnergyFluid<IsRelativistic>::specific_entropy_from_density_and_energy(
+    const double rest_mass_density,
+    const double specific_internal_energy) const {
+  // Note: Since specific internal energy has a lower bound of -1, entropy will
+  // be undefined for values smaller than 0 or w = 0. Since this equation of
+  // state is almost never used, this function is included as a framework for
+  // the calculation. However, more careful attention is needed for users who
+  // wish to use it.
+  ASSERT(specific_internal_energy > 0.0,
+         "Entropy is undefined for non-positive specific internal energy.");
+  ASSERT(parameter_w_ > 0.0, "Entropy is undefined for $w = 0$.");
+  return log(specific_internal_energy / pow(rest_mass_density, parameter_w_)) /
+         parameter_w_;
 }
 }  // namespace EquationsOfState
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.hpp
@@ -128,6 +128,9 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
 
+  double specific_entropy_from_density_and_energy(double density,
+                                                  double energy) const;
+
   double parameter_w_ = std::numeric_limits<double>::signaling_NaN();
 };
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp
@@ -223,6 +223,36 @@ class EquationOfState<IsRelativistic, 1> : public PUP::able {
 
   /// @{
   /*!
+   * Computes the specific entropy \f$s\f$ from the rest mass density
+   * \f$\rho\f$.
+   */
+  virtual Scalar<double> specific_entropy_from_density(
+      const Scalar<double>& /*rest_mass_density*/) const {
+    return Scalar<double>{0.0};
+  }
+  virtual Scalar<DataVector> specific_entropy_from_density(
+      const Scalar<DataVector>& rest_mass_density) const {
+    return make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+  }
+  /// @}
+
+  /// @{
+  /*!
+   * Computes the specific entropy \f$s\f$ from the specific internal energy
+   * \f$\epsilon\f$.
+   */
+  virtual Scalar<double> specific_entropy_from_specific_internal_energy(
+      const Scalar<double>& /*specific_internal_energy*/) const {
+    return Scalar<double>{0.0};
+  }
+  virtual Scalar<DataVector> specific_entropy_from_specific_internal_energy(
+      const Scalar<DataVector>& specific_internal_energy) const {
+    return make_with_value<Scalar<DataVector>>(specific_internal_energy, 0.0);
+  }
+  /// @}
+
+  /// @{
+  /*!
    * Computes the specific internal energy \f$\epsilon\f$ from the rest mass
    * density \f$\rho\f$.
    */
@@ -418,6 +448,34 @@ class EquationOfState<IsRelativistic, 2> : public PUP::able {
   virtual Scalar<DataVector> pressure_from_density_and_enthalpy(
       const Scalar<DataVector>& /*rest_mass_density*/,
       const Scalar<DataVector>& /*specific_enthalpy*/) const = 0;
+  /// @}
+
+  /// @{
+  /*!
+   * Computes the specific entropy \f$s\f$ from the rest mass density \f$\rho\f$
+   * and the specific internal energy \f$\epsilon\f$.
+   */
+  virtual Scalar<double> specific_entropy_from_density_and_energy(
+      const Scalar<double>& /*rest_mass_density*/,
+      const Scalar<double>& /*specific_internal_energy*/) const = 0;
+
+  virtual Scalar<DataVector> specific_entropy_from_density_and_energy(
+      const Scalar<DataVector>& /*rest_mass_density*/,
+      const Scalar<DataVector>& /*specific_internal_energy*/) const = 0;
+  /// @}
+
+  /// @{
+  /*!
+   * Computes the specific entropy \f$s\f$ from the rest mass density \f$\rho\f$
+   * and the temperature \f$T\f$.
+   */
+  virtual Scalar<double> specific_entropy_from_density_and_temperature(
+      const Scalar<double>& /*rest_mass_density*/,
+      const Scalar<double>& /*temperature*/) const = 0;
+
+  virtual Scalar<DataVector> specific_entropy_from_density_and_temperature(
+      const Scalar<DataVector>& /*rest_mass_density*/,
+      const Scalar<DataVector>& /*temperature*/) const = 0;
   /// @}
 
   /// @{
@@ -625,6 +683,39 @@ class EquationOfState<IsRelativistic, 3> : public PUP::able {
 
   /// @{
   /*!
+   * Computes the specific entropy \f$s\f$ from the rest mass density \f$\rho\f$
+   * and the specific internal energy \f$\epsilon\f$ and electron fraction
+   * \f$Y_e\f$.
+   */
+  virtual Scalar<double> specific_entropy_from_density_and_energy(
+      const Scalar<double>& /*rest_mass_density*/,
+      const Scalar<double>& /*specific_internal_energy*/,
+      const Scalar<double>& /*electron_fraction*/) const = 0;
+
+  virtual Scalar<DataVector> specific_entropy_from_density_and_energy(
+      const Scalar<DataVector>& /*rest_mass_density*/,
+      const Scalar<DataVector>& /*specific_internal_energy*/,
+      const Scalar<DataVector>& /*electron_fraction*/) const = 0;
+  /// @}
+
+  /// @{
+  /*!
+   * Computes the specific entropy \f$s\f$ from the rest mass density \f$\rho\f$
+   * and the temperature \f$T\f$ and electron fraction \f$Y_e\f$.
+   */
+  virtual Scalar<double> specific_entropy_from_density_and_temperature(
+      const Scalar<double>& /*rest_mass_density*/,
+      const Scalar<double>& /*temperature*/,
+      const Scalar<double>& /*electron_fraction*/) const = 0;
+
+  virtual Scalar<DataVector> specific_entropy_from_density_and_temperature(
+      const Scalar<DataVector>& /*rest_mass_density*/,
+      const Scalar<DataVector>& /*temperature*/,
+      const Scalar<DataVector>& /*electron_fraction*/) const = 0;
+  /// @}
+
+  /// @{
+  /*!
    * Computes the temperature \f$T\f$ from the rest mass
    * density \f$\rho\f$, the specific internal energy \f$\epsilon\f$,
    * and electron fraction \f$Y_e\f$.
@@ -783,6 +874,8 @@ bool operator!=(const EquationOfState<IsRelLhs, ThermoDimLhs>& lhs,
 
 #define EQUATION_OF_STATE_FUNCTIONS_2D                                   \
   (pressure_from_density_and_energy, pressure_from_density_and_enthalpy, \
+   specific_entropy_from_density_and_energy,                             \
+   specific_entropy_from_density_and_temperature,                        \
    specific_internal_energy_from_density_and_pressure,                   \
    temperature_from_density_and_energy,                                  \
    specific_internal_energy_from_density_and_temperature,                \
@@ -791,6 +884,8 @@ bool operator!=(const EquationOfState<IsRelLhs, ThermoDimLhs>& lhs,
 
 #define EQUATION_OF_STATE_FUNCTIONS_3D                                      \
   (pressure_from_density_and_energy, pressure_from_density_and_temperature, \
+   specific_entropy_from_density_and_energy,                                \
+   specific_entropy_from_density_and_temperature,                           \
    temperature_from_density_and_energy,                                     \
    specific_internal_energy_from_density_and_temperature,                   \
    sound_speed_squared_from_density_and_temperature)

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.cpp
@@ -92,6 +92,30 @@ Equilibrium3D<EquilEos>::temperature_from_density_and_energy_impl(
 
 template <typename EquilEos>
 template <class DataType>
+Scalar<DataType>
+Equilibrium3D<EquilEos>::specific_entropy_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.specific_entropy_from_density_and_energy(
+      rest_mass_density, specific_internal_energy);
+}
+
+template <typename EquilEos>
+template <class DataType>
+Scalar<DataType>
+Equilibrium3D<EquilEos>::specific_entropy_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& /*electron_fraction*/) const {
+  return underlying_eos_.specific_entropy_from_density_and_energy(
+      rest_mass_density,
+      underlying_eos_.specific_internal_energy_from_density_and_temperature(
+          rest_mass_density, temperature));
+}
+
+template <typename EquilEos>
+template <class DataType>
 Scalar<DataType> Equilibrium3D<EquilEos>::
     specific_internal_energy_from_density_and_temperature_impl(
         const Scalar<DataType>& rest_mass_density,

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.cpp
@@ -17,9 +17,11 @@
 namespace EquationsOfState {
 template <typename ColdEquationOfState>
 HybridEos<ColdEquationOfState>::HybridEos(ColdEquationOfState cold_eos,
-                                          const double thermal_adiabatic_index)
+                                          const double thermal_adiabatic_index,
+                                          const double min_temperature)
     : cold_eos_(std::move(cold_eos)),
-      thermal_adiabatic_index_(thermal_adiabatic_index) {}
+      thermal_adiabatic_index_(thermal_adiabatic_index),
+      min_temperature_(min_temperature) {}
 
 EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <typename ColdEquationOfState>,
                                      HybridEos<ColdEquationOfState>, double, 2)
@@ -47,7 +49,8 @@ template <typename ColdEquationOfState>
 bool HybridEos<ColdEquationOfState>::operator==(
     const HybridEos<ColdEquationOfState>& rhs) const {
   return cold_eos_ == rhs.cold_eos_ and
-         thermal_adiabatic_index_ == rhs.thermal_adiabatic_index_;
+         thermal_adiabatic_index_ == rhs.thermal_adiabatic_index_ and
+         min_temperature_ == rhs.min_temperature_;
 }
 
 template <typename ColdEquationOfState>
@@ -73,6 +76,7 @@ void HybridEos<ColdEquationOfState>::pup(PUP::er& p) {
   EquationOfState<is_relativistic, 2>::pup(p);
   p | cold_eos_;
   p | thermal_adiabatic_index_;
+  p | min_temperature_;
 }
 
 template <typename ColdEquationOfState>
@@ -147,6 +151,52 @@ HybridEos<ColdEquationOfState>::temperature_from_density_and_energy_impl(
 
 template <typename ColdEquationOfState>
 template <class DataType>
+Scalar<DataType>
+HybridEos<ColdEquationOfState>::specific_entropy_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy) const {
+  using std::max;
+  DataType thermal_specific_internal_energy =
+      max(get(specific_internal_energy) -
+              get(cold_eos_.specific_internal_energy_from_density(
+                  rest_mass_density)),
+          0.0);
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{specific_entropy_from_density_and_thermal_energy(
+        get(rest_mass_density), thermal_specific_internal_energy)};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = specific_entropy_from_density_and_thermal_energy(
+          get(rest_mass_density)[i], thermal_specific_internal_energy[i]);
+    }
+    return result;
+  }
+}
+
+template <typename ColdEquationOfState>
+template <class DataType>
+Scalar<DataType> HybridEos<ColdEquationOfState>::
+    specific_entropy_from_density_and_temperature_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& temperature) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{specific_entropy_from_density_and_thermal_energy(
+        get(rest_mass_density),
+        get(temperature) / (thermal_adiabatic_index_ - 1.0))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = specific_entropy_from_density_and_thermal_energy(
+          get(rest_mass_density)[i],
+          get(temperature)[i] / (thermal_adiabatic_index_ - 1.0));
+    }
+    return result;
+  }
+}
+
+template <typename ColdEquationOfState>
+template <class DataType>
 Scalar<DataType> HybridEos<ColdEquationOfState>::
     specific_internal_energy_from_density_and_temperature_impl(
         const Scalar<DataType>& rest_mass_density,
@@ -187,6 +237,23 @@ Scalar<DataType> HybridEos<ColdEquationOfState>::
           max((get(specific_internal_energy) -
                get(cold_eos_.specific_internal_energy_from_density(
                    rest_mass_density))), 0.0)};
+}
+
+template <typename ColdEquationOfState>
+double HybridEos<ColdEquationOfState>::
+    specific_entropy_from_density_and_thermal_energy(
+        const double rest_mass_density,
+        const double thermal_specific_internal_energy) const {
+  using std::max;
+  const double floored_thermal_specific_internal_energy =
+      max(min_temperature_ / (thermal_adiabatic_index_ - 1.0),
+          thermal_specific_internal_energy);
+  ASSERT(floored_thermal_specific_internal_energy > 0.0,
+         "The entropy is only well defined for positive nonzero temperatures. "
+         "Try setting the minimum temperature to be greater than 0.");
+  return log(floored_thermal_specific_internal_energy /
+             pow(rest_mass_density, thermal_adiabatic_index_ - 1.0)) /
+         (thermal_adiabatic_index_ - 1.0);
 }
 }  // namespace EquationsOfState
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.hpp
@@ -82,6 +82,14 @@ class HybridEos
     static constexpr Options::String help = {"Adiabatic index Gamma_th"};
   };
 
+  struct MinTemperature {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static constexpr Options::String help = {
+        "Minimum temperature. "
+        "This value must be non-negative."};
+  };
+
   static constexpr Options::String help = {
       "A hybrid equation of state combining a cold EOS with a simple thermal "
       "part.  The pressure is related to the rest mass density by "
@@ -92,7 +100,7 @@ class HybridEos
       "using the cold EOS and Gamma_th is the adiabatic index for the thermal "
       "part."};
 
-  using options = tmpl::list<ColdEos, ThermalAdiabaticIndex>;
+  using options = tmpl::list<ColdEos, ThermalAdiabaticIndex, MinTemperature>;
 
   HybridEos() = default;
   HybridEos(const HybridEos&) = default;
@@ -101,7 +109,8 @@ class HybridEos
   HybridEos& operator=(HybridEos&&) = default;
   ~HybridEos() override = default;
 
-  HybridEos(ColdEquationOfState cold_eos, double thermal_adiabatic_index);
+  HybridEos(ColdEquationOfState cold_eos, double thermal_adiabatic_index,
+            double min_temperature = 0.0);
 
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(HybridEos, 2)
 
@@ -142,7 +151,8 @@ class HybridEos
   double specific_internal_energy_lower_bound(
       const double rest_mass_density) const override {
     return get(cold_eos_.specific_internal_energy_from_density(
-        Scalar<double>{rest_mass_density}));
+               Scalar<double>{rest_mass_density})) +
+           (min_temperature_) / (thermal_adiabatic_index_ - 1.0);
   }
 
   /// The upper bound of the specific internal energy that is valid for this EOS
@@ -154,8 +164,15 @@ class HybridEos
 
   /// The lower bound of the specific enthalpy that is valid for this EOS
   double specific_enthalpy_lower_bound() const override {
-    return cold_eos_.specific_enthalpy_lower_bound();
+    return cold_eos_.specific_enthalpy_lower_bound() +
+           (thermal_adiabatic_index_ * min_temperature_) /
+               (thermal_adiabatic_index_ - 1.0);
   }
+
+  /// The lower bound of the temperature that is valid for this EOS.
+  /// Non-zero lower bound could be set to impose floor on the specific
+  /// internal energy.
+  double temperature_lower_bound() const override { return min_temperature_; }
 
   /// The vacuum baryon mass for this EoS
   double baryon_mass() const override { return cold_eos_.baryon_mass(); }
@@ -163,9 +180,13 @@ class HybridEos
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
 
+  double specific_entropy_from_density_and_thermal_energy(
+      double density, double energy) const;
+
   ColdEquationOfState cold_eos_;
   double thermal_adiabatic_index_ =
       std::numeric_limits<double>::signaling_NaN();
+  double min_temperature_ = std::numeric_limits<double>::signaling_NaN();
 };
 
 /// \cond

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.cpp
@@ -3,6 +3,7 @@
 
 #include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
 
+#include <cmath>
 #include <limits>
 
 #include "DataStructures/DataVector.hpp"
@@ -98,6 +99,45 @@ Scalar<DataType> IdealFluid<false>::pressure_from_density_and_enthalpy_impl(
 
 template <bool IsRelativistic>
 template <class DataType>
+Scalar<DataType>
+IdealFluid<IsRelativistic>::specific_entropy_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{specific_entropy_from_density_and_energy(
+        get(rest_mass_density), get(specific_internal_energy))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = specific_entropy_from_density_and_energy(
+          get(rest_mass_density)[i], get(specific_internal_energy)[i]);
+    }
+    return result;
+  }
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType>
+IdealFluid<IsRelativistic>::specific_entropy_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature) const {
+  if constexpr (std::is_same_v<DataType, double>) {
+    return Scalar<double>{specific_entropy_from_density_and_energy(
+        get(rest_mass_density), get(temperature) / (adiabatic_index_ - 1.0))};
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    auto result = make_with_value<Scalar<DataVector>>(rest_mass_density, 0.0);
+    for (size_t i = 0; i < get(result).size(); ++i) {
+      get(result)[i] = specific_entropy_from_density_and_energy(
+          get(rest_mass_density)[i],
+          get(temperature)[i] / (adiabatic_index_ - 1.0));
+    }
+    return result;
+  }
+}
+
+template <bool IsRelativistic>
+template <class DataType>
 Scalar<DataType> IdealFluid<IsRelativistic>::
     specific_internal_energy_from_density_and_pressure_impl(
         const Scalar<DataType>& rest_mass_density,
@@ -154,6 +194,22 @@ double IdealFluid<IsRelativistic>::specific_internal_energy_upper_bound(
     return 1.0 / (adiabatic_index_ - 2.0);
   }
   return std::numeric_limits<double>::max();
+}
+
+template <bool IsRelativistic>
+double IdealFluid<IsRelativistic>::specific_entropy_from_density_and_energy(
+    const double rest_mass_density,
+    const double specific_internal_energy) const {
+  using std::max;
+  const double floored_specific_internal_energy =
+      max(specific_internal_energy_lower_bound(rest_mass_density),
+          specific_internal_energy);
+  ASSERT(floored_specific_internal_energy > 0.0,
+         "The entropy is only well defined for positive nonzero temperatures. "
+         "Try setting the minimum temperature to be greater than 0.");
+  return log(floored_specific_internal_energy /
+             pow(rest_mass_density, adiabatic_index_ - 1.0)) /
+         (adiabatic_index_ - 1.0);
 }
 }  // namespace EquationsOfState
 

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp
@@ -147,6 +147,9 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
  private:
   EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
 
+  double specific_entropy_from_density_and_energy(double density,
+                                                  double energy) const;
+
   double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
   double min_temperature_ = std::numeric_limits<double>::signaling_NaN();
 };

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
@@ -133,6 +133,7 @@ void Tabulated3D<IsRelativistic>::initialize(const h5::EosTable& spectre_eos) {
   auto pressure = spectre_eos.read_quantity("pressure");
   auto eps = spectre_eos.read_quantity("specific internal energy");
   auto cs2 = spectre_eos.read_quantity("sound speed squared");
+  auto specific_entropy = spectre_eos.read_quantity("specific entropy");
 
   auto mu_l = spectre_eos.read_quantity("lepton chemical potential");
   //  WILL BE NEEDED FOR FUTURE PR
@@ -180,16 +181,20 @@ void Tabulated3D<IsRelativistic>::initialize(const h5::EosTable& spectre_eos) {
 
         double* table_point = &(table_data[index_tab3D * NumberOfVars]);
 
+        // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         table_point[Pressure] =
             std::log(press_MeV_to_geom * pressure[index_spectre]);
         table_point[Epsilon] = std::log(eps[index_spectre] - energy_shift);
         table_point[CsSquared] = cs2[index_spectre];
         table_point[DeltaMu] = mu_l[index_spectre];
+        table_point[SpecificEntropy] =
+            std::log(specific_entropy[index_spectre]);
 
         // Determine specific enthalpy minimum
         double h = 1. + table_point[Epsilon] +
                    table_point[Pressure] / std::exp(log_density[iR]);
         enthalpy_minimum = std::min(enthalpy_minimum, h);
+        // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       }
     }
   }
@@ -495,6 +500,61 @@ Tabulated3D<IsRelativistic>::temperature_from_density_and_energy_impl(
     }
   }
   return temperature;
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType>
+Tabulated3D<IsRelativistic>::specific_entropy_from_density_and_energy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& electron_fraction) const {
+  auto temperature = temperature_from_density_and_energy_impl(
+      rest_mass_density, specific_internal_energy, electron_fraction);
+
+  return specific_entropy_from_density_and_temperature_impl(
+      rest_mass_density, temperature, electron_fraction);
+}
+
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType>
+Tabulated3D<IsRelativistic>::specific_entropy_from_density_and_temperature_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& electron_fraction) const {
+  Scalar<DataType> converted_electron_fraction;
+  Scalar<DataType> log_rest_mass_density;
+  Scalar<DataType> log_temperature;
+
+  convert_to_table_quantities(
+      make_not_null(&converted_electron_fraction),
+      make_not_null(&log_rest_mass_density), make_not_null(&log_temperature),
+      electron_fraction, rest_mass_density, temperature);
+
+  Scalar<DataType> specific_entropy =
+      make_with_value<Scalar<DataType>>(get(rest_mass_density), 0.0);
+
+  if constexpr (std::is_same_v<DataType, double>) {
+    auto weights = interpolator_.get_weights(get(log_temperature),
+                                             get(log_rest_mass_density),
+                                             get(converted_electron_fraction));
+    auto interpolated_state =
+        interpolator_.template interpolate<SpecificEntropy>(weights);
+    get(specific_entropy) = std::exp(interpolated_state[0]);
+
+  } else if constexpr (std::is_same_v<DataType, DataVector>) {
+    for (size_t s = 0; s < get(electron_fraction).size(); ++s) {
+      auto weights = interpolator_.get_weights(
+          get(log_temperature)[s], get(log_rest_mass_density)[s],
+          get(converted_electron_fraction)[s]);
+      auto interpolated_state =
+          interpolator_.template interpolate<SpecificEntropy>(weights);
+      get(specific_entropy)[s] = std::exp(interpolated_state[0]);
+    }
+  }
+
+  return specific_entropy;
 }
 
 template <bool IsRelativistic>

--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.hpp
@@ -69,7 +69,14 @@ class Tabulated3D : public EquationOfState<IsRelativistic, 3> {
   using options = tmpl::list<TableFilename, TableSubFilename>;
 
   /// Fields stored in the table
-  enum : size_t { Epsilon = 0, Pressure, CsSquared, DeltaMu, NumberOfVars };
+  enum : size_t {
+    Epsilon = 0,
+    Pressure,
+    CsSquared,
+    DeltaMu,
+    SpecificEntropy,
+    NumberOfVars
+  };
 
   Tabulated3D() = default;
   Tabulated3D(const Tabulated3D&) = default;

--- a/src/PointwiseFunctions/Hydro/SpecificEntropy.cpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEntropy.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/SpecificEntropy.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace hydro {
+
+template <typename DataType, size_t ThermodynamicDim>
+void specific_entropy(
+    const gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& electron_fraction,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) {
+  if constexpr (ThermodynamicDim == 1) {
+    get(*result) =
+        get(equation_of_state.specific_entropy_from_density(rest_mass_density));
+  } else if constexpr (ThermodynamicDim == 2) {
+    get(*result) =
+        get(equation_of_state.specific_entropy_from_density_and_temperature(
+            rest_mass_density, temperature));
+  } else if constexpr (ThermodynamicDim == 3) {
+    get(*result) =
+        get(equation_of_state.specific_entropy_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction));
+  }
+}
+
+template <typename DataType, size_t ThermodynamicDim>
+Scalar<DataType> specific_entropy(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& electron_fraction,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) {
+  Scalar<DataType> result{};
+  specific_entropy(make_not_null(&result), rest_mass_density, temperature,
+                   electron_fraction, equation_of_state);
+  return result;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                           \
+  template void specific_entropy(                                      \
+      const gsl::not_null<Scalar<DTYPE(data)>*> result,                \
+      const Scalar<DTYPE(data)>& rest_mass_density,                    \
+      const Scalar<DTYPE(data)>& temperature,                          \
+      const Scalar<DTYPE(data)>& electron_fraction,                    \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& \
+          equation_of_state);                                          \
+  template Scalar<DTYPE(data)> specific_entropy(                       \
+      const Scalar<DTYPE(data)>& rest_mass_density,                    \
+      const Scalar<DTYPE(data)>& temperature,                          \
+      const Scalar<DTYPE(data)>& electron_fraction,                    \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& \
+          equation_of_state);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3))
+
+#undef DTYPE
+#undef THERMO_DIM
+#undef INSTANTIATE
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/SpecificEntropy.hpp
+++ b/src/PointwiseFunctions/Hydro/SpecificEntropy.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+/// \endcond
+
+namespace hydro {
+/// @{
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief Computes the specific entropy
+ */
+template <typename DataType, size_t ThermodynamicDim>
+void specific_entropy(
+    gsl::not_null<Scalar<DataType>*> result,
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& electron_fraction,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state);
+
+template <typename DataType, size_t ThermodynamicDim>
+Scalar<DataType> specific_entropy(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& electron_fraction,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state);
+/// @}
+
+namespace Tags {
+/// Compute item for the specific entropy \f$s\f$.
+/// \see hydro::specific_entropy
+///
+/// Can be retrieved using `hydro::Tags::SpecificEntropy`
+template <typename DataType>
+struct SpecificEntropyCompute : SpecificEntropy<DataType>, db::ComputeTag {
+  using argument_tags =
+      typename tmpl::list<RestMassDensity<DataType>, Temperature<DataType>,
+                          ElectronFraction<DataType>,
+                          hydro::Tags::GrmhdEquationOfState>;
+
+  using return_type = Scalar<DataType>;
+
+  template <typename EquationOfStateType>
+  static void function(const gsl::not_null<Scalar<DataType>*> result,
+                       const Scalar<DataType>& rest_mass_density,
+                       const Scalar<DataType>& temperature,
+                       const Scalar<DataType>& electron_fraction,
+                       const EquationOfStateType& equation_of_state) {
+    specific_entropy(result, rest_mass_density, temperature, electron_fraction,
+                     equation_of_state);
+  }
+
+  using base = SpecificEntropy<DataType>;
+};
+}  // namespace Tags
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -275,6 +275,12 @@ struct SpatialVelocitySquared : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// The specific entropy \f$s\f$.
+template <typename DataType>
+struct SpecificEntropy : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
 /// The relativistic specific enthalpy \f$h\f$.
 template <typename DataType>
 struct SpecificEnthalpy : db::SimpleTag {

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -63,6 +63,8 @@ struct SpatialVelocityOneForm;
 template <typename DataType>
 struct SpatialVelocitySquared;
 template <typename DataType>
+struct SpecificEntropy;
+template <typename DataType>
 struct SpecificEnthalpy;
 template <typename DataType>
 struct SpecificInternalEnergy;

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -52,6 +52,7 @@ EquationOfState: &eos
         PolytropicConstant: 123.6
         PolytropicExponent: 2.
       ThermalAdiabaticIndex: 2.0
+      MinTemperature: 1.e-16
 
 DomainCreator:
   BinaryCompactObject:

--- a/tests/Unit/Helpers/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/Helpers/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -19,5 +19,6 @@ target_link_libraries(
 
   PUBLIC
   DataStructures
+  Framework
   Utilities
   )

--- a/tests/Unit/Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/Hydro/EquationsOfState/TestHelpers.hpp
@@ -169,8 +169,23 @@ void check_impl(
         python_file_name,
         python_function_prefix + "_temperature_from_density_and_energy",
         random_value_bounds, member_args_tuple, used_for_size);
-    INFO("Done\nTesting specific_int_energy_from_density_and_temperature...");
+    INFO("Done\nTesting specific_entropy_from_density_and_energy...");
+    pypp::check_with_random_values<2>(
+        func = &EoS::specific_entropy_from_density_and_energy, *eos,
+        python_file_name,
+        python_function_prefix + "_specific_entropy_from_density_and_energy",
+        random_value_bounds, member_args_tuple, used_for_size);
+    INFO("Done\nTesting specific_entropy_from_density_and_temperature...");
     Approx custom_approx = Approx::custom().epsilon(1.e-9);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        eos->specific_entropy_from_density_and_temperature(
+            rest_mass_density,
+            eos->temperature_from_density_and_energy(rest_mass_density,
+                                                     specific_internal_energy)),
+        eos->specific_entropy_from_density_and_energy(rest_mass_density,
+                                                      specific_internal_energy),
+        custom_approx);
+    INFO("Done\nTesting specific_int_energy_from_density_and_temperature...");
     CHECK_ITERABLE_CUSTOM_APPROX(
         specific_internal_energy,
         eos->specific_internal_energy_from_density_and_temperature(
@@ -247,6 +262,19 @@ void check_impl(
   const auto helper = [&](const std::unique_ptr<EoS>& eos) {
     // need func variable to work around GCC bug
     Function func{&EoS::temperature_from_density_and_energy};
+    INFO("Done\nTesting specific_entropy_from_density_and_energy...");
+    pypp::check_with_random_values<3>(
+        func = &EoS::specific_entropy_from_density_and_energy, *eos,
+        python_file_name,
+        python_function_prefix + "_specific_entropy_from_density_and_energy",
+        random_value_bounds, member_args_tuple, used_for_size);
+    INFO("Done\nTesting specific_entropy_from_density_and_temperature...");
+    pypp::check_with_random_values<3>(
+        func = &EoS::specific_entropy_from_density_and_temperature, *eos,
+        python_file_name,
+        python_function_prefix +
+            "_specific_entropy_from_density_and_temperature",
+        random_value_bounds, member_args_tuple, used_for_size);
     INFO("Done\nTesting specific_int_energy_from_density_and_temperature...");
     pypp::check_with_random_values<3>(
         func = &EoS::specific_internal_energy_from_density_and_temperature,

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_QuadrupoleFormula.cpp
   Test_SoundSpeedSquared.cpp
   Test_SpecificEnthalpy.cpp
+  Test_SpecificEntropy.cpp
   Test_StressEnergy.cpp
   Test_Tags.cpp
   Test_Temperature.cpp

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/DarkEnergyFluid.py
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import math
+
 
 def dark_energy_fluid_pressure_from_density_and_energy(
     rest_mass_density, specific_internal_energy, parameter_w
@@ -29,6 +31,24 @@ def dark_energy_fluid_temperature_from_density_and_energy(
     rest_mass_density, specific_internal_energy, parameter_w
 ):
     return parameter_w * specific_internal_energy
+
+
+def dark_energy_fluid_specific_entropy_from_density_and_energy(
+    rest_mass_density, specific_internal_energy, parameter_w
+):
+    return (
+        math.log(specific_internal_energy / rest_mass_density**parameter_w)
+        / parameter_w
+    )
+
+
+def dark_energy_fluid_specific_entropy_from_density_and_temperature(
+    rest_mass_density, temperature, parameter_w
+):
+    return (
+        math.log(temperature / (parameter_w * rest_mass_density**parameter_w))
+        / parameter_w
+    )
 
 
 def dark_energy_fluid_specific_internal_energy_from_density_and_pressure(

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/HybridEos.py
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import math
+
 from PolytropicFluid import (
     polytropic_pressure_from_density,
     polytropic_specific_internal_energy_from_density,
@@ -13,6 +15,7 @@ def hybrid_polytrope_pressure_from_density_and_energy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -31,6 +34,7 @@ def hybrid_polytrope_rel_pressure_from_density_and_enthalpy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -52,6 +56,7 @@ def hybrid_polytrope_temperature_from_density_and_energy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     eps_c = polytropic_specific_internal_energy_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -67,6 +72,7 @@ def hybrid_polytrope_newt_pressure_from_density_and_enthalpy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -88,6 +94,7 @@ def hybrid_polytrope_rel_specific_enthalpy_from_density_and_energy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -109,6 +116,7 @@ def hybrid_polytrope_newt_specific_enthalpy_from_density_and_energy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -123,12 +131,50 @@ def hybrid_polytrope_newt_specific_enthalpy_from_density_and_energy(
     )
 
 
+def hybrid_polytrope_specific_entropy_from_density_and_energy(
+    rest_mass_density,
+    specific_internal_energy,
+    polytropic_constant,
+    polytropic_exponent,
+    thermal_adiabatic_index,
+    minimum_temperature,
+):
+    eps_c = polytropic_specific_internal_energy_from_density(
+        rest_mass_density, polytropic_constant, polytropic_exponent
+    )
+    return math.log(
+        max(
+            specific_internal_energy - eps_c,
+            minimum_temperature / (thermal_adiabatic_index - 1.0),
+        )
+        / rest_mass_density ** (thermal_adiabatic_index - 1.0)
+    ) / (thermal_adiabatic_index - 1.0)
+
+
+def hybrid_polytrope_specific_entropy_from_density_and_temperature(
+    rest_mass_density,
+    temperature,
+    polytropic_constant,
+    polytropic_exponent,
+    thermal_adiabatic_index,
+    minimum_temperature,
+):
+    return math.log(
+        max(temperature, minimum_temperature)
+        / (
+            (thermal_adiabatic_index - 1.0)
+            * rest_mass_density ** (thermal_adiabatic_index - 1.0)
+        )
+    ) / (thermal_adiabatic_index - 1.0)
+
+
 def hybrid_polytrope_specific_internal_energy_from_density_and_pressure(
     rest_mass_density,
     pressure,
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -150,6 +196,7 @@ def hybrid_polytrope_chi_from_density_and_energy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent
@@ -168,6 +215,7 @@ def hybrid_polytrope_kappa_times_p_over_rho_squared_from_density_and_energy(
     polytropic_constant,
     polytropic_exponent,
     thermal_adiabatic_index,
+    minimum_temperature,
 ):
     p_c = polytropic_pressure_from_density(
         rest_mass_density, polytropic_constant, polytropic_exponent

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.py
@@ -1,9 +1,14 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import math
+
 
 def ideal_fluid_pressure_from_density_and_energy(
-    rest_mass_density, specific_internal_energy, adiabatic_index
+    rest_mass_density,
+    specific_internal_energy,
+    adiabatic_index,
+    minimum_temperature,
 ):
     return (
         rest_mass_density * specific_internal_energy * (adiabatic_index - 1.0)
@@ -11,13 +16,16 @@ def ideal_fluid_pressure_from_density_and_energy(
 
 
 def ideal_fluid_temperature_from_density_and_energy(
-    rest_mass_density, specific_internal_energy, adiabatic_index
+    rest_mass_density,
+    specific_internal_energy,
+    adiabatic_index,
+    minimum_temperature,
 ):
     return (adiabatic_index - 1.0) * specific_internal_energy
 
 
 def ideal_fluid_rel_pressure_from_density_and_enthalpy(
-    rest_mass_density, specific_enthalpy, adiabatic_index
+    rest_mass_density, specific_enthalpy, adiabatic_index, minimum_temperature
 ):
     return (
         rest_mass_density
@@ -28,7 +36,7 @@ def ideal_fluid_rel_pressure_from_density_and_enthalpy(
 
 
 def ideal_fluid_newt_pressure_from_density_and_enthalpy(
-    rest_mass_density, specific_enthalpy, adiabatic_index
+    rest_mass_density, specific_enthalpy, adiabatic_index, minimum_temperature
 ):
     return (
         rest_mass_density
@@ -39,30 +47,72 @@ def ideal_fluid_newt_pressure_from_density_and_enthalpy(
 
 
 def ideal_fluid_rel_specific_enthalpy_from_density_and_energy(
-    rest_mass_density, specific_internal_energy, adiabatic_index
+    rest_mass_density,
+    specific_internal_energy,
+    adiabatic_index,
+    minimum_temperature,
 ):
     return 1.0 + adiabatic_index * specific_internal_energy
 
 
 def ideal_fluid_newt_specific_enthalpy_from_density_and_energy(
-    rest_mass_density, specific_internal_energy, adiabatic_index
+    rest_mass_density,
+    specific_internal_energy,
+    adiabatic_index,
+    minimum_temperature,
 ):
     return adiabatic_index * specific_internal_energy
 
 
+def ideal_fluid_specific_entropy_from_density_and_energy(
+    rest_mass_density,
+    specific_internal_energy,
+    adiabatic_index,
+    minimum_temperature,
+):
+    return math.log(
+        max(
+            specific_internal_energy,
+            minimum_temperature / (adiabatic_index - 1.0),
+        )
+        / rest_mass_density ** (adiabatic_index - 1.0)
+    ) / (adiabatic_index - 1.0)
+
+
+def ideal_fluid_specific_entropy_from_density_and_temperature(
+    rest_mass_density,
+    temperature,
+    adiabatic_index,
+    minimum_temperature,
+):
+    return math.log(
+        max(temperature, minimum_temperature)
+        / (
+            (adiabatic_index - 1.0)
+            * rest_mass_density ** (adiabatic_index - 1.0)
+        )
+    ) / (adiabatic_index - 1.0)
+
+
 def ideal_fluid_specific_internal_energy_from_density_and_pressure(
-    rest_mass_density, pressure, adiabatic_index
+    rest_mass_density, pressure, adiabatic_index, minimum_temperature
 ):
     return pressure / (adiabatic_index - 1.0) / rest_mass_density
 
 
 def ideal_fluid_chi_from_density_and_energy(
-    rest_mass_density, specific_internal_energy, adiabatic_index
+    rest_mass_density,
+    specific_internal_energy,
+    adiabatic_index,
+    minimum_temperature,
 ):
     return specific_internal_energy * (adiabatic_index - 1.0)
 
 
 def ideal_fluid_kappa_times_p_over_rho_squared_from_density_and_energy(
-    rest_mass_density, specific_internal_energy, adiabatic_index
+    rest_mass_density,
+    specific_internal_energy,
+    adiabatic_index,
+    minimum_temperature,
 ):
     return specific_internal_energy * (adiabatic_index - 1.0) ** 2

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Equilibrium3D.cpp
@@ -186,7 +186,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Equilibrium3D",
              "    ThermalAdiabaticIndex: 2.0\n"
              "    PolytropicFluid:\n"
              "      PolytropicConstant: 100.0\n"
-             "      PolytropicExponent: 2.0"}));
+             "      PolytropicExponent: 2.0\n"
+             "    MinTemperature: 0.0"}));
     const EoS::Equilibrium3D<EoS::HybridEos<EoS::PolytropicFluid<true>>>&
         deserialized_eos = dynamic_cast<const EoS::Equilibrium3D<
             EoS::HybridEos<EoS::PolytropicFluid<true>>>&>(*eos_pointer);

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_HybridEos.cpp
@@ -33,15 +33,16 @@ void check_random_polytrope() {
       EquationsOfState::HybridEos<
           EquationsOfState::PolytropicFluid<IsRelativistic>>{
           EquationsOfState::PolytropicFluid<IsRelativistic>{100.0, 4.0 / 3.0},
-          5.0 / 3.0},
-      "HybridEos", "hybrid_polytrope", d_for_size, 100.0, 4.0 / 3.0, 5.0 / 3.0);
+          5.0 / 3.0, 1.e-3},
+      "HybridEos", "hybrid_polytrope", d_for_size, 100.0, 4.0 / 3.0, 5.0 / 3.0,
+      1.e-3);
   TestHelpers::EquationsOfState::check(
       EquationsOfState::HybridEos<
           EquationsOfState::PolytropicFluid<IsRelativistic>>{
           EquationsOfState::PolytropicFluid<IsRelativistic>{100.0, 4.0 / 3.0},
-          5.0 / 3.0},
-      "HybridEos", "hybrid_polytrope", dv_for_size, 100.0, 4.0 / 3.0,
-      5.0 / 3.0);
+          5.0 / 3.0, 1.e-3},
+      "HybridEos", "hybrid_polytrope", dv_for_size, 100.0, 4.0 / 3.0, 5.0 / 3.0,
+      1.e-3);
 }
 
 template <bool IsRelativistic>
@@ -95,19 +96,38 @@ void check_exact_polytrope() {
   CHECK(not eos.is_barotropic());
 }
 
-template <bool IsRelativistic>
+template <bool IsRelativistic, bool NonZeroMinTemp>
 void check_bounds() {
   const auto cold_eos =
       EquationsOfState::PolytropicFluid<IsRelativistic>{100.0, 1.5};
+  auto min_temperature = 0.0;
+  if constexpr (NonZeroMinTemp) {
+    const auto seed = std::random_device{}();
+    MAKE_GENERATOR(generator, seed);
+    CAPTURE(seed);
+    auto distribution = std::uniform_real_distribution<>{1.e-15, 1.e-5};
+    min_temperature = distribution(generator);
+  }
+  const auto thermal_adiabatic_index = 1.5;
+  CAPTURE(min_temperature);
+  CAPTURE(thermal_adiabatic_index);
   const EquationsOfState::HybridEos<
       EquationsOfState::PolytropicFluid<IsRelativistic>>
-      eos{cold_eos, 1.5};
+      eos{cold_eos, thermal_adiabatic_index, min_temperature};
   CHECK(0.0 == eos.rest_mass_density_lower_bound());
-  CHECK(200.0 == eos.specific_internal_energy_lower_bound(1.0));
+  CHECK(min_temperature == eos.temperature_lower_bound());
+  CHECK(
+      get(cold_eos.specific_internal_energy_from_density(Scalar<double>{1.0})) +
+          min_temperature / (thermal_adiabatic_index - 1) ==
+      eos.specific_internal_energy_lower_bound(1.0));
   if constexpr (IsRelativistic) {
-    CHECK(1.0 == eos.specific_enthalpy_lower_bound());
+    CHECK(1.0 + (thermal_adiabatic_index * min_temperature) /
+                    (thermal_adiabatic_index - 1.0) ==
+          eos.specific_enthalpy_lower_bound());
   } else {
-    CHECK(0.0 == eos.specific_enthalpy_lower_bound());
+    CHECK((thermal_adiabatic_index * min_temperature) /
+              (thermal_adiabatic_index - 1.0) ==
+          eos.specific_enthalpy_lower_bound());
   }
   const double max_double = std::numeric_limits<double>::max();
   CHECK(max_double == eos.rest_mass_density_upper_bound());
@@ -126,6 +146,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.HybridEos",
   check_random_polytrope<false>();
   check_exact_polytrope<true>();
   check_exact_polytrope<false>();
-  check_bounds<true>();
-  check_bounds<false>();
+  check_bounds<true, true>();
+  check_bounds<true, false>();
+  check_bounds<false, true>();
+  check_bounds<false, false>();
 }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_IdealFluid.cpp
@@ -101,48 +101,48 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.IdealFluid",
   CHECK(not eos.is_barotropic());
   CHECK(not other_eos.is_barotropic());
 
-  TestHelpers::EquationsOfState::check(EoS::IdealFluid<true>{5.0 / 3.0},
+  TestHelpers::EquationsOfState::check(EoS::IdealFluid<true>{5.0 / 3.0, 1.e-3},
                                        "IdealFluid", "ideal_fluid", d_for_size,
-                                       5.0 / 3.0);
-  TestHelpers::EquationsOfState::check(EoS::IdealFluid<true>{4.0 / 3.0},
+                                       5.0 / 3.0, 1.e-3);
+  TestHelpers::EquationsOfState::check(EoS::IdealFluid<true>{4.0 / 3.0, 1.e-3},
                                        "IdealFluid", "ideal_fluid", dv_for_size,
-                                       4.0 / 3.0);
-  TestHelpers::EquationsOfState::check(EoS::IdealFluid<false>{5.0 / 3.0},
+                                       4.0 / 3.0, 1.e-3);
+  TestHelpers::EquationsOfState::check(EoS::IdealFluid<false>{5.0 / 3.0, 1.e-3},
                                        "IdealFluid", "ideal_fluid", d_for_size,
-                                       5.0 / 3.0);
-  TestHelpers::EquationsOfState::check(EoS::IdealFluid<false>{4.0 / 3.0},
+                                       5.0 / 3.0, 1.e-3);
+  TestHelpers::EquationsOfState::check(EoS::IdealFluid<false>{4.0 / 3.0, 1.e-3},
                                        "IdealFluid", "ideal_fluid", dv_for_size,
-                                       4.0 / 3.0);
+                                       4.0 / 3.0, 1.e-3);
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.6666666666666667\n"
-           "  MinTemperature: 0.0\n"}),
-      "IdealFluid", "ideal_fluid", d_for_size, 5.0 / 3.0);
+           "  MinTemperature: 1.e-3\n"}),
+      "IdealFluid", "ideal_fluid", d_for_size, 5.0 / 3.0, 1.e-3);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<true, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.3333333333333333\n"
-           "  MinTemperature: 0.0\n"}),
-      "IdealFluid", "ideal_fluid", dv_for_size, 4.0 / 3.0);
+           "  MinTemperature: 1.e-3\n"}),
+      "IdealFluid", "ideal_fluid", dv_for_size, 4.0 / 3.0, 1.e-3);
 
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<false, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.6666666666666667\n"
-           "  MinTemperature: 0.0\n"}),
-      "IdealFluid", "ideal_fluid", d_for_size, 5.0 / 3.0);
+           "  MinTemperature: 1.e-3\n"}),
+      "IdealFluid", "ideal_fluid", d_for_size, 5.0 / 3.0, 1.e-3);
   TestHelpers::EquationsOfState::check(
       TestHelpers::test_creation<
           std::unique_ptr<EoS::EquationOfState<false, 2>>>(
           {"IdealFluid:\n"
            "  AdiabaticIndex: 1.3333333333333333\n"
-           "  MinTemperature: 0.0\n"}),
-      "IdealFluid", "ideal_fluid", dv_for_size, 4.0 / 3.0);
+           "  MinTemperature: 1.e-3\n"}),
+      "IdealFluid", "ideal_fluid", dv_for_size, 4.0 / 3.0, 1.e-3);
 
   check_bounds<true, true>();
   check_bounds<true, false>();

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
@@ -118,6 +118,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
     vars[TEoS::Epsilon] = state[TableIndex::Temp];
     vars[TEoS::Pressure] = state[TableIndex::Temp] + state[TableIndex::Rho];
     vars[TEoS::CsSquared] = state[TableIndex::Ye];
+    vars[TEoS::SpecificEntropy] =
+        (vars[TEoS::Epsilon] - state[TableIndex::Rho] * state[TableIndex::Ye]) /
+        state[TableIndex::Ye];
 
     return vars;
   };
@@ -191,10 +194,12 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
   CHECK(std::abs((std::exp(output[TEoS::Pressure])) -
                  get(eos.pressure_from_density_and_temperature(
                      state[1], state[0], state[2]))) < 1.e-12);
-  CHECK(std::abs(output[TEoS::CsSquared]) -
-            get(eos.sound_speed_squared_from_density_and_temperature(
-                state[1], state[0], state[2])) <
-        1.e-12);
+  CHECK(std::abs(output[TEoS::CsSquared] -
+                 get(eos.sound_speed_squared_from_density_and_temperature(
+                     state[1], state[0], state[2]))) < 1.e-12);
+  CHECK(std::abs(std::exp(output[TEoS::SpecificEntropy]) -
+                 get(eos.specific_entropy_from_density_and_temperature(
+                     state[1], state[0], state[2]))) < 2.e-12);
   CHECK(not eos.is_barotropic());
   CHECK(not eos.is_equilibrium());
 
@@ -225,6 +230,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
                  get(eos.sound_speed_squared_from_density_and_temperature(
                      vector_state[1], vector_state[0], vector_state[2]))[0]) <
         1.e-12);
+  CHECK(std::abs(std::exp(output[TEoS::SpecificEntropy]) -
+                 get(eos.specific_entropy_from_density_and_temperature(
+                     vector_state[1], vector_state[0], vector_state[2]))[0]) <
+        2.e-12);
 
   const auto eps_interp_vector =
       eos.specific_internal_energy_from_density_and_temperature(
@@ -250,6 +259,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
         get(this_eos.sound_speed_squared_from_density_and_temperature(
             state[1], state[0], state[2])),
         0.41669901507784435);
+    CHECK_ITERABLE_APPROX(
+        get(this_eos.specific_entropy_from_density_and_temperature(
+            state[1], state[0], state[2])),
+        0.19418671736233717);
   };
 
   // Test against reference values

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_SpecificEntropy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_SpecificEntropy.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <limits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/PointwiseFunctions/Hydro/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/Equilibrium3D.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEntropy.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+template <typename DataType, typename EquationOfStateType>
+void test_compute_item_in_databox(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& temperature,
+    const Scalar<DataType>& electron_fraction,
+    const EquationOfStateType& equation_of_state) {
+  TestHelpers::db::test_compute_tag<hydro::Tags::SpecificEntropyCompute<
+      DataType>>("SpecificEntropy");
+  const auto box = db::create<
+      db::AddSimpleTags<hydro::Tags::RestMassDensity<DataType>,
+                        hydro::Tags::Temperature<DataType>,
+                        hydro::Tags::ElectronFraction<DataType>,
+                        hydro::Tags::GrmhdEquationOfState>,
+      db::AddComputeTags<hydro::Tags::SpecificEntropyCompute<DataType>>>(
+      rest_mass_density, temperature, electron_fraction,
+      equation_of_state.get_clone());
+
+  const auto expected_specific_entropy = hydro::specific_entropy(
+      rest_mass_density, temperature, electron_fraction, equation_of_state);
+  CHECK(db::get<hydro::Tags::SpecificEntropy<DataType>>(box) ==
+        expected_specific_entropy);
+}
+
+template <typename DataType>
+void test_specific_entropy(const DataType& used_for_size) {
+  MAKE_GENERATOR(generator);
+
+  const auto rest_mass_density = TestHelpers::hydro::random_density(
+      make_not_null(&generator), used_for_size);
+  const auto temperature = TestHelpers::hydro::random_specific_internal_energy(
+      make_not_null(&generator), used_for_size);
+  const Scalar<DataType> electron_fraction{};
+
+  // check with representative equation of state of two independent variables
+  const EquationsOfState::Equilibrium3D<EquationsOfState::IdealFluid<true>> eos(
+      EquationsOfState::IdealFluid<true>{5.0 / 3.0});
+  CHECK(Scalar<DataType>{get(eos.specific_entropy_from_density_and_temperature(
+            rest_mass_density, temperature, electron_fraction))} ==
+        hydro::specific_entropy(rest_mass_density, temperature,
+                                electron_fraction, eos));
+  test_compute_item_in_databox(rest_mass_density, temperature,
+                               electron_fraction, eos);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.SpecificEntropy",
+                  "[Unit][Evolution]") {
+  test_specific_entropy(std::numeric_limits<double>::signaling_NaN());
+  test_specific_entropy(DataVector(5));
+}


### PR DESCRIPTION
## Proposed changes

Adds functions in the equations of state for computing specific entropy. Also adds a compute tag to compute this quantity from the equation of state used in the evolution, allowing for observation in simulation outputs.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

Currently assumes that the specific entropy is 0 in 1D EoSs, since there is not a well defined temperature for these cases. If there is a 1D EoS which uses a temperature profile slice from a higher dimensional EoS, then perhaps this can be circumvented in those cases.

Also, the `DarkEnergyFluid` EoS is a bit perplexing because specific internal energy can be less than 0, which would break the logarithm in the formula. For now I'm including asserts which would catch these cases, but since they're presumably permitted, this will need to be revisited for someone who wants to use this EoS. I assume this is okay for now since no one currently uses this EoS, and probably no one will for a while...
(Alternatively, I could replace the asserts to instead return NaNs in offending cases, that way it wouldn't break a running simulation.)
