### PR TITLE
Add hessian to SecondPartialDerivatives

### DIFF
--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -126,6 +126,50 @@ class ElementMap {
     return jac;
   }
 
+#ifdef SPECTRE_AUTODIFF
+  /*!
+   * \brief The inverse Hessian of the element map.
+   *
+   * Let \f$ \xi^i \f$ be the element logical coordinates, \f$ x^i \f$ be the
+   * block logical coordinates, and \f$ y^i \f$ be the inertial coordinates.
+   * The element map maps \f$ \xi^i \rightarrow x^i \rightarrow y^i \f$. Thus,
+   * the inverse Hessian is
+   * \f[
+   * \frac{\partial^2\xi^i}{\partial y^j \partial y^k} =
+   * \frac{\partial}{\partial y^j}\frac{\partial x^l}{\partial y^k}
+   * \frac{\partial \xi^i}{\partial x^l}} =
+   * \frac{\partial^2 x^l}{\partial y^j \partial y^k}
+   * \frac{\partial \xi^i}{\partial x^l}
+   * \f]
+   * where we have used the fact
+   * \f[
+   * \frac{\partial^2 \xi^i}{\partial x^l \partial x^n} = 0.
+   * \f]
+   */
+  template <typename T>
+  InverseHessian<T, Dim, Frame::ElementLogical, TargetFrame> inv_hessian(
+      const tnsr::I<T, Dim, Frame::ElementLogical>& source_point,
+      const double time = std::numeric_limits<double>::signaling_NaN(),
+      const domain::FunctionsOfTimeMap& functions_of_time = {}) const {
+    auto block_source_point =
+        apply_affine_transformation_to_point(source_point);
+    auto block_inv_jac =
+        block_map_->inv_jacobian(block_source_point, time, functions_of_time);
+    auto block_inv_hes = block_map_->inv_hessian(
+        std::move(block_source_point), block_inv_jac, time, functions_of_time);
+    InverseHessian<T, Dim, Frame::ElementLogical, TargetFrame> inv_hes;
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = 0; j < Dim; ++j) {
+        for (size_t k = j; k < Dim; ++k) {
+          inv_hes.get(i, j, k) =
+              block_inv_hes.get(i, j, k) / gsl::at(map_slope_, i);
+        }
+      }
+    }
+    return inv_hes;
+  }
+#endif  // SPECTRE_AUTODIFF
+
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 

--- a/src/Evolution/DgSubcell/Tags/Jacobians.hpp
+++ b/src/Evolution/DgSubcell/Tags/Jacobians.hpp
@@ -58,6 +58,32 @@ struct InverseJacobianLogicalToInertial : db::SimpleTag {
                                  Frame::Inertial>;
 };
 
+/// \brief The inverse Hessian from the element logical frame to the grid frame
+/// at the cell centers.
+///
+/// Specifically, \f$\partial^2 x^{\bar{i}} / {\partial x^i \partial x^j}\f$,
+/// where \f$\bar{i}\f$ denotes the element logical frame and \f$i\f$ denotes
+/// the grid frame.
+template <size_t Dim>
+struct InverseHessianLogicalToGrid : db::SimpleTag {
+  static std::string name() { return "InverseHessian(Logical,Grid)"; }
+  using type =
+      ::InverseHessian<DataVector, Dim, Frame::ElementLogical, Frame::Grid>;
+};
+
+/// \brief The inverse Hessian from the element logical frame to the inertial
+/// frame at the cell centers.
+///
+/// Specifically, \f$\partial^2 x^{\bar{i}} / {\partial x^i \partial x^j}\f$,
+/// where \f$\bar{i}\f$ denotes the element logical frame and \f$i\f$ denotes
+/// the inertial frame.
+template <size_t Dim>
+struct InverseHessianLogicalToInertial : db::SimpleTag {
+  static std::string name() { return "InverseHessian(Logical,Inertial)"; }
+  using type =
+      ::InverseHessian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>;
+};
+
 /// Compute item for the inverse jacobian matrix from logical to
 /// grid coordinates
 template <typename MapTagLogicalToGrid, size_t Dim>
@@ -190,4 +216,103 @@ struct DetInverseJacobianLogicalToInertialCompute
     }
   }
 };
