### PR TITLE
Add evolution characteristics to SoCcz4

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1264,6 +1264,20 @@ eprint = {https://doi.org/10.1137/0916035}
   primaryClass   = "gr-qc",
 }
 
+@article{Gundlach:2005ta,
+    author = "Gundlach, Carsten and Martin-Garcia, Jose M.",
+    title = "{Hyperbolicity of second-order in space systems of evolution
+              equations}",
+    eprint = "gr-qc/0506037",
+    archivePrefix = "arXiv",
+    doi = "10.1088/0264-9381/23/16/S06",
+    url = "https://doi.org/10.1088/0264-9381/23/16/S06",
+    journal = "Class. Quant. Grav.",
+    volume = "23",
+    pages = "S387--S404",
+    year = "2006"
+}
+
 @book{Hairer1993,
   address = {Berlin},
   author = {Hairer, E. and N{\o}rsett, S.P. and Wanner, G.},

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -447,6 +447,12 @@ using iiJJ = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 2, 1, 1>,
                                SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
                                SpatialIndex<SpatialDim, UpLo::Up, Fr>,
                                SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using ijKL = Tensor<DataType, tmpl::integral_list<std::int32_t, 4, 3, 2, 1>,
+                    index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Up, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
 }  // namespace tnsr
 
 /*!

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   ApplyFilter.cpp
+  Characteristics.cpp
   Derivatives.cpp
   DummyReconstructor.cpp
   EnforceConstrainedEvolution.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   HEADERS
   ApplyFilter.hpp
   BoundaryConditionGhostData.hpp
+  Characteristics.hpp
   Derivatives.hpp
   DummyReconstructor.hpp
   EnforceConstrainedEvolution.hpp

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Characteristics.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Characteristics.cpp
@@ -1,0 +1,1013 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Ccz4/FiniteDifference/Characteristics.hpp"
+
+#include "DataStructures/Tensor/ContractFirstNIndices.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/Expressions/SquareRoot.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "Evolution/Systems/Ccz4/Tags.hpp"
+#include "Evolution/Systems/Ccz4/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Ccz4::fd {
+namespace detail {
+// Helper function to compute a rank-2 symmetric tensor from TT components
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, Dim, Frame> reconstruct_symmetric_tensor_from_tt(
+    const tnsr::ii<DataType, Dim, Frame>& tensor_tt,
+    const tnsr::i<DataType, Dim, Frame>& tensor_perp_n,
+    const Scalar<DataVector>& tensor_nn,
+    const Scalar<DataVector>& tensor_transverse_trace,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& unit_normal_one_form) {
+  const auto q_dd = projector_dd(spatial_metric, unit_normal_one_form);
+  tnsr::ii<DataType, Dim, Frame> tensor{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&tensor),
+      tensor_nn() * unit_normal_one_form(ti::i) * unit_normal_one_form(ti::j) +
+          0.5 * tensor_transverse_trace() * q_dd(ti::i, ti::j) +
+          unit_normal_one_form(ti::i) * tensor_perp_n(ti::j) +
+          unit_normal_one_form(ti::j) * tensor_perp_n(ti::i) +
+          tensor_tt(ti::i, ti::j));
+  return tensor;
+}
+
+// Helper functions to compute the constants (Scalar)
+// c_phi^\pm, c_gamma^\pm, c_alpha^\pm, c_k^\pm, c_theta^\pm, c_beta^\pm
+template <typename DataType>
+using coefficients_tags_list =
+    tmpl::list<Tags::CPhi<DataType>, Tags::CGamma<DataType>,
+               Tags::CAlpha<DataType>, Tags::CK<DataType>,
+               Tags::CTheta<DataType>, Tags::CBeta<DataType>>;
+template <typename DataType>
+Variables<coefficients_tags_list<DataType>> compute_coefficients_plus(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& conformal_factor,
+    const Scalar<DataType>& shift_dot_normal, const double f) {
+  Variables<coefficients_tags_list<DataType>> coefficients{get(lapse).size()};
+
+  if (::Ccz4::fd::System::shifting_shift) {
+    const auto denom_1 =
+        -4.0 * f + 3 * pow<2>(get(lapse) * get(conformal_factor));
+    const auto denom_2 =
+        -2.0 * f + 3 * get(lapse) * pow<2>(get(conformal_factor));
+    auto& c_phi = get<Tags::CPhi<DataType>>(coefficients);
+    auto& c_gamma = get<Tags::CGamma<DataType>>(coefficients);
+    auto& c_alpha = get<Tags::CAlpha<DataType>>(coefficients);
+    auto& c_k = get<Tags::CK<DataType>>(coefficients);
+    auto& c_theta = get<Tags::CTheta<DataType>>(coefficients);
+    auto& c_beta = get<Tags::CBeta<DataType>>(coefficients);
+    get(c_phi) = 4.0 * pow<2>(get(lapse)) / denom_1 / get(conformal_factor);
+    get(c_gamma) = pow<2>(get(lapse) * get(conformal_factor)) / denom_1;
+    get(c_alpha) = -2.0 * get(lapse) / denom_2;
+    get(c_k) = -4.0 * get(lapse) * sqrt(f) / denom_2 / get(conformal_factor) /
+               sqrt(3.0);
+    get(c_theta) = 4.0 * sqrt(3.0 * f) * get(lapse) *
+                   (-2.0 * f + get(lapse) * (2 * get(lapse) - 1.0) *
+                                   pow<2>(get(conformal_factor))) /
+                   (denom_1 * denom_2 * get(conformal_factor));
+    get(c_beta) = -2.0 / sqrt(3.0 * f) / get(conformal_factor);
+    return coefficients;
+  } else {
+    const auto three_beta_n_phi_squared_plus_sqrt =
+        get(conformal_factor) *
+        (3.0 * get(shift_dot_normal) * get(conformal_factor) +
+         sqrt(48.0 * f +
+              9.0 * pow<2>(get(shift_dot_normal) * get(conformal_factor))));
+    const auto three_beta_n_phi_squared_minus_sqrt =
+        get(conformal_factor) *
+        (3.0 * get(shift_dot_normal) * get(conformal_factor) -
+         sqrt(48.0 * f +
+              9.0 * pow<2>(get(shift_dot_normal) * get(conformal_factor))));
+    const auto denom_1 =
+        8.0 * f + get(shift_dot_normal) * three_beta_n_phi_squared_plus_sqrt -
+        6 * pow<2>(get(lapse) * get(conformal_factor));
+    const auto denom_2 =
+        8.0 * f + get(shift_dot_normal) * three_beta_n_phi_squared_plus_sqrt -
+        12.0 * get(lapse) * pow<2>(get(conformal_factor));
+    auto& c_phi = get<Tags::CPhi<DataType>>(coefficients);
+    auto& c_gamma = get<Tags::CGamma<DataType>>(coefficients);
+    auto& c_alpha = get<Tags::CAlpha<DataType>>(coefficients);
+    auto& c_k = get<Tags::CK<DataType>>(coefficients);
+    auto& c_theta = get<Tags::CTheta<DataType>>(coefficients);
+    auto& c_beta = get<Tags::CBeta<DataType>>(coefficients);
+    get(c_phi) = -pow<2>(get(lapse)) *
+                 (get(shift_dot_normal) * three_beta_n_phi_squared_minus_sqrt +
+                  8.0 * f) /
+                 (denom_1 * get(conformal_factor) * f);
+    get(c_k) = -4.0 * get(lapse) * three_beta_n_phi_squared_minus_sqrt /
+               (3.0 * denom_2 * pow<2>(get(conformal_factor)));
+    get(c_theta) =
+        2.0 * get(lapse) * three_beta_n_phi_squared_minus_sqrt *
+        (8.0 * f + get(shift_dot_normal) * three_beta_n_phi_squared_plus_sqrt +
+         4.0 * (1.0 - 2.0 * get(lapse)) * get(lapse) *
+             pow<2>(get(conformal_factor))) /
+        (denom_1 * denom_2 * pow<2>(get(conformal_factor)));
+    get(c_gamma) =
+        -(get(shift_dot_normal) * f * three_beta_n_phi_squared_plus_sqrt +
+          pow<2>(get(lapse) * get(conformal_factor)) *
+              (get(shift_dot_normal) * three_beta_n_phi_squared_minus_sqrt +
+               2.0 * f)) /
+        (denom_1 * f);
+    get(c_alpha) = get(lapse) * pow<2>(three_beta_n_phi_squared_minus_sqrt) /
+                   (6.0 * denom_2 * f * pow<2>(get(conformal_factor)));
+    get(c_beta) = three_beta_n_phi_squared_minus_sqrt /
+                  (6.0 * f * pow<2>(get(conformal_factor)));
+    return coefficients;
+  }
+}
+
+template <typename DataType>
+using coefficients_tags_list =
+    tmpl::list<Tags::CPhi<DataType>, Tags::CGamma<DataType>,
+               Tags::CAlpha<DataType>, Tags::CK<DataType>,
+               Tags::CTheta<DataType>, Tags::CBeta<DataType>>;
+template <typename DataType>
+Variables<coefficients_tags_list<DataType>> compute_coefficients_minus(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& conformal_factor,
+    const Scalar<DataType>& shift_dot_normal, const double f) {
+  Variables<coefficients_tags_list<DataType>> coefficients{get(lapse).size()};
+
+  if (::Ccz4::fd::System::shifting_shift) {
+    const auto denom_1 =
+        -4.0 * f + 3 * pow<2>(get(lapse) * get(conformal_factor));
+    const auto denom_2 =
+        -2.0 * f + 3 * get(lapse) * pow<2>(get(conformal_factor));
+    auto& c_phi = get<Tags::CPhi<DataType>>(coefficients);
+    auto& c_gamma = get<Tags::CGamma<DataType>>(coefficients);
+    auto& c_alpha = get<Tags::CAlpha<DataType>>(coefficients);
+    auto& c_k = get<Tags::CK<DataType>>(coefficients);
+    auto& c_theta = get<Tags::CTheta<DataType>>(coefficients);
+    auto& c_beta = get<Tags::CBeta<DataType>>(coefficients);
+    get(c_phi) = 4.0 * pow<2>(get(lapse)) / denom_1 / get(conformal_factor);
+    get(c_gamma) = pow<2>(get(lapse) * get(conformal_factor)) / denom_1;
+    get(c_alpha) = -2.0 * get(lapse) / denom_2;
+    get(c_k) = 4.0 * get(lapse) * sqrt(f) / denom_2 / get(conformal_factor) /
+               sqrt(3.0);
+    get(c_theta) = -4.0 * sqrt(3.0 * f) * get(lapse) *
+                   (-2.0 * f + get(lapse) * (2 * get(lapse) - 1.0) *
+                                   pow<2>(get(conformal_factor))) /
+                   (denom_1 * denom_2 * get(conformal_factor));
+    get(c_beta) = 2.0 / sqrt(3.0 * f) / get(conformal_factor);
+    return coefficients;
+  } else {
+    const auto three_beta_n_phi_squared_plus_sqrt =
+        get(conformal_factor) *
+        (3.0 * get(shift_dot_normal) * get(conformal_factor) +
+         sqrt(48.0 * f +
+              9.0 * pow<2>(get(shift_dot_normal) * get(conformal_factor))));
+    const auto three_beta_n_phi_squared_minus_sqrt =
+        get(conformal_factor) *
+        (3.0 * get(shift_dot_normal) * get(conformal_factor) -
+         sqrt(48.0 * f +
+              9.0 * pow<2>(get(shift_dot_normal) * get(conformal_factor))));
+    const auto denom_1 =
+        get(shift_dot_normal) * three_beta_n_phi_squared_minus_sqrt + 8.0 * f -
+        6 * pow<2>(get(lapse) * get(conformal_factor));
+    const auto denom_2 =
+        get(shift_dot_normal) * three_beta_n_phi_squared_minus_sqrt + 8.0 * f -
+        12.0 * get(lapse) * pow<2>(get(conformal_factor));
+    auto& c_phi = get<Tags::CPhi<DataType>>(coefficients);
+    auto& c_gamma = get<Tags::CGamma<DataType>>(coefficients);
+    auto& c_alpha = get<Tags::CAlpha<DataType>>(coefficients);
+    auto& c_k = get<Tags::CK<DataType>>(coefficients);
+    auto& c_theta = get<Tags::CTheta<DataType>>(coefficients);
+    auto& c_beta = get<Tags::CBeta<DataType>>(coefficients);
+    get(c_phi) = -(pow<2>(get(lapse)) *
+                   (8.0 * f + get(shift_dot_normal) *
+                                  three_beta_n_phi_squared_plus_sqrt)) /
+                 (denom_1 * get(conformal_factor) * f);
+    get(c_k) = -4.0 * get(lapse) * three_beta_n_phi_squared_plus_sqrt /
+               (3.0 * denom_2 * pow<2>(get(conformal_factor)));
+    get(c_theta) =
+        2.0 * get(lapse) * three_beta_n_phi_squared_plus_sqrt *
+        (8.0 * f + get(shift_dot_normal) * three_beta_n_phi_squared_minus_sqrt +
+         4.0 * (1.0 - 2.0 * get(lapse)) * get(lapse) *
+             pow<2>(get(conformal_factor))) /
+        (denom_1 * denom_2 * pow<2>(get(conformal_factor)));
+    get(c_gamma) =
+        -(get(shift_dot_normal) * f * three_beta_n_phi_squared_minus_sqrt +
+          pow<2>(get(lapse) * get(conformal_factor)) *
+              (get(shift_dot_normal) * three_beta_n_phi_squared_plus_sqrt +
+               2.0 * f)) /
+        (denom_1 * f);
+    get(c_alpha) = get(lapse) * pow<2>(three_beta_n_phi_squared_plus_sqrt) /
+                   (6.0 * denom_2 * f * pow<2>(get(conformal_factor)));
+    get(c_beta) = three_beta_n_phi_squared_plus_sqrt /
+                  (6.0 * f * pow<2>(get(conformal_factor)));
+    return coefficients;
+  }
+}
+}  // namespace detail
+
+// Helper function to compute the projector q_{ij} = gamma_{ij} - n_i n_j
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, Dim, Frame> projector_dd(
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& unit_normal_one_form) {
+  return gr::transverse_projection_operator(spatial_metric,
+                                            unit_normal_one_form);
+}
+
+// Helper function to compute the TT part of a symmetric rank-2 tensor
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, Dim, Frame> compute_tt_symmetric_tensor(
+    const tnsr::ii<DataType, Dim, Frame>& tensor,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& unit_normal_one_form) {
+  const tnsr::ii<DataType, Dim, Frame> q_dd =
+      projector_dd(spatial_metric, unit_normal_one_form);
+  tnsr::iJ<DataType, Dim, Frame> q_dU{};
+  ::tenex::evaluate<ti::i, ti::J>(
+      make_not_null(&q_dU),
+      q_dd(ti::i, ti::k) * inverse_spatial_metric(ti::K, ti::J));
+  tnsr::II<DataType, Dim, Frame> q_UU{};
+  ::tenex::evaluate<ti::I, ti::J>(
+      make_not_null(&q_UU),
+      inverse_spatial_metric(ti::I, ti::K) * q_dU(ti::k, ti::J));
+
+  tnsr::ii<DataType, Dim, Frame> tensor_tt{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&tensor_tt),
+      (q_dU(ti::i, ti::K) * q_dU(ti::j, ti::L) -
+       0.5 * q_dd(ti::i, ti::j) * q_UU(ti::K, ti::L)) *
+          tensor(ti::k, ti::l));
+  return tensor_tt;
+}
+
+template <typename Frame>
+std::array<DataVector, 16> characteristic_speeds(
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& conformal_factor, const double f,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) {
+  auto char_speeds =
+      make_with_value<typename Tags::CharacteristicSpeeds<DataVector>::type>(
+          get(lapse), 0.);
+  characteristic_speeds(make_not_null(&char_speeds), lapse, shift,
+                        conformal_factor, f, unit_normal_one_form);
+  return char_speeds;
+}
+
+template <typename Frame>
+void characteristic_speeds(
+    const gsl::not_null<std::array<DataVector, 16>*> char_speeds,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& conformal_factor, const double f,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) {
+  constexpr bool shifting_shift = ::Ccz4::fd::System::shifting_shift;
+  const DataVector shift_dot_normal =
+    get(dot_product(shift, unit_normal_one_form));
+  // tensor sector
+  (*char_speeds)[0] = -shift_dot_normal + get(lapse);  // tensor +
+  (*char_speeds)[1] = -shift_dot_normal - get(lapse);  // tensor -
+  // vector sector
+  const auto sqrt_f_over_conformal_factor = sqrt(f) / get(conformal_factor);
+  (*char_speeds)[2] =
+      shifting_shift ? -shift_dot_normal : 0.0 * shift_dot_normal;
+  (*char_speeds)[3] = (*char_speeds)[0];
+  (*char_speeds)[4] = (*char_speeds)[1];
+  if (shifting_shift) {
+    (*char_speeds)[5] = -shift_dot_normal + sqrt_f_over_conformal_factor;
+    (*char_speeds)[6] = -shift_dot_normal - sqrt_f_over_conformal_factor;
+  } else {
+    (*char_speeds)[5] =
+        -0.5 * shift_dot_normal +
+        sqrt(4.0 * f + pow<2>(shift_dot_normal * get(conformal_factor))) /
+            (2.0 * get(conformal_factor));
+    (*char_speeds)[6] =
+        -0.5 * shift_dot_normal -
+        sqrt(4.0 * f + pow<2>(shift_dot_normal * get(conformal_factor))) /
+            (2.0 * get(conformal_factor));
+  }
+  // scalar sector
+  (*char_speeds)[7] =
+      shifting_shift ? -shift_dot_normal : 0.0 * shift_dot_normal;
+  (*char_speeds)[8] = (*char_speeds)[0];
+  (*char_speeds)[9] = (*char_speeds)[1];
+  (*char_speeds)[10] = (*char_speeds)[0];
+  (*char_speeds)[11] = (*char_speeds)[1];
+  (*char_speeds)[12] = -shift_dot_normal + sqrt(2.0 * get(lapse));
+  (*char_speeds)[13] = -shift_dot_normal - sqrt(2.0 * get(lapse));
+  if (shifting_shift) {
+    const auto v_s = (2.0) / sqrt(3.0) * sqrt_f_over_conformal_factor;
+    (*char_speeds)[14] = -shift_dot_normal + v_s;
+    (*char_speeds)[15] = -shift_dot_normal - v_s;
+  } else {
+    const auto v_s = sqrt(48.0 * f + 9.0 * pow<2>(shift_dot_normal *
+                                                  get(conformal_factor))) /
+                     (6.0 * get(conformal_factor));
+    (*char_speeds)[14] = -0.5 * shift_dot_normal + v_s;
+    (*char_speeds)[15] = -0.5 * shift_dot_normal - v_s;
+  }
+}
+
+template <typename Frame>
+typename Tags::CharacteristicFields<DataVector, Dim, Frame>::type
+characteristic_fields(
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const tnsr::ii<DataVector, Dim, Frame>& a_tilde,
+    const Scalar<DataVector>& theta,
+    const tnsr::I<DataVector, Dim, Frame>& gamma_hat,
+    const tnsr::I<DataVector, Dim, Frame>& auxiliary_field_b,
+    const tnsr::ijj<DataVector, Dim, Frame>& d_conformal_spatial_metric,
+    const tnsr::i<DataVector, Dim, Frame>& d_conformal_factor,
+    const tnsr::i<DataVector, Dim, Frame>& d_lapse,
+    const tnsr::iJ<DataVector, Dim, Frame>& d_shift, const double f) {
+  auto char_fields = make_with_value<
+      typename Tags::CharacteristicFields<DataVector, Dim, Frame>::type>(
+      get(lapse), 0.);
+  characteristic_fields(
+      make_not_null(&char_fields), unit_normal_one_form,
+      conformal_spatial_metric, conformal_factor, lapse, shift,
+      trace_extrinsic_curvature, a_tilde, theta, gamma_hat, auxiliary_field_b,
+      d_conformal_spatial_metric, d_conformal_factor, d_lapse, d_shift, f);
+  return char_fields;
+}
+
+template <typename Frame>
+void characteristic_fields(
+    gsl::not_null<
+        typename Tags::CharacteristicFields<DataVector, Dim, Frame>::type*>
+        char_fields,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const tnsr::ii<DataVector, Dim, Frame>& a_tilde,
+    const Scalar<DataVector>& theta,
+    const tnsr::I<DataVector, Dim, Frame>& gamma_hat,
+    const tnsr::I<DataVector, Dim, Frame>& auxiliary_field_b,
+    const tnsr::ijj<DataVector, Dim, Frame>& d_conformal_spatial_metric,
+    const tnsr::i<DataVector, Dim, Frame>& d_conformal_factor,
+    const tnsr::i<DataVector, Dim, Frame>& d_lapse,
+    const tnsr::iJ<DataVector, Dim, Frame>& d_shift, const double f) {
+  const auto number_of_grid_points = get(lapse).size();
+  if (UNLIKELY(number_of_grid_points != char_fields->number_of_grid_points())) {
+    char_fields->initialize(number_of_grid_points);
+  }
+  constexpr bool shifting_shift = ::Ccz4::fd::System::shifting_shift;
+  const Scalar<DataVector> shift_n = dot_product(shift, unit_normal_one_form);
+
+  // Compute u_tnsr_plus and u_tnsr_minus
+  tnsr::ii<DataVector, Dim, Frame> spatial_metric{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&spatial_metric),
+      conformal_spatial_metric(ti::i, ti::j) /
+          (conformal_factor() * conformal_factor()));
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto a_tilde_tt = compute_tt_symmetric_tensor(
+      a_tilde, spatial_metric, inverse_spatial_metric, unit_normal_one_form);
+  const auto unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+  tnsr::ii<DataVector, Dim, Frame> dn_conformal_spatial_metric{};
+  contract_first_n_indices<1>(make_not_null(&dn_conformal_spatial_metric),
+                              unit_normal_vector, d_conformal_spatial_metric);
+  const auto dn_conformal_spatial_metric_tt =
+      compute_tt_symmetric_tensor(dn_conformal_spatial_metric, spatial_metric,
+                                  inverse_spatial_metric, unit_normal_one_form);
+  auto& u_tnsr_plus =
+      get<Tags::UTensorPlus<DataVector, Dim, Frame>>(*char_fields);
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&u_tnsr_plus),
+      a_tilde_tt(ti::i, ti::j) +
+          0.5 * dn_conformal_spatial_metric_tt(ti::i, ti::j));
+  auto& u_tnsr_minus =
+      get<Tags::UTensorMinus<DataVector, Dim, Frame>>(*char_fields);
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&u_tnsr_minus),
+      a_tilde_tt(ti::i, ti::j) -
+          0.5 * dn_conformal_spatial_metric_tt(ti::i, ti::j));
+
+  // Compute u_vector1_zero
+  const auto q_dd = projector_dd(spatial_metric, unit_normal_one_form);
+  auto& u_vector1_zero =
+      get<Tags::UVector1Zero<DataVector, Dim, Frame>>(*char_fields);
+  ::tenex::evaluate<ti::i>(
+      make_not_null(&u_vector1_zero),
+      q_dd(ti::i, ti::j) * (auxiliary_field_b(ti::J) - gamma_hat(ti::J)));
+
+  // Compute u_vector2_plus and u_vector2_minus
+  // Potential optimization: rescale the characteristic fields so that
+  // there is no division by conformal_factor
+  tnsr::iJ<DataVector, Dim, Frame> q_dU{};
+  ::tenex::evaluate<ti::i, ti::J>(
+      make_not_null(&q_dU),
+      q_dd(ti::i, ti::k) * inverse_spatial_metric(ti::K, ti::J));
+  auto& u_vector2_plus =
+      get<Tags::UVector2Plus<DataVector, Dim, Frame>>(*char_fields);
+  ::tenex::evaluate<ti::i>(make_not_null(&u_vector2_plus),
+                           q_dd(ti::i, ti::j) * gamma_hat(ti::J) -
+                               unit_normal_vector(ti::J) * q_dU(ti::i, ti::K) /
+                                   (conformal_factor() * conformal_factor() *
+                                    conformal_factor() * conformal_factor()) *
+                                   (dn_conformal_spatial_metric(ti::k, ti::j) +
+                                    2.0 * a_tilde(ti::k, ti::j)));
+  auto& u_vector2_minus =
+      get<Tags::UVector2Minus<DataVector, Dim, Frame>>(*char_fields);
+  ::tenex::evaluate<ti::i>(make_not_null(&u_vector2_minus),
+                           q_dd(ti::i, ti::j) * gamma_hat(ti::J) -
+                               unit_normal_vector(ti::J) * q_dU(ti::i, ti::K) /
+                                   (conformal_factor() * conformal_factor() *
+                                    conformal_factor() * conformal_factor()) *
+                                   (dn_conformal_spatial_metric(ti::k, ti::j) -
+                                    2.0 * a_tilde(ti::k, ti::j)));
+
+  // Compute u_vector3_plus and u_vector3_minus
+  auto& u_vector3_plus =
+      get<Tags::UVector3Plus<DataVector, Dim, Frame>>(*char_fields);
+  if (shifting_shift) {
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_plus),
+        q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) -
+            unit_normal_vector(ti::J) * q_dd(ti::i, ti::k) /
+                (sqrt(f) * conformal_factor()) * d_shift(ti::j, ti::K));
+  } else {
+    Scalar<DataVector> beta_n_times_phi_minus_sqrt_over_two_f{};
+    get(beta_n_times_phi_minus_sqrt_over_two_f) =
+        (get(shift_n) * get(conformal_factor) -
+         sqrt(4.0 * f + pow<2>(get(shift_n) * get(conformal_factor)))) /
+        (2.0 * f);
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_plus),
+        q_dd(ti::i, ti::j) * gamma_hat(ti::J) * shift_n() *
+                beta_n_times_phi_minus_sqrt_over_two_f() * conformal_factor() +
+            q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) +
+            unit_normal_vector(ti::J) * q_dd(ti::i, ti::k) *
+                d_shift(ti::j, ti::K) *
+                beta_n_times_phi_minus_sqrt_over_two_f() / conformal_factor());
+  }
+  auto& u_vector3_minus =
+      get<Tags::UVector3Minus<DataVector, Dim, Frame>>(*char_fields);
+  if (shifting_shift) {
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_minus),
+        q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) +
+            unit_normal_vector(ti::J) * q_dd(ti::i, ti::k) /
+                (sqrt(f) * conformal_factor()) * d_shift(ti::j, ti::K));
+  } else {
+    Scalar<DataVector> beta_n_times_phi_plus_sqrt_over_two_f{};
+    get(beta_n_times_phi_plus_sqrt_over_two_f) =
+        (get(shift_n) * get(conformal_factor) +
+         sqrt(4.0 * f + pow<2>(get(shift_n) * get(conformal_factor)))) /
+        (2.0 * f);
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_minus),
+        q_dd(ti::i, ti::j) * gamma_hat(ti::J) * shift_n() *
+                beta_n_times_phi_plus_sqrt_over_two_f() * conformal_factor() +
+            q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) +
+            unit_normal_vector(ti::J) * q_dd(ti::i, ti::k) *
+                d_shift(ti::j, ti::K) *
+                beta_n_times_phi_plus_sqrt_over_two_f() / conformal_factor());
+  }
+
+  // Compute u_scalar1_zero
+  auto& u_scalar1_zero = get<Tags::UScalar1Zero<DataVector>>(*char_fields);
+  ::tenex::evaluate(make_not_null(&u_scalar1_zero),
+                    unit_normal_one_form(ti::i) *
+                        (auxiliary_field_b(ti::I) - gamma_hat(ti::I)));
+
+  // Compute u_scalar2_plus and u_scalar2_minus
+  auto& u_scalar2_plus = get<Tags::UScalar2Plus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar2_plus),
+      unit_normal_vector(ti::I) * unit_normal_vector(ti::J) *
+              (a_tilde(ti::i, ti::j) +
+               0.5 * dn_conformal_spatial_metric(ti::i, ti::j)) +
+          2.0 * conformal_factor() *
+              (unit_normal_vector(ti::I) * d_conformal_factor(ti::i) -
+               conformal_factor() * trace_extrinsic_curvature() / 3.0));
+  auto& u_scalar2_minus = get<Tags::UScalar2Minus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar2_minus),
+      unit_normal_vector(ti::I) * unit_normal_vector(ti::J) *
+              (a_tilde(ti::i, ti::j) -
+               0.5 * dn_conformal_spatial_metric(ti::i, ti::j)) -
+          2.0 * conformal_factor() *
+              (unit_normal_vector(ti::I) * d_conformal_factor(ti::i) +
+               conformal_factor() * trace_extrinsic_curvature() / 3.0));
+
+  // Compute u_scalar3_plus and u_scalar3_minus
+  auto& u_scalar3_plus = get<Tags::UScalar3Plus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar3_plus),
+      unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+          2.0 / (conformal_factor() * conformal_factor()) *
+              (2.0 / conformal_factor() * d_conformal_factor(ti::i) *
+                   unit_normal_vector(ti::I) -
+               theta()));
+  auto& u_scalar3_minus = get<Tags::UScalar3Minus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar3_minus),
+      unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+          2.0 / (conformal_factor() * conformal_factor()) *
+              (2.0 / conformal_factor() * d_conformal_factor(ti::i) *
+                   unit_normal_vector(ti::I) +
+               theta()));
+
+  // Compute u_scalar4_plus and u_scalar4_minus
+  auto& u_scalar4_plus = get<Tags::UScalar4Plus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar4_plus),
+      unit_normal_vector(ti::I) * d_lapse(ti::i) +
+          sqrt(2.0 * lapse()) * (trace_extrinsic_curvature() - 2.0 * theta()));
+  auto& u_scalar4_minus = get<Tags::UScalar4Minus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar4_minus),
+      unit_normal_vector(ti::I) * d_lapse(ti::i) -
+          sqrt(2.0 * lapse()) * (trace_extrinsic_curvature() - 2.0 * theta()));
+
+  // Compute u_scalar5_plus and u_scalar5_minus
+  const auto coefficients_plus =
+      detail::compute_coefficients_plus(lapse, conformal_factor, shift_n, f);
+  const auto& c_phi_plus = get<Tags::CPhi<DataVector>>(coefficients_plus);
+  const auto& c_gamma_plus = get<Tags::CGamma<DataVector>>(coefficients_plus);
+  const auto& c_alpha_plus = get<Tags::CAlpha<DataVector>>(coefficients_plus);
+  const auto& c_k_plus = get<Tags::CK<DataVector>>(coefficients_plus);
+  const auto& c_theta_plus = get<Tags::CTheta<DataVector>>(coefficients_plus);
+  const auto& c_beta_plus = get<Tags::CBeta<DataVector>>(coefficients_plus);
+  auto& u_scalar5_plus = get<Tags::UScalar5Plus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar5_plus),
+      unit_normal_one_form(ti::i) * auxiliary_field_b(ti::I) +
+          c_phi_plus() * unit_normal_vector(ti::I) * d_conformal_factor(ti::i) +
+          c_k_plus() * trace_extrinsic_curvature() + c_theta_plus() * theta() +
+          c_gamma_plus() * unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+          c_alpha_plus() * unit_normal_vector(ti::I) * d_lapse(ti::i) +
+          c_beta_plus() * unit_normal_vector(ti::I) *
+              unit_normal_one_form(ti::j) * d_shift(ti::i, ti::J));
+
+  const auto coefficients_minus =
+      detail::compute_coefficients_minus(lapse, conformal_factor, shift_n, f);
+  const auto& c_phi_minus = get<Tags::CPhi<DataVector>>(coefficients_minus);
+  const auto& c_gamma_minus = get<Tags::CGamma<DataVector>>(coefficients_minus);
+  const auto& c_alpha_minus = get<Tags::CAlpha<DataVector>>(coefficients_minus);
+  const auto& c_k_minus = get<Tags::CK<DataVector>>(coefficients_minus);
+  const auto& c_theta_minus = get<Tags::CTheta<DataVector>>(coefficients_minus);
+  const auto& c_beta_minus = get<Tags::CBeta<DataVector>>(coefficients_minus);
+  auto& u_scalar5_minus = get<Tags::UScalar5Minus<DataVector>>(*char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar5_minus),
+      unit_normal_one_form(ti::i) * auxiliary_field_b(ti::I) +
+          c_phi_minus() * unit_normal_vector(ti::I) *
+              d_conformal_factor(ti::i) +
+          c_k_minus() * trace_extrinsic_curvature() +
+          c_theta_minus() * theta() +
+          c_gamma_minus() * unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+          c_alpha_minus() * unit_normal_vector(ti::I) * d_lapse(ti::i) +
+          c_beta_minus() * unit_normal_vector(ti::I) *
+              unit_normal_one_form(ti::j) * d_shift(ti::i, ti::J));
+}
+
+template <typename Frame>
+typename Tags::EvolvedSpaceFromCharacteristicFields<DataVector, Dim,
+                                                    Frame>::type
+evolved_space_from_characteristic_fields(
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_plus,
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector1_zero,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_minus,
+    const Scalar<DataVector>& u_scalar1_zero,
+    const Scalar<DataVector>& u_scalar2_plus,
+    const Scalar<DataVector>& u_scalar2_minus,
+    const Scalar<DataVector>& u_scalar3_plus,
+    const Scalar<DataVector>& u_scalar3_minus,
+    const Scalar<DataVector>& u_scalar4_plus,
+    const Scalar<DataVector>& u_scalar4_minus,
+    const Scalar<DataVector>& u_scalar5_plus,
+    const Scalar<DataVector>& u_scalar5_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift, const double f) {
+  auto evolved_space =
+      make_with_value<typename Tags::EvolvedSpaceFromCharacteristicFields<
+          DataVector, Dim, Frame>::type>(get(u_scalar1_zero), 0.);
+  evolved_space_from_characteristic_fields(
+      make_not_null(&evolved_space), u_tnsr_plus, u_tnsr_minus, u_vector1_zero,
+      u_vector2_plus, u_vector2_minus, u_vector3_plus, u_vector3_minus,
+      u_scalar1_zero, u_scalar2_plus, u_scalar2_minus, u_scalar3_plus,
+      u_scalar3_minus, u_scalar4_plus, u_scalar4_minus, u_scalar5_plus,
+      u_scalar5_minus, unit_normal_one_form, conformal_spatial_metric,
+      conformal_factor, lapse, shift, f);
+  return evolved_space;
+}
+
+template <typename Frame>
+void evolved_space_from_characteristic_fields(
+    gsl::not_null<typename Tags::EvolvedSpaceFromCharacteristicFields<
+        DataVector, Dim, Frame>::type*>
+        evolved_space,
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_plus,
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector1_zero,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_minus,
+    const Scalar<DataVector>& u_scalar1_zero,
+    const Scalar<DataVector>& u_scalar2_plus,
+    const Scalar<DataVector>& u_scalar2_minus,
+    const Scalar<DataVector>& u_scalar3_plus,
+    const Scalar<DataVector>& u_scalar3_minus,
+    const Scalar<DataVector>& u_scalar4_plus,
+    const Scalar<DataVector>& u_scalar4_minus,
+    const Scalar<DataVector>& u_scalar5_plus,
+    const Scalar<DataVector>& u_scalar5_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift, const double f) {
+  const auto number_of_grid_points = get(u_scalar1_zero).size();
+  if (UNLIKELY(number_of_grid_points !=
+               evolved_space->number_of_grid_points())) {
+    evolved_space->initialize(number_of_grid_points);
+  }
+  constexpr bool shifting_shift = ::Ccz4::fd::System::shifting_shift;
+  const Scalar<DataVector> shift_n = dot_product(shift, unit_normal_one_form);
+
+  // Reconstruct gamma_hat
+  const auto coefficients_plus =
+      detail::compute_coefficients_plus(lapse, conformal_factor, shift_n, f);
+  const auto& c_phi_plus = get<Tags::CPhi<DataVector>>(coefficients_plus);
+  const auto& c_gamma_plus = get<Tags::CGamma<DataVector>>(coefficients_plus);
+  const auto& c_alpha_plus = get<Tags::CAlpha<DataVector>>(coefficients_plus);
+  const auto& c_k_plus = get<Tags::CK<DataVector>>(coefficients_plus);
+  const auto& c_theta_plus = get<Tags::CTheta<DataVector>>(coefficients_plus);
+  const auto& c_beta_plus = get<Tags::CBeta<DataVector>>(coefficients_plus);
+  const auto coefficients_minus =
+      detail::compute_coefficients_minus(lapse, conformal_factor, shift_n, f);
+  const auto& c_phi_minus = get<Tags::CPhi<DataVector>>(coefficients_minus);
+  const auto& c_gamma_minus = get<Tags::CGamma<DataVector>>(coefficients_minus);
+  const auto& c_alpha_minus = get<Tags::CAlpha<DataVector>>(coefficients_minus);
+  const auto& c_k_minus = get<Tags::CK<DataVector>>(coefficients_minus);
+  const auto& c_theta_minus = get<Tags::CTheta<DataVector>>(coefficients_minus);
+  const auto& c_beta_minus = get<Tags::CBeta<DataVector>>(coefficients_minus);
+  Scalar<DataVector> gamma_hat_n{};
+  Scalar<DataVector> source_plus{};
+  get(source_plus) =
+      get(u_scalar5_plus) - get(u_scalar1_zero) -
+      pow<3>(get(conformal_factor)) / 8.0 * get(c_phi_plus) *
+          (get(u_scalar3_plus) + get(u_scalar3_minus)) -
+      0.5 * get(c_alpha_plus) * (get(u_scalar4_plus) + get(u_scalar4_minus)) -
+      get(c_k_plus) * ((get(u_scalar4_plus) - get(u_scalar4_minus)) /
+                           (2.0 * sqrt(2.0 * get(lapse))) -
+                       0.5 * pow<2>(get(conformal_factor)) *
+                           (get(u_scalar3_plus) - get(u_scalar3_minus))) +
+      0.25 * get(c_theta_plus) * pow<2>(get(conformal_factor)) *
+          (get(u_scalar3_plus) - get(u_scalar3_minus));
+  Scalar<DataVector> source_minus{};
+  get(source_minus) =
+      get(u_scalar5_minus) - get(u_scalar1_zero) -
+      pow<3>(get(conformal_factor)) / 8.0 * get(c_phi_minus) *
+          (get(u_scalar3_plus) + get(u_scalar3_minus)) -
+      0.5 * get(c_alpha_minus) * (get(u_scalar4_plus) + get(u_scalar4_minus)) -
+      get(c_k_minus) * ((get(u_scalar4_plus) - get(u_scalar4_minus)) /
+                            (2.0 * sqrt(2.0 * get(lapse))) -
+                        0.5 * pow<2>(get(conformal_factor)) *
+                            (get(u_scalar3_plus) - get(u_scalar3_minus))) +
+      0.25 * get(c_theta_minus) * pow<2>(get(conformal_factor)) *
+          (get(u_scalar3_plus) - get(u_scalar3_minus));
+  Scalar<DataVector> denom{};
+  get(denom) = get(c_beta_plus) *
+                   ((1 + get(c_gamma_minus)) -
+                    get(c_phi_minus) * pow<3>(get(conformal_factor)) / 4.0) -
+               get(c_beta_minus) *
+                   ((1 + get(c_gamma_plus)) -
+                    get(c_phi_plus) * pow<3>(get(conformal_factor)) / 4.0);
+  get(gamma_hat_n) = (get(c_beta_plus) * get(source_minus) -
+                      get(c_beta_minus) * get(source_plus)) /
+                     get(denom);
+
+  Scalar<DataVector> c_gamma_vec_plus{};
+  Scalar<DataVector> c_gamma_vec_minus{};
+  Scalar<DataVector> c_beta_vec_plus{};
+  Scalar<DataVector> c_beta_vec_minus{};
+  if (shifting_shift) {
+    get(c_gamma_vec_plus) = 0.0 * get(conformal_factor);
+    get(c_gamma_vec_minus) = 0.0 * get(conformal_factor);
+    get(c_beta_vec_plus) = -1.0 / get(conformal_factor) / sqrt(f);
+    get(c_beta_vec_minus) = 1.0 / get(conformal_factor) / sqrt(f);
+  } else {
+    get(c_beta_vec_plus) =
+        (get(shift_n) -
+         sqrt(4.0 * f + pow<2>(get(shift_n) * get(conformal_factor))) /
+             get(conformal_factor)) /
+        (2.0 * f);
+    get(c_beta_vec_minus) =
+        (get(shift_n) +
+         sqrt(4.0 * f + pow<2>(get(shift_n) * get(conformal_factor))) /
+             get(conformal_factor)) /
+        (2.0 * f);
+    get(c_gamma_vec_plus) =
+        get(shift_n) * pow<2>(get(conformal_factor)) * get(c_beta_vec_plus);
+    get(c_gamma_vec_minus) =
+        get(shift_n) * pow<2>(get(conformal_factor)) * get(c_beta_vec_minus);
+  }
+
+  Scalar<DataVector> denom_vec{};
+  get(denom_vec) = get(c_beta_vec_plus) * (1.0 + get(c_gamma_vec_minus)) -
+                   get(c_beta_vec_minus) * (1.0 + get(c_gamma_vec_plus));
+  tnsr::i<DataVector, Dim, Frame> gamma_hat_perp{};
+  ::tenex::evaluate<ti::j>(
+      make_not_null(&gamma_hat_perp),
+      (c_beta_vec_plus() * u_vector3_minus(ti::j) -
+       c_beta_vec_minus() * u_vector3_plus(ti::j) +
+       (c_beta_vec_minus() - c_beta_vec_plus()) * u_vector1_zero(ti::j)) /
+          denom_vec());
+
+  tnsr::ii<DataVector, Dim, Frame> spatial_metric{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&spatial_metric),
+      conformal_spatial_metric(ti::i, ti::j) /
+          (conformal_factor() * conformal_factor()));
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  auto& gamma_hat =
+      get<::Ccz4::Tags::GammaHat<DataVector, Dim, Frame>>(*evolved_space);
+  ::tenex::evaluate<ti::I>(make_not_null(&gamma_hat),
+                           inverse_spatial_metric(ti::I, ti::J) *
+                               // gamma_hat_perp part
+                               (gamma_hat_perp(ti::j) +
+                                // gamma_hat_n part
+                                gamma_hat_n() * unit_normal_one_form(ti::j)));
+
+  // Reconstruct dn_conformal_spatial_metric
+  tnsr::ii<DataVector, Dim, Frame> dn_conformal_spatial_metric_tt{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&dn_conformal_spatial_metric_tt),
+      u_tnsr_plus(ti::i, ti::j) - u_tnsr_minus(ti::i, ti::j));
+  tnsr::i<DataVector, Dim, Frame> dn_conformal_spatial_metric_perp_n{};
+  ::tenex::evaluate<ti::i>(
+      make_not_null(&dn_conformal_spatial_metric_perp_n),
+      conformal_factor() * conformal_factor() * conformal_factor() *
+          conformal_factor() *
+          (gamma_hat_perp(ti::i) -
+           0.5 * (u_vector2_plus(ti::i) + u_vector2_minus(ti::i))));
+  Scalar<DataVector> dn_conformal_spatial_metric_nn{};
+  get(dn_conformal_spatial_metric_nn) =
+      (get(u_scalar2_plus) - get(u_scalar2_minus)) -
+      pow<4>(get(conformal_factor)) *
+          (0.5 * (get(u_scalar3_plus) + get(u_scalar3_minus)) -
+           get(gamma_hat_n));
+  // By the Jacobi formula,
+  // dn_conformal_spatial_metric_transverse_trace =
+  // -dn_conformal_spatial_metric_nn
+  Scalar<DataVector> dn_conformal_spatial_metric_transverse_trace{};
+  get(dn_conformal_spatial_metric_transverse_trace) =
+      -get(dn_conformal_spatial_metric_nn);
+  get<Tags::DnConformalMetric<DataVector, Dim, Frame>>(*evolved_space) =
+      detail::reconstruct_symmetric_tensor_from_tt(
+          dn_conformal_spatial_metric_tt, dn_conformal_spatial_metric_perp_n,
+          dn_conformal_spatial_metric_nn,
+          dn_conformal_spatial_metric_transverse_trace, spatial_metric,
+          unit_normal_one_form);
+
+  // Reconstruct a_tilde
+  tnsr::ii<DataVector, Dim, Frame> a_tilde_tt{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&a_tilde_tt),
+      0.5 * (u_tnsr_plus(ti::i, ti::j) + u_tnsr_minus(ti::i, ti::j)));
+  tnsr::i<DataVector, Dim, Frame> a_tilde_perp_n{};
+  ::tenex::evaluate<ti::i>(
+      make_not_null(&a_tilde_perp_n),
+      -0.25 * conformal_factor() * conformal_factor() * conformal_factor() *
+          conformal_factor() *
+          (u_vector2_plus(ti::i) - u_vector2_minus(ti::i)));
+  Scalar<DataVector> a_tilde_nn{};
+  get(a_tilde_nn) = 0.5 * (get(u_scalar2_plus) + get(u_scalar2_minus)) +
+                    2.0 / 3.0 * pow<2>(get(conformal_factor)) *
+                        ((get(u_scalar4_plus) - get(u_scalar4_minus)) /
+                             (2.0 * sqrt(2.0 * get(lapse))) -
+                         0.5 * pow<2>(get(conformal_factor)) *
+                             (get(u_scalar3_plus) - get(u_scalar3_minus)));
+  // Since a_tilde is trace-free, a_tilde_transverse_trace = - a_tilde_nn
+  Scalar<DataVector> a_tilde_transverse_trace{};
+  get(a_tilde_transverse_trace) = -get(a_tilde_nn);
+  get<::Ccz4::Tags::ATilde<DataVector, Dim, Frame>>(*evolved_space) =
+      detail::reconstruct_symmetric_tensor_from_tt(
+          a_tilde_tt, a_tilde_perp_n, a_tilde_nn, a_tilde_transverse_trace,
+          spatial_metric, unit_normal_one_form);
+
+  // Reconstruct auxiliary_field_b
+  auto& auxiliary_field_b =
+      get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim, Frame>>(
+          *evolved_space);
+  ::tenex::evaluate<ti::I>(
+      make_not_null(&auxiliary_field_b),
+      inverse_spatial_metric(ti::I, ti::J) *
+          // b_perp part
+          (u_vector1_zero(ti::j) + gamma_hat_perp(ti::j) +
+           // b_n part
+           (u_scalar1_zero() + gamma_hat_n()) * unit_normal_one_form(ti::j)));
+
+  // Reconstruct dn_shift
+  Scalar<DataVector> dn_shift_n{};
+  get(dn_shift_n) =
+      (get(source_plus) *
+           (1.0 + get(c_gamma_minus) -
+            get(c_phi_minus) * pow<3>(get(conformal_factor)) / 4.0) -
+       get(source_minus) *
+           (1.0 + get(c_gamma_plus) -
+            get(c_phi_plus) * pow<3>(get(conformal_factor)) / 4.0)) /
+      get(denom);
+  auto& dn_shift = get<Tags::DnShift<DataVector, Dim, Frame>>(*evolved_space);
+  ::tenex::evaluate<ti::I>(
+      make_not_null(&dn_shift),
+      inverse_spatial_metric(ti::I, ti::J) *
+          // dn_shift_perp part
+          (((1.0 + c_gamma_vec_minus()) * u_vector3_plus(ti::j) -
+            (1.0 + c_gamma_vec_plus()) * u_vector3_minus(ti::j) +
+            (c_gamma_vec_plus() - c_gamma_vec_minus()) *
+                u_vector1_zero(ti::j)) /
+               denom_vec() +
+           // dn_shift_n part
+           dn_shift_n() * unit_normal_one_form(ti::j)));
+
+  // Reconstruct theta
+  auto& theta = get<::Ccz4::Tags::Theta<DataVector>>(*evolved_space);
+  get(theta) = -0.25 * pow<2>(get(conformal_factor)) *
+               (get(u_scalar3_plus) - get(u_scalar3_minus));
+
+  // Reconstruct dn_lapse
+  auto& dn_lapse = get<Tags::DnLapse<DataVector>>(*evolved_space);
+  get(dn_lapse) = 0.5 * (get(u_scalar4_plus) + get(u_scalar4_minus));
+
+  // Reconstruct trace_extrinsic_curvature
+  auto& trace_extrinsic_curvature =
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(*evolved_space);
+  get(trace_extrinsic_curvature) =
+      2.0 * get(theta) + (get(u_scalar4_plus) - get(u_scalar4_minus)) /
+                             (2.0 * sqrt(2.0 * get(lapse)));
+
+  // Reconstruct dn_conformal_factor
+  auto& dn_conformal_factor =
+      get<Tags::DnConformalFactor<DataVector>>(*evolved_space);
+  get(dn_conformal_factor) =
+      0.25 * pow<3>(get(conformal_factor)) *
+      (0.5 * (get(u_scalar3_plus) + get(u_scalar3_minus)) - get(gamma_hat_n));
+}
+}  // namespace Ccz4::fd
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                                 \
+  template tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>                    \
+  Ccz4::fd::projector_dd<DataVector, FRAME(data)>(                             \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& spatial_metric,  \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          unit_normal_one_form);                                               \
+  template tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>                    \
+  Ccz4::fd::compute_tt_symmetric_tensor<DataVector, FRAME(data)>(              \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& tensor,          \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& spatial_metric,  \
+      const tnsr::II<DataVector, Ccz4::fd::Dim, FRAME(data)>&                  \
+          inverse_spatial_metric,                                              \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          unit_normal_one_form);                                               \
+  template std::array<DataVector, 16>                                          \
+  Ccz4::fd::characteristic_speeds<FRAME(data)>(                                \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& shift,            \
+      const Scalar<DataVector>& conformal_factor, const double f,              \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          unit_normal_one_form);                                               \
+  template void Ccz4::fd::characteristic_speeds<FRAME(data)>(                  \
+      const gsl::not_null<std::array<DataVector, 16>*> char_speeds,            \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& shift,            \
+      const Scalar<DataVector>& conformal_factor, const double f,              \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          unit_normal_one_form);                                               \
+  template struct Ccz4::fd::CharacteristicSpeedsCompute<FRAME(data)>;          \
+  template                                                                     \
+      typename Ccz4::fd::Tags::CharacteristicFields<DataVector, Ccz4::fd::Dim, \
+                                                    FRAME(data)>::type         \
+      Ccz4::fd::characteristic_fields<FRAME(data)>(                            \
+          const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&               \
+              unit_normal_one_form,                                            \
+          const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>&              \
+              conformal_spatial_metric,                                        \
+          const Scalar<DataVector>& conformal_factor,                          \
+          const Scalar<DataVector>& lapse,                                     \
+          const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& shift,        \
+          const Scalar<DataVector>& trace_extrinsic_curvature,                 \
+          const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& a_tilde,     \
+          const Scalar<DataVector>& theta,                                     \
+          const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& gamma_hat,    \
+          const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>&               \
+              auxiliary_field_b,                                               \
+          const tnsr::ijj<DataVector, Ccz4::fd::Dim, FRAME(data)>&             \
+              d_conformal_spatial_metric,                                      \
+          const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&               \
+              d_conformal_factor,                                              \
+          const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& d_lapse,      \
+          const tnsr::iJ<DataVector, Ccz4::fd::Dim, FRAME(data)>& d_shift,     \
+          const double f);                                                     \
+  template void Ccz4::fd::characteristic_fields<FRAME(data)>(                  \
+      gsl::not_null<typename Ccz4::fd::Tags::CharacteristicFields<             \
+          DataVector, Ccz4::fd::Dim, FRAME(data)>::type*>                      \
+          char_fields,                                                         \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          unit_normal_one_form,                                                \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>&                  \
+          conformal_spatial_metric,                                            \
+      const Scalar<DataVector>& conformal_factor,                              \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& shift,            \
+      const Scalar<DataVector>& trace_extrinsic_curvature,                     \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& a_tilde,         \
+      const Scalar<DataVector>& theta,                                         \
+      const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& gamma_hat,        \
+      const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          auxiliary_field_b,                                                   \
+      const tnsr::ijj<DataVector, Ccz4::fd::Dim, FRAME(data)>&                 \
+          d_conformal_spatial_metric,                                          \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          d_conformal_factor,                                                  \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& d_lapse,          \
+      const tnsr::iJ<DataVector, Ccz4::fd::Dim, FRAME(data)>& d_shift,         \
+      const double f);                                                         \
+  template struct Ccz4::fd::CharacteristicFieldsCompute<FRAME(data)>;          \
+  template typename Ccz4::fd::Tags::EvolvedSpaceFromCharacteristicFields<      \
+      DataVector, Ccz4::fd::Dim, FRAME(data)>::type                            \
+  Ccz4::fd::evolved_space_from_characteristic_fields<FRAME(data)>(             \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_tnsr_plus,     \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_tnsr_minus,    \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector1_zero,   \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector2_plus,   \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector2_minus,  \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector3_plus,   \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector3_minus,  \
+      const Scalar<DataVector>& u_scalar1_zero,                                \
+      const Scalar<DataVector>& u_scalar2_plus,                                \
+      const Scalar<DataVector>& u_scalar2_minus,                               \
+      const Scalar<DataVector>& u_scalar3_plus,                                \
+      const Scalar<DataVector>& u_scalar3_minus,                               \
+      const Scalar<DataVector>& u_scalar4_plus,                                \
+      const Scalar<DataVector>& u_scalar4_minus,                               \
+      const Scalar<DataVector>& u_scalar5_plus,                                \
+      const Scalar<DataVector>& u_scalar5_minus,                               \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          unit_normal_one_form,                                                \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>&                  \
+          conformal_spatial_metric,                                            \
+      const Scalar<DataVector>& conformal_factor,                              \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& shift,            \
+      const double f);                                                         \
+  template void                                                                \
+  Ccz4::fd::evolved_space_from_characteristic_fields<FRAME(data)>(             \
+      gsl::not_null<                                                           \
+          typename Ccz4::fd::Tags::EvolvedSpaceFromCharacteristicFields<       \
+              DataVector, Ccz4::fd::Dim, FRAME(data)>::type*>                  \
+          evolved_space,                                                       \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_tnsr_plus,     \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_tnsr_minus,    \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector1_zero,   \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector2_plus,   \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector2_minus,  \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector3_plus,   \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>& u_vector3_minus,  \
+      const Scalar<DataVector>& u_scalar1_zero,                                \
+      const Scalar<DataVector>& u_scalar2_plus,                                \
+      const Scalar<DataVector>& u_scalar2_minus,                               \
+      const Scalar<DataVector>& u_scalar3_plus,                                \
+      const Scalar<DataVector>& u_scalar3_minus,                               \
+      const Scalar<DataVector>& u_scalar4_plus,                                \
+      const Scalar<DataVector>& u_scalar4_minus,                               \
+      const Scalar<DataVector>& u_scalar5_plus,                                \
+      const Scalar<DataVector>& u_scalar5_minus,                               \
+      const tnsr::i<DataVector, Ccz4::fd::Dim, FRAME(data)>&                   \
+          unit_normal_one_form,                                                \
+      const tnsr::ii<DataVector, Ccz4::fd::Dim, FRAME(data)>&                  \
+          conformal_spatial_metric,                                            \
+      const Scalar<DataVector>& conformal_factor,                              \
+      const Scalar<DataVector>& lapse,                                         \
+      const tnsr::I<DataVector, Ccz4::fd::Dim, FRAME(data)>& shift,            \
+      const double f);                                                         \
+  template struct Ccz4::fd::EvolvedSpaceFromCharacteristicFieldsCompute<FRAME( \
+      data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (Frame::Inertial, Frame::Grid))
+
+#undef INSTANTIATION
+#undef FRAME

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Characteristics.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Characteristics.hpp
@@ -1,0 +1,645 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+namespace Tags {
+template <typename Tag>
+struct Normalized;
+}  // namespace Tags
+/// \endcond
+
+namespace Ccz4::fd {
+static constexpr size_t Dim = System::volume_dim;
+
+/// Helper function to compute the projector q_{ij} = gamma_{ij} - n_i n_j
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, Dim, Frame> projector_dd(
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& unit_normal_one_form);
+
+/// Helper function to compute the TT part of a symmetric rank-2 tensor
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, Dim, Frame> compute_tt_symmetric_tensor(
+    const tnsr::ii<DataType, Dim, Frame>& tensor,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric,
+    const tnsr::i<DataType, Dim, Frame>& unit_normal_one_form);
+
+/// @{
+/*!
+ * \brief Compute the characteristic speeds for the SoCcz4 system.
+ *
+ * There are totally 23 characteristic fields, 2*2 from the tensor sector,
+ * 2*5 from the vector sector, and 9 from the scalar sector. In the
+ * following, we only compute 2+5+9=16 characteristic speeds as the
+ * two transverse characteristics in the tensor and vector sectors
+ * have the same speeds.
+ *
+ * We list the characteristic fields and speeds (superscripts) below.
+ * See \ref characteristic_fields() for the definitions of the characteristic
+ * fields.
+ *
+ * If \b Ccz4::fd::System::shifting_shift is true, the characteristic speeds
+ * are:
+ *
+ * char_speeds[0]: $U_{ij}^{\alpha-\beta^n}$
+ *
+ * char_speeds[1]: $U_{ij}^{-\alpha-\beta^n}$
+ *
+ * char_speeds[2]: $U_i^{-\beta^n}$
+ *
+ * char_speeds[3]: $U_i^{\alpha-\beta^n}$
+ *
+ * char_speeds[4]: $U_i^{-\alpha-\beta^n}$
+ *
+ * char_speeds[5]: $U_i^{\lambda_+}$
+ *
+ * char_speeds[6]: $U_i^{\lambda_-}$
+ *
+ * char_speeds[7]: $U^{-\beta^n}$
+ *
+ * char_speeds[8]: $U_{(1)}^{\alpha-\beta^n}$
+ *
+ * char_speeds[9]: $U_{(1)}^{-\alpha-\beta^n}$
+ *
+ * char_speeds[10]: $U_{(2)}^{\alpha-\beta^n}$
+ *
+ * char_speeds[11]: $U_{(2)}^{-\alpha-\beta^n}$
+ *
+ * char_speeds[12]: $U^{\sqrt{2\alpha}-\beta^n}$
+ *
+ * char_speeds[13]: $U^{-\sqrt{2\alpha}-\beta^n}$
+ *
+ * char_speeds[14]: $U^{\mu_+}$
+ *
+ * char_speeds[15]: $U^{\mu_-}$
+ *
+ * where $\beta^n = \beta^i n_i$; $n_i$ is a spatial unit normal
+ * (w.r.t. the physical background metric) one-form. And
+ * $\mu_\pm = \pm v_s-\beta^n$,
+ * $v_s = \frac{2\sqrt{f}}{\sqrt{3}\phi}$, and $\lambda_\pm = \pm\sqrt{f}/\phi -
+ * \beta^n$.
+ *
+ * If \b Ccz4::fd::System::shifting_shift is false, the following characteristic
+ * speeds are changed:
+ *
+ * char_speeds[2]: $U_i^0$
+ *
+ * char_speeds[5]: $U_i^{\lambda_+}$
+ *
+ * char_speeds[6]: $U_i^{\lambda_-}$
+ *
+ * char_speeds[7]: $U^0$
+ *
+ * char_speeds[14]: $U^{\mu_+}$
+ *
+ * char_speeds[15]: $U^{\mu_-}$
+ *
+ * where $\lambda_{\pm} = -\frac{1}{2}\beta^n \pm \frac{\sqrt{4f + (\beta^n
+ * \phi)^2}}{2\phi}$ and $\mu_{\pm} = -\frac{1}{2}\beta^n \pm \frac{\sqrt{48f +
+ * 9(\beta^n \phi)^2}}{6\phi}$.
+ *
+ * \note It is assumed that the algebraic constraints
+ * $\text{det}(\tilde{\gamma}_{ij})=1$ and $\tilde{\gamma}^{ij}\tilde{A}_{ij}=0$
+ * are enforced and lapse and shift are evolved. Otherwise, the system is
+ * not strongly hyperbolic.
+ *
+ */
+template <typename Frame>
+std::array<DataVector, 16> characteristic_speeds(
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& conformal_factor, double f,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form);
+
+template <typename Frame>
+void characteristic_speeds(
+    gsl::not_null<std::array<DataVector, 16>*> char_speeds,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& conformal_factor, double f,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form);
+
+template <typename Frame>
+struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<DataVector>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds<DataVector>;
+  using type = typename base::type;
+  using argument_tags = tmpl::list<
+      gr::Tags::Lapse<DataVector>, gr::Tags::Shift<DataVector, Dim, Frame>,
+      Ccz4::Tags::ConformalFactor<DataVector>,
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+  using return_type = typename base::type;
+  static void function(
+      const gsl::not_null<return_type*> result, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame>& shift,
+      const Scalar<DataVector>& conformal_factor,
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) {
+    static constexpr double f = Ccz4::fd::System::f;
+    characteristic_speeds(result, lapse, shift, conformal_factor, f,
+                          unit_normal_one_form);
+  };
+};
+/// @}
+
+/// @{
+/*!
+ * \brief Compute the characteristic variables for the SoCcz4 system.
+ *
+ * Define the projector $q_{ij}=\gamma_{ij}-n_i n_j$ where $n_i$ is a spatial
+ * unit normal (w.r.t. the physical background metric) one-form. Then for a
+ * vector $v^i$ \f[ v_i^\perp := q_{ij}v^j, \qquad v_n := v^i n_i \f].
+ *
+ * If \b Ccz4::fd::System::shifting_shift is true, the characteristic fields
+ * are:
+ *
+ * <b>%Tensor Sector</b>
+ *
+ * u_tnsr_plus/minus:
+ * \f[
+ * U^{\pm\alpha-\beta^n}_{ij}
+ * ={\tilde A}^{TT}_{ij}\ \pm\ \frac12\,\partial_n{\tilde\gamma}^{TT}_{ij}.
+ * \f]
+ *
+ * <b>%Vector Sector</b>
+ *
+ * u_vector1_zero:
+ * \f[
+ * U^{-\beta^n}_i= b^\perp_i-{\hat\Gamma}{}^\perp_i.
+ * \f]
+ * u_vector2_plus/minus:
+ * \f[
+ * U^{\pm\alpha-\beta^n}_i
+ * ={\hat\Gamma}{}^\perp_i\
+ * -\ \frac{1}{\phi^4}\partial_n{\tilde\gamma}^\perp_{ni}\
+ * \mp\ \frac{2}{\phi^4}{\tilde A}^\perp_{ni}.
+ * \f]
+ * u_vector3_plus/minus:
+ * \f[
+ * U^{\lambda_\pm}_i
+ * = b^\perp_i\ + V_\Gamma^\pm\hat{\Gamma}_i^\perp +
+ * V_\beta^\pm\partial_n\beta^\perp_i. \f]
+ * where $V_\Gamma^\pm = 0$ and
+ * $V_\beta^\pm = \mp\ \frac{1}{\sqrt{f}\phi}$.
+ *
+ * <b>%Scalar Sector</b>
+ *
+ * u_scalar1_zero:
+ * \f[
+ * U^{-\beta^n}= b^{n}-{\hat\Gamma}{}^{\,n}.
+ * \f]
+ * u_scalar2_plus/minus:
+ * \f[
+ * U^{\pm\alpha-\beta^n}_{(1)}
+ * ={\tilde
+ * A}_{nn}\ \pm\ \frac12\,\partial_n{\tilde\gamma}_{nn}\
+ * \pm\ 2\phi\,\partial_n\phi\
+ * -\ \frac{2}{3}\phi^2 K. \f]
+ * u_scalar3_plus/minus:
+ * \f[
+ * U^{\pm\alpha-\beta^n}_{(2)}
+ * ={\hat\Gamma}{}^{\,n}\ +\ \frac{4}{\phi^3}\partial_n\phi\
+ * \mp\ \frac{2}{\phi^2}\Theta.
+ * \f]
+ * u_scalar4_plus/minus:
+ * \f[
+ * U^{\pm\sqrt{2\alpha}-\beta^n}
+ * =\partial_n\alpha\ \pm\ \sqrt{2\alpha}\,( K-2\Theta).
+ * \f]
+ * u_scalar5_plus/minus:
+ * \f[
+ * U^{\mu_\pm}
+ * = b^{n}
+ * + C_\phi^\pm\,\partial_n\phi + C_K^\pm K + C_\Theta^\pm \Theta + C_\Gamma^\pm
+ * \hat{\Gamma}^{n}
+ * + C_\alpha^\pm\,\partial_n\alpha + C_\beta^\pm\,\partial_n\beta^{n},
+ * \f]
+ * where
+ * \f[ C_\phi^\pm = \frac{4\alpha^2}{-4f\phi+3\alpha^2\phi^3}, \qquad
+ *     C_K^\pm = \pm \frac{4\alpha\sqrt f}{\sqrt3\,(2f\phi-3\alpha\phi^3)},
+ * \qquad C_\Theta^\pm = \pm\frac{4\sqrt3\,\alpha\sqrt
+ * f\,\big(-2f+\alpha(-1+2\alpha)\phi^2\big)}
+ *          {\phi(-2f+3\alpha\phi^2)(-4f+3\alpha^2\phi^2)}, \f]
+ * \f[ C_\Gamma^\pm = \frac{\alpha^2\phi^2}{-4f+3\alpha^2\phi^2}, \qquad
+ *     C_\alpha^\pm = \frac{2\alpha}{2f-3\alpha\phi^2}, \qquad
+ *     C_\beta^\pm = \mp\ \frac{2}{\sqrt3\,\sqrt f\,\phi}.\f]
+ *
+ * If \b Ccz4::fd::System::shifting_shift is false, the definitions of
+ * u_vector3_plus/minus and u_scalar5_plus/minus are changed to:
+ *
+ * u_vector3_plus/minus:
+ * \f[
+ * U^{\lambda_\pm}_i
+ * = b^\perp_i\ + V_\Gamma^\pm\hat{\Gamma}_i^\perp +
+ * V_\beta^\pm\partial_n\beta^\perp_i. \f]
+ * where $V_\Gamma^\pm=\beta^n\phi^2
+ * V_\beta^\pm = \beta^n\phi^2 \left( \frac{\beta^n}{2f} \pm
+ * \frac{\sqrt{4f+(\beta^n\phi)^2}}{2f\phi} \right)$
+ *
+ * u_scalar5_plus/minus:
+ * \f[
+ * U^{\mu_\pm}
+ * = b^{n}
+ * + C_\phi^\pm\,\partial_n\phi + C_K^\pm K + C_\Theta^\pm \Theta + C_\Gamma^\pm
+ * \hat{\Gamma}^{n}
+ * + C_\alpha^\pm\,\partial_n\alpha + C_\beta^\pm\,\partial_n\beta^{n},
+ * \f]
+ * where
+ * \f[
+ * C_\phi^\pm = -\frac{\alpha^2(\beta^n N^\pm + 8f)}{f\phi D_1^\pm}
+ * \f]
+ * \f[
+ * C_K^\pm = -\frac{4\alpha N^\pm}{3\phi^2 D_2^\pm}
+ * \f]
+ * \f[
+ * C_\Theta^\pm = \frac{2\alpha N^\pm(8f+\beta^n N^\mp\ +
+ * 4(1-2\alpha)\alpha\phi^2)}{\phi^2 D_1^\pm D_2^\pm} \f]
+ * \f[ C_\Gamma^\pm =
+ * -\frac{\beta^n f N^\mp\ + \alpha^2(\beta^n N^\pm + 2f)\phi^2}{f D_1^\pm} \f]
+ * \f[
+ * C_\alpha^\pm = \frac{\alpha (N^\pm)^2}{6f\phi^2 D_2^\pm}
+ * \f]
+ * \f[
+ * C_\beta^\pm = \frac{N^\pm}{6f\phi^2}
+ * \f]
+ * \f[
+ * N^\pm = 3\beta^n\phi^2 \mp\ \phi\sqrt{48f+9(\beta^n\phi)^2}
+ * \f]
+ * \f[
+ * D_1^\pm = 8f + \beta^n N^\mp\ - 6\alpha^2\phi^2
+ * \f]
+ * \f[
+ * D_2^\pm = 8f + \beta^n N^\mp\ - 12\alpha\phi^2
+ * \f]
+ *
+ * u_scalar1_zero and u_vector1_zero remain the same but with different
+ * characteristic speeds.
+ *
+ * Note that the characteristic fields are defined up to transverse derivatives.
+ * See \cite Gundlach:2005ta.
+ *
+ * \note It is assumed that the algebraic constraints
+ * $\text{det}(\tilde{\gamma}_{ij})=1$ and $\tilde{\gamma}^{ij}\tilde{A}_{ij}=0$
+ * are enforced and lapse and shift are evolved. Otherwise, the system is
+ * not strongly hyperbolic.
+ */
+template <typename Frame>
+typename Tags::CharacteristicFields<DataVector, Dim, Frame>::type
+characteristic_fields(
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const tnsr::ii<DataVector, Dim, Frame>& a_tilde,
+    const Scalar<DataVector>& theta,
+    const tnsr::I<DataVector, Dim, Frame>& gamma_hat,
+    const tnsr::I<DataVector, Dim, Frame>& auxiliary_field_b,
+    const tnsr::ijj<DataVector, Dim, Frame>& d_conformal_spatial_metric,
+    const tnsr::i<DataVector, Dim, Frame>& d_conformal_factor,
+    const tnsr::i<DataVector, Dim, Frame>& d_lapse,
+    const tnsr::iJ<DataVector, Dim, Frame>& d_shift, double f);
+
+template <typename Frame>
+void characteristic_fields(
+    gsl::not_null<
+        typename Tags::CharacteristicFields<DataVector, Dim, Frame>::type*>
+        char_fields,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const Scalar<DataVector>& trace_extrinsic_curvature,
+    const tnsr::ii<DataVector, Dim, Frame>& a_tilde,
+    const Scalar<DataVector>& theta,
+    const tnsr::I<DataVector, Dim, Frame>& gamma_hat,
+    const tnsr::I<DataVector, Dim, Frame>& auxiliary_field_b,
+    const tnsr::ijj<DataVector, Dim, Frame>& d_conformal_spatial_metric,
+    const tnsr::i<DataVector, Dim, Frame>& d_conformal_factor,
+    const tnsr::i<DataVector, Dim, Frame>& d_lapse,
+    const tnsr::iJ<DataVector, Dim, Frame>& d_shift, double f);
+
+template <typename Frame>
+struct CharacteristicFieldsCompute
+    : Tags::CharacteristicFields<DataVector, Dim, Frame>,
+      db::ComputeTag {
+  using base = Tags::CharacteristicFields<DataVector, Dim, Frame>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>,
+      Ccz4::Tags::ConformalMetric<DataVector, Dim, Frame>,
+      Ccz4::Tags::ConformalFactor<DataVector>, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<DataVector, Dim, Frame>,
+      gr::Tags::TraceExtrinsicCurvature<DataVector>,
+      Ccz4::Tags::ATilde<DataVector, Dim, Frame>, Ccz4::Tags::Theta<DataVector>,
+      Ccz4::Tags::GammaHat<DataVector, Dim, Frame>,
+      Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim, Frame>,
+      ::Tags::deriv<Ccz4::Tags::ConformalMetric<DataVector, Dim, Frame>,
+                    tmpl::size_t<Dim>, Frame>,
+      ::Tags::deriv<Ccz4::Tags::ConformalFactor<DataVector>, tmpl::size_t<Dim>,
+                    Frame>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>, Frame>,
+      ::Tags::deriv<gr::Tags::Shift<DataVector, Dim, Frame>, tmpl::size_t<Dim>,
+                    Frame>>;
+
+  static void function(
+      const gsl::not_null<return_type*> result,
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+      const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+      const Scalar<DataVector>& conformal_factor,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame>& shift,
+      const Scalar<DataVector>& trace_extrinsic_curvature,
+      const tnsr::ii<DataVector, Dim, Frame>& a_tilde,
+      const Scalar<DataVector>& theta,
+      const tnsr::I<DataVector, Dim, Frame>& gamma_hat,
+      const tnsr::I<DataVector, Dim, Frame>& auxiliary_field_b,
+      const tnsr::ijj<DataVector, Dim, Frame>& d_conformal_spatial_metric,
+      const tnsr::i<DataVector, Dim, Frame>& d_conformal_factor,
+      const tnsr::i<DataVector, Dim, Frame>& d_lapse,
+      const tnsr::iJ<DataVector, Dim, Frame>& d_shift) {
+    static constexpr double f = Ccz4::fd::System::f;
+    characteristic_fields(
+        result, unit_normal_one_form, conformal_spatial_metric,
+        conformal_factor, lapse, shift, trace_extrinsic_curvature, a_tilde,
+        theta, gamma_hat, auxiliary_field_b, d_conformal_spatial_metric,
+        d_conformal_factor, d_lapse, d_shift, f);
+  };
+};
+/// @}
+
+/// @{
+/*!
+ * \brief Compute the (normal derivatives of the) evolved fields from the
+ * characteristic fields for the SoCcz4 system.
+ *
+ * Since the SoCcz4 system is second order in space, the isomorphism
+ * between the characteristic space and the evolved space maps
+ * characteristic fields to a mixture of evolved fields and their normal
+ * derivatives. See \cite Gundlach:2005ta.
+ *
+ * For a characteristic field $U^\pm$, we define
+ * \f[ \Sigma(U^\pm):=U^+ + U^-, \qquad \Delta(U^\pm):=U^+ - U^- \f].
+ *
+ * If \b Ccz4::fd::System::shifting_shift is true, the inverse characteristic
+ * tansformation is given by
+ * \f[
+ * \partial_n\tilde{\gamma}^{TT}_{ij}
+ * =
+ * \Delta\!\left(U^{\pm\alpha-\beta^n}_{ij}\right),
+ * \qquad
+ * \tilde{A}^{TT}_{ij} =
+ * \frac12\,\Sigma\!\left(U^{\pm\alpha-\beta^n}_{ij}\right).
+ * \f]
+ * \f[
+ * \hat{\Gamma}_i^\perp
+ * =
+ * \frac{
+ * \left(U_i^{\lambda_-}-U_i^{-\beta^n} \right)V_\beta^+
+ * -
+ * \left(U_i^{\lambda_+}-U_i^0 \right)V_\beta^-
+ * }{V}
+ * \f]
+ * where
+ * \f[
+ * V=(1+V_\Gamma^-)V_\beta^+ - (1+V_\Gamma^+)V_\beta^-
+ * \f]
+ * \f[
+ * \partial_n\beta_i^\perp
+ * =
+ * \frac{
+ * (1+V_\Gamma^-)\left(U_i^{\lambda_+}-U_i^{-\beta^n}\right)
+ * -
+ * (1+V_\Gamma^+)\left(U_i^{\lambda_-}-U_i^{-\beta^n}\right)
+ * }{V}
+ * \f]
+ * \f[
+ * b_i^\perp = \hat{\Gamma}_i^\perp + U^{-\beta^n}_i,
+ * \f]
+ * \f[
+ * \tilde{A}^\perp_{ni}
+ * =
+ * -\frac{\phi^4}{4}\,
+ * \Delta\!\left(U^{\pm\alpha-\beta^n}_i\right).
+ * \f]
+ * \f[
+ * \partial_n\tilde{\gamma}^\perp_{ni}
+ * =
+ * \phi^4\left(
+ * \hat{\Gamma}_i^\perp
+ * -
+ * \frac12\,\Sigma\!\left(U^{\pm\alpha-\beta^n}_i\right)
+ * \right).
+ * \f]
+ * \f[
+ * \hat{\Gamma}^n=\frac{S^-C_\beta^+ - S^+C_\beta^-}{C}
+ * \f]
+ * where
+ * \f[
+ * \begin{aligned}
+ * S^\pm=\ &U^{\mu_\pm}-U^0
+ * -\frac{\phi^3}{8}C^\pm_\phi\Sigma\left(U_{(2)}^{\pm\alpha-\beta^n}\right)
+ * - \frac{1}{2}C_\alpha^\pm\Sigma\left(U^{\pm\sqrt{2\alpha}-\beta^n}\right)\\
+ * &- C_K^\pm\left[
+ * \frac{1}{2\sqrt{2\alpha}}\Delta\left(U^{\pm\sqrt{2\alpha}-\beta^n}\right)
+ * -\frac{\phi^2}{2}\Delta\left(U^{\pm\alpha-\beta^n}_{(2)}\right)\right]
+ * + \frac{\phi^2}{4}C_\Theta^\pm\Delta\left(U^{\pm\alpha-\beta^n}_{(2)}\right)
+ * \end{aligned}
+ * \f]
+ * \f[
+ * C=\left(1-\frac{\phi^3}{4}C_\phi^-+C_\Gamma^-\right)C_\beta^+
+ * -
+ * \left(1-\frac{\phi^3}{4}C_\phi^++C_\Gamma^+\right)C_\beta^-
+ * \f]
+ *
+ * \f[
+ * \partial_n\beta^n
+ * =
+ * \frac{
+ * \left(1-\frac{\phi^3}{4}C_\phi^-+C_\Gamma^-\right)S^+
+ * -
+ * \left(1-\frac{\phi^3}{4}C_\phi^++C_\Gamma^+\right)S^-
+ * }{C}
+ * \f]
+ * \f[
+ * \Theta \;=\;
+ * -\frac{\phi^2}{4}\,\Delta\!\left(U_{(2)}^{\pm\alpha-\beta^n}\right). \f]
+ * \f[
+ * \partial_n\alpha
+ * \;=\;\frac12\,\Sigma\!\left(U^{\pm\sqrt{2\alpha}-\beta^n}\right). \f]
+ * \f[
+ * K \;=\;
+ * \frac{1}{2\sqrt{2\alpha}}\,\Delta\!\left(U^{\pm\sqrt{2\alpha}-\beta^n}\right)
+ * \;-\;\frac{\phi^2}{2}\,\Delta\!\left(U_{(2)}^{\pm\alpha-\beta^n}\right).
+ * \f]
+ * \f[
+ * b^n
+ * =
+ * U^{-\beta^n}
+ * +
+ * \hat{\Gamma}^n
+ * \f]
+ * \f[
+ * \partial_n\phi
+ * =
+ * \frac{\phi^3}{8}\,\Sigma\!\left(U_{(2)}^{\pm\alpha-\beta^n}\right)
+ * -
+ * \frac{\phi^3}{4}\,
+ * \hat{\Gamma}^n
+ * \f]
+ * \f[
+ * \tilde A_{nn}
+ * =
+ * \frac12\,\Sigma\!\left(U_{(1)}^{\pm\alpha-\beta^n}\right)
+ * +
+ * \frac{2}{3}\phi^2\left[
+ * \frac{1}{2\sqrt{2\alpha}}\,\Delta\!\left(U^{\pm\sqrt{2\alpha}-\beta^n}\right)
+ * -\frac{\phi^2}{2}\,\Delta\!\left(U_{(2)}^{\pm\alpha-\beta^n}\right)
+ * \right].
+ * \f]
+ * \f[
+ * \partial_n\tilde\gamma_{nn}
+ * =
+ * \Delta\!\left(U_{(1)}^{\pm\alpha-\beta^n}\right)
+ * -
+ * \phi^4\left[
+ * \frac{1}{2}\,\Sigma\!\left(U_{(2)}^{\pm\alpha-\beta^n}\right)
+ * -
+ * \hat{\Gamma}^n
+ * \right].
+ * \f]
+ *
+ * If \b Ccz4::fd::System::shifting_shift is false, the inverse transformation
+ * is changed by replacing $U_i^{-\beta^n}$ and $U^{-\beta^n}$ above
+ * with $U_i^0$ and $U^0$, respectively, and updating the coeffiecients
+ * such as $V_\Gamma^\pm$, $V_\beta^\pm$, $C_\phi^\pm$, $C_K^\pm$, etc.
+ *
+ * \note It is assumed that the algebraic constraints
+ * $\text{det}(\tilde{\gamma}_{ij})=1$ and $\tilde{\gamma}^{ij}\tilde{A}_{ij}=0$
+ * are enforced and lapse and shift are evolved. Otherwise, the system is
+ * not strongly hyperbolic.
+ */
+template <typename Frame>
+typename Tags::EvolvedSpaceFromCharacteristicFields<DataVector, Dim,
+                                                    Frame>::type
+evolved_space_from_characteristic_fields(
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_plus,
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector1_zero,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_minus,
+    const Scalar<DataVector>& u_scalar1_zero,
+    const Scalar<DataVector>& u_scalar2_plus,
+    const Scalar<DataVector>& u_scalar2_minus,
+    const Scalar<DataVector>& u_scalar3_plus,
+    const Scalar<DataVector>& u_scalar3_minus,
+    const Scalar<DataVector>& u_scalar4_plus,
+    const Scalar<DataVector>& u_scalar4_minus,
+    const Scalar<DataVector>& u_scalar5_plus,
+    const Scalar<DataVector>& u_scalar5_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift, double f);
+
+template <typename Frame>
+void evolved_space_from_characteristic_fields(
+    gsl::not_null<typename Tags::EvolvedSpaceFromCharacteristicFields<
+        DataVector, Dim, Frame>::type*>
+        evolved_space,
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_plus,
+    const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector1_zero,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector2_minus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_plus,
+    const tnsr::i<DataVector, Dim, Frame>& u_vector3_minus,
+    const Scalar<DataVector>& u_scalar1_zero,
+    const Scalar<DataVector>& u_scalar2_plus,
+    const Scalar<DataVector>& u_scalar2_minus,
+    const Scalar<DataVector>& u_scalar3_plus,
+    const Scalar<DataVector>& u_scalar3_minus,
+    const Scalar<DataVector>& u_scalar4_plus,
+    const Scalar<DataVector>& u_scalar4_minus,
+    const Scalar<DataVector>& u_scalar5_plus,
+    const Scalar<DataVector>& u_scalar5_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+    const Scalar<DataVector>& conformal_factor, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift, double f);
+
+template <typename Frame>
+struct EvolvedSpaceFromCharacteristicFieldsCompute
+    : Tags::EvolvedSpaceFromCharacteristicFields<DataVector, Dim, Frame>,
+      db::ComputeTag {
+  using base =
+      Tags::EvolvedSpaceFromCharacteristicFields<DataVector, Dim, Frame>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      Tags::UTensorPlus<DataVector, Dim, Frame>,
+      Tags::UTensorMinus<DataVector, Dim, Frame>,
+      Tags::UVector1Zero<DataVector, Dim, Frame>,
+      Tags::UVector2Plus<DataVector, Dim, Frame>,
+      Tags::UVector2Minus<DataVector, Dim, Frame>,
+      Tags::UVector3Plus<DataVector, Dim, Frame>,
+      Tags::UVector3Minus<DataVector, Dim, Frame>,
+      Tags::UScalar1Zero<DataVector>, Tags::UScalar2Plus<DataVector>,
+      Tags::UScalar2Minus<DataVector>, Tags::UScalar3Plus<DataVector>,
+      Tags::UScalar3Minus<DataVector>, Tags::UScalar4Plus<DataVector>,
+      Tags::UScalar4Minus<DataVector>, Tags::UScalar5Plus<DataVector>,
+      Tags::UScalar5Minus<DataVector>,
+      ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim, Frame>>,
+      Ccz4::Tags::ConformalMetric<DataVector, Dim, Frame>,
+      Ccz4::Tags::ConformalFactor<DataVector>, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<DataVector, Dim, Frame>>;
+
+  static void function(
+      const gsl::not_null<return_type*> evolved_space,
+      const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_plus,
+      const tnsr::ii<DataVector, Dim, Frame>& u_tnsr_minus,
+      const tnsr::i<DataVector, Dim, Frame>& u_vector1_zero,
+      const tnsr::i<DataVector, Dim, Frame>& u_vector2_plus,
+      const tnsr::i<DataVector, Dim, Frame>& u_vector2_minus,
+      const tnsr::i<DataVector, Dim, Frame>& u_vector3_plus,
+      const tnsr::i<DataVector, Dim, Frame>& u_vector3_minus,
+      const Scalar<DataVector>& u_scalar1_zero,
+      const Scalar<DataVector>& u_scalar2_plus,
+      const Scalar<DataVector>& u_scalar2_minus,
+      const Scalar<DataVector>& u_scalar3_plus,
+      const Scalar<DataVector>& u_scalar3_minus,
+      const Scalar<DataVector>& u_scalar4_plus,
+      const Scalar<DataVector>& u_scalar4_minus,
+      const Scalar<DataVector>& u_scalar5_plus,
+      const Scalar<DataVector>& u_scalar5_minus,
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+      const tnsr::ii<DataVector, Dim, Frame>& conformal_spatial_metric,
+      const Scalar<DataVector>& conformal_factor,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame>& shift) {
+    static constexpr double f = Ccz4::fd::System::f;
+    evolved_space_from_characteristic_fields(
+        evolved_space, u_tnsr_plus, u_tnsr_minus, u_vector1_zero,
+        u_vector2_plus, u_vector2_minus, u_vector3_plus, u_vector3_minus,
+        u_scalar1_zero, u_scalar2_plus, u_scalar2_minus, u_scalar3_plus,
+        u_scalar3_minus, u_scalar4_plus, u_scalar4_minus, u_scalar5_plus,
+        u_scalar5_minus, unit_normal_one_form, conformal_spatial_metric,
+        conformal_factor, lapse, shift, f);
+  };
+};
+/// @}
+}  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp
@@ -117,5 +117,164 @@ struct KreissOligerEpsilon : db::SimpleTag {
 
 /// \brief Tags sent for second-order Ccz4 evolution.
 using spacetime_reconstruction_tags = System::variables_tag_list;
+
+template <typename DataType>
+struct CPhi : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct CGamma : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct CAlpha : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct CK : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct CTheta : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct CBeta : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = std::array<DataType, 16>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct UTensorPlus : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct UTensorMinus : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct UVector1Zero : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct UVector2Plus : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct UVector2Minus : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct UVector3Plus : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct UVector3Minus : db::SimpleTag {
+  using type = tnsr::i<DataType, Dim, Frame>;
+};
+
+template <typename DataType>
+struct UScalar1Zero : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar2Plus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar2Minus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar3Plus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar3Minus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar4Plus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar4Minus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar5Plus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType>
+struct UScalar5Minus : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct CharacteristicFields : db::SimpleTag {
+  using type = Variables<tmpl::list<
+      UTensorPlus<DataType, Dim, Frame>, UTensorMinus<DataType, Dim, Frame>,
+      UVector1Zero<DataType, Dim, Frame>, UVector2Plus<DataType, Dim, Frame>,
+      UVector2Minus<DataType, Dim, Frame>, UVector3Plus<DataType, Dim, Frame>,
+      UVector3Minus<DataType, Dim, Frame>, UScalar1Zero<DataType>,
+      UScalar2Plus<DataType>, UScalar2Minus<DataType>, UScalar3Plus<DataType>,
+      UScalar3Minus<DataType>, UScalar4Plus<DataType>, UScalar4Minus<DataType>,
+      UScalar5Plus<DataType>, UScalar5Minus<DataType>>>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct DnConformalMetric : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+};
+
+template <typename DataType>
+struct DnLapse : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct DnShift : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, Frame>;
+};
+
+template <typename DataType>
+struct DnConformalFactor : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+template <typename DataType, size_t Dim, typename Frame>
+struct EvolvedSpaceFromCharacteristicFields : db::SimpleTag {
+  using type = Variables<
+      tmpl::list<DnConformalMetric<DataType, Dim, Frame>, DnLapse<DataType>,
+                 DnShift<DataType, Dim, Frame>, DnConformalFactor<DataType>,
+                 ::Ccz4::Tags::ATilde<DataType, Dim, Frame>,
+                 gr::Tags::TraceExtrinsicCurvature<DataType>,
+                 ::Ccz4::Tags::Theta<DataType>,
+                 ::Ccz4::Tags::GammaHat<DataType, Dim, Frame>,
+                 ::Ccz4::Tags::AuxiliaryShiftB<DataType, Dim, Frame>>>;
+};
 }  // namespace Tags
 }  // namespace Ccz4::fd

