### PR TITLE
Added BoostFunction Tag and Test_Tags for Scalar Self Force

### DIFF
--- a/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
@@ -128,4 +128,18 @@ struct BoyerLindquistRadius : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+/*!
+ * \brief The hyperboloidal boost function $H(r_*)$.
+ */
+struct BoostFunction : db::SimpleTag {
+  using type = Scalar<ComplexDataVector>;
+};
+
+/*!
+ * \brief The radial derivative of the boost function, $H'(r_*)$.
+ */
+struct BoostFunctionDeriv : db::SimpleTag {
+  using type = Scalar<ComplexDataVector>;
+};
+
 }  // namespace ScalarSelfForce::Tags

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
@@ -1,6 +1,22 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(LIBRARY "Test_ScalarSelfForce")
+
+set(LIBRARY_SOURCES
+  Test_Tags.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DataStructuresHelpers
+  ScalarSelfForce
+  )
+
 add_subdirectory(AmrCriteria)
 add_subdirectory(AnalyticData)
 add_subdirectory(BoundaryConditions)

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <string>
+
+#include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+namespace ScalarSelfForce {
+
+SPECTRE_TEST_CASE(
+    "Unit.Elliptic.Systems.ScalarSelfForce.Tags", "[Unit][Elliptic]") {
+  TestHelpers::db::test_simple_tag<Tags::MMode>("MMode");
+  TestHelpers::db::test_simple_tag<Tags::Alpha>("Alpha");
+  TestHelpers::db::test_simple_tag<Tags::Beta>("Beta");
+  TestHelpers::db::test_simple_tag<Tags::Gamma>("Gamma");
+  TestHelpers::db::test_simple_tag<Tags::FieldIsRegularized>(
+      "FieldIsRegularized");
+  TestHelpers::db::test_simple_tag<Tags::SingularField>("SingularField");
+  TestHelpers::db::test_simple_tag<Tags::BoyerLindquistRadius>(
+      "BoyerLindquistRadius");
+  TestHelpers::db::test_simple_tag<Tags::BoostFunction>("BoostFunction");
+  TestHelpers::db::test_simple_tag<Tags::BoostFunctionDeriv>(
+      "BoostFunctionDeriv");
+}
+
+}  // namespace GrSelfForce


### PR DESCRIPTION
## Proposed changes

- Added BoostFunction and BoostFunctionDeriv tags for scalar self force
- Added unit test (Test_Tags) 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
