### PR TITLE
Generalize TE testing to take spatial and time spacetime indices

### DIFF
--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -47,138 +47,167 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
   test_contains_indices_to_contract();
 
   // Rank 0: double
-  TestHelpers::tenex::test_evaluate_rank_0<double>(-7.31);
+  TestHelpers::tenex::test_evaluate_rank_0<double>();
 
   // Rank 0: DataVector
-  TestHelpers::tenex::test_evaluate_rank_0<DataVector>(
-      DataVector{-3.1, 9.4, 0.0, -3.1, 2.4, 9.8});
+  TestHelpers::tenex::test_evaluate_rank_0<DataVector>();
 
   // Rank 1: double; spacetime
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spacetime_index>, ti::a, Frame::Inertial>();
+      true, double, indextype_list<spacetime_index>, ti::a, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spacetime_index>, ti::b, Frame::Grid>();
+      true, double, indextype_list<spacetime_index>, ti::b, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spacetime_index>, ti::A, Frame::Grid>();
+      true, double, indextype_list<spacetime_index>, ti::A, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spacetime_index>, ti::B, Frame::Inertial>();
+      true, double, indextype_list<spacetime_index>, ti::B, Frame::Inertial>();
 
   // Rank 1: double; spatial
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spatial_index>, ti::i, Frame::Grid>();
+      true, double, indextype_list<spatial_index>, ti::i, Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spatial_index>, ti::j, Frame::Inertial>();
+      true, double, indextype_list<spatial_index>, ti::j, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spatial_index>, ti::I, Frame::Inertial>();
+      true, double, indextype_list<spatial_index>, ti::I, Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_1<
-      double, indextype_list<spatial_index>, ti::J, Frame::Grid>();
+      true, double, indextype_list<spatial_index>, ti::J, Frame::Grid>();
 
   // Rank 1: DataVector
-  TestHelpers::tenex::test_evaluate_rank_1<
-      DataVector, indextype_list<spatial_index>, ti::L, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<true, DataVector,
+                                           indextype_list<spatial_index>, ti::L,
+                                           Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime only
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::a, ti::b, Frame::Inertial>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::a, ti::b,
+      Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::A, ti::B, Frame::Grid>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::A, ti::B,
+      Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::d, ti::c, Frame::Distorted>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::d, ti::c,
+      Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::D, ti::C, Frame::NoFrame>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::D, ti::C,
+      Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::e, ti::F, Frame::Inertial>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::e, ti::F,
+      Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::F, ti::e, Frame::Grid>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::F, ti::e,
+      Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::g, ti::B, Frame::Distorted>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::g, ti::B,
+      Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::G, ti::b, Frame::NoFrame>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::G, ti::b,
+      Frame::NoFrame>();
 
   // Rank 2: double; nonsymmetric; spatial only
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::i, ti::j, Frame::NoFrame>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::i, ti::j,
+      Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::I, ti::J, Frame::Distorted>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::I, ti::J,
+      Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::j, ti::i, Frame::Grid>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
+      Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::J, ti::I, Frame::Inertial>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::J, ti::I,
+      Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::i, ti::J, Frame::NoFrame>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::i, ti::J,
+      Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::I, ti::j, Frame::Distorted>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::I, ti::j,
+      Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::j, ti::I, Frame::Grid>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::j, ti::I,
+      Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::J, ti::i, Frame::Inertial>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::J, ti::i,
+      Frame::Inertial>();
 
   // Rank 2: double; nonsymmetric; spacetime and spatial mixed
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
-      ti::c, ti::I, Frame::Inertial>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spatial_index>, ti::c, ti::I,
+      Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
-      ti::A, ti::i, Frame::Grid>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spatial_index>, ti::A, ti::i,
+      Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
-      ti::J, ti::a, Frame::Distorted>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spacetime_index>, ti::J, ti::a,
+      Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
-      ti::i, ti::B, Frame::NoFrame>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spacetime_index>, ti::i, ti::B,
+      Frame::NoFrame>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
-      ti::e, ti::j, Frame::Inertial>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spatial_index>, ti::e, ti::j,
+      Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
-      ti::i, ti::d, Frame::Grid>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spacetime_index>, ti::i, ti::d,
+      Frame::Grid>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spacetime_index, spatial_index>,
-      ti::C, ti::I, Frame::Distorted>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spatial_index>, ti::C, ti::I,
+      Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<2, 1>, indextype_list<spatial_index, spacetime_index>,
-      ti::J, ti::A, Frame::NoFrame>();
+      true, double, Symmetry<2, 1>,
+      indextype_list<spatial_index, spacetime_index>, ti::J, ti::A,
+      Frame::NoFrame>();
 
   // Rank 2: double; symmetric; spacetime
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<1, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::a, ti::d, Frame::Inertial>();
+      true, double, Symmetry<1, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::a, ti::d,
+      Frame::Inertial>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<1, 1>, indextype_list<spacetime_index, spacetime_index>,
-      ti::G, ti::B, Frame::Grid>();
+      true, double, Symmetry<1, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::G, ti::B,
+      Frame::Grid>();
 
   // Rank 2: double; symmetric; spatial
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<1, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::j, ti::i, Frame::Distorted>();
+      true, double, Symmetry<1, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
+      Frame::Distorted>();
   TestHelpers::tenex::test_evaluate_rank_2<
-      double, Symmetry<1, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::I, ti::J, Frame::NoFrame>();
+      true, double, Symmetry<1, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::I, ti::J,
+      Frame::NoFrame>();
 
   // Rank 2: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_2<
-      DataVector, Symmetry<2, 1>,
+      true, DataVector, Symmetry<2, 1>,
       indextype_list<spacetime_index, spacetime_index>, ti::f, ti::G,
       Frame::Inertial>();
 
   // Rank 2: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_2<
-      DataVector, Symmetry<1, 1>, indextype_list<spatial_index, spatial_index>,
-      ti::j, ti::i, Frame::Grid>();
+      true, DataVector, Symmetry<1, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
+      Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -27,13 +27,13 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   // Rank 3: double; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      double, Symmetry<3, 2, 1>,
+      true, double, Symmetry<3, 2, 1>,
       indextype_list<spacetime_index, spatial_index, spacetime_index>, ti::D,
       ti::j, ti::B, Frame::Inertial>();
 
   // Rank 3: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      DataVector, Symmetry<3, 2, 1>,
+      true, DataVector, Symmetry<3, 2, 1>,
       indextype_list<spacetime_index, spatial_index, spacetime_index>, ti::D,
       ti::j, ti::B, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -27,49 +27,49 @@ SPECTRE_TEST_CASE(
     "[DataStructures][Unit]") {
   // Rank 3: double; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      double, Symmetry<2, 2, 1>,
+      true, double, Symmetry<2, 2, 1>,
       indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::b,
       ti::a, ti::C, Frame::Inertial>();
 
   // Rank 3: double; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      double, Symmetry<1, 2, 1>,
+      true, double, Symmetry<1, 2, 1>,
       indextype_list<spatial_index, spacetime_index, spatial_index>, ti::i,
       ti::f, ti::j, Frame::Grid>();
 
   // Rank 3: double; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      double, Symmetry<2, 1, 1>,
+      true, double, Symmetry<2, 1, 1>,
       indextype_list<spacetime_index, spatial_index, spatial_index>, ti::d,
       ti::J, ti::I, Frame::Distorted>();
 
   // Rank 3: double; symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      double, Symmetry<1, 1, 1>,
+      true, double, Symmetry<1, 1, 1>,
       indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::f,
       ti::d, ti::a, Frame::Inertial>();
 
   // Rank 3: DataVector; first and second indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      DataVector, Symmetry<2, 2, 1>,
+      true, DataVector, Symmetry<2, 2, 1>,
       indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::b,
       ti::a, ti::C, Frame::Grid>();
 
   // Rank 3: DataVector; first and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      DataVector, Symmetry<1, 2, 1>,
+      true, DataVector, Symmetry<1, 2, 1>,
       indextype_list<spatial_index, spacetime_index, spatial_index>, ti::i,
       ti::f, ti::j, Frame::Distorted>();
 
   // Rank 3: DataVector; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      DataVector, Symmetry<2, 1, 1>,
+      true, DataVector, Symmetry<2, 1, 1>,
       indextype_list<spacetime_index, spatial_index, spatial_index>, ti::d,
       ti::J, ti::I, Frame::Inertial>();
 
   // Rank 3: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_3<
-      DataVector, Symmetry<1, 1, 1>,
+      true, DataVector, Symmetry<1, 1, 1>,
       indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::f,
       ti::d, ti::a, Frame::Grid>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
@@ -13,7 +13,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                   "[DataStructures][Unit]") {
   // Rank 4: double; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      double, Symmetry<4, 3, 2, 1>,
+      true, double, Symmetry<4, 3, 2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                  SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
@@ -22,7 +22,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
 
   // Rank 4: double; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      double, Symmetry<3, 2, 2, 1>,
+      true, double, Symmetry<3, 2, 2, 1>,
       index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
@@ -31,7 +31,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
 
   // Rank 4: double; first, second, and fourth indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      double, Symmetry<2, 2, 1, 2>,
+      true, double, Symmetry<2, 2, 1, 2>,
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
@@ -40,7 +40,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
 
   // Rank 4: double; symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      double, Symmetry<1, 1, 1, 1>,
+      true, double, Symmetry<1, 1, 1, 1>,
       index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
@@ -49,7 +49,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
 
   // Rank 4: DataVector; nonsymmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      DataVector, Symmetry<4, 3, 2, 1>,
+      true, DataVector, Symmetry<4, 3, 2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
                  SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
@@ -58,7 +58,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
 
   // Rank 4: DataVector; second and third indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      DataVector, Symmetry<3, 2, 2, 1>,
+      true, DataVector, Symmetry<3, 2, 2, 1>,
       index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
@@ -67,7 +67,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
 
   // Rank 4: DataVector; first, second, and fourth indices symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      DataVector, Symmetry<2, 2, 1, 2>,
+      true, DataVector, Symmetry<2, 2, 1, 2>,
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
@@ -76,7 +76,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
 
   // Rank 4: DataVector; symmetric
   TestHelpers::tenex::test_evaluate_rank_4<
-      DataVector, Symmetry<1, 1, 1, 1>,
+      true, DataVector, Symmetry<1, 1, 1, 1>,
       index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Up, Frame::Grid>,

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -3,254 +3,114 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <complex>
-#include <cstddef>
-#include <random>
-
-#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
-#include "Framework/TestHelpers.hpp"
-#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp"
 
 namespace {
 // \brief Test evaluation of tensors where generic spatial indices are used for
 // RHS spacetime indices
 //
 // \tparam DataType the type of data being stored in the expression operands
-template <typename DataType, typename Generator>
-void test_rhs(const DataType& used_for_size,
-              const gsl::not_null<Generator*> generator) {
-  std::uniform_real_distribution<> distribution(0.1, 1.0);
-  constexpr size_t dim = 3;
+template <typename DataType>
+void test_rhs() {
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>();
 
-  const auto R = make_with_random_values<
-      Tensor<DataType, Symmetry<2, 1>,
-             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
-      generator, distribution, used_for_size);
-
-  // \f$L_{ai} = R_{ai}\f$
-  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
-  // return type of `evaluate`
-  const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                          SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ai = tenex::evaluate<ti::a, ti::i>(R(ti::a, ti::i));
-
-  // \f$L_{ia} = R_{ai}\f$
-  const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
-                          SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ai = tenex::evaluate<ti::i, ti::a>(R(ti::a, ti::i));
-
-  // \f$L_{ai} = R_{ia}\f$
-  const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                          SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ia = tenex::evaluate<ti::a, ti::i>(R(ti::i, ti::a));
-
-  // \f$L_{ia} = R_{ia}\f$
-  const Tensor<DataType, Symmetry<2, 1>,
-               index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
-                          SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ia = tenex::evaluate<ti::i, ti::a>(R(ti::i, ti::a));
-
-  for (size_t a = 0; a < dim + 1; a++) {
-    for (size_t i = 0; i < dim; i++) {
-      CHECK(Lai_from_R_ai.get(a, i) == R.get(a, i + 1));
-      CHECK(Lia_from_R_ai.get(i, a) == R.get(a, i + 1));
-      CHECK(Lai_from_R_ia.get(a, i) == R.get(i + 1, a));
-      CHECK(Lia_from_R_ia.get(i, a) == R.get(i + 1, a));
-    }
-  }
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::i, ti::a, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
 }
 
 // \brief Test evaluation of tensors where generic spatial indices are used for
 // LHS spacetime indices
 //
 // \tparam DataType the type of data being stored in the expression operands
-template <typename DataType, typename Generator>
-void test_lhs(const DataType& used_for_size,
-              const gsl::not_null<Generator*> generator) {
-  std::uniform_real_distribution<> distribution(0.1, 1.0);
-  constexpr size_t dim = 3;
+template <typename DataType>
+void test_lhs() {
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::a, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
 
-  const auto R = make_with_random_values<
-      Tensor<DataType, Symmetry<2, 1>,
-             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                        SpatialIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
-      generator, distribution, used_for_size);
-
-  // \f$L_{ai} = R_{ai}\f$
-  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
-  // return type of `evaluate`
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ai(used_for_size);
-  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_R_ai), R(ti::a, ti::i));
-
-  // \f$L_{ia} = R_{ai}\f$
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ai(used_for_size);
-  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_R_ai), R(ti::a, ti::i));
-
-  const auto S = make_with_random_values<
-      Tensor<DataType, Symmetry<2, 1>,
-             index_list<SpatialIndex<dim, UpLo::Lo, Frame::Inertial>,
-                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
-      generator, distribution, used_for_size);
-
-  // \f$L_{ia} = S_{ia}\f$
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_S_ia(used_for_size);
-  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_S_ia), S(ti::i, ti::a));
-
-  // \f$L_{ai} = S_{ia}\f$
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_S_ia(used_for_size);
-  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_S_ia), S(ti::i, ti::a));
-
-  for (size_t a = 0; a < dim + 1; a++) {
-    for (size_t i = 0; i < dim; i++) {
-      CHECK(Lai_from_R_ai.get(a, i + 1) == R.get(a, i));
-      CHECK(Lia_from_R_ai.get(i + 1, a) == R.get(a, i));
-      CHECK(Lia_from_S_ia.get(i + 1, a) == S.get(i, a));
-      CHECK(Lai_from_S_ia.get(a, i + 1) == S.get(i, a));
-    }
-  }
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::a, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
 }
 
 // \brief Test evaluation of rank 2 tensors where generic spatial indices are
 // used for RHS and LHS spacetime indices
 //
 // \tparam DataType the type of data being stored in the expression operands
-template <typename DataType, typename Generator>
-void test_rhs_and_lhs_rank2(const DataType& used_for_size,
-                            const gsl::not_null<Generator*> generator) {
-  std::uniform_real_distribution<> distribution(0.1, 1.0);
-  constexpr size_t dim = 3;
+template <typename DataType>
+void test_rhs_and_lhs_rank2() {
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
 
-  const auto R = make_with_random_values<
-      Tensor<DataType, Symmetry<2, 1>,
-             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
-      generator, distribution, used_for_size);
-
-  // \f$L_{ai} = R_{ai}\f$
-  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
-  // return type of `evaluate`
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ai(used_for_size);
-  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_R_ai), R(ti::a, ti::i));
-
-  // \f$L_{ia} = R_{ai}\f$
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ai(used_for_size);
-  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_R_ai), R(ti::a, ti::i));
-
-  // \f$L_{ai} = R_{ia}\f$
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lai_from_R_ia(used_for_size);
-  tenex::evaluate<ti::a, ti::i>(make_not_null(&Lai_from_R_ia), R(ti::i, ti::a));
-
-  // \f$L_{ia} = R_{ia}\f$
-  Tensor<DataType, Symmetry<2, 1>,
-         index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      Lia_from_R_ia(used_for_size);
-  tenex::evaluate<ti::i, ti::a>(make_not_null(&Lia_from_R_ia), R(ti::i, ti::a));
-
-  for (size_t a = 0; a < dim + 1; a++) {
-    for (size_t i = 0; i < dim; i++) {
-      CHECK(Lai_from_R_ai.get(a, i + 1) == R.get(a, i + 1));
-      CHECK(Lia_from_R_ai.get(i + 1, a) == R.get(a, i + 1));
-      CHECK(Lai_from_R_ia.get(a, i + 1) == R.get(i + 1, a));
-      CHECK(Lia_from_R_ia.get(i + 1, a) == R.get(i + 1, a));
-    }
-  }
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::i, ti::a, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
 }
 
 // \brief Test evaluation of rank 4 tensors where generic spatial indices are
 // used for RHS and LHS spacetime indices
 //
 // \tparam DataType the type of data being stored in the expression operands
