### PR TITLE
Add block_ids_from_names

### DIFF
--- a/src/Domain/Structure/BlockGroups.cpp
+++ b/src/Domain/Structure/BlockGroups.cpp
@@ -58,4 +58,21 @@ std::unordered_set<std::string> expand_block_groups_to_block_names(
   return expanded_block_names;
 }
 
+std::set<size_t> block_ids_from_names(
+    const std::vector<std::string>& block_or_group_names,
+    const std::vector<std::string>& all_block_names,
+    const std::unordered_map<std::string, std::unordered_set<std::string>>&
+        block_groups) {
+  std::set<size_t> result{};
+  // Get the block ID of each block name
+  for (const auto& block_name : expand_block_groups_to_block_names(
+           block_or_group_names, all_block_names, block_groups)) {
+    result.insert(static_cast<size_t>(
+        std::distance(all_block_names.begin(),
+                      std::find(all_block_names.begin(), all_block_names.end(),
+                                block_name))));
+  }
+  return result;
+}
+
 }  // namespace domain

--- a/src/Domain/Structure/BlockGroups.hpp
+++ b/src/Domain/Structure/BlockGroups.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -37,6 +38,21 @@ bool block_is_in_group(
  * names from that group are included. Overlaps between groups are allowed.
  */
 std::unordered_set<std::string> expand_block_groups_to_block_names(
+    const std::vector<std::string>& block_or_group_names,
+    const std::vector<std::string>& all_block_names,
+    const std::unordered_map<std::string, std::unordered_set<std::string>>&
+        block_groups);
+
+/*!
+ * \brief Get the block IDs corresponding to the given block or group names.
+ *
+ * \param block_or_group_names Block names to get the IDs of. Any block groups
+ * in this list are expanded.
+ * \param all_block_names All block names in the domain.
+ * \param block_groups Block groups used to expand the names.
+ * \return std::set<size_t> Set of block IDs.
+ */
+std::set<size_t> block_ids_from_names(
     const std::vector<std::string>& block_or_group_names,
     const std::vector<std::string>& all_block_names,
     const std::unordered_map<std::string, std::unordered_set<std::string>>&

--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -167,15 +167,12 @@ struct SetSubcellGrid {
         [&subcell_options](const auto& direction_and_neighbor) {
           const size_t first_block_id =
               direction_and_neighbor.second.ids().begin()->block_id();
-          return std::binary_search(subcell_options.only_dg_block_ids().begin(),
-                                    subcell_options.only_dg_block_ids().end(),
-                                    first_block_id);
+          return subcell_options.only_dg_block_ids().contains(first_block_id);
         });
 
     const bool subcell_allowed_in_element =
-        not std::binary_search(subcell_options.only_dg_block_ids().begin(),
-                               subcell_options.only_dg_block_ids().end(),
-                               element.id().block_id()) and
+        not subcell_options.only_dg_block_ids().contains(
+            element.id().block_id()) and
         not bordering_dg_block;
     const bool cell_is_not_on_external_boundary =
         db::get<::domain::Tags::Element<Dim>>(box)

--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -150,18 +150,15 @@ struct TciAndRollback {
         [&subcell_options](const auto& direction_and_neighbor) {
           const size_t first_block_id =
               direction_and_neighbor.second.ids().begin()->block_id();
-          return std::binary_search(subcell_options.only_dg_block_ids().begin(),
-                                    subcell_options.only_dg_block_ids().end(),
-                                    first_block_id);
+          return subcell_options.only_dg_block_ids().contains(first_block_id);
         });
 
     // Subcell is allowed in the element if 2 conditions are met:
     // (i)  The current element block id is not marked as DG only
     // (ii) The current element is not bordering a DG only block.
     const bool subcell_allowed_in_element =
-        not std::binary_search(subcell_options.only_dg_block_ids().begin(),
-                               subcell_options.only_dg_block_ids().end(),
-                               element.id().block_id()) and
+        not subcell_options.only_dg_block_ids().contains(
+            element.id().block_id()) and
         not bordering_dg_block;
 
     // The reason we pass in the persson_exponent explicitly instead of

--- a/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp
@@ -173,9 +173,7 @@ struct TciAndSwitchToDg {
 
     // This should never be run if we are prohibited from using subcell on this
     // element.
-    ASSERT(not std::binary_search(
-               subcell_options.only_dg_block_ids().begin(),
-               subcell_options.only_dg_block_ids().end(),
+    ASSERT(not subcell_options.only_dg_block_ids().contains(
                db::get<domain::Tags::Element<Dim>>(box).id().block_id()),
            "Should never use subcell on element "
                << db::get<domain::Tags::Element<Dim>>(box).id());

--- a/src/Evolution/DgSubcell/SetInterpolators.hpp
+++ b/src/Evolution/DgSubcell/SetInterpolators.hpp
@@ -89,8 +89,7 @@ struct SetInterpolators {
       const ElementMap<Dim, Frame::Grid>& element_map,
       const ReconstructorType& reconstructor,
       const evolution::dg::subcell::SubcellOptions& subcell_options) {
-    if (alg::found(subcell_options.only_dg_block_ids(),
-                   element.id().block_id())) {
+    if (subcell_options.only_dg_block_ids().contains(element.id().block_id())) {
       return;
     }
     const bool enable_extension_directions =

--- a/src/Evolution/DgSubcell/SubcellOptions.cpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.cpp
@@ -47,7 +47,7 @@ SubcellOptions::SubcellOptions(
       min_clear_tci_before_dg_(min_clear_tci_before_dg),
       fd_to_fd_interp_order_(fd_to_fd_interp_order) {
   if (not only_dg_block_and_group_names_.has_value()) {
-    only_dg_block_ids_ = std::vector<size_t>{};
+    only_dg_block_ids_ = std::set<size_t>{};
   }
   ASSERT(number_of_steps_between_tci_calls_ > 0,
          "number_of_steps_between_tci_calls_ must be greater than zero.");
@@ -67,23 +67,10 @@ SubcellOptions::SubcellOptions(
     const SubcellOptions& subcell_options_with_block_names,
     const DomainCreator<Dim>& domain_creator) {
   *this = subcell_options_with_block_names;
-
-  const auto& only_dg_block_and_group_names =
-      subcell_options_with_block_names.only_dg_block_and_group_names_;
-  const auto block_names = domain_creator.block_names();
-  const auto only_dg_block_names = domain::expand_block_groups_to_block_names(
-      only_dg_block_and_group_names.value_or(std::vector<std::string>{}),
-      block_names, domain_creator.block_groups());
-  only_dg_block_ids_ = std::vector<size_t>{};
-  only_dg_block_ids_.value().reserve(only_dg_block_names.size());
-  // Get the block ID of each block name
-  for (const auto& block_name : only_dg_block_names) {
-    only_dg_block_ids_.value().push_back(static_cast<size_t>(std::distance(
-        block_names.begin(),
-        std::find(block_names.begin(), block_names.end(), block_name))));
-  }
-  // Sort the block IDs just so they're easier to deal with.
-  alg::sort(only_dg_block_ids_.value());
+  only_dg_block_ids_ = domain::block_ids_from_names(
+      subcell_options_with_block_names.only_dg_block_and_group_names_.value_or(
+          std::vector<std::string>{}),
+      domain_creator.block_names(), domain_creator.block_groups());
 }
 
 void SubcellOptions::pup(PUP::er& p) {

--- a/src/Evolution/DgSubcell/SubcellOptions.hpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <limits>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -272,7 +273,7 @@ class SubcellOptions {
 
   bool use_halo() const { return use_halo_; }
 
-  const std::vector<size_t>& only_dg_block_ids() const {
+  const std::set<size_t>& only_dg_block_ids() const {
     ASSERT(only_dg_block_ids_.has_value(),
            "The block IDs on which we are only allowed to do DG have not been "
            "set.");
@@ -322,7 +323,7 @@ class SubcellOptions {
       fd::ReconstructionMethod::AllDimsAtOnce;
   bool use_halo_{false};
   std::optional<std::vector<std::string>> only_dg_block_and_group_names_{};
-  std::optional<std::vector<size_t>> only_dg_block_ids_{};
+  std::optional<std::set<size_t>> only_dg_block_ids_{};
   ::fd::DerivativeOrder finite_difference_derivative_order_{};
   size_t number_of_steps_between_tci_calls_{1};
   size_t min_tci_calls_after_rollback_{1};

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ZeroTimeDerivatives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ZeroTimeDerivatives.hpp
@@ -41,13 +41,10 @@ struct ZeroMhdTimeDerivatives {
         [&subcell_options](const auto& direction_and_neighbor) {
           const size_t first_block_id =
               direction_and_neighbor.second.ids().begin()->block_id();
-          return std::binary_search(subcell_options.only_dg_block_ids().begin(),
-                                    subcell_options.only_dg_block_ids().end(),
-                                    first_block_id);
+          return subcell_options.only_dg_block_ids().contains(first_block_id);
         });
-    const bool in_dg_only_zone = std::binary_search(
-        subcell_options.only_dg_block_ids().begin(),
-        subcell_options.only_dg_block_ids().end(), element.id().block_id());
+    const bool in_dg_only_zone =
+        subcell_options.only_dg_block_ids().contains(element.id().block_id());
     if (bordering_dg_block and not in_dg_only_zone) {
       tmpl::for_each<
           typename grmhd::ValenciaDivClean::System::variables_tag::tags_list>(

--- a/src/IO/H5/CombineH5.cpp
+++ b/src/IO/H5/CombineH5.cpp
@@ -78,7 +78,7 @@ size_t get_number_of_elements(const std::vector<std::string>& input_filenames,
   return total_elements;
 }
 
-std::optional<std::unordered_set<size_t>> get_block_numbers_to_use(
+std::optional<std::set<size_t>> get_block_numbers_to_use(
     const std::string& file_name, const std::string& subfile_name,
     const std::optional<std::vector<std::string>>& blocks_to_combine) {
   if (not blocks_to_combine.has_value() or blocks_to_combine.value().empty()) {
@@ -96,51 +96,31 @@ std::optional<std::unordered_set<size_t>> get_block_numbers_to_use(
           << ". This means we cannot filter based on block names. You can "
              "still combine the files but will need to use all blocks.");
   }
-  std::unordered_set<std::string> block_names_to_combine{};
-  std::vector<std::string> block_names_in_domain{};
   switch (dim) {
     case 1: {
       const auto domain =
           deserialize<Domain<1>>(serialized_domain.value().data());
-      block_names_in_domain = domain.block_names();
-      block_names_to_combine = domain::expand_block_groups_to_block_names(
-          blocks_to_combine.value(), domain.block_names(),
-          domain.block_groups());
-      break;
+      return domain::block_ids_from_names(blocks_to_combine.value(),
+                                          domain.block_names(),
+                                          domain.block_groups());
     }
     case 2: {
       const auto domain =
           deserialize<Domain<2>>(serialized_domain.value().data());
-      block_names_in_domain = domain.block_names();
-      block_names_to_combine = domain::expand_block_groups_to_block_names(
-          blocks_to_combine.value(), domain.block_names(),
-          domain.block_groups());
-      break;
+      return domain::block_ids_from_names(blocks_to_combine.value(),
+                                          domain.block_names(),
+                                          domain.block_groups());
     }
     case 3: {
       const auto domain =
           deserialize<Domain<3>>(serialized_domain.value().data());
-      block_names_in_domain = domain.block_names();
-      block_names_to_combine = domain::expand_block_groups_to_block_names(
-          blocks_to_combine.value(), domain.block_names(),
-          domain.block_groups());
-      break;
+      return domain::block_ids_from_names(blocks_to_combine.value(),
+                                          domain.block_names(),
+                                          domain.block_groups());
     }
     default:
       ERROR("Only can handle 1, 2, or 3d domains not " << dim);
   };
-
-  std::unordered_set<size_t> blocks_to_use{};
-  for (const std::string& block_to_combine : block_names_to_combine) {
-    auto location_it = alg::find(block_names_in_domain, block_to_combine);
-    if (location_it == block_names_in_domain.end()) {
-      ERROR("Block name " << block_to_combine << " not found.");
-    }
-    blocks_to_use.insert(static_cast<size_t>(
-        std::distance(block_names_in_domain.begin(), location_it)));
-  }
-
-  return blocks_to_use;
 }
 }  // namespace
 
@@ -192,7 +172,7 @@ void combine_h5_vol(
     ERROR("No observation IDs found in subfile" << subfile_name);
   }
 
-  const std::optional<std::unordered_set<size_t>> blocks_to_use =
+  const std::optional<std::set<size_t>> blocks_to_use =
       get_block_numbers_to_use(file_names[0], subfile_name, blocks_to_combine);
 
   // Loops over observation ids to write volume data by observation id

--- a/tests/Unit/Domain/Structure/Test_BlockGroups.cpp
+++ b/tests/Unit/Domain/Structure/Test_BlockGroups.cpp
@@ -36,6 +36,8 @@ SPECTRE_TEST_CASE("Unit.Domain.BlockGroups", "[Domain][Unit]") {
       Catch::Matchers::ContainsSubstring(
           "The block or group 'NoBlock' is not one of the block names or "
           "groups of the domain."));
+  CHECK(block_ids_from_names({"Block1", "Group2"}, all_block_names,
+                             block_groups) == std::set<size_t>{0, 2, 3});
 }
 
 }  // namespace domain

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -341,12 +341,11 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
       [&subcell_options](const auto& direction_and_neighbor) {
         const size_t first_block_id =
             direction_and_neighbor.second.ids().begin()->block_id();
-        return alg::found(subcell_options.only_dg_block_ids(), first_block_id);
+        return subcell_options.only_dg_block_ids().contains(first_block_id);
       });
 
-  const bool self_block_dg_only = std::binary_search(
-      subcell_options.only_dg_block_ids().begin(),
-      subcell_options.only_dg_block_ids().end(), element.id().block_id());
+  const bool self_block_dg_only =
+      subcell_options.only_dg_block_ids().contains(element.id().block_id());
 
   // assign value of passed in variable.  Used as a test in apply() above
   metavars::expected_evolve_on_dg_after_tci_failure =


### PR DESCRIPTION
## Proposed changes

Useful to parse block and group names from options to block IDs. Factoring this out because I'm reusing it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
