### PR TITLE
Fix global stride in generate-xdmf (Codex)

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -386,8 +386,8 @@ def generate_xdmf(
         GridType="Collection",
         CollectionType="Temporal",
     )
-    # Collect timesteps in a hash map before inserting into XML so we can insert
-    # grids while stepping through H5 files
+    # Collect timestep records from all input files so stride can be applied
+    # globally rather than independently per file.
     timesteps = dict()
 
     for h5file, filename in h5files:
@@ -427,26 +427,34 @@ def generate_xdmf(
             key=lambda key_and_time: key_and_time[1],
         )
 
-        # Stride through timesteps
-        for temporal_id, time in temporal_ids_and_values[::stride]:
-            # Filter by start and end time
-            if start_time is not None and time < start_time:
-                continue
-            if stop_time is not None and time > stop_time:
-                break
+        for temporal_id, time in temporal_ids_and_values:
+            timestep_key = (time, temporal_id)
+            if timestep_key not in timesteps:
+                timesteps[timestep_key] = []
+            timesteps[timestep_key].append(
+                (vol_subfile, topo_dim, filename_in_output)
+            )
 
-            # A timestep is represented by a collection of grids. We store the
-            # grid collection in a hash map so each H5 file can insert grids.
-            if temporal_id in timesteps:
-                xmf_timestep_grid = timesteps[temporal_id]
-            else:
-                xmf_timestep_grid = ET.SubElement(
-                    xmf_timesteps, "Grid", Name="Grids", GridType="Collection"
-                )
-                # The time is stored as a `Time` tag in the grid collection
-                ET.SubElement(xmf_timestep_grid, "Time", Value=f"{time:.14e}")
-                timesteps[temporal_id] = xmf_timestep_grid
+    # Sort timesteps globally by time and apply stride to the global sequence.
+    sorted_timestep_items = sorted(
+        timesteps.items(), key=lambda item: (item[0][0], item[0][1])
+    )
+    for (time, temporal_id), timestep_records in sorted_timestep_items[
+        ::stride
+    ]:
+        # Filter by start and end time
+        if start_time is not None and time < start_time:
+            continue
+        if stop_time is not None and time > stop_time:
+            break
 
+        xmf_timestep_grid = ET.SubElement(
+            xmf_timesteps, "Grid", Name="Grids", GridType="Collection"
+        )
+        # The time is stored as a `Time` tag in the grid collection
+        ET.SubElement(xmf_timestep_grid, "Time", Value=f"{time:.14e}")
+
+        for vol_subfile, topo_dim, filename_in_output in timestep_records:
             # Construct the grid for this observation
             observation = vol_subfile[temporal_id]
             xmf_timestep_grid.append(

--- a/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
+++ b/tests/Unit/Visualization/Python/Test_GenerateXdmf.py
@@ -10,6 +10,7 @@ import unittest
 import xml.etree.ElementTree as ET
 
 import h5py
+import numpy as np
 from click.testing import CliRunner
 
 import spectre.Informer as spectre_informer
@@ -34,6 +35,61 @@ class TestGenerateXdmf(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.test_dir)
+
+    def write_test_volume_file(self, filename, observation_values):
+        with h5py.File(filename, "w") as open_h5file:
+            volfile = open_h5file.create_group("VolumeData.vol")
+            volfile.attrs["dimension"] = 3
+            for observation_id, observation_value in enumerate(
+                observation_values
+            ):
+                observation = volfile.create_group(
+                    f"ObservationId{observation_id}"
+                )
+                observation.attrs["observation_value"] = observation_value
+                observation.create_dataset(
+                    "connectivity", data=np.arange(8, dtype=np.int32)
+                )
+                observation.create_dataset(
+                    "total_extents", data=np.array([2, 2, 2], dtype=np.int32)
+                )
+                observation.create_dataset(
+                    "grid_names", data=np.array([b"Element0"])
+                )
+                observation.create_dataset(
+                    "bases", data=np.array([0, 0, 0], dtype=np.int32)
+                )
+                observation.create_dataset(
+                    "quadratures", data=np.array([0, 0, 0], dtype=np.int32)
+                )
+                observation.create_dataset(
+                    "InertialCoordinates_x",
+                    data=np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=float),
+                )
+                observation.create_dataset(
+                    "InertialCoordinates_y",
+                    data=np.array([0, 0, 1, 1, 0, 0, 1, 1], dtype=float),
+                )
+                observation.create_dataset(
+                    "InertialCoordinates_z",
+                    data=np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=float),
+                )
+                observation.create_dataset(
+                    "Psi",
+                    data=np.array(
+                        [
+                            observation_value,
+                            observation_value + 1.0,
+                            observation_value + 2.0,
+                            observation_value + 3.0,
+                            observation_value + 4.0,
+                            observation_value + 5.0,
+                            observation_value + 6.0,
+                            observation_value + 7.0,
+                        ],
+                        dtype=float,
+                    ),
+                )
 
     def test_generate_xdmf(self):
         for use_tetrahedral_connectivity in [False, True]:
@@ -151,6 +207,35 @@ class TestGenerateXdmf(unittest.TestCase):
         )
         self.assertEqual(result.exit_code, 0)
         self.assertIn("element_data", result.output)
+
+    def test_stride_across_multiple_files(self):
+        data_files = [
+            os.path.join(self.test_dir, "VolumeSegment0.h5"),
+            os.path.join(self.test_dir, "VolumeSegment1.h5"),
+            os.path.join(self.test_dir, "VolumeSegment2.h5"),
+        ]
+        self.write_test_volume_file(data_files[0], [0.0, 1000.0, 2000.0])
+        self.write_test_volume_file(
+            data_files[1], [2500.0, 3000.0, 3500.0, 4000.0, 4500.0]
+        )
+        self.write_test_volume_file(data_files[2], [4800.0])
+
+        output_filename = os.path.join(
+            self.test_dir, "Test_GenerateXdmf_stride_output"
+        )
+        generate_xdmf(
+            h5files=data_files,
+            output=output_filename,
+            subfile_name="VolumeData",
+            stride=2,
+        )
+
+        xmf_root = ET.parse(output_filename + ".xmf").getroot()
+        found_times = [
+            float(time_element.attrib["Value"])
+            for time_element in xmf_root.findall(".//Time")
+        ]
+        self.assertEqual(found_times, [0.0, 2000.0, 3000.0, 4000.0, 4800.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

This PR is an experiment with using a coding agent to fix an open issue (#6520).

I just gave the latest Codex CLI the prompt below, and it generated the commit in this PR.

If this is a successful experiment, maybe we can clear out backlogged issues using coding agents.

But in spite of my best efforts, I realize that AI generated PRs might end up being a drain on reviewers' time. If you start reviewing this and feel that it's a poor PR and a waste of your time, please don't hesitate to just close it and move on.

@wthrowe ... if you happen to try this out, does it fix the original bug you reported (#6520)?

```
Here is text from an issue I saw on github. Please review the relevant code and make a plan to 1) fix the issue, and 2) add a unit test or other test (as appropriate) to verify that the issue is fixed. We prefer that unit tests involving h5 files generate files in a temporary directory rather than rely on h5 files committed to the repo. Follow what other tests do in the repo and follow our style guide. Once you've solve the problem and the relevant unit test passes, commit your changes on the branch generatexdmf-fix-codex and while staying within the commit message limit, end the commit message with (Codex). If you have questions, stop and ask me; otherwise just do it

Each input h5 file is processed independently, so you always get the first time in each file. For example, in a run with three segments starting around times 0, 2500, and 4800 and observing every 100 M, dumping every 10th observation should give me 0, 1000, 2000, 3000, and 4000, but instead I get:
$ ~/spectre-build/bin/spectre generate-xdmf Segment_*/BbhVolume* -o Grid3.xmf -d VolumeData.vol --stride 10
$ grep Time Grid3.xmf 
        <Time Value="0.00000000000000e+00" />
        <Time Value="1.00000000000000e+03" />
        <Time Value="2.00000000000000e+03" />
        <Time Value="2.50000000000000e+03" />
        <Time Value="3.50000000000000e+03" />
        <Time Value="4.50000000000000e+03" />
        <Time Value="4.80000000000000e+03" />
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
