### PR TITLE
Add field_gradient support to Elliptic source terms

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -160,15 +160,17 @@ struct PrepareAndSendMortarData<
                          typename PrimalMortarFieldsTag::tags_list,
                          typename PrimalMortarFluxesTag::tags_list>;
   using BoundaryConditionsBase = typename System::boundary_conditions_base;
+  using DerivFieldsTag = db::add_tag_prefix<::Tags::deriv, PrimalFieldsTag,
+                                            tmpl::size_t<Dim>, Frame::Inertial>;
 
  public:
   // Request these tags be added to the DataBox. We
   // don't actually need to initialize them, because the
   // `PrimalFieldsTag` will be set by other actions before applying the operator
   // and the remaining tags hold output of the operator.
-  using simple_tags =
-      tmpl::list<TemporalIdTag, PrimalFieldsTag, PrimalFluxesTag,
-                 OperatorAppliedToFieldsTag, all_mortar_data_tag>;
+  using simple_tags = tmpl::list<TemporalIdTag, PrimalFieldsTag, DerivFieldsTag,
+                                 PrimalFluxesTag, OperatorAppliedToFieldsTag,
+                                 all_mortar_data_tag>;
   using compute_tags = tmpl::list<>;
   using const_global_cache_tags =
       tmpl::list<domain::Tags::ExternalBoundaryConditions<Dim>>;
