### PR TITLE
Adding higher order Sommerfeld boundary condition for ScalarSelfForce

### DIFF
--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Angular.cpp
+  None.cpp
   Sommerfeld.cpp
   )
 
@@ -18,6 +19,7 @@ spectre_target_headers(
   HEADERS
   Factory.hpp
   Angular.hpp
+  None.hpp
   Sommerfeld.hpp
   )
 

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Factory.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Angular.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -11,6 +12,6 @@
 namespace ScalarSelfForce::BoundaryConditions {
 
 /// List of all boundary conditions for the scalar self-force system.
-using standard_boundary_conditions = tmpl::list<Angular, Sommerfeld>;
+using standard_boundary_conditions = tmpl::list<Angular, Sommerfeld, None>;
 
 }  // namespace ScalarSelfForce::BoundaryConditions

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.hpp"
+
+namespace ScalarSelfForce::BoundaryConditions {
+
+None::None(CkMigrateMessage* m) : Base(m) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> None::get_clone()
+    const {
+  return std::make_unique<None>(*this);
+}
+
+void None::apply(
+    const gsl::not_null<Scalar<ComplexDataVector>*> /*field*/,
+    const gsl::not_null<Scalar<ComplexDataVector>*> /*n_dot_field_gradient*/,
+    const tnsr::i<ComplexDataVector, 2>& /*deriv_field*/) const {
+  // Nothing to do
+}
+
+void None::apply_linearized(
+    const gsl::not_null<Scalar<ComplexDataVector>*> /*field_correction*/,
+    const gsl::not_null<Scalar<ComplexDataVector>*>
+    /*n_dot_field_gradient_correction*/,
+    const tnsr::i<ComplexDataVector, 2>& /*deriv_field_correction*/) const {
+  // Nothing to do
+}
+
+bool operator==(const None& /*lhs*/, const None& /*rhs*/) { return true; }
+
+bool operator!=(const None& lhs, const None& rhs) { return not(lhs == rhs); }
+
+PUP::able::PUP_ID None::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace ScalarSelfForce::BoundaryConditions

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarSelfForce::BoundaryConditions {
+
+/*!
+ * \brief Applies no boundary condition at all. Used to impose nothing but
+ * regularity at the horizon in horizon-penetrating coordinates.
+ */
+class None : public elliptic::BoundaryConditions::BoundaryCondition<2> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<2>;
+
+ public:
+  static constexpr Options::String help =
+      "Applies no boundary condition at all. Used to impose nothing but "
+      "regularity at the horizon in horizon-penetrating coordinates.";
+  using options = tmpl::list<>;
+
+  None() = default;
+  None(const None&) = default;
+  None& operator=(const None&) = default;
+  None(None&&) = default;
+  None& operator=(None&&) = default;
+  ~None() override = default;
+
+  /// \cond
+  explicit None(CkMigrateMessage* m);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(None);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override;
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {elliptic::BoundaryConditionType::Neumann};
+  }
+
+  using argument_tags = tmpl::list<>;
+  using volume_tags = tmpl::list<>;
+
+  void apply(gsl::not_null<Scalar<ComplexDataVector>*> field,
+             gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient,
+             const tnsr::i<ComplexDataVector, 2>& deriv_field) const;
+
+  using argument_tags_linearized = tmpl::list<>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  void apply_linearized(
+      gsl::not_null<Scalar<ComplexDataVector>*> field_correction,
+      gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient_correction,
+      const tnsr::i<ComplexDataVector, 2>& deriv_field_correction) const;
+
+ private:
+  friend bool operator==(const None& lhs, const None& rhs);
+};
+
+bool operator!=(const None& lhs, const None& rhs);
+
+}  // namespace ScalarSelfForce::BoundaryConditions

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
@@ -16,12 +16,13 @@ namespace ScalarSelfForce::BoundaryConditions {
 Sommerfeld::Sommerfeld(const double black_hole_mass,
                        const double black_hole_spin,
                        const double orbital_radius, const int m_mode_number,
-                       const bool hyperboloidal_slicing)
+                       const bool hyperboloidal_slicing, const int order)
     : black_hole_mass_(black_hole_mass),
       black_hole_spin_(black_hole_spin),
       orbital_radius_(orbital_radius),
       m_mode_number_(m_mode_number),
-      hyperboloidal_slicing_(hyperboloidal_slicing) {}
+      hyperboloidal_slicing_(hyperboloidal_slicing),
+      order_(order) {}
 
 Sommerfeld::Sommerfeld(CkMigrateMessage* m) : Base(m) {}
 
