### PR TITLE
Reorganize GH char speed mesh velocity

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -281,15 +281,6 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
       three_index_constraint, gauge_source, spacetime_deriv_gauge_source, dt_pi,
       dt_phi, dt_spacetime_metric, d_pi, d_phi, d_spacetime_metric);
 
-  // Account for moving mesh: char speeds -> cher speeds - n_i v^i_g
-  if (face_mesh_velocity.has_value()) {
-    const auto radial_mesh_velocity =
-        get(dot_product(normal_covector, *face_mesh_velocity));
-    for (size_t a = 0; a < 4; ++a) {
-      char_speeds.at(a) -= radial_mesh_velocity;
-    }
-  }
-
   // If no point on the boundary has any incoming characteristic, return here
   if (min_characteristic_speed(char_speeds) >= 0.) {
     std::fill(dt_spacetime_metric_correction->begin(),

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -52,18 +52,9 @@ DemandOutgoingCharSpeeds<Dim>::dg_demand_outgoing_char_speeds(
   const auto char_speeds = characteristic_speeds(
       gamma_1, lapse, shift, outward_directed_normal_covector,
       face_mesh_velocity);
-  Scalar<DataVector> normal_dot_mesh_velocity;
-  if (face_mesh_velocity.has_value()) {
-    normal_dot_mesh_velocity = dot_product(outward_directed_normal_covector,
-                                           face_mesh_velocity.value());
-  }
   double min_speed = std::numeric_limits<double>::signaling_NaN();
   for (size_t i = 0; i < char_speeds.size(); ++i) {
-    if (face_mesh_velocity.has_value()) {
-      min_speed = min(gsl::at(char_speeds, i) - get(normal_dot_mesh_velocity));
-    } else {
-      min_speed = min(gsl::at(char_speeds, i));
-    }
+    min_speed = min(gsl::at(char_speeds, i));
     if (min_speed < 0.0) {
       return {MakeString{}
               << "DemandOutgoingCharSpeeds boundary condition violated with "

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -27,16 +27,20 @@ void characteristic_speeds(
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
     const std::optional<tnsr::I<DataVector, Dim, Frame>>& mesh_velocity) {
-  const auto shift_dot_normal = get(dot_product(shift, unit_normal_one_form));
+  auto shift_dot_normal = dot_product(shift, unit_normal_one_form);
   (*char_speeds)[0] =
-      -(1. + get(gamma_1)) * shift_dot_normal;  // lambda(VSpacetimeMetric)
+      -(1. + get(gamma_1)) * get(shift_dot_normal);  // lambda(VSpacetimeMetric)
+  (*char_speeds)[1] = -get(shift_dot_normal);        // lambda(VZero)
+  (*char_speeds)[2] = -get(shift_dot_normal) + get(lapse);  // lambda(VPlus)
+  (*char_speeds)[3] = -get(shift_dot_normal) - get(lapse);  // lambda(VMinus)
   if (mesh_velocity.has_value()) {
-    (*char_speeds)[0] -=
-        get(gamma_1) * get(dot_product((*mesh_velocity), unit_normal_one_form));
+    dot_product(make_not_null(&shift_dot_normal), *mesh_velocity,
+                unit_normal_one_form);
+    (*char_speeds)[0] -= (1. + get(gamma_1)) * get(shift_dot_normal);
+    (*char_speeds)[1] -= get(shift_dot_normal);
+    (*char_speeds)[2] -= get(shift_dot_normal);
+    (*char_speeds)[3] -= get(shift_dot_normal);
   }
-  (*char_speeds)[1] = -shift_dot_normal;        // lambda(VZero)
-  (*char_speeds)[2] = -shift_dot_normal + get(lapse);  // lambda(VPlus)
-  (*char_speeds)[3] = -shift_dot_normal - get(lapse);  // lambda(VMinus)
 }
 
 template <size_t Dim, typename Frame>

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/DemandOutgoingCharSpeeds.cpp
@@ -50,9 +50,6 @@ DemandOutgoingCharSpeeds::dg_demand_outgoing_char_speeds(
     for (auto& char_speed : csw_char_speeds) {
       char_speed -= get(face_speed);
     }
-    for (auto& char_speed : gh_char_speeds) {
-      char_speed -= get(face_speed);
-    }
   }
   for (size_t i = 0; i < csw_char_speeds.size(); ++i) {
     if (min(csw_char_speeds[i]) < 0.) {

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -623,12 +623,28 @@ def compute_intermediate_vars(
         "i,ia->a", unit_interface_normal_vector, two_index_constraint_
     )
 
-    char_speeds = [
-        ght.char_speed_upsi(gamma1, lapse, shift, normal_covector),
-        ght.char_speed_uzero(gamma1, lapse, shift, normal_covector),
-        ght.char_speed_uplus(gamma1, lapse, shift, normal_covector),
-        ght.char_speed_uminus(gamma1, lapse, shift, normal_covector),
-    ]
+    if face_mesh_velocity is not None:
+        char_speeds = [
+            ght.char_speed_upsi_moving_mesh(
+                gamma1, lapse, shift, normal_covector, face_mesh_velocity
+            ),
+            ght.char_speed_uzero_moving_mesh(
+                gamma1, lapse, shift, normal_covector, face_mesh_velocity
+            ),
+            ght.char_speed_uplus_moving_mesh(
+                gamma1, lapse, shift, normal_covector, face_mesh_velocity
+            ),
+            ght.char_speed_uminus_moving_mesh(
+                gamma1, lapse, shift, normal_covector, face_mesh_velocity
+            ),
+        ]
+    else:
+        char_speeds = [
+            ght.char_speed_upsi(gamma1, lapse, shift, normal_covector),
+            ght.char_speed_uzero(gamma1, lapse, shift, normal_covector),
+            ght.char_speed_uplus(gamma1, lapse, shift, normal_covector),
+            ght.char_speed_uminus(gamma1, lapse, shift, normal_covector),
+        ]
 
     return (
         unit_interface_normal_vector,
@@ -720,8 +736,6 @@ def error(
             d_phi,
             d_spacetime_metric,
         )
-        char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
-        char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
         if (np.amin(char_speeds) < 0.0) and (
             np.dot(face_mesh_velocity, normal_covector) > 0.0
         ):
@@ -808,9 +822,6 @@ def dt_corrs_ConstraintPreservingGauge(
         d_phi,
         d_spacetime_metric,
     )
-    if face_mesh_velocity is not None:
-        char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
-        char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
     if np.amin(char_speeds) >= 0.0:
         return (pi * 0, phi * 0, pi * 0, pi * 0)
     dt_v_psi = constraint_preserving_corrections_dt_v_psi(
@@ -919,9 +930,6 @@ def dt_corrs_ConstraintPreservingGaugePhysical(
         d_phi,
         d_spacetime_metric,
     )
-    if face_mesh_velocity is not None:
-        char_speeds = char_speeds - np.dot(normal_covector, face_mesh_velocity)
-        char_speeds[0] -= np.dot(normal_covector, face_mesh_velocity) * gamma1
     if np.amin(char_speeds) >= 0.0:
         return (pi * 0, phi * 0, pi * 0, pi * 0)
     dt_v_psi = constraint_preserving_corrections_dt_v_psi(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
@@ -30,10 +30,9 @@ def error(
             speeds[i] -= np.dot(
                 outward_directed_normal_covector, face_mesh_velocity
             )
-            speeds[0] -= (
-                np.dot(outward_directed_normal_covector, face_mesh_velocity)
-                * gamma_1
-            )
+            speeds[0] -= np.dot(
+                outward_directed_normal_covector, face_mesh_velocity
+            ) * (1 + gamma_1)
         if speeds[i] < 0.0:
             return "DemandOutgoingCharSpeeds boundary condition violated"
     return None

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_AveragedUpwindPenalty.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/Test_AveragedUpwindPenalty.cpp
@@ -221,13 +221,6 @@ void test(const gsl::not_null<std::mt19937*> gen, const size_t num_pts) {
         get<gh::Tags::ConstraintGamma1>(average_fields), lapse, shift,
         unit_normal_one_form,
         std::optional{get<MeshVelocity<Dim>>(average_fields)});
-    // Add mesh advection terms
-    const auto advection_speed =
-        tenex::evaluate(unit_normal_one_form(ti::i) *
-                        get<MeshVelocity<Dim>>(average_fields)(ti::I));
-    for (auto& speed : speeds) {
-      speed -= get(advection_speed);
-    }
 
     using CharacteristicFields = Variables<
         tmpl::list<gh::Tags::VSpacetimeMetric<DataVector, Dim, Frame::Inertial>,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -311,21 +311,43 @@ def char_speed_upsi(gamma1, lapse, shift, unit_normal):
 def char_speed_upsi_moving_mesh(
     gamma1, lapse, shift, unit_normal, mesh_velocity
 ):
-    return -(1.0 + gamma1) * np.dot(shift, unit_normal) - gamma1 * np.dot(
-        mesh_velocity, unit_normal
-    )
+    return -(1.0 + gamma1) * np.dot(shift, unit_normal) - (
+        1.0 + gamma1
+    ) * np.dot(mesh_velocity, unit_normal)
 
 
 def char_speed_uzero(gamma1, lapse, shift, unit_normal):
     return -np.dot(shift, unit_normal)
 
 
+def char_speed_uzero_moving_mesh(
+    gamma1, lapse, shift, unit_normal, mesh_velocity
+):
+    return -np.dot(shift, unit_normal) - np.dot(mesh_velocity, unit_normal)
+
+
 def char_speed_uplus(gamma1, lapse, shift, unit_normal):
     return -np.dot(shift, unit_normal) + lapse
 
 
+def char_speed_uplus_moving_mesh(
+    gamma1, lapse, shift, unit_normal, mesh_velocity
+):
+    return (
+        -np.dot(shift, unit_normal) + lapse - np.dot(mesh_velocity, unit_normal)
+    )
+
+
 def char_speed_uminus(gamma1, lapse, shift, unit_normal):
     return -np.dot(shift, unit_normal) - lapse
+
+
+def char_speed_uminus_moving_mesh(
+    gamma1, lapse, shift, unit_normal, mesh_velocity
+):
+    return (
+        -np.dot(shift, unit_normal) - lapse - np.dot(mesh_velocity, unit_normal)
+    )
 
 
 # End test functions for characteristic speeds

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -60,14 +60,14 @@ Scalar<DataVector> speed_with_index(
       gh::characteristic_speeds(gamma_1, lapse, shift, normal, {})[Index]};
 }
 
-template <size_t Dim, typename Frame>
-Scalar<DataVector> char_speed_upsi_with_moving_mesh(
+template <size_t Index, size_t Dim, typename Frame>
+Scalar<DataVector> char_speed_with_moving_mesh(
     const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
     const tnsr::I<DataVector, Dim, Frame>& shift,
     const tnsr::i<DataVector, Dim, Frame>& normal,
     const tnsr::I<DataVector, Dim, Frame>& mesh_velocity) {
   return Scalar<DataVector>{gh::characteristic_speeds(
-      gamma_1, lapse, shift, normal, {mesh_velocity})[0]};
+      gamma_1, lapse, shift, normal, {mesh_velocity})[Index]};
 }
 
 template <size_t Dim, typename Frame>
@@ -89,8 +89,17 @@ void test_characteristic_speeds() {
                                     {{{-2.0, 2.0}}}, used_for_size);
 
   pypp::check_with_random_values<1>(
-      char_speed_upsi_with_moving_mesh<Dim, Frame>, "TestFunctions",
+      char_speed_with_moving_mesh<0, Dim, Frame>, "TestFunctions",
       "char_speed_upsi_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      char_speed_with_moving_mesh<1, Dim, Frame>, "TestFunctions",
+      "char_speed_uzero_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      char_speed_with_moving_mesh<2, Dim, Frame>, "TestFunctions",
+      "char_speed_uplus_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      char_speed_with_moving_mesh<3, Dim, Frame>, "TestFunctions",
+      "char_speed_uminus_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
 }
 
 template <size_t Dim, typename Frame>
@@ -116,8 +125,17 @@ void test_characteristic_speeds_on_strahlkorper() {
                                     {{{-2.0, 2.0}}}, used_for_size);
 
   pypp::check_with_random_values<1>(
-      char_speed_upsi_with_moving_mesh<Dim, Frame>, "TestFunctions",
+      char_speed_with_moving_mesh<0, Dim, Frame>, "TestFunctions",
       "char_speed_upsi_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      char_speed_with_moving_mesh<1, Dim, Frame>, "TestFunctions",
+      "char_speed_uzero_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      char_speed_with_moving_mesh<3, Dim, Frame>, "TestFunctions",
+      "char_speed_uminus_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      char_speed_with_moving_mesh<2, Dim, Frame>, "TestFunctions",
+      "char_speed_uplus_moving_mesh", {{{-2.0, 2.0}}}, used_for_size);
 }
 
 // Test return-by-reference GH char speeds by comparing to Kerr-Schild


### PR DESCRIPTION
## Proposed changes

GH's `characteristic_speeds()` does not add all mesh velocity terms, so they had to be manually added throughout. This is probably due to using SpEC's structure. This fixes that.


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