--- a/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Ccz4/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   BoundaryConditions/Test_Sommerfeld.cpp
   FiniteDifference/Test_ApplyFilter.cpp
   FiniteDifference/Test_BoundaryConditionGhostData.cpp
+  FiniteDifference/Test_Characteristics.cpp
   FiniteDifference/Test_Derivatives.cpp
   FiniteDifference/Test_DummyReconstructor.cpp
   FiniteDifference/Test_EnforceConstrainedEvolution.cpp
@@ -34,6 +35,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   Ccz4
+  CoordinateMaps
   DataBoxTestHelpers
   DataStructures
   Domain

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Characteristics.cpp
@@ -1,0 +1,327 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Characteristics.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/Evolution/Systems/Ccz4/CharacteristicsTestHelpers.hpp"
+#include "Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+
+namespace {
+constexpr size_t Dim = Ccz4::fd::System::volume_dim;
+
+void test_characteristics(
+    const size_t points_per_dimension,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_one_form) {
+  ASSERT(pow<3>(points_per_dimension) == get<0>(normal_one_form).size(),
+         "The size of the unit normal one form must match the number of grid "
+         "points per dimension.");
+
+  const size_t ghost_zone_size = 3;
+  const size_t fd_deriv_order = 4;
+  const Mesh<Dim> subcell_mesh{points_per_dimension,
+                               Spectral::Basis::FiniteDifference,
+                               Spectral::Quadrature::CellCentered};
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+  const std::array<double, Dim> lower_bound{5.8, 5.0, 2.3};
+  const std::array<double, Dim> upper_bound{6.2, 5.2, 2.4};
+  const std::array<double, Dim> coords_range = upper_bound - lower_bound;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          Affine3D{
+              Affine{-1., 1., lower_bound[0], upper_bound[0]},
+              Affine{-1., 1., lower_bound[1], upper_bound[1]},
+              Affine{-1., 1., lower_bound[2], upper_bound[2]},
+          });
+  // set up displaced logical coords
+  const auto logical_coords =
+      TestHelpers::Ccz4::fd::detail::set_logical_coordinates(subcell_mesh);
+  const auto x = coord_map(logical_coords);
+  InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_jacobian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+  for (size_t i = 0; i < Dim; ++i) {
+    cell_centered_logical_to_inertial_inv_jacobian.get(i, i) =
+        2.0 / gsl::at(coords_range, i);
+  }
+
+  const Element<Dim> element = TestHelpers::Ccz4::fd::detail::set_element();
+
+  // Setup solution
+  const double mass = 2.0;
+  const std::array<double, Dim> spin{{0.2, 0.4, 0.8}};
+  const std::array<double, Dim> center{{0.2, 0.5, 0.1}};
+  const gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  const double f = Ccz4::fd::System::f;
+  const bool evolve_shift = true;
+  const DirectionalIdMap<Dim, evolution::dg::subcell::GhostData>
+      all_ghost_data =
+          TestHelpers::Ccz4::fd::detail::compute_ghost_data<Frame::Inertial>(
+              subcell_mesh, x, element.neighbors(), ghost_zone_size,
+              TestHelpers::Ccz4::fd::detail::KerrSchild::
+                  compute_prim_solution_for_KerrSchild,
+              coords_range, t, f, evolve_shift, solution);
+
+  auto volume_evolved_vars = TestHelpers::Ccz4::fd::detail::KerrSchild::
+      compute_prim_solution_for_KerrSchild(x, t, f, evolve_shift, solution);
+
+  Variables<
+      db::wrap_tags_in<Tags::deriv, typename Ccz4::fd::System::gradients_tags,
+                       tmpl::size_t<Dim>, Frame::Inertial>>
+      deriv_of_Ccz4_vars{subcell_mesh.number_of_grid_points()};
+
+  ::Ccz4::fd::spacetime_derivatives(
+      make_not_null(&deriv_of_Ccz4_vars), volume_evolved_vars, all_ghost_data,
+      fd_deriv_order, subcell_mesh,
+      cell_centered_logical_to_inertial_inv_jacobian);
+
+  // Compute normalized one-form
+  const auto& conformal_spatial_metric =
+      get<::Ccz4::Tags::ConformalMetric<DataVector, Dim>>(volume_evolved_vars);
+  const auto& conformal_factor =
+      get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars);
+  tnsr::ii<DataVector, Dim, Frame::Inertial> spatial_metric{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&spatial_metric),
+      conformal_spatial_metric(ti::i, ti::j) /
+          (conformal_factor() * conformal_factor()));
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal_one_form{};
+  DataVector magnitude =
+    sqrt(get(::tenex::evaluate(inverse_spatial_metric(ti::I, ti::J) *
+                          normal_one_form(ti::i) * normal_one_form(ti::j))));
+  for (size_t i = 0; i < Dim; ++i) {
+    unit_normal_one_form.get(i) = normal_one_form.get(i) / magnitude;
+  }
+
+  // Test characteristic speeds by coding twice
+  const auto char_speeds = Ccz4::fd::characteristic_speeds<Frame::Inertial>(
+      get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars),
+      get<gr::Tags::Shift<DataVector, Dim>>(volume_evolved_vars),
+      get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars), f,
+      unit_normal_one_form);
+  const auto expected_char_speeds =
+      TestHelpers::Ccz4::fd::detail::compute_expected_characteristic_speeds(
+          get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars),
+          get<gr::Tags::Shift<DataVector, Dim>>(volume_evolved_vars),
+          get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars),
+          f, unit_normal_one_form);
+  for (size_t i = 0; i < char_speeds.size(); ++i) {
+    CHECK_ITERABLE_APPROX(char_speeds.at(i), expected_char_speeds.at(i));
+  }
+
+  // Test characteristic transformation by coding twice
+  ::Ccz4::fd::Tags::CharacteristicFields<DataVector, Dim, Frame::Inertial>::type
+      char_fields{};
+  ::Ccz4::fd::CharacteristicFieldsCompute<Frame::Inertial>::function(
+      make_not_null(&char_fields), unit_normal_one_form,
+      get<::Ccz4::Tags::ConformalMetric<DataVector, Dim>>(volume_evolved_vars),
+      get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars),
+      get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars),
+      get<gr::Tags::Shift<DataVector, Dim>>(volume_evolved_vars),
+      get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(volume_evolved_vars),
+      get<::Ccz4::Tags::ATilde<DataVector, Dim>>(volume_evolved_vars),
+      get<::Ccz4::Tags::Theta<DataVector>>(volume_evolved_vars),
+      get<::Ccz4::Tags::GammaHat<DataVector, Dim>>(volume_evolved_vars),
+      get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>(volume_evolved_vars),
+      get<Tags::deriv<::Ccz4::Tags::ConformalMetric<DataVector, Dim>,
+                      tmpl::size_t<Dim>, Frame::Inertial>>(deriv_of_Ccz4_vars),
+      get<Tags::deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                      tmpl::size_t<Dim>, Frame::Inertial>>(deriv_of_Ccz4_vars),
+      get<Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                      Frame::Inertial>>(deriv_of_Ccz4_vars),
+      get<Tags::deriv<gr::Tags::Shift<DataVector, Dim>, tmpl::size_t<Dim>,
+                      Frame::Inertial>>(deriv_of_Ccz4_vars));
+  const auto expected_char_fields =
+      TestHelpers::Ccz4::fd::detail::compute_expected_characteristic_fields(
+          unit_normal_one_form,
+          get<::Ccz4::Tags::ConformalMetric<DataVector, Dim>>(
+              volume_evolved_vars),
+          get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars),
+          get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars),
+          get<gr::Tags::Shift<DataVector, Dim>>(volume_evolved_vars),
+          get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(
+              volume_evolved_vars),
+          get<::Ccz4::Tags::ATilde<DataVector, Dim>>(volume_evolved_vars),
+          get<::Ccz4::Tags::Theta<DataVector>>(volume_evolved_vars),
+          get<::Ccz4::Tags::GammaHat<DataVector, Dim>>(volume_evolved_vars),
+          get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>(
+              volume_evolved_vars),
+          get<Tags::deriv<::Ccz4::Tags::ConformalMetric<DataVector, Dim>,
+                          tmpl::size_t<Dim>, Frame::Inertial>>(
+              deriv_of_Ccz4_vars),
+          get<Tags::deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                          tmpl::size_t<Dim>, Frame::Inertial>>(
+              deriv_of_Ccz4_vars),
+          get<Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                          Frame::Inertial>>(deriv_of_Ccz4_vars),
+          get<Tags::deriv<gr::Tags::Shift<DataVector, Dim>, tmpl::size_t<Dim>,
+                          Frame::Inertial>>(deriv_of_Ccz4_vars),
+          f);
+  tmpl::for_each<typename ::Ccz4::fd::Tags::CharacteristicFields<
+      DataVector, Dim, Frame::Inertial>::type::tags_list>(
+      [&char_fields,
+       &expected_char_fields]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+        const std::string tag_name = db::tag_name<Tag>();
+        CAPTURE(tag_name);
+        double max_value = 0.0;
+        const auto& tensor = get<Tag>(char_fields);
+        for (size_t i = 0; i < tensor.size(); ++i) {
+          max_value = std::max(max_value, max(abs(tensor[i])));
+        }
+        const Approx custom_approx =
+            Approx::custom().epsilon(1.0e-12).scale(max_value);
+        CHECK_ITERABLE_CUSTOM_APPROX(get<Tag>(char_fields),
+                                     get<Tag>(expected_char_fields),
+                                     custom_approx);
+      });
+
+  // Test that inverse transformation recovers the original variables
+  typename ::Ccz4::fd::Tags::EvolvedSpaceFromCharacteristicFields<
+      DataVector, Dim, Frame::Inertial>::type recovered_vars{};
+  ::Ccz4::fd::EvolvedSpaceFromCharacteristicFieldsCompute<Frame::Inertial>::
+      function(
+          make_not_null(&recovered_vars),
+          get<::Ccz4::fd::Tags::UTensorPlus<DataVector, Dim, Frame::Inertial>>(
+              char_fields),
+          get<::Ccz4::fd::Tags::UTensorMinus<DataVector, Dim, Frame::Inertial>>(
+              char_fields),
+          get<::Ccz4::fd::Tags::UVector1Zero<DataVector, Dim, Frame::Inertial>>(
+              char_fields),
+          get<::Ccz4::fd::Tags::UVector2Plus<DataVector, Dim, Frame::Inertial>>(
+              char_fields),
+          get<::Ccz4::fd::Tags::UVector2Minus<DataVector, Dim,
+                                              Frame::Inertial>>(char_fields),
+          get<::Ccz4::fd::Tags::UVector3Plus<DataVector, Dim, Frame::Inertial>>(
+              char_fields),
+          get<::Ccz4::fd::Tags::UVector3Minus<DataVector, Dim,
+                                              Frame::Inertial>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar1Zero<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar2Plus<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar2Minus<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar3Plus<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar3Minus<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar4Plus<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar4Minus<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar5Plus<DataVector>>(char_fields),
+          get<::Ccz4::fd::Tags::UScalar5Minus<DataVector>>(char_fields),
+          unit_normal_one_form,
+          get<::Ccz4::Tags::ConformalMetric<DataVector, Dim>>(
+              volume_evolved_vars),
+          get<::Ccz4::Tags::ConformalFactor<DataVector>>(volume_evolved_vars),
+          get<gr::Tags::Lapse<DataVector>>(volume_evolved_vars),
+          get<gr::Tags::Shift<DataVector, Dim>>(volume_evolved_vars));
+
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-10).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::Tags::ATilde<DataVector, Dim>>(recovered_vars)),
+      (get<::Ccz4::Tags::ATilde<DataVector, Dim>>(volume_evolved_vars)),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(recovered_vars)),
+      (get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(volume_evolved_vars)),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::Tags::Theta<DataVector>>(recovered_vars)),
+      (get<::Ccz4::Tags::Theta<DataVector>>(volume_evolved_vars)),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::Tags::GammaHat<DataVector, Dim>>(recovered_vars)),
+      (get<::Ccz4::Tags::GammaHat<DataVector, Dim>>(volume_evolved_vars)),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>(recovered_vars)),
+      (get<::Ccz4::Tags::AuxiliaryShiftB<DataVector, Dim>>(
+          volume_evolved_vars)),
+      custom_approx);
+
+  const tnsr::I<DataVector, Dim, Frame::Inertial> unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+  magnitude = sqrt(get(dot_product(unit_normal_one_form, unit_normal_vector)));
+  CHECK_ITERABLE_APPROX(magnitude, DataVector(magnitude.size(), 1.0));
+
+  const auto& d_conformal_spatial_metric =
+      get<Tags::deriv<::Ccz4::Tags::ConformalMetric<DataVector, Dim>,
+                      tmpl::size_t<Dim>, Frame::Inertial>>(deriv_of_Ccz4_vars);
+  tnsr::ii<DataVector, Dim, Frame::Inertial>
+      original_dn_conformal_spatial_metric{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&original_dn_conformal_spatial_metric),
+      unit_normal_vector(ti::K) *
+          d_conformal_spatial_metric(ti::k, ti::i, ti::j));
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::fd::Tags::DnConformalMetric<
+           DataVector, Dim, Frame::Inertial>>(recovered_vars)),
+      original_dn_conformal_spatial_metric, custom_approx);
+
+  const auto& d_conformal_factor =
+      get<Tags::deriv<::Ccz4::Tags::ConformalFactor<DataVector>,
+                      tmpl::size_t<Dim>, Frame::Inertial>>(deriv_of_Ccz4_vars);
+  Scalar<DataVector> original_dn_conformal_factor{};
+  ::tenex::evaluate(make_not_null(&original_dn_conformal_factor),
+                    unit_normal_vector(ti::I) * d_conformal_factor(ti::i));
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::fd::Tags::DnConformalFactor<DataVector>>(recovered_vars)),
+      original_dn_conformal_factor, custom_approx);
+
+  const auto& d_lapse =
+      get<Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                      Frame::Inertial>>(deriv_of_Ccz4_vars);
+  Scalar<DataVector> original_dn_lapse{};
+  ::tenex::evaluate(make_not_null(&original_dn_lapse),
+                    unit_normal_vector(ti::I) * d_lapse(ti::i));
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::fd::Tags::DnLapse<DataVector>>(recovered_vars)),
+      original_dn_lapse, custom_approx);
+
+  const auto& d_shift =
+      get<Tags::deriv<gr::Tags::Shift<DataVector, Dim>, tmpl::size_t<Dim>,
+                      Frame::Inertial>>(deriv_of_Ccz4_vars);
+  tnsr::I<DataVector, Dim, Frame::Inertial> original_dn_shift{};
+  ::tenex::evaluate<ti::I>(make_not_null(&original_dn_shift),
+                           unit_normal_vector(ti::J) * d_shift(ti::j, ti::I));
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      (get<::Ccz4::fd::Tags::DnShift<DataVector, Dim, Frame::Inertial>>(
+          recovered_vars)),
+      original_dn_shift, custom_approx);
+}
+}  // namespace
+
+// [[TimeOut, 10]]
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Characteristics",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  const std::uniform_real_distribution<> distribution(1.0, 2.0);
+  const size_t points_per_dimension = 5;
+  auto normal_one_form =
+      make_with_random_values<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          make_not_null(&generator), distribution,
+          DataVector(pow<3>(points_per_dimension),
+                     std::numeric_limits<double>::signaling_NaN()));
+  test_characteristics(points_per_dimension, normal_one_form);
+}

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Tags.cpp
@@ -6,12 +6,15 @@
 #include <cstddef>
 #include <string>
 
