### PR TITLE
Reduce smoothstep to step function when lower-edge equals upper-edge

### DIFF
--- a/src/Utilities/Math.hpp
+++ b/src/Utilities/Math.hpp
@@ -109,10 +109,16 @@ constexpr T step_function(const T& arg) {
  *
  * This function is $C^N$ continuous at the edges, i.e. the first $N$
  * derivatives are continuous at the edges.
+ *
+ * If `lower_edge` and `upper_edge` are equal, this function reduces to the
+ * step function $\Theta(x - x_0)$.
  */
 template <size_t N, typename DataType>
 DataType smoothstep(const double lower_edge, const double upper_edge,
                     const DataType& arg) {
+  if (lower_edge == upper_edge) {
+    return step_function(arg - lower_edge);
+  }
   ASSERT(lower_edge < upper_edge,
          "Requires lower_edge < upper_edge, but lower_edge="
              << lower_edge << " and upper_edge=" << upper_edge);
@@ -143,10 +149,17 @@ DataType smoothstep(const double lower_edge, const double upper_edge,
  *
  * Since the smoothstep function is $C^N$ continuous at the edges, this
  * function is $C^{N-1}$ continuous at the edges.
+ *
+ * If `lower_edge` and `upper_edge` are equal, this function reduces to the
+ * derivative of the step function, which is zero everywhere except at the edge
+ * where it is not defined. We define it to be zero in this case as well.
  */
 template <size_t N, typename DataType>
 DataType smoothstep_deriv(const double lower_edge, const double upper_edge,
                           const DataType& arg) {
+  if (lower_edge == upper_edge) {
+    return make_with_value<DataType>(arg, 0.);
+  }
   ASSERT(lower_edge < upper_edge,
          "Requires lower_edge < upper_edge, but lower_edge="
              << lower_edge << " and upper_edge=" << upper_edge);

--- a/tests/Unit/Utilities/Test_Math.cpp
+++ b/tests/Unit/Utilities/Test_Math.cpp
@@ -87,7 +87,22 @@ SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
         DataVector({0., 0., 0., 0., 0., 0., 1.605224609375e-02, 1.03515625e-01,
                     0.5, 8.96484375e-01, 1.}));
   }
+  {
+    INFO("Test smoothstep with equal edges");
+    const double edge = 1.5;
+    CHECK(smoothstep<2>(edge, edge, 1.0) == approx(0.0));
+    CHECK(smoothstep<2>(edge, edge, 1.5) == approx(1.0));
+    CHECK(smoothstep<2>(edge, edge, 2.0) == approx(1.0));
 
+    INFO("Test smoothstep_deriv with equal edges");
+    CHECK(smoothstep_deriv<2>(edge, edge, 1.0) == approx(0.0));
+    CHECK(smoothstep_deriv<2>(edge, edge, 1.5) == approx(0.0));
+    CHECK(smoothstep_deriv<2>(edge, edge, 2.0) == approx(0.0));
+
+    CHECK_ITERABLE_APPROX(
+        smoothstep_deriv<2>(edge, edge, DataVector({1.0, 1.5, 2.0})),
+        DataVector({0.0, 0.0, 0.0}));
+  }
   {
     INFO("Test inverse roots and step_function");
     CHECK(step_function(1.0) == 1.0);


### PR DESCRIPTION
## Proposed changes

- For both smoothstep and smoothstep_deriv, we added the option when lower_edge = upper_edge 
- If lower_dege = upper_edge, smoothstep reduces to the step function $\Theta(x - x_0)$
- If lower_dege = upper_edge, smoothstep_deriv reduces to zero everywhere
- Test_Math was updated to check when lower_edge = upper_edge

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
