### PR TITLE
TensorYlm filtering for CurvedScalarWave

### DIFF
--- a/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
+++ b/src/Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp
@@ -15,6 +15,7 @@
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 #include "IO/Observer/Actions/GetLockPointer.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
@@ -28,12 +29,6 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-namespace CurvedScalarWave::Tags {
-struct Psi;
-struct Pi;
-template <size_t SpatialDim>
-struct Phi;
-}  // namespace CurvedScalarWave::Tags
 namespace Parallel {
 class NodeLock;
 }  // namespace Parallel

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -56,9 +56,9 @@ struct Pi : db::SimpleTag {
  * \details If \f$\Psi\f$ is the scalar field then we define
  * \f$\Phi_{i} = \partial_i \Psi\f$
  */
-template <size_t SpatialDim>
+template <size_t SpatialDim, typename Frame>
 struct Phi : db::SimpleTag {
-  using type = tnsr::i<DataVector, SpatialDim>;
+  using type = tnsr::i<DataVector, SpatialDim, Frame>;
 };
 
 struct ConstraintGamma1 : db::SimpleTag {

--- a/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp
@@ -5,13 +5,14 @@
 
 #include <cstddef>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \brief Tags for the curved scalar wave system
 namespace CurvedScalarWave::Tags {
 struct Psi;
 struct Pi;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct Phi;
 
 struct ConstraintGamma1;

--- a/src/NumericalAlgorithms/SphericalHarmonics/ApplyTensorYlmFilter.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/ApplyTensorYlmFilter.cpp
@@ -4,6 +4,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/ApplyTensorYlmFilter.hpp"
 
 #include <cstddef>
+#include <cstring>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
@@ -203,6 +204,26 @@ void transform_spatial_tensors_to_different_frame_without_hessians(
                           jac.get(2, i) * src_phi_k00.get(2);
   }
 }
+
+template <typename SrcFrame, typename DestFrame>
+void transform_spatial_tensors_to_different_frame_without_hessians(
+    const gsl::not_null<Variables<sw_vars_list<DestFrame>>*> dest,
+    const Variables<sw_vars_list<SrcFrame>>& src,
+    const InverseJacobian<DataVector, 3, SrcFrame, DestFrame>& jac) {
+  const auto& [src_psi, src_pi, src_phi] = src;
+  auto& [dest_psi, dest_pi, dest_phi] = *dest;
+
+  // Just copy the scalars.
+  get<>(dest_psi) = get<>(src_psi);
+  get<>(dest_pi) = get<>(src_pi);
+
+  // Now do the vector.
+  for (size_t i = 0; i < 3; ++i) {
+    dest_phi.get(i) = jac.get(0, i) * src_phi.get(0) +
+                      jac.get(1, i) * src_phi.get(1) +
+                      jac.get(2, i) * src_phi.get(2);
+  }
+}
 }  // namespace filter_detail
 
 void apply_tensor_ylm_filter(
@@ -385,9 +406,171 @@ void apply_tensor_ylm_filter(
                                                              gh_spatial_vars);
 }
 
+void apply_tensor_ylm_filter(
+    const gsl::not_null<
+        Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        sw_vars,
+    const gsl::not_null<
+        Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        temp_storage,
+    const InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>&
+        jac_inertial_to_grid,
+    const InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>&
+        jac_grid_to_inertial,
+    const SimpleSparseMatrix& filter_matrix_scalar,
+    const SimpleSparseMatrix& filter_matrix_i, const size_t ell_max,
+    const size_t radial_extents) {
+  const auto& ylm = ylm::get_spherepack_cache(ell_max);
+  ASSERT(
+      radial_extents * ylm.physical_size() == sw_vars->number_of_grid_points(),
+      "Mismatch " << radial_extents * ylm.physical_size() << " must equal "
+                  << sw_vars->number_of_grid_points());
+  ASSERT(radial_extents * ylm.spectral_size() <=
+             temp_storage->number_of_grid_points(),
+         "Mismatch " << radial_extents * ylm.spectral_size() << " must be <= "
+                     << temp_storage->number_of_grid_points());
+
+  // Here we re-use the same memory multiple times.  Note that
+  // 1. sw_vars_to_filter has the same number of components as
+  //    sw_spatial_decomp_vars, even though the components are arranged
+  //    differently. So we can create a non-owning Variables of either
+  //    tag that points into the storage of a Variables with the opposite tag.
+  // 2. temp_storage has a larger size than sw_vars, because temp_storage
+  //    is sized to hold spectral coefficients (in S2) and sw_vars holds
+  //    collocation points (in S2).  This means that we can create a
+  //    non-owning Variables to hold collocation points but that points into
+  //    temp_storage (but we cannot create a non-owning Variables to hold
+  //    spectral coefficients that points into sw_vars).
+  //
+  // We define two different Variables that point into temp_storage
+  // (and we should not use any them simultaneously) and one
+  // Variables that points into sw_vars (which we should not use
+  // simultaneously with sw_vars).
+  Variables<filter_detail::sw_vars_list<Frame::Grid>>
+      sw_spectral_vars(temp_storage->data(), temp_storage->size());
+  Variables<filter_detail::sw_vars_list<Frame::Grid>> temp_grid_vars(
+      sw_vars->data(), sw_vars->size());
+  // The following Variables uses sw_vars->size() which is smaller
+  // than temp_storage->size().
+  ASSERT(sw_vars->size() <= temp_storage->size(),
+         "Should have " << sw_vars->size() << " <= " << temp_storage->size());
+  Variables<filter_detail::sw_vars_list<Frame::Grid>> temp_sw_vars(
+      temp_storage->data(), sw_vars->size());
+
+  // 1. Multiply by inverse Jacobians to get into (mostly) grid frame.
+  //    It's not really the grid frame because there are no Hessian
+  //    corrections, but those don't matter for this purpose.
+  // src: sw_vars
+  // dest: temp_sw_vars
+  filter_detail::transform_spatial_tensors_to_different_frame_without_hessians<
+      Frame::Inertial, Frame::Grid>(make_not_null(&temp_sw_vars), *sw_vars,
+                                    jac_inertial_to_grid);
+
+  // 1a. Copy
+  // src: temp_sw_vars
+  // dest: temp_grid_vars
+  std::memcpy(temp_grid_vars.data(), temp_sw_vars.data(),
+              temp_sw_vars.size() * sizeof(double));
+
+  // 2. Nodal to modal transformation.
+  // src: temp_grid_vars
+  // dest: sw_spectral_vars
+  filter_detail::nodal_to_modal_ylm(make_not_null(&sw_spectral_vars),
+                                    temp_grid_vars, ylm, radial_extents);
+
+  // 3. Filter
+  // src: sw_spectral_vars
+  // dest: sw_spectral_vars
+  // but using temp_grid_vars as temp storage for each tensor
+  tmpl::for_each<filter_detail::sw_vars_list<Frame::Grid>>(
+      [&sw_spectral_vars, &temp_grid_vars, radial_extents,
+       &filter_matrix_i,
+       &filter_matrix_scalar]<class Tag>(const tmpl::type_<Tag> /*meta*/) {
+        // Different compilers disagree on whether radial_extents
+        // needs to be in the capture list of this lambda, and
+        // whether radial_extents is 'used' in the lambda.
+        // Adding it to the capture list and adding a cast here
+        // satisfies everyone.
+        (void)radial_extents;
+        constexpr size_t num_independent_components =
+            Tag::type::structure::size();
+        // Create destination tensor: non-owning and pointing into
+        // temp_grid_vars.  temp_grid_vars is larger than any
+        // *SINGLE* tensor in sw_spectral_vars, so this is ok.
+        // Note that sw_spectral_vars.number_of_grid_points()
+        // is used for the size because that is the spectral size.
+        ASSERT(sw_spectral_vars.number_of_grid_points() *
+                       num_independent_components <=
+                   temp_grid_vars.size(),
+               "Insufficient size: must have "
+                   << sw_spectral_vars.number_of_grid_points() *
+                          num_independent_components
+                   << " <= " << temp_grid_vars.size());
+
+        Variables<tmpl::list<Tag>> dest_tensor(
+            temp_grid_vars.data(),
+            sw_spectral_vars.number_of_grid_points() *
+                num_independent_components);
+
+        // Delta term
+        get<Tag>(dest_tensor) = get<Tag>(sw_spectral_vars);
+        // The rest of the terms.
+
+        // Here we assume that different components in a given
+        // tensor are stored contiguously in memory, so we can grab a
+        // pointer to the first component of the tensor and pass that
+        // pointer to increment_multiply_on_right.
+        const gsl::span<double> src(
+            get<Tag>(sw_spectral_vars)[0].data(),
+            num_independent_components *
+                sw_spectral_vars.number_of_grid_points());
+        gsl::span<double> dest(
+            get<Tag>(dest_tensor)[0].data(),
+            num_independent_components * dest_tensor.number_of_grid_points());
+        // If the mesh is 3-dimensional (i.e. radial_extents>1), then
+        // we need to loop over offsets.  If not, then there's only
+        // one loop iteration.
+        const size_t stride = radial_extents;
+        for (size_t offset = 0; offset < stride; ++offset) {
+          // Each type of tensor gets a different filter matrix.
+          if constexpr (std::is_same_v<typename Tag::type::structure::symmetry,
+                                       Symmetry<1>>) {
+            filter_matrix_i.increment_multiply_on_right(
+                make_not_null(&dest), offset, stride, src, offset, stride);
+          } else {
+            filter_matrix_scalar.increment_multiply_on_right(
+                make_not_null(&dest), offset, stride, src, offset, stride);
+          }
+        }
+        // Copy the result for this tensor back into sw_spectral_vars.
+        get<Tag>(sw_spectral_vars) = get<Tag>(dest_tensor);
+      });
+
+  // 4. Modal to nodal transformation.
+  // src: sw_spectral_vars
+  // dest: temp_grid_vars
+  filter_detail::modal_to_nodal_ylm(make_not_null(&temp_grid_vars),
+                                    sw_spectral_vars, ylm, radial_extents);
+
+  // 4a. Copy
+  // src: temp_grid_vars
+  // dest: temp_sw_vars
+  std::memcpy(temp_sw_vars.data(), temp_grid_vars.data(),
+              temp_grid_vars.size() * sizeof(double));
+
+  // 5. Multiply by Jacobians to get back into inertial frame.
+  // src: temp_sw_vars
+  // dest: sw_vars
+  filter_detail::transform_spatial_tensors_to_different_frame_without_hessians<
+      Frame::Grid, Frame::Inertial>(sw_vars, temp_sw_vars,
+                                    jac_grid_to_inertial);
+}
+
 // Explicit instantiations
 
 namespace filter_detail {
+
+// generalized harmonic instantiations.
 
 template void nodal_to_modal_ylm<gh_spatial_vars_list<Frame::Grid>>(
     gsl::not_null<Variables<gh_spatial_vars_list<Frame::Grid>>*> modal,
@@ -420,6 +603,41 @@ template void transform_spatial_tensors_to_different_frame_without_hessians<
     gsl::not_null<Variables<gh_spatial_vars_list<Frame::Grid>>*> dest,
     const Variables<gh_spatial_vars_list<Frame::Inertial>>& src,
     const InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>& jac);
+
+// scalar wave instantiations
+
+template void nodal_to_modal_ylm<sw_vars_list<Frame::Grid>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Grid>>*> modal,
+    const Variables<sw_vars_list<Frame::Grid>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
+
+template void nodal_to_modal_ylm<sw_vars_list<Frame::Inertial>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Inertial>>*> modal,
+    const Variables<sw_vars_list<Frame::Inertial>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
+
+template void modal_to_nodal_ylm<sw_vars_list<Frame::Grid>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Grid>>*> modal,
+    const Variables<sw_vars_list<Frame::Grid>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
+
+template void modal_to_nodal_ylm<sw_vars_list<Frame::Inertial>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Inertial>>*> modal,
+    const Variables<sw_vars_list<Frame::Inertial>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
+
+template void transform_spatial_tensors_to_different_frame_without_hessians<
+    Frame::Grid, Frame::Inertial>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Inertial>>*> dest,
+    const Variables<sw_vars_list<Frame::Grid>>& src,
+    const InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>& jac);
+
+template void transform_spatial_tensors_to_different_frame_without_hessians<
+    Frame::Inertial, Frame::Grid>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Grid>>*> dest,
+    const Variables<sw_vars_list<Frame::Inertial>>& src,
+    const InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>& jac);
+
 }  // namespace filter_detail
 
 }  // namespace ylm::TensorYlm