+#include "DataStructures/DataVector.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace {
 struct ArbitraryFrame;
+}  // namespace
 
+template <typename DataType, size_t Dim, typename Frame>
 void test_simple_tags() {
   TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::Reconstructor>(
       "Reconstructor");
@@ -21,9 +24,65 @@ void test_simple_tags() {
       "ConstrainedEvolution");
   TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::KreissOligerEpsilon>(
       "KreissOligerEpsilon");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::CPhi<DataType>>("CPhi");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::CGamma<DataType>>("CGamma");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::CAlpha<DataType>>("CAlpha");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::CK<DataType>>("CK");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::CTheta<DataType>>("CTheta");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::CBeta<DataType>>("CBeta");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::CharacteristicSpeeds<DataType>>("CharacteristicSpeeds");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::UTensorPlus<DataType, Dim, Frame>>("UTensorPlus");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::UTensorMinus<DataType, Dim, Frame>>("UTensorMinus");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::UVector1Zero<DataType, Dim, Frame>>("UVector1Zero");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::UVector2Plus<DataType, Dim, Frame>>("UVector2Plus");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::UVector2Minus<DataType, Dim, Frame>>("UVector2Minus");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::UVector3Plus<DataType, Dim, Frame>>("UVector3Plus");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::UVector3Minus<DataType, Dim, Frame>>("UVector3Minus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar1Zero<DataType>>(
+      "UScalar1Zero");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar2Plus<DataType>>(
+      "UScalar2Plus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar2Minus<DataType>>(
+      "UScalar2Minus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar3Plus<DataType>>(
+      "UScalar3Plus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar3Minus<DataType>>(
+      "UScalar3Minus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar4Plus<DataType>>(
+      "UScalar4Plus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar4Minus<DataType>>(
+      "UScalar4Minus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar5Plus<DataType>>(
+      "UScalar5Plus");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::UScalar5Minus<DataType>>(
+      "UScalar5Minus");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::CharacteristicFields<DataType, Dim, Frame>>(
+      "CharacteristicFields");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::DnConformalMetric<DataType, Dim, Frame>>(
+      "DnConformalMetric");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::DnLapse<DataType>>(
+      "DnLapse");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::DnShift<DataType, Dim, Frame>>("DnShift");
+  TestHelpers::db::test_simple_tag<Ccz4::fd::Tags::DnConformalFactor<DataType>>(
+      "DnConformalFactor");
+  TestHelpers::db::test_simple_tag<
+      Ccz4::fd::Tags::EvolvedSpaceFromCharacteristicFields<DataType, Dim,
+                                                           Frame>>(
+      "EvolvedSpaceFromCharacteristicFields");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.fd.Ccz4.Tags", "[Unit][Evolution]") {
-  test_simple_tags();
+  test_simple_tags<double, 3, ArbitraryFrame>();
+  test_simple_tags<DataVector, 3, ArbitraryFrame>();
 }