+
+#ifdef SPECTRE_AUTODIFF
+/// Compute item for the inverse hessian matrix from logical to
+/// grid coordinates
+template <typename MapTagLogicalToGrid, size_t Dim>
+struct InverseHessianLogicalToGridCompute : InverseHessianLogicalToGrid<Dim>,
+                                            db::ComputeTag {
+  static constexpr size_t dim = Dim;
+  using base = InverseHessianLogicalToGrid<Dim>;
+  using return_type = typename base::type;
+  using argument_tags = tmpl::list<
+      MapTagLogicalToGrid,
+      evolution::dg::subcell::Tags::Coordinates<dim, Frame::ElementLogical>>;
+  static void function(
+      const gsl::not_null<return_type*> inverse_hessian_logical_to_grid,
+      const ElementMap<Dim, Frame::Grid>& logical_to_grid_map,
+      const tnsr::I<DataVector, dim, Frame::ElementLogical>& logical_coords) {
+    *inverse_hessian_logical_to_grid =
+        logical_to_grid_map.inv_hessian(logical_coords);
+  }
+};
+
+/// Compute item for the inverse hessian matrix from logical to
+/// inertial coordinates
+template <typename MapTagGridToInertial, size_t Dim>
+struct InverseHessianLogicalToInertialCompute
+    : InverseHessianLogicalToInertial<Dim>,
+      db::ComputeTag {
+  static constexpr size_t dim = Dim;
+  using base = InverseHessianLogicalToInertial<Dim>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<MapTagGridToInertial,
+                 evolution::dg::subcell::Tags::Coordinates<dim, Frame::Grid>,
+                 ::Tags::Time, ::domain::Tags::FunctionsOfTime,
+                 InverseJacobianLogicalToGrid<Dim>,
+                 InverseHessianLogicalToGrid<Dim>>;
+  static void function(
+      const gsl::not_null<return_type*> inverse_hessian_logical_to_inertial,
+      const ::domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, dim>&
+          grid_to_inertial_map,
+      const tnsr::I<DataVector, dim, Frame::Grid>& grid_coords,
+      const double time,
+      const std::unordered_map<
+          std::string,
+          std::unique_ptr<::domain::FunctionsOfTime::FunctionOfTime>>&
+          functions_of_time,
+      const ::InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                              Frame::Grid>& inverse_jacobian_logical_to_grid,
+      const ::InverseHessian<DataVector, Dim, Frame::ElementLogical,
+                             Frame::Grid>& inverse_hessian_logical_to_grid) {
+    if (grid_to_inertial_map.is_identity()) {
+      // Optimization for time-independent maps; we just point to the
+      // logical-to-grid inverse hessian.
+      const size_t num_pts = inverse_hessian_logical_to_grid[0].size();
+      for (size_t storage_index = 0;
+           storage_index < inverse_hessian_logical_to_grid.size();
+           ++storage_index) {
+        make_const_view(
+            make_not_null(&std::as_const(
+                (*inverse_hessian_logical_to_inertial)[storage_index])),
+            inverse_hessian_logical_to_grid[storage_index], 0, num_pts);
+      }
+    } else {
+      set_number_of_grid_points(inverse_hessian_logical_to_inertial,
+                                get<0>(grid_coords).size());
+      // Get grid to inertial inverse jacobian
+      const auto& inverse_jacobian_grid_to_inertial =
+          grid_to_inertial_map.inv_jacobian(grid_coords, time,
+                                            functions_of_time);
+      // Get grid to inertial inverse hessian
+      const auto& inverse_hessian_grid_to_inertial =
+          grid_to_inertial_map.inv_hessian(grid_coords,
+                                           inverse_jacobian_grid_to_inertial,
+                                           time, functions_of_time);
+      for (size_t i = 0; i < Dim; i++) {
+        for (size_t j = 0; j < Dim; j++) {
+          for (size_t k = j; k < Dim; k++) {
+            auto& inv_hessian_component =
+                inverse_hessian_logical_to_inertial->get(i, j, k);
+            inv_hessian_component = 0.;
+            for (size_t n = 0; n < Dim; n++) {
+              inv_hessian_component +=
+                  inverse_hessian_grid_to_inertial.get(n, j, k) *
+                  inverse_jacobian_logical_to_grid.get(i, n);
+              for (size_t m = 0; m < Dim; m++) {
+                inv_hessian_component +=
+                    inverse_jacobian_grid_to_inertial.get(n, k) *
+                    inverse_hessian_logical_to_grid.get(i, m, n) *
+                    inverse_jacobian_grid_to_inertial.get(m, j);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+#endif  // SPECTRE_AUTODIFF
 }  // namespace evolution::dg::subcell::fd::Tags

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.cpp
@@ -93,9 +93,9 @@ void spacetime_derivatives(
 }
 
 void second_spacetime_derivatives(
-    const gsl::not_null<Variables<
-        db::wrap_tags_in<::Tags::second_deriv, System::gradients_tags,
-                         tmpl::size_t<3>, Frame::Inertial>>*>
+    const gsl::not_null<
+        Variables<db::wrap_tags_in<::Tags::second_deriv, System::gradients_tags,
+                                   tmpl::size_t<3>, Frame::Inertial>>*>
         result,
     const Variables<typename System::variables_tag::tags_list>&
         volume_evolved_variables,
@@ -104,7 +104,9 @@ void second_spacetime_derivatives(
     const size_t& deriv_order, const Mesh<3>& volume_mesh,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&
-        cell_centered_logical_to_inertial_inv_jacobian) {
+        cell_centered_logical_to_inertial_inv_jacobian,
+    const InverseHessian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>&
+        cell_centered_logical_to_inertial_inv_hessian) {
   ASSERT(deriv_order == 4,
          "Only fourth order second partial derivatives have been implemented.");
 
@@ -157,6 +159,7 @@ void second_spacetime_derivatives(
   ::fd::second_partial_derivatives<gradients_tags>(
       result, volume_Ccz4_vars, ghost_cell_vars, volume_mesh,
       number_of_Ccz4_components, deriv_order,
-      cell_centered_logical_to_inertial_inv_jacobian);
+      cell_centered_logical_to_inertial_inv_jacobian,
+      cell_centered_logical_to_inertial_inv_hessian);
 }
 }  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
@@ -62,9 +62,9 @@ void spacetime_derivatives(
  * in this stencil
  */
 void second_spacetime_derivatives(
-    gsl::not_null<Variables<
-        db::wrap_tags_in<::Tags::second_deriv, System::gradients_tags,
-                         tmpl::size_t<3>, Frame::Inertial>>*>
+    gsl::not_null<
+        Variables<db::wrap_tags_in<::Tags::second_deriv, System::gradients_tags,
+                                   tmpl::size_t<3>, Frame::Inertial>>*>
         result,
     const Variables<typename System::variables_tag::tags_list>&
         volume_evolved_variables,
@@ -73,5 +73,7 @@ void second_spacetime_derivatives(
     const size_t& deriv_order, const Mesh<3>& volume_mesh,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&
-        cell_centered_logical_to_inertial_inv_jacobian);
+        cell_centered_logical_to_inertial_inv_jacobian,
+    const InverseHessian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>&
+        cell_centered_logical_to_inertial_inv_hessian);
 }  // namespace Ccz4::fd

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/SoTimeDerivative.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VectorImpl.hpp"
+#include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/Jacobians.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
@@ -564,6 +565,9 @@ struct SoTimeDerivative {
     const auto& cell_centered_logical_to_inertial_inv_jacobian =
         db::get<evolution::dg::subcell::fd::Tags::
                     InverseJacobianLogicalToInertial<Dim>>(*box);
+    const auto& cell_centered_logical_to_inertial_inv_hessian = db::get<
+        evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertial<Dim>>(
+        *box);
 
     constexpr bool subcell_enabled_at_external_boundary =
         std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
@@ -630,7 +634,8 @@ struct SoTimeDerivative {
         make_not_null(&cell_centered_Ccz4_second_derivs), evolved_vars,
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
             *box),
-        fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian);
+        fd_order, subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
+        cell_centered_logical_to_inertial_inv_hessian);
 
     // compute spatial derivative of the four auxiliary fields
     const auto& d_d_lapse =

--- a/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp
@@ -82,9 +82,6 @@ void second_logical_partial_derivatives(
  * First and second logical partial derivatives are first computed using the
  * `fd::logical_partial_derivatives()` and
  * `fd::second_logical_partial_derivatives()` function.
- *
- * \note The `inverse_hessian` has not been implemented, so currently inertial
- * coordinates cannot mix logical coordinates.
  */
 template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
 void second_partial_derivatives(
@@ -94,8 +91,9 @@ void second_partial_derivatives(
         second_partial_derivatives,
     const gsl::span<const double>& volume_vars,
     const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
-    const Mesh<Dim>& volume_mesh, size_t number_of_variables,
-    size_t fd_order,
+    const Mesh<Dim>& volume_mesh, size_t number_of_variables, size_t fd_order,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                          DerivativeFrame>& inverse_jacobian);
+                          DerivativeFrame>& inverse_jacobian,
+    const InverseHessian<DataVector, Dim, Frame::ElementLogical,
+                         DerivativeFrame>& inverse_hessian);
 }  // namespace fd

--- a/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.tpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -45,28 +46,46 @@ template <typename ResultTags, size_t Dim, typename DerivativeFrame,
           typename VectorType = typename Variables<ResultTags>::vector_type>
 void second_partial_derivatives_impl(
     const gsl::not_null<Variables<ResultTags>*> ddu,
-    // we will need the first logical derivatives when implementing
-    // inverse_hessian
-    /*const std::array<const ValueType*, Dim>&
-        first_logical_partial_derivatives_of_u,*/
+    const std::array<const ValueType*, Dim>&
+        first_logical_partial_derivatives_of_u,
     const std::array<const ValueType*, Dim>&
         pure_second_logical_partial_derivatives_of_u,
     const std::array<const ValueType*, Dim>&
         mixed_second_logical_partial_derivatives_of_u,
     const size_t number_of_independent_components,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                          DerivativeFrame>& inverse_jacobian) {
+                          DerivativeFrame>& inverse_jacobian,
+    const InverseHessian<DataVector, Dim, Frame::ElementLogical,
+                         DerivativeFrame>& inverse_hessian) {
   ValueType* ptr_ddu = ddu->data();
   const size_t num_grid_points = ddu->number_of_grid_points();
   VectorType lhs{};
+  VectorType first_logical_du{};
   VectorType second_logical_du{};
 
+  // The storage indices into the inverse Jacobian are precomputed to avoid
+  // having to recompute them for each tensor component of `u`.
   std::array<std::array<size_t, Dim>, Dim> jacobian_indices{};
   for (size_t deriv_index = 0; deriv_index < Dim; ++deriv_index) {
     for (size_t d = 0; d < Dim; ++d) {
       gsl::at(gsl::at(jacobian_indices, d), deriv_index) =
           InverseJacobian<DataVector, Dim, Frame::ElementLogical,
                           DerivativeFrame>::get_storage_index(d, deriv_index);
+    }
+  }
+  std::array<std::array<std::array<size_t, Dim>, Dim>, Dim> hessian_indices{};
+  for (size_t d = 0; d < Dim; ++d) {
+    for (size_t first_deriv_index = 0; first_deriv_index < Dim;
+         ++first_deriv_index) {
+      for (size_t second_deriv_index = 0; second_deriv_index < Dim;
+           ++second_deriv_index) {
+        gsl::at(gsl::at(gsl::at(hessian_indices, d), first_deriv_index),
+                second_deriv_index) =
+            InverseHessian<
+                DataVector, Dim, Frame::ElementLogical,
+                DerivativeFrame>::get_storage_index(d, first_deriv_index,
+                                                    second_deriv_index);
+      }
     }
   }
 
@@ -82,7 +101,7 @@ void second_partial_derivatives_impl(
         // clang-tidy: const cast is fine since we won't modify the data and we
         // need it to easily hook into the expression templates.
         second_logical_du.set_data_ref(
-          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
             const_cast<ValueType*>(
                 gsl::at(pure_second_logical_partial_derivatives_of_u, 0)) +
                 component_index * num_grid_points,
@@ -103,11 +122,11 @@ void second_partial_derivatives_impl(
                 // clang-tidy: const cast is fine since we won't modify the data
                 // and we need it to easily hook into the expression templates.
                 second_logical_du.set_data_ref(
-                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                     const_cast<ValueType*>(
                         gsl::at(pure_second_logical_partial_derivatives_of_u,
-                                first_logical_deriv_index))
-                        + component_index * num_grid_points,
+                                first_logical_deriv_index)) +
+                        component_index * num_grid_points,
                     num_grid_points);
               } else {
                 // we need to map (first_logical_deriv_index,
@@ -134,11 +153,11 @@ void second_partial_derivatives_impl(
                 // clang-tidy: const cast is fine since we won't modify the data
                 // and we need it to easily hook into the expression templates.
                 second_logical_du.set_data_ref(
-                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                     const_cast<ValueType*>(
                         gsl::at(mixed_second_logical_partial_derivatives_of_u,
-                                single_mixed_partial_index))
-                        + component_index * num_grid_points,
+                                single_mixed_partial_index)) +
+                        component_index * num_grid_points,
                     num_grid_points);
               }
 
@@ -154,6 +173,22 @@ void second_partial_derivatives_impl(
                   second_logical_du;
             }
           }
+        }
+        // Now add in the terms with the inverse hessian
+        for (size_t d = 0; d < Dim; ++d) {
+          // clang-tidy: const cast is fine since we won't modify the data
+          // and we need it to easily hook into the expression templates.
+          first_logical_du.set_data_ref(
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+              const_cast<ValueType*>(
+                  gsl::at(first_logical_partial_derivatives_of_u, d)) +
+                  component_index * num_grid_points,
+              num_grid_points);
+          lhs += (*(inverse_hessian.begin() +
+                    gsl::at(
+                        gsl::at(gsl::at(hessian_indices, d), first_deriv_index),
+                        second_deriv_index))) *
+                 first_logical_du;
         }
       }
     }
@@ -172,7 +207,9 @@ void second_partial_derivatives(
     const Mesh<Dim>& volume_mesh, const size_t number_of_variables,
     const size_t fd_order,
     const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
-                          DerivativeFrame>& inverse_jacobian) {
+                          DerivativeFrame>& inverse_jacobian,
+    const InverseHessian<DataVector, Dim, Frame::ElementLogical,
+                         DerivativeFrame>& inverse_hessian) {
   // Note: Tags::second_deriv ensures the first two indices (partial derivative
   // indices) of tensors in second_partial_derivatives are symmetric.
   ASSERT(fd_order == 4, "Only fd_order == 4 is supported at the moment.");
@@ -218,6 +255,14 @@ void second_partial_derivatives(
       gsl::make_span(&buffer[3 * Dim * volume_vars.size()],
                      second_logical_derivs_internal_buffer_size);
 
+  // Compute first logical derivatives (used in the inverse-hessian terms)
+  // Potential optimization: since we compute first logical derivatives here,
+  // it may be a good idea to have an option to compute the first inertial
+  // derivatives as well together with the second inertial derivatives.
+  fd::logical_partial_derivatives(make_not_null(&first_logical_partial_derivs),
+                                  volume_vars, ghost_cell_vars, volume_mesh,
+                                  number_of_variables, fd_order);
+
   detail::second_logical_partial_derivatives_impl(
       make_not_null(&pure_second_logical_partial_derivs),
       make_not_null(&mixed_second_logical_partial_derivs), &span_buffer,
@@ -242,9 +287,10 @@ void second_partial_derivatives(
   }
 
   partial_derivatives_detail::second_partial_derivatives_impl(
-      second_partial_derivatives, pure_second_logical_partial_derivs_ptrs,
+      second_partial_derivatives, first_logical_partial_derivs_ptrs,
+      pure_second_logical_partial_derivs_ptrs,
       mixed_second_logical_partial_derivs_ptrs,
       Variables<DerivativeTags>::number_of_independent_components,
-      inverse_jacobian);
+      inverse_jacobian, inverse_hessian);
 }
 }  // namespace fd

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -74,22 +74,43 @@ void test_element_impl(
           composed_map.inverse(inertial_point_double).value());
   }
 
+  const auto composed_map_inv_jacobian_dv =
+      composed_map.inv_jacobian(logical_point_dv);
   CHECK_ITERABLE_APPROX(element_map.inv_jacobian(logical_point_dv),
-                        composed_map.inv_jacobian(logical_point_dv));
+                        composed_map_inv_jacobian_dv);
+  const auto composed_map_inv_jacobian_double =
+      composed_map.inv_jacobian(logical_point_double);
   CHECK_ITERABLE_APPROX(element_map.inv_jacobian(logical_point_double),
-                        composed_map.inv_jacobian(logical_point_double));
+                        composed_map_inv_jacobian_double);
   CHECK_ITERABLE_APPROX(element_map_deserialized.inv_jacobian(logical_point_dv),
-                        composed_map.inv_jacobian(logical_point_dv));
+                        composed_map_inv_jacobian_dv);
   CHECK_ITERABLE_APPROX(
       element_map_deserialized.inv_jacobian(logical_point_double),
-      composed_map.inv_jacobian(logical_point_double));
+      composed_map_inv_jacobian_double);
 
