### PR TITLE
Enable BBH completion based on constraints, common horizon finds

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -46,6 +46,11 @@
 #include "Evolution/Initialization/NonconservativeSystem.hpp"
 #include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/Callbacks/UpdateCompletionCriteria.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionSingleton.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CheckConstraintThresholds.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CheckpointAndExitIfComplete.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletMinkowski.hpp"
@@ -264,7 +269,8 @@ struct EvolutionMetavars {
     using horizon_find_callbacks = tmpl::append<
         tmpl::conditional_t<
             Horizon == ::domain::ObjectLabel::C,
-            tmpl::list<ah::callbacks::SendDependencyToObserverWriter<Ah, true>>,
+            tmpl::list<ah::callbacks::SendDependencyToObserverWriter<Ah, true>,
+                       gh::bbh::callbacks::UpdateCompletionCriteria<Ah>>,
             tmpl::list<>>,
         tmpl::list<ah::callbacks::ObserveFieldsOnHorizon<
                        ::ah::surface_tags_for_observing, Ah>,
@@ -492,6 +498,7 @@ struct EvolutionMetavars {
                        ah::Events::FindApparentHorizon<AhB>,
                        ah::Events::FindCommonHorizon<AhC, observe_fields,
                                                      non_tensor_compute_tags>,
+                       gh::bbh::Events::CheckConstraintThresholds,
                        intrp::Events::InterpolateWithoutInterpComponent<
                            3, BondiSachs, source_vars_no_deriv>,
                        intrp::Events::InterpolateWithoutInterpComponent<
@@ -526,7 +533,10 @@ struct EvolutionMetavars {
         // Restrict to monotonic time steppers in LTS to avoid control
         // systems deadlocking.
         tmpl::pair<LtsTimeStepper, TimeSteppers::monotonic_lts_time_steppers>,
-        tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
+        tmpl::pair<PhaseChange,
+                   tmpl::push_back<
+                       PhaseControl::factory_creatable_classes,
+                       gh::bbh::phase_control::CheckpointAndExitIfComplete>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
         tmpl::pair<
@@ -550,6 +560,8 @@ struct EvolutionMetavars {
                  gh::Tags::DampingFunctionGamma0<volume_dim, Frame::Grid>,
                  gh::Tags::DampingFunctionGamma1<volume_dim, Frame::Grid>,
                  gh::Tags::DampingFunctionGamma2<volume_dim, Frame::Grid>>;
+
+  using mutable_global_cache_tags = tmpl::list<>;
 
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
@@ -619,6 +631,8 @@ struct EvolutionMetavars {
       Initialization::Actions::AddComputeTags<
           tmpl::push_back<StepChoosers::step_chooser_compute_tags<
               EvolutionMetavars, local_time_stepping>>>,
+      Initialization::Actions::AddSimpleTags<
+          gh::bbh::Actions::InitializeElementCompletionRequested>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,
       intrp::Actions::ElementInitInterpPoints<volume_dim,
                                               interpolation_target_tags>,
@@ -729,6 +743,7 @@ struct EvolutionMetavars {
                             interpolation_target_tags>,
                     tmpl::bind<intrp::Tags::PointInfo, tmpl::_1,
                                tmpl::pin<tmpl::size_t<volume_dim>>>>>,
+            gh::bbh::Tags::ElementCompletionRequested,
             Tags::ChangeSlabSize::NumberOfExpectedMessages,
             Tags::ChangeSlabSize::NewSlabSize>>>;
     static constexpr bool keep_coarse_grids = false;
@@ -741,6 +756,7 @@ struct EvolutionMetavars {
       observers::ObserverWriter<EvolutionMetavars>,
       importers::ElementDataReader<EvolutionMetavars>,
       mem_monitor::MemoryMonitor<EvolutionMetavars>,
+      gh::bbh::CompletionSingleton<EvolutionMetavars>,
       ah::Component<EvolutionMetavars, AhA>,
       ah::Component<EvolutionMetavars, AhB>,
       ah::Component<EvolutionMetavars, AhC>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  CompletionCriteria.hpp
+  CompletionSingleton.hpp
+  )
+
+add_subdirectory(Callbacks)
+add_subdirectory(Events)
+add_subdirectory(PhaseControl)

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Callbacks/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Callbacks/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  UpdateCompletionCriteria.hpp
+  )

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Callbacks/UpdateCompletionCriteria.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Callbacks/UpdateCompletionCriteria.hpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionSingleton.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Tags.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/Callback.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace gh::bbh::callbacks {
+/*!
+ * \brief Apparent-horizon callback that updates binary-black-hole completion
+ * criteria from successful common-horizon finds.
+ *
+ * \details This callback forwards each successful AhC find (`temporal_id`,
+ * `LMax`) to `gh::bbh::CompletionSingleton`, where completion criteria are
+ * evaluated in a temporally robust, centralized way.
+ */
+template <typename HorizonMetavars>
+struct UpdateCompletionCriteria : tt::ConformsTo<ah::protocols::Callback> {
+  using const_global_cache_tags = tmpl::list<>;
+  using mutable_global_cache_tags = tmpl::list<>;
+
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const FastFlow::Status /*status*/) {
+    const auto& current_time = db::get<ah::Tags::CurrentTime>(box);
+    ASSERT(current_time.has_value(),
+           "AhC completion callback requires a current temporal id.");
+    const size_t l_max =
+        db::get<ylm::Tags::Strahlkorper<typename HorizonMetavars::frame>>(box)
+            .l_max();
+    Parallel::simple_action<gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        Parallel::get_parallel_component<
+            gh::bbh::CompletionSingleton<Metavariables>>(cache),
+        *current_time, l_max);
+  }
+};
+}  // namespace gh::bbh::callbacks

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp
@@ -1,0 +1,203 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace gh::bbh {
+namespace OptionTags {
+/// BBH inspiral-completion controls that are read from input options.
+struct CompletionCriteria {
+  static std::string name() { return "BbhCompletionCriteria"; }
+  static constexpr Options::String help =
+      "Options controlling inspiral termination based on global BBH criteria.";
+};
+
+struct MinCommonHorizonSuccessesBeforeChecks {
+  using type = size_t;
+  using group = CompletionCriteria;
+  static constexpr Options::String help =
+      "Do not evaluate binary-black-hole completion checks before this many "
+      "successful common-horizon finds.";
+};
+
+struct MaxCommonHorizonSuccesses {
+  using type = size_t;
+  using group = CompletionCriteria;
+  static constexpr Options::String help =
+      "When successful common-horizon finds reach this count in a "
+      "binary-black-hole simulation, request completion.";
+};
+
+struct GaugeConstraintLinfThreshold {
+  using type = double;
+  using group = CompletionCriteria;
+  static constexpr Options::String help =
+      "When the reduced Linf norm of the gauge constraint is greater than or "
+      "equal to this threshold in a binary-black-hole simulation, request "
+      "completion.";
+};
+
+struct ThreeIndexConstraintLinfThreshold {
+  using type = double;
+  using group = CompletionCriteria;
+  static constexpr Options::String help =
+      "When the reduced Linf norm of the three-index constraint is greater "
+      "than or equal to this threshold in a binary-black-hole simulation, "
+      "request completion.";
+};
+
+struct CommonHorizonLMaxThreshold {
+  using type = size_t;
+  using group = CompletionCriteria;
+  static constexpr Options::String help =
+      "When the common-horizon LMax is less than or equal to this value in a "
+      "binary-black-hole simulation, request completion (after the minimum "
+      "common-horizon success count is reached).";
+};
+
+struct ConstraintCheckVerbose {
+  using type = bool;
+  using group = CompletionCriteria;
+  static constexpr Options::String help =
+      "Whether to print reduced binary-black-hole constraint norms at each "
+      "constraint-threshold check.";
+};
+}  // namespace OptionTags
+
+namespace Tags {
+/// Minimum number of successful common-horizon finds required before
+/// completion checks are evaluated.
+struct MinCommonHorizonSuccessesBeforeChecks : db::SimpleTag {
+  using type = size_t;
+  using option_tags =
+      tmpl::list<OptionTags::MinCommonHorizonSuccessesBeforeChecks>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type value) { return value; }
+};
+
+/// Number of successful common-horizon finds that triggers completion.
+/// Controlled by `gh::bbh::OptionTags::MaxCommonHorizonSuccesses`.
+struct MaxCommonHorizonSuccesses : db::SimpleTag {
+  using type = size_t;
+  using option_tags = tmpl::list<OptionTags::MaxCommonHorizonSuccesses>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type value) { return value; }
+};
+
+/// Threshold for requesting completion from the reduced gauge-constraint Linf
+/// criterion:
+/// when Linf(gauge constraint) >= this threshold in a binary-black-hole
+/// simulation, request completion.
+/// Controlled by `gh::bbh::OptionTags::GaugeConstraintLinfThreshold`.
+struct GaugeConstraintLinfThreshold : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::GaugeConstraintLinfThreshold>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type value) { return value; }
+};
+
+/// Threshold for requesting completion from the reduced three-index-constraint
+/// Linf criterion:
+/// when Linf(three-index constraint) >= this threshold in a binary-black-hole
+/// simulation, request completion.
+/// Controlled by `gh::bbh::OptionTags::ThreeIndexConstraintLinfThreshold`.
+struct ThreeIndexConstraintLinfThreshold : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<OptionTags::ThreeIndexConstraintLinfThreshold>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type value) { return value; }
+};
+
+/// Common-horizon `LMax` threshold criterion for requesting completion
+/// (after the minimum common-horizon success count is reached):
+/// when common-horizon `LMax` <= this threshold in a binary-black-hole
+/// simulation, request completion.
+/// Controlled by `gh::bbh::OptionTags::CommonHorizonLMaxThreshold`.
+struct CommonHorizonLMaxThreshold : db::SimpleTag {
+  using type = size_t;
+  using option_tags = tmpl::list<OptionTags::CommonHorizonLMaxThreshold>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type value) { return value; }
+};
+
+/// Verbosity control for reduced constraint checks.
+/// Controlled by `gh::bbh::OptionTags::ConstraintCheckVerbose`.
+struct ConstraintCheckVerbose : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<OptionTags::ConstraintCheckVerbose>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(const type value) { return value; }
+};
+
+/// Latch indicating that the reduced gauge-constraint criterion was met.
+struct GaugeConstraintExceeded : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return false; }
+};
+
+/// Latch indicating that the reduced three-index-constraint criterion was met.
+struct ThreeIndexConstraintExceeded : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return false; }
+};
+
+/// Latch indicating that a successful common-horizon find satisfied the `LMax`
+/// criterion.
+struct CommonHorizonLMaxBelowOrEqualThreshold : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return false; }
+};
+
+/// Count of successful common-horizon finds.
+struct CommonHorizonSuccessCount : db::SimpleTag {
+  using type = size_t;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return 0; }
+};
+
+/// Latch used by phase control to checkpoint-and-exit the binary-black-hole
+/// simulation when completion is requested by any criterion.
+struct CompletionRequested : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return false; }
+};
+
+/// Element-local latch mirrored from the BBH completion singleton and used by
+/// phase control to request checkpoint-and-exit.
+struct ElementCompletionRequested : db::SimpleTag {
+  using type = bool;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return false; }
+};
+}  // namespace Tags
+}  // namespace gh::bbh

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionSingleton.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionSingleton.hpp
@@ -1,0 +1,377 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp"
+#include "Parallel/Algorithms/AlgorithmSingletonDeclarations.hpp"
+#include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
+#include "Parallel/ArrayCollection/SimpleActionOnElement.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Local.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/Printf/Printf.hpp"
+#include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
+#include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace gh::bbh {
+namespace Tags {
+/// Successful AhC finds keyed by temporal id, storing the corresponding `LMax`.
+struct CommonHorizonSuccessRecords : db::SimpleTag {
+  using type = std::map<LinkedMessageId<double>, size_t>;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return {}; }
+};
+
+/// Reduced constraint maxima keyed by time.
+struct ConstraintCheckRecords : db::SimpleTag {
+  using key_type = double;
+  using mapped_type = std::pair<double, double>;
+  using type = std::map<key_type, mapped_type>;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return {}; }
+};
+
+/// Constraint checks already reported at verbose level.
+struct ReportedConstraintCheckRecords : db::SimpleTag {
+  using type = std::set<gh::bbh::Tags::ConstraintCheckRecords::key_type>;
+  using option_tags = tmpl::list<>;
+
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options() { return {}; }
+};
+}  // namespace Tags
+
+namespace Actions {
+/// Element simple action that latches completion-request state in the DataBox.
+struct SetElementCompletionRequested {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/) {
+    db::mutate<gh::bbh::Tags::ElementCompletionRequested>(
+        [](const gsl::not_null<bool*> element_completion_requested) {
+          *element_completion_requested = true;
+        },
+        make_not_null(&box));
+  }
+};
+}  // namespace Actions
+
+namespace detail {
+template <typename Metavariables>
+struct BroadcastCompletionRequestToElements {
+  static void apply(Parallel::GlobalCache<Metavariables>& cache) {
+    using dg_array = typename Metavariables::gh_dg_element_array;
+    if constexpr (Parallel::is_dg_element_collection_v<dg_array>) {
+      Parallel::threaded_action<Parallel::Actions::SimpleActionOnElement<
+          gh::bbh::Actions::SetElementCompletionRequested, true>>(
+          Parallel::get_parallel_component<dg_array>(cache));
+    } else {
+      Parallel::simple_action<gh::bbh::Actions::SetElementCompletionRequested>(
+          Parallel::get_parallel_component<dg_array>(cache));
+    }
+  }
+};
+
+template <typename DbTags, typename Metavariables>
+void recompute_completion_state(const gsl::not_null<db::DataBox<DbTags>*> box,
+                                Parallel::GlobalCache<Metavariables>& cache) {
+  const size_t min_successes =
+      Parallel::get<gh::bbh::Tags::MinCommonHorizonSuccessesBeforeChecks>(
+          cache);
+  const size_t max_successes =
+      Parallel::get<gh::bbh::Tags::MaxCommonHorizonSuccesses>(cache);
+  const size_t l_max_threshold =
+      Parallel::get<gh::bbh::Tags::CommonHorizonLMaxThreshold>(cache);
+  const double gauge_constraint_threshold =
+      Parallel::get<gh::bbh::Tags::GaugeConstraintLinfThreshold>(cache);
+  const double three_index_constraint_threshold =
+      Parallel::get<gh::bbh::Tags::ThreeIndexConstraintLinfThreshold>(cache);
+  const bool verbose =
+      Parallel::get<gh::bbh::Tags::ConstraintCheckVerbose>(cache);
+  if (max_successes < min_successes) {
+    ERROR_NO_TRACE("MaxCommonHorizonSuccesses ("
+                   << max_successes << ") must be >= "
+                   << "MinCommonHorizonSuccessesBeforeChecks (" << min_successes
+                   << ").");
+  }
+
+  const auto& horizon_records =
+      db::get<gh::bbh::Tags::CommonHorizonSuccessRecords>(*box);
+  const size_t success_count = horizon_records.size();
+  bool lmax_latched = false;
+  std::optional<std::pair<double, size_t>> first_lmax_match{};
+  for (const auto& [time_id, l_max] : horizon_records) {
+    if (l_max <= l_max_threshold) {
+      lmax_latched = true;
+      first_lmax_match = std::pair{time_id.id, l_max};
+      break;
+    }
+  }
+
+  std::optional<double> first_gauge_match_time{};
+  std::optional<double> first_three_index_match_time{};
+  size_t successes_up_to_constraint_time = 0;
+  auto horizon_it = horizon_records.begin();
+  const auto& constraint_records =
+      db::get<gh::bbh::Tags::ConstraintCheckRecords>(*box);
+  const auto& reported_constraint_records =
+      db::get<gh::bbh::Tags::ReportedConstraintCheckRecords>(*box);
+  std::vector<gh::bbh::Tags::ConstraintCheckRecords::key_type>
+      newly_reported_constraint_records{};
+  for (const auto& [constraint_time, maxima] : constraint_records) {
+    while (horizon_it != horizon_records.end() and
+           horizon_it->first.id <= constraint_time) {
+      ++successes_up_to_constraint_time;
+      ++horizon_it;
+    }
+    if (successes_up_to_constraint_time < min_successes) {
+      continue;
+    }
+    if (verbose and not reported_constraint_records.contains(constraint_time)) {
+      Parallel::printf(
+          "BBH completion constraint check at t=%.16f: "
+          "Linf(GaugeConstraint)=%.16e (threshold %.16e), "
+          "Linf(ThreeIndexConstraint)=%.16e (threshold %.16e).\n",
+          constraint_time, maxima.first, gauge_constraint_threshold,
+          maxima.second, three_index_constraint_threshold);
+      newly_reported_constraint_records.push_back(constraint_time);
+    }
+    if (not first_gauge_match_time.has_value() and
+        maxima.first >= gauge_constraint_threshold) {
+      first_gauge_match_time = constraint_time;
+    }
+    if (not first_three_index_match_time.has_value() and
+        maxima.second >= three_index_constraint_threshold) {
+      first_three_index_match_time = constraint_time;
+    }
+  }
+  const bool horizon_completion_requested =
+      success_count >= min_successes and
+      (success_count >= max_successes or lmax_latched);
+  const bool completion_requested = horizon_completion_requested or
+                                    first_gauge_match_time.has_value() or
+                                    first_three_index_match_time.has_value();
+
+  const bool old_gauge_exceeded =
+      db::get<gh::bbh::Tags::GaugeConstraintExceeded>(*box);
+  const bool old_three_index_exceeded =
+      db::get<gh::bbh::Tags::ThreeIndexConstraintExceeded>(*box);
+  const bool old_lmax_latched =
+      db::get<gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold>(*box);
+  const size_t old_success_count =
+      db::get<gh::bbh::Tags::CommonHorizonSuccessCount>(*box);
+  const bool old_completion_requested =
+      db::get<gh::bbh::Tags::CompletionRequested>(*box);
+  db::mutate<gh::bbh::Tags::GaugeConstraintExceeded,
+             gh::bbh::Tags::ThreeIndexConstraintExceeded,
+             gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold,
+             gh::bbh::Tags::CommonHorizonSuccessCount,
+             gh::bbh::Tags::CompletionRequested>(
+      [&first_gauge_match_time, &first_three_index_match_time, &lmax_latched,
+       &success_count, &completion_requested](
+          const gsl::not_null<bool*> gauge_constraint_exceeded_flag,
+          const gsl::not_null<bool*> three_index_constraint_exceeded_flag,
+          const gsl::not_null<bool*> lmax_latched_flag,
+          const gsl::not_null<size_t*> common_horizon_success_count,
+          const gsl::not_null<bool*> completion_requested_flag) {
+        *gauge_constraint_exceeded_flag = first_gauge_match_time.has_value();
+        *three_index_constraint_exceeded_flag =
+            first_three_index_match_time.has_value();
+        *lmax_latched_flag = lmax_latched;
+        *common_horizon_success_count = success_count;
+        *completion_requested_flag = completion_requested;
+      },
+      box);
+  if (not newly_reported_constraint_records.empty()) {
+    db::mutate<gh::bbh::Tags::ReportedConstraintCheckRecords>(
+        [&newly_reported_constraint_records](
+            const gsl::not_null<
+                gh::bbh::Tags::ReportedConstraintCheckRecords::type*>
+                records) {
+          for (const auto& key : newly_reported_constraint_records) {
+            records->insert(key);
+          }
+        },
+        box);
+  }
+  if (old_success_count < min_successes and success_count >= min_successes) {
+    Parallel::printf(
+        "BBH completion criterion armed: AhC successes reached %zu (minimum "
+        "required: %zu).\n",
+        success_count, min_successes);
+  }
+  if (not old_lmax_latched and lmax_latched and first_lmax_match.has_value()) {
+    Parallel::printf(
+        "BBH completion criterion met at t=%.16f: AhC Lmax=%zu <= %zu.\n",
+        first_lmax_match->first, first_lmax_match->second, l_max_threshold);
+  }
+  if (not old_gauge_exceeded and first_gauge_match_time.has_value()) {
+    Parallel::printf(
+        "BBH completion criterion met at t=%.16f: "
+        "Linf(GaugeConstraint) >= %.16e.\n",
+        *first_gauge_match_time, gauge_constraint_threshold);
+  }
+  if (not old_three_index_exceeded and
+      first_three_index_match_time.has_value()) {
+    Parallel::printf(
+        "BBH completion criterion met at t=%.16f: "
+        "Linf(ThreeIndexConstraint) >= %.16e.\n",
+        *first_three_index_match_time, three_index_constraint_threshold);
+  }
+  if (not old_completion_requested and completion_requested) {
+    Parallel::printf("BBH completion criteria request latched.\n");
+    BroadcastCompletionRequestToElements<Metavariables>::apply(cache);
+  }
+}
+
+struct InitializeCompletionState : tt::ConformsTo<db::protocols::Mutator> {
+  using return_tags =
+      tmpl::list<gh::bbh::Tags::GaugeConstraintExceeded,
+                 gh::bbh::Tags::ThreeIndexConstraintExceeded,
+                 gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold,
+                 gh::bbh::Tags::CommonHorizonSuccessCount,
+                 gh::bbh::Tags::CompletionRequested,
+                 gh::bbh::Tags::CommonHorizonSuccessRecords,
+                 gh::bbh::Tags::ConstraintCheckRecords,
+                 gh::bbh::Tags::ReportedConstraintCheckRecords>;
+  using argument_tags = tmpl::list<>;
+
+  static void apply(
+      const gsl::not_null<bool*> gauge_constraint_exceeded,
+      const gsl::not_null<bool*> three_index_constraint_exceeded,
+      const gsl::not_null<bool*> common_horizon_lmax_below_or_equal_threshold,
+      const gsl::not_null<size_t*> common_horizon_success_count,
+      const gsl::not_null<bool*> completion_requested,
+      const gsl::not_null<gh::bbh::Tags::CommonHorizonSuccessRecords::type*>
+          common_horizon_success_records,
+      const gsl::not_null<gh::bbh::Tags::ConstraintCheckRecords::type*>
+          constraint_check_records,
+      const gsl::not_null<gh::bbh::Tags::ReportedConstraintCheckRecords::type*>
+          reported_constraint_check_records) {
+    *gauge_constraint_exceeded = false;
+    *three_index_constraint_exceeded = false;
+    *common_horizon_lmax_below_or_equal_threshold = false;
+    *common_horizon_success_count = 0;
+    *completion_requested = false;
+    common_horizon_success_records->clear();
+    constraint_check_records->clear();
+    reported_constraint_check_records->clear();
+  }
+};
+}  // namespace detail
+
+namespace Actions {
+/// Records a successful AhC find and updates BBH completion state.
+struct RecordCommonHorizonSuccess {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const LinkedMessageId<double>& temporal_id,
+                    const size_t l_max) {
+    auto& common_horizon_success_records =
+        db::get_mutable_reference<gh::bbh::Tags::CommonHorizonSuccessRecords>(
+            make_not_null(&box));
+    const bool inserted =
+        common_horizon_success_records.emplace(temporal_id, l_max).second;
+    if (not inserted) {
+      ERROR("Duplicate common-horizon completion record for temporal id "
+            << temporal_id << ".");
+    }
+    detail::recompute_completion_state(make_not_null(&box), cache);
+  }
+};
+
+/// Reduction target callback that records reduced constraint maxima and updates
+/// BBH completion state.
+struct ProcessConstraintMaxima {
+  template <typename ParallelComponent, typename DbTags, typename Metavariables,
+            typename ArrayIndex>
+  static void apply(db::DataBox<DbTags>& box,
+                    Parallel::GlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/, const double time,
+                    const double max_gauge_linf,
+                    const double max_three_index_linf) {
+    auto& constraint_check_records =
+        db::get_mutable_reference<gh::bbh::Tags::ConstraintCheckRecords>(
+            make_not_null(&box));
+    const bool inserted =
+        constraint_check_records
+            .emplace(time,
+                     gh::bbh::Tags::ConstraintCheckRecords::mapped_type{
+                         max_gauge_linf, max_three_index_linf})
+            .second;
+    if (not inserted) {
+      ERROR("Duplicate BBH completion constraint-max record at t=" << time
+                                                                   << ".");
+    }
+    detail::recompute_completion_state(make_not_null(&box), cache);
+  }
+};
+
+/// Initializes the element-local completion-request tag.
+struct InitializeElementCompletionRequested
+    : tt::ConformsTo<db::protocols::Mutator> {
+  using return_tags = tmpl::list<gh::bbh::Tags::ElementCompletionRequested>;
+  using argument_tags = tmpl::list<>;
+
+  static void apply(const gsl::not_null<bool*> element_completion_requested) {
+    *element_completion_requested = false;
+  }
+};
+}  // namespace Actions
+
+template <class Metavariables>
+struct CompletionSingleton {
+  using chare_type = Parallel::Algorithms::Singleton;
+  static constexpr bool checkpoint_data = true;
+  using metavariables = Metavariables;
+  using const_global_cache_tags =
+      tmpl::list<gh::bbh::Tags::MinCommonHorizonSuccessesBeforeChecks,
+                 gh::bbh::Tags::MaxCommonHorizonSuccesses,
+                 gh::bbh::Tags::GaugeConstraintLinfThreshold,
+                 gh::bbh::Tags::ThreeIndexConstraintLinfThreshold,
+                 gh::bbh::Tags::CommonHorizonLMaxThreshold,
+                 gh::bbh::Tags::ConstraintCheckVerbose>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<Initialization::Actions::AddSimpleTags<
+                     gh::bbh::detail::InitializeCompletionState>,
+                 Parallel::Actions::TerminatePhase>>>;
+  using simple_tags_from_options = tmpl::list<>;
+
+  static void execute_next_phase(
+      const Parallel::Phase next_phase,
+      Parallel::CProxy_GlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *Parallel::local_branch(global_cache);
+    Parallel::get_parallel_component<CompletionSingleton<Metavariables>>(
+        local_cache)
+        .start_phase(next_phase);
+  }
+};
+}  // namespace gh::bbh

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  CheckConstraintThresholds.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  CheckConstraintThresholds.hpp
+  )

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CheckConstraintThresholds.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CheckConstraintThresholds.cpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CheckConstraintThresholds.hpp"
+
+namespace gh::bbh::Events {
+PUP::able::PUP_ID CheckConstraintThresholds::my_PUP_ID = 0;  // NOLINT
+}  // namespace gh::bbh::Events

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CheckConstraintThresholds.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/Events/CheckConstraintThresholds.hpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionSingleton.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/String.hpp"
+#include "Parallel/ArrayCollection/IsDgElementCollection.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Reduction.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/Event.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace gh::bbh::Events {
+/*!
+ * \brief Computes per-element Linf norms of the generalized-harmonic
+ * constraints, latching BBH completion criteria when thresholds are exceeded.
+ *
+ * \details This event is intended to run once common-horizon finding is
+ * active (typically behind a separation-based trigger). It monitors the gauge
+ * and three-index constraints, using a reduction to determine if their Linf
+ * norms exceed completion thresholds.
+ */
+class CheckConstraintThresholds : public Event {
+  using ReductionData = Parallel::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<double, funcl::Max<>>,
+      Parallel::ReductionDatum<double, funcl::Max<>>>;
+
+ public:
+  /// \cond
+  explicit CheckConstraintThresholds(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(CheckConstraintThresholds);  // NOLINT
+  /// \endcond
+
+  using compute_tags_for_observation_box =
+      tmpl::list<gh::Tags::GaugeConstraintCompute<3, Frame::Inertial>,
+                 gh::Tags::ThreeIndexConstraintCompute<3, Frame::Inertial>>;
+  using options = tmpl::list<>;
+  static constexpr Options::String help =
+      "Checks local Linf norms of constraints against BBH completion "
+      "thresholds and forwards reduced maxima to the BBH completion singleton "
+      "reduction callback.";
+  static std::string name() { return "BbhCheckConstraintThresholds"; }
+
+  CheckConstraintThresholds() = default;
+
+  using return_tags = tmpl::list<>;
+  using argument_tags = tmpl::list<
+      ::Tags::Time, gh::Tags::GaugeConstraint<DataVector, 3, Frame::Inertial>,
+      gh::Tags::ThreeIndexConstraint<DataVector, 3, Frame::Inertial>>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  void operator()(
+      const double time,
+      const tnsr::a<DataVector, 3, Frame::Inertial>& gauge_constraint,
+      const tnsr::iaa<DataVector, 3, Frame::Inertial>& three_index_constraint,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const Component* const /*component*/,
+      const ObservationValue& /*observation_value*/) const {
+    const double local_gauge_linf = local_linf_norm(gauge_constraint);
+    const double local_three_index_linf =
+        local_linf_norm(three_index_constraint);
+    if constexpr (Parallel::is_dg_element_collection_v<Component>) {
+      ERROR(
+          "BbhCheckConstraintThresholds currently requires array components "
+          "(not DgElementCollection).");
+    } else {
+      const auto& self_proxy =
+          Parallel::get_parallel_component<Component>(cache)[array_index];
+      auto& reduction_target_proxy = Parallel::get_parallel_component<
+          gh::bbh::CompletionSingleton<Metavariables>>(cache);
+      Parallel::contribute_to_reduction<
+          gh::bbh::Actions::ProcessConstraintMaxima>(
+          ReductionData{time, local_gauge_linf, local_three_index_linf},
+          self_proxy, reduction_target_proxy);
+    }
+  }
+
+  using is_ready_argument_tags = tmpl::list<>;
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  bool is_ready(Parallel::GlobalCache<Metavariables>& /*cache*/,
+                const ArrayIndex& /*array_index*/,
+                const Component* const /*meta*/) const {
+    return true;
+  }
+
+  bool needs_evolved_variables() const override { return true; }
+
+ private:
+  template <typename TensorType>
+  static double local_linf_norm(const TensorType& tensor) {
+    double result = 0.0;
+    for (size_t storage_index = 0; storage_index < tensor.size();
+         ++storage_index) {
+      const auto& component = tensor[storage_index];
+      result = std::max(result, max(abs(component)));
+    }
+    return result;
+  }
+};
+}  // namespace gh::bbh::Events

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  CheckpointAndExitIfComplete.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  CheckpointAndExitIfComplete.hpp
+  )

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CheckpointAndExitIfComplete.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CheckpointAndExitIfComplete.cpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CheckpointAndExitIfComplete.hpp"
+
+namespace gh::bbh::phase_control {
+void CheckpointAndExitIfComplete::pup(PUP::er& p) { PhaseChange::pup(p); }
+
+PUP::able::PUP_ID CheckpointAndExitIfComplete::my_PUP_ID = 0;  // NOLINT
+}  // namespace gh::bbh::phase_control