-}  // namespace

--- a/tests/Unit/Helpers/Evolution/Systems/Ccz4/CharacteristicsTestHelpers.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Ccz4/CharacteristicsTestHelpers.hpp
@@ -1,0 +1,432 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
+#include "Evolution/Systems/Ccz4/FiniteDifference/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+
+namespace TestHelpers::Ccz4::fd::detail {
+static constexpr size_t Dim = ::Ccz4::fd::System::volume_dim;
+
+template <typename DataType>
+typename std::array<DataType, 16> compute_expected_characteristic_speeds(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, Dim, Frame::Inertial>& shift,
+    const Scalar<DataType>& conformal_factor, const double f,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& unit_normal_one_form) {
+  constexpr bool shifting_shift = ::Ccz4::fd::System::shifting_shift;
+  std::array<DataType, 16> expected_char_speeds{};
+  // tensor sector characteristic speeds
+  const DataVector shift_n = get(dot_product(shift, unit_normal_one_form));
+  expected_char_speeds[0] = -1.0 * shift_n + get(lapse);  // u_tensor_plus
+  expected_char_speeds[1] = -1.0 * shift_n - get(lapse);  // u_tensor_minus
+
+  // vector sector characteristic speeds
+  expected_char_speeds[2] =
+      shifting_shift ? -1.0 * shift_n : 0.0 * shift_n;    // u_vector1_zero
+  expected_char_speeds[3] = -1.0 * shift_n + get(lapse);  // u_vector2_plus
+  expected_char_speeds[4] = -1.0 * shift_n - get(lapse);  // u_vector2_minus
+  const auto sqrt_f_over_phi = sqrt(f) / get(conformal_factor);
+  if (shifting_shift) {
+    // u_vector3_plus
+    expected_char_speeds[5] = -1.0 * shift_n + sqrt_f_over_phi;
+    // u_vector3_minus
+    expected_char_speeds[6] = -1.0 * shift_n - sqrt_f_over_phi;
+  } else {
+    // u_vector3_plus
+    expected_char_speeds[5] =
+        -0.5 * shift_n +
+        0.5 * sqrt(4.0 * f + pow<2>(shift_n * get(conformal_factor))) /
+            get(conformal_factor);
+    // u_vector3_minus
+    expected_char_speeds[6] =
+        -0.5 * shift_n -
+        0.5 * sqrt(4.0 * f + pow<2>(shift_n * get(conformal_factor))) /
+            get(conformal_factor);
+  }
+
+  // scalar sector characteristic speeds
+  expected_char_speeds[7] =
+      shifting_shift ? -1.0 * shift_n : 0.0 * shift_n;     // u_scalar1_zero
+  expected_char_speeds[8] = -1.0 * shift_n + get(lapse);   // u_scalar2_plus
+  expected_char_speeds[9] = -1.0 * shift_n - get(lapse);   // u_scalar2_minus
+  expected_char_speeds[10] = -1.0 * shift_n + get(lapse);  // u_scalar3_plus
+  expected_char_speeds[11] = -1.0 * shift_n - get(lapse);  // u_scalar3_minus
+  expected_char_speeds[12] =
+      -1.0 * shift_n + sqrt(2.0 * get(lapse));  // u_scalar4_plus
+  expected_char_speeds[13] =
+      -1.0 * shift_n - sqrt(2.0 * get(lapse));  // u_scalar4_minus
+  if (shifting_shift) {
+    const auto v_s = (2.0) / sqrt(3.0) * sqrt_f_over_phi;
+    // u_scalar5_plus
+    expected_char_speeds[14] = -1.0 * shift_n + v_s;
+    // u_scalar5_minus
+    expected_char_speeds[15] = -1.0 * shift_n - v_s;
+  } else {
+    // u_scalar5_plus
+    expected_char_speeds[14] =
+        -0.5 * shift_n +
+        sqrt(48.0 * f + 9 * pow<2>(shift_n * get(conformal_factor))) /
+            (6.0 * get(conformal_factor));
+    // u_scalar5_minus
+    expected_char_speeds[15] =
+        -0.5 * shift_n -
+        sqrt(48.0 * f + 9 * pow<2>(shift_n * get(conformal_factor))) /
+            (6.0 * get(conformal_factor));
+  }
+
+  return expected_char_speeds;
+}
+
+template <typename DataType>
+typename ::Ccz4::fd::Tags::CharacteristicFields<DataType, Dim,
+                                                Frame::Inertial>::type
+compute_expected_characteristic_fields(
+    const tnsr::i<DataType, Dim, Frame::Inertial>& unit_normal_one_form,
+    const tnsr::ii<DataType, Dim, Frame::Inertial>& conformal_spatial_metric,
+    const Scalar<DataType>& conformal_factor, const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, Dim, Frame::Inertial>& shift,
+    const Scalar<DataType>& trace_extrinsic_curvature,
+    const tnsr::ii<DataType, Dim, Frame::Inertial>& a_tilde,
+    const Scalar<DataType>& theta,
+    const tnsr::I<DataType, Dim, Frame::Inertial>& gamma_hat,
+    const tnsr::I<DataType, Dim, Frame::Inertial>& auxiliary_field_b,
+    const tnsr::ijj<DataType, Dim, Frame::Inertial>& d_conformal_spatial_metric,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& d_conformal_factor,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& d_lapse,
+    const tnsr::iJ<DataType, Dim, Frame::Inertial>& d_shift, const double f) {
+  const DataVector shift_n = get(dot_product(shift, unit_normal_one_form));
+  constexpr bool shifting_shift = ::Ccz4::fd::System::shifting_shift;
+  typename ::Ccz4::fd::Tags::CharacteristicFields<
+      DataType, Dim, Frame::Inertial>::type expected_char_fields{
+      get(lapse).size()};
+
+  tnsr::ii<DataType, Dim, Frame::Inertial> spatial_metric{};
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&spatial_metric),
+      conformal_spatial_metric(ti::i, ti::j) /
+          (conformal_factor() * conformal_factor()));
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto q_dd =
+      gr::transverse_projection_operator(spatial_metric, unit_normal_one_form);
+  tnsr::I<DataType, Dim, Frame::Inertial> unit_normal_vector{};
+  ::tenex::evaluate<ti::I>(
+      make_not_null(&unit_normal_vector),
+      inverse_spatial_metric(ti::I, ti::J) * unit_normal_one_form(ti::j));
+  const auto q_Ud = gr::transverse_projection_operator(unit_normal_vector,
+                                                       unit_normal_one_form);
+  const auto q_UU = gr::transverse_projection_operator(inverse_spatial_metric,
+                                                       unit_normal_vector);
+  tnsr::ijKL<DataType, Dim, Frame::Inertial> tt_projector{};
+  ::tenex::evaluate<ti::i, ti::j, ti::K, ti::L>(
+      make_not_null(&tt_projector),
+      q_Ud(ti::K, ti::i) * q_Ud(ti::L, ti::j) -
+          0.5 * q_UU(ti::K, ti::L) * q_dd(ti::i, ti::j));
+
+  // tensor sector
+  auto& u_tnsr_plus =
+      get<::Ccz4::fd::Tags::UTensorPlus<DataType, Dim, Frame::Inertial>>(
+          expected_char_fields);
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&u_tnsr_plus),
+      tt_projector(ti::i, ti::j, ti::K, ti::L) *
+          (a_tilde(ti::k, ti::l) +
+           0.5 * unit_normal_vector(ti::M) *
+               d_conformal_spatial_metric(ti::m, ti::k, ti::l)));
+  auto& u_tnsr_minus =
+      get<::Ccz4::fd::Tags::UTensorMinus<DataType, Dim, Frame::Inertial>>(
+          expected_char_fields);
+  ::tenex::evaluate<ti::i, ti::j>(
+      make_not_null(&u_tnsr_minus),
+      tt_projector(ti::i, ti::j, ti::K, ti::L) *
+          (a_tilde(ti::k, ti::l) -
+           0.5 * unit_normal_vector(ti::M) *
+               d_conformal_spatial_metric(ti::m, ti::k, ti::l)));
+
+  // vector sector
+  auto& u_vector1_zero =
+      get<::Ccz4::fd::Tags::UVector1Zero<DataType, Dim, Frame::Inertial>>(
+          expected_char_fields);
+  ::tenex::evaluate<ti::i>(make_not_null(&u_vector1_zero),
+                           q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) -
+                               q_dd(ti::i, ti::j) * gamma_hat(ti::J));
+  auto& u_vector2_plus =
+      get<::Ccz4::fd::Tags::UVector2Plus<DataType, Dim, Frame::Inertial>>(
+          expected_char_fields);
+  ::tenex::evaluate<ti::i>(
+      make_not_null(&u_vector2_plus),
+      q_dd(ti::i, ti::j) * gamma_hat(ti::J) -
+          unit_normal_vector(ti::J) * q_Ud(ti::K, ti::i) /
+              (conformal_factor() * conformal_factor() * conformal_factor() *
+               conformal_factor()) *
+              (unit_normal_vector(ti::L) *
+                   d_conformal_spatial_metric(ti::l, ti::k, ti::j) +
+               2.0 * a_tilde(ti::k, ti::j)));
+  auto& u_vector2_minus =
+      get<::Ccz4::fd::Tags::UVector2Minus<DataType, Dim, Frame::Inertial>>(
+          expected_char_fields);
+  ::tenex::evaluate<ti::i>(
+      make_not_null(&u_vector2_minus),
+      q_dd(ti::i, ti::j) * gamma_hat(ti::J) -
+          unit_normal_vector(ti::J) * q_Ud(ti::K, ti::i) /
+              (conformal_factor() * conformal_factor() * conformal_factor() *
+               conformal_factor()) *
+              (unit_normal_vector(ti::L) *
+                   d_conformal_spatial_metric(ti::l, ti::k, ti::j) -
+               2.0 * a_tilde(ti::k, ti::j)));
+  auto& u_vector3_plus =
+      get<::Ccz4::fd::Tags::UVector3Plus<DataType, Dim, Frame::Inertial>>(
+          expected_char_fields);
+  auto& u_vector3_minus =
+      get<::Ccz4::fd::Tags::UVector3Minus<DataType, Dim, Frame::Inertial>>(
+          expected_char_fields);
+  if (shifting_shift) {
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_plus),
+        q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) -
+            1.0 / (sqrt(f) * conformal_factor()) * unit_normal_vector(ti::J) *
+                q_dd(ti::i, ti::k) * d_shift(ti::j, ti::K));
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_minus),
+        q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) +
+            1.0 / (sqrt(f) * conformal_factor()) * unit_normal_vector(ti::J) *
+                q_dd(ti::i, ti::k) * d_shift(ti::j, ti::K));
+  } else {
+    Scalar<DataType> v_beta_plus{};
+    Scalar<DataType> v_beta_minus{};
+    get(v_beta_plus) =
+        (shift_n - sqrt(4.0 * f + pow<2>(shift_n * get(conformal_factor))) /
+                       get(conformal_factor)) /
+        (2.0 * f);
+    get(v_beta_minus) =
+        (shift_n + sqrt(4.0 * f + pow<2>(shift_n * get(conformal_factor))) /
+                       get(conformal_factor)) /
+        (2.0 * f);
+    Scalar<DataType> v_gamma_plus{};
+    Scalar<DataType> v_gamma_minus{};
+    get(v_gamma_plus) =
+        shift_n * pow<2>(get(conformal_factor)) * get(v_beta_plus);
+    get(v_gamma_minus) =
+        shift_n * pow<2>(get(conformal_factor)) * get(v_beta_minus);
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_plus),
+        q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) +
+            v_gamma_plus() * q_dd(ti::i, ti::j) * gamma_hat(ti::J) +
+            v_beta_plus() * unit_normal_vector(ti::J) * q_dd(ti::i, ti::k) *
+                d_shift(ti::j, ti::K));
+    ::tenex::evaluate<ti::i>(
+        make_not_null(&u_vector3_minus),
+        q_dd(ti::i, ti::j) * auxiliary_field_b(ti::J) +
+            v_gamma_minus() * q_dd(ti::i, ti::j) * gamma_hat(ti::J) +
+            v_beta_minus() * unit_normal_vector(ti::J) * q_dd(ti::i, ti::k) *
+                d_shift(ti::j, ti::K));
+  }
+
+  // scalar sector
+  auto& u_scalar1_zero =
+      get<::Ccz4::fd::Tags::UScalar1Zero<DataType>>(expected_char_fields);
+  ::tenex::evaluate(make_not_null(&u_scalar1_zero),
+                    unit_normal_one_form(ti::i) *
+                        (auxiliary_field_b(ti::I) - gamma_hat(ti::I)));
+  auto& u_scalar2_plus =
+      get<::Ccz4::fd::Tags::UScalar2Plus<DataType>>(expected_char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar2_plus),
+      unit_normal_vector(ti::I) * unit_normal_vector(ti::J) *
+              (a_tilde(ti::i, ti::j) +
+               0.5 * unit_normal_vector(ti::K) *
+                   d_conformal_spatial_metric(ti::k, ti::i, ti::j)) +
+          2.0 * conformal_factor() * unit_normal_vector(ti::K) *
+              d_conformal_factor(ti::k) -
+          2.0 / 3.0 * conformal_factor() * conformal_factor() *
+              trace_extrinsic_curvature());
+  auto& u_scalar2_minus =
+      get<::Ccz4::fd::Tags::UScalar2Minus<DataType>>(expected_char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar2_minus),
+      unit_normal_vector(ti::I) * unit_normal_vector(ti::J) *
+              (a_tilde(ti::i, ti::j) -
+               0.5 * unit_normal_vector(ti::K) *
+                   d_conformal_spatial_metric(ti::k, ti::i, ti::j)) -
+          2.0 * conformal_factor() * unit_normal_vector(ti::K) *
+              d_conformal_factor(ti::k) -
+          2.0 / 3.0 * conformal_factor() * conformal_factor() *
+              trace_extrinsic_curvature());
+  auto& u_scalar3_plus =
+      get<::Ccz4::fd::Tags::UScalar3Plus<DataType>>(expected_char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar3_plus),
+      unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+          2.0 / (conformal_factor() * conformal_factor()) *
+              (2.0 * unit_normal_vector(ti::I) * d_conformal_factor(ti::i) /
+                   conformal_factor() -
+               theta()));
+  auto& u_scalar3_minus =
+      get<::Ccz4::fd::Tags::UScalar3Minus<DataType>>(expected_char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar3_minus),
+      unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+          2.0 / (conformal_factor() * conformal_factor()) *
+              (2.0 * unit_normal_vector(ti::I) * d_conformal_factor(ti::i) /
+                   conformal_factor() +
+               theta()));
+  auto& u_scalar4_plus =
+      get<::Ccz4::fd::Tags::UScalar4Plus<DataType>>(expected_char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar4_plus),
+      unit_normal_vector(ti::I) * d_lapse(ti::i) +
+          sqrt(2.0 * lapse()) * (trace_extrinsic_curvature() - 2.0 * theta()));
+  auto& u_scalar4_minus =
+      get<::Ccz4::fd::Tags::UScalar4Minus<DataType>>(expected_char_fields);
+  ::tenex::evaluate(
+      make_not_null(&u_scalar4_minus),
+      unit_normal_vector(ti::I) * d_lapse(ti::i) -
+          sqrt(2.0 * lapse()) * (trace_extrinsic_curvature() - 2.0 * theta()));
+
+  auto& u_scalar5_plus =
+      get<::Ccz4::fd::Tags::UScalar5Plus<DataType>>(expected_char_fields);
+  auto& u_scalar5_minus =
+      get<::Ccz4::fd::Tags::UScalar5Minus<DataType>>(expected_char_fields);
+  if (shifting_shift) {
+    const DataType denom_1 =
+        -4.0 * f + 3.0 * pow<2>(get(lapse) * get(conformal_factor));
+    const DataType denom_2 =
+        -2.0 * f + 3.0 * get(lapse) * pow<2>(get(conformal_factor));
+    Scalar<DataType> c_phi{};
+    Scalar<DataType> c_gamma{};
+    Scalar<DataType> c_alpha{};
+    Scalar<DataType> c_k{};
+    Scalar<DataType> c_theta{};
+    Scalar<DataType> c_beta{};
+    get(c_phi) = 4.0 * pow<2>(get(lapse)) / (denom_1 * get(conformal_factor));
+    get(c_gamma) = pow<2>(get(lapse) * get(conformal_factor)) / denom_1;
+    get(c_alpha) = -2.0 * get(lapse) / denom_2;
+    get(c_k) = -4.0 * get(lapse) * sqrt(f) /
+               (sqrt(3.0) * denom_2 * get(conformal_factor));
+    get(c_theta) = 4.0 * sqrt(3.0 * f) * get(lapse) *
+                   (-2.0 * f + get(lapse) * pow<2>(get(conformal_factor)) *
+                                   (2.0 * get(lapse) - 1.0)) /
+                   (get(conformal_factor) * denom_1 * denom_2);
+    get(c_beta) = 2.0 / (sqrt(3.0 * f) * get(conformal_factor));
+
+    ::tenex::evaluate(
+        make_not_null(&u_scalar5_plus),
+        unit_normal_one_form(ti::i) * auxiliary_field_b(ti::I) +
+            c_phi() * unit_normal_vector(ti::I) * d_conformal_factor(ti::i) +
+            c_k() * trace_extrinsic_curvature() + c_theta() * theta() +
+            c_gamma() * unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+            c_alpha() * unit_normal_vector(ti::I) * d_lapse(ti::i) -
+            c_beta() * unit_normal_vector(ti::I) * unit_normal_one_form(ti::j) *
+                d_shift(ti::i, ti::J));
+
+    ::tenex::evaluate(
+        make_not_null(&u_scalar5_minus),
+        unit_normal_one_form(ti::i) * auxiliary_field_b(ti::I) +
+            c_phi() * unit_normal_vector(ti::I) * d_conformal_factor(ti::i) -
+            c_k() * trace_extrinsic_curvature() - c_theta() * theta() +
+            c_gamma() * unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+            c_alpha() * unit_normal_vector(ti::I) * d_lapse(ti::i) +
+            c_beta() * unit_normal_vector(ti::I) * unit_normal_one_form(ti::j) *
+                d_shift(ti::i, ti::J));
+  } else {
+    const auto n_plus =
+        3 * shift_n * pow<2>(get(conformal_factor)) -
+        get(conformal_factor) *
+            sqrt(48.0 * f + 9 * pow<2>(shift_n * get(conformal_factor)));
+    const auto n_minus =
+        3 * shift_n * pow<2>(get(conformal_factor)) +
+        get(conformal_factor) *
+            sqrt(48.0 * f + 9 * pow<2>(shift_n * get(conformal_factor)));
+    const auto d_1_plus = 8.0 * f + shift_n * n_minus -
+                          6.0 * pow<2>(get(lapse) * get(conformal_factor));
+    const auto d_1_minus = 8.0 * f + shift_n * n_plus -
+                           6.0 * pow<2>(get(lapse) * get(conformal_factor));
+    const auto d_2_plus = 8.0 * f + shift_n * n_minus -
+                          12.0 * get(lapse) * pow<2>(get(conformal_factor));
+    const auto d_2_minus = 8.0 * f + shift_n * n_plus -
+                           12.0 * get(lapse) * pow<2>(get(conformal_factor));
+    Scalar<DataType> c_phi_plus{};
+    Scalar<DataType> c_phi_minus{};
+    Scalar<DataType> c_k_plus{};
+    Scalar<DataType> c_k_minus{};
+    Scalar<DataType> c_theta_plus{};
+    Scalar<DataType> c_theta_minus{};
+    Scalar<DataType> c_gamma_plus{};
+    Scalar<DataType> c_gamma_minus{};
+    Scalar<DataType> c_alpha_plus{};
+    Scalar<DataType> c_alpha_minus{};
+    Scalar<DataType> c_beta_plus{};
+    Scalar<DataType> c_beta_minus{};
+    get(c_phi_plus) = -pow<2>(get(lapse)) * (shift_n * n_plus + 8.0 * f) /
+                      (f * get(conformal_factor) * d_1_plus);
+    get(c_phi_minus) = -pow<2>(get(lapse)) * (shift_n * n_minus + 8.0 * f) /
+                       (f * get(conformal_factor) * d_1_minus);
+    get(c_k_plus) = -4.0 * get(lapse) * n_plus /
+                    (3.0 * pow<2>(get(conformal_factor)) * d_2_plus);
+    get(c_k_minus) = -4.0 * get(lapse) * n_minus /
+                     (3.0 * pow<2>(get(conformal_factor)) * d_2_minus);
+    get(c_theta_plus) = 2.0 * get(lapse) * n_plus *
+                        (8.0 * f + shift_n * n_minus +
+                         4.0 * (1.0 - 2.0 * get(lapse)) * get(lapse) *
+                             pow<2>(get(conformal_factor))) /
+                        (pow<2>(get(conformal_factor)) * d_1_plus * d_2_plus);
+    get(c_theta_minus) =
+        2.0 * get(lapse) * n_minus *
+        (8.0 * f + shift_n * n_plus +
+         4.0 * (1.0 - 2.0 * get(lapse)) * get(lapse) *
+             pow<2>(get(conformal_factor))) /
+        (pow<2>(get(conformal_factor)) * d_1_minus * d_2_minus);
+    get(c_gamma_plus) = -1.0 *
+                        (shift_n * f * n_minus +
+                         pow<2>(get(lapse)) * (shift_n * n_plus + 2.0 * f) *
+                             pow<2>(get(conformal_factor))) /
+                        (f * d_1_plus);
+    get(c_gamma_minus) = -1.0 *
+                         (shift_n * f * n_plus +
+                          pow<2>(get(lapse)) * (shift_n * n_minus + 2.0 * f) *
+                              pow<2>(get(conformal_factor))) /
+                         (f * d_1_minus);
+    get(c_alpha_plus) = get(lapse) * pow<2>(n_plus) /
+                        (6.0 * f * pow<2>(get(conformal_factor)) * d_2_plus);
+    get(c_alpha_minus) = get(lapse) * pow<2>(n_minus) /
+                         (6.0 * f * pow<2>(get(conformal_factor)) * d_2_minus);
+    get(c_beta_plus) = n_plus / (6.0 * f * pow<2>(get(conformal_factor)));
+    get(c_beta_minus) = n_minus / (6.0 * f * pow<2>(get(conformal_factor)));
+    ::tenex::evaluate(
+        make_not_null(&u_scalar5_plus),
+        unit_normal_one_form(ti::i) * auxiliary_field_b(ti::I) +
+            c_phi_plus() * unit_normal_vector(ti::I) *
+                d_conformal_factor(ti::i) +
+            c_k_plus() * trace_extrinsic_curvature() +
+            c_theta_plus() * theta() +
+            c_gamma_plus() * unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+            c_alpha_plus() * unit_normal_vector(ti::I) * d_lapse(ti::i) +
+            c_beta_plus() * unit_normal_vector(ti::I) *
+                unit_normal_one_form(ti::j) * d_shift(ti::i, ti::J));
+    ::tenex::evaluate(
+        make_not_null(&u_scalar5_minus),
+        unit_normal_one_form(ti::i) * auxiliary_field_b(ti::I) +
+            c_phi_minus() * unit_normal_vector(ti::I) *
+                d_conformal_factor(ti::i) +
+            c_k_minus() * trace_extrinsic_curvature() +
+            c_theta_minus() * theta() +
+            c_gamma_minus() * unit_normal_one_form(ti::i) * gamma_hat(ti::I) +
+            c_alpha_minus() * unit_normal_vector(ti::I) * d_lapse(ti::i) +
+            c_beta_minus() * unit_normal_vector(ti::I) *
+                unit_normal_one_form(ti::j) * d_shift(ti::i, ti::J));
+  }
+
+  return expected_char_fields;
+}
+}  // namespace TestHelpers::Ccz4::fd::detail


### PR DESCRIPTION
## Proposed changes
Add compute tags to compute the characteristic speeds, variables, and their inverse to `SoCcz4`. These changes include two sets of characteristics, corresponding to the Gamma-driver w/o the advective terms  (`shifting_shift`==`true`/`false`). We do not consider the case where lapse and shift are fixed, as the evolution system turns out to be only weakly hyperbolic.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
