### PR TITLE
Make TensorExpression test helpers interface more general and uniform

### DIFF
--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank0.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp"
@@ -70,77 +71,101 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
                                            Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime only
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::a, ti::b, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::A, ti::B, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::d, ti::c, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::D, ti::C, Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::e, ti::F, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::F, ti::e, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::g, ti::B, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::G, ti::b, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::a, ti::b, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::A, ti::B, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::d, ti::c, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::D, ti::C, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::e, ti::F, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::F, ti::e, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::g, ti::B, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::G, ti::b, Frame::NoFrame>();
 
   // Rank 2: double; nonsymmetric; spatial only
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::i, ti::j, Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::I, ti::J, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::j, ti::i, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::J, ti::I, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::i, ti::J, Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::I, ti::j, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::j, ti::I, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::J, ti::i, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::i, ti::j,
+                                           Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::I, ti::J,
+                                           Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::j, ti::i,
+                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::J, ti::I,
+                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::i, ti::J,
+                                           Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::I, ti::j,
+                                           Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::j, ti::I,
+                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpatialIndex, ti::J, ti::i,
+                                           Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::c, ti::I, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::A, ti::i, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::J, ti::a, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::i, ti::B, Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::e, ti::j, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::i, ti::d, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::C, ti::I, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::J, ti::A, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpatialIndex, ti::c,
+                                           ti::I, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpatialIndex, ti::A,
+                                           ti::i, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpacetimeIndex, ti::J, ti::a,
+                                           Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpacetimeIndex, ti::i, ti::B,
+                                           Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpatialIndex, ti::e,
+                                           ti::j, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpacetimeIndex, ti::i, ti::d,
+                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpatialIndex, ti::C,
+                                           ti::I, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
+                                           SpacetimeIndex, ti::J, ti::A,
+                                           Frame::NoFrame>();
 
   // Rank 2: double; symmetric; spacetime
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
-      double, SpacetimeIndex, ti::a, ti::d, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
-      double, SpacetimeIndex, ti::G, ti::B, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<1, 1>, SpacetimeIndex, ti::a, ti::d, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<1, 1>, SpacetimeIndex, ti::G, ti::B, Frame::Grid>();
 
   // Rank 2: double; symmetric; spatial
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
-      double, SpatialIndex, ti::j, ti::i, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
-      double, SpatialIndex, ti::I, ti::J, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<1, 1>, SpatialIndex,
+                                           ti::j, ti::i, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<1, 1>, SpatialIndex,
+                                           ti::I, ti::J, Frame::NoFrame>();
 
   // Rank 2: DataVector; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, ti::f, ti::G,
-      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<DataVector, Symmetry<2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::f, ti::G, Frame::Inertial>();
 
   // Rank 2: DataVector; symmetric
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
-      DataVector, SpatialIndex, ti::j, ti::i, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      DataVector, Symmetry<1, 1>, SpatialIndex, ti::j, ti::i, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -46,91 +46,101 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       DataVector{-3.1, 9.4, 0.0, -3.1, 2.4, 9.8});
 
   // Rank 1: double; spacetime
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::a>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::b>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::A>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::B>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::a,
+                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::b,
+                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::A,
+                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::B,
+                                           Frame::Inertial>();
 
   // Rank 1: double; spatial
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::i>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::j>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::I>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::J>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::i,
+                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::j,
+                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::I,
+                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::J,
+                                           Frame::Grid>();
 
   // Rank 1: DataVector
-  TestHelpers::tenex::test_evaluate_rank_1<DataVector, SpatialIndex, ti::L>();
+  TestHelpers::tenex::test_evaluate_rank_1<DataVector, SpatialIndex, ti::L,
+                                           Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime only
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::a, ti::b>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::a, ti::b, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::A, ti::B>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::A, ti::B, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::d, ti::c>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::d, ti::c, Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::D, ti::C>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::D, ti::C, Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::e, ti::F>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::e, ti::F, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::F, ti::e>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::F, ti::e, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::g, ti::B>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::g, ti::B, Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::G, ti::b>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::G, ti::b, Frame::NoFrame>();
 
   // Rank 2: double; nonsymmetric; spatial only
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::i, ti::j>();
+      double, SpatialIndex, SpatialIndex, ti::i, ti::j, Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::I, ti::J>();
+      double, SpatialIndex, SpatialIndex, ti::I, ti::J, Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::j, ti::i>();
+      double, SpatialIndex, SpatialIndex, ti::j, ti::i, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::J, ti::I>();
+      double, SpatialIndex, SpatialIndex, ti::J, ti::I, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::i, ti::J>();
+      double, SpatialIndex, SpatialIndex, ti::i, ti::J, Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::I, ti::j>();
+      double, SpatialIndex, SpatialIndex, ti::I, ti::j, Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::j, ti::I>();
+      double, SpatialIndex, SpatialIndex, ti::j, ti::I, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, ti::J, ti::i>();
+      double, SpatialIndex, SpatialIndex, ti::J, ti::i, Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::c, ti::I>();
+      double, SpacetimeIndex, SpatialIndex, ti::c, ti::I, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::A, ti::i>();
+      double, SpacetimeIndex, SpatialIndex, ti::A, ti::i, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::J, ti::a>();
+      double, SpatialIndex, SpacetimeIndex, ti::J, ti::a, Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::i, ti::B>();
+      double, SpatialIndex, SpacetimeIndex, ti::i, ti::B, Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::e, ti::j>();
+      double, SpacetimeIndex, SpatialIndex, ti::e, ti::j, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::i, ti::d>();
+      double, SpatialIndex, SpacetimeIndex, ti::i, ti::d, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::C, ti::I>();
+      double, SpacetimeIndex, SpatialIndex, ti::C, ti::I, Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::J, ti::A>();
+      double, SpatialIndex, SpacetimeIndex, ti::J, ti::A, Frame::NoFrame>();
 
   // Rank 2: double; symmetric; spacetime
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
-                                                     ti::a, ti::d>();
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
-                                                     ti::G, ti::B>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
+      double, SpacetimeIndex, ti::a, ti::d, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
+      double, SpacetimeIndex, ti::G, ti::B, Frame::Grid>();
 
   // Rank 2: double; symmetric; spatial
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
-                                                     ti::j, ti::i>();
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
-                                                     ti::I, ti::J>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
+      double, SpatialIndex, ti::j, ti::i, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
+      double, SpatialIndex, ti::I, ti::J, Frame::NoFrame>();
 
   // Rank 2: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, ti::f, ti::G>();
+      DataVector, SpacetimeIndex, SpacetimeIndex, ti::f, ti::G,
+      Frame::Inertial>();
 
   // Rank 2: DataVector; symmetric