@@ -183,8 +185,7 @@ struct PrepareAndSendMortarData<
       const ParallelComponent* const /*meta*/) {
     const auto& temporal_id = db::get<TemporalIdTag>(box);
     const auto& element = db::get<domain::Tags::Element<Dim>>(box);
-    const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
-    const size_t num_points = mesh.number_of_grid_points();
+
     const auto& mortar_meshes =
         db::get<::Tags::Mortars<domain::Tags::Mesh<Dim - 1>, Dim>>(box);
     const auto& boundary_conditions =
@@ -222,22 +223,16 @@ struct PrepareAndSendMortarData<
     // dealing with AMR resizing the mortars. When we keep the memory around,
     // its size has to be adjusted when the mesh changes during AMR.
     typename PrimalFluxesTag::type primal_fluxes;
+    typename DerivFieldsTag::type deriv_fields;
     typename all_mortar_data_tag::type all_mortar_data{};
-    db::mutate<PrimalFluxesTag>(
-        [&primal_fluxes](const auto local_primal_fluxes) {
+    db::mutate<PrimalFluxesTag, DerivFieldsTag>(
+        [&primal_fluxes, &deriv_fields](const auto local_primal_fluxes,
+                                        const auto local_deriv_fields) {
           primal_fluxes = std::move(*local_primal_fluxes);
+          deriv_fields = std::move(*local_deriv_fields);
         },
         make_not_null(&box));
 
-    // Prepare mortar data
-    //
-    // These memory buffers will be discarded when the action returns so we
-    // don't inflate the memory usage of the simulation when the element is
-    // inactive.
-    Variables<db::wrap_tags_in<::Tags::deriv,
-                               typename PrimalFieldsTag::type::tags_list,
-                               tmpl::size_t<Dim>, Frame::Inertial>>
-        deriv_fields{num_points};
     elliptic::dg::prepare_mortar_data<System, Linearized>(
         make_not_null(&deriv_fields), make_not_null(&primal_fluxes),
         make_not_null(&all_mortar_data), db::get<PrimalFieldsTag>(box), element,
@@ -251,10 +246,12 @@ struct PrepareAndSendMortarData<
         std::forward_as_tuple(db::get<FluxesArgsTags>(box)...));
 
     // Move the mutated data back into the DataBox
-    db::mutate<PrimalFluxesTag, all_mortar_data_tag>(
-        [&primal_fluxes, &all_mortar_data](const auto local_primal_fluxes,
-                                           const auto local_all_mortar_data) {
+    db::mutate<PrimalFluxesTag, DerivFieldsTag, all_mortar_data_tag>(
+        [&primal_fluxes, &deriv_fields, &all_mortar_data](
+            const auto local_primal_fluxes, const auto local_deriv_fields,
+            const auto local_all_mortar_data) {
           *local_primal_fluxes = std::move(primal_fluxes);
+          *local_deriv_fields = std::move(deriv_fields);
           *local_all_mortar_data = std::move(all_mortar_data);
         },
         make_not_null(&box));
@@ -324,7 +321,8 @@ struct ReceiveMortarDataAndApplyOperator<
       MortarDataInboxTag<Dim, TemporalIdTag,
                          typename PrimalMortarFieldsTag::tags_list,
                          typename PrimalMortarFluxesTag::tags_list>;
-
+  using DerivFieldsTag = db::add_tag_prefix<::Tags::deriv, PrimalFieldsTag,
+                                            tmpl::size_t<Dim>, Frame::Inertial>;
  public:
   using const_global_cache_tags =
       tmpl::list<elliptic::dg::Tags::PenaltyParameter,
@@ -342,7 +340,7 @@ struct ReceiveMortarDataAndApplyOperator<
     const auto& temporal_id = get<TemporalIdTag>(box);
     const auto& element = get<domain::Tags::Element<Dim>>(box);
 
-    if (not ::dg::has_received_from_all_mortars<mortar_data_inbox_tag>(
+    if (not::dg::has_received_from_all_mortars<mortar_data_inbox_tag>(
             temporal_id, element, inboxes)) {
       return {Parallel::AlgorithmExecution::Retry, std::nullopt};
     }
@@ -387,7 +385,7 @@ struct ReceiveMortarDataAndApplyOperator<
           elliptic::dg::apply_operator<System, Linearized>(args...);
         },
         make_not_null(&box), db::get<PrimalFieldsTag>(box),
-        db::get<PrimalFluxesTag>(box), element,
+        db::get<DerivFieldsTag>(box), db::get<PrimalFluxesTag>(box), element,
         db::get<domain::Tags::Mesh<Dim>>(box),
         db::get<domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
                                               Frame::Inertial>>(box),
@@ -519,7 +517,8 @@ struct DgOperator {
 
  private:
   static constexpr size_t Dim = System::volume_dim;
-
+  using DerivVarsTag = db::add_tag_prefix<::Tags::deriv, PrimalFieldsTag,
+                                          tmpl::size_t<Dim>, Frame::Inertial>;
  public:
   using apply_actions =
       tmpl::list<detail::PrepareAndSendMortarData<
@@ -532,7 +531,7 @@ struct DgOperator {
                      PrimalMortarFieldsTag, PrimalMortarFluxesTag>>;
   using amr_projectors = tmpl::list<
       ::amr::projectors::DefaultInitialize<
-          PrimalFluxesTag, OperatorAppliedToFieldsTag,
+          DerivVarsTag, PrimalFluxesTag, OperatorAppliedToFieldsTag,
           ::Tags::Mortars<elliptic::dg::Tags::MortarData<
                               typename temporal_id_tag::type,
                               typename PrimalMortarFieldsTag::tags_list,

--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -237,14 +237,14 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
   static constexpr auto full_mortar_size =
       make_array<Dim - 1>(Spectral::SegmentSize::Full);
 
-  template <bool AllDataIsZero, typename... DerivTags, typename... PrimalVars,
+  template <bool AllDataIsZero, typename... DerivVars, typename... PrimalVars,
             typename... PrimalFluxesVars, typename... PrimalMortarVars,
             typename... PrimalMortarFluxes, typename TemporalId,
             typename ApplyBoundaryCondition, typename... FluxesArgs,
             typename DataIsZero = NoDataIsZero,
             typename DirectionsPredicate = AllDirections>
   static void prepare_mortar_data(
-      const gsl::not_null<Variables<tmpl::list<DerivTags...>>*> deriv_vars,
+      const gsl::not_null<Variables<tmpl::list<DerivVars...>>*> deriv_vars,
       const gsl::not_null<Variables<tmpl::list<PrimalFluxesVars...>>*>
           primal_fluxes,
       const gsl::not_null<::dg::MortarMap<
@@ -305,6 +305,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
     // of the fluxes in the `apply_operator` function below to compute the full
     // elliptic equation -div(F) + S = f(x).
     if (AllDataIsZero or local_data_is_zero) {
+      deriv_vars->initialize(num_points, 0.);
       primal_fluxes->initialize(num_points, 0.);
     } else {
       // Compute partial derivatives of the variables
@@ -319,13 +320,13 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
                   make_not_null(&get<PrimalFluxesVars>(*primal_fluxes))...,
                   expanded_fluxes_args..., element_id,
                   get<PrimalVars>(primal_vars)...,
-                  get<DerivTags>(*deriv_vars)...);
+                  get<DerivVars>(*deriv_vars)...);
             } else {
               (void)element_id;
               FluxesComputer::apply(
                   make_not_null(&get<PrimalFluxesVars>(*primal_fluxes))...,
                   expanded_fluxes_args..., get<PrimalVars>(primal_vars)...,
-                  get<DerivTags>(*deriv_vars)...);
+                  get<DerivVars>(*deriv_vars)...);
             }
           },
           fluxes_args);
@@ -456,7 +457,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
         // the boundary conditions is taken from the "interior" side of the
         // boundary, i.e. with a normal vector that points _out_ of the
         // computational domain.
-        Variables<tmpl::list<DerivTags...>> deriv_vars_on_boundary{};
+        Variables<tmpl::list<DerivVars...>> deriv_vars_on_boundary{};
         if (AllDataIsZero or local_data_is_zero) {
           deriv_vars_on_boundary.initialize(face_num_points, 0.);
         } else {
@@ -470,7 +471,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
             make_not_null(&get<PrimalMortarVars>(boundary_data.field_data))...,
             make_not_null(&get<::Tags::NormalDotFlux<PrimalMortarVars>>(
                 boundary_data.field_data))...,
-            get<DerivTags>(deriv_vars_on_boundary)...);
+            get<DerivVars>(deriv_vars_on_boundary)...);
 
         // Invert the sign of the fluxes to account for the inverted normal on
         // exterior faces. Also multiply by 2 and add the interior fluxes to
@@ -518,10 +519,10 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
   // --- This is essentially a break to communicate the mortar data ---
 
   template <typename... OperatorTags, typename... PrimalVars,
-            typename... PrimalFluxesVars, typename... PrimalMortarVars,
-            typename... PrimalMortarFluxes, typename TemporalId,
-            typename... FluxesArgs, typename... SourcesArgs,
-            typename DataIsZero = NoDataIsZero,
+            typename... DerivVars, typename... PrimalFluxesVars,
+            typename... PrimalMortarVars, typename... PrimalMortarFluxes,
+            typename TemporalId, typename... FluxesArgs,
+            typename... SourcesArgs, typename DataIsZero = NoDataIsZero,
             typename DirectionsPredicate = AllDirections>
   static void apply_operator(
       const gsl::not_null<Variables<tmpl::list<OperatorTags...>>*>
@@ -531,6 +532,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
                           tmpl::list<PrimalMortarFluxes...>>>*>
           all_mortar_data,
       const Variables<tmpl::list<PrimalVars...>>& primal_vars,
+      const Variables<tmpl::list<DerivVars...>>& deriv_vars,
       // Taking the primal fluxes computed in the `prepare_mortar_data` function
       // by const-ref here because other code might use them and so we don't
       // want to modify them by adding boundary corrections. E.g. linearized
@@ -656,11 +658,12 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
       if constexpr (not std::is_same_v<SourcesComputer, void>) {
         Variables<tmpl::list<OperatorTags...>> sources{num_points, 0.};
         std::apply(
-            [&sources, &primal_vars,
+            [&sources, &primal_vars, &deriv_vars,
              &primal_fluxes](const auto&... expanded_sources_args) {
               SourcesComputer::apply(
                   make_not_null(&get<OperatorTags>(sources))...,
                   expanded_sources_args..., get<PrimalVars>(primal_vars)...,
+                  get<DerivVars>(deriv_vars)...,
                   get<PrimalFluxesVars>(primal_fluxes)...);
             },
             sources_args);
@@ -1035,7 +1038,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
     Variables<tmpl::list<PrimalFluxes...>> primal_fluxes_buffer{num_points};
     Variables<tmpl::list<
         ::Tags::deriv<PrimalFields, tmpl::size_t<Dim>, Frame::Inertial>...>>
-        unused_deriv_vars_buffer{};
+        zero_deriv_vars{num_points, 0.};
     Variables<tmpl::list<FixedSourcesTags...>> operator_applied_to_zero_vars{
         num_points};
     // Set up data on mortars
@@ -1044,12 +1047,11 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
         all_mortar_data{};
     constexpr size_t temporal_id = std::numeric_limits<size_t>::max();
     // Apply the operator to the zero variables, skipping internal boundaries
-    prepare_mortar_data<true>(make_not_null(&unused_deriv_vars_buffer),
-                              make_not_null(&primal_fluxes_buffer),
-                              make_not_null(&all_mortar_data), zero_primal_vars,
-                              element, mesh, inv_jacobian, face_normals,
-                              all_mortar_meshes, all_mortar_sizes, temporal_id,
-                              apply_boundary_condition, fluxes_args);
+    prepare_mortar_data<true>(
+        make_not_null(&zero_deriv_vars), make_not_null(&primal_fluxes_buffer),
+        make_not_null(&all_mortar_data), zero_primal_vars, element, mesh,
+        inv_jacobian, face_normals, all_mortar_meshes, all_mortar_sizes,
+        temporal_id, apply_boundary_condition, fluxes_args);
     // Modify internal boundary data if needed, e.g. to transform from one
     // variable to another when crossing element boundaries. This is a nonlinear
     // operation in the sense that feeding zero through the operator is nonzero,
@@ -1088,15 +1090,15 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
         }
       }
     }
-    apply_operator(make_not_null(&operator_applied_to_zero_vars),
-                   make_not_null(&all_mortar_data), zero_primal_vars,
-                   primal_fluxes_buffer, element, mesh, inv_jacobian,
-                   det_inv_jacobian, det_jacobian, det_times_inv_jacobian,
-                   face_normals, face_normal_vectors, face_normal_magnitudes,
-                   face_jacobians, face_jacobian_times_inv_jacobians,
-                   all_mortar_meshes, all_mortar_sizes, mortar_jacobians,
-                   penalty_factors, massive, formulation, temporal_id,
-                   fluxes_args_on_faces, sources_args);
+    apply_operator(
+        make_not_null(&operator_applied_to_zero_vars),
+        make_not_null(&all_mortar_data), zero_primal_vars, zero_deriv_vars,
+        primal_fluxes_buffer, element, mesh, inv_jacobian, det_inv_jacobian,
+        det_jacobian, det_times_inv_jacobian, face_normals, face_normal_vectors,
+        face_normal_magnitudes, face_jacobians,
+        face_jacobian_times_inv_jacobians, all_mortar_meshes, all_mortar_sizes,
+        mortar_jacobians, penalty_factors, massive, formulation, temporal_id,
+        fluxes_args_on_faces, sources_args);
     // Impose the nonlinear (constant) boundary contribution as fixed sources on
     // the RHS of the equations
     *fixed_sources -= operator_applied_to_zero_vars;

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -621,7 +621,7 @@ struct SubdomainOperator
           elliptic::dg::apply_operator<System, linearized>(
               make_not_null(&result->element_data),
               make_not_null(&central_mortar_data_), operand.element_data,
-              central_primal_fluxes_, args...);
+              central_deriv_vars_, central_primal_fluxes_, args...);
         },
         box, temporal_id, fluxes_args_on_faces, sources_args, data_is_zero);
     // Apply on neighbors
