### PR TITLE
Add ProjectToMesh option for ObserveFields

### DIFF
--- a/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <pup.h>
 #include <string>
 #include <type_traits>
@@ -97,11 +98,12 @@ class FindCommonHorizon<
       const std::vector<std::string>& variables_to_observe,
       std::optional<std::vector<std::string>> active_block_or_block_groups = {},
       std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
+      std::optional<Mesh<VolumeDim>> projection_mesh = {},
       const Options::Context& context = {})
       : observe_fields_event_(subfile_name, coordinates_floating_point_type,
                               floating_point_types, variables_to_observe,
                               active_block_or_block_groups, interpolation_mesh,
-                              {name()}, context),
+                              projection_mesh, std::nullopt, context),
         interpolate_event_(subfile_name) {}
 
   using compute_tags_for_observation_box = tmpl::remove_duplicates<tmpl::append<
@@ -219,11 +221,12 @@ class FindCommonHorizon<HorizonMetavars, tmpl::list<Tensors...>,
       const std::vector<std::string>& variables_to_observe,
       std::optional<std::vector<std::string>> active_block_or_block_groups = {},
       std::optional<Mesh<3>> interpolation_mesh = {},
+      std::optional<Mesh<3>> projection_mesh = {},
       const Options::Context& context = {})
       : observe_fields_event_(subfile_name, coordinates_floating_point_type,
                               floating_point_types, variables_to_observe,
                               active_block_or_block_groups, interpolation_mesh,
-                              {name()}, context),
+                              projection_mesh, std::nullopt, context),
         horizon_find_event_(subfile_name) {}
 
   using compute_tags_for_observation_box = tmpl::remove_duplicates<tmpl::append<

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
@@ -30,6 +31,8 @@
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/VolumeActions.hpp"
 #include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Options/Auto.hpp"
 #include "Options/String.hpp"
 #include "Parallel/ArrayComponentId.hpp"
@@ -42,6 +45,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Numeric.hpp"
@@ -133,6 +137,17 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         "on a new mesh.";
   };
 
+  struct ProjectToMesh {
+    using type = Options::Auto<Mesh<VolumeDim>, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "An optional mesh to which the variables are projected. This mesh "
+        "must use a Legendre basis (Gauss or Gauss-Lobatto quadrature). This "
+        "option is mutually exclusive with InterpolateToMesh. Projection "
+        "truncates the fields in modal space but works only between two "
+        "Legendre meshes, whereas interpolation works with any mesh but is not "
+        "a clean truncation and therefore picks up an aliasing error.";
+  };
+
   /// The floating point type/precision with which to write the data to disk.
   ///
   /// Must be specified once for all data or individually for each variable
@@ -167,9 +182,9 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         "A list of block and group names on which to observe."};
   };
 
-  using options =
-      tmpl::list<SubfileName, CoordinatesFloatingPointType, FloatingPointTypes,
-                 VariablesToObserve, BlocksToObserve, InterpolateToMesh>;
+  using options = tmpl::list<SubfileName, CoordinatesFloatingPointType,
+                             FloatingPointTypes, VariablesToObserve,
+                             BlocksToObserve, InterpolateToMesh, ProjectToMesh>;
 
   static constexpr Options::String help =
       "Observe volume tensor fields.\n"
@@ -188,6 +203,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       const std::vector<std::string>& variables_to_observe,
       std::optional<std::vector<std::string>> active_block_or_block_groups = {},
       std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
+      std::optional<Mesh<VolumeDim>> projection_mesh = {},
       std::optional<std::string> dependency = {},
       const Options::Context& context = {});
 
@@ -198,11 +214,13 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       const std::vector<std::string>& variables_to_observe,
       std::optional<std::vector<std::string>> active_block_or_block_groups = {},
       std::optional<Mesh<VolumeDim>> interpolation_mesh = {},
+      std::optional<Mesh<VolumeDim>> projection_mesh = {},
       const Options::Context& context = {})
       : ObserveFields(subfile_name, coordinates_floating_point_type,
                       floating_point_types, variables_to_observe,
                       std::move(active_block_or_block_groups),
-                      std::move(interpolation_mesh), std::nullopt, context) {}
+                      std::move(interpolation_mesh), std::move(projection_mesh),
+                      std::nullopt, context) {}
 
   using compute_tags_for_observation_box =
       tmpl::list<Tensors..., NonTensorComputeTags...>;