-  TestHelpers::tenex::test_evaluate_rank_2_symmetric<DataVector, SpatialIndex,
-                                                     ti::j, ti::i>();
+  TestHelpers::tenex::test_evaluate_rank_2_symmetric<
+      DataVector, SpatialIndex, ti::j, ti::i, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -13,8 +13,15 @@
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank0.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
+template <IndexType... Is>
+using indextype_list = tmpl::integral_list<IndexType, Is...>;
+
+const IndexType spatial_index = IndexType::Spatial;
+const IndexType spacetime_index = IndexType::Spacetime;
+
 template <auto&... TensorIndices>
 void test_contains_indices_to_contract_impl(const bool expected) {
   CHECK(tenex::detail::contains_indices_to_contract<sizeof...(TensorIndices)>(
@@ -47,125 +54,131 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       DataVector{-3.1, 9.4, 0.0, -3.1, 2.4, 9.8});
 
   // Rank 1: double; spacetime
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::a,
-                                           Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::b,
-                                           Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::A,
-                                           Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::B,
-                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spacetime_index>, ti::a, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spacetime_index>, ti::b, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spacetime_index>, ti::A, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spacetime_index>, ti::B, Frame::Inertial>();
 
   // Rank 1: double; spatial
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::i,
-                                           Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::j,
-                                           Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::I,
-                                           Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::J,
-                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spatial_index>, ti::i, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spatial_index>, ti::j, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spatial_index>, ti::I, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      double, indextype_list<spatial_index>, ti::J, Frame::Grid>();
 
   // Rank 1: DataVector
-  TestHelpers::tenex::test_evaluate_rank_1<DataVector, SpatialIndex, ti::L,
-                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      DataVector, indextype_list<spatial_index>, ti::L, Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime only
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::a, ti::b, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::A, ti::B, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::d, ti::c, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::D, ti::C, Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::e, ti::F, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::F, ti::e, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::g, ti::B, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::G, ti::b, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::a, ti::b, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::A, ti::B, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::d, ti::c, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::D, ti::C, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::e, ti::F, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::F, ti::e, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::g, ti::B, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::G, ti::b, Frame::NoFrame>();
 
   // Rank 2: double; nonsymmetric; spatial only
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::i, ti::j,
-                                           Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::I, ti::J,
-                                           Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::j, ti::i,
-                                           Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::J, ti::I,
-                                           Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::i, ti::J,
-                                           Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::I, ti::j,
-                                           Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::j, ti::I,
-                                           Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpatialIndex, ti::J, ti::i,
-                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::i, ti::j, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::I, ti::J, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::j, ti::i, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::J, ti::I, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::i, ti::J, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::I, ti::j, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::j, ti::I, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::J, ti::i, Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpatialIndex, ti::c,
-                                           ti::I, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpatialIndex, ti::A,
-                                           ti::i, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpacetimeIndex, ti::J, ti::a,
-                                           Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpacetimeIndex, ti::i, ti::B,
-                                           Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpatialIndex, ti::e,
-                                           ti::j, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpacetimeIndex, ti::i, ti::d,
-                                           Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpatialIndex, ti::C,
-                                           ti::I, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<2, 1>, SpatialIndex,
-                                           SpacetimeIndex, ti::J, ti::A,
-                                           Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
+      ti::c, ti::I, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
+      ti::A, ti::i, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
+      ti::J, ti::a, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
+      ti::i, ti::B, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
+      ti::e, ti::j, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
+      ti::i, ti::d, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
+      ti::C, ti::I, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
+      ti::J, ti::A, Frame::NoFrame>();
 
   // Rank 2: double; symmetric; spacetime
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<1, 1>, SpacetimeIndex, ti::a, ti::d, Frame::Inertial>();
+      double, Symmetry<1, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::a, ti::d, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<1, 1>, SpacetimeIndex, ti::G, ti::B, Frame::Grid>();
+      double, Symmetry<1, 1>, indextype_list<spacetime_index, spacetime_index>,
+      ti::G, ti::B, Frame::Grid>();
 
   // Rank 2: double; symmetric; spatial
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<1, 1>, SpatialIndex,
-                                           ti::j, ti::i, Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<double, Symmetry<1, 1>, SpatialIndex,
-                                           ti::I, ti::J, Frame::NoFrame>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<1, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::j, ti::i, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      double, Symmetry<1, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::I, ti::J, Frame::NoFrame>();
 
   // Rank 2: DataVector; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_2<DataVector, Symmetry<2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::f, ti::G, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      DataVector, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::f, ti::G,
+      Frame::Inertial>();
 
   // Rank 2: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_2<
-      DataVector, Symmetry<1, 1>, SpatialIndex, ti::j, ti::i, Frame::Grid>();
+      DataVector, Symmetry<1, 1>, indextype_list<spatial_index, spatial_index>,
+      ti::j, ti::i, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -46,109 +46,91 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
       DataVector{-3.1, 9.4, 0.0, -3.1, 2.4, 9.8});
 
   // Rank 1: double; spacetime
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Lo,
-                                           ti::a>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Lo,
-                                           ti::b>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Up,
-                                           ti::A>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, UpLo::Up,
-                                           ti::B>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::a>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::b>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::A>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpacetimeIndex, ti::B>();
 
   // Rank 1: double; spatial
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Lo,
-                                           ti::i>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Lo,
-                                           ti::j>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Up,
-                                           ti::I>();
-  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, UpLo::Up,
-                                           ti::J>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::i>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::j>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::I>();
+  TestHelpers::tenex::test_evaluate_rank_1<double, SpatialIndex, ti::J>();
 
   // Rank 1: DataVector
-  TestHelpers::tenex::test_evaluate_rank_1<DataVector, SpatialIndex, UpLo::Up,
-                                           ti::L>();
+  TestHelpers::tenex::test_evaluate_rank_1<DataVector, SpatialIndex, ti::L>();
 
   // Rank 2: double; nonsymmetric; spacetime only
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::a,
-      ti::b>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::a, ti::b>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti::A,
-      ti::B>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::A, ti::B>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::d,
-      ti::c>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::d, ti::c>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti::D,
-      ti::C>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::D, ti::C>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::e,
-      ti::F>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::e, ti::F>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti::F,
-      ti::e>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::F, ti::e>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::g,
-      ti::B>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::g, ti::B>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti::G,
-      ti::b>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::G, ti::b>();
 
   // Rank 2: double; nonsymmetric; spatial only
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti::i, ti::j>();
+      double, SpatialIndex, SpatialIndex, ti::i, ti::j>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti::I, ti::J>();
+      double, SpatialIndex, SpatialIndex, ti::I, ti::J>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti::j, ti::i>();
+      double, SpatialIndex, SpatialIndex, ti::j, ti::i>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti::J, ti::I>();
+      double, SpatialIndex, SpatialIndex, ti::J, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::i, ti::J>();
+      double, SpatialIndex, SpatialIndex, ti::i, ti::J>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti::I, ti::j>();
+      double, SpatialIndex, SpatialIndex, ti::I, ti::j>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::j, ti::I>();
+      double, SpatialIndex, SpatialIndex, ti::j, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti::J, ti::i>();
+      double, SpatialIndex, SpatialIndex, ti::J, ti::i>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::c, ti::I>();
+      double, SpacetimeIndex, SpatialIndex, ti::c, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Lo, ti::A, ti::i>();
+      double, SpacetimeIndex, SpatialIndex, ti::A, ti::i>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo, ti::J, ti::a>();
+      double, SpatialIndex, SpacetimeIndex, ti::J, ti::a>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::i, ti::B>();
+      double, SpatialIndex, SpacetimeIndex, ti::i, ti::B>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Lo, ti::e, ti::j>();
+      double, SpacetimeIndex, SpatialIndex, ti::e, ti::j>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::i, ti::d>();
+      double, SpatialIndex, SpacetimeIndex, ti::i, ti::d>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Up, UpLo::Up, ti::C, ti::I>();
+      double, SpacetimeIndex, SpatialIndex, ti::C, ti::I>();
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Up, ti::J, ti::A>();
+      double, SpatialIndex, SpacetimeIndex, ti::J, ti::A>();
 
   // Rank 2: double; symmetric; spacetime
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
-                                                     UpLo::Lo, ti::a, ti::d>();
+                                                     ti::a, ti::d>();
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpacetimeIndex,
-                                                     UpLo::Up, ti::G, ti::B>();
+                                                     ti::G, ti::B>();
 
   // Rank 2: double; symmetric; spatial
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
-                                                     UpLo::Lo, ti::j, ti::i>();
+                                                     ti::j, ti::i>();
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<double, SpatialIndex,
-                                                     UpLo::Up, ti::I, ti::J>();
+                                                     ti::I, ti::J>();
 
   // Rank 2: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_2_no_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::f,
-      ti::G>();
+      DataVector, SpacetimeIndex, SpacetimeIndex, ti::f, ti::G>();
 
   // Rank 2: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_2_symmetric<DataVector, SpatialIndex,
-                                                     UpLo::Lo, ti::j, ti::i>();
+                                                     ti::j, ti::i>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -12,17 +12,28 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <IndexType... Is>
+using indextype_list = tmpl::integral_list<IndexType, Is...>;
+
+const IndexType spatial_index = IndexType::Spatial;
+const IndexType spacetime_index = IndexType::Spacetime;
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3NonSymmetric",
     "[DataStructures][Unit]") {
   // Rank 3: double; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      double, Symmetry<3, 2, 1>, SpacetimeIndex, SpatialIndex, SpacetimeIndex,
-      ti::D, ti::j, ti::B, Frame::Inertial>();
+      double, Symmetry<3, 2, 1>,
+      indextype_list<spacetime_index, spatial_index, spacetime_index>, ti::D,
+      ti::j, ti::B, Frame::Inertial>();
 
   // Rank 3: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      DataVector, Symmetry<3, 2, 1>, SpacetimeIndex, SpatialIndex,
-      SpacetimeIndex, ti::D, ti::j, ti::B, Frame::Grid>();
+      DataVector, Symmetry<3, 2, 1>,
+      indextype_list<spacetime_index, spatial_index, spacetime_index>, ti::D,
+      ti::j, ti::B, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -17,11 +17,11 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   // Rank 3: double; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, ti::D, ti::j,
-      ti::B>();
+      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, ti::D, ti::j, ti::B,
+      Frame::Inertial>();
 
   // Rank 3: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
       DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, ti::D, ti::j,
-      ti::B>();
+      ti::B, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -10,18 +10,19 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp"
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3NonSymmetric",
     "[DataStructures][Unit]") {
   // Rank 3: double; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, ti::D, ti::j, ti::B,
-      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      double, Symmetry<3, 2, 1>, SpacetimeIndex, SpatialIndex, SpacetimeIndex,
+      ti::D, ti::j, ti::B, Frame::Inertial>();
 
   // Rank 3: DataVector; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, ti::D, ti::j,
-      ti::B, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      DataVector, Symmetry<3, 2, 1>, SpacetimeIndex, SpatialIndex,
+      SpacetimeIndex, ti::D, ti::j, ti::B, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -17,11 +17,11 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   // Rank 3: double; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
-      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up, UpLo::Lo,
-      UpLo::Up, ti::D, ti::j, ti::B>();
+      double, SpacetimeIndex, SpatialIndex, SpacetimeIndex, ti::D, ti::j,
+      ti::B>();
 
   // Rank 3: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3_no_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, UpLo::Up,
-      UpLo::Lo, UpLo::Up, ti::D, ti::j, ti::B>();
+      DataVector, SpacetimeIndex, SpatialIndex, SpacetimeIndex, ti::D, ti::j,
+      ti::B>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -17,33 +17,38 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C,
+      Frame::Inertial>();
 
   // Rank 3: double; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j>();
+      double, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j, Frame::Grid>();
 
   // Rank 3: double; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I>();
+      double, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I,
+      Frame::Distorted>();
 
   // Rank 3: double; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<double, SpacetimeIndex,
-                                                        ti::f, ti::d, ti::a>();
+  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
+      double, SpacetimeIndex, ti::f, ti::d, ti::a, Frame::Inertial>();
 
   // Rank 3: DataVector; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C>();
+      DataVector, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C,
+      Frame::Grid>();
 
   // Rank 3: DataVector; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      DataVector, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j>();
+      DataVector, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j,
+      Frame::Distorted>();
 
   // Rank 3: DataVector; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I>();
+      DataVector, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I,
+      Frame::Inertial>();
 
   // Rank 3: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
-      DataVector, SpacetimeIndex, ti::f, ti::d, ti::a>();
+      DataVector, SpacetimeIndex, ti::f, ti::d, ti::a, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -10,45 +10,49 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp"
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3Symmetric",
     "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C,
-      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      double, Symmetry<2, 2, 1>, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a,
+      ti::C, Frame::Inertial>();
 
   // Rank 3: double; first and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      double, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_3<double, Symmetry<1, 2, 1>,
+                                           SpatialIndex, SpacetimeIndex, ti::i,
+                                           ti::f, ti::j, Frame::Grid>();
 
   // Rank 3: double; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      double, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I,
-      Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_3<double, Symmetry<2, 1, 1>,
+                                           SpacetimeIndex, SpatialIndex, ti::d,
+                                           ti::J, ti::I, Frame::Distorted>();
 
   // Rank 3: double; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
-      double, SpacetimeIndex, ti::f, ti::d, ti::a, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<double, Symmetry<1, 1, 1>,
+                                           SpacetimeIndex, ti::f, ti::d, ti::a,
+                                           Frame::Inertial>();
 
   // Rank 3: DataVector; first and second indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C,
-      Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<2, 2, 1>,
+                                           SpacetimeIndex, SpacetimeIndex,
+                                           ti::b, ti::a, ti::C, Frame::Grid>();
 
   // Rank 3: DataVector; first and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      DataVector, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j,
-      Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<1, 2, 1>,
+                                           SpatialIndex, SpacetimeIndex, ti::i,
+                                           ti::f, ti::j, Frame::Distorted>();
 
   // Rank 3: DataVector; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I,
-      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<2, 1, 1>,
+                                           SpacetimeIndex, SpatialIndex, ti::d,
+                                           ti::J, ti::I, Frame::Inertial>();
 
   // Rank 3: DataVector; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
-      DataVector, SpacetimeIndex, ti::f, ti::d, ti::a, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<1, 1, 1>,
+                                           SpacetimeIndex, ti::f, ti::d, ti::a,
+                                           Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -17,39 +17,33 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      double, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::b, ti::a,
-      ti::C>();
+      double, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C>();
 
   // Rank 3: double; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      double, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::i, ti::f,
-      ti::j>();
+      double, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j>();
 
   // Rank 3: double; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      double, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::d, ti::J,
-      ti::I>();
+      double, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I>();
 
   // Rank 3: double; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
-      double, SpacetimeIndex, UpLo::Lo, ti::f, ti::d, ti::a>();
+  TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<double, SpacetimeIndex,
+                                                        ti::f, ti::d, ti::a>();
 
   // Rank 3: DataVector; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ab_symmetry<
-      DataVector, SpacetimeIndex, SpacetimeIndex, UpLo::Lo, UpLo::Up, ti::b,
-      ti::a, ti::C>();
+      DataVector, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a, ti::C>();
 
   // Rank 3: DataVector; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_ac_symmetry<
-      DataVector, SpatialIndex, SpacetimeIndex, UpLo::Lo, UpLo::Lo, ti::i,
-      ti::f, ti::j>();
+      DataVector, SpatialIndex, SpacetimeIndex, ti::i, ti::f, ti::j>();
 
   // Rank 3: DataVector; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3_bc_symmetry<
-      DataVector, SpacetimeIndex, SpatialIndex, UpLo::Lo, UpLo::Up, ti::d,
-      ti::J, ti::I>();
+      DataVector, SpacetimeIndex, SpatialIndex, ti::d, ti::J, ti::I>();
 
   // Rank 3: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_3_abc_symmetry<
-      DataVector, SpacetimeIndex, UpLo::Lo, ti::f, ti::d, ti::a>();
+      DataVector, SpacetimeIndex, ti::f, ti::d, ti::a>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -12,47 +12,64 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <IndexType... Is>
+using indextype_list = tmpl::integral_list<IndexType, Is...>;
+
+const IndexType spatial_index = IndexType::Spatial;
+const IndexType spacetime_index = IndexType::Spacetime;
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3Symmetric",
     "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      double, Symmetry<2, 2, 1>, SpacetimeIndex, SpacetimeIndex, ti::b, ti::a,
-      ti::C, Frame::Inertial>();
+      double, Symmetry<2, 2, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::b,
+      ti::a, ti::C, Frame::Inertial>();
 
   // Rank 3: double; first and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<double, Symmetry<1, 2, 1>,
-                                           SpatialIndex, SpacetimeIndex, ti::i,
-                                           ti::f, ti::j, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      double, Symmetry<1, 2, 1>,
+      indextype_list<spatial_index, spacetime_index, spatial_index>, ti::i,
+      ti::f, ti::j, Frame::Grid>();
 
   // Rank 3: double; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<double, Symmetry<2, 1, 1>,
-                                           SpacetimeIndex, SpatialIndex, ti::d,
-                                           ti::J, ti::I, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      double, Symmetry<2, 1, 1>,
+      indextype_list<spacetime_index, spatial_index, spatial_index>, ti::d,
+      ti::J, ti::I, Frame::Distorted>();
 
   // Rank 3: double; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<double, Symmetry<1, 1, 1>,
-                                           SpacetimeIndex, ti::f, ti::d, ti::a,
-                                           Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      double, Symmetry<1, 1, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::f,
+      ti::d, ti::a, Frame::Inertial>();
 
   // Rank 3: DataVector; first and second indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<2, 2, 1>,
-                                           SpacetimeIndex, SpacetimeIndex,
-                                           ti::b, ti::a, ti::C, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      DataVector, Symmetry<2, 2, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::b,
+      ti::a, ti::C, Frame::Grid>();
 
   // Rank 3: DataVector; first and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<1, 2, 1>,
-                                           SpatialIndex, SpacetimeIndex, ti::i,
-                                           ti::f, ti::j, Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      DataVector, Symmetry<1, 2, 1>,
+      indextype_list<spatial_index, spacetime_index, spatial_index>, ti::i,
+      ti::f, ti::j, Frame::Distorted>();
 
   // Rank 3: DataVector; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<2, 1, 1>,
-                                           SpacetimeIndex, SpatialIndex, ti::d,
-                                           ti::J, ti::I, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      DataVector, Symmetry<2, 1, 1>,
+      indextype_list<spacetime_index, spatial_index, spatial_index>, ti::d,
+      ti::J, ti::I, Frame::Inertial>();
 
   // Rank 3: DataVector; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<DataVector, Symmetry<1, 1, 1>,
-                                           SpacetimeIndex, ti::f, ti::d, ti::a,
-                                           Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      DataVector, Symmetry<1, 1, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::f,
+      ti::d, ti::a, Frame::Grid>();
 }

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
@@ -73,20 +73,20 @@ void test_evaluate_rank_1_impl() {
 ///
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam TensorIndexType the Tensors' \ref SpacetimeIndex "TensorIndexType"
-/// \tparam Valence the valence of the Tensors' index
 /// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
 /// e.g. `ti::a`
 template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          template <size_t, UpLo, typename> class TensorIndexType,
           auto& TensorIndex>
 void test_evaluate_rank_1() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                               \
-  test_evaluate_rank_1_impl<                                                  \
-      DataType, index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
-      TensorIndex>();
+#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                                \
+  test_evaluate_rank_1_impl<DataType,                                          \
+                            index_list<TensorIndexType<                        \
+                                DIM(data), TensorIndex.valence, FRAME(data)>>, \
+                            TensorIndex>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_1_IMPL, (1, 2, 3),
                           (Frame::Grid, Frame::Inertial))

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
@@ -68,31 +68,29 @@ void test_evaluate_rank_1_impl() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \brief Iterate testing of evaluating single rank 1 Tensors on multiple Frame
-/// types and dimensions
+/// \brief Iterate testing of evaluating single rank 1 Tensors on multiple
+/// dimensions
 ///
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam TensorIndexType the Tensors' \ref SpacetimeIndex "TensorIndexType"
 /// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
 /// e.g. `ti::a`
