### PR TITLE
Add Fornberg routine to calculate derivatives

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolationWeights.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationWeights.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Matrix.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace intrp {
 template <typename TargetDataType>
@@ -37,6 +38,49 @@ Matrix fornberg_interpolation_matrix(const TargetDataType& x_target,
     }
   }
   return result;
+}
+
+template <size_t MaxOrder>
+void fornberg_derivative_interpolation_weights(
+    const gsl::not_null<std::array<DataVector, MaxOrder + 1>*> result,
+    const double x_target, const DataVector& x_source) {
+  auto& c = *result;
+
+  // Using convention that n is the index of the last point
+  const size_t n = x_source.size() - 1;
+
+  // Assign c and fill with zeros
+  for (size_t i = 0; i < MaxOrder + 1; ++i) {
+    gsl::at(c, i) = DataVector(n + 1, 0.0);
+  }
+
+  double c1 = 1.0;
+  double c4 = x_source[0] - x_target;
+  c[0][0] = 1.0;
+  for (size_t i = 1; i <= n; ++i) {
+    const size_t mn = (i < MaxOrder ? i : MaxOrder);
+    double c2 = 1.0;
+    const double c5 = c4;
+    c4 = x_source[i] - x_target;
+    for (size_t j = 0; j < i; ++j) {
+      const double c3 = x_source[i] - x_source[j];
+      c2 *= c3;
+      if (j == i - 1) {
+        for (size_t k = mn; k > 0; --k) {
+          gsl::at(c, k)[i] =
+              c1 * (k * gsl::at(c, k - 1)[i - 1] - c5 * gsl::at(c, k)[i - 1]) /
+              c2;
+        }
+        c[0][i] = -c1 * c5 * c[0][i - 1] / c2;
+      }
+      for (size_t k = mn; k > 0; --k) {
+        gsl::at(c, k)[j] =
+            (c4 * gsl::at(c, k)[j] - k * gsl::at(c, k - 1)[j]) / c3;
+      }
+      c[0][j] = c4 * c[0][j] / c3;
+    }
+    c1 = c2;
+  }
 }
 
 template <typename TargetDataType>
@@ -83,6 +127,18 @@ Matrix fourier_interpolation_matrix(const TargetDataType& x_target,
                                                const size_t n_source_points);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+#define DNUM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template void fornberg_derivative_interpolation_weights<DNUM(data)>(     \
+      const gsl::not_null<std::array<DataVector, DNUM(data) + 1>*> result, \
+      const double x_target, const DataVector& x_source);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3, 4))
 
 #undef DTYPE
 #undef INSTANTIATE

--- a/src/NumericalAlgorithms/Interpolation/InterpolationWeights.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationWeights.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include "Utilities/Gsl.hpp"
 
 /// \cond
 class DataVector;
@@ -29,9 +30,35 @@ Matrix fornberg_interpolation_matrix(const TargetDataType& x_target,
                                      const DataVector& x_source);
 
 /*!
- * \brief Computes the matrix for interpolating a periodic function known at the
- * set of \f$n\f$ equally spaced points on the periodic domain \f$[0, 2 \pi]\f$
- * to the set of points \f$x_{target}\f$
+ * \brief Computes the weights for polynomial interpolation of a non-periodic
+ * function known at the set of points \f$x_{source}\f$ to the point
+ * \f$x_{target}\f$
+ *
+ * \details The algorithm is from \cite Fornberg1998. The DataVectors in the
+ * array will be set to the size of \f$x_{source}\f$, where the first index
+ * of the array holds the weights to interpolate a function from the grid
+ * \f$x_{source}\f$ to \f$x_{target}\f$, the second index of the array holds
+ * the weights to interpolate the first derivative of a function, and
+ * so on.
+ *
+ * Calculating for the \f$n\f$-th derivative will yield all lower order
+ * derivatives as well. If you just want the interpolation coefficients, use
+ * `fornberg_interpolation_matrix`.
+ *
+ *
+ * \note The accuracy of the interpolation will depend upon the number and
+ * distribution of the source points.  It is strongly suggested that you
+ * carefully investigate the accuracy for your use case.
+ */
+template <size_t MaxOrder>
+void fornberg_derivative_interpolation_weights(
+    gsl::not_null<std::array<DataVector, MaxOrder + 1>*> result,
+    double x_target, const DataVector& x_source);
+
+/*!
+ * \brief Computes the matrix for interpolating a periodic function known at
+ * the set of \f$n\f$ equally spaced points on the periodic domain \f$[0, 2
+ * \pi]\f$ to the set of points \f$x_{target}\f$
  *
  * \details The returned matrix \f$M\f$ will have \f$n_{target}\f$ rows and
  * \f$n_{source}\f$ columns so that \f$f_{target} = M f_{source}\f$

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationWeights.cpp
@@ -13,9 +13,11 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationWeights.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/InterpolationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -48,6 +50,37 @@ void test_fornberg_matrix(const gsl::not_null<std::mt19937*> generator) {
                       x_target[0], get<0>(xi)) == fornberg_matrix);
           }
         }
+      }
+    }
+  }
+}
+
+void test_fornberg_derivative_coefficients(
+    const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
+  const size_t max_derivative = 4;
+  std::array<DataVector, max_derivative + 1> fornberg_weights{};
+  const size_t n_target_points = 5;
+  const auto x_targets = make_with_random_values<DataVector>(
+      generator, make_not_null(&xi_distribution), n_target_points);
+  for (size_t n_source_points = 3; n_source_points < 5; ++n_source_points) {
+    const Mesh<1> mesh{n_source_points, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::Gauss};
+    const auto xi = logical_coordinates(mesh);
+    for (auto x_target : x_targets) {
+      intrp::fornberg_derivative_interpolation_weights<max_derivative>(
+          make_not_null(&fornberg_weights), x_target, get<0>(xi));
+      double coefficient = 1.0;
+      auto power = static_cast<int>(n_source_points - 1);
+      for (size_t derivative = 0; derivative <= n_source_points; ++derivative) {
+        const DataVector function = pow(get<0>(xi), power);
+        const double result = std::inner_product(
+            function.begin(), function.end(),
+            gsl::at(fornberg_weights, derivative).begin(), 0.0);
+        CHECK(
+            approx(result) ==
+            coefficient * pow(x_target, power - static_cast<int>(derivative)));
+        coefficient *= power - static_cast<int>(derivative);
       }
     }
   }
@@ -87,5 +120,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.Weights",
                   "[Unit][NumericalAlgorithms]") {
   MAKE_GENERATOR(generator);
   test_fornberg_matrix(make_not_null(&generator));
+  test_fornberg_derivative_coefficients(make_not_null(&generator));
   test_fourier_matrix(make_not_null(&generator));
 }


### PR DESCRIPTION
## Proposed changes

This implements [the routine](https://epubs.siam.org/doi/10.1137/S0036144596322507) used in SpEC for derivatives on arbitrary grids. It is required for accurate Zernike derivatives.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