@@ -33,26 +34,48 @@ Sommerfeld::get_clone() const {
 void Sommerfeld::apply(
     const gsl::not_null<Scalar<ComplexDataVector>*> field,
     const gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient,
-    const tnsr::i<ComplexDataVector, 2>& /*deriv_field*/) const {
+    const tnsr::i<ComplexDataVector, 2>& /*deriv_field*/,
+    const tnsr::I<DataVector, 2>& /*x*/, const Scalar<ComplexDataVector>& beta,
+    const tnsr::i<ComplexDataVector, 2>& gamma) const {
   if (hyperboloidal_slicing_) {
-    get(*n_dot_field_gradient) = 0.;
+    if (order_ == 1) {
+      get(*n_dot_field_gradient) = 0.;
+    } else if (order_ == 2) {
+      get(*n_dot_field_gradient) = -get(beta) / get<0>(gamma) * get(*field);
+    } else {
+      ERROR("Order " << order_
+                     << " not implemented for Sommerfeld boundary condition "
+                        "with hyperboloidal slicing.");
+    }
     return;
   }
   const double a = black_hole_spin_ * black_hole_mass_;
   const double M = black_hole_mass_;
   const double r_0 = orbital_radius_;
   const double omega = 1. / (a + sqrt(cube(r_0) / M));
-  get(*n_dot_field_gradient) =
-      std::complex<double>(0.0, m_mode_number_ * omega) * get(*field);
+  const double k = m_mode_number_ * omega;
+  if (order_ == 1) {
+    get(*n_dot_field_gradient) = std::complex<double>(0.0, k) * get(*field);
+  } else if (order_ == 2) {
+    // get(*n_dot_field_gradient) -= 1. / get<0>(x) * get(*field);
+    get(*n_dot_field_gradient) =
+        (square(k) - get(beta)) /
+        (get<0>(gamma) - std::complex<double>(0.0, 2. * k)) * get(*field);
+  } else {
+    ERROR("Order " << order_
+                   << " not implemented for Sommerfeld boundary condition.");
+  }
 }
 
 void Sommerfeld::apply_linearized(
     const gsl::not_null<Scalar<ComplexDataVector>*> field_correction,
     const gsl::not_null<Scalar<ComplexDataVector>*>
         n_dot_field_gradient_correction,
-    const tnsr::i<ComplexDataVector, 2>& deriv_field_correction) const {
+    const tnsr::i<ComplexDataVector, 2>& deriv_field_correction,
+    const tnsr::I<DataVector, 2>& x, const Scalar<ComplexDataVector>& beta,
+    const tnsr::i<ComplexDataVector, 2>& gamma) const {
   apply(field_correction, n_dot_field_gradient_correction,
-        deriv_field_correction);
+        deriv_field_correction, x, beta, gamma);
 }
 
 void Sommerfeld::pup(PUP::er& p) {
@@ -62,6 +85,7 @@ void Sommerfeld::pup(PUP::er& p) {
   p | orbital_radius_;
   p | m_mode_number_;
   p | hyperboloidal_slicing_;
+  p | order_;
 }
 
 bool operator==(const Sommerfeld& lhs, const Sommerfeld& rhs) {
@@ -69,7 +93,8 @@ bool operator==(const Sommerfeld& lhs, const Sommerfeld& rhs) {
          lhs.black_hole_spin_ == rhs.black_hole_spin_ and
          lhs.orbital_radius_ == rhs.orbital_radius_ and
          lhs.m_mode_number_ == rhs.m_mode_number_ and
-         lhs.hyperboloidal_slicing_ == rhs.hyperboloidal_slicing_;
+         lhs.hyperboloidal_slicing_ == rhs.hyperboloidal_slicing_ and
+         lhs.order_ == rhs.order_;
 }
 
 bool operator!=(const Sommerfeld& lhs, const Sommerfeld& rhs) {

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.cpp
@@ -57,7 +57,6 @@ void Sommerfeld::apply(
   if (order_ == 1) {
     get(*n_dot_field_gradient) = std::complex<double>(0.0, k) * get(*field);
   } else if (order_ == 2) {
-    // get(*n_dot_field_gradient) -= 1. / get<0>(x) * get(*field);
     get(*n_dot_field_gradient) =
         (square(k) - get(beta)) /
         (get<0>(gamma) - std::complex<double>(0.0, 2. * k)) * get(*field);

--- a/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.hpp
@@ -12,6 +12,7 @@
 #include "Domain/Tags.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
 #include "Options/String.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -62,11 +63,18 @@ class Sommerfeld : public elliptic::BoundaryConditions::BoundaryCondition<2> {
         "boundary condition is applied.";
     using type = bool;
   };
+  struct Order {
+    static constexpr Options::String help =
+        "Order of the boundary condition. First order (Order=1) implements "
+        "just the leading 'i m Omega' term. Second order (Order=2) includes "
+        "the next-to-leading '1/r' term as well (Robin-type).";
+    using type = int;
+  };
 
   static constexpr Options::String help =
       "Radial Sommerfeld boundary condition";
   using options = tmpl::list<BlackHoleMass, BlackHoleSpin, OrbitalRadius,
-                             MModeNumber, HyperboloidalSlicing>;
+                             MModeNumber, HyperboloidalSlicing, Order>;
 
   Sommerfeld() = default;
   Sommerfeld(const Sommerfeld&) = default;
@@ -77,13 +85,14 @@ class Sommerfeld : public elliptic::BoundaryConditions::BoundaryCondition<2> {
 
   explicit Sommerfeld(double black_hole_mass, double black_hole_spin,
                       double orbital_radius, int m_mode_number,
-                      bool hyperboloidal_slicing);
+                      bool hyperboloidal_slicing, int order);
 
   double black_hole_mass() const { return black_hole_mass_; }
   double black_hole_spin() const { return black_hole_spin_; }
   double orbital_radius() const { return orbital_radius_; }
   int m_mode_number() const { return m_mode_number_; }
   bool hyperboloidal_slicing() const { return hyperboloidal_slicing_; }
+  int order() const { return order_; }
 
   /// \cond
   explicit Sommerfeld(CkMigrateMessage* m);
@@ -99,20 +108,29 @@ class Sommerfeld : public elliptic::BoundaryConditions::BoundaryCondition<2> {
     return {elliptic::BoundaryConditionType::Neumann};
   }
 
-  using argument_tags = tmpl::list<>;
+  using argument_tags =
+      tmpl::list<domain::Tags::Coordinates<2, Frame::Inertial>, Tags::Beta,
+                 Tags::Gamma>;
   using volume_tags = tmpl::list<>;
 
   void apply(gsl::not_null<Scalar<ComplexDataVector>*> field,
              gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient,
-             const tnsr::i<ComplexDataVector, 2>& deriv_field) const;
+             const tnsr::i<ComplexDataVector, 2>& deriv_field,
+             const tnsr::I<DataVector, 2>& x,
+             const Scalar<ComplexDataVector>& beta,
+             const tnsr::i<ComplexDataVector, 2>& gamma) const;
 
-  using argument_tags_linearized = tmpl::list<>;
+  using argument_tags_linearized =
+      tmpl::list<domain::Tags::Coordinates<2, Frame::Inertial>, Tags::Beta,
+                 Tags::Gamma>;
   using volume_tags_linearized = tmpl::list<>;
 
   void apply_linearized(
       gsl::not_null<Scalar<ComplexDataVector>*> field_correction,
       gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient_correction,
-      const tnsr::i<ComplexDataVector, 2>& deriv_field_correction) const;
+      const tnsr::i<ComplexDataVector, 2>& deriv_field_correction,
+      const tnsr::I<DataVector, 2>& x, const Scalar<ComplexDataVector>& beta,
+      const tnsr::i<ComplexDataVector, 2>& gamma) const;
 
   // NOLINTNEXTLINE
   void pup(PUP::er& p) override;
@@ -125,6 +143,7 @@ class Sommerfeld : public elliptic::BoundaryConditions::BoundaryCondition<2> {
   double orbital_radius_{std::numeric_limits<double>::signaling_NaN()};
   int m_mode_number_{};
   bool hyperboloidal_slicing_{};
+  int order_{};
 };
 
 bool operator!=(const Sommerfeld& lhs, const Sommerfeld& rhs);

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ScalarSelfForceBoundaryConditions")
 set(LIBRARY_SOURCES
   Test_Angular.cpp
   Test_Sommerfeld.cpp
+  Test_None.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_Angular.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_Angular.cpp
@@ -11,11 +11,15 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Angular.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Factory.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/Pypp.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
@@ -51,6 +55,7 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.BoundaryConditions.Angular",
   }
   {
     INFO("Apply boundary condition");
+    const Direction<2> direction = Direction<2>::lower_xi();
     const DataVector used_for_size(5);
     auto field = make_with_value<Scalar<ComplexDataVector>>(
         used_for_size, std::numeric_limits<double>::signaling_NaN());
@@ -58,10 +63,27 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.BoundaryConditions.Angular",
         used_for_size, std::numeric_limits<double>::signaling_NaN());
     const tnsr::i<ComplexDataVector, 2> deriv_field{
         used_for_size.size(), std::numeric_limits<double>::signaling_NaN()};
-    const auto box = db::create<db::AddSimpleTags<>>();
+    const tnsr::I<DataVector, 2> coords{used_for_size.size(), 0.0};
+    const Scalar<ComplexDataVector> beta{used_for_size.size(), 0.0};
+    const tnsr::i<ComplexDataVector, 2> gamma{used_for_size.size(), 0.0};
+
+    const DirectionMap<2, tnsr::I<DataVector, 2>> coords_map{
+        {direction, coords}};
+    const DirectionMap<2, Scalar<ComplexDataVector>> beta_map{
+        {direction, beta}};
+    const DirectionMap<2, tnsr::i<ComplexDataVector, 2>> gamma_map{
+        {direction, gamma}};
+
+    const auto box = db::create<db::AddSimpleTags<
+        domain::Tags::Faces<2, domain::Tags::Coordinates<2, Frame::Inertial>>,
+        domain::Tags::Faces<2, Tags::Beta>,
+        domain::Tags::Faces<2, Tags::Gamma>>>(
+            std::move(coords_map),
+            std::move(beta_map),
+            std::move(gamma_map));
     elliptic::apply_boundary_condition<false, void,
                                        standard_boundary_conditions>(
-        boundary_condition, box, Direction<1>::lower_xi(),
+        boundary_condition, box, direction,
         make_not_null(&field), make_not_null(&n_dot_field_gradient),
         deriv_field);
     const ComplexDataVector expected_value(used_for_size.size(), 0.);

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_None.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_None.cpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <complex>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Factory.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarSelfForce::BoundaryConditions {
+
+SPECTRE_TEST_CASE("Unit.ScalarSelfForce.BoundaryConditions.None",
+                  "[Unit][Elliptic]") {
+  // 1. Test factory-creation
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<2>, None>("None");
+  REQUIRE(dynamic_cast<const None*>(created.get()) != nullptr);
+  const auto& boundary_condition = dynamic_cast<const None&>(*created);
+  {
+    INFO("Semantics");
+    test_serialization(boundary_condition);
+    test_copy_semantics(boundary_condition);
+    auto move_boundary_condition = boundary_condition;
+    test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+  {
+    INFO("Apply boundary condition");
+    const DataVector used_for_size(5);
+    auto field = make_with_value<Scalar<ComplexDataVector>>(used_for_size, 1.2);
+    auto n_dot_field_gradient = make_with_value<Scalar<ComplexDataVector>>(
+        used_for_size, 3.4);
+    const tnsr::i<ComplexDataVector, 2> deriv_field{
+        used_for_size.size(), 5.6};
+    const auto box = db::create<db::AddSimpleTags<>>();
+    elliptic::apply_boundary_condition<
+        false, void, standard_boundary_conditions>(
+        boundary_condition, box, Direction<2>::lower_xi(),
+        make_not_null(&field), make_not_null(&n_dot_field_gradient),
+        deriv_field);
+    CHECK(get(field) == ComplexDataVector(5, 1.2));
+    CHECK(get(n_dot_field_gradient) == ComplexDataVector(5, 3.4));
+  }
+}
+
+}  // namespace ScalarSelfForce::BoundaryConditions

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_None.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_None.cpp
@@ -11,10 +11,14 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Factory.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/None.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Utilities/Gsl.hpp"
@@ -38,13 +42,32 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.BoundaryConditions.None",
   }
   {
     INFO("Apply boundary condition");
+    const Direction<2> direction = Direction<2>::lower_xi();
     const DataVector used_for_size(5);
+
     auto field = make_with_value<Scalar<ComplexDataVector>>(used_for_size, 1.2);
     auto n_dot_field_gradient = make_with_value<Scalar<ComplexDataVector>>(
         used_for_size, 3.4);
     const tnsr::i<ComplexDataVector, 2> deriv_field{
         used_for_size.size(), 5.6};
-    const auto box = db::create<db::AddSimpleTags<>>();
+    const tnsr::I<DataVector, 2> coords{used_for_size.size(), 0.0};
+    const Scalar<ComplexDataVector> beta{used_for_size.size(), 0.0};
+    const tnsr::i<ComplexDataVector, 2> gamma{used_for_size.size(), 0.0};
+
+    const DirectionMap<2, tnsr::I<DataVector, 2>> coords_map{
+        {direction, coords}};
+    const DirectionMap<2, Scalar<ComplexDataVector>> beta_map{
+        {direction, beta}};
+    const DirectionMap<2, tnsr::i<ComplexDataVector, 2>> gamma_map{
+        {direction, gamma}};
+
+    const auto box = db::create<db::AddSimpleTags<
+        domain::Tags::Faces<2, domain::Tags::Coordinates<2, Frame::Inertial>>,
+        domain::Tags::Faces<2, Tags::Beta>,
+        domain::Tags::Faces<2, Tags::Gamma>>>(
+            std::move(coords_map),
+            std::move(beta_map),
+            std::move(gamma_map));
     elliptic::apply_boundary_condition<
         false, void, standard_boundary_conditions>(
         boundary_condition, box, Direction<2>::lower_xi(),

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_Sommerfeld.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Test_Sommerfeld.cpp
@@ -12,13 +12,16 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/FaceNormal.hpp"
+#include "Domain/Tags/Faces.hpp"
 #include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Factory.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/BoundaryConditions/Sommerfeld.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/Pypp.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
@@ -28,55 +31,82 @@
 #include "Utilities/TMPL.hpp"
 
 namespace ScalarSelfForce::BoundaryConditions {
-
 SPECTRE_TEST_CASE("Unit.ScalarSelfForce.BoundaryConditions.Sommerfeld",
                   "[Unit][Elliptic]") {
-  // Test factory-creation
-  const auto created = TestHelpers::test_factory_creation<
-      elliptic::BoundaryConditions::BoundaryCondition<2>, Sommerfeld>(
-      "Sommerfeld:\n"
-      "  BlackHoleMass: 1.0\n"
-      "  BlackHoleSpin: 0.5\n"
-      "  OrbitalRadius: 10.0\n"
-      "  MModeNumber: 2\n"
-      "  HyperboloidalSlicing: False\n");
-  REQUIRE(dynamic_cast<const Sommerfeld*>(created.get()) != nullptr);
-  const auto& boundary_condition = dynamic_cast<const Sommerfeld&>(*created);
+  using BC = elliptic::BoundaryConditions::BoundaryCondition<2>;
+  const std::string base_sommerfeld =
+        "Sommerfeld:\n"
+        "  BlackHoleMass: 1.0\n"
+        "  BlackHoleSpin: 0.5\n"
+        "  OrbitalRadius: 10.0\n"
+        "  MModeNumber: 2\n";
+  const Direction<2> direction = Direction<2>::lower_xi();
+  const size_t num_pts = 5;
   {
-    INFO("Semantics");
-    test_serialization(boundary_condition);
-    test_copy_semantics(boundary_condition);
-    auto move_boundary_condition = boundary_condition;
-    test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+    INFO("Testing Order 1");
+    const auto created_1 = TestHelpers::test_factory_creation<BC, Sommerfeld>(
+        base_sommerfeld + "  HyperboloidalSlicing: False\n  Order: 1");
+    const auto& bc_1 = dynamic_cast<const Sommerfeld&>(*created_1);
+    {
+      INFO("Semantics");
+      test_serialization(bc_1);
+      test_copy_semantics(bc_1);
+      auto move_bc_1 = bc_1;
+      test_move_semantics(std::move(move_bc_1), bc_1);
+    }
+    auto field = make_with_value<Scalar<ComplexDataVector>>(num_pts, 1.0);
+    auto n_dot_grad = make_with_value<Scalar<ComplexDataVector>>(num_pts, 0.0);
+    const DirectionMap<2, tnsr::I<DataVector, 2>> coords_map{
+        {direction, tnsr::I<DataVector, 2>{num_pts, 0.0}}};
+    const DirectionMap<2, Scalar<ComplexDataVector>> beta_map{
+        {direction, make_with_value<Scalar<ComplexDataVector>>(num_pts, 0.0)}};
+    const DirectionMap<2, tnsr::i<ComplexDataVector, 2>> gamma_map{
+        {direction,
+         make_with_value<tnsr::i<ComplexDataVector, 2>>(num_pts, 0.0)}};
+
+    const auto box = db::create<db::AddSimpleTags<
+        domain::Tags::Faces<2, domain::Tags::Coordinates<2, Frame::Inertial>>,
+        domain::Tags::Faces<2, Tags::Beta>,
+        domain::Tags::Faces<2, Tags::Gamma>>>(
+        std::move(coords_map), std::move(beta_map), std::move(gamma_map));
+    elliptic::apply_boundary_condition<
+        false, void, standard_boundary_conditions>(
+        bc_1, box, direction, make_not_null(&field), make_not_null(&n_dot_grad),
+        tnsr::i<ComplexDataVector, 2>{num_pts, 0.0});
+    const ComplexDataVector expected_1{
+        num_pts, std::complex<double>(0., 0.06226111848298833)};
+    CHECK_ITERABLE_APPROX(get(n_dot_grad), expected_1);
   }
+
   {
-    INFO("Properties");
-    CHECK(boundary_condition.black_hole_mass() == 1.0);
-    CHECK(boundary_condition.black_hole_spin() == 0.5);
-    CHECK(boundary_condition.orbital_radius() == 10.0);
-    CHECK(boundary_condition.m_mode_number() == 2);
-    CHECK(boundary_condition.hyperboloidal_slicing() == false);
-    CHECK(boundary_condition.boundary_condition_types() ==
-          std::vector<elliptic::BoundaryConditionType>{
-              elliptic::BoundaryConditionType::Neumann});
-  }
-  {
-    INFO("Apply boundary condition");
-    const DataVector used_for_size(5);
-    auto field = make_with_value<Scalar<ComplexDataVector>>(used_for_size, 1.);
-    auto n_dot_field_gradient = make_with_value<Scalar<ComplexDataVector>>(
-        used_for_size, std::numeric_limits<double>::signaling_NaN());
-    const tnsr::i<ComplexDataVector, 2> deriv_field{
-        used_for_size.size(), std::numeric_limits<double>::signaling_NaN()};
-    const auto box = db::create<db::AddSimpleTags<>>();
-    elliptic::apply_boundary_condition<false, void,
-                                       standard_boundary_conditions>(
-        boundary_condition, box, Direction<1>::lower_xi(),
-        make_not_null(&field), make_not_null(&n_dot_field_gradient),
-        deriv_field);
-    const ComplexDataVector expected_value(
-        used_for_size.size(), std::complex<double>(0., 0.06226111848298833));
-    CHECK_ITERABLE_APPROX(get(n_dot_field_gradient), expected_value);
+    INFO("Testing Order 2");
+    const auto created_2 = TestHelpers::test_factory_creation<BC, Sommerfeld>(
+        base_sommerfeld + "  HyperboloidalSlicing: True\n  Order: 2");
+    const auto& bc_2 = dynamic_cast<const Sommerfeld&>(*created_2);
+    auto field = make_with_value<Scalar<ComplexDataVector>>(num_pts, 1.0);
+    auto n_dot_grad = make_with_value<Scalar<ComplexDataVector>>(num_pts, 0.0);
+    auto beta = make_with_value<
+        Scalar<ComplexDataVector>>(num_pts, std::complex<double>(0.5, 0.0));
+    auto gamma = make_with_value<tnsr::i<ComplexDataVector, 2>>(num_pts, 0.0);
+    get<0>(gamma) = ComplexDataVector{num_pts, {2.0, 0.0}};
+    const auto box_2 = db::create<db::AddSimpleTags<
+        domain::Tags::Faces<2, domain::Tags::Coordinates<2, Frame::Inertial>>,
+        domain::Tags::Faces<2, Tags::Beta>,
+        domain::Tags::Faces<2, Tags::Gamma>>>(
+            DirectionMap<2, tnsr::I<DataVector, 2>>{
+                {direction, tnsr::I<DataVector, 2>{num_pts, 0.0}}},
+            DirectionMap<2, Scalar<ComplexDataVector>>{
+                {direction, std::move(beta)}},
+            DirectionMap<2, tnsr::i<ComplexDataVector, 2>>{
+                {direction, std::move(gamma)}});
+    elliptic::apply_boundary_condition<
+        false, void, standard_boundary_conditions>(
+        bc_2, box_2, direction,
+        make_not_null(&field), make_not_null(&n_dot_grad),
+        tnsr::i<ComplexDataVector, 2>{num_pts, 0.0});
+    const ComplexDataVector expected_2(
+        num_pts, std::complex<double>(-0.25, 0.0));
+    CHECK_ITERABLE_APPROX(get(n_dot_grad), expected_2);
   }
 }
 


### PR DESCRIPTION
## Proposed changes
- Sommerfeld boundary condition has been updated to support Order: 2
- Test_Sommerfeld has been updated to verify order 2 with hyperboloidal slicing
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
