### PR TITLE
Disable OMP multithreading in submit scripts

### DIFF
--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -644,7 +644,13 @@ def schedule(
         logger.debug(f"Run command: {run_command}")
         if submit is False:
             return
-        process = subprocess.Popen(run_command, cwd=run_dir)
+        env = os.environ.copy()
+        # Disable multithreading so our executables have control over the
+        # parallelization
+        env["OMP_NUM_THREADS"] = "1"
+        env["OPENBLAS_NUM_THREADS"] = "1"
+        env["MKL_NUM_THREADS"] = "1"
+        process = subprocess.Popen(run_command, cwd=run_dir, env=env)
         # Realtime streaming of _captured_ stdout and stderr to the console
         # doesn't seem to work reliably, so we just let the process stream
         # directly to the console and wait for it to complete.

--- a/support/SubmitScripts/SubmitTemplateBase.sh
+++ b/support/SubmitScripts/SubmitTemplateBase.sh
@@ -45,6 +45,12 @@ echo
 module list
 {% endblock %}
 
+# Disable multithreading so our executables have control over the
+# parallelization
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+
 ############################################################################
 # Set desired permissions for files created with this script
 umask 0022


### PR DESCRIPTION
## Proposed changes

Dependencies are sometimes (often) compiled with OpenMP and do automatic multithreading. This conflicts with our parallelization and can slow down execution significantly. When we don't compile spectre with OpenMP, we can only disable this multithreading with environment variables. This PR sets the environment variables in submit scripts and when running executables with `spectre run`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
