### PR TITLE
Fix evaluation symmetric spacetime indices when spatial and time indices are used in TensorExpressions

### DIFF
--- a/src/DataStructures/Tensor/ContractFirstNIndices.hpp
+++ b/src/DataStructures/Tensor/ContractFirstNIndices.hpp
@@ -200,8 +200,10 @@ struct contract_first_n_indices_impl<
     tenex::detail::evaluate_impl<
         evaluate_subtrees,
         TensorIndex<result_tensor_index_values[ResultInts]>...>(
-        lhs_tensor, tensor1(TensorIndex<tensor_index_values1[Ints1]>{}...) *
-                        tensor2(TensorIndex<tensor_index_values2[Ints2]>{}...));
+        lhs_tensor,
+        tensor1(TensorIndex<tensor_index_values1[Ints1]>{}...) *
+            tensor2(TensorIndex<tensor_index_values2[Ints2]>{}...),
+        std::make_index_sequence<NumResultIndices>{});
   }
 
   // \brief Contract first N indices by evaluating a `TensorExpression`

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -16,12 +16,14 @@
 #include "DataStructures/Tensor/Expressions/DataTypeSupport.hpp"
 #include "DataStructures/Tensor/Expressions/IndexPropertyCheck.hpp"
 #include "DataStructures/Tensor/Expressions/LhsTensorSymmAndIndices.hpp"
+#include "DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
 #include "DataStructures/Tensor/Expressions/TensorIndexTransformation.hpp"
 #include "DataStructures/Tensor/Expressions/TimeIndex.hpp"
 #include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -103,6 +105,224 @@ struct CheckNoLhsAntiSymmetries<SymmList<Symm...>> {
   static constexpr bool value = (... and (Symm::value > 0));
 };
 
+/// \brief Given a tensor and its list of tensor indices, return the
+/// canonicalized order of the tensor indices according to the tensor's symmetry
+///
+/// \details
+/// The canonical ordering of a `Tensor`'s `TensorIndex`s
+/// (e.g. `ti::a`, `ti::b`, ti::c) is relevant to sets of indices that are
+/// symmetric. Within each set of symmetric indices, the `TensorIndex` used for
+/// each index can be freely reordered. Given a set of symmetric indices, this
+/// function defines the canonical order of the `TensorIndex`s assigned to them
+/// to be such that the lowest index positions take any generic spatial tensor
+/// indices (e.g. `ti::i`, `ti::j`), the next lowest index positions take any
+/// generic spacetime indices (e.g. `ti::a`, `ti::b`), and the highest index
+/// positions take any concrete time indices (e.g. `ti::t`, `ti::T`). We can
+/// imagine the canonical ordering of symmetric indices to look generally like:
+/// `[spatial indices ... | spacetime indices... | time indices...]`.
+///
+/// Within the subsets of spatial, spacetime, and time indices, the
+/// `TensorIndex`s in each will be ordered such that lowercase indices come
+/// before uppercase, where both are ordered alphabetically. Another way of
+/// saying this is that if we had a rank N `Tensor` that was fully symmetric,
+/// its canonical ordering would take the following form:
+///
+/// ```
+/// [ti::i, ti::j, ti::k, ..., ti::I, ti::J, ti::K, ...,  // spatial
+///  ti::a, ti::b, ti::c, ..., ti::A, ti::B, ti::C, ...,  // spacetime
+///  ti::t, ti::t, ti::t, ..., ti::T, ti::T, ti::T, ...]  // time
+/// ```
+///
+/// Here are some examples:
+///
+/// ```
+/// symmetry: <1, 1, 1>
+/// set of `TensorIndex`s: {ti::t, ti::i, ti::a}
+/// canonical ordering: [ti::i, ti::a, ti::t]
+///
+/// symmetry: <1, 1, 1>
+/// set of `TensorIndex`s: {ti::A, ti::a, ti::b}
+/// canonical ordering: [ti::a, ti::b, ti::A]
+/// ```
+///
+/// When a `Tensor` is not fully symmetric, the `TensorIndex` labels for any
+/// indices that do not have symmetry with any other will simply keep their
+/// label because it cannot be swapped:
+///
+/// ```
+/// symmetry: <1, 2, 1>
+/// set of `TensorIndex`s: {ti::a, ti::b, ti::i}
+/// canonical ordering: [ti::i, ti::b, ti::a]
+///
+/// symmetry: <2, 1, 1>
+/// set of `TensorIndex`s: {ti::t, ti::k, ti::j}
+/// canonical ordering: [ti::t, ti::j, ti::k]
+/// ```
+///
+/// If there is more than one set of symmetric indices, each of the subsets are
+/// individually reordered:
+///
+/// ```
+/// symmetry: <1, 2, 2, 1>
+/// set of `TensorIndex`s: {ti::a, ti::b, ti::t, ti::i}
+/// canonical ordering: [ti::i, ti::b, ti::t, ti::a]
+/// ```
+///
+/// The motivation for this specific canonical reordering is to quickly assess
+/// which components to assign to and which ones to skip when generic spatial
+/// and/or concrete time indices are used for symmetric spacetime indices in the
+/// resulting left hand side tensor when using `TensorExpression`s.
+///
+/// Let's take the spacetime metric \f$g_{ab}\f$ as our motivating example. This
+/// tensor has symmetric spacetime indices, and let's say we only want to assign
+/// to \f$g_{ti}\f$. We want to loop over all 10 independent components of
+/// \f$g_{ab}\f$ and skip components outside of \f$g_{ti}\f$, e.g. \f$g_{xy}\f$
+/// (or \f$g_{12}\f$) and \f$g_{tt}\f$ (or \f$g_{00}\f$). To do so, when we see
+/// a multi-index like `{2, 1}` in our loop, we align `{2, 1}` with `{t, i}` and
+/// ask if the `2` is a valid index for `t` and if the `1` is a valid index for
+/// `i`. `1` is valid for `i`, but `2` is not valid for `t`, so we correctly
+/// skip over `{2, 1}` and don't assign to this component.
+///
+/// However, this simple logic can lead to false positives or negatives when the
+/// indices are symmetric. What if the multi-index we're asking about is
+/// `{0, 1}` (\f$g_{01}\f$ or \f$g_{tx}\f$)? This logic would correctly
+/// determine that this is one of the components we want to assign to. But what
+/// if the multi-index was `{1, 0}`? The logic would incorrectly say to skip
+/// over and not assign to this multi-index because `1` is not a valid index for
+/// `t` and `0` is not valid for `i`. However, because \f$g_{ab}\f$ is
+/// symmetric, both `{0, 1}` and `{1, 0}` should give the same result, but
+/// `{1, 0}` gives us a false negative. Moreover and more generally, assigning
+/// to \f$g_{ti}\f$ and \f$g_{it}\f$ should yield the same behavior (assign to
+/// the same set of components).
+///
+/// One way to address this would be to check the multi-indices for all
+/// permutations of symmetric index values, e.g. is `{0, 1}` *or* `{1, 0}`
+/// valid? And if so, then evaluate it. However, this adds work at runtime and
+/// the number of permutations to check increases as we increase the number of
+/// symmetric indices.
+///
+/// The canonical reordering done by *this* function solves this problem by
+/// reordering the `TensorIndex`s to align nicely with the canonical multi-index
+/// ordering implemented by
+/// `::Tensor_detail::Structure::get_canonical_tensor_index`.
+/// `get_canonical_tensor_index` takes a storage index (which corresponds to an
+/// independent tensor component) and returns a canonical multi-index. This
+/// canonical multi-index is such that index values for symmetric indices will
+/// be ordered to increase from right to left. For example, for a rank 2
+/// symmetric tensor, `{1, 0}` is the canonical multi-index corresponding to the
+/// dependent multi-indices `{0, 1}` and `{1, 0}`. Therefore, `{1, 0}` would be
+/// the multi-index returned by `get_canonical_tensor_index` that corresponds to
+/// the single independent component. In other words, when we loop over the
+/// independent canonical multi-indices, we are looping over the multi-index
+/// permutations that are in the lower triangle of the N-dimensional matrix
+/// containing all multi-index permutations. The canonical reordering of LHS
+/// `TensorIndex`s for symmetric indices that is done by *this* function is
+/// implemented to match this: by making time indices the rightmost, then
+/// spacetime the next rightmost, and then spatial indices leftmost, we
+/// guarantee that looping over the lower triangle permutations given by
+/// `get_canonical_tensor_index` will not produce false positives or negatives
+/// using the earlier simple logic to check for valid multi-indices.
+///
+/// We can use the spacetime metric as an example to demonstrate this. The
+/// lower triangle multi-indices that are looped over are ordered with index
+/// values increasing right to left, e.g. `{0, 0}`, `{1, 0}`, `{2, 0}`,
+/// `{2, 1}`, etc. If a user wants to  assign to \f$g_{ti}\f$, then after this
+/// function internally reorders the LHS indices to \f$g_{it}\f$, when we loop
+/// and encounter `{1, 0}`, we correctly get that we should evaluate this
+/// component without having to check its other permutation. Likewise, if a user
+/// wants to assign to \f$g_{it}\f$, no reordering is done and we get the same
+/// correct behavior.
+///
+/// This function works in general because:
+/// - any `0`s in the symmetric indices will "first be dealt" to any time
+///   `TensorIndex`s in the rightmost index positions and then any spacetime
+///   `TensorIndex`s, where `0` is correctly valid for both, but
+/// - if there are more `0`s than time + spacetime `TensorIndex`s, they will be
+///   "dealt" to spatial indices, which is always correctly invalid, and
+/// - if there are more time `TensorIndex`s than `0`s, values `> 0` will be
+///   "dealt" to time indices, which is also always correctly invalid.
+///
+/// In this way, we don't ever have to check other permutations of sets of
+/// symmetric index values.
+///
+/// \tparam LhsTensorIndices the `TensorIndex`s of the `Tensor`, e.g. `ti::a`,
+/// `ti::b`, `ti::c`
+/// \param canonical_symmetry the canonicalized symmetry values of the tensor
+/// (see `Symmetry` for definition of the canonical ordering of symmetry values)
+/// \return reordered values of `LhsTensorIndices::value...`
+template <typename... LhsTensorIndices, size_t NumIndices>
+constexpr std::array<size_t, NumIndices> get_reordered_tensorindex_values(
+    const std::array<std::int32_t, NumIndices>& canonical_symmetry) {
+  constexpr std::array<size_t, NumIndices> lhs_tensorindex_values = {
+      {LhsTensorIndices::value...}};
+  if constexpr (NumIndices < 2) {
+    return lhs_tensorindex_values;
+  } else {
+    const auto compare = [](const size_t tensorindex_value1,
+                            const size_t tensorindex_value2) {
+      // clang-tidy thinks these two branches are the same but they aren't:
+      //   if (tensorindex_value2 == ti::T.value)
+      //   if (tensorindex_value2 == ti::t.value)
+      // NOLINTNEXTLINE (clang-tidy: bugprone-branch-clone)
+      if (tensorindex_value2 == ti::T.value) {
+        return false;
+      } else if (is_time_index_value(tensorindex_value1)) {
+        return true;
+      } else if (tensorindex_value2 == ti::t.value) {
+        return false;
+      }
+
+      return (is_generic_spacetime_index_value(tensorindex_value1) and
+              is_generic_spatial_index_value(tensorindex_value2)) or
+             (tensorindex_value1 > tensorindex_value2 and
+              is_generic_spacetime_index_value(tensorindex_value1) ==
+                  is_generic_spacetime_index_value(tensorindex_value2));
+    };
+
+    std::array<size_t, NumIndices> reordered_lhs_tensorindex_values =
+        lhs_tensorindex_values;
+
+    std::int32_t max_symm_value = *alg::max_element(canonical_symmetry);
+    std::int32_t symm_value_to_find = 1;
+    while (symm_value_to_find <= max_symm_value) {
+      size_t i = NumIndices - 1;
+      while (true) {
+        // skip forward until we get to the position with the value we want
+        while (i > 0 and canonical_symmetry[i] != symm_value_to_find) {
+          i--;
+        }
+        if (i == 0) {
+          break;
+        }
+
+        size_t max_tensorindex_value = reordered_lhs_tensorindex_values[i];
+        size_t max_index = i;
+
+        size_t j = i - 1;
+        // note: because we need to hit 0 and size_t wraps around to max size_t
+        while (j < NumIndices) {
+          const std::int32_t compare_symm_value = canonical_symmetry[j];
+          const size_t compare_tensorindex_value =
+              reordered_lhs_tensorindex_values[j];
+          if (compare_symm_value == symm_value_to_find and
+              compare(compare_tensorindex_value, max_tensorindex_value)) {
+            max_tensorindex_value = compare_tensorindex_value;
+            max_index = j;
+          }
+          j--;
+        }
+        reordered_lhs_tensorindex_values[max_index] =
+            reordered_lhs_tensorindex_values[i];
+        reordered_lhs_tensorindex_values[i] = max_tensorindex_value;
+        i--;
+      }
+      symm_value_to_find++;
+    }
+
+    return reordered_lhs_tensorindex_values;
+  }
+}
+
 /*!
  * \ingroup TensorExpressionsGroup
  * \brief Evaluate subtrees of the RHS expression or the RHS expression as a
@@ -146,13 +366,15 @@ struct CheckNoLhsAntiSymmetries<SymmList<Symm...>> {
 template <bool EvaluateSubtrees, typename... LhsTensorIndices,
           typename LhsDataType, typename LhsSymmetry, typename LhsIndexList,
           typename Derived, typename RhsDataType, typename RhsSymmetry,
-          typename RhsIndexList, typename... RhsTensorIndices>
+          typename RhsIndexList, typename... RhsTensorIndices,
+          size_t... LhsInts>
 void evaluate_impl(
     const gsl::not_null<Tensor<LhsDataType, LhsSymmetry, LhsIndexList>*>
         lhs_tensor,
     const TensorExpression<Derived, RhsDataType, RhsSymmetry, RhsIndexList,
                            tmpl::list<RhsTensorIndices...>>&
-        rhs_tensorexpression) {
+        rhs_tensorexpression,
+    const std::index_sequence<LhsInts...>& /*lhs_ints*/) {
   constexpr size_t num_lhs_indices = sizeof...(LhsTensorIndices);
   constexpr size_t num_rhs_indices = sizeof...(RhsTensorIndices);
 
@@ -247,15 +469,22 @@ void evaluate_impl(
     }
   }
 