@@ -656,6 +656,7 @@ struct SubdomainOperator
                   make_not_null(&extended_results_[overlap_id]),
                   make_not_null(&neighbors_mortar_data_.at(overlap_id)),
                   extended_operand_vars_.at(overlap_id),
+                  neighbors_deriv_vars_.at(overlap_id),
                   neighbors_primal_fluxes_.at(overlap_id), args...);
             },
             box, overlap_id, temporal_id, fluxes_args_on_overlap_faces,

--- a/src/Elliptic/Executables/Solver.hpp
+++ b/src/Elliptic/Executables/Solver.hpp
@@ -392,8 +392,11 @@ struct Solver {
       typename schwarz_smoother::amr_projectors,
       typename build_matrix::amr_projectors,
       ::amr::projectors::DefaultInitialize<tmpl::append<
-          tmpl::list<domain::Tags::InitialExtents<volume_dim>,
-                     domain::Tags::InitialRefinementLevels<volume_dim>>,
+          tmpl::list<
+              domain::Tags::InitialExtents<volume_dim>,
+              domain::Tags::InitialRefinementLevels<volume_dim>,
+              db::add_tag_prefix<::Tags::deriv, fields_tag,
+                                 tmpl::size_t<volume_dim>, Frame::Inertial>>,
           // Tags communicated on subdomain overlaps. No need to project
           // these during AMR because they will be communicated.
           db::wrap_tags_in<

--- a/src/Elliptic/Protocols/FirstOrderSystem.hpp
+++ b/src/Elliptic/Protocols/FirstOrderSystem.hpp
@@ -149,7 +149,8 @@ struct test_fields_and_fluxes<Dim, tmpl::list<PrimalFields...>,
  *      primal equations.
  *   2. The `argument_tags`
  *   3. The `primal_fields`
- *   4. The `primal_fluxes`
+ *   4. The partial derivatives of the `primal_fields`
+ *   5. The `primal_fluxes`
  *
  *   The function is expected to _add_ the sources \f$S_\alpha\f$ to the
  *   output buffers. It must also have the following alias:

--- a/src/Elliptic/Systems/BnsInitialData/Equations.cpp
+++ b/src/Elliptic/Systems/BnsInitialData/Equations.cpp
@@ -83,6 +83,7 @@ void Sources::apply(
         log_deriv_lapse_times_density_over_specific_enthalpy,
     const tnsr::i<DataVector, 3>& christoffel_contracted,
     const Scalar<DataVector>& /*velocity_potential*/,
+    const tnsr::i<DataVector, 3>& /*gradient_for_potential*/,
     const tnsr::I<DataVector, 3>& flux_for_potential) {
   add_potential_sources(equation_for_potential,
                         log_deriv_lapse_times_density_over_specific_enthalpy,

--- a/src/Elliptic/Systems/BnsInitialData/Equations.hpp
+++ b/src/Elliptic/Systems/BnsInitialData/Equations.hpp
@@ -107,6 +107,7 @@ struct Sources {
                         log_deriv_lapse_times_density_over_specific_enthalpy,
                     const tnsr::i<DataVector, 3>& christoffel_contracted,
                     const Scalar<DataVector>& velocity_potential,
+                    const tnsr::i<DataVector, 3>& /*gradient_for_potential*/,
                     const tnsr::I<DataVector, 3>& flux_for_potential);
 };
 

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -92,6 +92,7 @@ void Sources<Dim, Geometry::Curved, DataType>::apply(
     const gsl::not_null<Scalar<DataType>*> equation_for_field,
     const tnsr::i<DataVector, Dim>& christoffel_contracted,
     const Scalar<DataType>& /*field*/,
+    const tnsr::i<DataType, Dim>& /*field_gradient*/,
     const tnsr::I<DataType, Dim>& field_flux) {
   add_curved_sources(equation_for_field, christoffel_contracted, field_flux);
 }

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -131,6 +131,7 @@ struct Sources<Dim, Geometry::Curved, DataType> {
   static void apply(gsl::not_null<Scalar<DataType>*> equation_for_field,
                     const tnsr::i<DataVector, Dim>& christoffel_contracted,
                     const Scalar<DataType>& field,
+                    const tnsr::i<DataType, Dim>& /*field_gradient*/,
                     const tnsr::I<DataType, Dim>& field_flux);
 };
 

--- a/src/Elliptic/Systems/Punctures/Sources.cpp
+++ b/src/Elliptic/Systems/Punctures/Sources.cpp
@@ -33,6 +33,7 @@ void Sources::apply(const gsl::not_null<Scalar<DataVector>*> puncture_equation,
                     const Scalar<DataVector>& alpha,
                     const Scalar<DataVector>& beta,
                     const Scalar<DataVector>& field,
+                    const tnsr::i<DataVector, 3>& /*field_gradient*/,
                     const tnsr::I<DataVector, 3>& /*field_flux*/) {
   add_sources(puncture_equation, alpha, beta, field);
 }
@@ -41,6 +42,7 @@ void LinearizedSources::apply(
     const gsl::not_null<Scalar<DataVector>*> linearized_puncture_equation,
     const Scalar<DataVector>& alpha, const Scalar<DataVector>& beta,
     const Scalar<DataVector>& field, const Scalar<DataVector>& field_correction,
+    const tnsr::i<DataVector, 3>& /*field_gradient_correction*/,
     const tnsr::I<DataVector, 3>& /*field_flux_correction*/) {
   add_linearized_sources(linearized_puncture_equation, alpha, beta, field,
                          field_correction);

--- a/src/Elliptic/Systems/Punctures/Sources.hpp
+++ b/src/Elliptic/Systems/Punctures/Sources.hpp
@@ -54,6 +54,7 @@ struct Sources {
                     const Scalar<DataVector>& alpha,
                     const Scalar<DataVector>& beta,
                     const Scalar<DataVector>& field,
+                    const tnsr::i<DataVector, 3>& /*field_gradient*/,
                     const tnsr::I<DataVector, 3>& field_flux);
 };
 
@@ -69,6 +70,7 @@ struct LinearizedSources {
       const Scalar<DataVector>& alpha, const Scalar<DataVector>& beta,
       const Scalar<DataVector>& field,
       const Scalar<DataVector>& field_correction,
+      const tnsr::i<DataVector, 3>& /*field_gradient_correction*/,
       const tnsr::I<DataVector, 3>& field_flux_correction);
 };
 

--- a/src/Elliptic/Systems/ScalarGaussBonnet/Equations.cpp
+++ b/src/Elliptic/Systems/ScalarGaussBonnet/Equations.cpp
@@ -123,6 +123,7 @@ void Sources::apply(
     const tnsr::i<DataVector, 3>& conformal_factor_deriv, const double& eps2,
     const double& eps4, const Scalar<DataVector>& weyl_electric,
     const Scalar<DataVector>& weyl_magnetic, const Scalar<DataVector>& field,
+    const tnsr::i<DataVector, 3>& /*field_gradient*/,
     const tnsr::I<DataVector, 3>& field_flux) {
   add_curved_sources(equation_for_field, conformal_christoffel_contracted,
                      field_flux, deriv_lapse, lapse, conformal_factor,
@@ -141,6 +142,7 @@ void LinearizedSources::apply(
     const Scalar<DataVector>& weyl_electric,
     const Scalar<DataVector>& weyl_magnetic,
     const Scalar<DataVector>& field_correction,
+    const tnsr::i<DataVector, 3>& /*field_gradient_correction*/,
     const tnsr::I<DataVector, 3>& field_flux_correction) {
   add_curved_sources(linearized_equation_for_field,
                      conformal_christoffel_contracted, field_flux_correction,

--- a/src/Elliptic/Systems/ScalarGaussBonnet/Equations.hpp
+++ b/src/Elliptic/Systems/ScalarGaussBonnet/Equations.hpp
@@ -138,6 +138,7 @@ struct Sources {
       const tnsr::i<DataVector, 3>& conformal_factor_deriv, const double& eps2,
       const double& eps4, const Scalar<DataVector>& weyl_electric,
       const Scalar<DataVector>& weyl_magnetic, const Scalar<DataVector>& field,
+      const tnsr::i<DataVector, 3>& /*field_gradient*/,
       const tnsr::I<DataVector, 3>& field_flux);
 };
 
@@ -170,6 +171,7 @@ struct LinearizedSources {
       const Scalar<DataVector>& weyl_electric,
       const Scalar<DataVector>& weyl_magnetic,
       const Scalar<DataVector>& field_correction,
+      const tnsr::i<DataVector, 3>& /*field_gradient_correction*/,
       const tnsr::I<DataVector, 3>& field_flux_correction);
 };
 

--- a/src/Elliptic/Systems/SelfForce/Scalar/Equations.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Equations.cpp
@@ -58,6 +58,7 @@ void Sources::apply(
     const Scalar<ComplexDataVector>& beta,
     const tnsr::i<ComplexDataVector, 2>& gamma,
     const Scalar<ComplexDataVector>& field,
+    const tnsr::i<ComplexDataVector, 2>& /*field_gradient*/,
     const tnsr::I<ComplexDataVector, 2>& flux) {
   add_sources(scalar_equation, beta, gamma, field, flux);
 }

--- a/src/Elliptic/Systems/SelfForce/Scalar/Equations.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Equations.hpp
@@ -74,6 +74,7 @@ struct Sources {
                     const Scalar<ComplexDataVector>& beta,
                     const tnsr::i<ComplexDataVector, 2>& gamma,
                     const Scalar<ComplexDataVector>& field,
+                    const tnsr::i<ComplexDataVector, 2>& /*field_gradient*/,
                     const tnsr::I<ComplexDataVector, 2>& flux);
 };
 

--- a/src/Elliptic/Systems/Xcts/FluxesAndSources.cpp
+++ b/src/Elliptic/Systems/Xcts/FluxesAndSources.cpp
@@ -236,6 +236,7 @@ void Sources<Equations::Hamiltonian, Geometry::FlatCartesian,
           const Scalar<DataVector>&
               longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
           const Scalar<DataVector>& conformal_factor_minus_one,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
           const tnsr::I<DataVector, 3>& /*conformal_factor_flux*/) {
   add_hamiltonian_sources<ConformalMatterScale>(
       hamiltonian_constraint, conformal_energy_density,
@@ -256,13 +257,15 @@ void Sources<Equations::Hamiltonian, Geometry::Curved, ConformalMatterScale>::
           const tnsr::i<DataVector, 3>& conformal_christoffel_contracted,
           const Scalar<DataVector>& conformal_ricci_scalar,
           const Scalar<DataVector>& conformal_factor_minus_one,
+          const tnsr::i<DataVector, 3>& deriv_conformal_factor,
           const tnsr::I<DataVector, 3>& conformal_factor_flux) {
   Sources<Equations::Hamiltonian, Geometry::FlatCartesian,
           ConformalMatterScale>::
       apply(hamiltonian_constraint, conformal_energy_density,
             extrinsic_curvature_trace,
             longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
-            conformal_factor_minus_one, conformal_factor_flux);
+            conformal_factor_minus_one, deriv_conformal_factor,
+            conformal_factor_flux);
   add_curved_hamiltonian_or_lapse_sources(hamiltonian_constraint,
                                           conformal_ricci_scalar,
                                           conformal_factor_minus_one, 1.);
@@ -285,6 +288,9 @@ void Sources<Equations::HamiltonianAndLapse, Geometry::FlatCartesian,
           const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,
           const Scalar<DataVector>& conformal_factor_minus_one,
           const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+          const tnsr::i<DataVector, 3>&
+          /*deriv_lapse_times_conformal_factor*/,
           const tnsr::I<DataVector, 3>& /*conformal_factor_flux*/,
           const tnsr::I<DataVector, 3>&
           /*lapse_times_conformal_factor_flux*/) {
@@ -318,6 +324,8 @@ void Sources<Equations::HamiltonianAndLapse, Geometry::Curved,
           const Scalar<DataVector>& conformal_ricci_scalar,
           const Scalar<DataVector>& conformal_factor_minus_one,
           const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
+          const tnsr::i<DataVector, 3>& deriv_conformal_factor,
+          const tnsr::i<DataVector, 3>& deriv_lapse_times,
           const tnsr::I<DataVector, 3>& conformal_factor_flux,
           const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux) {
   Sources<Equations::HamiltonianAndLapse, Geometry::FlatCartesian,
@@ -328,6 +336,7 @@ void Sources<Equations::HamiltonianAndLapse, Geometry::Curved,
             longitudinal_shift_minus_dt_conformal_metric_square,
             shift_dot_deriv_extrinsic_curvature_trace,
             conformal_factor_minus_one, lapse_times_conformal_factor_minus_one,
+            deriv_conformal_factor,deriv_lapse_times,
             conformal_factor_flux, lapse_times_conformal_factor_flux);
   add_curved_hamiltonian_or_lapse_sources(hamiltonian_constraint,
                                           conformal_ricci_scalar,
@@ -362,6 +371,10 @@ void Sources<Equations::HamiltonianLapseAndShift, Geometry::FlatCartesian,
           const Scalar<DataVector>& conformal_factor_minus_one,
           const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
           const tnsr::I<DataVector, 3>& shift_excess,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+          const tnsr::i<DataVector, 3>&
+          /*deriv_lapse_times_conformal_factor*/,
+          const tnsr::iJ<DataVector, 3>& /*deriv_shift*/,
           const tnsr::I<DataVector, 3>& conformal_factor_flux,
           const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
           const tnsr::II<DataVector, 3>& longitudinal_shift_excess) {
@@ -420,6 +433,10 @@ void Sources<Equations::HamiltonianLapseAndShift, Geometry::Curved,
           const Scalar<DataVector>& conformal_factor_minus_one,
           const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
           const tnsr::I<DataVector, 3>& shift_excess,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor*/,
+          const tnsr::i<DataVector, 3>&
+          /*deriv_lapse_times_conformal_factor*/,
+          const tnsr::iJ<DataVector, 3>& /*deriv_shift*/,
           const tnsr::I<DataVector, 3>& conformal_factor_flux,
           const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
           const tnsr::II<DataVector, 3>& longitudinal_shift_excess) {
@@ -479,6 +496,7 @@ void LinearizedSources<Equations::Hamiltonian, Geometry::FlatCartesian,
               longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
           const Scalar<DataVector>& conformal_factor_minus_one,
           const Scalar<DataVector>& conformal_factor_correction,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
           const tnsr::I<DataVector, 3>&
           /*conformal_factor_flux_correction*/) {
   add_linearized_hamiltonian_sources<ConformalMatterScale>(
@@ -504,6 +522,7 @@ void LinearizedSources<Equations::Hamiltonian, Geometry::Curved,
           const Scalar<DataVector>& conformal_ricci_scalar,
           const Scalar<DataVector>& conformal_factor_minus_one,
           const Scalar<DataVector>& conformal_factor_correction,
+          const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
           const tnsr::I<DataVector, 3>& conformal_factor_flux_correction) {
   LinearizedSources<Equations::Hamiltonian, Geometry::FlatCartesian,
                     ConformalMatterScale>::
@@ -511,6 +530,7 @@ void LinearizedSources<Equations::Hamiltonian, Geometry::Curved,
             extrinsic_curvature_trace,
             longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
             conformal_factor_minus_one, conformal_factor_correction,
+            deriv_conformal_factor_correction,
             conformal_factor_flux_correction);
   add_curved_hamiltonian_or_lapse_sources(linearized_hamiltonian_constraint,
                                           conformal_ricci_scalar,
@@ -537,6 +557,9 @@ void LinearizedSources<Equations::HamiltonianAndLapse, Geometry::FlatCartesian,
           const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
           const Scalar<DataVector>& conformal_factor_correction,
           const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+          const tnsr::i<DataVector, 3>&
+          /*deriv_lapse_times_conformal_factor_correction*/,
           const tnsr::I<DataVector, 3>& /*conformal_factor_flux_correction*/,
           const tnsr::I<DataVector, 3>&
           /*lapse_times_conformal_factor_flux_correction*/) {
@@ -576,6 +599,9 @@ void LinearizedSources<Equations::HamiltonianAndLapse, Geometry::Curved,
           const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
           const Scalar<DataVector>& conformal_factor_correction,
           const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+          const tnsr::i<DataVector, 3>& deriv_conformal_factor_correction,
+          const tnsr::i<DataVector, 3>&
+          deriv_lapse_times_conformal_factor_correction,
           const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
           const tnsr::I<DataVector, 3>&
               lapse_times_conformal_factor_flux_correction) {
@@ -589,6 +615,8 @@ void LinearizedSources<Equations::HamiltonianAndLapse, Geometry::Curved,
             conformal_factor_minus_one, lapse_times_conformal_factor_minus_one,
             conformal_factor_correction,
             lapse_times_conformal_factor_correction,
+            deriv_conformal_factor_correction,
+            deriv_lapse_times_conformal_factor_correction,
             conformal_factor_flux_correction,
             lapse_times_conformal_factor_flux_correction);
   add_curved_hamiltonian_or_lapse_sources(linearized_hamiltonian_constraint,
@@ -633,6 +661,10 @@ void LinearizedSources<Equations::HamiltonianLapseAndShift,
           const Scalar<DataVector>& conformal_factor_correction,
           const Scalar<DataVector>& lapse_times_conformal_factor_correction,
           const tnsr::I<DataVector, 3>& shift_excess_correction,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+          const tnsr::i<DataVector, 3>&
+          /*deriv_lapse_times_conformal_factor_correction*/,
+          const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess_correction*/,
           const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
           const tnsr::I<DataVector, 3>&
               lapse_times_conformal_factor_flux_correction,
@@ -707,6 +739,10 @@ void LinearizedSources<Equations::HamiltonianLapseAndShift, Geometry::Curved,
           const Scalar<DataVector>& conformal_factor_correction,
           const Scalar<DataVector>& lapse_times_conformal_factor_correction,
           const tnsr::I<DataVector, 3>& shift_excess_correction,
+          const tnsr::i<DataVector, 3>& /*deriv_conformal_factor_correction*/,
+          const tnsr::i<DataVector, 3>&
+          /*deriv_lapse_times_conformal_factor_correction*/,
+          const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess_correction*/,
           const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
           const tnsr::I<DataVector, 3>&
               lapse_times_conformal_factor_flux_correction,

--- a/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
+++ b/src/Elliptic/Systems/Xcts/FluxesAndSources.hpp
@@ -225,6 +225,7 @@ struct Sources<Equations::Hamiltonian, Geometry::FlatCartesian,
       const Scalar<DataVector>&
           longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
       const Scalar<DataVector>& conformal_factor_minus_one,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux);
 };
 
@@ -245,6 +246,7 @@ struct Sources<Equations::Hamiltonian, Geometry::Curved, ConformalMatterScale> {
       const tnsr::i<DataVector, 3>& conformal_christoffel_contracted,
       const Scalar<DataVector>& conformal_ricci_scalar,
       const Scalar<DataVector>& conformal_factor_minus_one,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux);
 };
 
