### PR TITLE
higher order smooth function applied for the boost function in ScalarSelfForce

### DIFF
--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
@@ -23,15 +23,18 @@
 namespace ScalarSelfForce::AnalyticData {
 
 namespace {
+template <size_t Order>
 std::pair<DataVector, DataVector> boost_function_and_deriv(
     const DataVector& r_star, const std::array<double, 4>& transition_points) {
   return {
-      smoothstep<1>(transition_points[0], transition_points[1], r_star) +
-          smoothstep<1>(transition_points[2], transition_points[3], r_star) -
+      smoothstep<Order>(transition_points[0], transition_points[1], r_star) +
+          smoothstep<Order>(transition_points[2], transition_points[3],
+                            r_star) -
           1.0,
-      smoothstep_deriv<1>(transition_points[0], transition_points[1], r_star) +
-          smoothstep_deriv<1>(transition_points[2], transition_points[3],
-                              r_star)};
+      smoothstep_deriv<Order>(transition_points[0], transition_points[1],
+                              r_star) +
+          smoothstep_deriv<Order>(transition_points[2], transition_points[3],
+                                  r_star)};
 }
 }  // namespace
 
@@ -102,7 +105,7 @@ CircularOrbit::variables(
   get(alpha) *= sin_theta_squared;
   // Hyperboloidal slicing
   if (hyperboloidal_slicing_transitions_.has_value()) {
-    const auto [H, dH] = boost_function_and_deriv(
+    const auto [H, dH] = boost_function_and_deriv<2>(
         r_star, hyperboloidal_slicing_transitions_.value());
     const double k = m_mode_number_ * omega;
     get(beta) += std::complex<double>(0., -k) * dH + square(k) * square(H) +

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
@@ -25,6 +25,8 @@ namespace ScalarSelfForce::AnalyticData {
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarSelfForce.CircularOrbit",
                   "[PointwiseFunctions][Unit]") {
+
+  SECTION("Original Source and Equation Test") {
   // This test checks both the self-force equations and the effective source
   // computation in a very robust way: it ensures that the elliptic operator
   // applied to the singular field gives the effective source.
@@ -101,6 +103,46 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarSelfForce.CircularOrbit",
     // acting on the singular part.
     CHECK_ITERABLE_CUSTOM_APPROX(get(scalar_eqn), -get(effective_source),
                                  custom_approx);
+    }
+    }
+
+  SECTION("Hyperboloidal Slicing Test"){
+  // This test verifies that the hyperboloidal slicing transformation is
+  // correctly applied to the background shift (Beta)
+  // with boost function of order 2
+  const double r_0 = 10.0;
+  const double a = 0.5;
+  const double omega = 1. / (a + sqrt(cube(r_0) / 1.0));
+  const int m_mode_number = 2;
+  const double k = m_mode_number * omega;
+  const std::array<double, 4> transitions{{-25., -5., 20., 40.}};
+  const double r_star_test = 30.0;
+
+  const auto circular_orbit =
+        CircularOrbit{1.0, a, r_0 , m_mode_number, transitions};
+  const CircularOrbit base_orbit{1.0, a, r_0, m_mode_number, std::nullopt};
+  const tnsr::I<DataVector, 2, Frame::Inertial> x{
+    {{DataVector{r_star_test}, DataVector{0.0}}}};
+
+  const auto base_bg = base_orbit.variables(
+    x, CircularOrbit::background_tags{});
+  const auto& base_gamma = get<0>(get<Tags::Gamma>(base_bg));
+  const auto& base_beta = get(get<Tags::Beta>(base_bg));
+
+  const auto background = circular_orbit.variables(
+    x, CircularOrbit::background_tags{});
+  const auto& shifted_beta = get(get<Tags::Beta>(background));
+  const auto H = 0.5;
+  const auto dH = 1.875 / (transitions[3] - transitions[2]);
+  const double expected_re_delta_beta =
+        square(k) * square(H) - k * H * imag(base_gamma[0]);
+  const double expected_im_delta_beta =
+        -k * dH + k * H * real(base_gamma[0]);
+  const double re_delta_beta = real(shifted_beta[0]) - real(base_beta[0]);
+  const double im_delta_beta = imag(shifted_beta[0]) - imag(base_beta[0]);
+
+  CHECK(re_delta_beta == approx(expected_re_delta_beta));
+  CHECK(im_delta_beta == approx(expected_im_delta_beta));
   }
 }
 


### PR DESCRIPTION
## Proposed changes

- Higher order smoothstep and smoothstep_deriv implemented in the boost function for Scalar Self Force 
- Test_CircularOrbit verify that hyperboloidal slicing transformation with boost function (order = 2) have been correctly implemented 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