-template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexType,
-          auto& TensorIndex>
+/// \tparam Frame the frame of the tensor index
+template <typename DataType, typename RhsIndexTypeList, auto& TensorIndex,
+          typename Frame>
 void test_evaluate_rank_1() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                                \
-  test_evaluate_rank_1_impl<DataType,                                          \
-                            index_list<TensorIndexType<                        \
-                                DIM(data), TensorIndex.valence, FRAME(data)>>, \
-                            TensorIndex>();
+#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                           \
+  test_evaluate_rank_1_impl<                                              \
+      DataType,                                                           \
+      index_list<TensorIndexType<DIM(data), TensorIndex.valence, Frame>>, \
+      TensorIndex>();
 
-  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_1_IMPL, (1, 2, 3),
-                          (Frame::Grid, Frame::Inertial))
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_1_IMPL, (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_1_IMPL
-#undef FRAME
+
 #undef DIM
 }
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
@@ -72,19 +72,22 @@ void test_evaluate_rank_1_impl() {
 /// dimensions
 ///
 /// \tparam DataType the type of data being stored in the Tensors
-/// \tparam TensorIndexType the Tensors' \ref SpacetimeIndex "TensorIndexType"
+/// \tparam RhsIndexTypeList the RHS Tensor's integral list of `IndexType`s
 /// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
 /// e.g. `ti::a`
 /// \tparam Frame the frame of the tensor index
 template <typename DataType, typename RhsIndexTypeList, auto& TensorIndex,
           typename Frame>
 void test_evaluate_rank_1() {
+  constexpr IndexType rhs_indextype = tmpl::at_c<RhsIndexTypeList, 0>::value;
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                           \
-  test_evaluate_rank_1_impl<                                              \
-      DataType,                                                           \
-      index_list<TensorIndexType<DIM(data), TensorIndex.valence, Frame>>, \
+#define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                   \
+  test_evaluate_rank_1_impl<                                      \
+      DataType,                                                   \
+      index_list<::Tensor_detail::TensorIndexType<                \
+          DIM(data), TensorIndex.valence, Frame, rhs_indextype>>, \
       TensorIndex>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_1_IMPL, (1, 2, 3))

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
@@ -137,10 +137,7 @@ void test_evaluate_rank_2_impl() {
 ///
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
-/// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
-/// first index of the RHS Tensor
-/// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
-/// second index of the RHS Tensor
+/// \tparam RhsIndexTypeList the RHS Tensor's integral list of `IndexType`s
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
@@ -159,8 +156,11 @@ void test_evaluate_rank_2() {
 #define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                               \
   test_evaluate_rank_2_impl<                                                  \
       DataType, RhsSymmetry,                                                  \
-      index_list<TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,  \
-                 TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>>, \
+      index_list<                                                             \
+          ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence, \
+                                           Frame, rhs_indextype_a>,           \
+          ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence, \
+                                           Frame, rhs_indextype_b>>,          \
       TensorIndexA, TensorIndexB>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3), (1, 2, 3))
@@ -172,18 +172,23 @@ void test_evaluate_rank_2() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry,
-          template <size_t, UpLo, typename> class TensorIndexType,
+template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
           auto& TensorIndexA, auto& TensorIndexB, typename Frame,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 1>>> = nullptr>
 void test_evaluate_rank_2() {
+  constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                            \
-  test_evaluate_rank_2_impl<                                               \
-      DataType, RhsSymmetry,                                               \
-      index_list<TensorIndexType<DIM(data), TensorIndexA.valence, Frame>,  \
-                 TensorIndexType<DIM(data), TensorIndexB.valence, Frame>>, \
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                             \
+  test_evaluate_rank_2_impl<                                                \
+      DataType, RhsSymmetry,                                                \
+      index_list<                                                           \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexA.valence, \
+                                           Frame, rhs_indextype_a>,         \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexB.valence, \
+                                           Frame, rhs_indextype_b>>,        \
       TensorIndexA, TensorIndexB>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3))

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
@@ -139,10 +139,6 @@ void test_evaluate_rank_2_impl() {
 /// first index of the RHS Tensor
 /// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
 /// second index of the RHS Tensor
-/// \tparam ValenceA the valence of the first index used on the RHS of the
-/// TensorExpression
-/// \tparam ValenceB the valence of the second index used on the RHS of the
-/// TensorExpression
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
@@ -150,17 +146,18 @@ void test_evaluate_rank_2_impl() {
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeA,
           template <size_t, UpLo, typename> class TensorIndexTypeB,
-          UpLo ValenceA, UpLo ValenceB, auto& TensorIndexA, auto& TensorIndexB>
+          auto& TensorIndexA, auto& TensorIndexB>
 void test_evaluate_rank_2_no_symmetry() {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                         \
-  test_evaluate_rank_2_impl<                                            \
-      DataType, Symmetry<2, 1>,                                         \
-      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,  \
-                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                              \
+  test_evaluate_rank_2_impl<                                                 \
+      DataType, Symmetry<2, 1>,                                              \
+      index_list<                                                            \
+          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, FRAME(data)>,  \
+          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, FRAME(data)>>, \
       TensorIndexA, TensorIndexB>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3), (1, 2, 3),
@@ -175,17 +172,18 @@ void test_evaluate_rank_2_no_symmetry() {
 /// \ingroup TestingFrameworkGroup
 /// \copydoc test_evaluate_rank_2_no_symmetry()
 template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          template <size_t, UpLo, typename> class TensorIndexType,
           auto& TensorIndexA, auto& TensorIndexB>
 void test_evaluate_rank_2_symmetric() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                     \
-  test_evaluate_rank_2_impl<                                        \
-      DataType, Symmetry<1, 1>,                                     \
-      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
-                 TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                           \
+  test_evaluate_rank_2_impl<                                              \
+      DataType, Symmetry<1, 1>,                                           \
+      index_list<                                                         \
+          TensorIndexType<DIM(data), TensorIndexA.valence, FRAME(data)>,  \
+          TensorIndexType<DIM(data), TensorIndexB.valence, FRAME(data)>>, \
       TensorIndexA, TensorIndexB>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3),

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::tenex {
@@ -121,8 +122,8 @@ void test_evaluate_rank_2_impl() {
 /// We test nonsymmetric indices and symmetric indices across two functions to
 /// ensure that the code works correctly with symmetries. This function tests
 /// one of the following symmetries:
-/// - <2, 1> (`test_evaluate_rank_2_no_symmetry`)
-/// - <1, 1> (`test_evaluate_rank_2_symmetric`)
+/// - <2, 1>
+/// - <1, 1>
 ///
 /// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
 /// and are not necessarily `ti::a` and `ti::b`. The "A" and "B" suffixes just
@@ -135,6 +136,7 @@ void test_evaluate_rank_2_impl() {
 /// and valence
 ///
 /// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
 /// first index of the RHS Tensor
 /// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
@@ -156,7 +158,7 @@ void test_evaluate_rank_2() {
 
 #define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                               \
   test_evaluate_rank_2_impl<                                                  \
-      DataType, Symmetry<2, 1>,                                               \
+      DataType, RhsSymmetry,                                                  \
       index_list<TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,  \
                  TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>>, \
       TensorIndexA, TensorIndexB>();
@@ -170,16 +172,16 @@ void test_evaluate_rank_2() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \copydoc test_evaluate_rank_2_no_symmetry()
-template <typename DataType,
+template <typename DataType, typename RhsSymmetry,
           template <size_t, UpLo, typename> class TensorIndexType,
-          auto& TensorIndexA, auto& TensorIndexB, typename Frame>
-void test_evaluate_rank_2_symmetric() {
+          auto& TensorIndexA, auto& TensorIndexB, typename Frame,
+          Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 1>>> = nullptr>
+void test_evaluate_rank_2() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                            \
   test_evaluate_rank_2_impl<                                               \
-      DataType, Symmetry<1, 1>,                                            \
+      DataType, RhsSymmetry,                                               \
       index_list<TensorIndexType<DIM(data), TensorIndexA.valence, Frame>,  \
                  TensorIndexType<DIM(data), TensorIndexB.valence, Frame>>, \
       TensorIndexA, TensorIndexB>();

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
@@ -115,8 +115,8 @@ void test_evaluate_rank_2_impl() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \brief Iterate testing of evaluating single rank 2 Tensors on multiple Frame
-/// types and dimension combinations
+/// \brief Iterate testing of evaluating single rank 2 Tensors on multiple
+/// dimension combinations
 ///
 /// We test nonsymmetric indices and symmetric indices across two functions to
 /// ensure that the code works correctly with symmetries. This function tests
@@ -143,28 +143,28 @@ void test_evaluate_rank_2_impl() {
 /// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::B`
-template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexTypeA,
-          template <size_t, UpLo, typename> class TensorIndexTypeB,
-          auto& TensorIndexA, auto& TensorIndexB>
-void test_evaluate_rank_2_no_symmetry() {
+/// \tparam Frame the frame of the tensor indices
+template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
+          auto& TensorIndexA, auto& TensorIndexB, typename Frame,
+          Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 1>>> = nullptr>
+void test_evaluate_rank_2() {
+  constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                              \
-  test_evaluate_rank_2_impl<                                                 \
-      DataType, Symmetry<2, 1>,                                              \
-      index_list<                                                            \
-          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, FRAME(data)>,  \
-          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                               \
+  test_evaluate_rank_2_impl<                                                  \
+      DataType, Symmetry<2, 1>,                                               \
+      index_list<TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,  \
+                 TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>>, \
       TensorIndexA, TensorIndexB>();
 
-  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3), (1, 2, 3),
-                          (Frame::Grid, Frame::Inertial))
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3), (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_2_IMPL
-#undef FRAME
+
 #undef DIM_B
 #undef DIM_A
 }
@@ -173,24 +173,21 @@ void test_evaluate_rank_2_no_symmetry() {
 /// \copydoc test_evaluate_rank_2_no_symmetry()
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexType,
-          auto& TensorIndexA, auto& TensorIndexB>
+          auto& TensorIndexA, auto& TensorIndexB, typename Frame>
 void test_evaluate_rank_2_symmetric() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                           \
-  test_evaluate_rank_2_impl<                                              \
-      DataType, Symmetry<1, 1>,                                           \
-      index_list<                                                         \
-          TensorIndexType<DIM(data), TensorIndexA.valence, FRAME(data)>,  \
-          TensorIndexType<DIM(data), TensorIndexB.valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                            \
+  test_evaluate_rank_2_impl<                                               \
+      DataType, Symmetry<1, 1>,                                            \
+      index_list<TensorIndexType<DIM(data), TensorIndexA.valence, Frame>,  \
+                 TensorIndexType<DIM(data), TensorIndexB.valence, Frame>>, \
       TensorIndexA, TensorIndexB>();
 
-  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3),
-                          (Frame::Grid, Frame::Inertial))
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_2_IMPL
-#undef FRAME
+
 #undef DIM
 }
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
@@ -293,12 +293,6 @@ void test_evaluate_rank_3_impl() {
 /// second index of the RHS Tensor
 /// \tparam TensorIndexTypeC the \ref SpacetimeIndex "TensorIndexType" of the
 /// third index of the RHS Tensor
-/// \tparam ValenceA the valence of the first index used on the RHS of the
-/// TensorExpression
-/// \tparam ValenceB the valence of the second index used on the RHS of the
-/// TensorExpression
-/// \tparam ValenceC the valence of the third index used on the RHS of the
-/// TensorExpression
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
@@ -309,20 +303,20 @@ template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeA,
           template <size_t, UpLo, typename> class TensorIndexTypeB,
           template <size_t, UpLo, typename> class TensorIndexTypeC,
-          UpLo ValenceA, UpLo ValenceB, UpLo ValenceC, auto& TensorIndexA,
-          auto& TensorIndexB, auto& TensorIndexC>
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
 void test_evaluate_rank_3_no_symmetry() {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(2, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(3, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                         \
-  test_evaluate_rank_3_impl<                                            \
-      DataType, Symmetry<3, 2, 1>,                                      \
-      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,  \
-                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,  \
-                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                              \
+  test_evaluate_rank_3_impl<                                                 \
+      DataType, Symmetry<3, 2, 1>,                                           \
+      index_list<                                                            \
+          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, FRAME(data)>,  \
+          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, FRAME(data)>,  \
+          TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, FRAME(data)>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
@@ -340,19 +334,19 @@ void test_evaluate_rank_3_no_symmetry() {
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeAB,
           template <size_t, UpLo, typename> class TensorIndexTypeC,
-          UpLo ValenceAB, UpLo ValenceC, auto& TensorIndexA, auto& TensorIndexB,
-          auto& TensorIndexC>
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
 void test_evaluate_rank_3_ab_symmetry() {
 #define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                           \
-  test_evaluate_rank_3_impl<                                              \
-      DataType, Symmetry<2, 2, 1>,                                        \
-      index_list<TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>, \
-                 TensorIndexTypeAB<DIM_AB(data), ValenceAB, FRAME(data)>, \
-                 TensorIndexTypeC<DIM_C(data), ValenceC, FRAME(data)>>,   \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                               \
+  test_evaluate_rank_3_impl<                                                  \
+      DataType, Symmetry<2, 2, 1>,                                            \
+      index_list<                                                             \
+          TensorIndexTypeAB<DIM_AB(data), TensorIndexA.valence, FRAME(data)>, \
+          TensorIndexTypeAB<DIM_AB(data), TensorIndexB.valence, FRAME(data)>, \
+          TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, FRAME(data)>>,  \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
@@ -369,19 +363,19 @@ void test_evaluate_rank_3_ab_symmetry() {
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeAC,
           template <size_t, UpLo, typename> class TensorIndexTypeB,
-          UpLo ValenceAC, UpLo ValenceB, auto& TensorIndexA, auto& TensorIndexB,
-          auto& TensorIndexC>
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
 void test_evaluate_rank_3_ac_symmetry() {
 #define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
-  test_evaluate_rank_3_impl<                                               \
-      DataType, Symmetry<2, 1, 2>,                                         \
-      index_list<TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>,  \
-                 TensorIndexTypeB<DIM_B(data), ValenceB, FRAME(data)>,     \
-                 TensorIndexTypeAC<DIM_AC(data), ValenceAC, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
+  test_evaluate_rank_3_impl<                                                   \
+      DataType, Symmetry<2, 1, 2>,                                             \
+      index_list<                                                              \
+          TensorIndexTypeAC<DIM_AC(data), TensorIndexA.valence, FRAME(data)>,  \
+          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, FRAME(data)>,    \
+          TensorIndexTypeAC<DIM_AC(data), TensorIndexC.valence, FRAME(data)>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
@@ -395,21 +389,22 @@ void test_evaluate_rank_3_ac_symmetry() {
 
 /// \ingroup TestingFrameworkGroup
 /// \copydoc test_evaluate_rank_3_no_symmetry()
-template <
-    typename DataType, template <size_t, UpLo, typename> class TensorIndexTypeA,
-    template <size_t, UpLo, typename> class TensorIndexTypeBC, UpLo ValenceA,
-    UpLo ValenceBC, auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
+template <typename DataType,
+          template <size_t, UpLo, typename> class TensorIndexTypeA,
+          template <size_t, UpLo, typename> class TensorIndexTypeBC,
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
 void test_evaluate_rank_3_bc_symmetry() {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
-  test_evaluate_rank_3_impl<                                               \
-      DataType, Symmetry<2, 1, 1>,                                         \
-      index_list<TensorIndexTypeA<DIM_A(data), ValenceA, FRAME(data)>,     \
-                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>,  \
-                 TensorIndexTypeBC<DIM_BC(data), ValenceBC, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
+  test_evaluate_rank_3_impl<                                                   \
+      DataType, Symmetry<2, 1, 1>,                                             \
+      index_list<                                                              \
+          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, FRAME(data)>,    \
+          TensorIndexTypeBC<DIM_BC(data), TensorIndexB.valence, FRAME(data)>,  \
+          TensorIndexTypeBC<DIM_BC(data), TensorIndexC.valence, FRAME(data)>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
@@ -424,18 +419,19 @@ void test_evaluate_rank_3_bc_symmetry() {
 /// \ingroup TestingFrameworkGroup
 /// \copydoc test_evaluate_rank_3_no_symmetry()
 template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexType, UpLo Valence,
+          template <size_t, UpLo, typename> class TensorIndexType,
           auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
 void test_evaluate_rank_3_abc_symmetry() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                     \
-  test_evaluate_rank_3_impl<                                        \
-      DataType, Symmetry<1, 1, 1>,                                  \
-      index_list<TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
-                 TensorIndexType<DIM(data), Valence, FRAME(data)>,  \
-                 TensorIndexType<DIM(data), Valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                           \
+  test_evaluate_rank_3_impl<                                              \
+      DataType, Symmetry<1, 1, 1>,                                        \
+      index_list<                                                         \
+          TensorIndexType<DIM(data), TensorIndexA.valence, FRAME(data)>,  \
+          TensorIndexType<DIM(data), TensorIndexB.valence, FRAME(data)>,  \
+          TensorIndexType<DIM(data), TensorIndexC.valence, FRAME(data)>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3),

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
@@ -289,12 +289,7 @@ void test_evaluate_rank_3_impl() {
 ///
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
-/// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
-/// first index of the RHS Tensor
-/// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
-/// second index of the RHS Tensor
-/// \tparam TensorIndexTypeC the \ref SpacetimeIndex "TensorIndexType" of the
-/// third index of the RHS Tensor
+/// \tparam RhsIndexTypeList the RHS Tensor's integral list of `IndexType`s
 /// \tparam TensorIndexA the first TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
@@ -318,9 +313,13 @@ void test_evaluate_rank_3() {
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                               \
   test_evaluate_rank_3_impl<                                                  \
       DataType, RhsSymmetry,                                                  \
-      index_list<TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,  \
-                 TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>,  \
-                 TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, Frame>>, \
+      index_list<                                                             \
+          ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence, \
+                                           Frame, rhs_indextype_a>,           \
+          ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence, \
+                                           Frame, rhs_indextype_b>,           \
+          ::Tensor_detail::TensorIndexType<DIM_C(data), TensorIndexC.valence, \
+                                           Frame, rhs_indextype_c>>,          \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
@@ -334,22 +333,28 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry,
-          template <size_t, UpLo, typename> class TensorIndexTypeAB,
-          template <size_t, UpLo, typename> class TensorIndexTypeC,
+template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
           auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
           typename Frame,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 2, 1>>> = nullptr>
 void test_evaluate_rank_3() {
+  constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+  constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+
 #define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
   test_evaluate_rank_3_impl<                                                   \
       DataType, RhsSymmetry,                                                   \
-      index_list<TensorIndexTypeAB<DIM_AB(data), TensorIndexA.valence, Frame>, \
-                 TensorIndexTypeAB<DIM_AB(data), TensorIndexB.valence, Frame>, \
-                 TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, Frame>>,  \
+      index_list<                                                              \
+          ::Tensor_detail::TensorIndexType<DIM_AB(data), TensorIndexA.valence, \
+                                           Frame, rhs_indextype_a>,            \
+          ::Tensor_detail::TensorIndexType<DIM_AB(data), TensorIndexB.valence, \
+                                           Frame, rhs_indextype_b>,            \
+          ::Tensor_detail::TensorIndexType<DIM_C(data), TensorIndexC.valence,  \
+                                           Frame, rhs_indextype_c>>,           \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
@@ -361,23 +366,28 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry,
-          template <size_t, UpLo, typename> class TensorIndexTypeAC,
-          template <size_t, UpLo, typename> class TensorIndexTypeB,
+template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
           auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
           typename Frame,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 2, 1>>> = nullptr>
 void test_evaluate_rank_3() {
+  constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+  constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+
 #define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
-  test_evaluate_rank_3_impl<                                             \
-      DataType, RhsSymmetry,                                             \
-      index_list<                                                        \
-          TensorIndexTypeAC<DIM_AC(data), TensorIndexA.valence, Frame>,  \
-          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>,    \
-          TensorIndexTypeAC<DIM_AC(data), TensorIndexC.valence, Frame>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
+  test_evaluate_rank_3_impl<                                                   \
+      DataType, RhsSymmetry,                                                   \
+      index_list<                                                              \
+          ::Tensor_detail::TensorIndexType<DIM_AC(data), TensorIndexA.valence, \
+                                           Frame, rhs_indextype_a>,            \
+          ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence,  \
+                                           Frame, rhs_indextype_b>,            \
+          ::Tensor_detail::TensorIndexType<DIM_AC(data), TensorIndexC.valence, \
+                                           Frame, rhs_indextype_c>>,           \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
@@ -389,23 +399,28 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry,
-          template <size_t, UpLo, typename> class TensorIndexTypeA,
-          template <size_t, UpLo, typename> class TensorIndexTypeBC,
+template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
           auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
           typename Frame,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 1, 1>>> = nullptr>
 void test_evaluate_rank_3() {
+  constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+  constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
-  test_evaluate_rank_3_impl<                                             \
-      DataType, RhsSymmetry,                                             \
-      index_list<                                                        \
-          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,    \
-          TensorIndexTypeBC<DIM_BC(data), TensorIndexB.valence, Frame>,  \
-          TensorIndexTypeBC<DIM_BC(data), TensorIndexC.valence, Frame>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
+  test_evaluate_rank_3_impl<                                                   \
+      DataType, RhsSymmetry,                                                   \
+      index_list<                                                              \
+          ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence,  \
+                                           Frame, rhs_indextype_a>,            \
+          ::Tensor_detail::TensorIndexType<DIM_BC(data), TensorIndexB.valence, \
+                                           Frame, rhs_indextype_b>,            \
+          ::Tensor_detail::TensorIndexType<DIM_BC(data), TensorIndexC.valence, \
+                                           Frame, rhs_indextype_c>>,           \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
@@ -417,20 +432,27 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry,
-          template <size_t, UpLo, typename> class TensorIndexType,
+template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
           auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
           typename Frame,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 1, 1>>> = nullptr>
 void test_evaluate_rank_3() {
+  constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+  constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
-  test_evaluate_rank_3_impl<                                               \
-      DataType, RhsSymmetry,                                               \
-      index_list<TensorIndexType<DIM(data), TensorIndexA.valence, Frame>,  \
-                 TensorIndexType<DIM(data), TensorIndexB.valence, Frame>,  \
-                 TensorIndexType<DIM(data), TensorIndexC.valence, Frame>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                             \
+  test_evaluate_rank_3_impl<                                                \
+      DataType, RhsSymmetry,                                                \
+      index_list<                                                           \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexA.valence, \
+                                           Frame, rhs_indextype_a>,         \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexB.valence, \
+                                           Frame, rhs_indextype_b>,         \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexC.valence, \
+                                           Frame, rhs_indextype_c>>,        \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3))

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
@@ -263,8 +263,8 @@ void test_evaluate_rank_3_impl() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \brief Iterate testing of evaluating single rank 3 Tensors on multiple Frame
-/// types and dimension combinations
+/// \brief Iterate testing of evaluating single rank 3 Tensors on multiple
+/// dimension combinations
 ///
 /// We test various different symmetries across several functions to ensure that
 /// the code works correctly with symmetries. This function tests one of the
@@ -299,31 +299,33 @@ void test_evaluate_rank_3_impl() {
 /// TensorExpression, e.g. `ti::B`
 /// \tparam TensorIndexC the third TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::c`
-template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexTypeA,
-          template <size_t, UpLo, typename> class TensorIndexTypeB,
-          template <size_t, UpLo, typename> class TensorIndexTypeC,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
-void test_evaluate_rank_3_no_symmetry() {
+/// \tparam Frame the frame of the tensor indices
+template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
+          typename Frame,
+          Requires<std::is_same_v<RhsSymmetry, Symmetry<3, 2, 1>>> = nullptr>
+void test_evaluate_rank_3() {
+  constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+  constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(2, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(3, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                              \
-  test_evaluate_rank_3_impl<                                                 \
-      DataType, Symmetry<3, 2, 1>,                                           \
-      index_list<                                                            \
-          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, FRAME(data)>,  \
-          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, FRAME(data)>,  \
-          TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                               \
+  test_evaluate_rank_3_impl<                                                  \
+      DataType, Symmetry<3, 2, 1>,                                            \
+      index_list<TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,  \
+                 TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>,  \
+                 TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, Frame>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
-                          (1, 2, 3), (Frame::Grid, Frame::Inertial))
+                          (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_3_IMPL
-#undef FRAME
+
 #undef DIM_C
 #undef DIM_B
 #undef DIM_A
@@ -334,26 +336,24 @@ void test_evaluate_rank_3_no_symmetry() {
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeAB,
           template <size_t, UpLo, typename> class TensorIndexTypeC,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
+          typename Frame>
 void test_evaluate_rank_3_ab_symmetry() {
 #define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                               \
-  test_evaluate_rank_3_impl<                                                  \
-      DataType, Symmetry<2, 2, 1>,                                            \
-      index_list<                                                             \
-          TensorIndexTypeAB<DIM_AB(data), TensorIndexA.valence, FRAME(data)>, \
-          TensorIndexTypeAB<DIM_AB(data), TensorIndexB.valence, FRAME(data)>, \
-          TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, FRAME(data)>>,  \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
+  test_evaluate_rank_3_impl<                                                   \
+      DataType, Symmetry<2, 2, 1>,                                             \
+      index_list<TensorIndexTypeAB<DIM_AB(data), TensorIndexA.valence, Frame>, \
+                 TensorIndexTypeAB<DIM_AB(data), TensorIndexB.valence, Frame>, \
+                 TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, Frame>>,  \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
-  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
-                          (Frame::Grid, Frame::Inertial))
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_3_IMPL
-#undef FRAME
+
 #undef DIM_C
 #undef DIM_AB
 }
@@ -363,82 +363,76 @@ void test_evaluate_rank_3_ab_symmetry() {
 template <typename DataType,
           template <size_t, UpLo, typename> class TensorIndexTypeAC,
           template <size_t, UpLo, typename> class TensorIndexTypeB,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
+          typename Frame>
 void test_evaluate_rank_3_ac_symmetry() {
 #define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
-  test_evaluate_rank_3_impl<                                                   \
-      DataType, Symmetry<2, 1, 2>,                                             \
-      index_list<                                                              \
-          TensorIndexTypeAC<DIM_AC(data), TensorIndexA.valence, FRAME(data)>,  \
-          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, FRAME(data)>,    \
-          TensorIndexTypeAC<DIM_AC(data), TensorIndexC.valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
+  test_evaluate_rank_3_impl<                                             \
+      DataType, Symmetry<2, 1, 2>,                                       \
+      index_list<                                                        \
+          TensorIndexTypeAC<DIM_AC(data), TensorIndexA.valence, Frame>,  \
+          TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>,    \
+          TensorIndexTypeAC<DIM_AC(data), TensorIndexC.valence, Frame>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
-  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
-                          (Frame::Grid, Frame::Inertial))
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_3_IMPL
-#undef FRAME
+
 #undef DIM_B
 #undef DIM_AC
 }
 
 /// \ingroup TestingFrameworkGroup
 /// \copydoc test_evaluate_rank_3_no_symmetry()
-template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexTypeA,
-          template <size_t, UpLo, typename> class TensorIndexTypeBC,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
+template <
+    typename DataType, template <size_t, UpLo, typename> class TensorIndexTypeA,
+    template <size_t, UpLo, typename> class TensorIndexTypeBC,
+    auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC, typename Frame>
 void test_evaluate_rank_3_bc_symmetry() {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
-  test_evaluate_rank_3_impl<                                                   \
-      DataType, Symmetry<2, 1, 1>,                                             \
-      index_list<                                                              \
-          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, FRAME(data)>,    \
-          TensorIndexTypeBC<DIM_BC(data), TensorIndexB.valence, FRAME(data)>,  \
-          TensorIndexTypeBC<DIM_BC(data), TensorIndexC.valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
+  test_evaluate_rank_3_impl<                                             \
+      DataType, Symmetry<2, 1, 1>,                                       \
+      index_list<                                                        \
+          TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,    \
+          TensorIndexTypeBC<DIM_BC(data), TensorIndexB.valence, Frame>,  \
+          TensorIndexTypeBC<DIM_BC(data), TensorIndexC.valence, Frame>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
-  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
-                          (Frame::Grid, Frame::Inertial))
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_3_IMPL
-#undef FRAME
+
 #undef DIM_BC
 #undef DIM_A
 }
 
 /// \ingroup TestingFrameworkGroup
 /// \copydoc test_evaluate_rank_3_no_symmetry()
-template <typename DataType,
-          template <size_t, UpLo, typename> class TensorIndexType,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC>
+template <
+    typename DataType, template <size_t, UpLo, typename> class TensorIndexType,
+    auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC, typename Frame>
 void test_evaluate_rank_3_abc_symmetry() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                           \
-  test_evaluate_rank_3_impl<                                              \
-      DataType, Symmetry<1, 1, 1>,                                        \
-      index_list<                                                         \
-          TensorIndexType<DIM(data), TensorIndexA.valence, FRAME(data)>,  \
-          TensorIndexType<DIM(data), TensorIndexB.valence, FRAME(data)>,  \
-          TensorIndexType<DIM(data), TensorIndexC.valence, FRAME(data)>>, \
+#define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
+  test_evaluate_rank_3_impl<                                               \
+      DataType, Symmetry<1, 1, 1>,                                         \
+      index_list<TensorIndexType<DIM(data), TensorIndexA.valence, Frame>,  \
+                 TensorIndexType<DIM(data), TensorIndexB.valence, Frame>,  \
+                 TensorIndexType<DIM(data), TensorIndexC.valence, Frame>>, \
       TensorIndexA, TensorIndexB, TensorIndexC>();
 
-  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3),
-                          (Frame::Grid, Frame::Inertial))
+  GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3))
 
 #undef CALL_TEST_EVALUATE_RANK_3_IMPL
-#undef FRAME
+
 #undef DIM
 }
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::tenex {
@@ -269,11 +270,11 @@ void test_evaluate_rank_3_impl() {
 /// We test various different symmetries across several functions to ensure that
 /// the code works correctly with symmetries. This function tests one of the
 /// following symmetries:
-/// - <3, 2, 1> (`test_evaluate_rank_3_no_symmetry`)
-/// - <2, 2, 1> (`test_evaluate_rank_3_ab_symmetry`)
-/// - <2, 1, 2> (`test_evaluate_rank_3_ac_symmetry`)
-/// - <2, 1, 1> (`test_evaluate_rank_3_bc_symmetry`)
-/// - <1, 1, 1> (`test_evaluate_rank_3_abc_symmetry`)
+/// - <3, 2, 1>
+/// - <2, 2, 1>
+/// - <2, 1, 2>
+/// - <2, 1, 1>
+/// - <1, 1, 1>
 ///
 /// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
 /// of TensorIndex and are not necessarily `ti::a`, `ti::b`, and `ti::c`. The
@@ -287,6 +288,7 @@ void test_evaluate_rank_3_impl() {
 /// "TensorIndexType" and valence
 ///
 /// \tparam DataType the type of data being stored in the Tensors
+/// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam TensorIndexTypeA the \ref SpacetimeIndex "TensorIndexType" of the
 /// first index of the RHS Tensor
 /// \tparam TensorIndexTypeB the \ref SpacetimeIndex "TensorIndexType" of the
@@ -315,7 +317,7 @@ void test_evaluate_rank_3() {
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                               \
   test_evaluate_rank_3_impl<                                                  \
-      DataType, Symmetry<3, 2, 1>,                                            \
+      DataType, RhsSymmetry,                                                  \
       index_list<TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,  \
                  TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>,  \
                  TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, Frame>>, \
@@ -332,19 +334,19 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \copydoc test_evaluate_rank_3_no_symmetry()
-template <typename DataType,
+template <typename DataType, typename RhsSymmetry,
           template <size_t, UpLo, typename> class TensorIndexTypeAB,
           template <size_t, UpLo, typename> class TensorIndexTypeC,
           auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
-          typename Frame>
-void test_evaluate_rank_3_ab_symmetry() {
+          typename Frame,
+          Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 2, 1>>> = nullptr>
+void test_evaluate_rank_3() {
 #define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
   test_evaluate_rank_3_impl<                                                   \
-      DataType, Symmetry<2, 2, 1>,                                             \
+      DataType, RhsSymmetry,                                                   \
       index_list<TensorIndexTypeAB<DIM_AB(data), TensorIndexA.valence, Frame>, \
                  TensorIndexTypeAB<DIM_AB(data), TensorIndexB.valence, Frame>, \
                  TensorIndexTypeC<DIM_C(data), TensorIndexC.valence, Frame>>,  \
@@ -359,19 +361,19 @@ void test_evaluate_rank_3_ab_symmetry() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \copydoc test_evaluate_rank_3_no_symmetry()
-template <typename DataType,
+template <typename DataType, typename RhsSymmetry,
           template <size_t, UpLo, typename> class TensorIndexTypeAC,
           template <size_t, UpLo, typename> class TensorIndexTypeB,
           auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
-          typename Frame>
-void test_evaluate_rank_3_ac_symmetry() {
+          typename Frame,
+          Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 2, 1>>> = nullptr>
+void test_evaluate_rank_3() {
 #define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
   test_evaluate_rank_3_impl<                                             \
-      DataType, Symmetry<2, 1, 2>,                                       \
+      DataType, RhsSymmetry,                                             \
       index_list<                                                        \
           TensorIndexTypeAC<DIM_AC(data), TensorIndexA.valence, Frame>,  \
           TensorIndexTypeB<DIM_B(data), TensorIndexB.valence, Frame>,    \
@@ -387,18 +389,19 @@ void test_evaluate_rank_3_ac_symmetry() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \copydoc test_evaluate_rank_3_no_symmetry()
-template <
-    typename DataType, template <size_t, UpLo, typename> class TensorIndexTypeA,
-    template <size_t, UpLo, typename> class TensorIndexTypeBC,
-    auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC, typename Frame>
-void test_evaluate_rank_3_bc_symmetry() {
+template <typename DataType, typename RhsSymmetry,
+          template <size_t, UpLo, typename> class TensorIndexTypeA,
+          template <size_t, UpLo, typename> class TensorIndexTypeBC,
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
+          typename Frame,
+          Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 1, 1>>> = nullptr>
+void test_evaluate_rank_3() {
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                          \
   test_evaluate_rank_3_impl<                                             \
-      DataType, Symmetry<2, 1, 1>,                                       \
+      DataType, RhsSymmetry,                                             \
       index_list<                                                        \
           TensorIndexTypeA<DIM_A(data), TensorIndexA.valence, Frame>,    \
           TensorIndexTypeBC<DIM_BC(data), TensorIndexB.valence, Frame>,  \
@@ -414,16 +417,17 @@ void test_evaluate_rank_3_bc_symmetry() {
 }
 
 /// \ingroup TestingFrameworkGroup
-/// \copydoc test_evaluate_rank_3_no_symmetry()
-template <
-    typename DataType, template <size_t, UpLo, typename> class TensorIndexType,
-    auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC, typename Frame>
-void test_evaluate_rank_3_abc_symmetry() {
+template <typename DataType, typename RhsSymmetry,
+          template <size_t, UpLo, typename> class TensorIndexType,
+          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
+          typename Frame,
+          Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 1, 1>>> = nullptr>
+void test_evaluate_rank_3() {
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                            \
   test_evaluate_rank_3_impl<                                               \
-      DataType, Symmetry<1, 1, 1>,                                         \
+      DataType, RhsSymmetry,                                               \
       index_list<TensorIndexType<DIM(data), TensorIndexA.valence, Frame>,  \
                  TensorIndexType<DIM(data), TensorIndexB.valence, Frame>,  \
                  TensorIndexType<DIM(data), TensorIndexC.valence, Frame>>, \


### PR DESCRIPTION
## Proposed changes

This simply changes the template parameters for some `TensorExpression` test helper functions to make calling and using the functions more general.

This is a precursor for a followup PR that fixes a `TensorExpression` bug and makes use of the new, more general interface by adding many new test cases to increase test coverage easily. The changes in this PR were submitted separately to make code review of the future PR(s) easier. While these changes were motivated by increasing test coverage in a future PR (for symmetric tensors and where spatial and time indices are used for spacetime indices), this PR also has the effect of reducing some test bloat where coverage may have been more exhaustive in places than needed (testing all index dimension combinations for multiple frames may be overkill).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