@@ -273,6 +275,9 @@ struct Sources<Equations::HamiltonianAndLapse, Geometry::FlatCartesian,
       const Scalar<DataVector>& shift_dot_deriv_extrinsic_curvature_trace,
       const Scalar<DataVector>& conformal_factor_minus_one,
       const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux,
       const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux);
 };
@@ -300,6 +305,9 @@ struct Sources<Equations::HamiltonianAndLapse, Geometry::Curved,
       const Scalar<DataVector>& conformal_ricci_scalar,
       const Scalar<DataVector>& conformal_factor_minus_one,
       const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux,
       const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux);
 };
@@ -342,6 +350,10 @@ struct Sources<Equations::HamiltonianLapseAndShift, Geometry::FlatCartesian,
       const Scalar<DataVector>& conformal_factor_minus_one,
       const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
       const tnsr::I<DataVector, 3>& shift_excess,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient*/,
+      const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux,
       const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
       const tnsr::II<DataVector, 3>& longitudinal_shift_excess);
@@ -385,6 +397,10 @@ struct Sources<Equations::HamiltonianLapseAndShift, Geometry::Curved,
       const Scalar<DataVector>& conformal_factor_minus_one,
       const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
       const tnsr::I<DataVector, 3>& shift_excess,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient*/,
