### PR TITLE
Add event to observe tensor fields in modal space

### DIFF
--- a/src/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/src/ParallelAlgorithms/Events/CMakeLists.txt
@@ -27,6 +27,7 @@ spectre_target_headers(
   ObserveDataBox.hpp
   ObserveAtExtremum.hpp
   ObserveFields.hpp
+  ObserveModalFields.hpp
   ObserveNorms.hpp
   ObserveTimeStep.hpp
   ObserveTimeStep.tpp

--- a/src/ParallelAlgorithms/Events/Factory.hpp
+++ b/src/ParallelAlgorithms/Events/Factory.hpp
@@ -9,6 +9,7 @@
 #include "ParallelAlgorithms/Events/ErrorIfDataTooBig.hpp"
 #include "ParallelAlgorithms/Events/ObserveAdaptiveSteppingDiagnostics.hpp"
 #include "ParallelAlgorithms/Events/ObserveFields.hpp"
+#include "ParallelAlgorithms/Events/ObserveModalFields.hpp"
 #include "ParallelAlgorithms/Events/ObserveNorms.hpp"
 #include "ParallelAlgorithms/Events/ObserveTimeStep.hpp"
 #include "Time/ChangeSlabSize/Event.hpp"
@@ -21,6 +22,8 @@ using field_observations = tmpl::flatten<tmpl::list<
     ::Events::ErrorIfDataTooBig<VolumeDim, Fields, NonTensorComputeTagsList>,
     ObserveFields<VolumeDim, Fields, NonTensorComputeTagsList,
                   ArraySectionIdTag>,
+    ObserveModalFields<VolumeDim, Fields, NonTensorComputeTagsList,
+                       ArraySectionIdTag>,
     ::Events::ObserveNorms<Fields, NonTensorComputeTagsList,
                            ArraySectionIdTag>>>;
 }  // namespace dg::Events

