### PR TITLE
Test_Apply_TYlmFilter: fix logic bug.

### DIFF
--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ApplyTensorYlmFilter.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ApplyTensorYlmFilter.cpp
@@ -165,7 +165,7 @@ void test_modal_nodal_invertibility() {
 
 void test_apply_filter(const size_t num_to_kill) {
   constexpr size_t radial_extents = 2;
-  constexpr size_t ell_max = 7;
+  constexpr size_t ell_max = 9;
 
   const auto& ylm = ::ylm::get_spherepack_cache(ell_max);
   const size_t spectral_mesh_size = ylm.spectral_size() * radial_extents;
@@ -275,19 +275,36 @@ void test_apply_filter(const size_t num_to_kill) {
             for (it.reset(); it; ++it) {
               // If num_to_kill is zero, then all the coefs
               // should agree with the originals.
-              // If num_to_kill is nonzero, then all the modes
+              // If num_to_kill is nonzero, then:
+              //  - lcut is the largest mode that is LEFT ALONE
+              //    in the Spin-weighted basis.  So lcut=lmax-num_to_kill
+              //  - In the Cartesian basis, lcut+rank+1 is the smallest
+              //    mode that is zeroed.  This is lmax-num_to_kill+rank+1.
+              //  - In the Cartesian basis, lcut-rank is the largest mode
+              //    that is unaffected. This is lmax-num_to_kill-rank.
+              // Therefore all coefs
               // with (ell <= ell_max - num_to_kill - rank) should agree
-              // with the originals because they have not been affected,
-              // and all the modes with (ell >= ell_max - num_to_kill + rank-1)
+              // with the originals because they have not been affected, and
+              // all the modes with (ell >= ell_max - num_to_kill + rank+1)
               // should be zero because they have been killed by the filter.
               // For modes between those cases, they are modified in some
               // complicated way that we do not check here.
               if (num_to_kill == 0 or
                   it.l() <= ell_max - num_to_kill - tensor_b.rank()) {
+                CAPTURE(ell_max);
+                CAPTURE(it.l());
+                CAPTURE(num_to_kill);
+                CAPTURE(tensor_b.rank());
                 CHECK(a[it() + offset] == approx(b[it() + offset]));
               } else if (it.l() >=
-                         ell_max - num_to_kill + tensor_b.rank() - 1) {
-                CHECK(0.0 == approx(b[it() + offset]));
+                         ell_max - num_to_kill + tensor_a.rank() + 1) {
+                // The two tensors have the same rank, so it doesn't matter
+                // whether we use tensor_a.rank() or tensor_b.rank() here.
+                CAPTURE(ell_max);
+                CAPTURE(it.l());
+                CAPTURE(num_to_kill);
+                CAPTURE(tensor_a.rank());
+                CHECK(0.0 == approx(a[it() + offset]));
               }
             }
           }
@@ -295,15 +312,15 @@ void test_apply_filter(const size_t num_to_kill) {
       });
 }
 
-// Debug builds are slightly > 5 seconds, so increase the timeout.
-// [[TimeOut, 10]]
+// Debug builds are timing out slightly, so increase the timeout.
+// [[TimeOut, 20]]
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.ApplyTensorYlmFilter",
                   "[NumericalAlgorithms][Unit]") {
   test_break_spacetime_vars_into_spatial_pieces();
   test_transform_spatial_tensors_to_different_frame();
   test_modal_nodal_invertibility();
   test_apply_filter(0);
-  test_apply_filter(2);
+  test_apply_filter(5);
 }
 }  // namespace
 }  // namespace ylm::TensorYlm


### PR DESCRIPTION
The formula for modes that should be zeroed was previously calculated incorrectly.  It was a sign error.
The bug was only in the test, and for some reason it did not show up with num_to_kill=2

Added more CAPTUREs and more comments.

Now do the test with num_to_kill=3 where the previous bug showed up.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
