### PR TITLE
Add Legendre series evaluation from modal coefficients

### DIFF
--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/Legendre.cpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/Legendre.cpp
@@ -6,18 +6,25 @@
 #include <limits>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctionNormalizationSquare.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
 #include "NumericalAlgorithms/Spectral/InverseWeightFunctionValues.hpp"
+#include "NumericalAlgorithms/Spectral/Legendre.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -263,4 +270,74 @@ Matrix spectral_indefinite_integral_matrix<Basis::Legendre>(
   return constant * indef_int;
 }
 
+namespace {
+double evaluate_legendre_segment(gsl::span<const double> coefficients,
+                                 const double x) {
+  if (coefficients.empty()) {
+    return 0.0;
+  }
+  if (coefficients.size() == 1) {
+    return gsl::at(coefficients, 0);
+  }
+  const size_t n = coefficients.size() - 1;
+  double b_k_plus_two = 0.0;
+  double b_k_plus_one = 0.0;
+  for (int k = static_cast<int>(n); k >= 0; --k) {
+    const auto k_double = static_cast<double>(k);
+    const double a_k = (2.0 * k_double + 1.0) / (k_double + 1.0) * x;
+    const double b_kp1 = -(k_double + 1.0) / (k_double + 2.0);
+    const double b_k_current =
+        gsl::at(coefficients, k) + a_k * b_k_plus_one + b_kp1 * b_k_plus_two;
+    b_k_plus_two = b_k_plus_one;
+    b_k_plus_one = b_k_current;
+  }
+  return b_k_plus_one;
+}
+}  // namespace
+
+template <size_t Dim>
+double evaluate_legendre_series(
+    const ModalVector& coefficients, const Mesh<Dim>& mesh,
+    const tnsr::I<double, Dim, Frame::ElementLogical>& logical_coords) {
+  ASSERT(mesh.number_of_grid_points() == coefficients.size(),
+         "Mesh and coefficient sizes do not match: mesh has "
+             << mesh.number_of_grid_points() << " points but coefficients hold "
+             << coefficients.size() << " entries.");
+  for (size_t d = 0; d < Dim; ++d) {
+    ASSERT(mesh.basis(d) == Basis::Legendre,
+           "evaluate_legendre_series only supports Legendre bases. Found "
+               << mesh.basis(d) << " in dimension " << d << ".");
+  }
+  std::vector<double> working(coefficients.begin(), coefficients.end());
+  size_t current_size = working.size();
+  for (size_t dim = 0; dim < Dim; ++dim) {
+    const size_t extent = mesh.extents(dim);
+    ASSERT(extent > 0, "Mesh extent must be non-zero.");
+    const size_t num_slices = current_size / extent;
+    const double x_dim = logical_coords.get(dim);
+    const gsl::span<const double> working_view(working);
+    for (size_t slice = 0; slice < num_slices; ++slice) {
+      const auto slice_view = working_view.subspan(slice * extent, extent);
+      working[slice] = evaluate_legendre_segment(slice_view, x_dim);
+    }
+    current_size = num_slices;
+  }
+  ASSERT(current_size == 1,
+         "After evaluating all dimensions there should be a single value.");
+  return working.front();
+}
+
 }  // namespace Spectral
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template double Spectral::evaluate_legendre_series<DIM(data)>(    \
+      const ModalVector& coefficients, const Mesh<DIM(data)>& mesh, \
+      const tnsr::I<double, DIM(data), Frame::ElementLogical>&      \
+          logical_coords);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -52,6 +52,7 @@ spectre_target_headers(
   IntegrationMatrix.hpp
   InterpolationMatrix.hpp
   InverseWeightFunctionValues.hpp
+  Legendre.hpp
   LinearFilteringMatrix.hpp
   LogicalCoordinates.hpp
   MaximumNumberOfPoints.hpp

--- a/src/NumericalAlgorithms/Spectral/Legendre.hpp
+++ b/src/NumericalAlgorithms/Spectral/Legendre.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace Spectral {
+
+/*!
+ * \brief Evaluate a Legendre series from the modal coefficients at a given
+ * logical point using Clenshaw recurrence.
+ */
+template <size_t Dim>
+double evaluate_legendre_series(
+    const ModalVector& coefficients, const Mesh<Dim>& mesh,
+    const tnsr::I<double, Dim, Frame::ElementLogical>& logical_coords);
+
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Test_IndefiniteIntegral.cpp
   Test_IntegrationMatrix.cpp
   Test_InterpolationMatrix.cpp
+  Test_Legendre.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp
   Test_LinearFilterMatrix.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Legendre.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Legendre.cpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/Legendre.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+double evaluate_by_summing_legendre_basis(const ModalVector& coefficients,
+                                          const double x) {
+  double sum = 0.0;
+  for (size_t k = 0; k < coefficients.size(); ++k) {
+    sum +=
+        coefficients[k] *
+        Spectral::compute_basis_function_value<Spectral::Basis::Legendre>(k, x);
+  }
+  return sum;
+}
+
+template <size_t Dim>
+void check_against_irregular(
+    const std::array<size_t, Dim>& extents_array,
+    const gsl::not_null<std::mt19937*> generator,
+    std::uniform_real_distribution<>& coefficient_distribution,
+    std::uniform_real_distribution<>& logical_distribution) {
+  const size_t num_test_points = 100;
+  const Mesh<Dim> mesh(extents_array, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const auto modal_coefficients = make_with_random_values<ModalVector>(
+      generator, make_not_null(&coefficient_distribution),
+      ModalVector{mesh.number_of_grid_points()});
+  const auto logical_point =
+      make_with_random_values<tnsr::I<DataVector, Dim, Frame::ElementLogical>>(
+          generator, make_not_null(&logical_distribution), num_test_points);
+
+  const DataVector nodal_coefficients =
+      to_nodal_coefficients(modal_coefficients, mesh);
+  const intrp::Irregular<Dim> interpolant(mesh, logical_point);
+  const DataVector nodal_value = interpolant.interpolate(nodal_coefficients);
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  for (size_t i = 0; i < num_test_points; ++i) {
+    tnsr::I<double, Dim, Frame::ElementLogical> single_logical_point{};
+    for (size_t d = 0; d < Dim; ++d) {
+      single_logical_point.get(d) = logical_point.get(d)[i];
+    }
+    CHECK(Spectral::evaluate_legendre_series<Dim>(modal_coefficients, mesh,
+                                                  single_logical_point) ==
+          custom_approx(nodal_value[i]));
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Legendre.Series",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> coefficient_distribution(-2.0, 2.0);
+  std::uniform_real_distribution<> logical_distribution(-1.0, 1.0);
+  const auto evaluation_points = make_with_random_values<std::array<double, 5>>(
+      make_not_null(&generator), make_not_null(&logical_distribution),
+      std::array<double, 5>{});
+
+  const auto cubic_coefficients = make_with_random_values<ModalVector>(
+      make_not_null(&generator), make_not_null(&coefficient_distribution),
+      ModalVector{4});
+  const Mesh<1> cubic_mesh({{cubic_coefficients.size()}},
+                           Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto);
+  for (const double x : evaluation_points) {
+    CHECK(Spectral::evaluate_legendre_series<1>(
+              cubic_coefficients, cubic_mesh,
+              tnsr::I<double, 1, Frame::ElementLogical>{{{x}}}) ==
+          approx(evaluate_by_summing_legendre_basis(cubic_coefficients, x)));
+  }
+
+  const auto higher_order = make_with_random_values<ModalVector>(
+      make_not_null(&generator), make_not_null(&coefficient_distribution),
+      ModalVector{20});
+  const Mesh<1> higher_mesh({{higher_order.size()}}, Spectral::Basis::Legendre,
+                            Spectral::Quadrature::GaussLobatto);
+  for (const double x : evaluation_points) {
+    CHECK(Spectral::evaluate_legendre_series<1>(
+              higher_order, higher_mesh,
+              tnsr::I<double, 1, Frame::ElementLogical>{{{x}}}) ==
+          approx(evaluate_by_summing_legendre_basis(higher_order, x)));
+  }
+
+  check_against_irregular<1>({{17}}, make_not_null(&generator),
+                             coefficient_distribution, logical_distribution);
+  check_against_irregular<2>({{20, 19}}, make_not_null(&generator),
+                             coefficient_distribution, logical_distribution);
+  check_against_irregular<3>({{12, 10, 7}}, make_not_null(&generator),
+                             coefficient_distribution, logical_distribution);
+}


### PR DESCRIPTION
## Proposed changes
Adds a direct evaluation of a Legendre series from the Modal coefficients.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