-  CHECK_ITERABLE_APPROX(element_map.inv_jacobian(logical_point_dv),
-                        composed_map.inv_jacobian(logical_point_dv));
+#ifdef SPECTRE_AUTODIFF
+  CHECK_ITERABLE_APPROX(
+      element_map.inv_hessian(logical_point_dv),
+      composed_map.inv_hessian(logical_point_dv, composed_map_inv_jacobian_dv));
+  CHECK_ITERABLE_APPROX(
+      element_map.inv_hessian(logical_point_double),
+      composed_map.inv_hessian(logical_point_double,
+                               composed_map_inv_jacobian_double));
+  CHECK_ITERABLE_APPROX(
+      element_map_deserialized.inv_hessian(logical_point_dv),
+      composed_map.inv_hessian(logical_point_dv, composed_map_inv_jacobian_dv));
+  CHECK_ITERABLE_APPROX(
+      element_map_deserialized.inv_hessian(logical_point_double),
+      composed_map.inv_hessian(logical_point_double,
+                               composed_map_inv_jacobian_double));
+#endif  // SPECTRE_AUTODIFF
+
+  CHECK_ITERABLE_APPROX(element_map.jacobian(logical_point_dv),
+                        composed_map.jacobian(logical_point_dv));
   CHECK_ITERABLE_APPROX(element_map.jacobian(logical_point_double),
                         composed_map.jacobian(logical_point_double));