--- a/src/Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CheckpointAndExitIfComplete.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CheckpointAndExitIfComplete.hpp
@@ -1,0 +1,147 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp"
+#include "Options/String.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseControl/ContributeToPhaseChangeReduction.hpp"
+#include "Parallel/PhaseControl/PhaseChange.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace gh::bbh::phase_control {
+namespace Tags {
+/// Storage in the phase-change decision tuple for whether the
+/// BBH completion path has requested completion.
+struct CheckpointRequested {
+  using type = bool;
+  using combine_method = funcl::Or<>;
+  using main_combine_method = funcl::Or<>;
+};
+
+/// Storage in the phase-change decision tuple for jumping from
+/// `WriteCheckpoint` to `Exit`.
+struct ExitAfterWriteCheckpoint {
+  using type = bool;
+
+  struct combine_method {
+    bool operator()(const bool /*first*/, const bool /*second*/) {
+      ERROR(
+          "ExitAfterWriteCheckpoint should only be modified during "
+          "phase-change arbitration on Main.");
+    }
+  };
+
+  using main_combine_method = combine_method;
+};
+}  // namespace Tags
+
+/*!
+ * \brief If BBH completion has been requested, jump from `Evolve` to
+ * `WriteCheckpoint`, then immediately to `Exit`.
+ *
+ * \details The `WriteCheckpoint` phase executes checkpoint actions, typically
+ * including final volume data writes, as specified by
+ * `EventsAndTriggersAtCheckpoints`.
+ */
+struct CheckpointAndExitIfComplete : public PhaseChange {
+  /// \cond
+  CheckpointAndExitIfComplete() = default;
+  explicit CheckpointAndExitIfComplete(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(CheckpointAndExitIfComplete);  // NOLINT
+  /// \endcond
+
+  static std::string name() { return "BbhCheckpointAndExitIfComplete"; }
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "When BBH completion has been requested, jump from Evolve to "
+      "WriteCheckpoint so all elements write final volume data at a "
+      "synchronized time, then jump to Exit."};
+
+  using argument_tags = tmpl::list<gh::bbh::Tags::ElementCompletionRequested>;
+  using return_tags = tmpl::list<>;
+
+  using phase_change_tags_and_combines =
+      tmpl::list<Tags::CheckpointRequested, Tags::ExitAfterWriteCheckpoint>;
+
+  template <typename Metavariables>
+  using participating_components = typename Metavariables::component_list;
+
+  template <typename... DecisionTags>
+  void initialize_phase_data_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data) const {
+    tuples::get<Tags::CheckpointRequested>(*phase_change_decision_data) = false;
+    tuples::get<Tags::ExitAfterWriteCheckpoint>(*phase_change_decision_data) =
+        false;
+  }
+
+  template <typename ParallelComponent, typename ArrayIndex,
+            typename Metavariables>
+  void contribute_phase_data_impl(const bool element_completion_requested,
+                                  Parallel::GlobalCache<Metavariables>& cache,
+                                  const ArrayIndex& array_index) const {
+    if constexpr (std::is_same_v<typename ParallelComponent::chare_type,
+                                 Parallel::Algorithms::Array>) {
+      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+          tuples::TaggedTuple<Tags::CheckpointRequested>{
+              element_completion_requested},
+          cache, array_index);
+    } else {
+      Parallel::contribute_to_phase_change_reduction<ParallelComponent>(
+          tuples::TaggedTuple<Tags::CheckpointRequested>{
+              element_completion_requested},
+          cache);
+    }
+  }
+
+  template <typename... DecisionTags, typename Metavariables>
+  std::optional<std::pair<Parallel::Phase, PhaseControl::ArbitrationStrategy>>
+  arbitrate_phase_change_impl(
+      const gsl::not_null<tuples::TaggedTuple<DecisionTags...>*>
+          phase_change_decision_data,
+      const Parallel::Phase current_phase,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/) const {
+    auto& checkpoint_requested =
+        tuples::get<Tags::CheckpointRequested>(*phase_change_decision_data);
+    auto& exit_after_write_checkpoint =
+        tuples::get<Tags::ExitAfterWriteCheckpoint>(
+            *phase_change_decision_data);
+
+    if (current_phase == Parallel::Phase::WriteCheckpoint and
+        exit_after_write_checkpoint) {
+      exit_after_write_checkpoint = false;
+      return std::make_pair(
+          Parallel::Phase::Exit,
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately);
+    }
+
+    if (current_phase == Parallel::Phase::Evolve and checkpoint_requested) {
+      checkpoint_requested = false;
+      exit_after_write_checkpoint = true;
+      return std::make_pair(
+          Parallel::Phase::WriteCheckpoint,
+          PhaseControl::ArbitrationStrategy::RunPhaseImmediately);
+    }
+
+    checkpoint_requested = false;
+    return std::nullopt;
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+};
+}  // namespace gh::bbh::phase_control

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(Bbh)
 add_subdirectory(BoundaryConditions)
 add_subdirectory(BoundaryCorrections)
 add_subdirectory(GaugeSourceFunctions)

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -313,6 +313,12 @@ Amr:
   Verbosity: Quiet
 
 PhaseChangeAndTriggers:
+  - Trigger:
+      SeparationLessThan:
+        Value: &CommonHorizonActivationSeparation 2.38
+    PhaseChanges:
+      # Terminal completion path: Evolve -> WriteCheckpoint -> Exit.
+      - BbhCheckpointAndExitIfComplete
 {% if segments_dir is defined %}
   - Trigger:
       Slabs:
@@ -427,12 +433,13 @@ EventsAndTriggersAtSlabs:
 # Trigger to find common horizon and gather volume data needed for ringdown.
   - Trigger:
       SeparationLessThan:
-        Value: 2.38 # for q=1, spin=0, quasicircular
+        Value: *CommonHorizonActivationSeparation
     Events:
       - ChangeSlabSize:
           DelayChange: 0
           StepChoosers:
             - Constant: 0.01
+      - BbhCheckConstraintThresholds
       - ObservationAhC:
           SubfileName: ForContinuation
           VariablesToObserve:
@@ -445,13 +452,6 @@ EventsAndTriggersAtSlabs:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
           BlocksToObserve: All
-  # This separation has enough common horizon finds to start ringdown for q=1,
-  # spin=0, quasicircular
-  - Trigger:
-      SeparationLessThan:
-        Value: 2.138
-    Events:
-      - Completion
 {% if eccentricity_control %}
   # If running eccentricity control, only run short inspiral
   - Trigger:
@@ -509,6 +509,14 @@ EventsRunAtCleanup:
 
 Interpolator:
   Verbosity: Silent
+
+BbhCompletionCriteria:
+  MinCommonHorizonSuccessesBeforeChecks: 8
+  MaxCommonHorizonSuccesses: 100
+  GaugeConstraintLinfThreshold: 1.0
+  ThreeIndexConstraintLinfThreshold: 1.0
+  CommonHorizonLMaxThreshold: 8
+  ConstraintCheckVerbose: false
 
 ApparentHorizons:
   LMax: 33

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -296,6 +296,14 @@ EventsAndTriggersAtSlabs:
 
 EventsAndTriggersAtSteps:
 
+BbhCompletionCriteria:
+  MinCommonHorizonSuccessesBeforeChecks: 8
+  MaxCommonHorizonSuccesses: 100
+  GaugeConstraintLinfThreshold: 1.0
+  ThreeIndexConstraintLinfThreshold: 1.0
+  CommonHorizonLMaxThreshold: 8
+  ConstraintCheckVerbose: false
+
 Observers:
   VolumeFileName: "GhBinaryBlackHoleVolumeData"
   ReductionFileName: "GhBinaryBlackHoleReductionData"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -21,6 +21,9 @@ set(LIBRARY_SOURCES
   Test_DuDt.cpp
   Test_DuDtTempTags.cpp
   Test_Fluxes.cpp
+  Test_BbhCompletionCriteria.cpp
+  Test_BbhCompletionSingleton.cpp
+  Test_BbhCheckpointAndExitIfCompletePhaseChange.cpp
   Test_Tags.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BbhCheckpointAndExitIfCompletePhaseChange.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BbhCheckpointAndExitIfCompletePhaseChange.cpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <utility>
+
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/PhaseControl/CheckpointAndExitIfComplete.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseControl/PhaseChange.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct Metavariables {
+  using component_list = tmpl::list<>;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<tmpl::pair<
+        PhaseChange,
+        tmpl::list<gh::bbh::phase_control::CheckpointAndExitIfComplete>>>;
+  };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.GeneralizedHarmonic.BbhCheckpointAndExitIfCompletePhaseChange",
+    "[Unit][Evolution]") {
+  // `contribute_phase_data_impl` is not tested directly because reduction
+  // contributions are currently not supported in this unit-test style.
+  const Parallel::GlobalCache<Metavariables> cache{};
+  const gh::bbh::phase_control::CheckpointAndExitIfComplete phase_change{};
+  using PhaseChangeDecisionData = tuples::TaggedTuple<
+      gh::bbh::phase_control::Tags::CheckpointRequested,
+      gh::bbh::phase_control::Tags::ExitAfterWriteCheckpoint>;
+
+  {
+    INFO("Initialize decision data");
+    PhaseChangeDecisionData phase_change_decision_data{true, true};
+    phase_change.initialize_phase_data<Metavariables>(
+        make_not_null(&phase_change_decision_data));
+    CHECK(phase_change_decision_data == PhaseChangeDecisionData{false, false});
+  }
+  {
+    INFO("No request means no phase change");
+    PhaseChangeDecisionData phase_change_decision_data{false, false};
+    const auto decision_result = phase_change.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data), Parallel::Phase::Evolve,
+        cache);
+    CHECK(decision_result == std::nullopt);
+    CHECK(phase_change_decision_data == PhaseChangeDecisionData{false, false});
+  }
+  {
+    INFO("Completion request in Evolve jumps to WriteCheckpoint");
+    PhaseChangeDecisionData phase_change_decision_data{true, false};
+    const auto decision_result = phase_change.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data), Parallel::Phase::Evolve,
+        cache);
+    CHECK(
+        decision_result ==
+        std::make_pair(Parallel::Phase::WriteCheckpoint,
+                       PhaseControl::ArbitrationStrategy::RunPhaseImmediately));
+    CHECK(phase_change_decision_data == PhaseChangeDecisionData{false, true});
+  }
+  {
+    INFO("After WriteCheckpoint, jump to Exit");
+    PhaseChangeDecisionData phase_change_decision_data{false, true};
+    const auto decision_result = phase_change.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data),
+        Parallel::Phase::WriteCheckpoint, cache);
+    CHECK(
+        decision_result ==
+        std::make_pair(Parallel::Phase::Exit,
+                       PhaseControl::ArbitrationStrategy::RunPhaseImmediately));
+    CHECK(phase_change_decision_data == PhaseChangeDecisionData{false, false});
+  }
+  {
+    INFO("If both decisions are true in Evolve, prioritize WriteCheckpoint");
+    PhaseChangeDecisionData phase_change_decision_data{true, true};
+    const auto decision_result = phase_change.arbitrate_phase_change(
+        make_not_null(&phase_change_decision_data), Parallel::Phase::Evolve,
+        cache);
+    CHECK(
+        decision_result ==
+        std::make_pair(Parallel::Phase::WriteCheckpoint,
+                       PhaseControl::ArbitrationStrategy::RunPhaseImmediately));
+    CHECK(phase_change_decision_data == PhaseChangeDecisionData{false, true});
+  }
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BbhCompletionCriteria.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BbhCompletionCriteria.cpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.BbhCompletionCriteria",
+    "[Unit][Evolution]") {
+  TestHelpers::db::test_simple_tag<
+      gh::bbh::Tags::MinCommonHorizonSuccessesBeforeChecks>(
+      "MinCommonHorizonSuccessesBeforeChecks");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::MaxCommonHorizonSuccesses>(
+      "MaxCommonHorizonSuccesses");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::GaugeConstraintLinfThreshold>(
+      "GaugeConstraintLinfThreshold");
+  TestHelpers::db::test_simple_tag<
+      gh::bbh::Tags::ThreeIndexConstraintLinfThreshold>(
+      "ThreeIndexConstraintLinfThreshold");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::CommonHorizonLMaxThreshold>(
+      "CommonHorizonLMaxThreshold");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::ConstraintCheckVerbose>(
+      "ConstraintCheckVerbose");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::GaugeConstraintExceeded>(
+      "GaugeConstraintExceeded");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::ThreeIndexConstraintExceeded>(
+      "ThreeIndexConstraintExceeded");
+  TestHelpers::db::test_simple_tag<
+      gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold>(
+      "CommonHorizonLMaxBelowOrEqualThreshold");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::CommonHorizonSuccessCount>(
+      "CommonHorizonSuccessCount");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::CompletionRequested>(
+      "CompletionRequested");
+  TestHelpers::db::test_simple_tag<gh::bbh::Tags::ElementCompletionRequested>(
+      "ElementCompletionRequested");
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BbhCompletionSingleton.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_BbhCompletionSingleton.cpp
@@ -1,0 +1,309 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/LinkedMessageId.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionCriteria.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Bbh/CompletionSingleton.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+template <typename Metavariables>
+struct MockSingletonComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using simple_tags =
+      tmpl::list<gh::bbh::Tags::GaugeConstraintExceeded,
+                 gh::bbh::Tags::ThreeIndexConstraintExceeded,
+                 gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold,
+                 gh::bbh::Tags::CommonHorizonSuccessCount,
+                 gh::bbh::Tags::CompletionRequested,
+                 gh::bbh::Tags::CommonHorizonSuccessRecords,
+                 gh::bbh::Tags::ConstraintCheckRecords,
+                 gh::bbh::Tags::ReportedConstraintCheckRecords,
+                 gh::bbh::Tags::ElementCompletionRequested>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+template <typename Metavariables>
+struct MockElementComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using simple_tags = tmpl::list<gh::bbh::Tags::ElementCompletionRequested>;
+  using phase_dependent_action_list = tmpl::list<Parallel::PhaseActions<
+      Parallel::Phase::Initialization,
+      tmpl::list<ActionTesting::InitializeDataBox<simple_tags>>>>;
+};
+
+struct MockMetavariables {
+  using component_list = tmpl::list<MockSingletonComponent<MockMetavariables>,
+                                    MockElementComponent<MockMetavariables>>;
+  using gh_dg_element_array = MockElementComponent<MockMetavariables>;
+  using const_global_cache_tags =
+      tmpl::list<gh::bbh::Tags::MinCommonHorizonSuccessesBeforeChecks,
+                 gh::bbh::Tags::MaxCommonHorizonSuccesses,
+                 gh::bbh::Tags::GaugeConstraintLinfThreshold,
+                 gh::bbh::Tags::ThreeIndexConstraintLinfThreshold,
+                 gh::bbh::Tags::CommonHorizonLMaxThreshold,
+                 gh::bbh::Tags::ConstraintCheckVerbose>;
+  using mutable_global_cache_tags = tmpl::list<>;
+};
+
+using mock_component = MockSingletonComponent<MockMetavariables>;
+using mock_element_component = MockElementComponent<MockMetavariables>;
+
+auto make_runner(const size_t min_common_horizon_successes_before_checks = 2,
+                 const size_t max_common_horizon_successes = 100,
+                 const double gauge_constraint_linf_threshold = 10.0,
+                 const double three_index_constraint_linf_threshold = 20.0,
+                 const size_t common_horizon_lmax_threshold = 6,
+                 const bool constraint_check_verbose = false) {
+  return ActionTesting::MockRuntimeSystem<MockMetavariables>{
+      {min_common_horizon_successes_before_checks, max_common_horizon_successes,
+       gauge_constraint_linf_threshold, three_index_constraint_linf_threshold,
+       common_horizon_lmax_threshold, constraint_check_verbose}};
+}
+
+void initialize_components(
+    const gsl::not_null<ActionTesting::MockRuntimeSystem<MockMetavariables>*>
+        runner) {
+  ActionTesting::emplace_component_and_initialize<mock_component>(
+      runner, 0,
+      {false, false, false, 0_st, false,
+       gh::bbh::Tags::CommonHorizonSuccessRecords::type{},
+       gh::bbh::Tags::ConstraintCheckRecords::type{},
+       gh::bbh::Tags::ReportedConstraintCheckRecords::type{}, false});
+  ActionTesting::emplace_component_and_initialize<mock_element_component>(
+      runner, 0, {false});
+}
+
+SPECTRE_TEST_CASE("Unit.GeneralizedHarmonic.BbhCompletionSingleton",
+                  "[Unit][Evolution]") {
+  {
+    INFO("Constraint checks remain gated by min successes at their check time");
+    auto runner = make_runner();
+    initialize_components(make_not_null(&runner));
+    auto& box = ActionTesting::get_databox<mock_component>(runner, 0);
+    auto& element_box =
+        ActionTesting::get_databox<mock_element_component>(runner, 0);
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::ProcessConstraintMaxima>(
+        make_not_null(&runner), 0, 1.5, 11.0, 1.0);
+    CHECK_FALSE(db::get<gh::bbh::Tags::GaugeConstraintExceeded>(box));
+    CHECK_FALSE(db::get<gh::bbh::Tags::CompletionRequested>(box));
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{2.0, std::nullopt},
+        8_st);
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{3.0, std::nullopt},
+        8_st);
+    CHECK(db::get<gh::bbh::Tags::CommonHorizonSuccessCount>(box) == 2_st);
+    CHECK_FALSE(db::get<gh::bbh::Tags::GaugeConstraintExceeded>(box));
+    CHECK_FALSE(db::get<gh::bbh::Tags::CompletionRequested>(box));
+
+    // Delayed older successes still don't arm the t=1.5 constraint check until
+    // enough successes exist at or before that check time.
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{1.0, std::nullopt},
+        8_st);
+    CHECK_FALSE(db::get<gh::bbh::Tags::GaugeConstraintExceeded>(box));
+    CHECK_FALSE(db::get<gh::bbh::Tags::CompletionRequested>(box));
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{1.2, std::nullopt},
+        8_st);
+    CHECK(db::get<gh::bbh::Tags::CommonHorizonSuccessCount>(box) == 4_st);
+    CHECK(db::get<gh::bbh::Tags::GaugeConstraintExceeded>(box));
+    CHECK(db::get<gh::bbh::Tags::CompletionRequested>(box));
+    CHECK_FALSE(
+        ActionTesting::is_simple_action_queue_empty<mock_element_component>(
+            runner, 0));
+    ActionTesting::invoke_queued_simple_action<mock_element_component>(
+        make_not_null(&runner), 0);
+    CHECK(db::get<gh::bbh::Tags::ElementCompletionRequested>(element_box));
+  }
+
+  {
+    INFO("Delayed older AhC success can retroactively satisfy the LMax path");
+    auto runner = make_runner();
+    initialize_components(make_not_null(&runner));
+    auto& box = ActionTesting::get_databox<mock_component>(runner, 0);
+    auto& element_box =
+        ActionTesting::get_databox<mock_element_component>(runner, 0);
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{2.0, std::nullopt},
+        8_st);
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{3.0, std::nullopt},
+        8_st);
+    CHECK(db::get<gh::bbh::Tags::CommonHorizonSuccessCount>(box) == 2_st);
+    CHECK_FALSE(
+        db::get<gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold>(box));
+    CHECK_FALSE(db::get<gh::bbh::Tags::CompletionRequested>(box));
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{1.0, std::nullopt},
+        6_st);
+    CHECK(db::get<gh::bbh::Tags::CommonHorizonSuccessCount>(box) == 3_st);
+    CHECK(db::get<gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold>(box));
+    CHECK(db::get<gh::bbh::Tags::CompletionRequested>(box));
+    CHECK_FALSE(
+        ActionTesting::is_simple_action_queue_empty<mock_element_component>(
+            runner, 0));
+    ActionTesting::invoke_queued_simple_action<mock_element_component>(
+        make_not_null(&runner), 0);
+    CHECK(db::get<gh::bbh::Tags::ElementCompletionRequested>(element_box));
+  }
+
+  {
+    INFO("Max AhC successes can request completion");
+    auto runner = make_runner(2, 3, 1.0e6, 1.0e6, 0, false);
+    initialize_components(make_not_null(&runner));
+    auto& box = ActionTesting::get_databox<mock_component>(runner, 0);
+    auto& element_box =
+        ActionTesting::get_databox<mock_element_component>(runner, 0);
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{1.0, std::nullopt},
+        8_st);
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{2.0, std::nullopt},
+        8_st);
+    CHECK(db::get<gh::bbh::Tags::CommonHorizonSuccessCount>(box) == 2_st);
+    CHECK_FALSE(db::get<gh::bbh::Tags::CompletionRequested>(box));
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{3.0, std::nullopt},
+        8_st);
+    CHECK(db::get<gh::bbh::Tags::CommonHorizonSuccessCount>(box) == 3_st);
+    CHECK_FALSE(
+        db::get<gh::bbh::Tags::CommonHorizonLMaxBelowOrEqualThreshold>(box));
+    CHECK_FALSE(db::get<gh::bbh::Tags::GaugeConstraintExceeded>(box));
+    CHECK_FALSE(db::get<gh::bbh::Tags::ThreeIndexConstraintExceeded>(box));
+    CHECK(db::get<gh::bbh::Tags::CompletionRequested>(box));
+    CHECK_FALSE(
+        ActionTesting::is_simple_action_queue_empty<mock_element_component>(
+            runner, 0));
+    ActionTesting::invoke_queued_simple_action<mock_element_component>(
+        make_not_null(&runner), 0);
+    CHECK(db::get<gh::bbh::Tags::ElementCompletionRequested>(element_box));
+  }
+
+  {
+    INFO("Three-index threshold can request completion");
+    auto runner = make_runner(2, 100, 1.0e6, 20.0, 0, false);
+    initialize_components(make_not_null(&runner));
+    auto& box = ActionTesting::get_databox<mock_component>(runner, 0);
+    auto& element_box =
+        ActionTesting::get_databox<mock_element_component>(runner, 0);
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{1.0, std::nullopt},
+        8_st);
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{1.2, std::nullopt},
+        8_st);
+    CHECK_FALSE(db::get<gh::bbh::Tags::CompletionRequested>(box));
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::ProcessConstraintMaxima>(
+        make_not_null(&runner), 0, 1.5, 1.0, 21.0);
+    CHECK_FALSE(db::get<gh::bbh::Tags::GaugeConstraintExceeded>(box));
+    CHECK(db::get<gh::bbh::Tags::ThreeIndexConstraintExceeded>(box));
+    CHECK(db::get<gh::bbh::Tags::CompletionRequested>(box));
+    CHECK_FALSE(
+        ActionTesting::is_simple_action_queue_empty<mock_element_component>(
+            runner, 0));
+    ActionTesting::invoke_queued_simple_action<mock_element_component>(
+        make_not_null(&runner), 0);
+    CHECK(db::get<gh::bbh::Tags::ElementCompletionRequested>(element_box));
+  }
+
+  {
+    INFO("Invalid min/max input relation errors in release mode");
+    auto runner = make_runner(3, 2, 1.0e6, 1.0e6, 0, false);
+    initialize_components(make_not_null(&runner));
+
+    CHECK_THROWS_WITH(
+        (ActionTesting::simple_action<
+            mock_component, gh::bbh::Actions::RecordCommonHorizonSuccess>(
+            make_not_null(&runner), 0,
+            LinkedMessageId<double>{1.0, std::nullopt}, 8_st)),
+        Catch::Matchers::ContainsSubstring("MaxCommonHorizonSuccesses"));
+  }
+
+  {
+    INFO("Duplicate AhC records are rejected");
+    auto runner = make_runner(10, 100, 1.0e6, 1.0e6, 0, false);
+    initialize_components(make_not_null(&runner));
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::RecordCommonHorizonSuccess>(
+        make_not_null(&runner), 0, LinkedMessageId<double>{2.0, std::nullopt},
+        8_st);
+    CHECK_THROWS_WITH(
+        (ActionTesting::simple_action<
+            mock_component, gh::bbh::Actions::RecordCommonHorizonSuccess>(
+            make_not_null(&runner), 0,
+            LinkedMessageId<double>{2.0, std::nullopt}, 7_st)),
+        Catch::Matchers::ContainsSubstring(
+            "Duplicate common-horizon completion record"));
+  }
+
+  {
+    INFO("Duplicate constraint records are rejected");
+    auto runner = make_runner(10, 100, 1.0e6, 1.0e6, 0, false);
+    initialize_components(make_not_null(&runner));
+
+    ActionTesting::simple_action<mock_component,
+                                 gh::bbh::Actions::ProcessConstraintMaxima>(
+        make_not_null(&runner), 0, 2.0, 5.0, 6.0);
+    CHECK_THROWS_WITH(
+        (ActionTesting::simple_action<
+            mock_component, gh::bbh::Actions::ProcessConstraintMaxima>(
+            make_not_null(&runner), 0, 2.0, 8.0, 9.0)),
+        Catch::Matchers::ContainsSubstring(
+            "Duplicate BBH completion constraint-max record"));
+  }
+
+  {
+    INFO("Element completion-request simple action latches true");
+    auto runner = make_runner();
+    initialize_components(make_not_null(&runner));
+    auto& box = ActionTesting::get_databox<mock_element_component>(runner, 0);
+    ActionTesting::simple_action<
+        mock_element_component,
+        gh::bbh::Actions::SetElementCompletionRequested>(make_not_null(&runner),
+                                                         0);
+    CHECK(db::get<gh::bbh::Tags::ElementCompletionRequested>(box));
+  }
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