+      const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux,
       const tnsr::I<DataVector, 3>& lapse_times_conformal_factor_flux,
       const tnsr::II<DataVector, 3>& longitudinal_shift_excess);
@@ -416,6 +432,7 @@ struct LinearizedSources<Equations::Hamiltonian, Geometry::FlatCartesian,
           longitudinal_shift_minus_dt_conformal_metric_over_lapse_square,
       const Scalar<DataVector>& conformal_factor_minus_one,
       const Scalar<DataVector>& conformal_factor_correction,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient_correction*/,
       const tnsr::I<DataVector, 3>&
       /*conformal_factor_flux_correction*/);
 };
@@ -438,6 +455,7 @@ struct LinearizedSources<Equations::Hamiltonian, Geometry::Curved,
       const Scalar<DataVector>& conformal_ricci_scalar,
       const Scalar<DataVector>& conformal_factor_minus_one,
       const Scalar<DataVector>& conformal_factor_correction,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient_correction*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux_correction);
 };
 
@@ -464,6 +482,9 @@ struct LinearizedSources<Equations::HamiltonianAndLapse,
       const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
       const Scalar<DataVector>& conformal_factor_correction,
       const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient_correction*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient_correction*/,
       const tnsr::I<DataVector, 3>& /*conformal_factor_flux_correction*/,
       const tnsr::I<DataVector, 3>&
           lapse_times_conformal_factor_flux_correction);