--- a/src/ParallelAlgorithms/Events/ObserveModalFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveModalFields.hpp
@@ -1,0 +1,395 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <initializer_list>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
+#include "DataStructures/DataBox/ValidateSelection.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/Observer/GetSectionObservationKey.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Auto.hpp"
+#include "Options/String.hpp"
+#include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Local.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/OptionalHelpers.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace dg::Events {
+/// \cond
+template <size_t VolumeDim, typename Tensors,
+          typename NonTensorComputeTagsList = tmpl::list<>,
+          typename ArraySectionIdTag = void>
+class ObserveModalFields;
+/// \endcond
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Observe volume tensor fields in a modal basis.
+ *
+ * Writes modal expansion coefficients for the selected tensor components. If
+ * truncation extents are provided the coefficients are truncated to the
+ * specified extents.
+ */
+template <size_t VolumeDim, typename... Tensors,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+class ObserveModalFields<VolumeDim, tmpl::list<Tensors...>,
+                         tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>
+    : public Event {
+ public:
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "The name of the subfile inside the HDF5 file where the modes are to "
+        "be written. Give them without an extension and "
+        "without a preceding '/'."};
+  };
+
+  /// \cond
+  explicit ObserveModalFields(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(ObserveModalFields);  // NOLINT
+  /// \endcond
+
+  struct VariablesToObserve {
+    static constexpr Options::String help = "Subset of variables to observe";
+    using type = std::vector<std::string>;
+    static size_t lower_bound_on_size() { return 1; }
+  };
+
+  struct TruncateToExtents {
+    using type =
+        Options::Auto<std::array<size_t, VolumeDim>, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "Optional modal truncation extents. The extents must not increase the "
+        "number of points in any dimension; basis and quadrature are taken "
+        "from the element mesh.";
+  };
+
+  struct BlocksToObserve {
+    using type =
+        Options::Auto<std::vector<std::string>, Options::AutoLabel::All>;
+    static constexpr Options::String help = {
+        "A list of block and group names on which to observe."};
+  };
+
+  using options = tmpl::list<SubfileName, VariablesToObserve, BlocksToObserve,
+                             TruncateToExtents>;
+
+  static constexpr Options::String help =
+      "Observe volume tensor fields in a modal basis.\n"
+      "\n"
+      "Writes modal coefficients for tensors listed in the "
+      "'VariablesToObserve' option.\n"
+      "\n"
+      "The coefficients are written as double-precision real values.";
+
+  ObserveModalFields() = default;
+
+  ObserveModalFields(
+      const std::string& subfile_name,
+      const std::vector<std::string>& variables_to_observe,
+      std::optional<std::vector<std::string>> active_block_or_block_groups = {},
+      std::optional<std::array<size_t, VolumeDim>> truncation_extents = {},
+      const Options::Context& context = {});
+
+  using compute_tags_for_observation_box =
+      tmpl::list<Tensors..., NonTensorComputeTags...>;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<::Tags::ObservationBox,
+                                   ::Events::Tags::ObserverMesh<VolumeDim>>;
+
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename Metavariables, typename ParallelComponent>
+  void operator()(const ObservationBox<DataBoxType, ComputeTagsList>& box,
+                  const Mesh<VolumeDim>& mesh,
+                  Parallel::GlobalCache<Metavariables>& cache,
+                  const ElementId<VolumeDim>& array_index,
+                  const ParallelComponent* const component,
+                  const ObservationValue& observation_value) const {
+    if (not active_block(get<domain::Tags::Domain<VolumeDim>>(box),
+                         array_index)) {
+      return;
+    }
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    if (not section_observation_key.has_value()) {
+      return;
+    }
+    call_operator_impl(subfile_path_ + *section_observation_key,
+                       variables_to_observe_, truncation_extents_, mesh, box,
+                       cache, array_index, component, observation_value);
+  }
+
+  template <typename DataBoxType, typename ComputeTagsList,
+            typename Metavariables, typename ParallelComponent>
+  static void call_operator_impl(
+      const std::string& subfile_path,
+      const std::unordered_set<std::string>& variables_to_observe,
+      const std::optional<std::array<size_t, VolumeDim>>& truncation_extents,
+      const Mesh<VolumeDim>& mesh,
+      const ObservationBox<DataBoxType, ComputeTagsList>& box,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ElementId<VolumeDim>& element_id,
+      const ParallelComponent* const /*meta*/,
+      const ObservationValue& observation_value) {
+    Mesh<VolumeDim> mesh_for_output = mesh;
+    if (truncation_extents.has_value()) {
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        ASSERT(truncation_extents.value()[d] <= mesh.extents(d),
+               "Cannot increase resolution when truncating modal data. "
+               "Requested extent "
+                   << truncation_extents.value()[d]
+                   << " exceeds element extent " << mesh.extents(d)
+                   << " in dimension " << d);
+      }
+      mesh_for_output = make_truncation_mesh(mesh, truncation_extents.value());
+    }
+
+    std::vector<TensorComponent> components;
+    components.reserve(alg::accumulate(
+        std::initializer_list<size_t>{
+            std::decay_t<decltype(value(typename Tensors::type{}))>::size()...},
+        0_st));
+
+    tmpl::for_each<tmpl::list<Tensors...>>([&](auto tensor_tag_v) {
+      using tensor_tag = tmpl::type_from<decltype(tensor_tag_v)>;
+      const std::string tag_name = db::tag_name<tensor_tag>();
+      if (variables_to_observe.find(tag_name) == variables_to_observe.end()) {
+        return;
+      }
+      const auto& tensor = get<tensor_tag>(box);
+      ASSERT(has_value(tensor),
+             "ObserveModalFields cannot observe optional tag "
+                 << tag_name << " because it has not been evaluated.");
+      const auto& tensor_value = value(tensor);
+      using VectorType = typename std::decay_t<decltype(tensor_value)>::type;
+      static_assert(std::is_same_v<VectorType, DataVector>,
+                    "ObserveModalFields assumes real DataVector data.");
+      for (size_t i = 0; i < tensor_value.size(); ++i) {
+        const std::string component_name =
+            tag_name + tensor_value.component_suffix(i);
+        const ModalVector element_modal =
+            to_modal_coefficients(tensor_value[i], mesh);
+        const ModalVector truncated_modal =
+            truncate_modal(element_modal, mesh, mesh_for_output);
+        components.emplace_back(component_name,
+                                modal_to_datavector(truncated_modal));
+      }
+    });
+
+    const std::string modal_subfile_path = subfile_path + "_modal";
+
+    const Parallel::ArrayComponentId array_component_id{
+        std::add_pointer_t<ParallelComponent>{nullptr},
+        Parallel::ArrayIndex<ElementId<VolumeDim>>{element_id}};
+    ElementVolumeData element_volume_data{element_id, std::move(components),
+                                          mesh_for_output};
+    observers::ObservationId observation_id{observation_value.value,
+                                            modal_subfile_path + ".vol"};
+
+    auto& local_observer = *Parallel::local_branch(
+        Parallel::get_parallel_component<
+            tmpl::conditional_t<Parallel::is_nodegroup_v<ParallelComponent>,
+                                observers::ObserverWriter<Metavariables>,
+                                observers::Observer<Metavariables>>>(cache));
+
+    if constexpr (Parallel::is_nodegroup_v<ParallelComponent>) {
+      std::unordered_map<Parallel::ArrayComponentId,
+                         std::vector<ElementVolumeData>>
+          data_to_send{};
+      data_to_send[array_component_id] =
+          std::vector{std::move(element_volume_data)};
+      Parallel::threaded_action<
+          observers::ThreadedActions::ContributeVolumeDataToWriter>(
+          local_observer, std::move(observation_id), array_component_id,
+          modal_subfile_path, std::move(data_to_send));
+    } else {
+      Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+          local_observer, std::move(observation_id), modal_subfile_path,
+          array_component_id, std::move(element_volume_data));
+    }
+  }
+
+  using observation_registration_tags = tmpl::list<::Tags::DataBox>;
+
+  template <typename DbTagsList>
+  std::optional<
+      std::pair<observers::TypeOfObservation, observers::ObservationKey>>
+  get_observation_type_and_key_for_registration(
+      const db::DataBox<DbTagsList>& box) const {
+    if (not active_block(db::get<domain::Tags::Domain<VolumeDim>>(box),
+                         db::get<domain::Tags::Element<VolumeDim>>(box).id())) {
+      return std::nullopt;
+    }
+    const std::optional<std::string> section_observation_key =
+        observers::get_section_observation_key<ArraySectionIdTag>(box);
+    if (not section_observation_key.has_value()) {
+      return std::nullopt;
+    }
+    return {
+        {observers::TypeOfObservation::Volume,
+         observers::ObservationKey{
+             subfile_path_ + section_observation_key.value() + "_modal.vol"}}};
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override {
+    Event::pup(p);
+    p | subfile_path_;
+    p | variables_to_observe_;
+    p | active_block_or_block_groups_;
+    p | truncation_extents_;
+  }
+
+ private:
+  bool active_block(const Domain<VolumeDim>& domain,
+                    const ElementId<VolumeDim>& element_id) const {
+    if (not active_block_or_block_groups_.has_value()) {
+      return true;
+    }
+    const std::unordered_set<std::string> block_names =
+        domain::expand_block_groups_to_block_names(
+            active_block_or_block_groups_.value(), domain.block_names(),
+            domain.block_groups());
+    return alg::found(block_names,
+                      domain.blocks().at(element_id.block_id()).name());
+  }
+
+  std::string subfile_path_;
+  std::unordered_set<std::string> variables_to_observe_{};
+  std::optional<std::vector<std::string>> active_block_or_block_groups_{};
+  std::optional<std::array<size_t, VolumeDim>> truncation_extents_{};
+  static Mesh<VolumeDim> make_truncation_mesh(
+      const Mesh<VolumeDim>& mesh,
+      const std::array<size_t, VolumeDim>& truncation_extents) {
+    return Mesh<VolumeDim>(truncation_extents, mesh.basis(), mesh.quadrature());
+  }
+
+  static DataVector modal_to_datavector(const ModalVector& modal) {
+    DataVector result(modal.size());
+    for (size_t i = 0; i < modal.size(); ++i) {
+      result[i] = modal[i];
+    }
+    return result;
+  }
+
+  static ModalVector truncate_modal(const ModalVector& modal_in,
+                                    const Mesh<VolumeDim>& mesh,
+                                    const Mesh<VolumeDim>& mesh_for_output) {
+    if (mesh_for_output == mesh) {
+      return ModalVector{modal_in};
+    }
+    ModalVector modal_out(mesh_for_output.number_of_grid_points());
+    const Index<VolumeDim> source_extents(mesh.extents());
+    const Index<VolumeDim> target_extents(mesh_for_output.extents());
+    for (size_t target_linear = 0;
+         target_linear < mesh_for_output.number_of_grid_points();
+         ++target_linear) {
+      const Index<VolumeDim> target_multi =
+          expanded_index(target_linear, target_extents);
+      Index<VolumeDim> source_multi{0};
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        source_multi[d] = target_multi[d];
+      }
+      const size_t source_linear =
+          collapsed_index(source_multi, source_extents);
+      modal_out[target_linear] = modal_in[source_linear];
+    }
+    return modal_out;
+  }
+};
+
+template <size_t VolumeDim, typename... Tensors,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+ObserveModalFields<VolumeDim, tmpl::list<Tensors...>,
+                   tmpl::list<NonTensorComputeTags...>, ArraySectionIdTag>::
+    ObserveModalFields(
+        const std::string& subfile_name,
+        const std::vector<std::string>& variables_to_observe,
+        std::optional<std::vector<std::string>> active_block_or_block_groups,
+        std::optional<std::array<size_t, VolumeDim>> truncation_extents,
+        const Options::Context& context)
+    : subfile_path_("/" + subfile_name),
+      variables_to_observe_([&context, &variables_to_observe]() {
+        if (variables_to_observe.empty()) {
+          PARSE_ERROR(context,
+                      "ObserveModalFields requires at least one variable.");
+        }
+        std::unordered_set<std::string> result{};
+        result.reserve(variables_to_observe.size() + 1);
+        for (const auto& name : variables_to_observe) {
+          result.insert(name);
+        }
+        return result;
+      }()),
+      active_block_or_block_groups_(std::move(active_block_or_block_groups)),
+      truncation_extents_(std::move(truncation_extents)) {
+  db::validate_selection<tmpl::list<Tensors...>>(variables_to_observe, context);
+}
+
+/// \cond
+template <size_t VolumeDim, typename... Tensors,
+          typename... NonTensorComputeTags, typename ArraySectionIdTag>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID ObserveModalFields<VolumeDim, tmpl::list<Tensors...>,
+                                     tmpl::list<NonTensorComputeTags...>,
+                                     ArraySectionIdTag>::my_PUP_ID = 0;
+/// \endcond
+}  // namespace dg::Events