+  constexpr std::array<std::int32_t, num_lhs_indices> lhs_symmetry = {
+      {tmpl::at_c<LhsSymmetry, LhsInts>::value...}};
+  constexpr std::array<size_t, num_lhs_indices> reordered_tensorindex_values =
+      get_reordered_tensorindex_values<LhsTensorIndices...>(lhs_symmetry);
+  using reordered_lhs_tensorindex_list =
+      tmpl::list<TensorIndex<reordered_tensorindex_values[LhsInts]>...>;
+
   constexpr std::array<size_t, num_rhs_indices> index_transformation =
       compute_tensorindex_transformation<num_lhs_indices, num_rhs_indices>(
-          {{LhsTensorIndices::value...}}, {{RhsTensorIndices::value...}});
+          reordered_tensorindex_values, {{RhsTensorIndices::value...}});
 
   // positions of indices in LHS tensor where generic spatial indices are used
   // for spacetime indices
   constexpr auto lhs_spatial_spacetime_index_positions =
       get_spatial_spacetime_index_positions<LhsIndexList,
-                                            lhs_tensorindex_list>();
+                                            reordered_lhs_tensorindex_list>();
   // positions of indices in RHS tensor where generic spatial indices are used
   // for spacetime indices
   constexpr auto rhs_spatial_spacetime_index_positions =
@@ -264,7 +493,7 @@ void evaluate_impl(
 
   // positions of indices in LHS tensor where concrete time indices are used
   constexpr auto lhs_time_index_positions =
-      get_time_index_positions<lhs_tensorindex_list>();
+      get_time_index_positions<reordered_lhs_tensorindex_list>();
 
   using rhs_expression_type =
       typename std::decay_t<decltype(~rhs_tensorexpression)>;
@@ -329,10 +558,11 @@ void evaluate_impl(
  * @param rhs_value the RHS value to assigned
  */
 template <typename... LhsTensorIndices, typename X, typename LhsSymmetry,
-          typename LhsIndexList, typename NumberType>
+          typename LhsIndexList, typename NumberType, size_t... LhsInts>
 void evaluate_impl(
     const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
-    const NumberType& rhs_value) {
+    const NumberType& rhs_value,
+    const std::index_sequence<LhsInts...>& /*lhs_ints*/) {
   using lhs_tensor_type = typename std::decay_t<decltype(*lhs_tensor)>;
   constexpr size_t num_lhs_indices = sizeof...(LhsTensorIndices);
   using lhs_tensorindex_list = tmpl::list<LhsTensorIndices...>;
@@ -376,15 +606,23 @@ void evaluate_impl(
            "\n\tgsl::not_null<Tensor<VectorType, ...>*>, number).");
   }
 
+  constexpr std::array<std::int32_t, num_lhs_indices> lhs_symmetry = {
+      {tmpl::at_c<LhsSymmetry, LhsInts>::value...}};
+  constexpr std::array<size_t, num_lhs_indices> reordered_tensorindex_values =
+      get_reordered_tensorindex_values<LhsTensorIndices...>(lhs_symmetry);
+  (void)reordered_tensorindex_values;  // silence false unused variable warning
+  using reordered_lhs_tensorindex_list =
+      tmpl::list<TensorIndex<reordered_tensorindex_values[LhsInts]>...>;
+
   // positions of indices in LHS tensor where generic spatial indices are used
   // for spacetime indices
   constexpr auto lhs_spatial_spacetime_index_positions =
       get_spatial_spacetime_index_positions<LhsIndexList,
-                                            lhs_tensorindex_list>();
+                                            reordered_lhs_tensorindex_list>();
 
   // positions of indices in LHS tensor where concrete time indices are used
   constexpr auto lhs_time_index_positions =
-      get_time_index_positions<lhs_tensorindex_list>();
+      get_time_index_positions<reordered_lhs_tensorindex_list>();
 
   for (size_t i = 0; i < lhs_tensor_type::size(); i++) {
     auto lhs_multi_index =
@@ -455,7 +693,8 @@ void evaluate(
       rhs_expression_type::primary_subtree_contains_primary_start;
   detail::evaluate_impl<evaluate_subtrees,
                         std::decay_t<decltype(LhsTensorIndices)>...>(
-      lhs_tensor, rhs_tensorexpression);
+      lhs_tensor, rhs_tensorexpression,
+      std::make_index_sequence<sizeof...(LhsTensorIndices)>{});
 }
 
 /// @{
@@ -485,16 +724,18 @@ template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
 void evaluate(
     const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
     const N rhs_value) {
-  detail::evaluate_impl<std::decay_t<decltype(LhsTensorIndices)>...>(lhs_tensor,
-                                                                     rhs_value);
+  detail::evaluate_impl<std::decay_t<decltype(LhsTensorIndices)>...>(
+      lhs_tensor, rhs_value,
+      std::make_index_sequence<sizeof...(LhsTensorIndices)>{});
 }
 template <auto&... LhsTensorIndices, typename X, typename LhsSymmetry,
           typename LhsIndexList, typename N>
 void evaluate(
     const gsl::not_null<Tensor<X, LhsSymmetry, LhsIndexList>*> lhs_tensor,
     const std::complex<N>& rhs_value) {
-  detail::evaluate_impl<std::decay_t<decltype(LhsTensorIndices)>...>(lhs_tensor,
-                                                                     rhs_value);
+  detail::evaluate_impl<std::decay_t<decltype(LhsTensorIndices)>...>(
+      lhs_tensor, rhs_value,
+      std::make_index_sequence<sizeof...(LhsTensorIndices)>{});
 }
 /// @}
 
@@ -563,6 +804,7 @@ auto evaluate(const RhsTE& rhs_tensorexpression) {
   Tensor<typename RhsTE::type, typename lhs_tensor_symm_and_indices::symmetry,
          typename lhs_tensor_symm_and_indices::tensorindextype_list>
       lhs_tensor{};
+
   evaluate<LhsTensorIndices...>(make_not_null(&lhs_tensor),
                                 rhs_tensorexpression);
   return lhs_tensor;
@@ -626,6 +868,7 @@ void update(
           lhs_tensor);
 
   detail::evaluate_impl<false, std::decay_t<decltype(LhsTensorIndices)>...>(
-      lhs_tensor, rhs_tensorexpression);
+      lhs_tensor, rhs_tensorexpression,
+      std::make_index_sequence<sizeof...(LhsTensorIndices)>{});
 }
 }  // namespace tenex

--- a/src/DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp
+++ b/src/DataStructures/Tensor/Expressions/SpatialSpacetimeIndex.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
+#include "DataStructures/Tensor/Expressions/TimeIndex.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Utilities/Algorithm.hpp"
@@ -23,12 +24,37 @@
 
 namespace tenex {
 namespace detail {
+/// \brief Returns whether or not the provided value is a TensorIndex value
+/// that encodes a generic spatial index
+///
+/// \param value the value to check
+/// \return whether or not the value encodes a generic spatial index
+constexpr bool is_generic_spatial_index_value(const size_t value) {
+  return value >= tenex::TensorIndex_detail::spatial_sentinel;
+}
+
+/// \brief Returns whether or not the provided value is a TensorIndex value
+/// that encodes a generic spacetime index
+///
+/// \param value the value to check
+/// \return whether or not the value encodes a generic spacetime index
+constexpr bool is_generic_spacetime_index_value(const size_t value) {
+  return value < tenex::TensorIndex_detail::spatial_sentinel and
+         not is_time_index_value(value);
+}
+
+template <typename TensorIndexType, typename TensorIndex>
+constexpr bool is_spatial_spacetime_index() {
+  return TensorIndexType::index_type == IndexType::Spacetime and
+         not TensorIndex::is_spacetime;
+}
+
 template <typename State, typename Element, typename Iteration,
           typename TensorIndexList>
 struct spatial_spacetime_index_positions_impl {
   using type = typename std::conditional_t<
-      Element::index_type == IndexType::Spacetime and
-          not tmpl::at<TensorIndexList, Iteration>::is_spacetime,
+      is_spatial_spacetime_index<Element,
+                                 tmpl::at<TensorIndexList, Iteration>>(),
       tmpl::push_back<State, tmpl::integral_constant<size_t, Iteration::value>>,
       State>;
 };

--- a/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/Expressions/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_EvaluateRank3NonSymmetric.cpp
   Test_EvaluateRank3Symmetric.cpp
   Test_EvaluateRank4.cpp
+  Test_EvaluateSpatialAndTimeSpacetimeIndex.cpp
   Test_EvaluateSpatialSpacetimeIndex.cpp
   Test_EvaluateTimeIndex.cpp
   Test_MixedOperations.cpp

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_Evaluate.cpp
@@ -3,6 +3,8 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 #include "DataStructures/DataVector.hpp"
@@ -16,6 +18,9 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
+template <std::int32_t... Is>
+using expected_symm = tmpl::integral_list<std::int32_t, Is...>;
+
 template <IndexType... Is>
 using indextype_list = tmpl::integral_list<IndexType, Is...>;
 
@@ -28,6 +33,9 @@ void test_contains_indices_to_contract_impl(const bool expected) {
             {{std::decay_t<decltype(TensorIndices)>::value...}}) == expected);
 }
 