@@ -494,6 +515,9 @@ struct LinearizedSources<Equations::HamiltonianAndLapse, Geometry::Curved,
       const Scalar<DataVector>& lapse_times_conformal_factor_minus_one,
       const Scalar<DataVector>& conformal_factor_correction,
       const Scalar<DataVector>& lapse_times_conformal_factor_correction,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient_correction*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient_correction*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
       const tnsr::I<DataVector, 3>&
           lapse_times_conformal_factor_flux_correction);
@@ -539,6 +563,10 @@ struct LinearizedSources<Equations::HamiltonianLapseAndShift,
       const Scalar<DataVector>& conformal_factor_correction,
       const Scalar<DataVector>& lapse_times_conformal_factor_correction,
       const tnsr::I<DataVector, 3>& shift_excess_correction,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient_correction*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient_correction*/,
+      const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess_correction*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
       const tnsr::I<DataVector, 3>&
           lapse_times_conformal_factor_flux_correction,
@@ -590,6 +618,10 @@ struct LinearizedSources<Equations::HamiltonianLapseAndShift, Geometry::Curved,
       const Scalar<DataVector>& conformal_factor_correction,
       const Scalar<DataVector>& lapse_times_conformal_factor_correction,
       const tnsr::I<DataVector, 3>& shift_excess_correction,
