### PR TITLE
Status CLI: handle unavailable Slurm fields

### DIFF
--- a/tools/Status/Status.py
+++ b/tools/Status/Status.py
@@ -67,7 +67,32 @@ def fetch_job_data(
     try:
         completed_process.check_returncode()
     except subprocess.CalledProcessError as err:
-        raise ValueError(completed_process.stderr) from err
+        # Remove invalid fields and retry
+        match = re.search(
+            r'Invalid field requested: "(.*)"',
+            completed_process.stderr,
+        )
+        if match:
+            invalid_field = match.group(1)
+            logger.warning(
+                f"Field '{invalid_field}' is not valid for 'sacct --format'."
+                " Removing it and retrying. Some functionality may be"
+                " unavailable. Consider configuring Slurm to support this"
+                " field."
+            )
+            fields.remove(invalid_field)
+            job_data = fetch_job_data(
+                fields,
+                user=user,
+                allusers=allusers,
+                state=state,
+                starttime=starttime,
+                jobid=jobid,
+            )
+            job_data[invalid_field] = None
+            return job_data
+        else:
+            raise ValueError(completed_process.stderr) from err
     job_data = pd.read_table(
         StringIO(completed_process.stdout),
         sep="|",


### PR DESCRIPTION
## Proposed changes

On Mbot the `StdOut` and `StdErr` fields are unavailable, so we handle this case gracefully rather than aborting.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