+// Tests the helper function `tenex::detail::contains_indices_to_contract`
+// correctly determines whether or not a list of tensor indices contains at
+// least one index pair to contract
 void test_contains_indices_to_contract() {
   test_contains_indices_to_contract_impl<ti::a, ti::b, ti::c>(false);
   test_contains_indices_to_contract_impl<ti::I, ti::j>(false);
@@ -40,174 +48,249 @@ void test_contains_indices_to_contract() {
   test_contains_indices_to_contract_impl<ti::j, ti::c, ti::J, ti::A, ti::a>(
       true);
 }
+
+// Tests that the canonical ordering of symmetry values by `Symmetry` is
+// consistent with what `tenex::detail::get_reordered_tensorindex_values`
+// expects, which is that the symmetry values assigned to indepdenent indices
+// is ascending from the rightmost position moving leftward with the rightmost
+// symmetry value starting at 1
+void test_lhs_tensorindex_reorder_symm_consistency() {
+  const std::string error_msg =
+      "tenex::detail::get_reordered_tensorindex_values() assumes a canonical "
+      "form for Symmetry that is no longer the actual canonical form of "
+      "Symmetry. The logic of this unit test and "
+      "tenex::detail::get_reordered_tensorindex_values() must be updated to "
+      "agree with the current canonical form for Symmetry";
+  INFO(error_msg);
+
+  CHECK(std::is_same_v<Symmetry<>, expected_symm<>>);
+  CHECK(std::is_same_v<Symmetry<4>, expected_symm<1>>);
+  CHECK(std::is_same_v<Symmetry<1, 2>, expected_symm<2, 1>>);
+  CHECK(std::is_same_v<Symmetry<3, 5>, expected_symm<2, 1>>);
+  CHECK(std::is_same_v<Symmetry<2, 2, 2>, expected_symm<1, 1, 1>>);
+  CHECK(std::is_same_v<Symmetry<8, 4, 5, 5, 8>, expected_symm<1, 3, 2, 2, 1>>);
+}
+
+// Tests that the canonical ordering of multi-indices by
+// `Tensor_detail::Structure` is consistent with what
+// `tenex::detail::evaluate_impl` expects. Specifically, it checks that the
+// canonical multi-indices of independent tensor components are ordered such
+// that within each subset of symmetric indices, the index values are
+// ascending from the rightmost index to the left, which is what `evaluate_impl`
+// assumes.
+void test_evaluate_and_canon_multi_index_consistency() {
+  const std::string error_msg =
+      "tenex::evaluate() assumes a canonical form for multi-indices that is no "
+      "longer consistent with the canonical form defined by "
+      "Tensor_detail::Structure. The logic of this unit test and "
+      "tenex::detail::evaluate_impl must be updated to agree with the current "
+      "canonical form for multi-indices.";
+  INFO(error_msg);
+
+  using datatype = double;
+  using frame = Frame::Inertial;
+
+  using iii = tnsr::iii<datatype, 3>::structure;
+  using aaa = Tensor<datatype, Symmetry<1, 1, 1>,
+                     index_list<SpacetimeIndex<3, UpLo::Lo, frame>,
+                                SpacetimeIndex<3, UpLo::Lo, frame>,
+                                SpacetimeIndex<3, UpLo::Lo, frame>>>::structure;
+  using iaai = Tensor<datatype, Symmetry<1, 2, 2, 1>,
+                      index_list<SpatialIndex<3, UpLo::Lo, frame>,
+                                 SpacetimeIndex<3, UpLo::Lo, frame>,
+                                 SpacetimeIndex<3, UpLo::Lo, frame>,
+                                 SpatialIndex<3, UpLo::Lo, frame>>>::structure;
+  using iiaa =
+      Tensor<datatype, Symmetry<2, 2, 1, 1>,
+             index_list<SpatialIndex<2, UpLo::Lo, frame>,
+                        SpatialIndex<2, UpLo::Lo, frame>,
+                        SpacetimeIndex<2, UpLo::Lo, frame>,
+                        SpacetimeIndex<2, UpLo::Lo, frame>>>::structure;
+  using aiai = Tensor<datatype, Symmetry<2, 1, 2, 1>,
+                      index_list<SpacetimeIndex<3, UpLo::Lo, frame>,
+                                 SpatialIndex<3, UpLo::Lo, frame>,
+                                 SpacetimeIndex<3, UpLo::Lo, frame>,
+                                 SpatialIndex<3, UpLo::Lo, frame>>>::structure;
+  using iiii = Tensor<datatype, Symmetry<1, 1, 1, 1>,
+                      index_list<SpatialIndex<3, UpLo::Lo, frame>,
+                                 SpatialIndex<3, UpLo::Lo, frame>,
+                                 SpatialIndex<3, UpLo::Lo, frame>,
+                                 SpatialIndex<3, UpLo::Lo, frame>>>::structure;
+
+  for (size_t i = 0; i < iii::size(); i++) {
+    const auto canon_multi_index = iii::get_canonical_tensor_index(i);
+
+    CHECK(canon_multi_index[0] >= canon_multi_index[1]);
+    CHECK(canon_multi_index[1] >= canon_multi_index[2]);
+  }
+
+  for (size_t i = 0; i < aaa::size(); i++) {
+    const auto canon_multi_index = aaa::get_canonical_tensor_index(i);
+
+    CHECK(canon_multi_index[0] >= canon_multi_index[1]);
+    CHECK(canon_multi_index[1] >= canon_multi_index[2]);
+  }
+
+  for (size_t i = 0; i < iaai::size(); i++) {
+    const auto canon_multi_index = iaai::get_canonical_tensor_index(i);
+
+    CHECK(canon_multi_index[0] >= canon_multi_index[3]);
+    CHECK(canon_multi_index[1] >= canon_multi_index[2]);
+  }
+
+  for (size_t i = 0; i < iiaa::size(); i++) {
+    const auto canon_multi_index = iiaa::get_canonical_tensor_index(i);
+
+    CHECK(canon_multi_index[0] >= canon_multi_index[1]);
+    CHECK(canon_multi_index[2] >= canon_multi_index[3]);
+  }
+
+  for (size_t i = 0; i < aiai::size(); i++) {
+    const auto canon_multi_index = aiai::get_canonical_tensor_index(i);
+
+    CHECK(canon_multi_index[0] >= canon_multi_index[2]);
+    CHECK(canon_multi_index[1] >= canon_multi_index[3]);
+  }
+
+  for (size_t i = 0; i < iiii::size(); i++) {
+    const auto canon_multi_index = iiii::get_canonical_tensor_index(i);
+
+    CHECK(canon_multi_index[0] >= canon_multi_index[1]);
+    CHECK(canon_multi_index[1] >= canon_multi_index[2]);
+    CHECK(canon_multi_index[2] >= canon_multi_index[3]);
+  }
+}
+
+// \brief Test evaluation of rank 0, rank 1, and rank 2 tensors
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_evaluate_rank_012() {
+  // Rank 0
+  TestHelpers::tenex::test_evaluate_rank_0<DataType>();
+
+  // Rank 1: spacetime
+  TestHelpers::tenex::test_evaluate_rank_1<true, DataType,
+                                           indextype_list<spacetime_index>,
+                                           ti::a, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      true, DataType, indextype_list<spacetime_index>, ti::b, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<true, DataType,
+                                           indextype_list<spacetime_index>,
+                                           ti::A, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      true, DataType, indextype_list<spacetime_index>, ti::B, Frame::Grid>();
+
+  // Rank 1: spatial
+  TestHelpers::tenex::test_evaluate_rank_1<
+      true, DataType, indextype_list<spatial_index>, ti::i, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      true, DataType, indextype_list<spatial_index>, ti::j, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      true, DataType, indextype_list<spatial_index>, ti::I, Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_1<
+      true, DataType, indextype_list<spatial_index>, ti::J, Frame::Inertial>();
+
+  // Rank 2: nonsymmetric, spacetime only
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::a, ti::b,
+      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::D, ti::C,
+      Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::e, ti::F,
+      Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::G, ti::b,
+      Frame::ElementLogical>();
+
+  // Rank 2: nonsymmetric, spatial only
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
+      Frame::ElementLogical>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::I, ti::J,
+      Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::k, ti::M,
+      Frame::Distorted>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::M, ti::k,
+      Frame::Inertial>();
+
+  // Rank 2: nonsymmetric, spacetime and spatial mixed
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spatial_index>, ti::c, ti::I,
+      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spacetime_index, spatial_index>, ti::A, ti::i,
+      Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spatial_index, spacetime_index>, ti::J, ti::C,
+      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<2, 1>,
+      indextype_list<spatial_index, spacetime_index>, ti::m, ti::e,
+      Frame::Grid>();
+
+  // Rank 2: symmetric, spacetime
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<1, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::a, ti::d,
+      Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      false, DataType, Symmetry<1, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::a, ti::d,
+      Frame::Inertial, Symmetry<2, 1>>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<1, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::G, ti::B,
+      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      false, DataType, Symmetry<1, 1>,
+      indextype_list<spacetime_index, spacetime_index>, ti::G, ti::B,
+      Frame::Grid, Symmetry<2, 1>>();
+
+  // Rank 2: symmetric, spatial
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<1, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
+      Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      false, DataType, Symmetry<1, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::j, ti::i, Frame::Grid,
+      Symmetry<2, 1>>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      true, DataType, Symmetry<1, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::I, ti::J,
+      Frame::Grid>();
+  TestHelpers::tenex::test_evaluate_rank_2<
+      false, DataType, Symmetry<1, 1>,
+      indextype_list<spatial_index, spatial_index>, ti::I, ti::J,
+      Frame::Inertial, Symmetry<2, 1>>();
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.Evaluate",
                   "[DataStructures][Unit]") {
+  // Test tenex::evaluate implementation details
   test_contains_indices_to_contract();
+  test_lhs_tensorindex_reorder_symm_consistency();
+  test_evaluate_and_canon_multi_index_consistency();
 
-  // Rank 0: double
-  TestHelpers::tenex::test_evaluate_rank_0<double>();
-
-  // Rank 0: DataVector
-  TestHelpers::tenex::test_evaluate_rank_0<DataVector>();
-
-  // Rank 1: double; spacetime
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spacetime_index>, ti::a, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spacetime_index>, ti::b, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spacetime_index>, ti::A, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spacetime_index>, ti::B, Frame::Inertial>();
-
-  // Rank 1: double; spatial
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spatial_index>, ti::i, Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spatial_index>, ti::j, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spatial_index>, ti::I, Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_1<
-      true, double, indextype_list<spatial_index>, ti::J, Frame::Grid>();
-
-  // Rank 1: DataVector
-  TestHelpers::tenex::test_evaluate_rank_1<true, DataVector,
-                                           indextype_list<spatial_index>, ti::L,
-                                           Frame::Inertial>();
-
-  // Rank 2: double; nonsymmetric; spacetime only
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::a, ti::b,
-      Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::A, ti::B,
-      Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::d, ti::c,
-      Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::D, ti::C,
-      Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::e, ti::F,
-      Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::F, ti::e,
-      Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::g, ti::B,
-      Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::G, ti::b,
-      Frame::NoFrame>();
-
-  // Rank 2: double; nonsymmetric; spatial only
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::i, ti::j,
-      Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::I, ti::J,
-      Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
-      Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::J, ti::I,
-      Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::i, ti::J,
-      Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::I, ti::j,
-      Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::j, ti::I,
-      Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::J, ti::i,
-      Frame::Inertial>();
-
-  // Rank 2: double; nonsymmetric; spacetime and spatial mixed
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spatial_index>, ti::c, ti::I,
-      Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spatial_index>, ti::A, ti::i,
-      Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spacetime_index>, ti::J, ti::a,
-      Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spacetime_index>, ti::i, ti::B,
-      Frame::NoFrame>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spatial_index>, ti::e, ti::j,
-      Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spacetime_index>, ti::i, ti::d,
-      Frame::Grid>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spatial_index>, ti::C, ti::I,
-      Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<2, 1>,
-      indextype_list<spatial_index, spacetime_index>, ti::J, ti::A,
-      Frame::NoFrame>();
-
-  // Rank 2: double; symmetric; spacetime
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<1, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::a, ti::d,
-      Frame::Inertial>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<1, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::G, ti::B,
-      Frame::Grid>();
-
-  // Rank 2: double; symmetric; spatial
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<1, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
-      Frame::Distorted>();
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, double, Symmetry<1, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::I, ti::J,
-      Frame::NoFrame>();
-
-  // Rank 2: DataVector; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, DataVector, Symmetry<2, 1>,
-      indextype_list<spacetime_index, spacetime_index>, ti::f, ti::G,
-      Frame::Inertial>();
-
-  // Rank 2: DataVector; symmetric
-  TestHelpers::tenex::test_evaluate_rank_2<
-      true, DataVector, Symmetry<1, 1>,
-      indextype_list<spatial_index, spatial_index>, ti::j, ti::i,
-      Frame::Grid>();
+  // Test tenex::evaluate for ranks 0, 1, and 2 tensors
+  test_evaluate_rank_012<double>();
+  test_evaluate_rank_012<DataVector>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateComplex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateComplex.cpp
@@ -85,7 +85,7 @@ void test_assignment_to_single_term(const gsl::not_null<Generator*> generator,
   check_values_equal(get(L2), get(R2));
 
   // assign Tensor<LhsDataType, ...> to Tensor<RhsDataType, ...>
-  const auto R3 = make_with_random_values<tnsr::ij<RhsDataType, 3>>(
+  const auto R3 = make_with_random_values<tnsr::ii<RhsDataType, 3>>(
       generator, distribution, used_for_size_rhs);
   tnsr::ii<LhsDataType, 3> L3{used_for_size_lhs};
   tenex::evaluate<ti::j, ti::i>(make_not_null(&L3), R3(ti::i, ti::j));

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3NonSymmetric.cpp
@@ -20,20 +20,29 @@ using indextype_list = tmpl::integral_list<IndexType, Is...>;
 
 const IndexType spatial_index = IndexType::Spatial;
 const IndexType spacetime_index = IndexType::Spacetime;
+
+// \brief Test evaluation of rank 3 tensors with no symmetry
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_evaluate_rank_3() {
+  // spacetime, spacetime, spatial
+  TestHelpers::tenex::test_evaluate_rank_3<
+      true, DataType, Symmetry<3, 2, 1>,
+      indextype_list<spacetime_index, spacetime_index, spatial_index>, ti::d,
+      ti::A, ti::i, Frame::Inertial>();
+
+  // spatial, spacetime, spatial
+  TestHelpers::tenex::test_evaluate_rank_3<
+      true, DataType, Symmetry<3, 2, 1>,
+      indextype_list<spatial_index, spacetime_index, spatial_index>, ti::K,
+      ti::f, ti::m, Frame::Grid>();
+}
 }  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3NonSymmetric",
     "[DataStructures][Unit]") {
-  // Rank 3: double; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, double, Symmetry<3, 2, 1>,
-      indextype_list<spacetime_index, spatial_index, spacetime_index>, ti::D,
-      ti::j, ti::B, Frame::Inertial>();
-
-  // Rank 3: DataVector; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, DataVector, Symmetry<3, 2, 1>,
-      indextype_list<spacetime_index, spatial_index, spacetime_index>, ti::D,
-      ti::j, ti::B, Frame::Grid>();
+  test_evaluate_rank_3<double>();
+  test_evaluate_rank_3<DataVector>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank3Symmetric.cpp
@@ -20,56 +20,69 @@ using indextype_list = tmpl::integral_list<IndexType, Is...>;
 
 const IndexType spatial_index = IndexType::Spatial;
 const IndexType spacetime_index = IndexType::Spacetime;
+
+// \brief Test evaluation of rank 3 tensors with symmetry
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_evaluate_rank_3() {
+  // first and second indices symmetric
+  TestHelpers::tenex::test_evaluate_rank_3<
+      true, DataType, Symmetry<2, 2, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::b,
+      ti::a, ti::C, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      false, DataType, Symmetry<2, 2, 1>,
+      indextype_list<spatial_index, spatial_index, spacetime_index>, ti::L,
+      ti::J, ti::I, Frame::Grid, Symmetry<3, 2, 1>>();
+
+  // first and third indices symmetric
+  TestHelpers::tenex::test_evaluate_rank_3<
+      true, DataType, Symmetry<1, 2, 1>,
+      indextype_list<spatial_index, spatial_index, spatial_index>, ti::i, ti::k,
+      ti::j, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      false, DataType, Symmetry<1, 2, 1>,
+      indextype_list<spacetime_index, spatial_index, spacetime_index>, ti::f,
+      ti::M, ti::c, Frame::Grid, Symmetry<3, 2, 1>>();
+
+  // second and third indices symmetric
+  TestHelpers::tenex::test_evaluate_rank_3<
+      true, DataType, Symmetry<2, 1, 1>,
+      indextype_list<spacetime_index, spatial_index, spatial_index>, ti::c,
+      ti::I, ti::K, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      false, DataType, Symmetry<2, 1, 1>,
+      indextype_list<spatial_index, spacetime_index, spacetime_index>, ti::J,
+      ti::b, ti::c, Frame::Grid, Symmetry<3, 2, 1>>();
+
+  // fully symmetric
+  TestHelpers::tenex::test_evaluate_rank_3<
+      true, DataType, Symmetry<1, 1, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::f,
+      ti::d, ti::a, Frame::Inertial>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      false, DataType, Symmetry<1, 1, 1>,
+      indextype_list<spatial_index, spatial_index, spatial_index>, ti::k, ti::l,
+      ti::i, Frame::Grid, Symmetry<2, 2, 1>>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      false, DataType, Symmetry<1, 1, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::g,
+      ti::b, ti::c, Frame::Inertial, Symmetry<1, 2, 1>>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      false, DataType, Symmetry<1, 1, 1>,
+      indextype_list<spatial_index, spatial_index, spatial_index>, ti::M, ti::N,
+      ti::J, Frame::Grid, Symmetry<2, 1, 1>>();
+  TestHelpers::tenex::test_evaluate_rank_3<
+      false, DataType, Symmetry<1, 1, 1>,
+      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::E,
+      ti::A, ti::B, Frame::Distorted, Symmetry<3, 2, 1>>();
+}
 }  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.Expression.EvaluateRank3Symmetric",
     "[DataStructures][Unit]") {
-  // Rank 3: double; first and second indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, double, Symmetry<2, 2, 1>,
-      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::b,
-      ti::a, ti::C, Frame::Inertial>();
-
-  // Rank 3: double; first and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, double, Symmetry<1, 2, 1>,
-      indextype_list<spatial_index, spacetime_index, spatial_index>, ti::i,
-      ti::f, ti::j, Frame::Grid>();
-
-  // Rank 3: double; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, double, Symmetry<2, 1, 1>,
-      indextype_list<spacetime_index, spatial_index, spatial_index>, ti::d,
-      ti::J, ti::I, Frame::Distorted>();
-
-  // Rank 3: double; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, double, Symmetry<1, 1, 1>,
-      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::f,
-      ti::d, ti::a, Frame::Inertial>();
-
-  // Rank 3: DataVector; first and second indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, DataVector, Symmetry<2, 2, 1>,
-      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::b,
-      ti::a, ti::C, Frame::Grid>();
-
-  // Rank 3: DataVector; first and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, DataVector, Symmetry<1, 2, 1>,
-      indextype_list<spatial_index, spacetime_index, spatial_index>, ti::i,
-      ti::f, ti::j, Frame::Distorted>();
-
-  // Rank 3: DataVector; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, DataVector, Symmetry<2, 1, 1>,
-      indextype_list<spacetime_index, spatial_index, spatial_index>, ti::d,
-      ti::J, ti::I, Frame::Inertial>();
-
-  // Rank 3: DataVector; symmetric
-  TestHelpers::tenex::test_evaluate_rank_3<
-      true, DataVector, Symmetry<1, 1, 1>,
-      indextype_list<spacetime_index, spacetime_index, spacetime_index>, ti::f,
-      ti::d, ti::a, Frame::Grid>();
+  test_evaluate_rank_3<double>();
+  test_evaluate_rank_3<DataVector>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateRank4.cpp
@@ -9,77 +9,61 @@
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp"
 
+namespace {
+// \brief Test evaluation of rank 4 tensors
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_evaluate_rank_4() {
+  // nonsymmetric
+  TestHelpers::tenex::test_evaluate_rank_4<
+      true, DataType, Symmetry<4, 3, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::b, ti::A, ti::k, ti::l>();
+
+  // second and third indices symmetric
+  TestHelpers::tenex::test_evaluate_rank_4<
+      true, DataType, Symmetry<3, 2, 2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
+      ti::G, ti::d, ti::a, ti::j>();
+
+  // first, second, and fourth indices symmetric
+  TestHelpers::tenex::test_evaluate_rank_4<
+      true, DataType, Symmetry<2, 2, 1, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::j, ti::i, ti::k, ti::l>();
+
+  // fully symmetric
+  TestHelpers::tenex::test_evaluate_rank_4<
+      true, DataType, Symmetry<1, 1, 1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::F, ti::A, ti::C, ti::D>();
+
+  // different LHS symmetry
+  TestHelpers::tenex::test_evaluate_rank_4<
+      false, DataType, Symmetry<2, 1, 2, 2>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::j, ti::i, ti::k, ti::l, Symmetry<3, 2, 1, 1>>();
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateRank4",
                   "[DataStructures][Unit]") {
-  // Rank 4: double; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, double, Symmetry<4, 3, 2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
-      ti::b, ti::A, ti::k, ti::l>();
-
-  // Rank 4: double; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, double, Symmetry<3, 2, 2, 1>,
-      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
-      ti::G, ti::d, ti::a, ti::j>();
-
-  // Rank 4: double; first, second, and fourth indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, double, Symmetry<2, 2, 1, 2>,
-      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti::j, ti::i, ti::k, ti::l>();
-
-  // Rank 4: double; symmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, double, Symmetry<1, 1, 1, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
-      ti::F, ti::A, ti::C, ti::D>();
-
-  // Rank 4: DataVector; nonsymmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, DataVector, Symmetry<4, 3, 2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
-      ti::b, ti::A, ti::k, ti::l>();
-
-  // Rank 4: DataVector; second and third indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, DataVector, Symmetry<3, 2, 2, 1>,
-      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpatialIndex<1, UpLo::Lo, Frame::Grid>>,
-      ti::G, ti::d, ti::a, ti::j>();
-
-  // Rank 4: DataVector; first, second, and fourth indices symmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, DataVector, Symmetry<2, 2, 1, 2>,
-      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti::j, ti::i, ti::k, ti::l>();
-
-  // Rank 4: DataVector; symmetric
-  TestHelpers::tenex::test_evaluate_rank_4<
-      true, DataVector, Symmetry<1, 1, 1, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
-      ti::F, ti::A, ti::C, ti::D>();
+  test_evaluate_rank_4<double>();
+  test_evaluate_rank_4<DataVector>();
 }

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialAndTimeSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialAndTimeSpacetimeIndex.cpp
@@ -1,0 +1,574 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+// \brief Test evaluation of tensors where generic spatial indices and/or
+// concrete time indices are used for RHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename Generator, typename DataType>
+void test_rhs(const gsl::not_null<Generator*> generator,
+              const DataType& used_for_size) {
+  // Note: this function doesn't utilize test helper functions like
+  // test_evaluate() because they aren't generic enough to handle
+  // test cases where the number of indices on the RHS and LHS are not equal.
+  // Instead, we have to manually check each test case of interest.
+
+  const std::uniform_real_distribution<> distribution(0.1, 1.0);
+  constexpr size_t dim = 3;
+  using frame = Frame::Inertial;
+
+  // RHS tensors with non-symmetric spacetime indices
+  const auto R_ab = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_AB = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_Ab = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_aB = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+
+  // RHS tensors with symmetric spacetime indices
+  const auto S_ab = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto S_AB = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+
+  // Evaluations of non-symmetric RHS tensors
+
+  // \f$L_{i} = R_{it}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_it = tenex::evaluate<ti::i>(R_ab(ti::i, ti::t));
+  // \f$L_{i} = R_{ti}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_ti = tenex::evaluate<ti::i>(R_ab(ti::t, ti::i));
+  // \f$L^{i} = R^{it}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_IT = tenex::evaluate<ti::I>(R_AB(ti::I, ti::T));
+  // \f$L^{i} = R^{ti}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_TI = tenex::evaluate<ti::I>(R_AB(ti::T, ti::I));
+  // \f$L^{i} = R^{i}{}_{t}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_It = tenex::evaluate<ti::I>(R_Ab(ti::I, ti::t));
+  // \f$L_{i} = R^{t}{}_{i}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_Ti = tenex::evaluate<ti::i>(R_Ab(ti::T, ti::i));
+  // \f$L_{i} = R_{i}{}^{t}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_iT = tenex::evaluate<ti::i>(R_aB(ti::i, ti::T));
+  // \f$L^{i} = R_{t}{}^{i}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_tI = tenex::evaluate<ti::I>(R_aB(ti::t, ti::I));
+
+  // Evaluations of symmetric RHS tensors
+
+  // \f$L_{i} = S_{it}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_S_it = tenex::evaluate<ti::i>(S_ab(ti::i, ti::t));
+  // \f$L_{i} = S_{ti}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_S_ti = tenex::evaluate<ti::i>(S_ab(ti::t, ti::i));
+  // \f$L^{i} = S^{it}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_S_IT = tenex::evaluate<ti::I>(S_AB(ti::I, ti::T));
+  // \f$L^{i} = S^{ti}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_S_TI = tenex::evaluate<ti::I>(S_AB(ti::T, ti::I));
+
+  for (size_t i = 0; i < dim; i++) {
+    CHECK(L_i_from_R_it.get(i) == R_ab.get(i + 1, 0));
+    CHECK(L_i_from_R_ti.get(i) == R_ab.get(0, i + 1));
+    CHECK(L_I_from_R_IT.get(i) == R_AB.get(i + 1, 0));
+    CHECK(L_I_from_R_TI.get(i) == R_AB.get(0, i + 1));
+    CHECK(L_I_from_R_It.get(i) == R_Ab.get(i + 1, 0));
+    CHECK(L_i_from_R_Ti.get(i) == R_Ab.get(0, i + 1));
+    CHECK(L_i_from_R_iT.get(i) == R_aB.get(i + 1, 0));
+    CHECK(L_I_from_R_tI.get(i) == R_aB.get(0, i + 1));
+
+    CHECK(L_i_from_S_it.get(i) == S_ab.get(i + 1, 0));
+    CHECK(L_i_from_S_ti.get(i) == S_ab.get(0, i + 1));
+    CHECK(L_I_from_S_IT.get(i) == S_AB.get(i + 1, 0));
+    CHECK(L_I_from_S_TI.get(i) == S_AB.get(0, i + 1));
+  }
+}
+
+// \brief Test evaluation of tensors where generic spatial indices and/or
+// concrete time indices are used for LHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename Generator, typename DataType>
+void test_lhs(const gsl::not_null<Generator*> generator,
+              const DataType& used_for_size) {
+  // Note: this function doesn't utilize test helper functions like
+  // test_evaluate() because they aren't generic enough to handle
+  // test cases where the number of indices on the RHS and LHS are not equal.
+  // Instead, we have to manually check each test case of interest.
+
+  const std::uniform_real_distribution<> distribution(0.1, 1.0);
+  constexpr size_t dim = 3;
+  using frame = Frame::Inertial;
+
+  const auto R =
+      make_with_random_values<DataType>(generator, distribution, used_for_size);
+
+  if constexpr (not is_derived_of_vector_impl_v<DataType>) {
+    // Test evaluation of RHS scalar to non-symmetric LHS rank 2
+
+    // \f$L_{it} = R\f$
+    auto L_it_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                          SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::i, ti::t>(make_not_null(&L_it_from_R), R);
+    // \f$L_{ti} = R\f$
+    auto L_ti_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                          SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::t, ti::i>(make_not_null(&L_ti_from_R), R);
+    // \f$L^{it} = R\f$
+    auto L_IT_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                          SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::I, ti::T>(make_not_null(&L_IT_from_R), R);
+    // \f$L^{ti} = R\f$
+    auto L_TI_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                          SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::T, ti::I>(make_not_null(&L_TI_from_R), R);
+    // \f$L^{i}{}_{t} = R\f$
+    auto L_It_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                          SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::I, ti::t>(make_not_null(&L_It_from_R), R);
+    // \f$L^{t}{}_{i} = R\f$
+    auto L_Ti_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                          SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::T, ti::i>(make_not_null(&L_Ti_from_R), R);
+    // \f$L_{i}{}^{t} = R\f$
+    auto L_iT_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                          SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::i, ti::T>(make_not_null(&L_iT_from_R), R);
+    // \f$L_{t}{}^{i} = R\f$
+    auto L_tI_from_R = make_with_value<
+        Tensor<DataType, Symmetry<2, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                          SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::t, ti::I>(make_not_null(&L_tI_from_R), R);
+
+    for (size_t a = 0; a < dim + 1; a++) {
+      for (size_t b = 0; b < dim + 1; b++) {
+        const auto expected_value =
+            (a > 0 and b == 0)
+                ? R
+                : TestHelpers::tenex::component_placeholder_value<
+                      DataType>::value;
+        CHECK(L_it_from_R.get(a, b) == expected_value);
+        CHECK(L_ti_from_R.get(b, a) == expected_value);
+        CHECK(L_IT_from_R.get(a, b) == expected_value);
+        CHECK(L_TI_from_R.get(b, a) == expected_value);
+        CHECK(L_It_from_R.get(a, b) == expected_value);
+        CHECK(L_Ti_from_R.get(b, a) == expected_value);
+        CHECK(L_iT_from_R.get(a, b) == expected_value);
+        CHECK(L_tI_from_R.get(b, a) == expected_value);
+      }
+    }
+
+    // Test evaluation of RHS scalar to symmetric LHS rank 2
+
+    // \f$M_{it} = R\f$
+    auto M_it_from_R = make_with_value<
+        Tensor<DataType, Symmetry<1, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                          SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::i, ti::t>(make_not_null(&M_it_from_R), R);
+    // \f$M_{ti} = R\f$
+    auto M_ti_from_R = make_with_value<
+        Tensor<DataType, Symmetry<1, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                          SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::t, ti::i>(make_not_null(&M_ti_from_R), R);
+    // \f$M^{it} = R\f$
+    auto M_IT_from_R = make_with_value<
+        Tensor<DataType, Symmetry<1, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                          SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::I, ti::T>(make_not_null(&M_IT_from_R), R);
+    // \f$M^{ti} = R\f$
+    auto M_TI_from_R = make_with_value<
+        Tensor<DataType, Symmetry<1, 1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                          SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+        used_for_size,
+        TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    tenex::evaluate<ti::T, ti::I>(make_not_null(&M_TI_from_R), R);
+
+    for (size_t a = 0; a < dim + 1; a++) {
+      for (size_t b = a; b < dim + 1; b++) {
+        const auto expected_value =
+            (a == 0 and b > 0)
+                ? R
+                : TestHelpers::tenex::component_placeholder_value<
+                      DataType>::value;
+        CHECK(M_it_from_R.get(a, b) == expected_value);
+        CHECK(M_ti_from_R.get(b, a) == expected_value);
+        CHECK(M_IT_from_R.get(a, b) == expected_value);
+        CHECK(M_TI_from_R.get(b, a) == expected_value);
+      }
+    }
+  }
+
+  // RHS Rank 1
+
+  const auto R_i = make_with_random_values<tnsr::i<DataType, dim, frame>>(
+      generator, distribution, used_for_size);
+  const auto R_I = make_with_random_values<tnsr::I<DataType, dim, frame>>(
+      generator, distribution, used_for_size);
+
+  // Test evaluation of RHS rank 1 to non-symmetric LHS rank 2
+
+  // \f$L_{it} = R_i\f$
+  auto L_it_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::i, ti::t>(make_not_null(&L_it_from_R_i), R_i(ti::i));
+  // \f$L_{ti} = R_i\f$
+  auto L_ti_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::i>(make_not_null(&L_ti_from_R_i), R_i(ti::i));
+  // \f$L^{it} = R^i\f$
+  auto L_IT_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::I, ti::T>(make_not_null(&L_IT_from_R_I), R_I(ti::I));
+  // \f$L^{ti} = R^i\f$
+  auto L_TI_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::I>(make_not_null(&L_TI_from_R_I), R_I(ti::I));
+  // \f$L^{i}{}_{t} = R^i\f$
+  auto L_It_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::I, ti::t>(make_not_null(&L_It_from_R_I), R_I(ti::I));
+  // \f$L^{t}{}_{i} = R_i\f$
+  auto L_Ti_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::i>(make_not_null(&L_Ti_from_R_i), R_i(ti::i));
+  // \f$L_{i}{}^{t} = R_i\f$
+  auto L_iT_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::i, ti::T>(make_not_null(&L_iT_from_R_i), R_i(ti::i));
+  // \f$L_{t}{}^{i} = R^i\f$
+  auto L_tI_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::I>(make_not_null(&L_tI_from_R_I), R_I(ti::I));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    for (size_t b = 0; b < dim + 1; b++) {
+      if (a > 0 and b == 0) {
+        CHECK(L_it_from_R_i.get(a, b) == R_i.get(a - 1));
+        CHECK(L_ti_from_R_i.get(b, a) == R_i.get(a - 1));
+        CHECK(L_IT_from_R_I.get(a, b) == R_I.get(a - 1));
+        CHECK(L_TI_from_R_I.get(b, a) == R_I.get(a - 1));
+        CHECK(L_It_from_R_I.get(a, b) == R_I.get(a - 1));
+        CHECK(L_Ti_from_R_i.get(b, a) == R_i.get(a - 1));
+        CHECK(L_iT_from_R_i.get(a, b) == R_i.get(a - 1));
+        CHECK(L_tI_from_R_I.get(b, a) == R_I.get(a - 1));
+      } else {
+        CHECK(L_it_from_R_i.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_ti_from_R_i.get(b, a) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_IT_from_R_I.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_TI_from_R_I.get(b, a) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_It_from_R_I.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_Ti_from_R_i.get(b, a) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_iT_from_R_i.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_tI_from_R_I.get(b, a) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      }
+    }
+  }
+
+  // Test evaluation of RHS rank 1 to symmetric LHS rank 2
+
+  // \f$M_{it} = R_i\f$
+  auto M_it_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::i, ti::t>(make_not_null(&M_it_from_R_i), R_i(ti::i));
+  // \f$M_{ti} = R_i\f$
+  auto M_ti_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::i>(make_not_null(&M_ti_from_R_i), R_i(ti::i));
+  // \f$M^{it} = R^i\f$
+  auto M_IT_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::I, ti::T>(make_not_null(&M_IT_from_R_I), R_I(ti::I));
+  // \f$M^{ti} = R^i\f$
+  auto M_TI_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::I>(make_not_null(&M_TI_from_R_I), R_I(ti::I));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    for (size_t b = a; b < dim + 1; b++) {
+      if (a == 0 and b > 0) {
+        CHECK(M_it_from_R_i.get(a, b) == R_i.get(b - 1));
+        CHECK(M_ti_from_R_i.get(b, a) == R_i.get(b - 1));
+        CHECK(M_IT_from_R_I.get(a, b) == R_I.get(b - 1));
+        CHECK(M_TI_from_R_I.get(b, a) == R_I.get(b - 1));
+      } else {
+        CHECK(M_it_from_R_i.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(M_ti_from_R_i.get(b, a) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(M_IT_from_R_I.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(M_TI_from_R_I.get(b, a) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      }
+    }
+  }
+}
+
+// \brief Test evaluation of rank 2 tensors where generic spatial indices and/or
+// concrete time indices are used for RHS and LHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_rhs_and_lhs_rank_2() {
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::t>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::t, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::t, ti::i>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::t, ti::i, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::I, ti::T>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::I, ti::T, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::T, ti::I>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::T, ti::I, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::I, ti::t>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::T, ti::i>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::i, ti::T>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::t, ti::I>();
+}
+
+// \brief Test evaluation of rank 4 tensors where generic spatial indices and/or
+// concrete time indices are used for RHS and LHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_rhs_and_lhs_rank_4() {
+  using frame = Frame::Inertial;
+  using index_list_abcd = index_list<
+      SpacetimeIndex<3, UpLo::Lo, frame>, SpacetimeIndex<3, UpLo::Lo, frame>,
+      SpacetimeIndex<3, UpLo::Lo, frame>, SpacetimeIndex<3, UpLo::Lo, frame>>;
+
+  TestHelpers::tenex::test_evaluate_rank_4<
+      false, DataType, Symmetry<1, 2, 1, 1>, index_list_abcd, ti::t, ti::a,
+      ti::j, ti::i, Symmetry<1, 3, 2, 1>>();
+}
+
+// \brief Test evaluation of tensors where concrete time indices and spatial
+// indices are used for spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_evaluate_spatial_and_time_spacetime_index(
+    const DataType& used_for_size) {
+  MAKE_GENERATOR(generator);
+
+  test_rhs(make_not_null(&generator), used_for_size);
+  test_lhs(make_not_null(&generator), used_for_size);
+  test_rhs_and_lhs_rank_2<DataType>();
+  test_rhs_and_lhs_rank_4<DataType>();
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Tensor.Expression."
+    "EvaluateSpatialAndTimeSpacetimeIndex",
+    "[DataStructures][Unit]") {
+  test_evaluate_spatial_and_time_spacetime_index(
+      std::numeric_limits<double>::signaling_NaN());
+  test_evaluate_spatial_and_time_spacetime_index(
+      DataVector(3, std::numeric_limits<double>::signaling_NaN()));
+}

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateSpatialSpacetimeIndex.cpp
@@ -17,6 +17,7 @@ namespace {
 // \tparam DataType the type of data being stored in the expression operands
 template <typename DataType>
 void test_rhs() {
+  // test RHS Symmetry<2, 1>
   TestHelpers::tenex::test_evaluate_rank_2_impl<
       true, DataType, Symmetry<2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
@@ -32,6 +33,205 @@ void test_rhs() {
       ti::i, ti::a, Symmetry<2, 1>,
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::A, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::a, ti::I, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::I, ti::a, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::i, ti::A, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::A, ti::I, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Up, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::I, ti::A, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::j, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::j, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::j, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Grid>>,
+      ti::J, ti::k, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Grid>>,
+      ti::J, ti::k, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Grid>>,
+      ti::J, ti::k, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::l, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::l, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::l, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::K, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Up, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::K, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Up, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::K, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Up, Frame::Grid>>>();
+
+  // test RHS Symmetry<1, 1> to LHS Symmetry<1, 1> and <2, 1>
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::a, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::A, ti::I, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::I, ti::A, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Distorted>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Distorted>>,
+      ti::J, ti::I, Symmetry<1, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Distorted>,
+                 SpatialIndex<3, UpLo::Up, Frame::Distorted>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Distorted>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Distorted>>,
+      ti::J, ti::I, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Distorted>,
+                 SpatialIndex<3, UpLo::Up, Frame::Distorted>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      true, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::j, ti::k, Symmetry<1, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::j, ti::k, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>>();
 }
 
 // \brief Test evaluation of tensors where generic spatial indices are used for
@@ -40,21 +240,203 @@ void test_rhs() {
 // \tparam DataType the type of data being stored in the expression operands
 template <typename DataType>
 void test_lhs() {
+  // test RHS Symmetry<2, 1>
   TestHelpers::tenex::test_evaluate_rank_2_impl<
       false, DataType, Symmetry<2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
       ti::a, ti::i, Symmetry<2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::A, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::a, ti::I, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::A, ti::I, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::a, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::I, ti::a, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
 
   TestHelpers::tenex::test_evaluate_rank_2_impl<
       false, DataType, Symmetry<2, 1>,
       index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti::i, ti::a, Symmetry<2, 1>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::i, ti::A, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+      ti::I, ti::A, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::j, Symmetry<2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::i, ti::j, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::i, ti::j, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::J, ti::k, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::J, ti::k, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::J, ti::k, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::l, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::K, ti::I, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::K, ti::I, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::K, ti::I, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>>();
+
+  // test RHS Symmetry<1, 1> to LHS Symmetry<1, 1> and <2, 1>
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::K, ti::J, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::K, ti::J, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::K, ti::J, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::K, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::l, ti::k, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::l, ti::k, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::l, ti::k, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::l, ti::k, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
 }
 
 // \brief Test evaluation of rank 2 tensors where generic spatial indices are
@@ -63,42 +445,289 @@ void test_lhs() {
 // \tparam DataType the type of data being stored in the expression operands
 template <typename DataType>
 void test_rhs_and_lhs_rank2() {
+  // test RHS Symmetry<2, 1>
+
+  // - two lower spatial tensor indices
+  // - RHS one or two spacetime indices
+  // - LHS two spacetime indices
   TestHelpers::tenex::test_evaluate_rank_2_impl<
       false, DataType, Symmetry<2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::j, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
-      ti::a, ti::i, Symmetry<2, 1>,
+      ti::n, ti::m, Symmetry<2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
 
   TestHelpers::tenex::test_evaluate_rank_2_impl<
       false, DataType, Symmetry<2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
-      ti::i, ti::a, Symmetry<2, 1>,
-      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Grid>,
-                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>>();
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::m, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
+
+  // - upper spatial tensor index, lower spatial tensor index
+  // - RHS two spacetime indices
+  // - LHS one or two spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::I, ti::j, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::K, ti::i, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::N, ti::k, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
+
+  // - lower spatial tensor indices
+  // - RHS spatial index, spacetime index
+  // - LHS spatial index, spacetime index
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::j, ti::k>();
+
+  // - upper spatial tensor indices
+  // - RHS spacetime index, spatial index
+  // - LHS spatial index, spacetime index
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::L, ti::J, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>>();
+
+  // - lower spatial tensor index, upper spatial tensor index
+  // - RHS spatial index, spacetime index
+  // - LHS spacetime index, spatial index
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::i, ti::M, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>>();
+
+  // - lower spatial tensor indices
+  // - RHS spacetime index, spatial index
+  // - LHS spatial index, spacetime index
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::k, ti::j>();
+
+  // - upper spatial tensor indices
+  // - RHS spatial index, spacetime index
+  // - LHS spacetime index, spatial index
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::L, ti::J, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Up, Frame::Inertial>>>();
+
+  // - lower spacetime tensor index, lower spatial tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::i>();
+
+  // - lower spatial tensor index, lower spacetime tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::a>();
+
+  // - upper spacetime tensor index, upper spatial tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::A, ti::I>();
+
+  // - upper spatial tensor index, upper spacetime tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::I, ti::A>();
+
+  // - lower spatial tensor index, upper spacetime tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::i, ti::A>();
+
+  // - lower spacetime tensor index, upper spatial tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::a, ti::I>();
+
+  // - upper spatial tensor index, lower spacetime tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::I, ti::a>();
+
+  // - upper spacetime tensor index, lower spatial tensor index
+  // - RHS spacetime indices
+  // - LHS spacetime indices
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::A, ti::i>();
+
+  // test RHS Symmetry<1, 1> to LHS Symmetry<1, 1> and <2, 1>
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::i>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::i, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::A, ti::I>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::A, ti::I, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::a>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::a, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::I, ti::A>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::I, ti::A, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::j>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::j, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::J, ti::I>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::J, ti::I, Symmetry<2, 1>>();
 }
 
 // \brief Test evaluation of rank 4 tensors where generic spatial indices are
 // used for RHS and LHS spacetime indices
-//
-// \tparam DataType the type of data being stored in the expression operands
 template <typename DataType>
 void test_rhs_and_lhs_rank4() {
+  // tests that return type is what is expected
   TestHelpers::tenex::test_evaluate_rank_4<
-      false, DataType, Symmetry<3, 2, 1, 2>,
+      true, DataType, Symmetry<1, 2, 2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+      ti::i, ti::k, ti::a, ti::j, Symmetry<1, 3, 2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>>();
+
+  // tests that only spatial components are filled for LHS tensor arg
+  TestHelpers::tenex::test_evaluate_rank_4<
+      false, DataType, Symmetry<1, 1, 2, 1>,
       index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
-      ti::j, ti::a, ti::i, ti::k, Symmetry<4, 3, 2, 1>,
-      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
                  SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
-                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>>();
+                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::m, ti::c, ti::i, ti::j, Symmetry<1, 1, 2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>>();
 }
 
+// \brief Test evaluation of tensors where generic spatial indices are used for
+// spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
 template <typename DataType>
 void test_evaluate_spatial_spacetime_index() {
   test_rhs<DataType>();

--- a/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
+++ b/tests/Unit/DataStructures/Tensor/Expressions/Test_EvaluateTimeIndex.cpp
@@ -3,19 +3,19 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <complex>
 #include <cstddef>
+#include <limits>
 #include <random>
 
-#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/IndexType.hpp"
-#include "DataStructures/Tensor/Symmetry.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/DataStructures/Tensor/Expressions/ComponentPlaceholder.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank2.hpp"
+#include "Helpers/DataStructures/Tensor/Expressions/EvaluateRank4.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 namespace {
 // \brief Test evaluation of tensors where concrete time indices are used for
@@ -25,24 +25,244 @@ namespace {
 template <typename Generator, typename DataType>
 void test_rhs(const gsl::not_null<Generator*> generator,
               const DataType& used_for_size) {
+  // Note: this function doesn't utilize test helper functions like
+  // test_evaluate() because they aren't generic enough to handle
+  // test cases where the number of indices on the RHS and LHS are not equal.
+  // Instead, we have to manually check each test case of interest.
+
   std::uniform_real_distribution<> distribution(0.1, 1.0);
   constexpr size_t dim = 3;
+  using frame = Frame::Inertial;
 
-  const auto R = make_with_random_values<
-      Tensor<DataType, Symmetry<2, 1>,
-             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
+  // Rank 1 testing
+
+  const auto R_a = make_with_random_values<Tensor<
+      DataType, Symmetry<1>, index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_A = make_with_random_values<Tensor<
+      DataType, Symmetry<1>, index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>>(
       generator, distribution, used_for_size);
 
-  // \f$L_{a} = R_{at}\f$
+  // \f$L = R_{t}\f$
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
+  const Scalar<DataType> L_from_R_t = tenex::evaluate(R_a(ti::t));
+  // \f$L = R_{T}\f$
+  const Scalar<DataType> L_from_R_T = tenex::evaluate(R_A(ti::T));
+
+  CHECK(get(L_from_R_t) == R_a.get(0));
+  CHECK(get(L_from_R_T) == R_A.get(0));
+
+  // Rank 2 testing
+
+  // RHS tensors with non-symmetric spacetime indices
+  const auto R_ab = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_AB = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_Ab = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_aB = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+  // RHS tensors with one spacetime and one spatial index
+  const auto R_ai = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpatialIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_ia = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpatialIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_IA = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpatialIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_AI = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpatialIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_Ai = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpatialIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_Ia = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpatialIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_aI = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpatialIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_iA = make_with_random_values<
+      Tensor<DataType, Symmetry<2, 1>,
+             index_list<SpatialIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+  // RHS tensors with symmetric spacetime indices
+  const auto S_ab = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto S_AB = make_with_random_values<
+      Tensor<DataType, Symmetry<1, 1>,
+             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+
+  // Evaluations of non-symmetric RHS tensors
+
+  // \f$L_{a} = R_{at}\f$
   const Tensor<DataType, Symmetry<1>,
-               index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>
-      La_from_R_at = tenex::evaluate<ti::a>(R(ti::a, ti::t));
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>
+      L_a_from_R_at = tenex::evaluate<ti::a>(R_ab(ti::a, ti::t));
+  // \f$L_{a} = R_{ta}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>
+      L_a_from_R_ta = tenex::evaluate<ti::a>(R_ab(ti::t, ti::a));
+  // \f$L = R_{tt}\f$
+  const Scalar<DataType> L_from_R_tt = tenex::evaluate(R_ab(ti::t, ti::t));
+  // \f$L^{a} = R^{at}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>
+      L_A_from_R_AT = tenex::evaluate<ti::A>(R_AB(ti::A, ti::T));
+  // \f$L^{a} = R^{ta}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>
+      L_A_from_R_TA = tenex::evaluate<ti::A>(R_AB(ti::T, ti::A));
+  // \f$L = R^{tt}\f$
+  const Scalar<DataType> L_from_R_TT = tenex::evaluate(R_AB(ti::T, ti::T));
+  // \f$L^{a} = R^{a}{}_{t}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>
+      L_A_from_R_At = tenex::evaluate<ti::A>(R_Ab(ti::A, ti::t));
+  // \f$L_{a} = R^{t}{}_{a}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>
+      L_a_from_R_Ta = tenex::evaluate<ti::a>(R_Ab(ti::T, ti::a));
+  // \f$L = R^{t}{}_{t}\f$
+  const Scalar<DataType> L_from_R_Tt = tenex::evaluate(R_Ab(ti::T, ti::t));
+  // \f$L_{a} = R_{a}{}^{t}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>
+      L_a_from_R_aT = tenex::evaluate<ti::a>(R_aB(ti::a, ti::T));
+  // \f$L^{a} = R_{t}{}^{a}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>
+      L_A_from_R_tA = tenex::evaluate<ti::A>(R_aB(ti::t, ti::A));
+  // \f$L = R_{t}{}^{t}\f$
+  const Scalar<DataType> L_from_R_tT = tenex::evaluate(R_aB(ti::t, ti::T));
+
+  // Evaluations of symmetric RHS tensors
+
+  // \f$L_{a} = S_{at}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>
+      L_a_from_S_at = tenex::evaluate<ti::a>(S_ab(ti::a, ti::t));
+  // \f$L_{a} = S_{ta}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>
+      L_a_from_S_ta = tenex::evaluate<ti::a>(S_ab(ti::t, ti::a));
+  // \f$L = S_{tt}\f$
+  const Scalar<DataType> L_from_S_tt = tenex::evaluate(S_ab(ti::t, ti::t));
+  // \f$L^{a} = S^{at}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>
+      L_A_from_S_AT = tenex::evaluate<ti::A>(S_AB(ti::A, ti::T));
+  // \f$L^{a} = S^{ta}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>
+      L_A_from_S_TA = tenex::evaluate<ti::A>(S_AB(ti::T, ti::A));
+  // \f$L = S^{tt}\f$
+  const Scalar<DataType> L_from_S_TT = tenex::evaluate(S_AB(ti::T, ti::T));
+
+  // Evaluations of RHS tensors with one spatial and one spacetime index
+
+  // \f$L_{i} = R_{it}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_it = tenex::evaluate<ti::i>(R_ia(ti::i, ti::t));
+  // \f$L_{i} = R_{ti}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_ti = tenex::evaluate<ti::i>(R_ai(ti::t, ti::i));
+  // \f$L^{i} = R^{it}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_IT = tenex::evaluate<ti::I>(R_IA(ti::I, ti::T));
+  // \f$L^{i} = R^{ti}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_TI = tenex::evaluate<ti::I>(R_AI(ti::T, ti::I));
+  // \f$L^{i} = R^{i}{}_{t}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_It = tenex::evaluate<ti::I>(R_Ia(ti::I, ti::t));
+  // \f$L_{i} = R^{t}{}_{i}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_Ti = tenex::evaluate<ti::i>(R_Ai(ti::T, ti::i));
+  // \f$L_{i} = R_{i}{}^{t}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Lo, frame>>>
+      L_i_from_R_iT = tenex::evaluate<ti::i>(R_iA(ti::i, ti::T));
+  // \f$L^{i} = R_{t}{}^{i}\f$
+  const Tensor<DataType, Symmetry<1>,
+               index_list<SpatialIndex<dim, UpLo::Up, frame>>>
+      L_I_from_R_tI = tenex::evaluate<ti::I>(R_aI(ti::t, ti::I));
+
+  CHECK(get(L_from_R_tt) == R_ab.get(0, 0));
+  CHECK(get(L_from_R_TT) == R_AB.get(0, 0));
+  CHECK(get(L_from_R_Tt) == R_Ab.get(0, 0));
+  CHECK(get(L_from_R_tT) == R_aB.get(0, 0));
+
+  CHECK(get(L_from_S_tt) == S_ab.get(0, 0));
+  CHECK(get(L_from_S_TT) == S_AB.get(0, 0));
 
   for (size_t a = 0; a < dim + 1; a++) {
-    CHECK(La_from_R_at.get(a) == R.get(a, 0));
+    CHECK(L_a_from_R_at.get(a) == R_ab.get(a, 0));
+    CHECK(L_a_from_R_ta.get(a) == R_ab.get(0, a));
+    CHECK(L_A_from_R_AT.get(a) == R_AB.get(a, 0));
+    CHECK(L_A_from_R_TA.get(a) == R_AB.get(0, a));
+    CHECK(L_A_from_R_At.get(a) == R_Ab.get(a, 0));
+    CHECK(L_a_from_R_Ta.get(a) == R_Ab.get(0, a));
+    CHECK(L_a_from_R_aT.get(a) == R_aB.get(a, 0));
+    CHECK(L_A_from_R_tA.get(a) == R_aB.get(0, a));
+
+    CHECK(L_a_from_S_at.get(a) == S_ab.get(a, 0));
+    CHECK(L_a_from_S_ta.get(a) == S_ab.get(0, a));
+    CHECK(L_A_from_S_AT.get(a) == S_AB.get(a, 0));
+    CHECK(L_A_from_S_TA.get(a) == S_AB.get(0, a));
+  }
+
+  for (size_t i = 0; i < dim; i++) {
+    CHECK(L_i_from_R_it.get(i) == R_ia.get(i, 0));
+    CHECK(L_i_from_R_ti.get(i) == R_ai.get(0, i));
+    CHECK(L_I_from_R_IT.get(i) == R_IA.get(i, 0));
+    CHECK(L_I_from_R_TI.get(i) == R_AI.get(0, i));
+    CHECK(L_I_from_R_It.get(i) == R_Ia.get(i, 0));
+    CHECK(L_i_from_R_Ti.get(i) == R_Ai.get(0, i));
+    CHECK(L_i_from_R_iT.get(i) == R_iA.get(i, 0));
+    CHECK(L_I_from_R_tI.get(i) == R_aI.get(0, i));
   }
 }
 
@@ -53,15 +273,21 @@ void test_rhs(const gsl::not_null<Generator*> generator,
 template <typename Generator, typename DataType>
 void test_lhs(const gsl::not_null<Generator*> generator,
               const DataType& used_for_size) {
+  // Note: this function doesn't utilize test helper functions like
+  // test_evaluate() because they aren't generic enough to handle
+  // test cases where the number of indices on the RHS and LHS are not equal.
+  // Instead, we have to manually check each test case of interest.
+
   std::uniform_real_distribution<> distribution(0.1, 1.0);
   constexpr size_t dim = 3;
+  using frame = Frame::Inertial;
 
-  const auto R = make_with_random_values<
-      Tensor<DataType, Symmetry<1>,
-             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
+  const auto R = make_with_random_values<Scalar<DataType>>(
       generator, distribution, used_for_size);
 
-  // \f$L_{at} = R_{a}\f$
+  // Test evaluation of RHS scalar to LHS rank 1
+
+  // \f$L_{t} = R\f$
   //
   // Use explicit type (vs auto) for LHS Tensor so the compiler checks the
   // return type of `evaluate`
@@ -69,30 +295,493 @@ void test_lhs(const gsl::not_null<Generator*> generator,
   // Assign a placeholder to the LHS tensor's components before it is computed
   // so that when test expressions below only compute time components, we can
   // check that LHS spatial components haven't changed
-  auto Lat_from_R_a = make_with_value<
-      Tensor<DataType, Symmetry<2, 1>,
-             index_list<SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>,
-                        SpacetimeIndex<dim, UpLo::Lo, Frame::Inertial>>>>(
-      used_for_size,
-      TestHelpers::tenex::component_placeholder_value<DataType>::value);
-  tenex::evaluate<ti::a, ti::t>(make_not_null(&Lat_from_R_a), R(ti::a));
+  auto L_t_from_R =
+      make_with_value<Tensor<DataType, Symmetry<1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t>(make_not_null(&L_t_from_R), R());
+  // \f$L_{T} = R\f$
+  auto L_T_from_R =
+      make_with_value<Tensor<DataType, Symmetry<1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T>(make_not_null(&L_T_from_R), R());
+
+  CHECK(L_t_from_R.get(0) == get(R));
+  CHECK(L_T_from_R.get(0) == get(R));
+  for (size_t i = 0; i < dim; i++) {
+    CHECK(L_t_from_R.get(i + 1) ==
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    CHECK(L_T_from_R.get(i + 1) ==
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  }
+
+  // Test evaluation of RHS scalar to non-symmetric LHS rank 2
+
+  // \f$L_{tt} = R\f$
+  auto L_tt_from_R =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::t>(make_not_null(&L_tt_from_R), R());
+  // \f$L^{tt} = R\f$
+  auto L_TT_from_R =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::T>(make_not_null(&L_TT_from_R), R());
+  // \f$L^{t}{}_{t} = R\f$
+  auto L_Tt_from_R =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::t>(make_not_null(&L_Tt_from_R), R());
+  // \f$L_{t}{}^{t} = R\f$
+  auto L_tT_from_R =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::T>(make_not_null(&L_tT_from_R), R());
+
+  // Test evaluation of RHS scalar to symmetric LHS rank 2
+
+  // \f$M_{tt} = R\f$
+  auto M_tt_from_R =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::t>(make_not_null(&M_tt_from_R), R());
+  // \f$M^{tt} = R\f$
+  auto M_TT_from_R =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::T>(make_not_null(&M_TT_from_R), R());
+  // \f$M^{t}{}_{t} = R\f$
 
   for (size_t a = 0; a < dim + 1; a++) {
-    CHECK(Lat_from_R_a.get(a, 0) == R.get(a));
+    for (size_t b = 0; b < dim + 1; b++) {
+      if (a == 0 and b == 0) {
+        CHECK(L_tt_from_R.get(0, 0) == get(R));
+        CHECK(L_TT_from_R.get(0, 0) == get(R));
+        CHECK(L_Tt_from_R.get(0, 0) == get(R));
+        CHECK(L_tT_from_R.get(0, 0) == get(R));
+
+        CHECK(M_tt_from_R.get(0, 0) == get(R));
+        CHECK(M_TT_from_R.get(0, 0) == get(R));
+      } else {
+        CHECK(L_tt_from_R.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_TT_from_R.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_Tt_from_R.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(L_tT_from_R.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+
+        CHECK(M_tt_from_R.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(M_TT_from_R.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      }
+    }
+  }
+
+  // Evaluations of non-symmetric LHS tensors
+
+  const auto R_a = make_with_random_values<Tensor<
+      DataType, Symmetry<1>, index_list<SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_A = make_with_random_values<Tensor<
+      DataType, Symmetry<1>, index_list<SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{at} = R_{a}\f$
+  auto L_at_from_R_a =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::a, ti::t>(make_not_null(&L_at_from_R_a), R_a(ti::a));
+  // \f$L_{ta} = R_{a}\f$
+  auto L_ta_from_R_a =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::a>(make_not_null(&L_ta_from_R_a), R_a(ti::a));
+  // \f$L^{at} = R^{a}\f$
+  auto L_AT_from_R_A =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::A, ti::T>(make_not_null(&L_AT_from_R_A), R_A(ti::A));
+  // \f$L^{ta} = R^{a}\f$
+  auto L_TA_from_R_A =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::A>(make_not_null(&L_TA_from_R_A), R_A(ti::A));
+  // \f$L^{a}{}_{t} = R^{a}\f$
+  auto L_At_from_R_A =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::A, ti::t>(make_not_null(&L_At_from_R_A), R_A(ti::A));
+  // \f$L^{t}{}_{a} = R_{a}\f$
+  auto L_Ta_from_R_a =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::a>(make_not_null(&L_Ta_from_R_a), R_a(ti::a));
+  // \f$L_{a}{}^{t} = R_{a}\f$
+  auto L_aT_from_R_a =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::a, ti::T>(make_not_null(&L_aT_from_R_a), R_a(ti::a));
+  // \f$L_{t}{}^{a} = R^{a}\f$
+  auto L_tA_from_R_A =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::A>(make_not_null(&L_tA_from_R_A), R_A(ti::A));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    CHECK(L_at_from_R_a.get(a, 0) == R_a.get(a));
+    CHECK(L_ta_from_R_a.get(0, a) == R_a.get(a));
+    CHECK(L_AT_from_R_A.get(a, 0) == R_A.get(a));
+    CHECK(L_TA_from_R_A.get(0, a) == R_A.get(a));
+    CHECK(L_At_from_R_A.get(a, 0) == R_A.get(a));
+    CHECK(L_Ta_from_R_a.get(0, a) == R_a.get(a));
+    CHECK(L_aT_from_R_a.get(a, 0) == R_a.get(a));
+    CHECK(L_tA_from_R_A.get(0, a) == R_A.get(a));
+
     for (size_t i = 0; i < dim; i++) {
-      CHECK(Lat_from_R_a.get(a, i + 1) ==
+      CHECK(L_at_from_R_a.get(a, i + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_ta_from_R_a.get(i + 1, a) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_AT_from_R_A.get(a, i + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_TA_from_R_A.get(i + 1, a) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_At_from_R_A.get(a, i + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_Ta_from_R_a.get(i + 1, a) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_aT_from_R_a.get(a, i + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_tA_from_R_A.get(i + 1, a) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+    }
+  }
+
+  // Evaluations of symmetric LHS tensors
+
+  // \f$M_{at} = R_{a}\f$
+  auto M_at_from_R_a =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::a, ti::t>(make_not_null(&M_at_from_R_a), R_a(ti::a));
+  // \f$M_{ta} = R_{a}\f$
+  auto M_ta_from_R_a =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::a>(make_not_null(&M_ta_from_R_a), R_a(ti::a));
+  // \f$M^{at} = R^{a}\f$
+  auto M_AT_from_R_A =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::A, ti::T>(make_not_null(&M_AT_from_R_A), R_A(ti::A));
+  // \f$M^{ta} = R^{a}\f$
+  auto M_TA_from_R_A =
+      make_with_value<Tensor<DataType, Symmetry<1, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::A>(make_not_null(&M_TA_from_R_A), R_A(ti::A));
+
+  for (size_t a = 0; a < dim + 1; a++) {
+    for (size_t b = a; b < dim + 1; b++) {
+      if (a == 0) {
+        CHECK(M_at_from_R_a.get(a, b) == R_a.get(b));
+        CHECK(M_ta_from_R_a.get(a, b) == R_a.get(b));
+        CHECK(M_AT_from_R_A.get(a, b) == R_A.get(b));
+        CHECK(M_TA_from_R_A.get(a, b) == R_A.get(b));
+      } else {
+        CHECK(M_at_from_R_a.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(M_ta_from_R_a.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(M_AT_from_R_A.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+        CHECK(M_TA_from_R_A.get(a, b) ==
+              TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      }
+    }
+  }
+
+  // Evaluations of RHS tensors with one spatial and one spacetime index
+
+  const auto R_i = make_with_random_values<Tensor<
+      DataType, Symmetry<1>, index_list<SpatialIndex<dim, UpLo::Lo, frame>>>>(
+      generator, distribution, used_for_size);
+  const auto R_I = make_with_random_values<Tensor<
+      DataType, Symmetry<1>, index_list<SpatialIndex<dim, UpLo::Up, frame>>>>(
+      generator, distribution, used_for_size);
+
+  // \f$L_{it} = R_{i}\f$
+  auto L_it_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpatialIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::i, ti::t>(make_not_null(&L_it_from_R_i), R_i(ti::i));
+  // \f$L_{ti} = R_{i}\f$
+  auto L_ti_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpatialIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::i>(make_not_null(&L_ti_from_R_i), R_i(ti::i));
+  // \f$L^{it} = R^{i}\f$
+  auto L_IT_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpatialIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::I, ti::T>(make_not_null(&L_IT_from_R_I), R_I(ti::I));
+  // \f$L^{ti} = R^{i}\f$
+  auto L_TI_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpatialIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::I>(make_not_null(&L_TI_from_R_I), R_I(ti::I));
+  // \f$L^{i}{}_{t} = R^{i}\f$
+  auto L_It_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpatialIndex<dim, UpLo::Up, frame>,
+                                        SpacetimeIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::I, ti::t>(make_not_null(&L_It_from_R_I), R_I(ti::I));
+  // \f$L^{t}{}_{i} = R_{i}\f$
+  auto L_Ti_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Up, frame>,
+                                        SpatialIndex<dim, UpLo::Lo, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::T, ti::i>(make_not_null(&L_Ti_from_R_i), R_i(ti::i));
+  // \f$L_{i}{}^{t} = R_{i}\f$
+  auto L_iT_from_R_i =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpatialIndex<dim, UpLo::Lo, frame>,
+                                        SpacetimeIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::i, ti::T>(make_not_null(&L_iT_from_R_i), R_i(ti::i));
+  // \f$L_{t}{}^{i} = R^{i}\f$
+  auto L_tI_from_R_I =
+      make_with_value<Tensor<DataType, Symmetry<2, 1>,
+                             index_list<SpacetimeIndex<dim, UpLo::Lo, frame>,
+                                        SpatialIndex<dim, UpLo::Up, frame>>>>(
+          used_for_size,
+          TestHelpers::tenex::component_placeholder_value<DataType>::value);
+  tenex::evaluate<ti::t, ti::I>(make_not_null(&L_tI_from_R_I), R_I(ti::I));
+
+  for (size_t i = 0; i < dim; i++) {
+    CHECK(L_it_from_R_i.get(i, 0) == R_i.get(i));
+    CHECK(L_ti_from_R_i.get(0, i) == R_i.get(i));
+    CHECK(L_IT_from_R_I.get(i, 0) == R_I.get(i));
+    CHECK(L_TI_from_R_I.get(0, i) == R_I.get(i));
+    CHECK(L_It_from_R_I.get(i, 0) == R_I.get(i));
+    CHECK(L_Ti_from_R_i.get(0, i) == R_i.get(i));
+    CHECK(L_iT_from_R_i.get(i, 0) == R_i.get(i));
+    CHECK(L_tI_from_R_I.get(0, i) == R_I.get(i));
+    for (size_t j = 0; j < dim; j++) {
+      CHECK(L_it_from_R_i.get(i, j + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_ti_from_R_i.get(j + 1, i) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_IT_from_R_I.get(i, j + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_TI_from_R_I.get(j + 1, i) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_It_from_R_I.get(i, j + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_Ti_from_R_i.get(j + 1, i) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_iT_from_R_i.get(i, j + 1) ==
+            TestHelpers::tenex::component_placeholder_value<DataType>::value);
+      CHECK(L_tI_from_R_I.get(j + 1, i) ==
             TestHelpers::tenex::component_placeholder_value<DataType>::value);
     }
   }
 }
 
-// \brief Test evaluation of tensors where concrete time indices are used for
-// RHS and LHS spacetime indices
+// \brief Test evaluation of rank 2 tensors where concrete time indices are used
+// for RHS and LHS spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
+template <typename DataType>
+void test_rhs_and_lhs_rank_2() {
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::t>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::a, ti::t, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::t, ti::a>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::t, ti::a, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::t, ti::t>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::t, ti::t, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::T, ti::T>();
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<1, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::T, ti::T, Symmetry<2, 1>>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::A, ti::t>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::T, ti::a>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::a, ti::T>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::t, ti::A>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::t, ti::i>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>>,
+      ti::i, ti::t>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::I, ti::t>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                 SpatialIndex<2, UpLo::Lo, Frame::Inertial>>,
+      ti::T, ti::i>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                 SpacetimeIndex<2, UpLo::Up, Frame::Inertial>>,
+      ti::i, ti::T>();
+
+  TestHelpers::tenex::test_evaluate_rank_2_impl<
+      false, DataType, Symmetry<2, 1>,
+      index_list<SpacetimeIndex<3, UpLo::Lo, Frame::Inertial>,
+                 SpatialIndex<3, UpLo::Up, Frame::Inertial>>,
+      ti::t, ti::I>();
+}
+
+// \brief Test evaluation of rank 4 tensors where concrete time indices are used
+// for RHS and LHS spacetime indices
 //
 // \tparam DataType the type of data being stored in the expression operands
 template <typename Generator, typename DataType>
-void test_rhs_and_lhs(const gsl::not_null<Generator*> generator,
-                      const DataType& used_for_size) {
+void test_rhs_and_lhs_rank_4(const gsl::not_null<Generator*> generator,
+                             const DataType& used_for_size) {
   std::uniform_real_distribution<> distribution(0.1, 1.0);
   constexpr size_t dim = 3;
 
@@ -137,25 +826,24 @@ void test_rhs_and_lhs(const gsl::not_null<Generator*> generator,
   }
 }
 
+// \brief Test evaluation of tensors where concrete time indices are used for
+// spacetime indices
+//
+// \tparam DataType the type of data being stored in the expression operands
 template <typename DataType>
-void test_evaluate_spatial_spacetime_index(const DataType& used_for_size) {
+void test_evaluate_time_index(const DataType& used_for_size) {
   MAKE_GENERATOR(generator);
 
   test_rhs(make_not_null(&generator), used_for_size);
   test_lhs(make_not_null(&generator), used_for_size);
-  test_rhs_and_lhs(make_not_null(&generator), used_for_size);
+  test_rhs_and_lhs_rank_2<DataType>();
+  test_rhs_and_lhs_rank_4(make_not_null(&generator), used_for_size);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.EvaluateTimeIndex",
                   "[DataStructures][Unit]") {
-  test_evaluate_spatial_spacetime_index(
-      std::numeric_limits<double>::signaling_NaN());
-  test_evaluate_spatial_spacetime_index(
-      std::complex<double>(std::numeric_limits<double>::signaling_NaN(),
-                           std::numeric_limits<double>::signaling_NaN()));
-  test_evaluate_spatial_spacetime_index(
-      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
-  test_evaluate_spatial_spacetime_index(
-      ComplexDataVector(5, std::numeric_limits<double>::signaling_NaN()));
+  test_evaluate_time_index(std::numeric_limits<double>::signaling_NaN());
+  test_evaluate_time_index(
+      DataVector(3, std::numeric_limits<double>::signaling_NaN()));
 }


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug where `TensorExpression`s was not always correctly evaluating the right subset of components when spatial and/or time `TensorIndex`s were used for **symmetric** spacetime indices.

The following test case revealed the bug and motivated the fix in this PR, where `g` (spacetime metric) is a rank 2 symmetric spacetime tensor :
```
// g_{ti} = ...
 tenex::evaluate<ti::t, ti::i>(g, ...);
```
`tenex::evaluate` would loop over the canonical multi-indices (defined by `Tensor_detail::Structure`), hit the multi-index `{1, 0}` and not evaluate it (`g_{10}`) because the existing logic simply checks if `1` is a valid index value for `t` and `0` for `i`. However, `{1, 0}` *should* be evaluated, due to symmetry.

This PR reorders the LHS indices to avoid false negatives fand false positives like this, and it greatly expands test coverage for `tenex::evaluate` with tensors that have symmetric indices and spacetime indices where spatial and/or time indices are used. This increased test coverage is both to demonstrate that the solution works and because test coverage for symmetric indices should be increased, anyway.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