This PR improves how binary-black-hole inspirals choose to complete the inspiral and begin the transition to ringdown.

Currently, the completion criterion is just when the coordinate separation decreases below a constant threshold in the yaml file. The problem is that the correct separation to choose differs for different simulations and is not known in advance.

This PR implements a strategy similar to the one SpEC uses (which @markscheel and @AlexCarpenter46 helped me understand). Specifically, it chooses to complete a binary-black-hole inspiral simulation when i) there are more than a user-specified minimum number of successful common horizon finds, and ii) one of the following is true: a) the gauge constraint or three-index constraint exceed a user-specified threshold, or b) the resolution LMax of the common horizon decreases (when using adaptive-L horizon finding) below a user-specified threshold, or c) there are more than a user-specified maximum number of common horizon finds. 

When the simulation requests completion, it changes phase to `Parallel::Phase::WriteCheckpoint` and then immediately to `Parallel::Phase::Exit`. During the checkpoint phase, `EventsAndTriggersAtCheckpoints` run, writing the volume data needed for continuation.

Note that this strategy is slightly different from the one used in SpEC. I use the gauge and 3-index constraint, while SpEC checks the constraint energy. Spectre often computes only the gauge and three-index constraints, because the constraint energy is much more expensive, and constraint growth tends to affect all constraints. I also added the option to specify a maximum number of common horizon finds; this is especially useful for simulations that are not using the adaptive apparent horizon finder to set the common horizon's resolution.

