### PR TITLE
Add Parallel::FifoCache

### DIFF
--- a/src/Parallel/CMakeLists.txt
+++ b/src/Parallel/CMakeLists.txt
@@ -37,6 +37,7 @@ spectre_target_headers(
   DomainDiagnosticInfo.hpp
   ElementRegistration.hpp
   ExitCode.hpp
+  FifoCache.hpp
   GetSection.hpp
   GlobalCache.hpp
   GlobalCacheDeclare.hpp

--- a/src/Parallel/FifoCache.hpp
+++ b/src/Parallel/FifoCache.hpp
@@ -1,0 +1,265 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <atomic>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <new>  // for hardware_destructive_interference_size
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "Parallel/MultiReaderSpinlock.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Parallel {
+/*!
+ * \brief A threadsafe parallel first-in-first-out cache.
+ */
+template <class T>
+class FifoCache {
+  using stored_type = std::pair<MultiReaderSpinlock, T>;
+  using value_type = std::vector<stored_type>;
+
+ public:
+  /*!
+   * \brief Wrapper type used as the result from `find` to ensure correct
+   * thread safety.
+   *
+   * Use `.value()` to get the stored value.
+   *
+   * Use `.has_value()` to check if a value is stored.
+   */
+  struct Cached {
+   public:
+    Cached() = delete;
+    explicit Cached(const stored_type* t);
+    /// NOLINTNEXTLINE(google-explicit-constructor)
+    Cached(const std::nullopt_t /*unused*/) : Cached{nullptr} {}
+    Cached(const Cached& rhs);
+    Cached& operator=(const Cached& rhs);
+    Cached(Cached&& rhs) noexcept(true);
+    Cached& operator=(Cached&& rhs) noexcept(true);
+    ~Cached() noexcept(true);
+
+    /// \brief Returns a reference to the held object.
+    ///
+    /// \throws std::runtime_error if no value
+    auto value() const -> const T&;
+
+    /// \brief Returns `true` if a value is stored, otherwise returns `false`.
+    bool has_value() const { return t_ != nullptr; }
+
+   private:
+    stored_type* t_;
+  };
+
+  /// \brief Create a FifoCache that has \p capacity.
+  explicit FifoCache(std::unsigned_integral auto capacity);
+
+  FifoCache() = delete;
+  FifoCache(const FifoCache& rhs) = delete;
+  FifoCache& operator=(const FifoCache& rhs) = delete;
+  FifoCache(FifoCache&& rhs) = delete;
+  FifoCache& operator=(FifoCache&& rhs) = delete;
+  ~FifoCache() = default;
+
+  /*!
+   * \brief Pushes the entry computed by `compute_value()` to the front of the
+   * queue, ejecting the last entry if the capacity is reached. The inserted
+   * entry is returned.
+   *
+   * This function allows lazy computation of the value, which means the
+   * computation is elided if another thread pushes the new cache entry before
+   * this one.
+   *
+   * The predicate must satisfy `predicate(t) == true` to avoid inserting
+   * duplicates. This is best guaranteed by passing the same predicate that
+   * would be passed to calls to `find()`.
+   */
+  template <class ComputeValue, class UnaryPredicate>
+  auto push(ComputeValue&& compute_value, const UnaryPredicate& predicate)
+      -> Cached;
+
+  /*!
+   * \brief Pushes the entry `t` to the front of the queue,
+   * ejecting the last entry if the capacity is reached. The inserted
+   * entry is returned.
+   *
+   * The predicate must satisfy `predicate(t) == true` to avoid inserting
+   * duplicates. This is best guaranteed by passing the same predicate that
+   * would be passed to calls to `find()`.
+   */
+  template <class UnaryPredicate>
+  auto push(T t, const UnaryPredicate& predicate) -> Cached;
+
+  /*!
+   * \brief Get the first element that matches `predicate`.
+   *
+   * If no value in the cache matches the predicate then `result.has_value()`
+   * is `false` and `result.value()` will throw.
+   *
+   * The return type is designed to handle the locking and unlocking
+   * of the data to ensure thread safety.
+   */
+  template <class UnaryPredicate>
+  [[nodiscard]] auto find(const UnaryPredicate& predicate) const -> Cached;
+
+ private:
+#if defined(__cpp_lib_hardware_interference_size)
+  static constexpr size_t cache_line_size_ =
+      std::hardware_destructive_interference_size;
+#else
+  static constexpr size_t cache_line_size_ = 64;
+#endif
+
+  // std::vector does not have an atomic size so in order to prevent tearing
+  // we have to track the size separately.
+  alignas(cache_line_size_) std::atomic<std::uint64_t> size_{0};
+  alignas(cache_line_size_) std::mutex write_lock_{};
+  alignas(cache_line_size_) value_type data_{};
+  // Ensure we pad the end to avoid false sharing. Unlikely to happen because
+  // of the layout, but better to be safe.
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+#endif
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  char padding_[cache_line_size_ - sizeof(value_type) % cache_line_size_] = {};
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+};
+
+template <class T>
+FifoCache<T>::FifoCache(const std::unsigned_integral auto capacity)
+    : data_(capacity) {
+  ASSERT(capacity > 0, "Must have a positive capacity but got " << capacity);
+}
+
+template <class T>
+template <class ComputeValue, class UnaryPredicate>
+auto FifoCache<T>::push(ComputeValue&& compute_value,
+                        const UnaryPredicate& predicate) -> Cached {
+  std::lock_guard guard(write_lock_);
+  auto size = size_.load(std::memory_order_acquire);
+  for (size_t i = 0; i < size; ++i) {
+    Cached vt{std::addressof(data_[i])};
+    if (predicate(vt.value())) {
+      return {vt};
+    }
+  }
+
+  // Compute the new value _before_ locking data to minimize locked time.
+  T new_value = std::forward<ComputeValue>(compute_value)();
+  if (size < data_.capacity()) {
+    ++size;
+  }
+  data_[size - 1].first.write_lock();
+  for (size_t i = size - 1; i > 0; --i) {
+    data_[i - 1].first.write_lock();
+    data_[i].second = std::move(data_[i - 1].second);
+  }
+  data_[0].second = std::move(new_value);
+  for (size_t i = 0; i < size; ++i) {
+    data_[i].first.write_unlock();
+  }
+  size_.store(size, std::memory_order_release);
+  return find(predicate);
+}
+
+template <class T>
+template <class UnaryPredicate>
+auto FifoCache<T>::push(T t, const UnaryPredicate& predicate) -> Cached {
+  return push(
+      [t_local = std::move(t)]() mutable -> T  // NOLINT(spectre-mutable)
+      { return std::move(t_local); },
+      predicate);
+}
+
+template <class T>
+template <class UnaryPredicate>
+[[nodiscard]] auto FifoCache<T>::find(const UnaryPredicate& predicate) const
+    -> Cached {
+  const auto size = size_.load(std::memory_order_relaxed);
+  for (size_t i = 0; i < size; ++i) {
+    Cached vt{std::addressof(data_[i])};
+    if (predicate(vt.value())) {
+      return vt;
+    }
+  }
+  return Cached{nullptr};
+}
+
+template <class T>
+FifoCache<T>::Cached::Cached(const stored_type* t)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    : t_(const_cast<stored_type*>(t)) {
+  if (t_ != nullptr) {
+    t_->first.read_lock();
+  }
+}
+
+template <class T>
+FifoCache<T>::Cached::Cached(const Cached& rhs) : t_(rhs.t_) {
+  if (t_ != nullptr) {
+    t_->first.read_lock();
+  }
+}
+
+template <class T>
+typename FifoCache<T>::Cached& FifoCache<T>::Cached::operator=(
+    const Cached& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  if (t_ != nullptr) {
+    t_->first.read_unlock();
+  }
+  t_ = rhs.t_;
+  if (t_ != nullptr) {
+    t_->first.read_lock();
+  }
+  return *this;
+}
+
+template <class T>
+FifoCache<T>::Cached::Cached(Cached&& rhs) noexcept(true) : t_(rhs.t_) {
+  rhs.t_ = nullptr;
+}
+
+template <class T>
+typename FifoCache<T>::Cached& FifoCache<T>::Cached::operator=(
+    Cached&& rhs) noexcept(true) {
+  if (&rhs == this) {
+    return *this;
+  }
+  if (t_ != nullptr) {
+    t_->first.read_unlock();
+  }
+  t_ = rhs.t_;
+  rhs.t_ = nullptr;
+  return *this;
+}
+
+template <class T>
+FifoCache<T>::Cached::~Cached() noexcept(true) {
+  if (t_ != nullptr) {
+    t_->first.read_unlock();
+  }
+}
+
+template <class T>
+auto FifoCache<T>::Cached::value() const -> const T& {
+  if (UNLIKELY(not has_value())) {
+    throw std::runtime_error{"No value in FifoCache."};
+  }
+  return t_->second;
+}
+}  // namespace Parallel