--- a/src/NumericalAlgorithms/SphericalHarmonics/ApplyTensorYlmFilter.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/ApplyTensorYlmFilter.hpp
@@ -6,6 +6,7 @@
 #include "DataStructures/SimpleSparseMatrix.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/TensorYlm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -80,6 +81,7 @@ template <typename DataType, size_t Dim, typename Frame>
 struct Phikij : db::SimpleTag {
   using type = tnsr::ijj<DataType, Dim, Frame>;
 };
+
 }  // namespace Tags
 
 using gh_spacetime_vars_list =
@@ -94,6 +96,11 @@ using gh_spatial_vars_list = tmpl::list<
     Tags::Pik0<DataVector, 3, Frame>, Tags::Pikj<DataVector, 3, Frame>,
     Tags::Phik00<DataVector, 3, Frame>, Tags::Phiki0<DataVector, 3, Frame>,
     Tags::Phikij<DataVector, 3, Frame>>;
+
+template <typename Frame>
+using sw_vars_list =
+    tmpl::list<::CurvedScalarWave::Tags::Psi, ::CurvedScalarWave::Tags::Pi,
+               ::CurvedScalarWave::Tags::Phi<3, Frame>>;
 
 /*!
  * \brief Does a nodal to modal transform on I1xS2, only in the S2 direction.
@@ -232,6 +239,54 @@ void apply_tensor_ylm_filter(
     const SimpleSparseMatrix& filter_matrix_ii,
     const SimpleSparseMatrix& filter_matrix_ij,
     const SimpleSparseMatrix& filter_matrix_kii, size_t ell_max,
+    size_t radial_extents);
+
+/*!
+ * \brief Applies TensorYlm filter in place to Curved Scalar Wave variables.
+ *
+ * When radial_extents is 1, sw_vars and temp_storage are assumed to
+ * be defined on a spherical slice, with number of grid points
+ * corresponding to a spherical-harmonic grid of ell_max, and the
+ * filter happens only on that slice.
+ *
+ * When radial_extents is > 1, sw_vars and temp_storage are assumed to
+ * be defined on a spherical shell of topology I1 x S2. The filter
+ * happens in the entire volume, internally iterating over each
+ * spherical slice at a time.
+ *
+ * For performance reasons, apply_tensor_ylm_filter does not allocate
+ * or deallocate memory, but it does take a temp_storage buffer.  The
+ * size of temp_storage should at least
+ * radial_extents*spectral_size*num_components, where num_components
+ * is the total number of independent components in the SW variable
+ * list (i.e. 5), and spectral_size is the size of the S2 Spherepack
+ * spectral coefficient array for ell_max, as obtained from the member
+ * function ylm::Spherepack::spectral_size().  Note that for S2 on
+ * Spherepack, the number of collocation points is different than the
+ * number of spectral coefficients, and both are different than the
+ * size of the Spherepack storage array.
+ *
+ * \param sw_vars Scalar wave variables at collocation points.
+ * \param temp_storage Temporary storage for scalar wave variables,
+ *   allocated outside apply_tensor_ylm_filter. See above for size requirements.
+ * \param jac_inertial_to_grid Jacobian taking V_x from inertial to grid.
+ * \param jac_grid_to_inertial Jacobian taking V_x from grid to inertial.
+ * \param filter_matrix_scalar The scalar filter matrix computed by fill_filter.
+ * \param filter_matrix_i The Rank-1 matrix computed by fill_filter.
+ * \param ell_max The maximum ylm ell.
+ * \param radial_extents The number of radial grid points, can be 1 for slices.
+ */
+void apply_tensor_ylm_filter(
+    gsl::not_null<Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        sw_vars,
+    gsl::not_null<Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        temp_storage,
+    const InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>&
+        jac_inertial_to_grid,
+    const InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>&
+        jac_grid_to_inertial,
+    const SimpleSparseMatrix& filter_matrix_scalar,
+    const SimpleSparseMatrix& filter_matrix_i, size_t ell_max,
     size_t radial_extents);
 
 }  // namespace ylm::TensorYlm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ApplyTensorYlmFilter.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_ApplyTensorYlmFilter.cpp