@@ -230,9 +248,9 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       return;
     }
     call_operator_impl(subfile_path_ + *section_observation_key,
-                       variables_to_observe_, interpolation_mesh_, mesh, box,
-                       cache, array_index, component, observation_value,
-                       dependency_);
+                       variables_to_observe_, interpolation_mesh_,
+                       projection_mesh_, mesh, box, cache, array_index,
+                       component, observation_value, dependency_);
   }
 
   // We factor out the work into a static member function so it can  be shared
@@ -245,6 +263,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       const std::unordered_map<std::string, FloatingPointType>&
           variables_to_observe,
       const std::optional<Mesh<VolumeDim>>& interpolation_mesh,
+      const std::optional<Mesh<VolumeDim>>& projection_mesh,
       const Mesh<VolumeDim>& mesh,
       const ObservationBox<DataBoxType, ComputeTagsList>& box,
       Parallel::GlobalCache<Metavariables>& cache,
@@ -252,10 +271,33 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       const ParallelComponent* const /*meta*/,
       const ObservationValue& observation_value,
       const std::optional<std::string>& dependency) {
-    // if no interpolation_mesh is provided, the interpolation is essentially
+    const bool do_projection = projection_mesh.has_value();
+    const Mesh<VolumeDim>& target_mesh =
+        do_projection ? projection_mesh.value()
+                      : interpolation_mesh.value_or(mesh);
+    if (do_projection) {
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        if (mesh.basis(d) != Spectral::Basis::Legendre or
+            target_mesh.basis(d) != Spectral::Basis::Legendre) {
+          ERROR("ProjectToMesh requires Legendre basis.");
+        }
+        if ((mesh.quadrature(d) != Spectral::Quadrature::Gauss and
+             mesh.quadrature(d) != Spectral::Quadrature::GaussLobatto) or
+            (target_mesh.quadrature(d) != Spectral::Quadrature::Gauss and
+             target_mesh.quadrature(d) != Spectral::Quadrature::GaussLobatto)) {
+          ERROR("ProjectToMesh requires Gauss or Gauss-Lobatto quadrature.");
+        }
+      }
+    }
+    // If no interpolation_mesh is provided, the interpolation is essentially
     // ignored by the RegularGridInterpolant except for a single copy.
-    const intrp::RegularGrid interpolant(mesh,
-                                         interpolation_mesh.value_or(mesh));
+    const intrp::RegularGrid interpolant(mesh, target_mesh);
+    const std::optional<
+        std::array<std::reference_wrapper<const Matrix>, VolumeDim>>
+        projection_matrices =
+            do_projection ? std::make_optional(Spectral::p_projection_matrices(
+                                mesh, target_mesh))
+                          : std::nullopt;
 
     // Remove tensor types, only storing individual components.
     std::vector<TensorComponent> components;
@@ -282,13 +324,17 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         };
 
     const auto record_tensor_components_impl =
-        [&record_tensor_component_impl, &interpolant](
-            const auto& tensor, const FloatingPointType floating_point_type,
-            const std::string& tag_name) {
+        [&record_tensor_component_impl, &interpolant, &projection_matrices,
+         &mesh, do_projection](const auto& tensor,
+                               const FloatingPointType floating_point_type,
+                               const std::string& tag_name) {
           using TensorType = std::decay_t<decltype(tensor)>;
           using VectorType = typename TensorType::type;
           for (size_t i = 0; i < tensor.size(); ++i) {
-            auto tensor_component = interpolant.interpolate(tensor[i]);
+            auto tensor_component =
+                do_projection ? apply_matrices(*projection_matrices, tensor[i],
+                                               mesh.extents())
+                              : interpolant.interpolate(tensor[i]);
             const std::string component_name =
                 tag_name + tensor.component_suffix(i);
             if constexpr (std::is_same_v<VectorType, ComplexDataVector>) {
@@ -330,7 +376,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         std::add_pointer_t<ParallelComponent>{nullptr},
         Parallel::ArrayIndex<ElementId<VolumeDim>>{element_id}};
     ElementVolumeData element_volume_data{element_id, std::move(components),
-                                          interpolation_mesh.value_or(mesh)};
+                                          target_mesh};
     observers::ObservationId observation_id{observation_value.value,
                                             subfile_path + ".vol"};
 
@@ -379,6 +425,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
     p | variables_to_observe_;
     p | active_block_or_block_groups_;
     p | interpolation_mesh_;
+    p | projection_mesh_;
     p | dependency_;
   }
 
@@ -412,6 +459,7 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
   std::unordered_map<std::string, FloatingPointType> variables_to_observe_{};
   std::optional<std::vector<std::string>> active_block_or_block_groups_{};
   std::optional<Mesh<VolumeDim>> interpolation_mesh_{};
+  std::optional<Mesh<VolumeDim>> projection_mesh_{};
   std::optional<std::string> dependency_;
 };
 
