### PR TITLE
Drop commit/CI check for noexcept markings

### DIFF
--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -634,35 +634,6 @@ enable_if_test() {
 }
 standard_checks+=(enable_if)
 
-# Check for noexcept
-noexcept() {
-    whitelist "$1" \
-              "src/Utilities/StdHelpers/Bit.hpp" \
-              "src/Parallel/MultiReaderSpinlock.hpp$" \
-              'src/Parallel/StaticSpscQueue.hpp' \
-              "src/Parallel/NodeLock..pp$" \
-              "src/Evolution/DiscontinuousGalerkin/\
-AtomicInboxBoundaryData..pp$" && \
-        is_c++ "$1" && \
-        staged_grep -q 'noexcept ' "$1"
-}
-noexcept_report() {
-    echo "Found occurrences of 'noexcept', please remove."
-    pretty_grep noexcept "$@"
-}
-noexcept_test() {
-    test_check pass foo.cpp ''
-    test_check pass foo.hpp ''
-    test_check pass foo.tpp ''
-    test_check fail foo.hpp 'noexcept '
-    test_check fail foo.cpp 'noexcept '
-    test_check fail foo.tpp 'noexcept '
-    test_check pass foo.hpp 'noexcept(true)'
-    test_check pass foo.cpp 'noexcept(true)'
-    test_check pass foo.tpp 'noexcept(true)'
-}
-standard_checks+=(noexcept)
-
 # Check for mutable
 mutable() {
     # We talk about mutable stuff a lot, so try to avoid flagging


### PR DESCRIPTION
This was added for the transition away from everything-noexcept so we didn't accidentally add markings in new PRs.  That was over four years ago and everyone is used to the new policy now, so we can stop forcing everyone to write noexcpet(true) in the cases where a function actually should be noexcept.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