-  CHECK_ITERABLE_APPROX(element_map_deserialized.inv_jacobian(logical_point_dv),
-                        composed_map.inv_jacobian(logical_point_dv));
+  CHECK_ITERABLE_APPROX(element_map_deserialized.jacobian(logical_point_dv),
+                        composed_map.jacobian(logical_point_dv));
   CHECK_ITERABLE_APPROX(element_map_deserialized.jacobian(logical_point_double),
                         composed_map.jacobian(logical_point_double));
 

--- a/tests/Unit/Evolution/DgSubcell/Test_JacobianCompute.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_JacobianCompute.cpp
@@ -57,33 +57,44 @@ void test() {
   const Mesh<3> subcell_mesh{2, Spectral::Basis::FiniteDifference,
                              Spectral::Quadrature::CellCentered};
 
+  using compute_tags = tmpl::list<
+      evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>,
+      ::domain::Tags::MappedCoordinates<
+          ::domain::Tags::ElementMap<3, Frame::Grid>,
+          evolution::dg::subcell::Tags::Coordinates<3, Frame::ElementLogical>,
+          evolution::dg::subcell::Tags::Coordinates>,
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGridCompute<
+          ::domain::Tags::ElementMap<3, Frame::Grid>, 3>,
+      evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertialCompute<
+          ::domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                        Frame::Inertial>,
+          3>,
+      evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToGridCompute<
+          3>,
+      evolution::dg::subcell::fd::Tags::
+          DetInverseJacobianLogicalToInertialCompute<
+              ::domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                            Frame::Inertial>,
+              3>>;
+#ifdef SPECTRE_AUTODIFF
+  using hessian_compute_tags = tmpl::list<
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToGridCompute<
+          ::domain::Tags::ElementMap<3, Frame::Grid>, 3>,
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertialCompute<
+          ::domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                        Frame::Inertial>,
+          3>>;
+#else
+  using hessian_compute_tags = tmpl::list<>;
+#endif  // SPECTRE_AUTODIFF
+
   auto box = db::create<
       db::AddSimpleTags<evolution::dg::subcell::Tags::Mesh<3>,
                         domain::Tags::ElementMap<3, Frame::Grid>,
                         domain::CoordinateMaps::Tags::CoordinateMap<
                             3, Frame::Grid, Frame::Inertial>,
                         ::Tags::Time, domain::Tags::FunctionsOfTimeInitialize>,
-      db::AddComputeTags<
-          evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>,
-          ::domain::Tags::MappedCoordinates<
-              ::domain::Tags::ElementMap<3, Frame::Grid>,
-              evolution::dg::subcell::Tags::Coordinates<3,
-                                                        Frame::ElementLogical>,
-              evolution::dg::subcell::Tags::Coordinates>,
-          evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGridCompute<
-              ::domain::Tags::ElementMap<3, Frame::Grid>, 3>,
-          evolution::dg::subcell::fd::Tags::
-              InverseJacobianLogicalToInertialCompute<
-                  ::domain::CoordinateMaps::Tags::CoordinateMap<
-                      3, Frame::Grid, Frame::Inertial>,
-                  3>,
-          evolution::dg::subcell::fd::Tags::
-              DetInverseJacobianLogicalToGridCompute<3>,
-          evolution::dg::subcell::fd::Tags::
-              DetInverseJacobianLogicalToInertialCompute<
-                  ::domain::CoordinateMaps::Tags::CoordinateMap<
-                      3, Frame::Grid, Frame::Inertial>,
-                  3>>>(
+      db::AddComputeTags<tmpl::append<compute_tags, hessian_compute_tags>>>(
       subcell_mesh, std::move(element_map),
       domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
           domain::CoordinateMaps::Identity<3>{}),
@@ -106,6 +117,17 @@ void test() {
               ::domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
                                                             Frame::Inertial>,
               3>>("Det(InverseJacobian(Logical,Inertial))");
+#ifdef SPECTRE_AUTODIFF
+  TestHelpers::db::test_compute_tag<
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToGridCompute<
+          ::domain::Tags::ElementMap<3, Frame::Grid>, 3>>(
+      "InverseHessian(Logical,Grid)");
+  TestHelpers::db::test_compute_tag<
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertialCompute<
+          ::domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                        Frame::Inertial>,
+          3>>("InverseHessian(Logical,Inertial)");
+#endif  // SPECTRE_AUTODIFF
 
   const auto& inv_jac_grid = db::get<
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<3>>(box);
@@ -127,6 +149,23 @@ void test() {
       evolution::dg::subcell::fd::Tags::DetInverseJacobianLogicalToInertial>(
       box);
   CHECK_ITERABLE_APPROX(get(det_inv_jac_inertial), get(det_inv_jac_grid));
+
+#ifdef SPECTRE_AUTODIFF
+  const auto& inv_hess_grid =
+      db::get<evolution::dg::subcell::fd::Tags::InverseHessianLogicalToGrid<3>>(
+          box);
+  const auto& inv_hess_inertial = db::get<
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertial<3>>(
+      box);
+
+  // Check that the two hessians in frames connected by an identity map are
+  // identical
+  for (size_t storage_index = 0; storage_index < inv_hess_inertial.size();
+       ++storage_index) {
+    CHECK_ITERABLE_APPROX(inv_hess_inertial[storage_index],
+                          inv_hess_grid[storage_index]);
+  }
+#endif  // SPECTRE_AUTODIFF
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.DgSubcell.JacobianCompute",

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Derivatives.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_Derivatives.cpp
@@ -44,6 +44,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
   for (size_t i = 0; i < 3; ++i) {
     cell_centered_logical_to_inertial_inv_jacobian.get(i, i) = 1.0;
   }
+  const InverseHessian<DataVector, 3, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_hessian{
+          subcell_mesh.number_of_grid_points(), 0.0};
 
   const Element<3> element = TestHelpers::Ccz4::fd::detail::set_element();
 
@@ -266,7 +269,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
   ::Ccz4::fd::second_spacetime_derivatives(
       make_not_null(&second_deriv_of_Ccz4_vars), volume_evolved_vars,
       all_ghost_data, fd_deriv_order, subcell_mesh,
-      cell_centered_logical_to_inertial_inv_jacobian);
+      cell_centered_logical_to_inertial_inv_jacobian,
+      cell_centered_logical_to_inertial_inv_hessian);
 
   Variables<db::wrap_tags_in<::Tags::second_deriv,
                              typename Ccz4::fd::System::gradients_tags,
@@ -397,6 +401,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
       expected_second_d_lapse.get(i, j) = i == j ? 2 : 0.0;
+      if ((i == 0 and j == 2) or (i == 2 and j == 0)) {
+        expected_second_d_lapse.get(i, j) += 1.0;
+      }
     }
   }
 
@@ -467,7 +474,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.FiniteDifference.Derivatives",
         Ccz4::fd::second_spacetime_derivatives(
             make_not_null(&second_deriv_of_Ccz4_vars), volume_evolved_vars,
             bad_ghost_data, fd_deriv_order, subcell_mesh,
-            cell_centered_logical_to_inertial_inv_jacobian),
+            cell_centered_logical_to_inertial_inv_jacobian,
+            cell_centered_logical_to_inertial_inv_hessian),
         Catch::Matchers::ContainsSubstring(match_string));
   }
 #endif  // SPECTRE_DEBUG

