### PR TITLE
Add Parity enum class

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -26,6 +26,7 @@ spectre_target_sources(
   Mesh.cpp
   ModalToNodalMatrix.cpp
   NodalToModalMatrix.cpp
+  Parity.cpp
   Projection.cpp
   Quadrature.cpp
   QuadratureWeights.cpp
@@ -60,6 +61,7 @@ spectre_target_headers(
   ModalToNodalMatrix.hpp
   Namespace.hpp
   NodalToModalMatrix.hpp
+  Parity.hpp
   PrecomputedSpectralQuantity.hpp
   Projection.hpp
   Quadrature.hpp

--- a/src/NumericalAlgorithms/Spectral/Parity.cpp
+++ b/src/NumericalAlgorithms/Spectral/Parity.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+
+#include <array>
+#include <ostream>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace Spectral {
+
+std::array<Parity, 3> all_parities() {
+  return std::array{Parity::Uninitialized, Parity::Even, Parity::Odd};
+}
+
+std::ostream& operator<<(std::ostream& os, const Parity& parity) {
+  switch (parity) {
+    case Parity::Even:
+      return os << "Even";
+    case Parity::Odd:
+      return os << "Odd";
+    case Parity::Uninitialized:
+      return os << "Uninitialized";
+    default:
+      ERROR("Unknown value of Parity trying to be streamed");
+  }
+}
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Parity.hpp
+++ b/src/NumericalAlgorithms/Spectral/Parity.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <ostream>
+
+namespace Spectral {
+/*!
+ * \brief Used to label parity, either Even or Odd.
+ */
+enum class Parity : std::uint8_t { Uninitialized, Even, Odd };
+
+/// All possible values of Parity
+std::array<Parity, 3> all_parities();
+
+// Output operator for a Basis
+std::ostream& operator<<(std::ostream& os, const Parity& parity);
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIBRARY_SOURCES
   Test_Mesh.cpp
   Test_ModalToNodalMatrix.cpp
   Test_NodalToModalMatrix.cpp
+  Test_Parity.cpp
   Test_Projection.cpp
   Test_Quadrature.cpp
   Test_QuadratureWeights.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Parity.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Parity.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Spectral.Parity", "[NumericalAlgorithms][Unit]") {
+  CHECK(get_output(Spectral::Parity::Uninitialized) == "Uninitialized");
+  CHECK(get_output(Spectral::Parity::Even) == "Even");
+  CHECK(get_output(Spectral::Parity::Odd) == "Odd");
+}


### PR DESCRIPTION
## Proposed changes

This will be useful to label parity of functions represented by the Zernike basis.

As a note, this has been used only with respect to `ZernikeB1` (for my cartoon things), in which case just knowing parity is enough (I always use m=0 or m=1). When coupling `ZernikeB2` to an angular direction for a disk, the actual m values will be changing, so while the idea of parity is universal for somethings (e.g. derivatives and interpolation), it may be abused in the future PR's where I assume even→m=0 and odd→m=1 (e.g. filtering). That will obviously have to be updated once disks are actually tried.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
