### PR TITLE
Fix bug in SoCcz4 test

### DIFF
--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
@@ -315,7 +315,9 @@ void test_kerrschild(const bool evolve_lapse_and_shift) {
       Approx::custom().epsilon(1.0e-9).scale(*std::max_element(
           evolved_vars.data(), evolved_vars.data() + evolved_vars.size() - 1));
 
-  tmpl::for_each<Ccz4::fd::System::variables_tag_list>(
+  // Remove dt_b from the list, which will be checked separately below
+  tmpl::for_each<tmpl::remove<Ccz4::fd::System::variables_tag_list,
+    ::Ccz4::Tags::AuxiliaryShiftB<DataVector, SpatialDim>>>(
       [&]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
         const std::string tag_name = db::tag_name<::Tags::dt<Tag>>();
         CAPTURE(tag_name);


### PR DESCRIPTION
## Proposed changes
Fix a minor bug in `Test_SoTimeDerivative.cpp` which incorrectly tests the time derivative of `AuxiliaryShiftB` using the Kerr-Schild solution.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