+      const tnsr::i<DataVector, 3>& /*conformal_factor_gradient_correction*/,
+      const tnsr::i<DataVector, 3>&
+      /*lapse_times_conformal_factor_gradient_correction*/,
+      const tnsr::iJ<DataVector, 3>& /*deriv_shift_excess_correction*/,
       const tnsr::I<DataVector, 3>& conformal_factor_flux_correction,
       const tnsr::I<DataVector, 3>&
           lapse_times_conformal_factor_flux_correction,

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
@@ -91,7 +91,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarSelfForce.CircularOrbit",
     auto scalar_eqn = divergence(flux_singular_field, mesh, inv_jacobian);
     get(scalar_eqn) *= -1.;
     ScalarSelfForce::Sources::apply(make_not_null(&scalar_eqn), beta, gamma,
-                                    singular_field, flux_singular_field);
+                                    singular_field, deriv_singular_field,
+                                    flux_singular_field);
     // Minus sign is from the definition of the effective source:
     //   \psi = \psi_R + \psi_P = 0
     // where \psi_R is the regular part and \psi_P is the singular part

--- a/tests/Unit/Helpers/Elliptic/FirstOrderSystem.hpp
+++ b/tests/Unit/Helpers/Elliptic/FirstOrderSystem.hpp
@@ -119,7 +119,7 @@ void test_first_order_fluxes_computer_impl(
     FluxesComputer::apply(make_not_null(&get<PrimalFluxes>(fluxes_on_face))...,
                           get<FluxesArgsTags>(fluxes_args)..., face_normal,
                           face_normal_vector, get<PrimalFields>(vars)...);
-  CHECK_VARIABLES_APPROX(fluxes_on_face, expected_fluxes);
+    CHECK_VARIABLES_APPROX(fluxes_on_face, expected_fluxes);
   }
 }
 