-template <typename DataType, typename Generator>
-void test_rhs_and_lhs_rank4(const DataType& used_for_size,
-                            const gsl::not_null<Generator*> generator) {
-  std::uniform_real_distribution<> distribution(0.1, 1.0);
-  constexpr size_t dim = 3;
-
-  const auto R = make_with_random_values<
-      Tensor<DataType, Symmetry<3, 2, 1, 2>,
-             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
-                        SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
-                        SpatialIndex<dim, UpLo::Lo, Frame::Grid>,
-                        SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>>>>(
-      generator, distribution, used_for_size);
-
-  // \f$L_{ai} = R_{ai}\f$
-  // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
-  // return type of `evaluate`
-  Tensor<DataType, Symmetry<4, 3, 2, 1>,
-         index_list<SpatialIndex<dim, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
-                    SpacetimeIndex<dim, UpLo::Lo, Frame::Grid>,
-                    SpatialIndex<dim, UpLo::Lo, Frame::Grid>>>
-      Likaj_from_R_jaik(used_for_size);
-  tenex::evaluate<ti::i, ti::k, ti::a, ti::j>(make_not_null(&Likaj_from_R_jaik),
-                                              R(ti::j, ti::a, ti::i, ti::k));
-
-  for (size_t i = 0; i < dim; i++) {
-    for (size_t k = 0; k < dim; k++) {
-      for (size_t a = 0; a < dim + 1; a++) {
-        for (size_t j = 0; j < dim; j++) {
-          CHECK(Likaj_from_R_jaik.get(i, k + 1, a, j) ==
-                R.get(j + 1, a, i, k + 1));
-        }
-      }
-    }
-  }
+template <typename DataType>
+void test_rhs_and_lhs_rank4() {
+  TestHelpers::tenex::test_evaluate_rank_4<
+      false, DataType, Symmetry<3, 2, 1, 2>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::j, ti::a, ti::i, ti::k, Symmetry<4, 3, 2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>();
 }
 
 template <typename DataType>
-void test_evaluate_spatial_spacetime_index(const DataType& used_for_size) {
-  MAKE_GENERATOR(generator);
-
-  test_rhs(used_for_size, make_not_null(&generator));
-  test_lhs(used_for_size, make_not_null(&generator));
-  test_rhs_and_lhs_rank2(used_for_size, make_not_null(&generator));
-  test_rhs_and_lhs_rank4(used_for_size, make_not_null(&generator));
+void test_evaluate_spatial_spacetime_index() {
+  test_rhs<DataType>();
+  test_lhs<DataType>();
+  test_rhs_and_lhs_rank2<DataType>();
+  test_rhs_and_lhs_rank4<DataType>();
 }
 }  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateSpatialSpacetimeIndex",
     "[DataStructures][Unit]") {
-  test_evaluate_spatial_spacetime_index(
-      std::numeric_limits<double>::signaling_NaN());
-  test_evaluate_spatial_spacetime_index(
-      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
-                           std::numeric_limits<double>::signaling_NaN()));
-  test_evaluate_spatial_spacetime_index(
-      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
-  test_evaluate_spatial_spacetime_index(
-      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_evaluate_spatial_spacetime_index<double>();
+  test_evaluate_spatial_spacetime_index<DataVector>();
 }

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank0.hpp
@@ -3,11 +3,17 @@
 
 #pragma once
 
-#include <type_traits>
+#include <limits>
+#include <random>
 
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -18,29 +24,38 @@ namespace TestHelpers::tenex {
 /// single rank 0 tensor correctly assigns the data to the evaluated left hand
 /// side tensor
 ///
-/// \param data the data being stored in the Tensors
+/// \tparam DataType the type of data being stored in the Tensors
 template <typename DataType>
-void test_evaluate_rank_0(const DataType& data) {
-  const Tensor<DataType> R{{{data}}};
+void test_evaluate_rank_0() {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-5.0, 5.0);
+  const size_t used_for_size = 3;
+  const auto R = make_with_random_values<Tensor<DataType>>(
+      make_not_null(&generator), distribution, used_for_size);
 
-  // Use explicit type (vs auto) so the compiler checks the return type of
-  // `evaluate`
-  const Tensor<DataType> L_returned = ::tenex::evaluate(R());
-  Tensor<DataType> L_filled{};
-  ::tenex::evaluate(make_not_null(&L_filled), R());
+  Scalar<DataType> L(used_for_size);
+  // component placeholder is used to detect if LHS scalar was not modified
+  std::fill(L.begin(), L.end(), component_placeholder_value<DataType>::value);
+  call_evaluate<true>(make_not_null(&L), R());
 
-  CHECK(L_returned.get() == data);
-  CHECK(L_filled.get() == data);
+  CHECK(L == R);  // check LHS evaluated correctly
 
-  // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
-    Variables<tmpl::list<::Tags::TempTensor<1, Tensor<DataType>>>> L_var{
-        data.size()};
-    Tensor<DataType>& L_temp =
-        get<::Tags::TempTensor<1, Tensor<DataType>>>(L_var);
-    ::tenex::evaluate(make_not_null(&L_temp), R());
+  // Test with Variables
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
+    Variables<tmpl::list<::Tags::TempTensor<0, Scalar<DataType>>,
+                         ::Tags::TempTensor<1, Scalar<DataType>>>>
+        vars(used_for_size, std::numeric_limits<double>::signaling_NaN());
 
-    CHECK(L_temp.get() == data);
+    Scalar<DataType>& R_temp =
+        get<::Tags::TempTensor<0, Scalar<DataType>>>(vars);
+    get(R_temp) = get(R);
+
+    Scalar<DataType>& L_temp =
+        get<::Tags::TempTensor<1, Scalar<DataType>>>(vars);
+    call_evaluate<true>(make_not_null(&L_temp), R());
+
+    CHECK(R_temp == R);  // check RHS wasn't modified
+    CHECK(L_temp == R);  // check LHS evaluated correctly
   }
 }
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank1.hpp
@@ -3,18 +3,22 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
-#include <iterator>
-#include <numeric>
-#include <type_traits>
+#include <random>
+#include <utility>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/IndexType.hpp"
-#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/TestHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::tenex {
@@ -24,46 +28,81 @@ namespace TestHelpers::tenex {
 /// single rank 1 tensor correctly assigns the data to the evaluated left hand
 /// side tensor
 ///
+/// \details See `test_evaluate_rank_3_impl` for general details.
+///
+/// \tparam ReturnLhsTensor whether to test tensor expression evaluation by
+/// returning the result tensor or not, which instead tests evaluation by
+/// assigning to the result tensor passed in as an argument
 /// \tparam DataType the type of data being stored in the Tensors
-/// \tparam TensorIndexTypeList the Tensors' typelist containing their
-/// \ref SpacetimeIndex "TensorIndexType"
+/// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
 /// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
 /// e.g. `ti::a`
-template <typename DataType, typename TensorIndexTypeList, auto& TensorIndex>
+/// \tparam LhsTensorIndexTypeList the LHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+template <bool ReturnLhsTensor, typename DataType,
+          typename RhsTensorIndexTypeList, auto& TensorIndex,
+          typename LhsTensorIndexTypeList = RhsTensorIndexTypeList>
 void test_evaluate_rank_1_impl() {
-  const size_t used_for_size = 5;
-  using tensor_type = Tensor<DataType, Symmetry<1>, TensorIndexTypeList>;
-  tensor_type R_a(used_for_size);
-  std::iota(R_a.begin(), R_a.end(), 0.0);
+  using symmetry = Symmetry<1>;
+  using L_a_type = Tensor<DataType, symmetry, LhsTensorIndexTypeList>;
+  using R_a_type = Tensor<DataType, symmetry, RhsTensorIndexTypeList>;
 
-  // L_a = R_a
-  // Use explicit type (vs auto) so the compiler checks return type of
-  // `evaluate`
-  const tensor_type L_a_returned =
-      ::tenex::evaluate<TensorIndex>(R_a(TensorIndex));
-  tensor_type L_a_filled{};
-  ::tenex::evaluate<TensorIndex>(make_not_null(&L_a_filled), R_a(TensorIndex));
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-5.0, 5.0);
+  const size_t used_for_size = 3;
+  const auto R_a = make_with_random_values<R_a_type>(
+      make_not_null(&generator), distribution, used_for_size);
+  auto expected_L_a =
+      ReturnLhsTensor
+          ? L_a_type{}
+          : make_with_value<L_a_type>(
+                used_for_size, component_placeholder_value<DataType>::value);
 
-  const size_t dim = tmpl::at_c<TensorIndexTypeList, 0>::dim;
+  using lhs_tensorindextype = tmpl::at_c<LhsTensorIndexTypeList, 0>;
+  using rhs_tensorindextype = tmpl::at_c<RhsTensorIndexTypeList, 0>;
 
-  // For L_a = R_a, check that L_i == R_i
-  for (size_t i = 0; i < dim; ++i) {
-    CHECK(L_a_returned.get(i) == R_a.get(i));
-    CHECK(L_a_filled.get(i) == R_a.get(i));
+  const std::pair<size_t, size_t> lhs_index_value_range =
+      get_index_value_range<lhs_tensorindextype, TensorIndex>();
+  const std::pair<size_t, size_t> rhs_index_value_range =
+      get_index_value_range<rhs_tensorindextype, TensorIndex>();
+
+  for (size_t lhs_a = lhs_index_value_range.first,
+              rhs_a = rhs_index_value_range.first;
+       lhs_a <= lhs_index_value_range.second; lhs_a++, rhs_a++) {
+    expected_L_a.get(lhs_a) = R_a.get(rhs_a);
   }
 
-  // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
-    // L_a = R_a
-    Variables<tmpl::list<::Tags::TempTensor<1, tensor_type>>> L_a_var{
-        used_for_size};
-    tensor_type& L_a_temp = get<::Tags::TempTensor<1, tensor_type>>(L_a_var);
-    ::tenex::evaluate<TensorIndex>(make_not_null(&L_a_temp), R_a(TensorIndex));
+  // L_a = R_a
+  L_a_type L_a(used_for_size);
+  // component placeholder is used to detect which components have incorrectly
+  // or correctly (in the case of using spatial or time indices for spacetime
+  // indices) not been modified by evaluation of the RHS expression
+  std::fill(L_a.begin(), L_a.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndex>(make_not_null(&L_a),
+                                              R_a(TensorIndex));
 
-    // For L_a = R_a, check that L_i == R_i
-    for (size_t i = 0; i < dim; ++i) {
-      CHECK(L_a_temp.get(i) == R_a.get(i));
-    }
+  CHECK(L_a == expected_L_a);  // check LHS evaluated correctly
+
+  // Test with Variables
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
+    Variables<tmpl::list<::Tags::TempTensor<0, R_a_type>,
+                         ::Tags::TempTensor<1, L_a_type>>>
+        vars(used_for_size, std::numeric_limits<double>::signaling_NaN());
+
+    R_a_type& R_a_temp = get<::Tags::TempTensor<0, R_a_type>>(vars);
+    R_a_temp = R_a;
+
+    // L_a = R_a
+    L_a_type& L_a_temp = get<::Tags::TempTensor<1, L_a_type>>(vars);
+    std::fill(L_a_temp.begin(), L_a_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndex>(make_not_null(&L_a_temp),
+                                                R_a(TensorIndex));
+
+    CHECK(R_a_temp == R_a);           // check RHS wasn't modified
+    CHECK(L_a_temp == expected_L_a);  // check LHS evaluated correctly
   }
 }
 
@@ -71,24 +110,34 @@ void test_evaluate_rank_1_impl() {
 /// \brief Iterate testing of evaluating single rank 1 Tensors on multiple
 /// dimensions
 ///
+/// \details See `test_evaluate_rank_3_impl` for general details.
+///
+/// \tparam ReturnLhsTensor whether to test tensor expression evaluation by
+/// returning the result tensor or not, which instead tests evaluation by
+/// assigning to the result tensor passed in as an argument
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsIndexTypeList the RHS Tensor's integral list of `IndexType`s
 /// \tparam TensorIndex the TensorIndex used in the the TensorExpression,
 /// e.g. `ti::a`
 /// \tparam Frame the frame of the tensor index
-template <typename DataType, typename RhsIndexTypeList, auto& TensorIndex,
-          typename Frame>
+/// \tparam LhsIndexTypeList the LHS Tensor's integral list of `IndexType`s
+template <bool ReturnLhsTensor, typename DataType, typename RhsIndexTypeList,
+          auto& TensorIndex, typename Frame,
+          typename LhsIndexTypeList = RhsIndexTypeList>
 void test_evaluate_rank_1() {
   constexpr IndexType rhs_indextype = tmpl::at_c<RhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype = tmpl::at_c<LhsIndexTypeList, 0>::value;
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define CALL_TEST_EVALUATE_RANK_1_IMPL(_, data)                   \
   test_evaluate_rank_1_impl<                                      \
-      DataType,                                                   \
+      ReturnLhsTensor, DataType,                                  \
       index_list<::Tensor_detail::TensorIndexType<                \
           DIM(data), TensorIndex.valence, Frame, rhs_indextype>>, \
-      TensorIndex>();
+      TensorIndex,                                                \
+      index_list<::Tensor_detail::TensorIndexType<                \
+          DIM(data), TensorIndex.valence, Frame, lhs_indextype>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_1_IMPL, (1, 2, 3))
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp
@@ -3,18 +3,26 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
-#include <numeric>
-#include <type_traits>
+#include <limits>
+#include <random>
+#include <utility>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/IndexType.hpp"
-#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/TestHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -25,18 +33,11 @@ namespace TestHelpers::tenex {
 /// single rank 2 tensor correctly assigns the data to the evaluated left hand
 /// side tensor
 ///
-/// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti::a` and `ti::b`. The "A" and "B" suffixes just
-/// denote the ordering of the generic indices of the RHS tensor expression. In
-/// the RHS tensor expression, it means `TensorIndexA` is the first index used
-/// and `TensorIndexB` is the second index used.
+/// \details See `test_evaluate_rank_3_impl` for general details.
 ///
-/// If we consider the RHS tensor's generic indices to be (a, b), then this test
-/// checks that the data in the evaluated LHS tensor is correct according to the
-/// index orders of the LHS and RHS. The two possible cases that are checked are
-/// when the LHS tensor is evaluated with index order (a, b) and when it is
-/// evaluated with the index order (b, a).
-///
+/// \tparam ReturnLhsTensor whether to test tensor expression evaluation by
+/// returning the result tensor or not, which instead tests evaluation by
+/// assigning to the result tensor passed in as an argument
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
@@ -45,71 +46,127 @@ namespace TestHelpers::tenex {
 /// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::B`
-template <typename DataType, typename RhsSymmetry,
+/// \tparam LhsSymmetry the ::Symmetry of the LHS Tensor
+/// \tparam LhsTensorIndexTypeList the LHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
-          auto& TensorIndexB>
+          auto& TensorIndexB, typename LhsSymmetry = RhsSymmetry,
+          typename LhsTensorIndexTypeList = RhsTensorIndexTypeList>
 void test_evaluate_rank_2_impl() {
-  const size_t used_for_size = 5;
-  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_ab(used_for_size);
-  std::iota(R_ab.begin(), R_ab.end(), 0.0);
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-5.0, 5.0);
+  const size_t used_for_size = 3;
+  using R_ab_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
+  const auto R_ab = make_with_random_values<R_ab_type>(
+      make_not_null(&generator), distribution, used_for_size);
+  auto expected_L_ab =
+      ReturnLhsTensor
+          ? Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>{}
+          : make_with_value<
+                Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>>(
+                used_for_size, component_placeholder_value<DataType>::value);
 
-  // L_{ab} = R_{ab}
-  // Use explicit type (vs auto) so the compiler checks the return type of
-  // `evaluate`
-  using L_ab_type = decltype(R_ab);
-  const L_ab_type L_ab_returned = ::tenex::evaluate<TensorIndexA, TensorIndexB>(
-      R_ab(TensorIndexA, TensorIndexB));
-  L_ab_type L_ab_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexB>(
-      make_not_null(&L_ab_filled), R_ab(TensorIndexA, TensorIndexB));
+  const std::int32_t lhs_symmetry_element_a = tmpl::at_c<LhsSymmetry, 0>::value;
+  const std::int32_t lhs_symmetry_element_b = tmpl::at_c<LhsSymmetry, 1>::value;
+  using lhs_tensorindextype_a = tmpl::at_c<LhsTensorIndexTypeList, 0>;
+  using lhs_tensorindextype_b = tmpl::at_c<LhsTensorIndexTypeList, 1>;
+  using rhs_tensorindextype_a = tmpl::at_c<RhsTensorIndexTypeList, 0>;
+  using rhs_tensorindextype_b = tmpl::at_c<RhsTensorIndexTypeList, 1>;
 
-  // L_{ba} = R_{ab}
-  using L_ba_tensorindextype_list =
-      tmpl::list<tmpl::at_c<RhsTensorIndexTypeList, 1>,
-                 tmpl::at_c<RhsTensorIndexTypeList, 0>>;
-  using L_ba_type = Tensor<DataType, RhsSymmetry, L_ba_tensorindextype_list>;
-  const L_ba_type L_ba_returned = ::tenex::evaluate<TensorIndexB, TensorIndexA>(
-      R_ab(TensorIndexA, TensorIndexB));
-  L_ba_type L_ba_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexA>(
-      make_not_null(&L_ba_filled), R_ab(TensorIndexA, TensorIndexB));
+  std::array<std::pair<size_t, size_t>, 2> lhs_index_value_ranges{};
+  lhs_index_value_ranges[0] =
+      get_index_value_range<lhs_tensorindextype_a, TensorIndexA>();
+  lhs_index_value_ranges[1] =
+      get_index_value_range<lhs_tensorindextype_b, TensorIndexB>();
+  std::array<std::pair<size_t, size_t>, 2> rhs_index_value_ranges{};
+  rhs_index_value_ranges[0] =
+      get_index_value_range<rhs_tensorindextype_a, TensorIndexA>();
+  rhs_index_value_ranges[1] =
+      get_index_value_range<rhs_tensorindextype_b, TensorIndexB>();
 
-  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
-  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
-
-  for (size_t i = 0; i < dim_a; ++i) {
-    for (size_t j = 0; j < dim_b; ++j) {
-      // For L_{ab} = R_{ab}, check that L_{ij} == R_{ij}
-      CHECK(L_ab_returned.get(i, j) == R_ab.get(i, j));
-      CHECK(L_ab_filled.get(i, j) == R_ab.get(i, j));
-      // For L_{ba} = R_{ab}, check that L_{ji} == R_{ij}
-      CHECK(L_ba_returned.get(j, i) == R_ab.get(i, j));
-      CHECK(L_ba_filled.get(j, i) == R_ab.get(i, j));
+  for (size_t lhs_a = lhs_index_value_ranges[0].first,
+              rhs_a = rhs_index_value_ranges[0].first;
+       lhs_a <= lhs_index_value_ranges[0].second; lhs_a++, rhs_a++) {
+    for (size_t lhs_b = lhs_index_value_ranges[1].first,
+                rhs_b = rhs_index_value_ranges[1].first;
+         lhs_b <= lhs_index_value_ranges[1].second; lhs_b++, rhs_b++) {
+      expected_L_ab.get(lhs_a, lhs_b) = R_ab.get(rhs_a, rhs_b);
     }
   }
 
-  // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
+  const auto rhs_expression = R_ab(TensorIndexA, TensorIndexB);
+
+  // L_{ab} = R_{ab}
+  using L_ab_type = Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>;
+  L_ab_type L_ab(used_for_size);
+  // component placeholder is used to detect which components have incorrectly
+  // or correctly (in the case of using spatial or time indices for spacetime
+  // indices) not been modified by evaluation of the RHS expression
+  std::fill(L_ab.begin(), L_ab.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexB>(
+      make_not_null(&L_ab), rhs_expression);
+
+  // L_{ba} = R_{ab}
+  using L_ba_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_a>;
+  using L_ba_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_a>;
+  using L_ba_type = Tensor<DataType, L_ba_symmetry, L_ba_tensorindextype_list>;
+  L_ba_type L_ba(used_for_size);
+  std::fill(L_ba.begin(), L_ba.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexA>(
+      make_not_null(&L_ba), rhs_expression);
+
+  const size_t dim_a = tmpl::at_c<LhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<LhsTensorIndexTypeList, 1>::dim;
+
+  // check LHS evaluated correctly
+  for (size_t lhs_a = 0; lhs_a < dim_a; ++lhs_a) {
+    for (size_t lhs_b = 0; lhs_b < dim_b; ++lhs_b) {
+      const auto& expected_result = expected_L_ab.get(lhs_a, lhs_b);
+
+      CHECK(L_ab.get(lhs_a, lhs_b) == expected_result);
+      CHECK(L_ba.get(lhs_b, lhs_a) == expected_result);
+    }
+  }
+
+  // Test with Variables
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
+    Variables<tmpl::list<::Tags::TempTensor<0, R_ab_type>,
+                         ::Tags::TempTensor<1, L_ab_type>,
+                         ::Tags::TempTensor<2, L_ba_type>>>
+        vars(used_for_size, std::numeric_limits<double>::signaling_NaN());
+
+    R_ab_type& R_ab_temp = get<::Tags::TempTensor<0, R_ab_type>>(vars);
+    R_ab_temp = R_ab;
+
     // L_{ab} = R_{ab}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_ab_type>>> L_ab_var{
-        used_for_size};
-    L_ab_type& L_ab_temp = get<::Tags::TempTensor<1, L_ab_type>>(L_ab_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexB>(
-        make_not_null(&L_ab_temp), R_ab(TensorIndexA, TensorIndexB));
+    L_ab_type& L_ab_temp = get<::Tags::TempTensor<1, L_ab_type>>(vars);
+    std::fill(L_ab_temp.begin(), L_ab_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexB>(
+        make_not_null(&L_ab_temp), rhs_expression);
 
     // L_{ba} = R_{ab}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_ba_type>>> L_ba_var{
-        used_for_size};
-    L_ba_type& L_ba_temp = get<::Tags::TempTensor<1, L_ba_type>>(L_ba_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexA>(
-        make_not_null(&L_ba_temp), R_ab(TensorIndexA, TensorIndexB));
+    L_ba_type& L_ba_temp = get<::Tags::TempTensor<2, L_ba_type>>(vars);
+    std::fill(L_ba_temp.begin(), L_ba_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexA>(
+        make_not_null(&L_ba_temp), rhs_expression);
 
-    for (size_t i = 0; i < dim_a; ++i) {
-      for (size_t j = 0; j < dim_b; ++j) {
-        // For L_{ab} = R_{ab}, check that L_{ij} == R_{ij}
-        CHECK(L_ab_temp.get(i, j) == R_ab.get(i, j));
-        // For L_{ba} = R_{ab}, check that L_{ji} == R_{ij}
-        CHECK(L_ba_temp.get(j, i) == R_ab.get(i, j));
+    // check RHS wasn't modified
+    CHECK(R_ab_temp == R_ab);
+
+    // check LHS evaluated correctly
+    for (size_t lhs_a = 0; lhs_a < dim_a; ++lhs_a) {
+      for (size_t lhs_b = 0; lhs_b < dim_b; ++lhs_b) {
+        const auto& expected_result = expected_L_ab.get(lhs_a, lhs_b);
+
+        CHECK(L_ab_temp.get(lhs_a, lhs_b) == expected_result);
+        CHECK(L_ba_temp.get(lhs_b, lhs_a) == expected_result);
       }
     }
   }
@@ -125,16 +182,11 @@ void test_evaluate_rank_2_impl() {
 /// - <2, 1>
 /// - <1, 1>
 ///
-/// \details `TensorIndexA` and `TensorIndexB` can be any type of TensorIndex
-/// and are not necessarily `ti::a` and `ti::b`. The "A" and "B" suffixes just
-/// denote the ordering of the generic indices of the RHS tensor expression. In
-/// the RHS tensor expression, it means `TensorIndexA` is the first index used
-/// and `TensorIndexB` is the second index used.
+/// \details See `test_evaluate_rank_3_impl` for general details.
 ///
-/// Note: `test_evaluate_rank_2_symmetric` has fewer template parameters due to
-/// the two indices having a shared \ref SpacetimeIndex "TensorIndexType" and
-/// and valence
-///
+/// \tparam ReturnLhsTensor whether to test tensor expression evaluation by
+/// returning the result tensor or not, which instead tests evaluation by
+/// assigning to the result tensor passed in as an argument
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsIndexTypeList the RHS Tensor's integral list of `IndexType`s
@@ -142,26 +194,37 @@ void test_evaluate_rank_2_impl() {
 /// TensorExpression, e.g. `ti::a`
 /// \tparam TensorIndexB the second TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::B`
-/// \tparam Frame the frame of the tensor indices
-template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
-          auto& TensorIndexA, auto& TensorIndexB, typename Frame,
+/// \tparam Frame the frame of the tensor index
+/// \tparam LhsSymmetry the ::Symmetry of the LHS Tensor
+/// \tparam LhsIndexTypeList the LHS Tensor's integral list of `IndexType`s
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
+          typename RhsIndexTypeList, auto& TensorIndexA, auto& TensorIndexB,
+          typename Frame, typename LhsSymmetry = RhsSymmetry,
+          typename LhsIndexTypeList = RhsIndexTypeList,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 1>>> = nullptr>
 void test_evaluate_rank_2() {
   constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
   constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+  constexpr IndexType lhs_indextype_a = tmpl::at_c<LhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype_b = tmpl::at_c<LhsIndexTypeList, 1>::value;
 
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                               \
   test_evaluate_rank_2_impl<                                                  \
-      DataType, RhsSymmetry,                                                  \
+      ReturnLhsTensor, DataType, RhsSymmetry,                                 \
       index_list<                                                             \
           ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence, \
                                            Frame, rhs_indextype_a>,           \
           ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence, \
                                            Frame, rhs_indextype_b>>,          \
-      TensorIndexA, TensorIndexB>();
+      TensorIndexA, TensorIndexB, LhsSymmetry,                                \
+      index_list<                                                             \
+          ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence, \
+                                           Frame, lhs_indextype_a>,           \
+          ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence, \
+                                           Frame, lhs_indextype_b>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3), (1, 2, 3))
 
@@ -172,24 +235,33 @@ void test_evaluate_rank_2() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
-          auto& TensorIndexA, auto& TensorIndexB, typename Frame,
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
+          typename RhsIndexTypeList, auto& TensorIndexA, auto& TensorIndexB,
+          typename Frame, typename LhsSymmetry = RhsSymmetry,
+          typename LhsIndexTypeList = RhsIndexTypeList,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 1>>> = nullptr>
 void test_evaluate_rank_2() {
   constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
   constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
+  constexpr IndexType lhs_indextype_a = tmpl::at_c<LhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype_b = tmpl::at_c<LhsIndexTypeList, 1>::value;
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define CALL_TEST_EVALUATE_RANK_2_IMPL(_, data)                             \
   test_evaluate_rank_2_impl<                                                \
-      DataType, RhsSymmetry,                                                \
+      ReturnLhsTensor, DataType, RhsSymmetry,                               \
       index_list<                                                           \
           ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexA.valence, \
                                            Frame, rhs_indextype_a>,         \
           ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexB.valence, \
                                            Frame, rhs_indextype_b>>,        \
-      TensorIndexA, TensorIndexB>();
+      TensorIndexA, TensorIndexB, LhsSymmetry,                              \
+      index_list<                                                           \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexA.valence, \
+                                           Frame, lhs_indextype_a>,         \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexB.valence, \
+                                           Frame, lhs_indextype_b>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_2_IMPL, (1, 2, 3))
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank3.hpp
@@ -3,19 +3,26 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
-#include <numeric>
-#include <type_traits>
+#include <limits>
+#include <random>
+#include <utility>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/IndexType.hpp"
-#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/TestHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -39,6 +46,27 @@ namespace TestHelpers::tenex {
 /// are when the LHS tensor is evaluated with index orders: (a, b, c),
 /// (a, c, b), (b, a, c), (b, c, a), (c, a, b), and (c, b, a).
 ///
+/// If `ReturnLhsTensor == true`, the `tenex::evaluate` overload that returns
+/// the LHS tensor will be tested. This, in turn, includes testing whether
+/// `tenex::evaluate` is deducing the correct LHS tensor return type, where
+/// `LhsSymmetry` is its expected symmetry and `LhsTensorIndexType` is its
+/// expected list of indices.
+///
+/// If `ReturnLhsTensor == false`, the `tenex::evaluate` overload that takes a
+/// LHS tensor as an argument will be tested. In this case, `LhsSymmetry` and
+/// `LhsTensorIndexList` can be different from and will override what would be
+/// automatically deduced from the RHS tensor expression. This is useful for
+/// testing evaluations where the desired LHS tensor type would not
+/// automatically be deduced from the RHS expression. For example, given some
+/// tensor \f$L_{abc}\f$ with three spacetime indices, one can test whether
+/// \f$L_{ijk} = ...\f$ correctly only assigns to the spatial-spatial-spatial
+/// components of the tensor. Likewise, `ReturnLhsTensor == false` is
+/// necessary to test cases where the LHS symmetry is different from what
+/// would be deduced from the RHS expression.
+///
+/// \tparam ReturnLhsTensor whether to test tensor expression evaluation by
+/// returning the result tensor or not, which instead tests evaluation by
+/// assigning to the result tensor passed in as an argument
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
@@ -49,214 +77,245 @@ namespace TestHelpers::tenex {
 /// TensorExpression, e.g. `ti::B`
 /// \tparam TensorIndexC the third TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::c`
-template <typename DataType, typename RhsSymmetry,
+/// \tparam LhsSymmetry the ::Symmetry of the LHS Tensor
+/// \tparam LhsTensorIndexTypeList the LHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
-          auto& TensorIndexB, auto& TensorIndexC>
+          auto& TensorIndexB, auto& TensorIndexC,
+          typename LhsSymmetry = RhsSymmetry,
+          typename LhsTensorIndexTypeList = RhsTensorIndexTypeList>
 void test_evaluate_rank_3_impl() {
-  const size_t used_for_size = 5;
-  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abc(used_for_size);
-  std::iota(R_abc.begin(), R_abc.end(), 0.0);
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-5.0, 5.0);
+  const size_t used_for_size = 3;
+  using R_abc_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
+  const auto R_abc = make_with_random_values<R_abc_type>(
+      make_not_null(&generator), distribution, used_for_size);
+  auto expected_L_abc =
+      ReturnLhsTensor
+          ? Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>{}
+          : make_with_value<
+                Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>>(
+                used_for_size, component_placeholder_value<DataType>::value);
 
-  // Used for enforcing the ordering of the symmetry and TensorIndexTypes of the
-  // LHS Tensor returned by `evaluate`
-  const std::int32_t rhs_symmetry_element_a = tmpl::at_c<RhsSymmetry, 0>::value;
-  const std::int32_t rhs_symmetry_element_b = tmpl::at_c<RhsSymmetry, 1>::value;
-  const std::int32_t rhs_symmetry_element_c = tmpl::at_c<RhsSymmetry, 2>::value;
+  const std::int32_t lhs_symmetry_element_a = tmpl::at_c<LhsSymmetry, 0>::value;
+  const std::int32_t lhs_symmetry_element_b = tmpl::at_c<LhsSymmetry, 1>::value;
+  const std::int32_t lhs_symmetry_element_c = tmpl::at_c<LhsSymmetry, 2>::value;
+  using lhs_tensorindextype_a = tmpl::at_c<LhsTensorIndexTypeList, 0>;
+  using lhs_tensorindextype_b = tmpl::at_c<LhsTensorIndexTypeList, 1>;
+  using lhs_tensorindextype_c = tmpl::at_c<LhsTensorIndexTypeList, 2>;
   using rhs_tensorindextype_a = tmpl::at_c<RhsTensorIndexTypeList, 0>;
   using rhs_tensorindextype_b = tmpl::at_c<RhsTensorIndexTypeList, 1>;
   using rhs_tensorindextype_c = tmpl::at_c<RhsTensorIndexTypeList, 2>;
 
-  // L_{abc} = R_{abc}
-  // Use explicit type (vs auto) so the compiler checks the return type of
-  // `evaluate`
-  using L_abc_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
-  const L_abc_type L_abc_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
-          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-  L_abc_type L_abc_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
-      make_not_null(&L_abc_filled),
-      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+  std::array<std::pair<size_t, size_t>, 3> lhs_index_value_ranges{};
+  lhs_index_value_ranges[0] =
+      get_index_value_range<lhs_tensorindextype_a, TensorIndexA>();
+  lhs_index_value_ranges[1] =
+      get_index_value_range<lhs_tensorindextype_b, TensorIndexB>();
+  lhs_index_value_ranges[2] =
+      get_index_value_range<lhs_tensorindextype_c, TensorIndexC>();
+  std::array<std::pair<size_t, size_t>, 3> rhs_index_value_ranges{};
+  rhs_index_value_ranges[0] =
+      get_index_value_range<rhs_tensorindextype_a, TensorIndexA>();
+  rhs_index_value_ranges[1] =
+      get_index_value_range<rhs_tensorindextype_b, TensorIndexB>();
+  rhs_index_value_ranges[2] =
+      get_index_value_range<rhs_tensorindextype_c, TensorIndexC>();
 
-  // L_{acb} = R_{abc}
-  using L_acb_symmetry =
-      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_c,
-               rhs_symmetry_element_b>;
-  using L_acb_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
-                 rhs_tensorindextype_b>;
-  using L_acb_type =
-      Tensor<DataType, L_acb_symmetry, L_acb_tensorindextype_list>;
-  const L_acb_type L_acb_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
-          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-  L_acb_type L_acb_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
-      make_not_null(&L_acb_filled),
-      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-
-  // L_{bac} = R_{abc}
-  using L_bac_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_a,
-               rhs_symmetry_element_c>;
-  using L_bac_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
-                 rhs_tensorindextype_c>;
-  using L_bac_type =
-      Tensor<DataType, L_bac_symmetry, L_bac_tensorindextype_list>;
-  const L_bac_type L_bac_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
-          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-  L_bac_type L_bac_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
-      make_not_null(&L_bac_filled),
-      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-
-  // L_{bca} = R_{abc}
-  using L_bca_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_c,
-               rhs_symmetry_element_a>;
-  using L_bca_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
-                 rhs_tensorindextype_a>;
-  using L_bca_type =
-      Tensor<DataType, L_bca_symmetry, L_bca_tensorindextype_list>;
-  const L_bca_type L_bca_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
-          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-  L_bca_type L_bca_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
-      make_not_null(&L_bca_filled),
-      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-
-  // L_{cab} = R_{abc}
-  using L_cab_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_a,
-               rhs_symmetry_element_b>;
-  using L_cab_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
-                 rhs_tensorindextype_b>;
-  using L_cab_type =
-      Tensor<DataType, L_cab_symmetry, L_cab_tensorindextype_list>;
-  const L_cab_type L_cab_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
-          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-  L_cab_type L_cab_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
-      make_not_null(&L_cab_filled),
-      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-
-  // L_{cba} = R_{abc}
-  using L_cba_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_b,
-               rhs_symmetry_element_a>;
-  using L_cba_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
-                 rhs_tensorindextype_a>;
-  using L_cba_type =
-      Tensor<DataType, L_cba_symmetry, L_cba_tensorindextype_list>;
-  const L_cba_type L_cba_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
-          R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-  L_cba_type L_cba_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
-      make_not_null(&L_cba_filled),
-      R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
-
-  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
-  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
-  const size_t dim_c = tmpl::at_c<RhsTensorIndexTypeList, 2>::dim;
-
-  for (size_t i = 0; i < dim_a; ++i) {
-    for (size_t j = 0; j < dim_b; ++j) {
-      for (size_t k = 0; k < dim_c; ++k) {
-        // For L_{abc} = R_{abc}, check that L_{ijk} == R_{ijk}
-        CHECK(L_abc_returned.get(i, j, k) == R_abc.get(i, j, k));
-        CHECK(L_abc_filled.get(i, j, k) == R_abc.get(i, j, k));
-        // For L_{acb} = R_{abc}, check that L_{ikj} == R_{ijk}
-        CHECK(L_acb_returned.get(i, k, j) == R_abc.get(i, j, k));
-        CHECK(L_acb_filled.get(i, k, j) == R_abc.get(i, j, k));
-        // For L_{bac} = R_{abc}, check that L_{jik} == R_{ijk}
-        CHECK(L_bac_returned.get(j, i, k) == R_abc.get(i, j, k));
-        CHECK(L_bac_filled.get(j, i, k) == R_abc.get(i, j, k));
-        // For L_{bca} = R_{abc}, check that L_{jki} == R_{ijk}
-        CHECK(L_bca_returned.get(j, k, i) == R_abc.get(i, j, k));
-        CHECK(L_bca_filled.get(j, k, i) == R_abc.get(i, j, k));
-        // For L_{cab} = R_{abc}, check that L_{kij} == R_{ijk}
-        CHECK(L_cab_returned.get(k, i, j) == R_abc.get(i, j, k));
-        CHECK(L_cab_filled.get(k, i, j) == R_abc.get(i, j, k));
-        // For L_{cba} = R_{abc}, check that L_{kji} == R_{ijk}
-        CHECK(L_cba_returned.get(k, j, i) == R_abc.get(i, j, k));
-        CHECK(L_cba_filled.get(k, j, i) == R_abc.get(i, j, k));
+  for (size_t lhs_a = lhs_index_value_ranges[0].first,
+              rhs_a = rhs_index_value_ranges[0].first;
+       lhs_a <= lhs_index_value_ranges[0].second; lhs_a++, rhs_a++) {
+    for (size_t lhs_b = lhs_index_value_ranges[1].first,
+                rhs_b = rhs_index_value_ranges[1].first;
+         lhs_b <= lhs_index_value_ranges[1].second; lhs_b++, rhs_b++) {
+      for (size_t lhs_c = lhs_index_value_ranges[2].first,
+                  rhs_c = rhs_index_value_ranges[2].first;
+           lhs_c <= lhs_index_value_ranges[2].second; lhs_c++, rhs_c++) {
+        expected_L_abc.get(lhs_a, lhs_b, lhs_c) =
+            R_abc.get(rhs_a, rhs_b, rhs_c);
       }
     }
   }
 
-  // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
+  const auto rhs_expression = R_abc(TensorIndexA, TensorIndexB, TensorIndexC);
+
+  // L_{abc} = R_{abc}
+  using L_abc_type = Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>;
+  L_abc_type L_abc(used_for_size);
+  // component placeholder is used to detect which components have incorrectly
+  // or correctly (in the case of using spatial or time indices for spacetime
+  // indices) not been modified by evaluation of the RHS expression
+  std::fill(L_abc.begin(), L_abc.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexB, TensorIndexC>(
+      make_not_null(&L_abc), rhs_expression);
+
+  // L_{acb} = R_{abc}
+  using L_acb_symmetry =
+      Symmetry<lhs_symmetry_element_a, lhs_symmetry_element_c,
+               lhs_symmetry_element_b>;
+  using L_acb_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_a, lhs_tensorindextype_c,
+                 lhs_tensorindextype_b>;
+  using L_acb_type =
+      Tensor<DataType, L_acb_symmetry, L_acb_tensorindextype_list>;
+  L_acb_type L_acb(used_for_size);
+  std::fill(L_acb.begin(), L_acb.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexC, TensorIndexB>(
+      make_not_null(&L_acb), rhs_expression);
+
+  // L_{bac} = R_{abc}
+  using L_bac_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_a,
+               lhs_symmetry_element_c>;
+  using L_bac_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_a,
+                 lhs_tensorindextype_c>;
+  using L_bac_type =
+      Tensor<DataType, L_bac_symmetry, L_bac_tensorindextype_list>;
+  L_bac_type L_bac(used_for_size);
+  std::fill(L_bac.begin(), L_bac.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexA, TensorIndexC>(
+      make_not_null(&L_bac), rhs_expression);
+
+  // L_{bca} = R_{abc}
+  using L_bca_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_c,
+               lhs_symmetry_element_a>;
+  using L_bca_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_c,
+                 lhs_tensorindextype_a>;
+  using L_bca_type =
+      Tensor<DataType, L_bca_symmetry, L_bca_tensorindextype_list>;
+  L_bca_type L_bca(used_for_size);
+  std::fill(L_bca.begin(), L_bca.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexC, TensorIndexA>(
+      make_not_null(&L_bca), rhs_expression);
+
+  // L_{cab} = R_{abc}
+  using L_cab_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_a,
+               lhs_symmetry_element_b>;
+  using L_cab_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_a,
+                 lhs_tensorindextype_b>;
+  using L_cab_type =
+      Tensor<DataType, L_cab_symmetry, L_cab_tensorindextype_list>;
+  L_cab_type L_cab(used_for_size);
+  std::fill(L_cab.begin(), L_cab.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexA, TensorIndexB>(
+      make_not_null(&L_cab), rhs_expression);
+
+  // L_{cba} = R_{abc}
+  using L_cba_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_b,
+               lhs_symmetry_element_a>;
+  using L_cba_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_b,
+                 lhs_tensorindextype_a>;
+  using L_cba_type =
+      Tensor<DataType, L_cba_symmetry, L_cba_tensorindextype_list>;
+  L_cba_type L_cba(used_for_size);
+  std::fill(L_cba.begin(), L_cba.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexB, TensorIndexA>(
+      make_not_null(&L_cba), rhs_expression);
+
+  const size_t dim_a = tmpl::at_c<LhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<LhsTensorIndexTypeList, 1>::dim;
+  const size_t dim_c = tmpl::at_c<LhsTensorIndexTypeList, 2>::dim;
+
+  // check LHS evaluated correctly
+  for (size_t lhs_a = 0; lhs_a < dim_a; ++lhs_a) {
+    for (size_t lhs_b = 0; lhs_b < dim_b; ++lhs_b) {
+      for (size_t lhs_c = 0; lhs_c < dim_c; ++lhs_c) {
+        const auto& expected_result = expected_L_abc.get(lhs_a, lhs_b, lhs_c);
+
+        CHECK(L_abc.get(lhs_a, lhs_b, lhs_c) == expected_result);
+        CHECK(L_acb.get(lhs_a, lhs_c, lhs_b) == expected_result);
+        CHECK(L_bac.get(lhs_b, lhs_a, lhs_c) == expected_result);
+        CHECK(L_bca.get(lhs_b, lhs_c, lhs_a) == expected_result);
+        CHECK(L_cab.get(lhs_c, lhs_a, lhs_b) == expected_result);
+        CHECK(L_cba.get(lhs_c, lhs_b, lhs_a) == expected_result);
+      }
+    }
+  }
+
+  // Test with Variables
+  if constexpr (is_derived_of_vector_impl_v<DataType>) {
+    Variables<tmpl::list<
+        ::Tags::TempTensor<0, R_abc_type>, ::Tags::TempTensor<1, L_abc_type>,
+        ::Tags::TempTensor<2, L_acb_type>, ::Tags::TempTensor<3, L_bac_type>,
+        ::Tags::TempTensor<4, L_bca_type>, ::Tags::TempTensor<5, L_cab_type>,
+        ::Tags::TempTensor<6, L_cba_type>>>
+        vars(used_for_size, std::numeric_limits<double>::signaling_NaN());
+
+    R_abc_type& R_abc_temp = get<::Tags::TempTensor<0, R_abc_type>>(vars);
+    R_abc_temp = R_abc;
+
     // L_{abc} = R_{abc}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_abc_type>>> L_abc_var{
-        used_for_size};
-    L_abc_type& L_abc_temp = get<::Tags::TempTensor<1, L_abc_type>>(L_abc_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC>(
-        make_not_null(&L_abc_temp),
-        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+    L_abc_type& L_abc_temp = get<::Tags::TempTensor<1, L_abc_type>>(vars);
+    std::fill(L_abc_temp.begin(), L_abc_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexB, TensorIndexC>(
+        make_not_null(&L_abc_temp), rhs_expression);
 
     // L_{acb} = R_{abc}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_acb_type>>> L_acb_var{
-        used_for_size};
-    L_acb_type& L_acb_temp = get<::Tags::TempTensor<1, L_acb_type>>(L_acb_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB>(
-        make_not_null(&L_acb_temp),
-        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+    L_acb_type& L_acb_temp = get<::Tags::TempTensor<2, L_acb_type>>(vars);
+    std::fill(L_acb_temp.begin(), L_acb_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexC, TensorIndexB>(
+        make_not_null(&L_acb_temp), rhs_expression);
 
     // L_{bac} = R_{abc}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_bac_type>>> L_bac_var{
-        used_for_size};
-    L_bac_type& L_bac_temp = get<::Tags::TempTensor<1, L_bac_type>>(L_bac_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC>(
-        make_not_null(&L_bac_temp),
-        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+    L_bac_type& L_bac_temp = get<::Tags::TempTensor<3, L_bac_type>>(vars);
+    std::fill(L_bac_temp.begin(), L_bac_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexA, TensorIndexC>(
+        make_not_null(&L_bac_temp), rhs_expression);
 
     // L_{bca} = R_{abc}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_bca_type>>> L_bca_var{
-        used_for_size};
-    L_bca_type& L_bca_temp = get<::Tags::TempTensor<1, L_bca_type>>(L_bca_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA>(
-        make_not_null(&L_bca_temp),
-        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+    L_bca_type& L_bca_temp = get<::Tags::TempTensor<4, L_bca_type>>(vars);
+    std::fill(L_bca_temp.begin(), L_bca_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexC, TensorIndexA>(
+        make_not_null(&L_bca_temp), rhs_expression);
 
     // L_{cab} = R_{abc}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cab_type>>> L_cab_var{
-        used_for_size};
-    L_cab_type& L_cab_temp = get<::Tags::TempTensor<1, L_cab_type>>(L_cab_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB>(
-        make_not_null(&L_cab_temp),
-        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+    L_cab_type& L_cab_temp = get<::Tags::TempTensor<5, L_cab_type>>(vars);
+    std::fill(L_cab_temp.begin(), L_cab_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexA, TensorIndexB>(
+        make_not_null(&L_cab_temp), rhs_expression);
 
     // L_{cba} = R_{abc}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cba_type>>> L_cba_var{
-        used_for_size};
-    L_cba_type& L_cba_temp = get<::Tags::TempTensor<1, L_cba_type>>(L_cba_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA>(
-        make_not_null(&L_cba_temp),
-        R_abc(TensorIndexA, TensorIndexB, TensorIndexC));
+    L_cba_type& L_cba_temp = get<::Tags::TempTensor<6, L_cba_type>>(vars);
+    std::fill(L_cba_temp.begin(), L_cba_temp.end(),
+              component_placeholder_value<DataType>::value);
+    call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexB, TensorIndexA>(
+        make_not_null(&L_cba_temp), rhs_expression);
 
-    for (size_t i = 0; i < dim_a; ++i) {
-      for (size_t j = 0; j < dim_b; ++j) {
-        for (size_t k = 0; k < dim_c; ++k) {
-          // For L_{abc} = R_{abc}, check that L_{ijk} == R_{ijk}
-          CHECK(L_abc_temp.get(i, j, k) == R_abc.get(i, j, k));
-          // For L_{acb} = R_{abc}, check that L_{ikj} == R_{ijk}
-          CHECK(L_acb_temp.get(i, k, j) == R_abc.get(i, j, k));
-          // For L_{bac} = R_{abc}, check that L_{jik} == R_{ijk}
-          CHECK(L_bac_temp.get(j, i, k) == R_abc.get(i, j, k));
-          // For L_{bca} = R_{abc}, check that L_{jki} == R_{ijk}
-          CHECK(L_bca_temp.get(j, k, i) == R_abc.get(i, j, k));
-          // For L_{cab} = R_{abc}, check that L_{kij} == R_{ijk}
-          CHECK(L_cab_temp.get(k, i, j) == R_abc.get(i, j, k));
-          // For L_{cba} = R_{abc}, check that L_{kji} == R_{ijk}
-          CHECK(L_cba_temp.get(k, j, i) == R_abc.get(i, j, k));
+    // check RHS wasn't modified
+    CHECK(R_abc_temp == R_abc);
+
+    // check LHS evaluated correctly
+    for (size_t lhs_a = 0; lhs_a < dim_a; ++lhs_a) {
+      for (size_t lhs_b = 0; lhs_b < dim_b; ++lhs_b) {
+        for (size_t lhs_c = 0; lhs_c < dim_c; ++lhs_c) {
+          const auto& expected_result = expected_L_abc.get(lhs_a, lhs_b, lhs_c);
+
+          CHECK(L_abc_temp.get(lhs_a, lhs_b, lhs_c) == expected_result);
+          CHECK(L_acb_temp.get(lhs_a, lhs_c, lhs_b) == expected_result);
+          CHECK(L_bac_temp.get(lhs_b, lhs_a, lhs_c) == expected_result);
+          CHECK(L_bca_temp.get(lhs_b, lhs_c, lhs_a) == expected_result);
+          CHECK(L_cab_temp.get(lhs_c, lhs_a, lhs_b) == expected_result);
+          CHECK(L_cba_temp.get(lhs_c, lhs_b, lhs_a) == expected_result);
         }
       }
     }
@@ -276,17 +335,11 @@ void test_evaluate_rank_3_impl() {
 /// - <2, 1, 1>
 /// - <1, 1, 1>
 ///
-/// \details `TensorIndexA`, `TensorIndexB`, and `TensorIndexC` can be any type
-/// of TensorIndex and are not necessarily `ti::a`, `ti::b`, and `ti::c`. The
-/// "A", "B", and "C" suffixes just denote the ordering of the generic indices
-/// of the RHS tensor expression. In the RHS tensor expression, it means
-/// `TensorIndexA` is the first index used, `TensorIndexB` is the second index
-/// used, and `TensorIndexC` is the third index used.
+/// \details See `test_evaluate_rank_3_impl` for general details.
 ///
-/// Note: the functions dealing with symmetric indices have fewer template
-/// parameters due to the indices having a shared \ref SpacetimeIndex
-/// "TensorIndexType" and valence
-///
+/// \tparam ReturnLhsTensor whether to test tensor expression evaluation by
+/// returning the result tensor or not, which instead tests evaluation by
+/// assigning to the result tensor passed in as an argument
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsIndexTypeList the RHS Tensor's integral list of `IndexType`s
@@ -296,15 +349,22 @@ void test_evaluate_rank_3_impl() {
 /// TensorExpression, e.g. `ti::B`
 /// \tparam TensorIndexC the third TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::c`
-/// \tparam Frame the frame of the tensor indices
-template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
-          typename Frame,
+/// \tparam Frame the frame of the tensor index
+/// \tparam LhsSymmetry the ::Symmetry of the LHS Tensor
+/// \tparam LhsIndexTypeList the LHS Tensor's integral list of `IndexType`s
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
+          typename RhsIndexTypeList, auto& TensorIndexA, auto& TensorIndexB,
+          auto& TensorIndexC, typename Frame,
+          typename LhsSymmetry = RhsSymmetry,
+          typename LhsIndexTypeList = RhsIndexTypeList,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<3, 2, 1>>> = nullptr>
 void test_evaluate_rank_3() {
   constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
   constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
   constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+  constexpr IndexType lhs_indextype_a = tmpl::at_c<LhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype_b = tmpl::at_c<LhsIndexTypeList, 1>::value;
+  constexpr IndexType lhs_indextype_c = tmpl::at_c<LhsIndexTypeList, 2>::value;
 
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
@@ -312,15 +372,23 @@ void test_evaluate_rank_3() {
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                               \
   test_evaluate_rank_3_impl<                                                  \
-      DataType, RhsSymmetry,                                                  \
+      ReturnLhsTensor, DataType, RhsSymmetry,                                 \
       index_list<                                                             \
+                                                                              \
           ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence, \
                                            Frame, rhs_indextype_a>,           \
           ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence, \
                                            Frame, rhs_indextype_b>,           \
           ::Tensor_detail::TensorIndexType<DIM_C(data), TensorIndexC.valence, \
                                            Frame, rhs_indextype_c>>,          \
-      TensorIndexA, TensorIndexB, TensorIndexC>();
+      TensorIndexA, TensorIndexB, TensorIndexC, LhsSymmetry,                  \
+      index_list<                                                             \
+          ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence, \
+                                           Frame, lhs_indextype_a>,           \
+          ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence, \
+                                           Frame, lhs_indextype_b>,           \
+          ::Tensor_detail::TensorIndexType<DIM_C(data), TensorIndexC.valence, \
+                                           Frame, lhs_indextype_c>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3),
                           (1, 2, 3))
@@ -333,21 +401,26 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
-          typename Frame,
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
+          typename RhsIndexTypeList, auto& TensorIndexA, auto& TensorIndexB,
+          auto& TensorIndexC, typename Frame,
+          typename LhsSymmetry = RhsSymmetry,
+          typename LhsIndexTypeList = RhsIndexTypeList,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 2, 1>>> = nullptr>
 void test_evaluate_rank_3() {
   constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
   constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
   constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+  constexpr IndexType lhs_indextype_a = tmpl::at_c<LhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype_b = tmpl::at_c<LhsIndexTypeList, 1>::value;
+  constexpr IndexType lhs_indextype_c = tmpl::at_c<LhsIndexTypeList, 2>::value;
 
 #define DIM_AB(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_C(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
   test_evaluate_rank_3_impl<                                                   \
-      DataType, RhsSymmetry,                                                   \
+      ReturnLhsTensor, DataType, RhsSymmetry,                                  \
       index_list<                                                              \
           ::Tensor_detail::TensorIndexType<DIM_AB(data), TensorIndexA.valence, \
                                            Frame, rhs_indextype_a>,            \
@@ -355,7 +428,14 @@ void test_evaluate_rank_3() {
                                            Frame, rhs_indextype_b>,            \
           ::Tensor_detail::TensorIndexType<DIM_C(data), TensorIndexC.valence,  \
                                            Frame, rhs_indextype_c>>,           \
-      TensorIndexA, TensorIndexB, TensorIndexC>();
+      TensorIndexA, TensorIndexB, TensorIndexC, LhsSymmetry,                   \
+      index_list<                                                              \
+          ::Tensor_detail::TensorIndexType<DIM_AB(data), TensorIndexA.valence, \
+                                           Frame, lhs_indextype_a>,            \
+          ::Tensor_detail::TensorIndexType<DIM_AB(data), TensorIndexB.valence, \
+                                           Frame, lhs_indextype_b>,            \
+          ::Tensor_detail::TensorIndexType<DIM_C(data), TensorIndexC.valence,  \
+                                           Frame, lhs_indextype_c>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
 
@@ -366,21 +446,26 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
-          typename Frame,
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
+          typename RhsIndexTypeList, auto& TensorIndexA, auto& TensorIndexB,
+          auto& TensorIndexC, typename Frame,
+          typename LhsSymmetry = RhsSymmetry,
+          typename LhsIndexTypeList = RhsIndexTypeList,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 2, 1>>> = nullptr>
 void test_evaluate_rank_3() {
   constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
   constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
   constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+  constexpr IndexType lhs_indextype_a = tmpl::at_c<LhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype_b = tmpl::at_c<LhsIndexTypeList, 1>::value;
+  constexpr IndexType lhs_indextype_c = tmpl::at_c<LhsIndexTypeList, 2>::value;
 
 #define DIM_AC(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_B(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
   test_evaluate_rank_3_impl<                                                   \
-      DataType, RhsSymmetry,                                                   \
+      ReturnLhsTensor, DataType, RhsSymmetry,                                  \
       index_list<                                                              \
           ::Tensor_detail::TensorIndexType<DIM_AC(data), TensorIndexA.valence, \
                                            Frame, rhs_indextype_a>,            \
@@ -388,7 +473,14 @@ void test_evaluate_rank_3() {
                                            Frame, rhs_indextype_b>,            \
           ::Tensor_detail::TensorIndexType<DIM_AC(data), TensorIndexC.valence, \
                                            Frame, rhs_indextype_c>>,           \
-      TensorIndexA, TensorIndexB, TensorIndexC>();
+      TensorIndexA, TensorIndexB, TensorIndexC, LhsSymmetry,                   \
+      index_list<                                                              \
+          ::Tensor_detail::TensorIndexType<DIM_AC(data), TensorIndexA.valence, \
+                                           Frame, lhs_indextype_a>,            \
+          ::Tensor_detail::TensorIndexType<DIM_B(data), TensorIndexB.valence,  \
+                                           Frame, lhs_indextype_b>,            \
+          ::Tensor_detail::TensorIndexType<DIM_AC(data), TensorIndexC.valence, \
+                                           Frame, lhs_indextype_c>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
 
@@ -399,21 +491,26 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
-          typename Frame,
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
+          typename RhsIndexTypeList, auto& TensorIndexA, auto& TensorIndexB,
+          auto& TensorIndexC, typename Frame,
+          typename LhsSymmetry = RhsSymmetry,
+          typename LhsIndexTypeList = RhsIndexTypeList,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<2, 1, 1>>> = nullptr>
 void test_evaluate_rank_3() {
   constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
   constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
   constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+  constexpr IndexType lhs_indextype_a = tmpl::at_c<LhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype_b = tmpl::at_c<LhsIndexTypeList, 1>::value;
+  constexpr IndexType lhs_indextype_c = tmpl::at_c<LhsIndexTypeList, 2>::value;
 
 #define DIM_A(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DIM_BC(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                                \
   test_evaluate_rank_3_impl<                                                   \
-      DataType, RhsSymmetry,                                                   \
+      ReturnLhsTensor, DataType, RhsSymmetry,                                  \
       index_list<                                                              \
           ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence,  \
                                            Frame, rhs_indextype_a>,            \
@@ -421,7 +518,14 @@ void test_evaluate_rank_3() {
                                            Frame, rhs_indextype_b>,            \
           ::Tensor_detail::TensorIndexType<DIM_BC(data), TensorIndexC.valence, \
                                            Frame, rhs_indextype_c>>,           \
-      TensorIndexA, TensorIndexB, TensorIndexC>();
+      TensorIndexA, TensorIndexB, TensorIndexC, LhsSymmetry,                   \
+      index_list<                                                              \
+          ::Tensor_detail::TensorIndexType<DIM_A(data), TensorIndexA.valence,  \
+                                           Frame, lhs_indextype_a>,            \
+          ::Tensor_detail::TensorIndexType<DIM_BC(data), TensorIndexB.valence, \
+                                           Frame, lhs_indextype_b>,            \
+          ::Tensor_detail::TensorIndexType<DIM_BC(data), TensorIndexC.valence, \
+                                           Frame, lhs_indextype_c>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3), (1, 2, 3))
 
@@ -432,20 +536,25 @@ void test_evaluate_rank_3() {
 }
 
 /// \ingroup TestingFrameworkGroup
-template <typename DataType, typename RhsSymmetry, typename RhsIndexTypeList,
-          auto& TensorIndexA, auto& TensorIndexB, auto& TensorIndexC,
-          typename Frame,
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
+          typename RhsIndexTypeList, auto& TensorIndexA, auto& TensorIndexB,
+          auto& TensorIndexC, typename Frame,
+          typename LhsSymmetry = RhsSymmetry,
+          typename LhsIndexTypeList = RhsIndexTypeList,
           Requires<std::is_same_v<RhsSymmetry, Symmetry<1, 1, 1>>> = nullptr>
 void test_evaluate_rank_3() {
   constexpr IndexType rhs_indextype_a = tmpl::at_c<RhsIndexTypeList, 0>::value;
   constexpr IndexType rhs_indextype_b = tmpl::at_c<RhsIndexTypeList, 1>::value;
   constexpr IndexType rhs_indextype_c = tmpl::at_c<RhsIndexTypeList, 2>::value;
+  constexpr IndexType lhs_indextype_a = tmpl::at_c<LhsIndexTypeList, 0>::value;
+  constexpr IndexType lhs_indextype_b = tmpl::at_c<LhsIndexTypeList, 1>::value;
+  constexpr IndexType lhs_indextype_c = tmpl::at_c<LhsIndexTypeList, 2>::value;
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define CALL_TEST_EVALUATE_RANK_3_IMPL(_, data)                             \
   test_evaluate_rank_3_impl<                                                \
-      DataType, RhsSymmetry,                                                \
+      ReturnLhsTensor, DataType, RhsSymmetry,                               \
       index_list<                                                           \
           ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexA.valence, \
                                            Frame, rhs_indextype_a>,         \
@@ -453,7 +562,14 @@ void test_evaluate_rank_3() {
                                            Frame, rhs_indextype_b>,         \
           ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexC.valence, \
                                            Frame, rhs_indextype_c>>,        \
-      TensorIndexA, TensorIndexB, TensorIndexC>();
+      TensorIndexA, TensorIndexB, TensorIndexC, LhsSymmetry,                \
+      index_list<                                                           \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexA.valence, \
+                                           Frame, lhs_indextype_a>,         \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexB.valence, \
+                                           Frame, lhs_indextype_b>,         \
+          ::Tensor_detail::TensorIndexType<DIM(data), TensorIndexC.valence, \
+                                           Frame, lhs_indextype_c>>>();
 
   GENERATE_INSTANTIATIONS(CALL_TEST_EVALUATE_RANK_3_IMPL, (1, 2, 3))
 

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp
@@ -3,17 +3,27 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
-#include <numeric>
-#include <type_traits>
+#include <limits>
+#include <random>
+#include <utility>
 
 #include "DataStructures/Tags/TempTensor.hpp"
-#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/TestHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace TestHelpers::tenex {
@@ -23,20 +33,11 @@ namespace TestHelpers::tenex {
 /// single rank 4 tensor correctly assigns the data to the evaluated left hand
 /// side tensor
 ///
-/// \details `TensorIndexA`, `TensorIndexB`, `TensorIndexC`, and  `TensorIndexD`
-/// can be any type of TensorIndex and are not necessarily `ti::a`, `ti::b`,
-/// `ti::c`, and `ti::d`. The "A", "B", "C", and "D" suffixes just denote the
-/// ordering of the generic indices of the RHS tensor expression. In the RHS
-/// tensor expression, it means `TensorIndexA` is the first index used,
-/// `TensorIndexB` is the second index used, `TensorIndexC` is the third index
-/// used, and `TensorIndexD` is the fourth index used.
+/// \details See `test_evaluate_rank_3_impl` for general details.
 ///
-/// If we consider the RHS tensor's generic indices to be (a, b, c, d), then
-/// this test checks that the data in the evaluated LHS tensor is correct
-/// according to the index orders of the LHS and RHS. The possible cases that
-/// are checked are when the LHS tensor is evaluated with index orders of all 24
-/// permutations of (a, b, c, d), e.g. (a, b, d, c), (a, c, b, d), ...
-///
+/// \tparam ReturnLhsTensor whether to test tensor expression evaluation by
+/// returning the result tensor or not, which instead tests evaluation by
+/// assigning to the result tensor passed in as an argument
 /// \tparam DataType the type of data being stored in the Tensors
 /// \tparam RhsSymmetry the ::Symmetry of the RHS Tensor
 /// \tparam RhsTensorIndexTypeList the RHS Tensor's typelist of
@@ -49,785 +50,475 @@ namespace TestHelpers::tenex {
 /// TensorExpression, e.g. `ti::c`
 /// \tparam TensorIndexD the fourth TensorIndex used on the RHS of the
 /// TensorExpression, e.g. `ti::D`
-template <typename DataType, typename RhsSymmetry,
+/// \tparam LhsSymmetry the ::Symmetry of the LHS Tensor
+/// \tparam LhsTensorIndexTypeList the LHS Tensor's typelist of
+/// \ref SpacetimeIndex "TensorIndexType"s
+template <bool ReturnLhsTensor, typename DataType, typename RhsSymmetry,
           typename RhsTensorIndexTypeList, auto& TensorIndexA,
-          auto& TensorIndexB, auto& TensorIndexC, auto& TensorIndexD>
+          auto& TensorIndexB, auto& TensorIndexC, auto& TensorIndexD,
+          typename LhsSymmetry = RhsSymmetry,
+          typename LhsTensorIndexTypeList = RhsTensorIndexTypeList>
 void test_evaluate_rank_4() {
-  const size_t used_for_size = 5;
-  Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList> R_abcd(used_for_size);
-  std::iota(R_abcd.begin(), R_abcd.end(), 0.0);
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> distribution(-5.0, 5.0);
+  const size_t used_for_size = 3;
+  const auto R_abcd = make_with_random_values<
+      Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>>(
+      make_not_null(&generator), distribution, used_for_size);
+  auto expected_L_abcd =
+      ReturnLhsTensor
+          ? Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>{}
+          : make_with_value<
+                Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>>(
+                used_for_size, component_placeholder_value<DataType>::value);
 
-  // Used for enforcing the ordering of the symmetry and TensorIndexTypes of the
-  // LHS Tensor returned by `evaluate`
-  const std::int32_t rhs_symmetry_element_a = tmpl::at_c<RhsSymmetry, 0>::value;
-  const std::int32_t rhs_symmetry_element_b = tmpl::at_c<RhsSymmetry, 1>::value;
-  const std::int32_t rhs_symmetry_element_c = tmpl::at_c<RhsSymmetry, 2>::value;
-  const std::int32_t rhs_symmetry_element_d = tmpl::at_c<RhsSymmetry, 3>::value;
+  const std::int32_t lhs_symmetry_element_a = tmpl::at_c<LhsSymmetry, 0>::value;
+  const std::int32_t lhs_symmetry_element_b = tmpl::at_c<LhsSymmetry, 1>::value;
+  const std::int32_t lhs_symmetry_element_c = tmpl::at_c<LhsSymmetry, 2>::value;
+  const std::int32_t lhs_symmetry_element_d = tmpl::at_c<LhsSymmetry, 3>::value;
+  using lhs_tensorindextype_a = tmpl::at_c<LhsTensorIndexTypeList, 0>;
+  using lhs_tensorindextype_b = tmpl::at_c<LhsTensorIndexTypeList, 1>;
+  using lhs_tensorindextype_c = tmpl::at_c<LhsTensorIndexTypeList, 2>;
+  using lhs_tensorindextype_d = tmpl::at_c<LhsTensorIndexTypeList, 3>;
   using rhs_tensorindextype_a = tmpl::at_c<RhsTensorIndexTypeList, 0>;
   using rhs_tensorindextype_b = tmpl::at_c<RhsTensorIndexTypeList, 1>;
   using rhs_tensorindextype_c = tmpl::at_c<RhsTensorIndexTypeList, 2>;
   using rhs_tensorindextype_d = tmpl::at_c<RhsTensorIndexTypeList, 3>;
 
-  // L_{abcd} = R_{abcd}
-  // Use explicit type (vs auto) so the compiler checks the return type of
-  // `evaluate`
-  using L_abcd_type = Tensor<DataType, RhsSymmetry, RhsTensorIndexTypeList>;
-  const L_abcd_type L_abcd_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_abcd_type L_abcd_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD>(
-      make_not_null(&L_abcd_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  std::array<std::pair<size_t, size_t>, 4> lhs_index_value_ranges{};
+  lhs_index_value_ranges[0] =
+      get_index_value_range<lhs_tensorindextype_a, TensorIndexA>();
+  lhs_index_value_ranges[1] =
+      get_index_value_range<lhs_tensorindextype_b, TensorIndexB>();
+  lhs_index_value_ranges[2] =
+      get_index_value_range<lhs_tensorindextype_c, TensorIndexC>();
+  lhs_index_value_ranges[3] =
+      get_index_value_range<lhs_tensorindextype_d, TensorIndexD>();
+  std::array<std::pair<size_t, size_t>, 4> rhs_index_value_ranges{};
+  rhs_index_value_ranges[0] =
+      get_index_value_range<rhs_tensorindextype_a, TensorIndexA>();
+  rhs_index_value_ranges[1] =
+      get_index_value_range<rhs_tensorindextype_b, TensorIndexB>();
+  rhs_index_value_ranges[2] =
+      get_index_value_range<rhs_tensorindextype_c, TensorIndexC>();
+  rhs_index_value_ranges[3] =
+      get_index_value_range<rhs_tensorindextype_d, TensorIndexD>();
 
-  // L_{abdc} = R_{abcd}
-  using L_abdc_symmetry =
-      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_b,
-               rhs_symmetry_element_d, rhs_symmetry_element_c>;
-  using L_abdc_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_b,
-                 rhs_tensorindextype_d, rhs_tensorindextype_c>;
-  using L_abdc_type =
-      Tensor<DataType, L_abdc_symmetry, L_abdc_tensorindextype_list>;
-  const L_abdc_type L_abdc_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexD, TensorIndexC>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_abdc_type L_abdc_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexD, TensorIndexC>(
-      make_not_null(&L_abdc_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{acbd} = R_{abcd}
-  using L_acbd_symmetry =
-      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_c,
-               rhs_symmetry_element_b, rhs_symmetry_element_d>;
-  using L_acbd_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
-                 rhs_tensorindextype_b, rhs_tensorindextype_d>;
-  using L_acbd_type =
-      Tensor<DataType, L_acbd_symmetry, L_acbd_tensorindextype_list>;
-  const L_acbd_type L_acbd_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB, TensorIndexD>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_acbd_type L_acbd_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB, TensorIndexD>(
-      make_not_null(&L_acbd_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{acdb} = R_{abcd}
-  using L_acdb_symmetry =
-      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_c,
-               rhs_symmetry_element_d, rhs_symmetry_element_b>;
-  using L_acdb_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_c,
-                 rhs_tensorindextype_d, rhs_tensorindextype_b>;
-  using L_acdb_type =
-      Tensor<DataType, L_acdb_symmetry, L_acdb_tensorindextype_list>;
-  const L_acdb_type L_acdb_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexD, TensorIndexB>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_acdb_type L_acdb_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexD, TensorIndexB>(
-      make_not_null(&L_acdb_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{adbc} = R_{abcd}
-  using L_adbc_symmetry =
-      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_d,
-               rhs_symmetry_element_b, rhs_symmetry_element_c>;
-  using L_adbc_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_d,
-                 rhs_tensorindextype_b, rhs_tensorindextype_c>;
-  using L_adbc_type =
-      Tensor<DataType, L_adbc_symmetry, L_adbc_tensorindextype_list>;
-  const L_adbc_type L_adbc_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexB, TensorIndexC>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_adbc_type L_adbc_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexB, TensorIndexC>(
-      make_not_null(&L_adbc_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{adcb} = R_{abcd}
-  using L_adcb_symmetry =
-      Symmetry<rhs_symmetry_element_a, rhs_symmetry_element_d,
-               rhs_symmetry_element_c, rhs_symmetry_element_b>;
-  using L_adcb_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_a, rhs_tensorindextype_d,
-                 rhs_tensorindextype_c, rhs_tensorindextype_b>;
-  using L_adcb_type =
-      Tensor<DataType, L_adcb_symmetry, L_adcb_tensorindextype_list>;
-  const L_adcb_type L_adcb_returned =
-      ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexC, TensorIndexB>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_adcb_type L_adcb_filled{};
-  ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexC, TensorIndexB>(
-      make_not_null(&L_adcb_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{bacd} = R_{abcd}
-  using L_bacd_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_a,
-               rhs_symmetry_element_c, rhs_symmetry_element_d>;
-  using L_bacd_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
-                 rhs_tensorindextype_c, rhs_tensorindextype_d>;
-  using L_bacd_type =
-      Tensor<DataType, L_bacd_symmetry, L_bacd_tensorindextype_list>;
-  const L_bacd_type L_bacd_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC, TensorIndexD>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_bacd_type L_bacd_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC, TensorIndexD>(
-      make_not_null(&L_bacd_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{badc} = R_{abcd}
-  using L_badc_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_a,
-               rhs_symmetry_element_d, rhs_symmetry_element_c>;
-  using L_badc_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_a,
-                 rhs_tensorindextype_d, rhs_tensorindextype_c>;
-  using L_badc_type =
-      Tensor<DataType, L_badc_symmetry, L_badc_tensorindextype_list>;
-  const L_badc_type L_badc_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexD, TensorIndexC>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_badc_type L_badc_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexD, TensorIndexC>(
-      make_not_null(&L_badc_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{bcad} = R_{abcd}
-  using L_bcad_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_c,
-               rhs_symmetry_element_a, rhs_symmetry_element_d>;
-  using L_bcad_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
-                 rhs_tensorindextype_a, rhs_tensorindextype_d>;
-  using L_bcad_type =
-      Tensor<DataType, L_bcad_symmetry, L_bcad_tensorindextype_list>;
-  const L_bcad_type L_bcad_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA, TensorIndexD>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_bcad_type L_bcad_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA, TensorIndexD>(
-      make_not_null(&L_bcad_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{bcda} = R_{abcd}
-  using L_bcda_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_c,
-               rhs_symmetry_element_d, rhs_symmetry_element_a>;
-  using L_bcda_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_c,
-                 rhs_tensorindextype_d, rhs_tensorindextype_a>;
-  using L_bcda_type =
-      Tensor<DataType, L_bcda_symmetry, L_bcda_tensorindextype_list>;
-  const L_bcda_type L_bcda_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexD, TensorIndexA>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_bcda_type L_bcda_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexD, TensorIndexA>(
-      make_not_null(&L_bcda_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{bdac} = R_{abcd}
-  using L_bdac_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_d,
-               rhs_symmetry_element_a, rhs_symmetry_element_c>;
-  using L_bdac_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_d,
-                 rhs_tensorindextype_a, rhs_tensorindextype_c>;
-  using L_bdac_type =
-      Tensor<DataType, L_bdac_symmetry, L_bdac_tensorindextype_list>;
-  const L_bdac_type L_bdac_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexA, TensorIndexC>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_bdac_type L_bdac_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexA, TensorIndexC>(
-      make_not_null(&L_bdac_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{bdca} = R_{abcd}
-  using L_bdca_symmetry =
-      Symmetry<rhs_symmetry_element_b, rhs_symmetry_element_d,
-               rhs_symmetry_element_c, rhs_symmetry_element_a>;
-  using L_bdca_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_b, rhs_tensorindextype_d,
-                 rhs_tensorindextype_c, rhs_tensorindextype_a>;
-  using L_bdca_type =
-      Tensor<DataType, L_bdca_symmetry, L_bdca_tensorindextype_list>;
-  const L_bdca_type L_bdca_returned =
-      ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexC, TensorIndexA>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_bdca_type L_bdca_filled{};
-  ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexC, TensorIndexA>(
-      make_not_null(&L_bdca_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{cabd} = R_{abcd}
-  using L_cabd_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_a,
-               rhs_symmetry_element_b, rhs_symmetry_element_d>;
-  using L_cabd_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
-                 rhs_tensorindextype_b, rhs_tensorindextype_d>;
-  using L_cabd_type =
-      Tensor<DataType, L_cabd_symmetry, L_cabd_tensorindextype_list>;
-  const L_cabd_type L_cabd_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB, TensorIndexD>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_cabd_type L_cabd_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB, TensorIndexD>(
-      make_not_null(&L_cabd_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{cadb} = R_{abcd}
-  using L_cadb_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_a,
-               rhs_symmetry_element_d, rhs_symmetry_element_b>;
-  using L_cadb_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_a,
-                 rhs_tensorindextype_d, rhs_tensorindextype_b>;
-  using L_cadb_type =
-      Tensor<DataType, L_cadb_symmetry, L_cadb_tensorindextype_list>;
-  const L_cadb_type L_cadb_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexD, TensorIndexB>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_cadb_type L_cadb_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexD, TensorIndexB>(
-      make_not_null(&L_cadb_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{cbad} = R_{abcd}
-  using L_cbad_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_b,
-               rhs_symmetry_element_a, rhs_symmetry_element_d>;
-  using L_cbad_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
-                 rhs_tensorindextype_a, rhs_tensorindextype_d>;
-  using L_cbad_type =
-      Tensor<DataType, L_cbad_symmetry, L_cbad_tensorindextype_list>;
-  const L_cbad_type L_cbad_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA, TensorIndexD>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_cbad_type L_cbad_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA, TensorIndexD>(
-      make_not_null(&L_cbad_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{cbda} = R_{abcd}
-  using L_cbda_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_b,
-               rhs_symmetry_element_d, rhs_symmetry_element_a>;
-  using L_cbda_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_b,
-                 rhs_tensorindextype_d, rhs_tensorindextype_a>;
-  using L_cbda_type =
-      Tensor<DataType, L_cbda_symmetry, L_cbda_tensorindextype_list>;
-  const L_cbda_type L_cbda_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexD, TensorIndexA>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_cbda_type L_cbda_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexD, TensorIndexA>(
-      make_not_null(&L_cbda_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{cdab} = R_{abcd}
-  using L_cdab_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_d,
-               rhs_symmetry_element_a, rhs_symmetry_element_b>;
-  using L_cdab_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_d,
-                 rhs_tensorindextype_a, rhs_tensorindextype_b>;
-  using L_cdab_type =
-      Tensor<DataType, L_cdab_symmetry, L_cdab_tensorindextype_list>;
-  const L_cdab_type L_cdab_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexA, TensorIndexB>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_cdab_type L_cdab_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexA, TensorIndexB>(
-      make_not_null(&L_cdab_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{cdba} = R_{abcd}
-  using L_cdba_symmetry =
-      Symmetry<rhs_symmetry_element_c, rhs_symmetry_element_d,
-               rhs_symmetry_element_b, rhs_symmetry_element_a>;
-  using L_cdba_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_c, rhs_tensorindextype_d,
-                 rhs_tensorindextype_b, rhs_tensorindextype_a>;
-  using L_cdba_type =
-      Tensor<DataType, L_cdba_symmetry, L_cdba_tensorindextype_list>;
-  const L_cdba_type L_cdba_returned =
-      ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexB, TensorIndexA>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_cdba_type L_cdba_filled{};
-  ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexB, TensorIndexA>(
-      make_not_null(&L_cdba_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{dabc} = R_{abcd}
-  using L_dabc_symmetry =
-      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_a,
-               rhs_symmetry_element_b, rhs_symmetry_element_c>;
-  using L_dabc_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_a,
-                 rhs_tensorindextype_b, rhs_tensorindextype_c>;
-  using L_dabc_type =
-      Tensor<DataType, L_dabc_symmetry, L_dabc_tensorindextype_list>;
-  const L_dabc_type L_dabc_returned =
-      ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexB, TensorIndexC>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_dabc_type L_dabc_filled{};
-  ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexB, TensorIndexC>(
-      make_not_null(&L_dabc_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{dacb} = R_{abcd}
-  using L_dacb_symmetry =
-      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_a,
-               rhs_symmetry_element_c, rhs_symmetry_element_b>;
-  using L_dacb_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_a,
-                 rhs_tensorindextype_c, rhs_tensorindextype_b>;
-  using L_dacb_type =
-      Tensor<DataType, L_dacb_symmetry, L_dacb_tensorindextype_list>;
-  const L_dacb_type L_dacb_returned =
-      ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexC, TensorIndexB>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_dacb_type L_dacb_filled{};
-  ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexC, TensorIndexB>(
-      make_not_null(&L_dacb_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{dbac} = R_{abcd}
-  using L_dbac_symmetry =
-      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_b,
-               rhs_symmetry_element_a, rhs_symmetry_element_c>;
-  using L_dbac_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_b,
-                 rhs_tensorindextype_a, rhs_tensorindextype_c>;
-  using L_dbac_type =
-      Tensor<DataType, L_dbac_symmetry, L_dbac_tensorindextype_list>;
-  const L_dbac_type L_dbac_returned =
-      ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexA, TensorIndexC>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_dbac_type L_dbac_filled{};
-  ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexA, TensorIndexC>(
-      make_not_null(&L_dbac_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{dbca} = R_{abcd}
-  using L_dbca_symmetry =
-      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_b,
-               rhs_symmetry_element_c, rhs_symmetry_element_a>;
-  using L_dbca_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_b,
-                 rhs_tensorindextype_c, rhs_tensorindextype_a>;
-  using L_dbca_type =
-      Tensor<DataType, L_dbca_symmetry, L_dbca_tensorindextype_list>;
-  const L_dbca_type L_dbca_returned =
-      ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexC, TensorIndexA>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_dbca_type L_dbca_filled{};
-  ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexC, TensorIndexA>(
-      make_not_null(&L_dbca_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{dcab} = R_{abcd}
-  using L_dcab_symmetry =
-      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_c,
-               rhs_symmetry_element_a, rhs_symmetry_element_b>;
-  using L_dcab_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_c,
-                 rhs_tensorindextype_a, rhs_tensorindextype_b>;
-  using L_dcab_type =
-      Tensor<DataType, L_dcab_symmetry, L_dcab_tensorindextype_list>;
-  const L_dcab_type L_dcab_returned =
-      ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexA, TensorIndexB>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_dcab_type L_dcab_filled{};
-  ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexA, TensorIndexB>(
-      make_not_null(&L_dcab_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  // L_{dcba} = R_{abcd}
-  using L_dcba_symmetry =
-      Symmetry<rhs_symmetry_element_d, rhs_symmetry_element_c,
-               rhs_symmetry_element_b, rhs_symmetry_element_a>;
-  using L_dcba_tensorindextype_list =
-      tmpl::list<rhs_tensorindextype_d, rhs_tensorindextype_c,
-                 rhs_tensorindextype_b, rhs_tensorindextype_a>;
-  using L_dcba_type =
-      Tensor<DataType, L_dcba_symmetry, L_dcba_tensorindextype_list>;
-  const L_dcba_type L_dcba_returned =
-      ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexB, TensorIndexA>(
-          R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-  L_dcba_type L_dcba_filled{};
-  ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexB, TensorIndexA>(
-      make_not_null(&L_dcba_filled),
-      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
-
-  const size_t dim_a = tmpl::at_c<RhsTensorIndexTypeList, 0>::dim;
-  const size_t dim_b = tmpl::at_c<RhsTensorIndexTypeList, 1>::dim;
-  const size_t dim_c = tmpl::at_c<RhsTensorIndexTypeList, 2>::dim;
-  const size_t dim_d = tmpl::at_c<RhsTensorIndexTypeList, 3>::dim;
-
-  for (size_t i = 0; i < dim_a; ++i) {
-    for (size_t j = 0; j < dim_b; ++j) {
-      for (size_t k = 0; k < dim_c; ++k) {
-          for (size_t l = 0; l < dim_d; ++l) {
-            // For L_{abcd} = R_{abcd}, check that L_{ijkl} == R_{ijkl}
-            CHECK(L_abcd_returned.get(i, j, k, l) == R_abcd.get(i, j, k, l));
-            CHECK(L_abcd_filled.get(i, j, k, l) == R_abcd.get(i, j, k, l));
-            // For L_{abdc} = R_{abcd}, check that L_{ijlk} == R_{ijkl}
-            CHECK(L_abdc_returned.get(i, j, l, k) == R_abcd.get(i, j, k, l));
-            CHECK(L_abdc_filled.get(i, j, l, k) == R_abcd.get(i, j, k, l));
-            // For L_{acbd} = R_{abcd}, check that L_{ikjl} == R_{ijkl}
-            CHECK(L_acbd_returned.get(i, k, j, l) == R_abcd.get(i, j, k, l));
-            CHECK(L_acbd_filled.get(i, k, j, l) == R_abcd.get(i, j, k, l));
-            // For L_{acdb} = R_{abcd}, check that L_{iklj} == R_{ijkl}
-            CHECK(L_acdb_returned.get(i, k, l, j) == R_abcd.get(i, j, k, l));
-            CHECK(L_acdb_filled.get(i, k, l, j) == R_abcd.get(i, j, k, l));
-            // For L_{adbc} = R_{abcd}, check that L_{iljk} == R_{ijkl}
-            CHECK(L_adbc_returned.get(i, l, j, k) == R_abcd.get(i, j, k, l));
-            CHECK(L_adbc_filled.get(i, l, j, k) == R_abcd.get(i, j, k, l));
-            // For L_{adcb} = R_{abcd}, check that L_{ilkj} == R_{ijkl}
-            CHECK(L_adcb_returned.get(i, l, k, j) == R_abcd.get(i, j, k, l));
-            CHECK(L_adcb_filled.get(i, l, k, j) == R_abcd.get(i, j, k, l));
-            // For L_{bacd} = R_{abcd}, check that L_{jikl} == R_{ijkl}
-            CHECK(L_bacd_returned.get(j, i, k, l) == R_abcd.get(i, j, k, l));
-            CHECK(L_bacd_filled.get(j, i, k, l) == R_abcd.get(i, j, k, l));
-            // For L_{badc} = R_{abcd}, check that L_{jilk} == R_{ijkl}
-            CHECK(L_badc_returned.get(j, i, l, k) == R_abcd.get(i, j, k, l));
-            CHECK(L_badc_filled.get(j, i, l, k) == R_abcd.get(i, j, k, l));
-            // For L_{bcad} = R_{abcd}, check that L_{jkil} == R_{ijkl}
-            CHECK(L_bcad_returned.get(j, k, i, l) == R_abcd.get(i, j, k, l));
-            CHECK(L_bcad_filled.get(j, k, i, l) == R_abcd.get(i, j, k, l));
-            // For L_{bcda} = R_{abcd}, check that L_{jkli} == R_{ijkl}
-            CHECK(L_bcda_returned.get(j, k, l, i) == R_abcd.get(i, j, k, l));
-            CHECK(L_bcda_filled.get(j, k, l, i) == R_abcd.get(i, j, k, l));
-            // For L_{bdac} = R_{abcd}, check that L_{jlik} == R_{ijkl}
-            CHECK(L_bdac_returned.get(j, l, i, k) == R_abcd.get(i, j, k, l));
-            CHECK(L_bdac_filled.get(j, l, i, k) == R_abcd.get(i, j, k, l));
-            // For L_{bdca} = R_{abcd}, check that L_{jlki} == R_{ijkl}
-            CHECK(L_bdca_returned.get(j, l, k, i) == R_abcd.get(i, j, k, l));
-            CHECK(L_bdca_filled.get(j, l, k, i) == R_abcd.get(i, j, k, l));
-            // For L_{cabd} = R_{abcd}, check that L_{kijl} == R_{ijkl}
-            CHECK(L_cabd_returned.get(k, i, j, l) == R_abcd.get(i, j, k, l));
-            CHECK(L_cabd_filled.get(k, i, j, l) == R_abcd.get(i, j, k, l));
-            // For L_{cadb} = R_{abcd}, check that L_{kilj} == R_{ijkl}
-            CHECK(L_cadb_returned.get(k, i, l, j) == R_abcd.get(i, j, k, l));
-            CHECK(L_cadb_filled.get(k, i, l, j) == R_abcd.get(i, j, k, l));
-            // For L_{cbad} = R_{abcd}, check that L_{kjil} == R_{ijkl}
-            CHECK(L_cbad_returned.get(k, j, i, l) == R_abcd.get(i, j, k, l));
-            CHECK(L_cbad_filled.get(k, j, i, l) == R_abcd.get(i, j, k, l));
-            // For L_{cbda} = R_{abcd}, check that L_{kjli} == R_{ijkl}
-            CHECK(L_cbda_returned.get(k, j, l, i) == R_abcd.get(i, j, k, l));
-            CHECK(L_cbda_filled.get(k, j, l, i) == R_abcd.get(i, j, k, l));
-            // For L_{cdab} = R_{abcd}, check that L_{klij} == R_{ijkl}
-            CHECK(L_cdab_returned.get(k, l, i, j) == R_abcd.get(i, j, k, l));
-            CHECK(L_cdab_filled.get(k, l, i, j) == R_abcd.get(i, j, k, l));
-            // For L_{cdba} = R_{abcd}, check that L_{klji} == R_{ijkl}
-            CHECK(L_cdba_returned.get(k, l, j, i) == R_abcd.get(i, j, k, l));
-            CHECK(L_cdba_filled.get(k, l, j, i) == R_abcd.get(i, j, k, l));
-            // For L_{dabc} = R_{abcd}, check that L_{lijk} == R_{ijkl}
-            CHECK(L_dabc_returned.get(l, i, j, k) == R_abcd.get(i, j, k, l));
-            CHECK(L_dabc_filled.get(l, i, j, k) == R_abcd.get(i, j, k, l));
-            // For L_{dacb} = R_{abcd}, check that L_{likj} == R_{ijkl}
-            CHECK(L_dacb_returned.get(l, i, k, j) == R_abcd.get(i, j, k, l));
-            CHECK(L_dacb_filled.get(l, i, k, j) == R_abcd.get(i, j, k, l));
-            // For L_{dbac} = R_{abcd}, check that L_{ljik} == R_{ijkl}
-            CHECK(L_dbac_returned.get(l, j, i, k) == R_abcd.get(i, j, k, l));
-            CHECK(L_dbac_filled.get(l, j, i, k) == R_abcd.get(i, j, k, l));
-            // For L_{dbca} = R_{abcd}, check that L_{ljki} == R_{ijkl}
-            CHECK(L_dbca_returned.get(l, j, k, i) == R_abcd.get(i, j, k, l));
-            CHECK(L_dbca_filled.get(l, j, k, i) == R_abcd.get(i, j, k, l));
-            // For L_{dcab} = R_{abcd}, check that L_{lkij} == R_{ijkl}
-            CHECK(L_dcab_returned.get(l, k, i, j) == R_abcd.get(i, j, k, l));
-            CHECK(L_dcab_filled.get(l, k, i, j) == R_abcd.get(i, j, k, l));
-            // For L_{dcba} = R_{abcd}, check that L_{lkji} == R_{ijkl}
-            CHECK(L_dcba_returned.get(l, k, j, i) == R_abcd.get(i, j, k, l));
-            CHECK(L_dcba_filled.get(l, k, j, i) == R_abcd.get(i, j, k, l));
+  for (size_t lhs_a = lhs_index_value_ranges[0].first,
+              rhs_a = rhs_index_value_ranges[0].first;
+       lhs_a <= lhs_index_value_ranges[0].second; lhs_a++, rhs_a++) {
+    for (size_t lhs_b = lhs_index_value_ranges[1].first,
+                rhs_b = rhs_index_value_ranges[1].first;
+         lhs_b <= lhs_index_value_ranges[1].second; lhs_b++, rhs_b++) {
+      for (size_t lhs_c = lhs_index_value_ranges[2].first,
+                  rhs_c = rhs_index_value_ranges[2].first;
+           lhs_c <= lhs_index_value_ranges[2].second; lhs_c++, rhs_c++) {
+        for (size_t lhs_d = lhs_index_value_ranges[3].first,
+                    rhs_d = rhs_index_value_ranges[3].first;
+             lhs_d <= lhs_index_value_ranges[3].second; lhs_d++, rhs_d++) {
+          expected_L_abcd.get(lhs_a, lhs_b, lhs_c, lhs_d) =
+              R_abcd.get(rhs_a, rhs_b, rhs_c, rhs_d);
         }
       }
     }
   }
 
-  // Test with TempTensor for LHS tensor
-  if constexpr (not std::is_same_v<DataType, double>) {
-    // L_{abcd} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_abcd_type>>> L_abcd_var{
-        used_for_size};
-    L_abcd_type& L_abcd_temp =
-        get<::Tags::TempTensor<1, L_abcd_type>>(L_abcd_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD>(
-        make_not_null(&L_abcd_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  const auto rhs_expression =
+      R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD);
 
-    // L_{abdc} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_abdc_type>>> L_abdc_var{
-        used_for_size};
-    L_abdc_type& L_abdc_temp =
-        get<::Tags::TempTensor<1, L_abdc_type>>(L_abdc_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexB, TensorIndexD, TensorIndexC>(
-        make_not_null(&L_abdc_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{abcd} = R_{abcd}
+  using L_abcd_type = Tensor<DataType, LhsSymmetry, LhsTensorIndexTypeList>;
+  L_abcd_type L_abcd(used_for_size);
+  // component placeholder is used to detect which components have incorrectly
+  // or correctly (in the case of using spatial or time indices for spacetime
+  // indices) not been modified by evaluation of the RHS expression
+  std::fill(L_abcd.begin(), L_abcd.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexB, TensorIndexC,
+                TensorIndexD>(make_not_null(&L_abcd), rhs_expression);
 
-    // L_{acbd} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_acbd_type>>> L_acbd_var{
-        used_for_size};
-    L_acbd_type& L_acbd_temp =
-        get<::Tags::TempTensor<1, L_acbd_type>>(L_acbd_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexB, TensorIndexD>(
-        make_not_null(&L_acbd_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{abdc} = R_{abcd}
+  using L_abdc_symmetry =
+      Symmetry<lhs_symmetry_element_a, lhs_symmetry_element_b,
+               lhs_symmetry_element_d, lhs_symmetry_element_c>;
+  using L_abdc_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_a, lhs_tensorindextype_b,
+                 lhs_tensorindextype_d, lhs_tensorindextype_c>;
+  using L_abdc_type =
+      Tensor<DataType, L_abdc_symmetry, L_abdc_tensorindextype_list>;
+  L_abdc_type L_abdc(used_for_size);
+  std::fill(L_abdc.begin(), L_abdc.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexB, TensorIndexD,
+                TensorIndexC>(make_not_null(&L_abdc), rhs_expression);
 
-    // L_{acdb} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_acdb_type>>> L_acdb_var{
-        used_for_size};
-    L_acdb_type& L_acdb_temp =
-        get<::Tags::TempTensor<1, L_acdb_type>>(L_acdb_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexC, TensorIndexD, TensorIndexB>(
-        make_not_null(&L_acdb_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{acbd} = R_{abcd}
+  using L_acbd_symmetry =
+      Symmetry<lhs_symmetry_element_a, lhs_symmetry_element_c,
+               lhs_symmetry_element_b, lhs_symmetry_element_d>;
+  using L_acbd_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_a, lhs_tensorindextype_c,
+                 lhs_tensorindextype_b, lhs_tensorindextype_d>;
+  using L_acbd_type =
+      Tensor<DataType, L_acbd_symmetry, L_acbd_tensorindextype_list>;
+  L_acbd_type L_acbd(used_for_size);
+  std::fill(L_acbd.begin(), L_acbd.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexC, TensorIndexB,
+                TensorIndexD>(make_not_null(&L_acbd), rhs_expression);
 
-    // L_{adbc} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_adbc_type>>> L_adbc_var{
-        used_for_size};
-    L_adbc_type& L_adbc_temp =
-        get<::Tags::TempTensor<1, L_adbc_type>>(L_adbc_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexB, TensorIndexC>(
-        make_not_null(&L_adbc_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{acdb} = R_{abcd}
+  using L_acdb_symmetry =
+      Symmetry<lhs_symmetry_element_a, lhs_symmetry_element_c,
+               lhs_symmetry_element_d, lhs_symmetry_element_b>;
+  using L_acdb_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_a, lhs_tensorindextype_c,
+                 lhs_tensorindextype_d, lhs_tensorindextype_b>;
+  using L_acdb_type =
+      Tensor<DataType, L_acdb_symmetry, L_acdb_tensorindextype_list>;
+  L_acdb_type L_acdb(used_for_size);
+  std::fill(L_acdb.begin(), L_acdb.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexC, TensorIndexD,
+                TensorIndexB>(make_not_null(&L_acdb), rhs_expression);
 
-    // L_{adcb} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_adcb_type>>> L_adcb_var{
-        used_for_size};
-    L_adcb_type& L_adcb_temp =
-        get<::Tags::TempTensor<1, L_adcb_type>>(L_adcb_var);
-    ::tenex::evaluate<TensorIndexA, TensorIndexD, TensorIndexC, TensorIndexB>(
-        make_not_null(&L_adcb_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{adbc} = R_{abcd}
+  using L_adbc_symmetry =
+      Symmetry<lhs_symmetry_element_a, lhs_symmetry_element_d,
+               lhs_symmetry_element_b, lhs_symmetry_element_c>;
+  using L_adbc_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_a, lhs_tensorindextype_d,
+                 lhs_tensorindextype_b, lhs_tensorindextype_c>;
+  using L_adbc_type =
+      Tensor<DataType, L_adbc_symmetry, L_adbc_tensorindextype_list>;
+  L_adbc_type L_adbc(used_for_size);
+  std::fill(L_adbc.begin(), L_adbc.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexD, TensorIndexB,
+                TensorIndexC>(make_not_null(&L_adbc), rhs_expression);
 
-    // L_{bacd} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_bacd_type>>> L_bacd_var{
-        used_for_size};
-    L_bacd_type& L_bacd_temp =
-        get<::Tags::TempTensor<1, L_bacd_type>>(L_bacd_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexC, TensorIndexD>(
-        make_not_null(&L_bacd_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{adcb} = R_{abcd}
+  using L_adcb_symmetry =
+      Symmetry<lhs_symmetry_element_a, lhs_symmetry_element_d,
+               lhs_symmetry_element_c, lhs_symmetry_element_b>;
+  using L_adcb_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_a, lhs_tensorindextype_d,
+                 lhs_tensorindextype_c, lhs_tensorindextype_b>;
+  using L_adcb_type =
+      Tensor<DataType, L_adcb_symmetry, L_adcb_tensorindextype_list>;
+  L_adcb_type L_adcb(used_for_size);
+  std::fill(L_adcb.begin(), L_adcb.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexA, TensorIndexD, TensorIndexC,
+                TensorIndexB>(make_not_null(&L_adcb), rhs_expression);
 
-    // L_{badc} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_badc_type>>> L_badc_var{
-        used_for_size};
-    L_badc_type& L_badc_temp =
-        get<::Tags::TempTensor<1, L_badc_type>>(L_badc_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexA, TensorIndexD, TensorIndexC>(
-        make_not_null(&L_badc_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{bacd} = R_{abcd}
+  using L_bacd_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_a,
+               lhs_symmetry_element_c, lhs_symmetry_element_d>;
+  using L_bacd_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_a,
+                 lhs_tensorindextype_c, lhs_tensorindextype_d>;
+  using L_bacd_type =
+      Tensor<DataType, L_bacd_symmetry, L_bacd_tensorindextype_list>;
+  L_bacd_type L_bacd(used_for_size);
+  std::fill(L_bacd.begin(), L_bacd.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexA, TensorIndexC,
+                TensorIndexD>(make_not_null(&L_bacd), rhs_expression);
 
-    // L_{bcad} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_bcad_type>>> L_bcad_var{
-        used_for_size};
-    L_bcad_type& L_bcad_temp =
-        get<::Tags::TempTensor<1, L_bcad_type>>(L_bcad_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexA, TensorIndexD>(
-        make_not_null(&L_bcad_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{badc} = R_{abcd}
+  using L_badc_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_a,
+               lhs_symmetry_element_d, lhs_symmetry_element_c>;
+  using L_badc_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_a,
+                 lhs_tensorindextype_d, lhs_tensorindextype_c>;
+  using L_badc_type =
+      Tensor<DataType, L_badc_symmetry, L_badc_tensorindextype_list>;
+  L_badc_type L_badc(used_for_size);
+  std::fill(L_badc.begin(), L_badc.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexA, TensorIndexD,
+                TensorIndexC>(make_not_null(&L_badc), rhs_expression);
 
-    // L_{bcda} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_bcda_type>>> L_bcda_var{
-        used_for_size};
-    L_bcda_type& L_bcda_temp =
-        get<::Tags::TempTensor<1, L_bcda_type>>(L_bcda_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexC, TensorIndexD, TensorIndexA>(
-        make_not_null(&L_bcda_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{bcad} = R_{abcd}
+  using L_bcad_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_c,
+               lhs_symmetry_element_a, lhs_symmetry_element_d>;
+  using L_bcad_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_c,
+                 lhs_tensorindextype_a, lhs_tensorindextype_d>;
+  using L_bcad_type =
+      Tensor<DataType, L_bcad_symmetry, L_bcad_tensorindextype_list>;
+  L_bcad_type L_bcad(used_for_size);
+  std::fill(L_bcad.begin(), L_bcad.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexC, TensorIndexA,
+                TensorIndexD>(make_not_null(&L_bcad), rhs_expression);
 
-    // L_{bdac} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_bdac_type>>> L_bdac_var{
-        used_for_size};
-    L_bdac_type& L_bdac_temp =
-        get<::Tags::TempTensor<1, L_bdac_type>>(L_bdac_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexA, TensorIndexC>(
-        make_not_null(&L_bdac_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{bcda} = R_{abcd}
+  using L_bcda_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_c,
+               lhs_symmetry_element_d, lhs_symmetry_element_a>;
+  using L_bcda_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_c,
+                 lhs_tensorindextype_d, lhs_tensorindextype_a>;
+  using L_bcda_type =
+      Tensor<DataType, L_bcda_symmetry, L_bcda_tensorindextype_list>;
+  L_bcda_type L_bcda(used_for_size);
+  std::fill(L_bcda.begin(), L_bcda.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexC, TensorIndexD,
+                TensorIndexA>(make_not_null(&L_bcda), rhs_expression);
 
-    // L_{bdca} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_bdca_type>>> L_bdca_var{
-        used_for_size};
-    L_bdca_type& L_bdca_temp =
-        get<::Tags::TempTensor<1, L_bdca_type>>(L_bdca_var);
-    ::tenex::evaluate<TensorIndexB, TensorIndexD, TensorIndexC, TensorIndexA>(
-        make_not_null(&L_bdca_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{bdac} = R_{abcd}
+  using L_bdac_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_d,
+               lhs_symmetry_element_a, lhs_symmetry_element_c>;
+  using L_bdac_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_d,
+                 lhs_tensorindextype_a, lhs_tensorindextype_c>;
+  using L_bdac_type =
+      Tensor<DataType, L_bdac_symmetry, L_bdac_tensorindextype_list>;
+  L_bdac_type L_bdac(used_for_size);
+  std::fill(L_bdac.begin(), L_bdac.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexD, TensorIndexA,
+                TensorIndexC>(make_not_null(&L_bdac), rhs_expression);
 
-    // L_{cabd} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cabd_type>>> L_cabd_var{
-        used_for_size};
-    L_cabd_type& L_cabd_temp =
-        get<::Tags::TempTensor<1, L_cabd_type>>(L_cabd_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexB, TensorIndexD>(
-        make_not_null(&L_cabd_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{bdca} = R_{abcd}
+  using L_bdca_symmetry =
+      Symmetry<lhs_symmetry_element_b, lhs_symmetry_element_d,
+               lhs_symmetry_element_c, lhs_symmetry_element_a>;
+  using L_bdca_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_b, lhs_tensorindextype_d,
+                 lhs_tensorindextype_c, lhs_tensorindextype_a>;
+  using L_bdca_type =
+      Tensor<DataType, L_bdca_symmetry, L_bdca_tensorindextype_list>;
+  L_bdca_type L_bdca(used_for_size);
+  std::fill(L_bdca.begin(), L_bdca.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexB, TensorIndexD, TensorIndexC,
+                TensorIndexA>(make_not_null(&L_bdca), rhs_expression);
 
-    // L_{cadb} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cadb_type>>> L_cadb_var{
-        used_for_size};
-    L_cadb_type& L_cadb_temp =
-        get<::Tags::TempTensor<1, L_cadb_type>>(L_cadb_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexA, TensorIndexD, TensorIndexB>(
-        make_not_null(&L_cadb_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{cabd} = R_{abcd}
+  using L_cabd_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_a,
+               lhs_symmetry_element_b, lhs_symmetry_element_d>;
+  using L_cabd_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_a,
+                 lhs_tensorindextype_b, lhs_tensorindextype_d>;
+  using L_cabd_type =
+      Tensor<DataType, L_cabd_symmetry, L_cabd_tensorindextype_list>;
+  L_cabd_type L_cabd(used_for_size);
+  std::fill(L_cabd.begin(), L_cabd.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexA, TensorIndexB,
+                TensorIndexD>(make_not_null(&L_cabd), rhs_expression);
 
-    // L_{cbad} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cbad_type>>> L_cbad_var{
-        used_for_size};
-    L_cbad_type& L_cbad_temp =
-        get<::Tags::TempTensor<1, L_cbad_type>>(L_cbad_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexA, TensorIndexD>(
-        make_not_null(&L_cbad_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{cadb} = R_{abcd}
+  using L_cadb_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_a,
+               lhs_symmetry_element_d, lhs_symmetry_element_b>;
+  using L_cadb_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_a,
+                 lhs_tensorindextype_d, lhs_tensorindextype_b>;
+  using L_cadb_type =
+      Tensor<DataType, L_cadb_symmetry, L_cadb_tensorindextype_list>;
+  L_cadb_type L_cadb(used_for_size);
+  std::fill(L_cadb.begin(), L_cadb.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexA, TensorIndexD,
+                TensorIndexB>(make_not_null(&L_cadb), rhs_expression);
 
-    // L_{cbda} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cbda_type>>> L_cbda_var{
-        used_for_size};
-    L_cbda_type& L_cbda_temp =
-        get<::Tags::TempTensor<1, L_cbda_type>>(L_cbda_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexB, TensorIndexD, TensorIndexA>(
-        make_not_null(&L_cbda_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{cbad} = R_{abcd}
+  using L_cbad_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_b,
+               lhs_symmetry_element_a, lhs_symmetry_element_d>;
+  using L_cbad_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_b,
+                 lhs_tensorindextype_a, lhs_tensorindextype_d>;
+  using L_cbad_type =
+      Tensor<DataType, L_cbad_symmetry, L_cbad_tensorindextype_list>;
+  L_cbad_type L_cbad(used_for_size);
+  std::fill(L_cbad.begin(), L_cbad.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexB, TensorIndexA,
+                TensorIndexD>(make_not_null(&L_cbad), rhs_expression);
 
-    // L_{cdab} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cdab_type>>> L_cdab_var{
-        used_for_size};
-    L_cdab_type& L_cdab_temp =
-        get<::Tags::TempTensor<1, L_cdab_type>>(L_cdab_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexA, TensorIndexB>(
-        make_not_null(&L_cdab_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{cbda} = R_{abcd}
+  using L_cbda_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_b,
+               lhs_symmetry_element_d, lhs_symmetry_element_a>;
+  using L_cbda_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_b,
+                 lhs_tensorindextype_d, lhs_tensorindextype_a>;
+  using L_cbda_type =
+      Tensor<DataType, L_cbda_symmetry, L_cbda_tensorindextype_list>;
+  L_cbda_type L_cbda(used_for_size);
+  std::fill(L_cbda.begin(), L_cbda.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexB, TensorIndexD,
+                TensorIndexA>(make_not_null(&L_cbda), rhs_expression);
 
-    // L_{cdba} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_cdba_type>>> L_cdba_var{
-        used_for_size};
-    L_cdba_type& L_cdba_temp =
-        get<::Tags::TempTensor<1, L_cdba_type>>(L_cdba_var);
-    ::tenex::evaluate<TensorIndexC, TensorIndexD, TensorIndexB, TensorIndexA>(
-        make_not_null(&L_cdba_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{cdab} = R_{abcd}
+  using L_cdab_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_d,
+               lhs_symmetry_element_a, lhs_symmetry_element_b>;
+  using L_cdab_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_d,
+                 lhs_tensorindextype_a, lhs_tensorindextype_b>;
+  using L_cdab_type =
+      Tensor<DataType, L_cdab_symmetry, L_cdab_tensorindextype_list>;
+  L_cdab_type L_cdab(used_for_size);
+  std::fill(L_cdab.begin(), L_cdab.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexD, TensorIndexA,
+                TensorIndexB>(make_not_null(&L_cdab), rhs_expression);
 
-    // L_{dabc} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_dabc_type>>> L_dabc_var{
-        used_for_size};
-    L_dabc_type& L_dabc_temp =
-        get<::Tags::TempTensor<1, L_dabc_type>>(L_dabc_var);
-    ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexB, TensorIndexC>(
-        make_not_null(&L_dabc_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{cdba} = R_{abcd}
+  using L_cdba_symmetry =
+      Symmetry<lhs_symmetry_element_c, lhs_symmetry_element_d,
+               lhs_symmetry_element_b, lhs_symmetry_element_a>;
+  using L_cdba_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_c, lhs_tensorindextype_d,
+                 lhs_tensorindextype_b, lhs_tensorindextype_a>;
+  using L_cdba_type =
+      Tensor<DataType, L_cdba_symmetry, L_cdba_tensorindextype_list>;
+  L_cdba_type L_cdba(used_for_size);
+  std::fill(L_cdba.begin(), L_cdba.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexC, TensorIndexD, TensorIndexB,
+                TensorIndexA>(make_not_null(&L_cdba), rhs_expression);
 
-    // L_{dacb} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_dacb_type>>> L_dacb_var{
-        used_for_size};
-    L_dacb_type& L_dacb_temp =
-        get<::Tags::TempTensor<1, L_dacb_type>>(L_dacb_var);
-    ::tenex::evaluate<TensorIndexD, TensorIndexA, TensorIndexC, TensorIndexB>(
-        make_not_null(&L_dacb_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{dabc} = R_{abcd}
+  using L_dabc_symmetry =
+      Symmetry<lhs_symmetry_element_d, lhs_symmetry_element_a,
+               lhs_symmetry_element_b, lhs_symmetry_element_c>;
+  using L_dabc_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_d, lhs_tensorindextype_a,
+                 lhs_tensorindextype_b, lhs_tensorindextype_c>;
+  using L_dabc_type =
+      Tensor<DataType, L_dabc_symmetry, L_dabc_tensorindextype_list>;
+  L_dabc_type L_dabc(used_for_size);
+  std::fill(L_dabc.begin(), L_dabc.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexD, TensorIndexA, TensorIndexB,
+                TensorIndexC>(make_not_null(&L_dabc), rhs_expression);
 
-    // L_{dbac} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_dbac_type>>> L_dbac_var{
-        used_for_size};
-    L_dbac_type& L_dbac_temp =
-        get<::Tags::TempTensor<1, L_dbac_type>>(L_dbac_var);
-    ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexA, TensorIndexC>(
-        make_not_null(&L_dbac_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{dacb} = R_{abcd}
+  using L_dacb_symmetry =
+      Symmetry<lhs_symmetry_element_d, lhs_symmetry_element_a,
+               lhs_symmetry_element_c, lhs_symmetry_element_b>;
+  using L_dacb_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_d, lhs_tensorindextype_a,
+                 lhs_tensorindextype_c, lhs_tensorindextype_b>;
+  using L_dacb_type =
+      Tensor<DataType, L_dacb_symmetry, L_dacb_tensorindextype_list>;
+  L_dacb_type L_dacb(used_for_size);
+  std::fill(L_dacb.begin(), L_dacb.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexD, TensorIndexA, TensorIndexC,
+                TensorIndexB>(make_not_null(&L_dacb), rhs_expression);
 
-    // L_{dbca} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_dbca_type>>> L_dbca_var{
-        used_for_size};
-    L_dbca_type& L_dbca_temp =
-        get<::Tags::TempTensor<1, L_dbca_type>>(L_dbca_var);
-    ::tenex::evaluate<TensorIndexD, TensorIndexB, TensorIndexC, TensorIndexA>(
-        make_not_null(&L_dbca_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{dbac} = R_{abcd}
+  using L_dbac_symmetry =
+      Symmetry<lhs_symmetry_element_d, lhs_symmetry_element_b,
+               lhs_symmetry_element_a, lhs_symmetry_element_c>;
+  using L_dbac_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_d, lhs_tensorindextype_b,
+                 lhs_tensorindextype_a, lhs_tensorindextype_c>;
+  using L_dbac_type =
+      Tensor<DataType, L_dbac_symmetry, L_dbac_tensorindextype_list>;
+  L_dbac_type L_dbac(used_for_size);
+  std::fill(L_dbac.begin(), L_dbac.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexD, TensorIndexB, TensorIndexA,
+                TensorIndexC>(make_not_null(&L_dbac), rhs_expression);
 
-    // L_{dcab} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_dcab_type>>> L_dcab_var{
-        used_for_size};
-    L_dcab_type& L_dcab_temp =
-        get<::Tags::TempTensor<1, L_dcab_type>>(L_dcab_var);
-    ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexA, TensorIndexB>(
-        make_not_null(&L_dcab_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{dbca} = R_{abcd}
+  using L_dbca_symmetry =
+      Symmetry<lhs_symmetry_element_d, lhs_symmetry_element_b,
+               lhs_symmetry_element_c, lhs_symmetry_element_a>;
+  using L_dbca_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_d, lhs_tensorindextype_b,
+                 lhs_tensorindextype_c, lhs_tensorindextype_a>;
+  using L_dbca_type =
+      Tensor<DataType, L_dbca_symmetry, L_dbca_tensorindextype_list>;
+  L_dbca_type L_dbca(used_for_size);
+  std::fill(L_dbca.begin(), L_dbca.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexD, TensorIndexB, TensorIndexC,
+                TensorIndexA>(make_not_null(&L_dbca), rhs_expression);
 
-    // L_{dcba} = R_{abcd}
-    Variables<tmpl::list<::Tags::TempTensor<1, L_dcba_type>>> L_dcba_var{
-        used_for_size};
-    L_dcba_type& L_dcba_temp =
-        get<::Tags::TempTensor<1, L_dcba_type>>(L_dcba_var);
-    ::tenex::evaluate<TensorIndexD, TensorIndexC, TensorIndexB, TensorIndexA>(
-        make_not_null(&L_dcba_temp),
-        R_abcd(TensorIndexA, TensorIndexB, TensorIndexC, TensorIndexD));
+  // L_{dcab} = R_{abcd}
+  using L_dcab_symmetry =
+      Symmetry<lhs_symmetry_element_d, lhs_symmetry_element_c,
+               lhs_symmetry_element_a, lhs_symmetry_element_b>;
+  using L_dcab_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_d, lhs_tensorindextype_c,
+                 lhs_tensorindextype_a, lhs_tensorindextype_b>;
+  using L_dcab_type =
+      Tensor<DataType, L_dcab_symmetry, L_dcab_tensorindextype_list>;
+  L_dcab_type L_dcab(used_for_size);
+  std::fill(L_dcab.begin(), L_dcab.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexD, TensorIndexC, TensorIndexA,
+                TensorIndexB>(make_not_null(&L_dcab), rhs_expression);
 
-    for (size_t i = 0; i < dim_a; ++i) {
-      for (size_t j = 0; j < dim_b; ++j) {
-        for (size_t k = 0; k < dim_c; ++k) {
-          for (size_t l = 0; l < dim_d; ++l) {
-            // For L_{abcd} = R_{abcd}, check that L_{ijkl} == R_{ijkl}
-            CHECK(L_abcd_temp.get(i, j, k, l) == R_abcd.get(i, j, k, l));
-            // For L_{abdc} = R_{abcd}, check that L_{ijlk} == R_{ijkl}
-            CHECK(L_abdc_temp.get(i, j, l, k) == R_abcd.get(i, j, k, l));
-            // For L_{acbd} = R_{abcd}, check that L_{ikjl} == R_{ijkl}
-            CHECK(L_acbd_temp.get(i, k, j, l) == R_abcd.get(i, j, k, l));
-            // For L_{acdb} = R_{abcd}, check that L_{iklj} == R_{ijkl}
-            CHECK(L_acdb_temp.get(i, k, l, j) == R_abcd.get(i, j, k, l));
-            // For L_{adbc} = R_{abcd}, check that L_{iljk} == R_{ijkl}
-            CHECK(L_adbc_temp.get(i, l, j, k) == R_abcd.get(i, j, k, l));
-            // For L_{adcb} = R_{abcd}, check that L_{ilkj} == R_{ijkl}
-            CHECK(L_adcb_temp.get(i, l, k, j) == R_abcd.get(i, j, k, l));
-            // For L_{bacd} = R_{abcd}, check that L_{jikl} == R_{ijkl}
-            CHECK(L_bacd_temp.get(j, i, k, l) == R_abcd.get(i, j, k, l));
-            // For L_{badc} = R_{abcd}, check that L_{jilk} == R_{ijkl}
-            CHECK(L_badc_temp.get(j, i, l, k) == R_abcd.get(i, j, k, l));
-            // For L_{bcad} = R_{abcd}, check that L_{jkil} == R_{ijkl}
-            CHECK(L_bcad_temp.get(j, k, i, l) == R_abcd.get(i, j, k, l));
-            // For L_{bcda} = R_{abcd}, check that L_{jkli} == R_{ijkl}
-            CHECK(L_bcda_temp.get(j, k, l, i) == R_abcd.get(i, j, k, l));
-            // For L_{bdac} = R_{abcd}, check that L_{jlik} == R_{ijkl}
-            CHECK(L_bdac_temp.get(j, l, i, k) == R_abcd.get(i, j, k, l));
-            // For L_{bdca} = R_{abcd}, check that L_{jlki} == R_{ijkl}
-            CHECK(L_bdca_temp.get(j, l, k, i) == R_abcd.get(i, j, k, l));
-            // For L_{cabd} = R_{abcd}, check that L_{kijl} == R_{ijkl}
-            CHECK(L_cabd_temp.get(k, i, j, l) == R_abcd.get(i, j, k, l));
-            // For L_{cadb} = R_{abcd}, check that L_{kilj} == R_{ijkl}
-            CHECK(L_cadb_temp.get(k, i, l, j) == R_abcd.get(i, j, k, l));
-            // For L_{cbad} = R_{abcd}, check that L_{kjil} == R_{ijkl}
-            CHECK(L_cbad_temp.get(k, j, i, l) == R_abcd.get(i, j, k, l));
-            // For L_{cbda} = R_{abcd}, check that L_{kjli} == R_{ijkl}
-            CHECK(L_cbda_temp.get(k, j, l, i) == R_abcd.get(i, j, k, l));
-            // For L_{cdab} = R_{abcd}, check that L_{klij} == R_{ijkl}
-            CHECK(L_cdab_temp.get(k, l, i, j) == R_abcd.get(i, j, k, l));
-            // For L_{cdba} = R_{abcd}, check that L_{klji} == R_{ijkl}
-            CHECK(L_cdba_temp.get(k, l, j, i) == R_abcd.get(i, j, k, l));
-            // For L_{dabc} = R_{abcd}, check that L_{lijk} == R_{ijkl}
-            CHECK(L_dabc_temp.get(l, i, j, k) == R_abcd.get(i, j, k, l));
-            // For L_{dacb} = R_{abcd}, check that L_{likj} == R_{ijkl}
-            CHECK(L_dacb_temp.get(l, i, k, j) == R_abcd.get(i, j, k, l));
-            // For L_{dbac} = R_{abcd}, check that L_{ljik} == R_{ijkl}
-            CHECK(L_dbac_temp.get(l, j, i, k) == R_abcd.get(i, j, k, l));
-            // For L_{dbca} = R_{abcd}, check that L_{ljki} == R_{ijkl}
-            CHECK(L_dbca_temp.get(l, j, k, i) == R_abcd.get(i, j, k, l));
-            // For L_{dcab} = R_{abcd}, check that L_{lkij} == R_{ijkl}
-            CHECK(L_dcab_temp.get(l, k, i, j) == R_abcd.get(i, j, k, l));
-            // For L_{dcba} = R_{abcd}, check that L_{lkji} == R_{ijkl}
-            CHECK(L_dcba_temp.get(l, k, j, i) == R_abcd.get(i, j, k, l));
-          }
+  // L_{dcba} = R_{abcd}
+  using L_dcba_symmetry =
+      Symmetry<lhs_symmetry_element_d, lhs_symmetry_element_c,
+               lhs_symmetry_element_b, lhs_symmetry_element_a>;
+  using L_dcba_tensorindextype_list =
+      tmpl::list<lhs_tensorindextype_d, lhs_tensorindextype_c,
+                 lhs_tensorindextype_b, lhs_tensorindextype_a>;
+  using L_dcba_type =
+      Tensor<DataType, L_dcba_symmetry, L_dcba_tensorindextype_list>;
+  L_dcba_type L_dcba(used_for_size);
+  std::fill(L_dcba.begin(), L_dcba.end(),
+            component_placeholder_value<DataType>::value);
+  call_evaluate<ReturnLhsTensor, TensorIndexD, TensorIndexC, TensorIndexB,
+                TensorIndexA>(make_not_null(&L_dcba), rhs_expression);
+
+  const size_t dim_a = tmpl::at_c<LhsTensorIndexTypeList, 0>::dim;
+  const size_t dim_b = tmpl::at_c<LhsTensorIndexTypeList, 1>::dim;
+  const size_t dim_c = tmpl::at_c<LhsTensorIndexTypeList, 2>::dim;
+  const size_t dim_d = tmpl::at_c<LhsTensorIndexTypeList, 3>::dim;
+
+  // check LHS evaluated correctly
+  for (size_t lhs_a = 0; lhs_a < dim_a; ++lhs_a) {
+    for (size_t lhs_b = 0; lhs_b < dim_b; ++lhs_b) {
+      for (size_t lhs_c = 0; lhs_c < dim_c; ++lhs_c) {
+        for (size_t lhs_d = 0; lhs_d < dim_d; ++lhs_d) {
+          const auto& expected_result =
+              expected_L_abcd.get(lhs_a, lhs_b, lhs_c, lhs_d);
+
+          CHECK(L_abcd.get(lhs_a, lhs_b, lhs_c, lhs_d) == expected_result);
+          CHECK(L_abdc.get(lhs_a, lhs_b, lhs_d, lhs_c) == expected_result);
+          CHECK(L_acbd.get(lhs_a, lhs_c, lhs_b, lhs_d) == expected_result);
+          CHECK(L_acdb.get(lhs_a, lhs_c, lhs_d, lhs_b) == expected_result);
+          CHECK(L_adbc.get(lhs_a, lhs_d, lhs_b, lhs_c) == expected_result);
+          CHECK(L_adcb.get(lhs_a, lhs_d, lhs_c, lhs_b) == expected_result);
+          CHECK(L_bacd.get(lhs_b, lhs_a, lhs_c, lhs_d) == expected_result);
+          CHECK(L_badc.get(lhs_b, lhs_a, lhs_d, lhs_c) == expected_result);
+          CHECK(L_bcad.get(lhs_b, lhs_c, lhs_a, lhs_d) == expected_result);
+          CHECK(L_bcda.get(lhs_b, lhs_c, lhs_d, lhs_a) == expected_result);
+          CHECK(L_bdac.get(lhs_b, lhs_d, lhs_a, lhs_c) == expected_result);
+          CHECK(L_bdca.get(lhs_b, lhs_d, lhs_c, lhs_a) == expected_result);
+          CHECK(L_cabd.get(lhs_c, lhs_a, lhs_b, lhs_d) == expected_result);
+          CHECK(L_cadb.get(lhs_c, lhs_a, lhs_d, lhs_b) == expected_result);
+          CHECK(L_cbad.get(lhs_c, lhs_b, lhs_a, lhs_d) == expected_result);
+          CHECK(L_cbda.get(lhs_c, lhs_b, lhs_d, lhs_a) == expected_result);
+          CHECK(L_cdab.get(lhs_c, lhs_d, lhs_a, lhs_b) == expected_result);
+          CHECK(L_cdba.get(lhs_c, lhs_d, lhs_b, lhs_a) == expected_result);
+          CHECK(L_dabc.get(lhs_d, lhs_a, lhs_b, lhs_c) == expected_result);
+          CHECK(L_dacb.get(lhs_d, lhs_a, lhs_c, lhs_b) == expected_result);
+          CHECK(L_dbac.get(lhs_d, lhs_b, lhs_a, lhs_c) == expected_result);
+          CHECK(L_dbca.get(lhs_d, lhs_b, lhs_c, lhs_a) == expected_result);
+          CHECK(L_dcab.get(lhs_d, lhs_c, lhs_a, lhs_b) == expected_result);
+          CHECK(L_dcba.get(lhs_d, lhs_c, lhs_b, lhs_a) == expected_result);
         }
       }
     }

--- a/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TestHelpers.hpp
+++ b/tests/Unit/Helpers/DataStructures/Tensor/Expressions/TestHelpers.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \ingroup TestingFrameworkGroup
+/// Functions for testing `TensorExpression`s
+namespace TestHelpers::tenex {
+// Helper that simply calls `tenex::evaluate`
+template <bool ReturnLhsTensor, auto&... LhsTensorIndices, typename LhsTensor,
+          typename RhsExpression>
+void call_evaluate(const gsl::not_null<LhsTensor*> lhs_tensor,
+                   const RhsExpression& rhs_expression) {
+  if constexpr (ReturnLhsTensor) {
+    *lhs_tensor = ::tenex::evaluate<LhsTensorIndices...>(rhs_expression);
+  } else {
+    ::tenex::evaluate<LhsTensorIndices...>(lhs_tensor, rhs_expression);
+  }
+}
+
+// Returns the subset of index positions of an `Index` that a `TensorIndex`
+// refers to given the kind of index (e.g. spatial, spacetime, time) that
+// `Index` and `TensorIndex` each are
+//
+// - spatial `Index` and spatial `TensorIndex`: [0, Index::Dim - 1]
+// - spacetime `Index` and spacetime `TensorIndex`: [0, Index::Dim - 1]
+// - spacetime `Index` and spatial `TensorIndex`: [1, Index::Dim - 1]
+// - spacetime `Index` and concrete time `TensorIndex`: [0, 0]
+template <typename Index, auto& TensorIndex>
+constexpr std::pair<size_t, size_t> get_index_value_range() {
+  constexpr bool tensorindex_is_time =
+      ::tenex::detail::is_time_index_value(TensorIndex.value);
+  static_assert(
+      not(Index::index_type == IndexType::Spatial and tensorindex_is_time),
+      "Cannot use a concrete time TensorIndex with a SpatialIndex.");
+  std::pair<size_t, size_t> range{};
+  range.first =
+      Index::index_type == IndexType::Spacetime and not TensorIndex.is_spacetime
+          ? 1
+          : 0;
+  range.second = tensorindex_is_time ? 0 : Index::dim - 1;
+  return range;
+}
+}  // namespace TestHelpers::tenex


### PR DESCRIPTION
## Proposed changes

This generalizes the `TensorExpression` testing functions to also work with testing expressions where spatial or time indices are used for spacetime indices.

This is a precursor for a followup PR that fixes a TensorExpression bug and makes use of the new, more general interface by adding many new test cases to increase test coverage easily. The changes in this PR were submitted separately to make code review of the future PR easier.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