### Note on AI usage
I used OpenAI Codex  to prepare this PR as follows: 
* Back and forth discussion helped me settle on the design, including the decision to use the phase change approach here. 
* Codex generated all of the code in this PR based on the design I requested. 
* I went through two rounds of review, checking every line of code and then requesting changes as I thought best. I did not identify any code that appeared to duplicate known algorithms or public code outside of the spectre repository.
* I verified that the PR functions as expected by testing it on a full BBH simulation. I restarted PBJ-style the simulation at a time shortly (~1.5M) before common horizon formation, and I verified for different option choices that the simulation completed cleanly for the expected reason.
* I also edited the codex-generated documentation, especially doxygen comments, because it was easier than getting Codex to write prose the way I wanted.
* Codex assisted in diagnosing some CI failures in earlier versions of the branch this PR is based on, and Codex implemented the fixes for those failures.
* In response to feedback from human reviewers, I am discussing further changes with Codex, choosing responses or design changes, and then asking codex to implement the planned responses or changes.

After the above process, I think this is ready for a look by a second reviewer.

Overall, I spent about 1 week preparing this PR; much of the time was taken up by the long iteration loop involved in testing on a real simulation on the Ocean2 cluster (just rebuilding `EvolveGhBinaryBlackHole takes about 30 minutes, and the simulations took about 30-60 minutes to restart and then complete successfully).

I welcome feedback, both with the code in this PR and the process of using AI agents for spectre development. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Binary-black-hole inspiral termination critera are now controlled with a now options block in the inspiral YAML file. You should add this block if you are writing your own YAML file (rather than using the BBH pipeline). Here is an example of these options:

```
BbhCompletionCriteria:
  MinCommonHorizonSuccessesBeforeChecks: 8
  MaxCommonHorizonSuccesses: 100
  GaugeConstraintLinfThreshold: 1.0
  ThreeIndexConstraintLinfThreshold: 1.0
  CommonHorizonLMaxThreshold: 8
  ConstraintCheckInterval: 0.1
  ConstraintCheckVerbose: false
```

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