@@ -163,6 +163,7 @@ void test_modal_nodal_invertibility() {
       });
 }
 
+template<typename VarsList>
 void test_apply_filter(const size_t num_to_kill) {
   constexpr size_t radial_extents = 2;
   constexpr size_t ell_max = 9;
@@ -173,12 +174,12 @@ void test_apply_filter(const size_t num_to_kill) {
 
   // Fill modal variables with random numbers in each mode.
   // Note that we fill only valid modes in the storage.
-  Variables<filter_detail::gh_spacetime_vars_list> inertial_modal_vars(
+  Variables<VarsList> inertial_modal_vars(
       spectral_mesh_size, 0.0);
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<double> dist{-1.0, 1.0};
   ylm::SpherepackIterator it(ell_max, ell_max, radial_extents, true);
-  tmpl::for_each<filter_detail::gh_spacetime_vars_list>(
+  tmpl::for_each<VarsList>(
       [&inertial_modal_vars, &it, &dist,
        &generator]<class Tag>(const tmpl::type_<Tag> /*meta*/) {
         auto& tensor = get<Tag>(inertial_modal_vars);
@@ -197,13 +198,13 @@ void test_apply_filter(const size_t num_to_kill) {
       });
 
   // Do modal to nodal.
-  Variables<filter_detail::gh_spacetime_vars_list> inertial_nodal_vars(
+  Variables<VarsList> inertial_nodal_vars(
       physical_mesh_size);
   filter_detail::modal_to_nodal_ylm(make_not_null(&inertial_nodal_vars),
                                     inertial_modal_vars, ylm, radial_extents);
 
   // Save a copy of the modal vars
-  const Variables<filter_detail::gh_spacetime_vars_list>
+  const Variables<VarsList>
       test_inertial_modal_vars(inertial_modal_vars);
 
   // Even if num_to_kill is zero, the filter does
@@ -220,12 +221,15 @@ void test_apply_filter(const size_t num_to_kill) {
       make_not_null(&filter_matrix_scalar), ell_max, num_to_kill, std::nullopt);
   fill_filter<tnsr::i<DataVector, 3>::structure>(
       make_not_null(&filter_matrix_i), ell_max, num_to_kill, std::nullopt);
-  fill_filter<tnsr::ii<DataVector, 3>::structure>(
-      make_not_null(&filter_matrix_ii), ell_max, num_to_kill, std::nullopt);
-  fill_filter<tnsr::ij<DataVector, 3>::structure>(
-      make_not_null(&filter_matrix_ij), ell_max, num_to_kill, std::nullopt);
-  fill_filter<tnsr::ijj<DataVector, 3>::structure>(
-      make_not_null(&filter_matrix_kii), ell_max, num_to_kill, std::nullopt);
+  if constexpr (std::is_same_v<
+                    VarsList, typename filter_detail::gh_spacetime_vars_list>) {
+    fill_filter<tnsr::ii<DataVector, 3>::structure>(
+        make_not_null(&filter_matrix_ii), ell_max, num_to_kill, std::nullopt);
+    fill_filter<tnsr::ij<DataVector, 3>::structure>(
+        make_not_null(&filter_matrix_ij), ell_max, num_to_kill, std::nullopt);
+    fill_filter<tnsr::ijj<DataVector, 3>::structure>(
+        make_not_null(&filter_matrix_kii), ell_max, num_to_kill, std::nullopt);
+  }
 
   // Make up bogus jacobians with random numbers, and make
   // them diagonally dominant so that they are invertible.
@@ -249,18 +253,28 @@ void test_apply_filter(const size_t num_to_kill) {
 
   // Now carry out the entire filtering algorithm,
   // using inertial_modal_vars as temporary storage.
-  apply_tensor_ylm_filter(
-      make_not_null(&inertial_nodal_vars), make_not_null(&inertial_modal_vars),
-      jac_inertial_to_grid, jac_grid_to_inertial, filter_matrix_scalar,
-      filter_matrix_i, filter_matrix_ii, filter_matrix_ij, filter_matrix_kii,
-      ell_max, radial_extents);
+  if constexpr (std::is_same_v<
+                    VarsList, typename filter_detail::gh_spacetime_vars_list>) {
+    apply_tensor_ylm_filter(make_not_null(&inertial_nodal_vars),
+                            make_not_null(&inertial_modal_vars),
+                            jac_inertial_to_grid, jac_grid_to_inertial,
+                            filter_matrix_scalar, filter_matrix_i,
+                            filter_matrix_ii, filter_matrix_ij,
+                            filter_matrix_kii, ell_max, radial_extents);
+  } else {
+    apply_tensor_ylm_filter(make_not_null(&inertial_nodal_vars),
+                            make_not_null(&inertial_modal_vars),
+                            jac_inertial_to_grid, jac_grid_to_inertial,
+                            filter_matrix_scalar, filter_matrix_i, ell_max,
+                            radial_extents);
+  }
 
   // Do nodal to modal of the result (for comparison).
   filter_detail::nodal_to_modal_ylm(make_not_null(&inertial_modal_vars),
                                     inertial_nodal_vars, ylm, radial_extents);
 
   // We should get back the original modal vars, to roundoff.
-  tmpl::for_each<filter_detail::gh_spacetime_vars_list>(
+  tmpl::for_each<VarsList>(
       [&inertial_modal_vars, &test_inertial_modal_vars, &ell_max, &num_to_kill,
        &it]<class Tag>(const tmpl::type_<Tag> /*meta*/) {
         constexpr size_t num_independent_components =
@@ -319,8 +333,10 @@ SPECTRE_TEST_CASE("Unit.SphericalHarmonics.ApplyTensorYlmFilter",
   test_break_spacetime_vars_into_spatial_pieces();
   test_transform_spatial_tensors_to_different_frame();
   test_modal_nodal_invertibility();
-  test_apply_filter(0);
-  test_apply_filter(5);
+  test_apply_filter<filter_detail::gh_spacetime_vars_list>(0);
+  test_apply_filter<filter_detail::gh_spacetime_vars_list>(5);
+  test_apply_filter<filter_detail::sw_vars_list<Frame::Inertial>>(0);
+  test_apply_filter<filter_detail::sw_vars_list<Frame::Inertial>>(5);
 }
 }  // namespace
 }  // namespace ylm::TensorYlm


### PR DESCRIPTION
## Proposed changes

Adds `apply_tensor_ylm_filter` for ScalarWaveCurved variables.

Depends on (and includes) #7060

Also allows for CurvedScalarWave Tags to have a Frame (only relevant for Phi).

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