--- a/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/Events/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ObserveAdaptiveSteppingDiagnostics.cpp
   Test_ObserveAtExtremum.cpp
   Test_ObserveFields.cpp
+  Test_ObserveModalFields.cpp
   Test_ObserveNorms.cpp
   Test_ObserveTimeStep.cpp
   Test_ObserveTimeStepVolume.cpp

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveModalFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveModalFields.cpp
@@ -1,0 +1,282 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/MetavariablesTag.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Creators/Rectilinear.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Framework/TestCreation.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "ParallelAlgorithms/Events/ObserveModalFields.hpp"
+#include "ParallelAlgorithms/Events/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct MockContributeVolumeData {
+  struct Results {
+    observers::ObservationId observation_id{};
+    std::string subfile_name{};
+    Parallel::ArrayComponentId array_component_id{};
+    ElementVolumeData received_volume_data{};
+  };
+
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static Results results;
+
+  template <typename ParallelComponent, typename... DbTags,
+            typename Metavariables, typename ArrayIndex>
+  static void apply(
+      db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/,
+      const observers::ObservationId& observation_id,
+      const std::string& subfile_name,
+      const Parallel::ArrayComponentId& array_component_id,
+      ElementVolumeData&& received_volume_data,
+      const std::optional<std::string>& /*dependency*/ = std::nullopt) {
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.array_component_id = array_component_id;
+    results.received_volume_data = std::move(received_volume_data);
+  }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+MockContributeVolumeData::Results MockContributeVolumeData::results{};
+
+template <typename Metavariables>
+struct ElementComponent {
+  using component_being_mocked = void;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Metavariables::volume_dim>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+};
+
+template <typename Metavariables>
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeVolumeData>;
+  using with_these_simple_actions = tmpl::list<MockContributeVolumeData>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockGroupChare;
+  using array_index = int;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization, tmpl::list<>>>;
+};
+
+struct MinimalSystem {
+  using data_type = DataVector;
+  static constexpr size_t volume_dim = 3;
+
+  struct ScalarVar : db::SimpleTag {
+    static std::string name() { return "Scalar"; }
+    using type = Scalar<DataVector>;
+  };
+
+  struct VectorVar : db::SimpleTag {
+    static std::string name() { return "Vector"; }
+    using type = tnsr::i<DataVector, volume_dim, Frame::Inertial>;
+  };
+
+  using variables_tag = ::Tags::Variables<tmpl::list<ScalarVar, VectorVar>>;
+  using ObserveEvent =
+      dg::Events::ObserveModalFields<volume_dim,
+                                     tmpl::list<ScalarVar, VectorVar>>;
+};
+
+struct Metavariables {
+  using system = MinimalSystem;
+  static constexpr size_t volume_dim = system::volume_dim;
+  using component_list = tmpl::list<ElementComponent<Metavariables>,
+                                    MockObserverComponent<Metavariables>>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<Event, tmpl::list<typename system::ObserveEvent>>>;
+  };
+};
+
+template <typename ObserveEvent>
+void test_modal_observe(
+    const ObserveEvent& observe,
+    const std::optional<std::array<size_t, Metavariables::volume_dim>>&
+        truncation_extents) {
+  using metavariables = Metavariables;
+  constexpr size_t volume_dim = Metavariables::volume_dim;
+  using element_component = ElementComponent<metavariables>;
+  using observer_component = MockObserverComponent<metavariables>;
+
+  const ElementId<volume_dim> element_id(0);
+  const Element<volume_dim> element(element_id, {});
+  const domain::creators::Rectilinear<volume_dim> rectilinear{
+      make_array<volume_dim>(-2.0), make_array<volume_dim>(2.0),
+      make_array<volume_dim>(0_st), make_array<volume_dim>(5_st),
+      make_array<volume_dim>(true)};
+  const Mesh<volume_dim> mesh(5, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto);
+
+  const double observation_time = 2.0;
+  Variables<typename MinimalSystem::variables_tag::tags_list> vars(
+      mesh.number_of_grid_points());
+  std::iota(vars.data(), vars.data() + vars.size(), 1.0);
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  MockRuntimeSystem runner{{}};
+  ActionTesting::emplace_component<element_component>(make_not_null(&runner),
+                                                      element_id);
+  ActionTesting::emplace_group_component<observer_component>(&runner);
+
+  auto box = db::create<db::AddSimpleTags<
+      Parallel::Tags::MetavariablesImpl<metavariables>,
+      domain::Tags::Domain<volume_dim>, domain::Tags::Element<volume_dim>,
+      domain::Tags::Mesh<volume_dim>,
+      ::Tags::Variables<typename decltype(vars)::tags_list>,
+      observers::Tags::ObservationKey<void>>>(
+      metavariables{}, rectilinear.create_domain(), element, mesh, vars,
+      std::optional<std::string>{});
+
+  MockContributeVolumeData::results = {};
+
+  auto obs_box = make_observation_box<tmpl::push_back<
+      tmpl::filter<typename ObserveEvent::compute_tags_for_observation_box,
+                   db::is_compute_tag<tmpl::_1>>,
+      ::Events::Tags::ObserverMeshCompute<volume_dim>>>(make_not_null(&box));
+
+  const Event::ObservationValue observation_value{"TestObservation",
+                                                  observation_time};
+
+  observe(obs_box, mesh,
+          ActionTesting::cache<element_component>(runner, element_id),
+          element_id, static_cast<const element_component*>(nullptr),
+          observation_value);
+  runner.template invoke_queued_simple_action<observer_component>(0);
+
+  const auto& results = MockContributeVolumeData::results;
+  const Mesh<volume_dim> mesh_for_output =
+      truncation_extents.has_value()
+          ? Mesh<volume_dim>(truncation_extents.value(), mesh.basis(),
+                             mesh.quadrature())
+          : mesh;
+  const auto mesh_extents = mesh_for_output.extents();
+  const std::vector<size_t> expected_extents{mesh_extents.begin(),
+                                             mesh_extents.end()};
+  CHECK(results.received_volume_data.extents == expected_extents);
+  std::unordered_map<std::string, DataVector> expected_components{};
+  const auto modal_data = [&mesh, &mesh_for_output](const DataVector& nodal) {
+    ModalVector modal = to_modal_coefficients(nodal, mesh);
+    if (mesh_for_output != mesh) {
+      ModalVector truncated(mesh_for_output.number_of_grid_points());
+      const Index<volume_dim> source_extents(mesh.extents());
+      const Index<volume_dim> target_extents(mesh_for_output.extents());
+      for (size_t target_linear = 0;
+           target_linear < mesh_for_output.number_of_grid_points();
+           ++target_linear) {
+        const Index<volume_dim> target_multi =
+            expanded_index(target_linear, target_extents);
+        Index<volume_dim> source_multi{0};
+        for (size_t d = 0; d < volume_dim; ++d) {
+          source_multi[d] = target_multi[d];
+        }
+        const size_t source_linear =
+            collapsed_index(source_multi, source_extents);
+        truncated[target_linear] = modal[source_linear];
+      }
+      modal = std::move(truncated);
+    }
+    DataVector result(modal.size());
+    for (size_t i = 0; i < modal.size(); ++i) {
+      result[i] = modal[i];
+    }
+    return result;
+  };
+
+  expected_components["Scalar"] =
+      modal_data(get<MinimalSystem::ScalarVar>(vars).get());
+  const auto& vector = get<MinimalSystem::VectorVar>(vars);
+  for (size_t i = 0; i < volume_dim; ++i) {
+    expected_components["Vector" + vector.component_suffix(i)] =
+        modal_data(vector.get(i));
+  }
+
+  REQUIRE(results.received_volume_data.tensor_components.size() ==
+          expected_components.size());
+  for (const auto& component : results.received_volume_data.tensor_components) {
+    const auto expected_it = expected_components.find(component.name);
+    REQUIRE(expected_it != expected_components.end());
+    CHECK(std::holds_alternative<DataVector>(component.data));
+    CHECK_ITERABLE_APPROX(std::get<DataVector>(component.data),
+                          expected_it->second);
+  }
+}
+
+void test_modal_factory_creation() {
+  const auto obs =
+      TestHelpers::test_creation<std::unique_ptr<Event>, Metavariables>(
+          "ObserveModalFields:\n"
+          "  SubfileName: element_data\n"
+          "  VariablesToObserve: [Scalar, Vector]\n"
+          "  BlocksToObserve: All\n"
+          "  TruncateToExtents: None\n");
+  CHECK(obs != nullptr);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Events.ObserveModalFields",
+                  "[Unit][ParallelAlgorithms]") {
+  const MinimalSystem::ObserveEvent observe{
+      "element_data", std::vector<std::string>{"Scalar", "Vector"},
+      std::nullopt, std::nullopt};
+
+  test_modal_observe(observe, std::nullopt);
+
+  const std::array<size_t, MinimalSystem::volume_dim> truncation_extents{3, 3,
+                                                                         3};
+  const MinimalSystem::ObserveEvent observe_truncated{
+      "element_data", std::vector<std::string>{"Scalar", "Vector"},
+      std::nullopt, truncation_extents};
+  test_modal_observe(observe_truncated, truncation_extents);
+
+  test_modal_factory_creation();
+}


### PR DESCRIPTION
## Proposed changes

Adds an event that observes some tensor fields, converts them to modal coefficients and truncates them according to the input file. This is needed for a new spacetime interpolator based on mode decomposition.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