--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -165,6 +165,7 @@ set(LIBRARY_SOURCES
   Test_DomainDiagnosticInfo.cpp
   Test_ExitCode.cpp
   Test_GlobalCacheDataBox.cpp
+  Test_FifoCache.cpp
   Test_InboxInserters.cpp
   Test_InitializationTag.cpp
   Test_MemoryMonitor.cpp

--- a/tests/Unit/Parallel/Test_FifoCache.cpp
+++ b/tests/Unit/Parallel/Test_FifoCache.cpp
@@ -1,0 +1,188 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "Parallel/FifoCache.hpp"
+
+namespace {
+struct T0 {
+  int a;
+  float b;
+  bool operator==(const T0& rhs) const = default;
+};
+
+void test_basic() {
+#if defined(SPECTRE_DEBUG)
+  {
+    CHECK_THROWS_WITH(Parallel::FifoCache<T0>(0u),
+                      Catch::Matchers::ContainsSubstring(
+                          "Must have a positive capacity but got 0"));
+  }
+#endif
+  Parallel::FifoCache<T0> fc{3u};
+  CHECK_FALSE(
+      fc.find([](const T0& t0) -> bool { return t0.a == 1; }).has_value());
+  {
+    INFO("Test push.");
+    const auto t0a1 =
+        fc.push(T0{1, 1.32}, [](const T0& t0) -> bool { return t0.a == 1; });
+    REQUIRE(t0a1.has_value());
+    CHECK(t0a1.value() == T0{1, 1.32});
+  }
+  {
+    INFO("Test finding pushed value more than once.");
+    const auto t0a1 = fc.find([](const T0& t0) -> bool { return t0.a == 1; });
+    REQUIRE(t0a1.has_value());
+    CHECK(t0a1.value() == T0{1, 1.32});
+    const auto t0a1_2 = fc.find([](const T0& t0) -> bool { return t0.a == 1; });
+    REQUIRE(t0a1_2.has_value());
+    CHECK(std::addressof(t0a1) != std::addressof(t0a1_2));
+    CHECK(std::addressof(t0a1.value()) == std::addressof(t0a1_2.value()));
+    CHECK_FALSE(
+        fc.find([](const T0& t0) -> bool { return t0.a == 2; }).has_value());
+  }
+  {
+    INFO("Test pushing same value doesn't change exist object.");
+    const auto t0a1 = fc.find([](const T0& t0) -> bool { return t0.a == 1; });
+    REQUIRE(t0a1.has_value());
+    CHECK(t0a1.value() == T0{1, 1.32});
+    const auto t0a1_2 =
+        fc.push(T0{1, 1.32}, [](const T0& t0) -> bool { return t0.a == 1; });
+    REQUIRE(t0a1_2.has_value());
+    CHECK(std::addressof(t0a1) != std::addressof(t0a1_2));
+    CHECK(std::addressof(t0a1.value()) == std::addressof(t0a1_2.value()));
+    CHECK_FALSE(
+        fc.find([](const T0& t0) -> bool { return t0.a == 2; }).has_value());
+  }
+  {
+    INFO("Insert to fill.");
+    {
+      const auto a2 =
+          fc.push(T0{2, 2.32}, [](const T0& t0) -> bool { return t0.a == 2; });
+      REQUIRE(a2.has_value());
+      CHECK(a2.value() == T0{2, 2.32});
+    }
+    {
+      const auto a1 = fc.find([](const T0& t0) -> bool { return t0.a == 1; });
+      REQUIRE(a1.has_value());
+      CHECK(a1.value() == T0{1, 1.32});
+    }
+    {
+      const auto a3 =
+          fc.push(T0{3, 3.32}, [](const T0& t0) -> bool { return t0.a == 3; });
+      REQUIRE(a3.has_value());
+      CHECK(a3.value() == T0{3, 3.32});
+    }
+    {
+      const auto a1 = fc.find([](const T0& t0) -> bool { return t0.a == 1; });
+      REQUIRE(a1.has_value());
+      CHECK(a1.value() == T0{1, 1.32});
+      const auto a2 = fc.find([](const T0& t0) -> bool { return t0.a == 2; });
+      REQUIRE(a2.has_value());
+      CHECK(a2.value() == T0{2, 2.32});
+      const auto a3 = fc.find([](const T0& t0) -> bool { return t0.a == 3; });
+      REQUIRE(a3.has_value());
+      CHECK(a3.value() == T0{3, 3.32});
+    }
+    {
+      const auto a4 =
+          fc.push(T0{4, 4.32}, [](const T0& t0) -> bool { return t0.a == 4; });
+      REQUIRE(a4.has_value());
+      CHECK(a4.value() == T0{4, 4.32});
+    }
+    {
+      const auto a1 = fc.find([](const T0& t0) -> bool { return t0.a == 1; });
+      REQUIRE_FALSE(a1.has_value());
+      const auto a2 = fc.find([](const T0& t0) -> bool { return t0.a == 2; });
+      REQUIRE(a2.has_value());
+      CHECK(a2.value() == T0{2, 2.32});
+      const auto a3 = fc.find([](const T0& t0) -> bool { return t0.a == 3; });
+      REQUIRE(a3.has_value());
+      CHECK(a3.value() == T0{3, 3.32});
+      const auto a4 = fc.find([](const T0& t0) -> bool { return t0.a == 4; });
+      REQUIRE(a4.has_value());
+      CHECK(a4.value() == T0{4, 4.32});
+    }
+  }
+  {
+    INFO("Compute call is lazily evaluated.");
+    {
+      bool invoked_compute_value = false;
+      const auto compute_value = [&invoked_compute_value]() {
+        CHECK_FALSE(invoked_compute_value);
+        invoked_compute_value = true;
+        return T0{5, 5.32};
+      };
+      const auto a5 = fc.push(compute_value,
+                              [](const T0& t0) -> bool { return t0.a == 5; });
+      REQUIRE(invoked_compute_value);
+      REQUIRE(a5.has_value());
+      CHECK(a5.value() == T0{5, 5.32});
+
+      invoked_compute_value = false;
+      const auto a5b = fc.push(compute_value,
+                               [](const T0& t0) -> bool { return t0.a == 5; });
+      REQUIRE_FALSE(invoked_compute_value);
+      REQUIRE(a5b.has_value());
+      CHECK(a5b.value() == T0{5, 5.32});
+
+      CHECK(std::addressof(a5) != std::addressof(a5b));
+      CHECK(std::addressof(a5.value()) == std::addressof(a5b.value()));
+    }
+  }
+}
+
+void test_non_copyable() {
+  Parallel::FifoCache<std::unique_ptr<T0>> fc{3u};
+  CHECK_FALSE(fc.find([](const std::unique_ptr<T0>& t0) -> bool {
+                  return t0->a == 1;
+                }).has_value());
+  const auto t0a1 =
+      fc.push(std::make_unique<T0>(T0{1, 1.32}),
+              [](const std::unique_ptr<T0>& t0) -> bool { return t0->a == 1; });
+  REQUIRE(t0a1.has_value());
+  REQUIRE(t0a1.value() != nullptr);
+  CHECK(*(t0a1.value()) == T0{1, 1.32});
+}
+
+void test_deadlock() {
+  Parallel::FifoCache<T0> fc{3u};
+  CHECK_FALSE(
+      fc.find([](const T0& t0) -> bool { return t0.a == 1; }).has_value());
+  auto t0a1 =
+      fc.push(T0{1, 1.32}, [](const T0& t0) -> bool { return t0.a == 1; });
+  REQUIRE(t0a1.has_value());
+  CHECK(t0a1.value() == T0{1, 1.32});
+
+  std::atomic<int> t0_state{0};
+  std::thread thread0{[&fc, &t0_state]() {
+    t0_state.store(1, std::memory_order_release);
+    const auto t0a2 =
+        fc.push(T0{2, 1.32}, [](const T0& t0) -> bool { return t0.a == 2; });
+    t0_state.store(2, std::memory_order_release);
+  }};
+
+  while (t0_state.load(std::memory_order_acquire) < 1) {
+  }
+  REQUIRE(t0_state.load(std::memory_order_acquire) == 1);
+
+  // Wait 1s to give other thread plenty of time to not be deadlocked.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  REQUIRE(t0_state.load(std::memory_order_acquire) == 1);
+
+  t0a1 = std::nullopt;
+  thread0.join();
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.FifoCache", "[Parallel][Unit]") {
+  test_basic();
+  test_non_copyable();
+  test_deadlock();
+}


### PR DESCRIPTION
## Proposed changes

This provides a way of have a thread safe cache that is also size-limited. For Spherepack objects this is something we'll want since they can end up taking up a large amount of memory but are also expensive to compute.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