--- a/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/FiniteDifference/Test_SoTimeDerivative.cpp
@@ -105,11 +105,18 @@ void test_minkowski(const bool evolve_lapse_and_shift) {
                   Frame::Inertial>
       cell_centered_logical_to_inertial_inv_jacobian{
           subcell_mesh.number_of_grid_points(), 0.0};
-
   for (size_t i = 0; i < SpatialDim; ++i) {
     cell_centered_logical_to_inertial_inv_jacobian.get(i, i) =
         2.0 / gsl::at(coords_range, i);
   }
+
+  // We use a trivial inverse hessian here as this test is testing the time
+  // derivative. The only place where the inverse hessian is used in time
+  // derivative is in second_spacetime_derivatives, which is already tested in
+  // Test_Derivatives.cpp.
+  InverseHessian<DataVector, SpatialDim, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_hessian{
+          subcell_mesh.number_of_grid_points(), 0.0};
 
   const Element<SpatialDim> element =
       TestHelpers::Ccz4::fd::detail::set_element();
@@ -155,6 +162,8 @@ void test_minkowski(const bool evolve_lapse_and_shift) {
       evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertial<
+          SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>,
       domain::Tags::ExternalBoundaryConditions<SpatialDim>,
       evolution::dg::subcell::Tags::Coordinates<SpatialDim, Frame::Inertial>>>(
@@ -166,7 +175,7 @@ void test_minkowski(const bool evolve_lapse_and_shift) {
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
-      all_ghost_data,
+      cell_centered_logical_to_inertial_inv_hessian, all_ghost_data,
       std::vector<DirectionMap<
           SpatialDim,
           std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>{},
@@ -226,6 +235,14 @@ void test_kerrschild(const bool evolve_lapse_and_shift) {
     cell_centered_logical_to_inertial_inv_jacobian.get(i, i) =
         2.0 / gsl::at(coords_range, i);
   }
+
+  // We use a trivial inverse hessian here as this test is testing the time
+  // derivative. The only place where the inverse hessian is used in time
+  // derivative is in second_spacetime_derivatives, which is already tested in
+  // Test_Derivatives.cpp.
+  InverseHessian<DataVector, SpatialDim, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_hessian{
+          subcell_mesh.number_of_grid_points(), 0.0};
 
   const Element<SpatialDim> element =
       TestHelpers::Ccz4::fd::detail::set_element();
@@ -291,10 +308,11 @@ void test_kerrschild(const bool evolve_lapse_and_shift) {
       evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertial<
+          SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>,
       domain::Tags::ExternalBoundaryConditions<SpatialDim>,
-        evolution::dg::subcell::Tags::Coordinates<
-            SpatialDim, Frame::Inertial>>>(
+      evolution::dg::subcell::Tags::Coordinates<SpatialDim, Frame::Inertial>>>(
       kappa_1, kappa_2, kappa_3, evolve_lapse_and_shift, element,
       std::unique_ptr<Ccz4::fd::Reconstructor>{
           std::make_unique<std::decay_t<decltype(recons)>>(recons)},
@@ -303,7 +321,7 @@ void test_kerrschild(const bool evolve_lapse_and_shift) {
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
-      all_ghost_data,
+      cell_centered_logical_to_inertial_inv_hessian, all_ghost_data,
       std::vector<DirectionMap<
           SpatialDim,
           std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>{},
@@ -383,6 +401,14 @@ void test_gauge_plane_wave(
         2.0 / gsl::at(coords_range, i);
   }
 
+  // We use a trivial inverse hessian here as this test is testing the time
+  // derivative. The only place where the inverse hessian is used in time
+  // derivative is in second_spacetime_derivatives, which is already tested in
+  // Test_Derivatives.cpp.
+  InverseHessian<DataVector, SpatialDim, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_hessian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+
   double omega = 0.0;
   for (const auto& k : wave_vector) {
     omega += square(k);
@@ -453,10 +479,11 @@ void test_gauge_plane_wave(
       evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertial<
+          SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>,
       domain::Tags::ExternalBoundaryConditions<SpatialDim>,
-        evolution::dg::subcell::Tags::Coordinates<
-            SpatialDim, Frame::Inertial>>>(
+      evolution::dg::subcell::Tags::Coordinates<SpatialDim, Frame::Inertial>>>(
       kappa_1, kappa_2, kappa_3, evolve_lapse_and_shift, element,
       std::unique_ptr<Ccz4::fd::Reconstructor>{
           std::make_unique<std::decay_t<decltype(recons)>>(recons)},
@@ -465,7 +492,7 @@ void test_gauge_plane_wave(
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
-      all_ghost_data,
+      cell_centered_logical_to_inertial_inv_hessian, all_ghost_data,
       std::vector<DirectionMap<
           SpatialDim,
           std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>{},
@@ -735,6 +762,14 @@ void test_sommerfeld_bc(const bool evolve_lapse_and_shift) {
         2.0 / gsl::at(coords_range, i);
   }
 
+  // We use a trivial inverse hessian here as this test is testing the time
+  // derivative. The only place where the inverse hessian is used in time
+  // derivative is in second_spacetime_derivatives, which is already tested in
+  // Test_Derivatives.cpp.
+  InverseHessian<DataVector, SpatialDim, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_hessian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+
   // Ghost data from interior neighbors (none for the external face, which is
   // set by BCs)
   const DirectionalIdMap<SpatialDim, evolution::dg::subcell::GhostData>
@@ -792,11 +827,12 @@ void test_sommerfeld_bc(const bool evolve_lapse_and_shift) {
       evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertial<
+          SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>,
       domain::Tags::ExternalBoundaryConditions<SpatialDim>,
       evolution::dg::subcell::Tags::Coordinates<SpatialDim, Frame::Inertial>,
-      ::Tags::Time,
-      domain::Tags::FunctionsOfTime,
+      ::Tags::Time, domain::Tags::FunctionsOfTime,
       domain::Tags::ElementMap<SpatialDim, Frame::Grid>,
       domain::CoordinateMaps::Tags::CoordinateMap<SpatialDim, Frame::Grid,
                                                   Frame::Inertial>>>(
@@ -808,9 +844,9 @@ void test_sommerfeld_bc(const bool evolve_lapse_and_shift) {
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
-      all_ghost_data, std::move(external_bcs_per_block), x, 0.0,
-      std::move(functions_of_time), std::move(element_map),
-      grid_to_inertial_map.get_clone());
+      cell_centered_logical_to_inertial_inv_hessian, all_ghost_data,
+      std::move(external_bcs_per_block), x, 0.0, std::move(functions_of_time),
+      std::move(element_map), grid_to_inertial_map.get_clone());
 
   ::Ccz4::fd::SoTimeDerivative::apply(make_not_null(&box));
 
@@ -1016,6 +1052,14 @@ void test_dirichlet_analytic_bc(const bool evolve_lapse_and_shift) {
         2.0 / gsl::at(coords_range, i);
   }
 
+  // We use a trivial inverse hessian here as this test is testing the time
+  // derivative. The only place where the inverse hessian is used in time
+  // derivative is in second_spacetime_derivatives, which is already tested in
+  // Test_Derivatives.cpp.
+  InverseHessian<DataVector, SpatialDim, Frame::ElementLogical, Frame::Inertial>
+      cell_centered_logical_to_inertial_inv_hessian{
+          subcell_mesh.number_of_grid_points(), 0.0};
+
   // Ghost data from interior neighbors (none for the external face, which is
   // set by BCs)
   const DirectionalIdMap<SpatialDim, evolution::dg::subcell::GhostData>
@@ -1076,11 +1120,12 @@ void test_dirichlet_analytic_bc(const bool evolve_lapse_and_shift) {
       evolution::dg::subcell::Tags::Mesh<SpatialDim>,
       evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToInertial<
           SpatialDim>,
+      evolution::dg::subcell::fd::Tags::InverseHessianLogicalToInertial<
+          SpatialDim>,
       evolution::dg::subcell::Tags::GhostDataForReconstruction<SpatialDim>,
       domain::Tags::ExternalBoundaryConditions<SpatialDim>,
       evolution::dg::subcell::Tags::Coordinates<SpatialDim, Frame::Inertial>,
-      ::Tags::Time,
-      domain::Tags::FunctionsOfTime,
+      ::Tags::Time, domain::Tags::FunctionsOfTime,
       domain::Tags::ElementMap<SpatialDim, Frame::Grid>,
       domain::CoordinateMaps::Tags::CoordinateMap<SpatialDim, Frame::Grid,
                                                   Frame::Inertial>>>(
@@ -1092,9 +1137,9 @@ void test_dirichlet_analytic_bc(const bool evolve_lapse_and_shift) {
       Variables<typename dt_variables_tag::tags_list>{
           subcell_mesh.number_of_grid_points()},
       subcell_mesh, cell_centered_logical_to_inertial_inv_jacobian,
-      all_ghost_data, std::move(external_bcs_per_block), x, 0.0,
-      std::move(functions_of_time), std::move(element_map),
-      grid_to_inertial_map.get_clone());
+      cell_centered_logical_to_inertial_inv_hessian, all_ghost_data,
+      std::move(external_bcs_per_block), x, 0.0, std::move(functions_of_time),
+      std::move(element_map), grid_to_inertial_map.get_clone());
 
   ::Ccz4::fd::SoTimeDerivative::apply(make_not_null(&box));
 

--- a/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Ccz4/PrimReconstructor.hpp
@@ -179,7 +179,7 @@ compute_prim_solution_for_second_deriv(
   get(get<ConformalFactor>(vars)) += 2.0;
   get(get<TraceExtrinsicCurvature>(vars)) += 15.0;
   get(get<Theta>(vars)) += 30.0;
-  get(get<Lapse>(vars)) += 50.0;
+  get(get<Lapse>(vars)) += 50.0 + coords.get(0) * coords.get(2);
   for (size_t j = 0; j < 3; ++j) {
     get<GammaHat>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 10);
     get<Shift>(vars).get(j) += 1.0e-2 * static_cast<double>((j + 2) + 60);

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_SecondPartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_SecondPartialDerivatives.cpp
@@ -270,6 +270,11 @@ void test(const size_t points_per_dimension, const size_t fd_order) {
   inverse_jacobian.get(2, 0) = -0.5 / logical_coords.get(0);
   inverse_jacobian.get(2, 2) = 1.0;
 
+  InverseHessian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>
+      inverse_hessian(mesh.number_of_grid_points(), 0.0);
+  inverse_hessian.get(0, 0, 0) = -0.25 / pow<3>(logical_coords.get(0));
+  inverse_hessian.get(2, 0, 0) = 0.25 / pow<3>(logical_coords.get(0));
+
   using derivative_tags =
       tmpl::list<Tags::Tempi<0, Dim, Frame::Inertial, DataVector>,
                  Tags::TempScalar<1, DataVector>>;
@@ -344,7 +349,7 @@ void test(const size_t points_per_dimension, const size_t fd_order) {
       gsl::make_span(volume_vars_for_tensor.data(),
                      volume_vars_for_tensor.size()),
       ghost_cell_vars, mesh, number_of_independent_components, 4,
-      inverse_jacobian);
+      inverse_jacobian, inverse_hessian);
 
   Variables<db::wrap_tags_in<Tags::second_deriv, derivative_tags,
                              tmpl::size_t<Dim>, Frame::Inertial>>
@@ -354,7 +359,12 @@ void test(const size_t points_per_dimension, const size_t fd_order) {
   gsl::at(expected_pure_second_d_var1, 0) =
       (1 + 2 * logical_coords.get(0) + logical_coords.get(1) +
        2 * logical_coords.get(2)) /
-      (2 * square(logical_coords.get(0)));
+          (2 * square(logical_coords.get(0))) +
+      // the only non-zero contribution from inverse_hessian
+      (0.25 * (logical_coords.get(2) - logical_coords.get(0)) *
+       (1 + 2 * logical_coords.get(0) + logical_coords.get(1) +
+        2 * logical_coords.get(2))) /
+          (pow<3>(logical_coords.get(0)));
   gsl::at(expected_pure_second_d_var1, 1) =
       2 * (1 + logical_coords.get(0) + 3 * logical_coords.get(1) +
            logical_coords.get(2));
@@ -364,7 +374,12 @@ void test(const size_t points_per_dimension, const size_t fd_order) {
   gsl::at(expected_pure_second_d_var2, 0) =
       (1 + 2 * logical_coords.get(0) + logical_coords.get(1) +
        2 * logical_coords.get(2)) /
-      (2 * square(logical_coords.get(0)));
+          (2 * square(logical_coords.get(0))) +
+      // the only non-zero contribution from inverse_hessian
+      (0.25 * (logical_coords.get(2) - logical_coords.get(0)) *
+       (1 + 2 * logical_coords.get(0) + logical_coords.get(1) +
+        2 * logical_coords.get(2))) /
+          (pow<3>(logical_coords.get(0)));
   gsl::at(expected_pure_second_d_var2, 1) =
       2 * (1 + logical_coords.get(0) + 3 * logical_coords.get(1) +
            logical_coords.get(2));


### PR DESCRIPTION
## Proposed changes
The `SecondPartialDerivatives.*` using finite difference stencil so far only works in grid frames where the logical to grid maps are linear in logical coordinates, as inverse Hessian was not implemented. Since inverse Hessian is implemented now, we can make `SecondPartialDerivatives.*` work for any grid frame where the logical to grid maps support inverse hessians (i.e. support autodiff).

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
