### PR TITLE
Update macos CI runners and support using yaml-cpp version 0.9.0

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -1007,16 +1007,10 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # The number of cores is given at:
-          # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-          - arch: x86
-            macos-version: 13  # Intel
-            NUM_CORES: 4
-          - arch: arm64
-            macos-version: 14  # Apple Silicon
-            NUM_CORES: 3
-    runs-on: macos-${{ matrix.macos-version }}
+        os:
+          - macos-15-intel
+          - macos-15
+    runs-on: ${{ matrix.os }}
     env:
       # We install some low-level dependencies with Homebrew. They get picked up
       # by `spack external find`.
@@ -1039,6 +1033,12 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         id: start
         run: |
           echo "time=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - name: Get CPU cores
+        id: get_cores
+        run: |
+          CORES=$(sysctl -n hw.ncpu)
+          echo "NUM_CORES=$CORES" >> $GITHUB_ENV
+          echo "Detect $CORES cores"
       - name: Checkout repository
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -1055,7 +1055,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         uses: actions/cache/restore@v4
         id: restore-dependencies
         env:
-          CACHE_KEY_PREFIX: "dependencies-macos-${{ matrix.macos-version }}"
+          CACHE_KEY_PREFIX: "dependencies-${{ matrix.os }}"
         with:
           path: ~/dependencies
           key: "${{ env.CACHE_KEY_PREFIX }}-${{ github.run_id }}"
@@ -1133,7 +1133,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         uses: actions/cache/restore@v4
         id: restore-ccache
         env:
-          CACHE_KEY_PREFIX: "ccache-macos-${{ matrix.macos-version }}"
+          CACHE_KEY_PREFIX: "ccache-${{ matrix.os }}"
         with:
           path: ~/ccache
           key: "${{ env.CACHE_KEY_PREFIX }}-${{ github.run_id }}"

--- a/src/Options/ParseOptions.cpp
+++ b/src/Options/ParseOptions.cpp
@@ -50,6 +50,30 @@ YAML::Node load_and_check_yaml(const std::string& options,
                                const bool require_metadata) {
   std::vector<YAML::Node> yaml_docs = YAML::LoadAll(options);
   if (yaml_docs.empty()) {
+    // yaml-cpp v 0.9.0 returns immediately on an empty root, so need to
+    // handle this
+    if (require_metadata) {
+      const size_t pos = options.find("---\n---\n");
+      if (pos == std::string::npos) {
+        throw std::runtime_error(
+            "Missing metadata in input file. YAML input files begin with a "
+            "metadata section terminated by '---':\n\n"
+            "# Metadata here\n\n"
+            "---\n\n"
+            "# Options start here\n\n"
+            "The metadata section may also be empty:\n\n"
+            "---\n"
+            "---\n\n"
+            "# Options start here\n\n"
+            "See option parsing documentation for details.");
+      } else {
+        std::string options_after_empty_metadata = options;
+        options_after_empty_metadata.erase(pos, 8);
+        std::vector<YAML::Node> yaml_docs_after_metadata =
+            YAML::LoadAll(options_after_empty_metadata);
+        return yaml_docs_after_metadata[0];
+      }
+    }
     return {};
   } else if (yaml_docs.size() == 1) {
     if (require_metadata) {

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -17,7 +17,8 @@ spectre_add_python_bindings_test(
   "tools.Status"
   Test_Status.py
   "Python"
-  None)
+  None
+  TIMEOUT 30)
 
 spectre_add_python_bindings_test(
   "tools.ValidateInputFile"


### PR DESCRIPTION
## Proposed changes

- Replace mac CI runners with their latest stable versions.
- Updated ParseOptions to work with the latest yaml-cpp version as [this change](https://github.com/jbeder/yaml-cpp/commit/bc671571091601f446d1dc07dbba4df6c775e757) broke how we parsed empty metadata in input files. (One of the runners uses the latest version of yaml-cpp).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
