### PR TITLE
Added NullSlicingBlocks for ScalarSelfForce

### DIFF
--- a/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
@@ -5,6 +5,9 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
 
 /// \cond
 class ComplexDataVector;
@@ -18,10 +21,27 @@ class DataVector;
  *
  * \see ScalarSelfForce::FirstOrderSystem
  */
-namespace ScalarSelfForce {}
+namespace ScalarSelfForce {
+
+namespace OptionTags {
+
+struct OptionGroup {
+  static std::string name() { return "ScalarSelfForce"; }
+  static constexpr Options::String help =
+      "Options for the scalar self-force system";
+};
+
+struct NullSlicingBlocks {
+  using group = OptionGroup;
+  using type = std::vector<std::string>;
+  static constexpr Options::String help =
+      "The blocks in which to use null slicing (vtu-slicing).";
+};
+
+}  // namespace OptionTags
 
 /// Tags for the ScalarSelfForce system.
-namespace ScalarSelfForce::Tags {
+namespace Tags {
 
 /*!
  * \brief The complex m-mode field $\Psi_m$.
@@ -129,6 +149,23 @@ struct BoyerLindquistRadius : db::SimpleTag {
 };
 
 /*!
+ * \brief Blocks in which we use null slicing (vtu-slicing).
+ */
+struct NullSlicingBlocks : db::SimpleTag {
+  using type = std::set<size_t>;
+  using option_tags = tmpl::list<OptionTags::NullSlicingBlocks,
+                                 domain::OptionTags::DomainCreator<2>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const std::vector<std::string>& null_slicing_blocks,
+      const std::unique_ptr<DomainCreator<2>>& domain_creator) {
+    return domain::block_ids_from_names(null_slicing_blocks,
+                                        domain_creator->block_names(),
+                                        domain_creator->block_groups());
+  }
+};
+
+/*!
  * \brief The hyperboloidal boost function $H(r_*)$.
  */
 struct BoostFunction : db::SimpleTag {
@@ -142,4 +179,5 @@ struct BoostFunctionDeriv : db::SimpleTag {
   using type = Scalar<ComplexDataVector>;
 };
 
-}  // namespace ScalarSelfForce::Tags
+}  // namespace Tags
+}  // namespace ScalarSelfForce

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(
   PRIVATE
   DataStructures
   DataStructuresHelpers
+  DomainCreators
+  DomainStructure
+  Options
   ScalarSelfForce
   )
 

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
@@ -3,12 +3,43 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
 #include <string>
+#include <vector>
 
+#include "Domain/Creators/AlignedLattice.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace ScalarSelfForce {
+namespace {
+
+void test_null_slicing_tag_logic() {
+  INFO("Testing NullSlicingBlocks structure");
+  const std::array<std::vector<double>, 2> coords{
+    {{0.0, 0.25, 0.5}, {0.0, 0.5}}};
+  using Region = domain::creators::RefinementRegion<2>;
+  const std::unique_ptr<DomainCreator<2>> lattice =
+    std::make_unique<domain::creators::AlignedLattice<2>>(
+        std::array<std::vector<double>, 2>{
+            {{0., 0.25, 0.5}, {0., 0.5}}},
+        std::array<size_t, 2>{{0, 0}},
+        std::array<size_t, 2>{{3, 2}},
+        std::vector<Region>{
+            Region{{0, 0}, {1, 1}, {0, 1}}},
+        std::vector<Region>{},
+        std::vector<std::array<size_t, 2>>{},
+        std::array<bool, 2>{{false, false}},
+        Options::Context{});
+
+  const std::vector<std::string> blocks{
+    "Block(0,0)", "Block(1,0)"};
+  const std::set<size_t> result =
+      Tags::NullSlicingBlocks::create_from_options(blocks, lattice);
+  const std::set<size_t> expected{0, 1};
+  CHECK(result == expected);
+}
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.Elliptic.Systems.ScalarSelfForce.Tags", "[Unit][Elliptic]") {
@@ -24,6 +55,8 @@ SPECTRE_TEST_CASE(
   TestHelpers::db::test_simple_tag<Tags::BoostFunction>("BoostFunction");
   TestHelpers::db::test_simple_tag<Tags::BoostFunctionDeriv>(
       "BoostFunctionDeriv");
+
+  test_null_slicing_tag_logic();
 }
 
 }  // namespace ScalarSelfForce


### PR DESCRIPTION
## Proposed changes

- Added NullSlicingBlocks in ScalarSelfForce tag

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