@@ -426,6 +474,7 @@ ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         const std::vector<std::string>& variables_to_observe,
         std::optional<std::vector<std::string>> active_block_or_block_groups,
         std::optional<Mesh<VolumeDim>> interpolation_mesh,
+        std::optional<Mesh<VolumeDim>> projection_mesh,
         std::optional<std::string> dependency, const Options::Context& context)
     : subfile_path_("/" + subfile_name),
       variables_to_observe_([&context, &floating_point_types,
@@ -455,7 +504,26 @@ ObserveFields<VolumeDim, tmpl::list<Tensors...>,
       }()),
       active_block_or_block_groups_(std::move(active_block_or_block_groups)),
       interpolation_mesh_(interpolation_mesh),
+      projection_mesh_(projection_mesh),
       dependency_(std::move(dependency)) {
+  if (interpolation_mesh_.has_value() and projection_mesh_.has_value()) {
+    PARSE_ERROR(context,
+                "Specify only one of InterpolateToMesh or ProjectToMesh.");
+  }
+  if (projection_mesh_.has_value()) {
+    const auto& proj_mesh = projection_mesh_.value();
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      if (proj_mesh.basis(d) != Spectral::Basis::Legendre) {
+        PARSE_ERROR(context, "ProjectToMesh requires Legendre basis.");
+      }
+      if (proj_mesh.quadrature(d) != Spectral::Quadrature::Gauss and
+          proj_mesh.quadrature(d) != Spectral::Quadrature::GaussLobatto) {
+        PARSE_ERROR(
+            context,
+            "ProjectToMesh requires Gauss or Gauss-Lobatto quadrature.");
+      }
+    }
+  }
   ASSERT(
       (... or (db::tag_name<Tensors>() == "InertialCoordinates")),
       "There is no tag with name 'InertialCoordinates' specified "

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -264,6 +264,7 @@ EventsAndTriggersAtIterations:
             - SpatialRicci
             - RadiallyCompressedCoordinates
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -336,6 +336,7 @@ EventsAndTriggersAtCheckpoints:
             - Pi
             - Phi
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
@@ -419,6 +420,7 @@ EventsAndTriggersAtSlabs:
           InterpolateToMesh: None
           # Save disk space by saving single precision data. This is enough
           # for visualization.
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All
@@ -438,6 +440,7 @@ EventsAndTriggersAtSlabs:
             - Pi
             - Phi
           InterpolateToMesh: None
+          ProjectToMesh: None
           # This volume data is for ringdown, so double precision is needed.
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
@@ -464,6 +467,7 @@ EventsAndTriggersAtSlabs:
             - Pi
             - Phi
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -210,6 +210,7 @@ EventsAndTriggersAtCheckpoints:
             - Pi
             - Phi
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
@@ -286,6 +287,7 @@ EventsAndTriggersAtSlabs:
             - SpatialRicciScalar
             - Psi4Real
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -102,6 +102,7 @@ EventsAndTriggersAtSlabs:
           SubfileName: VolumePsi0And25
           VariablesToObserve: ["Psi"]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
@@ -119,6 +120,7 @@ EventsAndTriggersAtSlabs:
             - Phi
             - PointwiseL2Norm(OneIndexConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -113,6 +113,7 @@ EventsAndTriggersAtSlabs:
             - Psi
             - OneIndexConstraint
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -109,6 +109,7 @@ EventsAndTriggersAtIterations:
             - Displacement
             - PotentialEnergyDensity
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -142,6 +142,7 @@ EventsAndTriggersAtIterations:
             - Stress
             - PotentialEnergyDensity
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -159,6 +159,7 @@ EventsAndTriggersAtIterations:
             - Stress
             - PotentialEnergyDensity
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -244,6 +244,7 @@ EventsAndTriggersAtSlabs:
             - PointwiseL2Norm(ThreeIndexConstraint)
             - PointwiseL2Norm(FourIndexConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
@@ -274,6 +275,7 @@ EventsAndTriggersAtSlabs:
             - Pi
             - Phi
           InterpolateToMesh: None
+          ProjectToMesh: None
           # This volume data is for ringdown, so double precision is needed.
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -148,6 +148,7 @@ EventsAndTriggersAtSlabs:
             - PointwiseL2Norm(GaugeConstraint)
             - PointwiseL2Norm(ThreeIndexConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -141,6 +141,7 @@ EventsAndTriggersAtSlabs:
             - PointwiseL2Norm(ThreeIndexConstraint)
             - PointwiseL2Norm(FourIndexConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -200,6 +200,7 @@ EventsAndTriggersAtSlabs:
             - PointwiseL2Norm(ThreeIndexConstraint)
             - PointwiseL2Norm(FourIndexConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -388,6 +388,7 @@ EventsAndTriggersAtSlabs:
             - SpacetimeMetric
             - DetSpatialMetric
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All
@@ -401,6 +402,7 @@ EventsAndTriggersAtSlabs:
             - MagneticField
             - DivergenceCleaningField
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: [ObjectA, ObjectB]
@@ -422,6 +424,7 @@ EventsAndTriggersAtSlabs:
             - PointwiseL2Norm(ThreeIndexConstraint)
             - TciStatus
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All
@@ -478,6 +481,7 @@ EventsRunAtCleanup:
           - PointwiseL2Norm(ThreeIndexConstraint)
           - TciStatus
         InterpolateToMesh: None
+        ProjectToMesh: None
         CoordinatesFloatingPointType: Double
         FloatingPointTypes: [Double]
         BlocksToObserve: All

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -269,6 +269,7 @@ EventsAndTriggersAtSlabs:
             - PointwiseL2Norm(ThreeIndexConstraint)
             - ThreeIndexConstraint
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
   - Trigger:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -216,6 +216,7 @@ EventsAndTriggersAtSlabs:
             - MagneticField
             - PointwiseL2Norm(GaugeConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
           BlocksToObserve: All

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -256,6 +256,7 @@ EventsAndTriggersAtSlabs:
             - MagneticField
             - PointwiseL2Norm(GaugeConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Double, Double, Double, Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -137,6 +137,7 @@ EventsAndTriggersAtIterations:
             - RadiallyCompressedCoordinates
             - FixedSource(Field)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -159,6 +159,7 @@ EventsAndTriggersAtIterations:
           SubfileName: VolumeData
           VariablesToObserve: [Field]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -112,6 +112,7 @@ EventsAndTriggersAtIterations:
           SubfileName: VolumeData
           VariablesToObserve: [Field]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -115,6 +115,7 @@ EventsAndTriggersAtIterations:
           SubfileName: VolumeData
           VariablesToObserve: [Field]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -174,6 +174,7 @@ EventsAndTriggersAtIterations:
             - Alpha
             - Beta
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -86,6 +86,7 @@ EventsAndTriggersAtSlabs:
           SubfileName: VolumeData
           VariablesToObserve: [U, TciStatus]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -87,6 +87,7 @@ EventsAndTriggersAtSlabs:
           SubfileName: VolumeData
           VariablesToObserve: [U, TciStatus]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -86,6 +86,7 @@ EventsAndTriggersAtSlabs:
           SubfileName: VolumeData
           VariablesToObserve: [U, TciStatus]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Float, Float]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -186,6 +186,7 @@ EventsAndTriggersAtSlabs:
             - PointwiseL2Norm(GaugeConstraint)
             - PointwiseL2Norm(TwoIndexConstraint)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -129,6 +129,7 @@ EventsAndTriggersAtCheckpoints:
           SubfileName: CheckpointVolumeData
           VariablesToObserve: ["Psi", "Pi", "Phi"]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -99,6 +99,7 @@ EventsAndTriggersAtSlabs:
           SubfileName: Fields
           VariablesToObserve: [Psi]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -146,6 +146,7 @@ EventsAndTriggersAtSlabs:
           SubfileName: VolumePsiPiPhiEvery50Slabs
           VariablesToObserve: ["Psi", "Pi", "Phi"]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double, Float, Float]
           BlocksToObserve: All

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.overlay_0000.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.overlay_0000.yaml
@@ -38,6 +38,7 @@ EventsAndTriggersAtSlabs:
           SubfileName: FieldsFinal
           VariablesToObserve: [Psi]
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -274,6 +274,7 @@ EventsAndTriggersAtIterations:
             - MomentumConstraint
             - RadiallyCompressedCoordinates
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -223,6 +223,7 @@ EventsAndTriggersAtIterations:
             - MagneticField
             - RadiallyCompressedCoordinates
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -245,6 +245,7 @@ EventsAndTriggersAtIterations:
             - Error(LapseTimesConformalFactorMinusOne)
             - Error(ShiftExcess)
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -157,6 +157,7 @@ EventsAndTriggersAtIterations:
             - Conformal(StressTrace)
             - HamiltonianConstraint
           InterpolateToMesh: None
+          ProjectToMesh: None
           CoordinatesFloatingPointType: Float
           FloatingPointTypes: [Float]
           BlocksToObserve: All

--- a/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/tests/Unit/Helpers/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -238,6 +238,7 @@ struct ScalarSystem {
       "  BlocksToObserve: All\n";
   static ObserveEvent make_test_object(
       const std::optional<Mesh<volume_dim>>& interpolating_mesh,
+      const std::optional<Mesh<volume_dim>>& projection_mesh,
       std::optional<std::vector<std::string>> active_block_or_block_groups =
           std::nullopt,
       std::optional<std::string> dependency = std::nullopt) {
@@ -248,6 +249,7 @@ struct ScalarSystem {
         {"Scalar", "ScalarVarTimesTwo", "ScalarVarTimesThree", "Error(Scalar)"},
         std::move(active_block_or_block_groups),
         interpolating_mesh,
+        projection_mesh,
         std::move(dependency)};
   }
 };
@@ -367,6 +369,7 @@ struct ComplicatedSystem {
 
   static ObserveEvent make_test_object(
       const std::optional<Mesh<volume_dim>>& interpolating_mesh,
+      const std::optional<Mesh<volume_dim>>& projection_mesh,
       std::optional<std::vector<std::string>> active_block_or_block_groups =
           std::nullopt,
       std::optional<std::string> dependency = std::nullopt) {
@@ -379,7 +382,7 @@ struct ComplicatedSystem {
         {"Scalar", "ScalarVarTimesTwo", "ScalarVarTimesThree", "Vector",
          "Tensor", "Tensor2", "Error(Vector)", "Error(Tensor2)"},
         std::move(active_block_or_block_groups), interpolating_mesh,
-        std::move(dependency));
+        projection_mesh, std::move(dependency));
   }
 };
 }  // namespace TestHelpers::dg::Events::ObserveFields

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/MetavariablesTag.hpp"
@@ -39,6 +40,7 @@
 #include "IO/Observer/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "Parallel/ArrayComponentId.hpp"
 #include "Parallel/ArrayIndex.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -98,6 +100,7 @@ template <typename System, typename ArraySectionIdTag = void,
 void test_observe(
     const std::unique_ptr<ObserveEvent> observe,
     const std::optional<Mesh<System::volume_dim>>& interpolating_mesh,
+    const std::optional<Mesh<System::volume_dim>>& projection_mesh,
     const bool has_analytic_solutions, const bool test_specific_blocks,
     const std::optional<std::string>& section = std::nullopt,
     const std::optional<std::string>& dependency = std::nullopt) {
@@ -122,7 +125,17 @@ void test_observe(
   const Mesh<volume_dim> mesh(5, Spectral::Basis::Legendre,
                               Spectral::Quadrature::GaussLobatto);
 
-  const intrp::RegularGrid interpolant(mesh, interpolating_mesh.value_or(mesh));
+  const bool do_projection = projection_mesh.has_value();
+  const Mesh<volume_dim>& target_mesh = do_projection
+                                            ? projection_mesh.value()
+                                            : interpolating_mesh.value_or(mesh);
+  const intrp::RegularGrid interpolant(mesh, target_mesh);
+  const std::optional<
+      std::array<std::reference_wrapper<const Matrix>, volume_dim>>
+      projection_matrices =
+          do_projection ? std::make_optional(Spectral::p_projection_matrices(
+                              mesh, target_mesh))
+                        : std::nullopt;
   const double observation_time = 2.0;
   Variables<typename System::variables_tag::tags_list> vars(
       mesh.number_of_grid_points());
@@ -231,13 +244,13 @@ void test_observe(
   CHECK(results.received_volume_data.extents.size() == volume_dim);
   CHECK(std::equal(results.received_volume_data.extents.begin(),
                    results.received_volume_data.extents.end(),
-                   interpolating_mesh.value_or(mesh).extents().begin()));
+                   target_mesh.extents().begin()));
   CHECK(std::equal(results.received_volume_data.basis.begin(),
                    results.received_volume_data.basis.end(),
-                   interpolating_mesh.value_or(mesh).basis().begin()));
+                   target_mesh.basis().begin()));
   CHECK(std::equal(results.received_volume_data.quadrature.begin(),
                    results.received_volume_data.quadrature.end(),
-                   interpolating_mesh.value_or(mesh).quadrature().begin()));
+                   target_mesh.quadrature().begin()));
 
   size_t num_components_observed = 0;
   // gcc 6.4.0 gets confused if we try to capture tensor_data by
@@ -246,11 +259,14 @@ void test_observe(
   const auto check_component_impl =
       [&num_components_observed,
        tensor_data = &results.received_volume_data.tensor_components,
-       &interpolant](const std::string& component, const DataVector& expected) {
+       &interpolant, &projection_matrices, &mesh, do_projection](
+          const std::string& component, const DataVector& expected) {
         CAPTURE(*tensor_data);
         CAPTURE(component);
         const DataVector interpolated_expected =
-            interpolant.interpolate(expected);
+            do_projection
+                ? apply_matrices(*projection_matrices, expected, mesh.extents())
+                : interpolant.interpolate(expected);
         const auto it =
             alg::find_if(*tensor_data, [&component](const TensorComponent& tc) {
               return tc.name == component;
@@ -327,6 +343,7 @@ template <typename System>
 void test_system(
     const std::string& mesh_creation_string,
     const std::optional<Mesh<System::volume_dim>>& interpolating_mesh = {},
+    const std::optional<Mesh<System::volume_dim>>& projection_mesh = {},
     const bool has_analytic_solutions = true,
     const std::optional<std::string>& section = std::nullopt,
     const std::optional<std::string>& dependency = std::nullopt) {
@@ -341,10 +358,10 @@ void test_system(
   for (const bool test_specific_blocks : {false, true}) {
     test_observe<System, ArraySectionIdTag>(
         std::make_unique<typename System::ObserveEvent>(
-            System::make_test_object(interpolating_mesh, std::nullopt,
-                                     dependency)),
-        interpolating_mesh, has_analytic_solutions, test_specific_blocks,
-        section, dependency);
+            System::make_test_object(interpolating_mesh, projection_mesh,
+                                     std::nullopt, dependency)),
+        interpolating_mesh, projection_mesh, has_analytic_solutions,
+        test_specific_blocks, section, dependency);
     INFO("create/serialize");
     register_factory_classes_with_charm<metavariables>();
     {
@@ -356,7 +373,7 @@ void test_system(
       auto serialized_event = serialize_and_deserialize(factory_event);
       // No dependency from factory creation
       test_observe<System, ArraySectionIdTag>(
-          std::move(serialized_event), interpolating_mesh,
+          std::move(serialized_event), interpolating_mesh, projection_mesh,
           has_analytic_solutions, test_specific_blocks, section, std::nullopt);
     }
   }
@@ -366,23 +383,28 @@ void test_system(
 SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
   {
     INFO("No Interpolation");
-    const std::string interpolating_mesh_str = "  InterpolateToMesh: None\n";
+    const std::string interpolating_mesh_str =
+        "  InterpolateToMesh: None\n"
+        "  ProjectToMesh: None\n";
     using system_no_section = ScalarSystem<dg::Events::ObserveFields, void>;
     using system_with_section =
         ScalarSystem<dg::Events::ObserveFields, TestSectionIdTag>;
     using system_complex =
         ScalarSystem<dg::Events::ObserveFields, void, ComplexDataVector>;
     INVOKE_TEST_FUNCTION(
-        test_system, (interpolating_mesh_str, std::nullopt, true, std::nullopt),
+        test_system,
+        (interpolating_mesh_str, std::nullopt, std::nullopt, true,
+         std::nullopt),
         (system_no_section, system_with_section, system_complex,
          ComplicatedSystem<dg::Events::ObserveFields>));
     INVOKE_TEST_FUNCTION(
-        test_system, (interpolating_mesh_str, std::nullopt, true, "Section0"),
+        test_system,
+        (interpolating_mesh_str, std::nullopt, std::nullopt, true, "Section0"),
         (system_no_section, system_with_section,
          ComplicatedSystem<dg::Events::ObserveFields>));
     INVOKE_TEST_FUNCTION(test_system,
-                         (interpolating_mesh_str, std::nullopt, false,
-                          std::nullopt, "TestDependency"),
+                         (interpolating_mesh_str, std::nullopt, std::nullopt,
+                          false, std::nullopt, "TestDependency"),
                          (ScalarSystem<dg::Events::ObserveFields>,
                           ComplicatedSystem<dg::Events::ObserveFields>));
   }
@@ -393,15 +415,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
         "  InterpolateToMesh:\n"
         "    Extents: 12\n"
         "    Basis: Legendre\n"
-        "    Quadrature: GaussLobatto";
+        "    Quadrature: GaussLobatto\n"
+        "  ProjectToMesh: None";
     const Mesh<1> interpolating_mesh_1d{12, Spectral::Basis::Legendre,
                                         Spectral::Quadrature::GaussLobatto};
-    INVOKE_TEST_FUNCTION(test_system,
-                         (interpolating_mesh_str, interpolating_mesh_1d, true),
-                         (ScalarSystem<dg::Events::ObserveFields>));
-    INVOKE_TEST_FUNCTION(test_system,
-                         (interpolating_mesh_str, interpolating_mesh_1d, false),
-                         (ScalarSystem<dg::Events::ObserveFields>));
+    INVOKE_TEST_FUNCTION(
+        test_system,
+        (interpolating_mesh_str, interpolating_mesh_1d, std::nullopt, true),
+        (ScalarSystem<dg::Events::ObserveFields>));
+    INVOKE_TEST_FUNCTION(
+        test_system,
+        (interpolating_mesh_str, interpolating_mesh_1d, std::nullopt, false),
+        (ScalarSystem<dg::Events::ObserveFields>));
     const Mesh<2> interpolating_mesh_2d{12, Spectral::Basis::Legendre,
                                         Spectral::Quadrature::GaussLobatto};
     test_system<ComplicatedSystem<dg::Events::ObserveFields>>(
@@ -414,7 +439,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
         "  InterpolateToMesh:\n"
         "    Extents: 3\n"
         "    Basis: Legendre\n"
-        "    Quadrature: GaussLobatto";
+        "    Quadrature: GaussLobatto\n"
+        "  ProjectToMesh: None";
     const Mesh<1> interpolating_mesh_1{3, Spectral::Basis::Legendre,
                                        Spectral::Quadrature::GaussLobatto};
     const Mesh<2> interpolating_mesh_2{3, Spectral::Basis::Legendre,
@@ -431,7 +457,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
         "  InterpolateToMesh:\n"
         "    Extents: 5\n"
         "    Basis: Chebyshev\n"
-        "    Quadrature: GaussLobatto";
+        "    Quadrature: GaussLobatto\n"
+        "  ProjectToMesh: None";
     const Mesh<1> interpolating_mesh_1{5, Spectral::Basis::Chebyshev,
                                        Spectral::Quadrature::GaussLobatto};
     const Mesh<2> interpolating_mesh_2{5, Spectral::Basis::Chebyshev,
@@ -448,7 +475,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
         "  InterpolateToMesh:\n"
         "    Extents: 5\n"
         "    Basis: Legendre\n"
-        "    Quadrature: Gauss";
+        "    Quadrature: Gauss\n"
+        "  ProjectToMesh: None";
     const Mesh<1> interpolating_mesh_1{5, Spectral::Basis::Legendre,
                                        Spectral::Quadrature::Gauss};
     const Mesh<2> interpolating_mesh_2{5, Spectral::Basis::Legendre,
@@ -465,7 +493,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
         "  InterpolateToMesh:\n"
         "    Extents: 8\n"
         "    Basis: FiniteDifference\n"
-        "    Quadrature: CellCentered";
+        "    Quadrature: CellCentered\n"
+        "  ProjectToMesh: None";
     const Mesh<1> interpolating_mesh_1{8, Spectral::Basis::FiniteDifference,
                                        Spectral::Quadrature::CellCentered};
     const Mesh<2> interpolating_mesh_2{8, Spectral::Basis::FiniteDifference,
@@ -474,6 +503,24 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
                                                          interpolating_mesh_1);
     test_system<ComplicatedSystem<dg::Events::ObserveFields>>(
         interpolating_mesh_str, interpolating_mesh_2);
+  }
+
+  {
+    INFO("Project to coarser mesh");
+    const std::string projecting_mesh_str =
+        "  ProjectToMesh:\n"
+        "    Extents: 3\n"
+        "    Basis: Legendre\n"
+        "    Quadrature: GaussLobatto\n"
+        "  InterpolateToMesh: None";
+    const Mesh<1> projection_mesh_1{3, Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto};
+    const Mesh<2> projection_mesh_2{3, Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto};
+    test_system<ScalarSystem<dg::Events::ObserveFields>>(
+        projecting_mesh_str, std::nullopt, projection_mesh_1);
+    test_system<ComplicatedSystem<dg::Events::ObserveFields>>(
+        projecting_mesh_str, std::nullopt, projection_mesh_2);
   }
 
   {
@@ -487,8 +534,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
         std::make_unique<typename ComplicatedSystem<
             dg::Events::ObserveFields>::ObserveEvent>(
             ComplicatedSystem<dg::Events::ObserveFields>::make_test_object(
-                interpolating_mesh)),
-        interpolating_mesh, true, false);
+                interpolating_mesh, std::nullopt)),
+        interpolating_mesh, std::nullopt, true, false);
   }
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<
@@ -498,8 +545,27 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
           "VariablesToObserve: [NotAVar]\n"
           "FloatingPointTypes: [Double]\n"
           "InterpolateToMesh: None\n"
+          "ProjectToMesh: None\n"
           "BlocksToObserve: All\n"),
       Catch::Matchers::ContainsSubstring("Invalid selection: NotAVar"));
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<
+          typename ScalarSystem<dg::Events::ObserveFields>::ObserveEvent>(
+          "SubfileName: VolumeData\n"
+          "CoordinatesFloatingPointType: Double\n"
+          "VariablesToObserve: [Scalar]\n"
+          "FloatingPointTypes: [Double]\n"
+          "InterpolateToMesh:\n"
+          "  Extents: 5\n"
+          "  Basis: Legendre\n"
+          "  Quadrature: Gauss\n"
+          "ProjectToMesh:\n"
+          "  Extents: 3\n"
+          "  Basis: Legendre\n"
+          "  Quadrature: GaussLobatto\n"
+          "BlocksToObserve: All\n"),
+      Catch::Matchers::ContainsSubstring(
+          "Specify only one of InterpolateToMesh or ProjectToMesh."));
 
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<
@@ -509,6 +575,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.ObserveFields", "[Unit][Evolution]") {
           "VariablesToObserve: [Scalar, Scalar]\n"
           "FloatingPointTypes: [Double]\n"
           "InterpolateToMesh: None\n"
+          "ProjectToMesh: None\n"
           "BlocksToObserve: All\n"),
       Catch::Matchers::ContainsSubstring("Scalar specified multiple times"));
 }


### PR DESCRIPTION
## Proposed changes

Adds the option to ProjectToMesh when observing fields. At the moment we only have the option to interpolate using the regular grid interpolant. However, when interpolating to a coarser grid, the nodes get an aliasing error from the higher order terms that were omitted. The projection allows a clean interpolation to a coarser grid by effectively setting all the higher modes to zero while leaving the lower modes unchanged. 

This is needed for the modal spacetime interpolator.

replaces #7043 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

Input files that create an ObserveFields event need to add the ProjectToMesh option. Specify `None` if you do not want to project or you want to interpolate instead.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