@@ -151,13 +151,17 @@ void test_first_order_sources_computer_impl(
     const DataVector& used_for_size, tmpl::list<PrimalFields...> /*meta*/,
     tmpl::list<PrimalFluxes...> /*meta*/,
     tmpl::list<SourcesArgsTags...> /*meta*/) {
+  static constexpr size_t Dim = tmpl::front<
+      typename tmpl::front<tmpl::list<PrimalFluxes...>>::type::index_list>::dim;
   using vars_tag = ::Tags::Variables<tmpl::list<PrimalFields...>>;
   using VarsType = typename vars_tag::type;
   using fluxes_tag = ::Tags::Variables<tmpl::list<PrimalFluxes...>>;
   using FluxesType = typename fluxes_tag::type;
   using sources_tag = db::add_tag_prefix<::Tags::Source, vars_tag>;
   using SourcesType = typename sources_tag::type;
-
+  using deriv_vars_tag = db::add_tag_prefix<::Tags::deriv, vars_tag,
+                                            tmpl::size_t<Dim>, Frame::Inertial>;
+  using DerivVarsType = typename deriv_vars_tag::type;
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> dist(0.5, 2.);
 
@@ -169,6 +173,8 @@ void test_first_order_sources_computer_impl(
       make_not_null(&generator), make_not_null(&dist), used_for_size);
   const auto fluxes = make_with_random_values<FluxesType>(
       make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto deriv_vars = make_with_random_values<DerivVarsType>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
 
   // Generate sources from the variables with random arguments
   tuples::TaggedTuple<SourcesArgsTags...> sources_args{
@@ -177,23 +183,27 @@ void test_first_order_sources_computer_impl(
   // Silence unused variable warning when sources args is empty
   (void)sources_args;
   SourcesType expected_sources{used_for_size.size(), 0.};
+
   SourcesComputer::apply(
       make_not_null(&get<::Tags::Source<PrimalFields>>(expected_sources))...,
       get<SourcesArgsTags>(sources_args)..., get<PrimalFields>(vars)...,
+      get<::Tags::deriv<PrimalFields, tmpl::size_t<Dim>, Frame::Inertial>>(
+          deriv_vars)...,
       get<PrimalFluxes>(fluxes)...);
-
   // Create a DataBox
-  auto box = db::create<
-      db::AddSimpleTags<vars_tag, fluxes_tag, sources_tag, SourcesArgsTags...>>(
-      vars, fluxes,
+  auto box = db::create<db::AddSimpleTags<vars_tag, deriv_vars_tag, fluxes_tag,
+                                          sources_tag, SourcesArgsTags...>>(
+      vars, deriv_vars, fluxes,
       make_with_value<typename sources_tag::type>(used_for_size, 0.),
       get<SourcesArgsTags>(sources_args)...);
 
   // Apply the sources computer to the DataBox
-  db::mutate_apply<
-      tmpl::list<::Tags::Source<PrimalFields>...>,
-      tmpl::list<SourcesArgsTags..., PrimalFields..., PrimalFluxes...>>(
-      SourcesComputer{}, make_not_null(&box));
+  db::mutate_apply<tmpl::list<::Tags::Source<PrimalFields>...>,
+                   tmpl::list<SourcesArgsTags..., PrimalFields...,
+                              ::Tags::deriv<PrimalFields, tmpl::size_t<Dim>,
+                                            Frame::Inertial>...,
+                              PrimalFluxes...>>(SourcesComputer{},
+                                                make_not_null(&box));
   CHECK(expected_sources == get<sources_tag>(box));
 }
 

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -103,6 +103,8 @@ void verify_solution_impl(
               make_not_null(&get<Tags::OperatorAppliedTo<PrimalFields>>(
                   operator_applied_to_fields))...,
               expanded_sources_args..., get<PrimalFields>(solution_fields)...,
+              get<::Tags::deriv<PrimalFields, tmpl::size_t<Dim>,
+              Frame::Inertial>>(solution_fields)...,
               get<PrimalFluxes>(fluxes)...);
         },
         sources_args);


### PR DESCRIPTION
## Proposed changes

- Added the field_gradient argument to Sources across all Elliptic systems  but left it commented out

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
