### PR TITLE
Fix ProjectionOperator lower-index bug

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -487,10 +487,10 @@ void ConstraintPreservingBjorhus<Dim>::compute_intermediate_vars(
 
   gr::interface_null_normal(incoming_null_one_form,
                             spacetime_unit_normal_one_form, normal_covector,
-                            -1.);
+                            shift, -1.);
   gr::interface_null_normal(outgoing_null_one_form,
                             spacetime_unit_normal_one_form, normal_covector,
-                            1.);
+                            shift, 1.);
   gr::interface_null_normal(incoming_null_vector, spacetime_unit_normal_vector,
                             *unit_interface_normal_vector, -1.);
   gr::interface_null_normal(outgoing_null_vector, spacetime_unit_normal_vector,
@@ -498,11 +498,11 @@ void ConstraintPreservingBjorhus<Dim>::compute_intermediate_vars(
 
   gr::transverse_projection_operator(projection_ab, spacetime_metric,
                                      spacetime_unit_normal_one_form,
-                                     normal_covector);
+                                     normal_covector, shift);
   gr::transverse_projection_operator(
       projection_Ab, spacetime_unit_normal_vector,
       spacetime_unit_normal_one_form, *unit_interface_normal_vector,
-      normal_covector);
+      normal_covector, shift);
   gr::transverse_projection_operator(projection_AB, inverse_spacetime_metric,
                                      spacetime_unit_normal_vector,
                                      *unit_interface_normal_vector);

--- a/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -15,7 +16,7 @@ template <typename DataType, size_t VolumeDim, typename Frame>
 tnsr::a<DataType, VolumeDim, Frame> interface_null_normal(
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
-    const double sign) {
+    const tnsr::I<DataType, VolumeDim, Frame>& shift, const double sign) {
   ASSERT((sign == 1.) or (sign == -1.),
          "Calculation of interface null normal accepts only +1/-1 to indicate "
          "whether the outgoing/incoming normal is needed.");
@@ -23,7 +24,7 @@ tnsr::a<DataType, VolumeDim, Frame> interface_null_normal(
       get_size(get<0>(spacetime_normal_one_form)));
   interface_null_normal(make_not_null(&null_one_form),
                         spacetime_normal_one_form,
-                        interface_unit_normal_one_form, sign);
+                        interface_unit_normal_one_form, shift, sign);
   return null_one_form;
 }
 
@@ -32,13 +33,18 @@ void interface_null_normal(
     gsl::not_null<tnsr::a<DataType, VolumeDim, Frame>*> null_one_form,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
-    const double sign) {
+    const tnsr::I<DataType, VolumeDim, Frame>& shift, const double sign) {
   ASSERT((sign == 1.) or (sign == -1.),
          "Calculation of interface null normal accepts only +1/-1 to indicate "
          "whether the outgoing/incoming normal is needed.");
 
+  const auto interface_unit_normal_time_component =
+      dot_product(interface_unit_normal_one_form, shift);
+  const auto& interface_unit_normal_time =
+      get(interface_unit_normal_time_component);
   const double one_by_sqrt_2 = 1. / sqrt(2.);
-  get<0>(*null_one_form) = one_by_sqrt_2 * get<0>(spacetime_normal_one_form);
+  get<0>(*null_one_form) = one_by_sqrt_2 * (get<0>(spacetime_normal_one_form) +
+                                            sign * interface_unit_normal_time);
   for (size_t a = 1; a < VolumeDim + 1; ++a) {
     null_one_form->get(a) =
         one_by_sqrt_2 * (spacetime_normal_one_form.get(a) +
@@ -92,6 +98,7 @@ void interface_null_normal(
           spacetime_normal_one_form,                                     \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                \
           interface_unit_normal_one_form,                                \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,         \
       const double sign);                                                \
   template void gr::interface_null_normal(                               \
       const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*> \
@@ -100,6 +107,7 @@ void interface_null_normal(
           spacetime_normal_one_form,                                     \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                \
           interface_unit_normal_one_form,                                \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,         \
       const double sign);                                                \
   template tnsr::A<DTYPE(data), DIM(data), FRAME(data)>                  \
   gr::interface_null_normal(                                             \

--- a/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp
@@ -30,19 +30,51 @@ namespace gr {
  * \f{align*}
  * k_a = \frac{1}{\sqrt{2}}\left(n_a \pm s_a\right).
  * \f}
+ *
+ * Here \f$n_a = g_{ab} n^b\f$ and \f$s_a = g_{ab} s^b\f$ are the spacetime
+ * one-forms corresponding to the spacetime vectors \f$n^a\f$ and \f$s^a\f$.
+ *
+ * If \f$t^a=(1,0,0,0)\f$ is a vector in the time direction, then the unit
+ * normal to the spatial slice \f$n^a\f$ is determined by the relation
+ * \f$t^a = \alpha n^a + \beta^a\f$ (e.g. Eq. (2.98) of \cite BaumgarteShapiro),
+ * where \f$\alpha\f$ is the lapse, \f$\beta^a = (0, \beta^i)\f$, and
+ * \f$\beta^i\f$ is the shift. Solving for \f$n^a\f$ then gives
+ * \f$n^a = \alpha^{-1}(t^a - \beta^a)\f$. Then since \f$n_a = g_{ab} n^b\f$,
+ * the normal one-form is given by
+ * \f$n_a = g_{ab} n^b = \alpha^{-1}(g_{at} - g_{ab} \beta^b)\f$. This implies
+ * \f$n_i = \alpha^{-1}(g_{it} - g_{ij} \beta^j)\f$, or
+ * \f$ n_i = -\alpha^{-1}(\beta_i - \beta_i) = 0\f$. Only \f$n_t\f$ is nonzero:
+ * it is \f$n_t = \alpha^{-1}(g_{tt} - g_{tj} \beta^j)\f$, or
+ * \f$n_t = \alpha^{-1}(-\alpha^2 + \beta_j \beta^j - \beta_j \beta^j)\f$, or
+ * \f$n_t = -\alpha\f$. Note that \f$n^a\f$ is a unit timelike vector, since
+ * \f$n^a n_a = n^t n_t = \alpha^{-1}(-\alpha) = -1\f$.
+ *
+ * The unit normal to the boundary \f$s^a\f$ is orthogonal to \f$n^a\f$ and has
+ * components \f$s^a = (0, s^i)\f$, where \f$s^i\f$ is the spatial unit normal
+ * vector to the boundary. Since it is a spacelike unit normal vector whose
+ * time component vanishes, \f$s^a s_a = s^i s_i = 1\f$.
+ * Note that \f$s_a = g_{ab} s^b = g_{aj} s^j\f$, so
+ * \f$s_i = g_{ij} s^j = \gamma_{ij} s^j\f$, where \f$\gamma_{ij}\f$ is the
+ * spatial metric, while \f$s_t = g_{tj} s^j = \beta_j s^j = \beta^j s_j\f$.
+ * Thus \f$n^a\f$ and \f$s_a\f$ are orthogonal, since
+ * \f$n^a s_a = \alpha^{-1}(t^a s_a - \beta^a s_a)\f$, or
+ * \f$n^a s_a = \alpha^{-1}(\beta^j s_j - \beta^j s_j) = 0\f$.
+ *
+ * This function computes \f$s_a\f$ from the inputs \f$s_i\f$ (provided as
+ * `interface_unit_normal_one_form`) and \f$\beta^i\f$ (provided as `shift`).
  */
 template <typename DataType, size_t VolumeDim, typename Frame>
 tnsr::a<DataType, VolumeDim, Frame> interface_null_normal(
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
-    double sign);
+    const tnsr::I<DataType, VolumeDim, Frame>& shift, double sign);
 
 template <typename DataType, size_t VolumeDim, typename Frame>
 void interface_null_normal(
     gsl::not_null<tnsr::a<DataType, VolumeDim, Frame>*> null_one_form,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
-    double sign);
+    const tnsr::I<DataType, VolumeDim, Frame>& shift, double sign);
 /// @}
 
 /*!

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.cpp
@@ -3,10 +3,12 @@
 
 #include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
 
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 namespace gr {
 template <typename DataType, size_t VolumeDim, typename Frame>
@@ -127,12 +129,13 @@ template <typename DataType, size_t VolumeDim, typename Frame>
 tnsr::aa<DataType, VolumeDim, Frame> transverse_projection_operator(
     const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form) {
-  tnsr::aa<DataType, VolumeDim, Frame> projection_tensor(
-      get_size(get<0>(spacetime_normal_one_form)));
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift) {
+  tnsr::aa<DataType, VolumeDim, Frame> projection_tensor{
+      get_size(get<0>(spacetime_normal_one_form))};
   transverse_projection_operator(make_not_null(&projection_tensor),
                                  spacetime_metric, spacetime_normal_one_form,
-                                 interface_unit_normal_one_form);
+                                 interface_unit_normal_one_form, shift);
   return projection_tensor;
 }
 
@@ -142,19 +145,25 @@ void transverse_projection_operator(
         projection_tensor,
     const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form) {
-  for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
-    projection_tensor->get(a, b) =
-        spacetime_metric.get(a, b) +
-        spacetime_normal_one_form.get(a) * spacetime_normal_one_form.get(b);
-  }
-  for (size_t a = 1; a < VolumeDim + 1; ++a) {
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift) {
+  const auto interface_unit_normal_time_component =
+      dot_product(interface_unit_normal_one_form, shift);
+  const auto& interface_unit_normal_time =
+      get(interface_unit_normal_time_component);
+
+  for (size_t a = 0; a < VolumeDim + 1; ++a) {
+    const auto& interface_unit_normal_a =
+        (a == 0 ? interface_unit_normal_time
+                : interface_unit_normal_one_form.get(a - 1));
     for (size_t b = a; b < VolumeDim + 1; ++b) {
+      const auto& interface_unit_normal_b =
+          (b == 0 ? interface_unit_normal_time
+                  : interface_unit_normal_one_form.get(b - 1));
       projection_tensor->get(a, b) =
           spacetime_metric.get(a, b) +
           spacetime_normal_one_form.get(a) * spacetime_normal_one_form.get(b) -
-          interface_unit_normal_one_form.get(a - 1) *
-              interface_unit_normal_one_form.get(b - 1);
+          interface_unit_normal_a * interface_unit_normal_b;
     }
   }
 }
@@ -164,13 +173,14 @@ tnsr::Ab<DataType, VolumeDim, Frame> transverse_projection_operator(
     const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form) {
-  tnsr::Ab<DataType, VolumeDim, Frame> projection_tensor(
-      get_size(get<0>(spacetime_normal_vector)));
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift) {
+  tnsr::Ab<DataType, VolumeDim, Frame> projection_tensor{
+      get_size(get<0>(spacetime_normal_vector))};
   transverse_projection_operator(
       make_not_null(&projection_tensor), spacetime_normal_vector,
       spacetime_normal_one_form, interface_unit_normal_vector,
-      interface_unit_normal_one_form);
+      interface_unit_normal_one_form, shift);
   return projection_tensor;
 }
 
@@ -181,23 +191,30 @@ void transverse_projection_operator(
     const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form) {
-  for (size_t a = 0, b = 0; b < VolumeDim + 1; ++b) {
-    projection_tensor->get(a, b) =
-        spacetime_normal_vector.get(a) * spacetime_normal_one_form.get(b);
-    projection_tensor->get(b, a) =
-        spacetime_normal_vector.get(b) * spacetime_normal_one_form.get(a);
-  }
-  get<0, 0>(*projection_tensor) += 1.;
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift) {
+  const auto interface_unit_normal_time_component =
+      dot_product(interface_unit_normal_one_form, shift);
+  const auto& interface_unit_normal_time =
+      get(interface_unit_normal_time_component);
+  const auto interface_unit_normal_vector_time =
+      make_with_value<DataType>(interface_unit_normal_vector.get(0), 0.0);
 
-  for (size_t a = 1; a < VolumeDim + 1; ++a) {
-    for (size_t b = 1; b < VolumeDim + 1; ++b) {
+  for (size_t a = 0; a < VolumeDim + 1; ++a) {
+    const auto& interface_unit_normal_a =
+        (a == 0 ? interface_unit_normal_vector_time
+                : interface_unit_normal_vector.get(a - 1));
+    for (size_t b = 0; b < VolumeDim + 1; ++b) {
+      const auto& interface_unit_normal_b =
+          (b == 0 ? interface_unit_normal_time
+                  : interface_unit_normal_one_form.get(b - 1));
       projection_tensor->get(a, b) =
           spacetime_normal_vector.get(a) * spacetime_normal_one_form.get(b) -
-          interface_unit_normal_vector.get(a - 1) *
-              interface_unit_normal_one_form.get(b - 1);
+          interface_unit_normal_a * interface_unit_normal_b;
+      if (a == b) {
+        projection_tensor->get(a, b) += 1.;
+      }
     }
-    projection_tensor->get(a, a) += 1.;
   }
 }
 }  // namespace gr
@@ -250,7 +267,8 @@ void transverse_projection_operator(
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
           spacetime_normal_one_form,                                         \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
-          interface_unit_normal_one_form);                                   \
+          interface_unit_normal_one_form,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift);            \
   template tnsr::Ab<DTYPE(data), DIM(data), FRAME(data)>                     \
   gr::transverse_projection_operator(                                        \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
@@ -260,7 +278,8 @@ void transverse_projection_operator(
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
           interface_unit_normal_vector,                                      \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
-          interface_unit_normal_one_form);                                   \
+          interface_unit_normal_one_form,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift);            \
   template void gr::transverse_projection_operator(                          \
       const gsl::not_null<tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>*>    \
           projection_tensor,                                                 \
@@ -277,7 +296,8 @@ void transverse_projection_operator(
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
           spacetime_normal_one_form,                                         \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
-          interface_unit_normal_one_form);                                   \
+          interface_unit_normal_one_form,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift);            \
   template void gr::transverse_projection_operator(                          \
       const gsl::not_null<tnsr::Ab<DTYPE(data), DIM(data), FRAME(data)>*>    \
           projection_tensor,                                                 \
@@ -288,7 +308,8 @@ void transverse_projection_operator(
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>&                    \
           interface_unit_normal_vector,                                      \
       const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&                    \
-          interface_unit_normal_one_form);
+          interface_unit_normal_one_form,                                    \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp
@@ -107,19 +107,53 @@ void transverse_projection_operator(
  * \f{align*}
  * P_{ab} = g_{ab} + n_a n_b - s_a s_b = \gamma_{ab} - s_a s_b.
  * \f}
+ *
+ * Here \f$n_a = g_{ab} n^b\f$ and \f$s_a = g_{ab} s^b\f$ are the spacetime
+ * one-forms corresponding to the spacetime vectors \f$n^a\f$ and \f$s^a\f$.
+ *
+ * If \f$t^a=(1,0,0,0)\f$ is a vector in the time direction, then the unit
+ * normal to the spatial slice \f$n^a\f$ is determined by the relation
+ * \f$t^a = \alpha n^a + \beta^a\f$ (e.g. Eq. (2.98) of \cite BaumgarteShapiro),
+ * where \f$\alpha\f$ is the lapse, \f$\beta^a = (0, \beta^i)\f$, and
+ * \f$\beta^i\f$ is the shift. Solving for \f$n^a\f$ then gives
+ * \f$n^a = \alpha^{-1}(t^a - \beta^a)\f$. Then since \f$n_a = g_{ab} n^b\f$,
+ * the normal one-form is given by
+ * \f$n_a = g_{ab} n^b = \alpha^{-1}(g_{at} - g_{ab} \beta^b)\f$. This implies
+ * \f$n_i = \alpha^{-1}(g_{it} - g_{ij} \beta^j)\f$, or
+ * \f$ n_i = -\alpha^{-1}(\beta_i - \beta_i) = 0\f$. Only \f$n_t\f$ is nonzero:
+ * it is \f$n_t = \alpha^{-1}(g_{tt} - g_{tj} \beta^j)\f$, or
+ * \f$n_t = \alpha^{-1}(-\alpha^2 + \beta_j \beta^j - \beta_j \beta^j)\f$, or
+ * \f$n_t = -\alpha\f$. Note that \f$n^a\f$ is a unit timelike vector, since
+ * \f$n^a n_a = n^t n_t = \alpha^{-1}(-\alpha) = -1\f$.
+ *
+ * The unit normal to the boundary \f$s^a\f$ is orthogonal to \f$n^a\f$ and has
+ * components \f$s^a = (0, s^i)\f$, where \f$s^i\f$ is the spatial unit normal
+ * vector to the boundary. Since it is a spacelike unit normal vector whose
+ * time component vanishes, \f$s^a s_a = s^i s_i = 1\f$.
+ * Note that \f$s_a = g_{ab} s^b = g_{aj} s^j\f$, so
+ * \f$s_i = g_{ij} s^j = \gamma_{ij} s^j\f$, where \f$\gamma_{ij}\f$ is the
+ * spatial metric, while \f$s_t = g_{tj} s^j = \beta_j s^j = \beta^j s_j\f$.
+ * Thus \f$n^a\f$ and \f$s_a\f$ are orthogonal, since
+ * \f$n^a s_a = \alpha^{-1}(t^a s_a - \beta^a s_a)\f$, or
+ * \f$n^a s_a = \alpha^{-1}(\beta^j s_j - \beta^j s_j) = 0\f$.
+ *
+ * This function computes $s_a$ from the inputs $s_i$ (provided as
+ * `interface_unit_normal_one_form`) and \f$\beta^i\f$ (provided as `shift`).
  */
 template <typename DataType, size_t VolumeDim, typename Frame>
 tnsr::aa<DataType, VolumeDim, Frame> transverse_projection_operator(
     const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form);
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift);
 
 template <typename DataType, size_t VolumeDim, typename Frame>
 void transverse_projection_operator(
     gsl::not_null<tnsr::aa<DataType, VolumeDim, Frame>*> projection_tensor,
     const tnsr::aa<DataType, VolumeDim, Frame>& spacetime_metric,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form);
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift);
 /// @}
 
 /*!
@@ -181,13 +215,47 @@ void transverse_projection_operator(
  * \f{align*}
  * P^a_b = \delta^a_b + n^a n_b - s^a s_b.
  * \f}
+ *
+ * Here \f$n_a = g_{ab} n^b\f$ and \f$s_a = g_{ab} s^b\f$ are the spacetime
+ * one-forms corresponding to the spacetime vectors \f$n^a\f$ and \f$s^a\f$.
+ *
+ * If \f$t^a=(1,0,0,0)\f$ is a vector in the time direction, then the unit
+ * normal to the spatial slice \f$n^a\f$ is determined by the relation
+ * \f$t^a = \alpha n^a + \beta^a\f$ (e.g. Eq. (2.98) of \cite BaumgarteShapiro),
+ * where \f$\alpha\f$ is the lapse, \f$\beta^a = (0, \beta^i)\f$, and
+ * \f$\beta^i\f$ is the shift. Solving for \f$n^a\f$ then gives
+ * \f$n^a = \alpha^{-1}(t^a - \beta^a)\f$. Then since \f$n_a = g_{ab} n^b\f$,
+ * the normal one-form is given by
+ * \f$n_a = g_{ab} n^b = \alpha^{-1}(g_{at} - g_{ab} \beta^b)\f$. This implies
+ * \f$n_i = \alpha^{-1}(g_{it} - g_{ij} \beta^j)\f$, or
+ * \f$ n_i = -\alpha^{-1}(\beta_i - \beta_i) = 0\f$. Only \f$n_t\f$ is nonzero:
+ * it is \f$n_t = \alpha^{-1}(g_{tt} - g_{tj} \beta^j)\f$, or
+ * \f$n_t = \alpha^{-1}(-\alpha^2 + \beta_j \beta^j - \beta_j \beta^j)\f$, or
+ * \f$n_t = -\alpha\f$. Note that \f$n^a\f$ is a unit timelike vector, since
+ * \f$n^a n_a = n^t n_t = \alpha^{-1}(-\alpha) = -1\f$.
+ *
+ * The unit normal to the boundary \f$s^a\f$ is orthogonal to \f$n^a\f$ and has
+ * components \f$s^a = (0, s^i)\f$, where \f$s^i\f$ is the spatial unit normal
+ * vector to the boundary. Since it is a spacelike unit normal vector whose
+ * time component vanishes, \f$s^a s_a = s^i s_i = 1\f$.
+ * Note that \f$s_a = g_{ab} s^b = g_{aj} s^j\f$, so
+ * \f$s_i = g_{ij} s^j = \gamma_{ij} s^j\f$, where \f$\gamma_{ij}\f$ is the
+ * spatial metric, while \f$s_t = g_{tj} s^j = \beta_j s^j = \beta^j s_j\f$.
+ * Thus \f$n^a\f$ and \f$s_a\f$ are orthogonal, since
+ * \f$n^a s_a = \alpha^{-1}(t^a s_a - \beta^a s_a)\f$, or
+ * \f$n^a s_a = \alpha^{-1}(\beta^j s_j - \beta^j s_j) = 0\f$.
+ *
+ * This function computes \f$s_a\f$ from the inputs \f$s_i\f$ (provided as
+ * `interface_unit_normal_one_form`) and \f$\beta^i\f$ (provided as `shift`),
+ * and it computes \f$s^a\f$ from \f$s^i\f$ (since \f$s^t=0\f$).
  */
 template <typename DataType, size_t VolumeDim, typename Frame>
 tnsr::Ab<DataType, VolumeDim, Frame> transverse_projection_operator(
     const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form);
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift);
 
 template <typename DataType, size_t VolumeDim, typename Frame>
 void transverse_projection_operator(
@@ -195,6 +263,7 @@ void transverse_projection_operator(
     const tnsr::A<DataType, VolumeDim, Frame>& spacetime_normal_vector,
     const tnsr::a<DataType, VolumeDim, Frame>& spacetime_normal_one_form,
     const tnsr::I<DataType, VolumeDim, Frame>& interface_unit_normal_vector,
-    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form);
+    const tnsr::i<DataType, VolumeDim, Frame>& interface_unit_normal_one_form,
+    const tnsr::I<DataType, VolumeDim, Frame>& shift);
 /// @}
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Python/Bindings.cpp
@@ -88,9 +88,11 @@ void bind_impl(py::module& m) {  // NOLINT
   m.def("interface_null_normal",
         static_cast<tnsr::a<DataVector, Dim> (*)(
             const tnsr::a<DataVector, Dim>&, const tnsr::i<DataVector, Dim>&,
-            const double)>(&::gr::interface_null_normal),
+            const tnsr::I<DataVector, Dim>&, const double)>(
+            &::gr::interface_null_normal),
         py::arg("spacetime_normal_one_form"),
-        py::arg("interface_unit_normal_one_form"), py::arg("sign"));
+        py::arg("interface_unit_normal_one_form"), py::arg("shift"),
+        py::arg("sign"));
 
   m.def("inverse_spacetime_metric",
         static_cast<tnsr::AA<DataVector, Dim> (*)(
@@ -171,10 +173,10 @@ void bind_impl(py::module& m) {  // NOLINT
   m.def("transverse_projection_operator",
         static_cast<tnsr::aa<DataVector, Dim> (*)(
             const tnsr::aa<DataVector, Dim>&, const tnsr::a<DataVector, Dim>&,
-            const tnsr::i<DataVector, Dim>&)>(
+            const tnsr::i<DataVector, Dim>&, const tnsr::I<DataVector, Dim>&)>(
             &::gr::transverse_projection_operator),
         py::arg("spacetime_metric"), py::arg("spacetime_normal_one_form"),
-        py::arg("interface_unit_normal_one_form"));
+        py::arg("interface_unit_normal_one_form"), py::arg("shift"));
 
   m.def("transverse_projection_operator",
         static_cast<tnsr::AA<DataVector, Dim> (*)(
@@ -187,12 +189,13 @@ void bind_impl(py::module& m) {  // NOLINT
   m.def("transverse_projection_operator",
         static_cast<tnsr::Ab<DataVector, Dim> (*)(
             const tnsr::A<DataVector, Dim>&, const tnsr::a<DataVector, Dim>&,
-            const tnsr::I<DataVector, Dim>&, const tnsr::i<DataVector, Dim>&)>(
+            const tnsr::I<DataVector, Dim>&, const tnsr::i<DataVector, Dim>&,
+            const tnsr::I<DataVector, Dim>&)>(
             &::gr::transverse_projection_operator),
         py::arg("spacetime_normal_vector"),
         py::arg("spacetime_normal_one_form"),
         py::arg("interface_unit_normal_vector"),
-        py::arg("interface_unit_normal_one_form"));
+        py::arg("interface_unit_normal_one_form"), py::arg("shift"));
 
   m.def(
       "shift",

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -529,10 +529,10 @@ def compute_intermediate_vars(
         four_index_constraint = ght.four_index_constraint(d_phi)
 
     incoming_null_one_form = nn.interface_incoming_null_normal(
-        spacetime_unit_normal_one_form, normal_covector
+        spacetime_unit_normal_one_form, normal_covector, shift
     )
     outgoing_null_one_form = nn.interface_outgoing_null_normal(
-        spacetime_unit_normal_one_form, normal_covector
+        spacetime_unit_normal_one_form, normal_covector, shift
     )
     incoming_null_vector = nn.interface_incoming_null_normal(
         spacetime_unit_normal_vector, unit_interface_normal_vector
@@ -542,13 +542,17 @@ def compute_intermediate_vars(
     )
 
     projection_ab = proj.projection_operator_transverse_to_interface(
-        spacetime_metric, spacetime_unit_normal_one_form, normal_covector
+        spacetime_metric,
+        spacetime_unit_normal_one_form,
+        normal_covector,
+        shift,
     )
     projection_Ab = proj.projection_operator_transverse_to_interface_mixed(
         spacetime_unit_normal_vector,
         spacetime_unit_normal_one_form,
         unit_interface_normal_vector,
         normal_covector,
+        shift,
     )
     projection_AB = proj.projection_operator_transverse_to_interface(
         inverse_spacetime_metric,

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.py
@@ -5,9 +5,17 @@ import numpy as np
 
 
 def interface_outgoing_null_normal(
-    spacetime_normal_vector_or_one_form, interface_normal_vector_or_one_form
+    spacetime_normal_vector_or_one_form,
+    interface_normal_vector_or_one_form,
+    shift=None,
 ):
     result = (2.0**-0.5) * spacetime_normal_vector_or_one_form
+    if shift is not None:
+        result[0] = result[0] + (2.0**-0.5) * np.einsum(
+            "i...,i...->...",
+            interface_normal_vector_or_one_form,
+            shift,
+        )
     result[1:] = (
         result[1:] + (2.0**-0.5) * interface_normal_vector_or_one_form
     )
@@ -15,9 +23,17 @@ def interface_outgoing_null_normal(
 
 
 def interface_incoming_null_normal(
-    spacetime_normal_vector_or_one_form, interface_normal_vector_or_one_form
+    spacetime_normal_vector_or_one_form,
+    interface_normal_vector_or_one_form,
+    shift=None,
 ):
     result = (2.0**-0.5) * spacetime_normal_vector_or_one_form
+    if shift is not None:
+        result[0] = result[0] - (2.0**-0.5) * np.einsum(
+            "i...,i...->...",
+            interface_normal_vector_or_one_form,
+            shift,
+        )
     result[1:] = (
         result[1:] - (2.0**-0.5) * interface_normal_vector_or_one_form
     )

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ProjectionOperators.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ProjectionOperators.py
@@ -32,8 +32,13 @@ def projection_operator_transverse_to_interface(
     spacetime_metric_or_its_inverse,
     normal_vector_or_one_form,
     interface_normal_vector_or_one_form,
+    shift=None,
 ):
     interface_normal = np.zeros(1 + len(interface_normal_vector_or_one_form))
+    if shift is not None:
+        interface_normal[0] = np.einsum(
+            "i,i->", interface_normal_vector_or_one_form, shift
+        )
     interface_normal[1:] = interface_normal_vector_or_one_form
     return (
         spacetime_metric_or_its_inverse
@@ -49,10 +54,14 @@ def projection_operator_transverse_to_interface_mixed(
     normal_one_form,
     interface_normal_vector,
     interface_normal_one_form,
+    shift,
 ):
     interface_normal_vec = np.zeros(1 + len(interface_normal_vector))
     interface_normal_1form = np.zeros(1 + len(interface_normal_one_form))
     interface_normal_vec[1:] = interface_normal_vector
+    interface_normal_1form[0] = np.einsum(
+        "i,i->", interface_normal_one_form, shift
+    )
     interface_normal_1form[1:] = interface_normal_one_form
     return (
         np.eye(np.shape(normal_vector)[0])

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Python/Test_Bindings.py
@@ -56,8 +56,12 @@ class TestBindings(unittest.TestCase):
         interface_unit_normal_one_form = tnsr.i[DataVector, 3](
             num_points=1, fill=1.0
         )
+        shift_ = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
         inter_null_norm = interface_null_normal(
-            spacetime_normal_one_form, interface_unit_normal_one_form, sign=1.0
+            spacetime_normal_one_form,
+            interface_unit_normal_one_form,
+            shift_,
+            sign=1.0,
         )
 
     def test_lapse_shift_normals(self):
@@ -80,6 +84,7 @@ class TestBindings(unittest.TestCase):
         # tnsr.Ij
         transverse_projection_operator(normal_vector, normal_one_form)
         spacetime_metric = tnsr.aa[DataVector, 3](num_points=1, fill=1.0)
+        shift = tnsr.I[DataVector, 3](num_points=1, fill=1.0)
         spacetime_normal_one_form = tnsr.a[DataVector, 3](
             num_points=1, fill=1.0
         )
@@ -91,6 +96,7 @@ class TestBindings(unittest.TestCase):
             spacetime_metric,
             spacetime_normal_one_form,
             interface_unit_normal_one_form,
+            shift,
         )
         inverse_spacetime_metric = tnsr.AA[DataVector, 3](
             num_points=1, fill=1.0
@@ -111,6 +117,7 @@ class TestBindings(unittest.TestCase):
             spacetime_normal_one_form,
             interface_unit_normal_vector,
             interface_unit_normal_one_form,
+            shift,
         )
 
     def test_psi4(self):

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_InterfaceNullNormal.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_InterfaceNullNormal.cpp
@@ -3,34 +3,56 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
+#include <cmath>
 #include <cstddef>
+#include <numbers>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/MakeRandomVectorInMagnitudeRange.hpp"
+#include "Helpers/DataStructures/RandomUnitNormal.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
+const Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+
 template <size_t SpatialDim, typename DataType>
-tnsr::A<DataType, SpatialDim, Frame::Inertial>
+tnsr::a<DataType, SpatialDim, Frame::Inertial>
 interface_outgoing_null_normal_one_form(
-    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+    const tnsr::a<DataType, SpatialDim, Frame::Inertial>&
         spacetime_normal_one_form,
-    const tnsr::I<DataType, SpatialDim, Frame::Inertial>&
-        interface_normal_one_form) {
+    const tnsr::i<DataType, SpatialDim, Frame::Inertial>&
+        interface_normal_one_form,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>& shift) {
   return gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
-      spacetime_normal_one_form, interface_normal_one_form, 1.);
+      spacetime_normal_one_form, interface_normal_one_form, shift, 1.);
 }
 template <size_t SpatialDim, typename DataType>
-tnsr::A<DataType, SpatialDim, Frame::Inertial>
+tnsr::a<DataType, SpatialDim, Frame::Inertial>
 interface_incoming_null_normal_one_form(
-    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+    const tnsr::a<DataType, SpatialDim, Frame::Inertial>&
         spacetime_normal_one_form,
-    const tnsr::I<DataType, SpatialDim, Frame::Inertial>&
-        interface_normal_one_form) {
+    const tnsr::i<DataType, SpatialDim, Frame::Inertial>&
+        interface_normal_one_form,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>& shift) {
   return gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
-      spacetime_normal_one_form, interface_normal_one_form, -1.);
+      spacetime_normal_one_form, interface_normal_one_form, shift, -1.);
 }
 template <size_t SpatialDim, typename DataType>
 tnsr::A<DataType, SpatialDim, Frame::Inertial>
@@ -51,6 +73,36 @@ interface_incoming_null_normal_vector(
         interface_normal_vector) {
   return gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
       spacetime_normal_vector, interface_normal_vector, -1.);
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame::Inertial>
+extend_spatial_vector_to_spacetime(
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>& spatial_vector,
+    const DataType& used_for_size) {
+  auto spacetime_vector =
+      make_with_value<tnsr::A<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    spacetime_vector.get(i + 1) = spatial_vector.get(i);
+  }
+  return spacetime_vector;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame::Inertial>
+extend_spatial_one_form_to_spacetime(
+    const tnsr::i<DataType, SpatialDim, Frame::Inertial>& spatial_one_form,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>& shift,
+    const DataType& used_for_size) {
+  auto spacetime_one_form =
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    spacetime_one_form.get(i + 1) = spatial_one_form.get(i);
+  }
+  spacetime_one_form.get(0) = get(dot_product(shift, spatial_one_form));
+  return spacetime_one_form;
 }
 
 template <size_t SpatialDim, typename DataType>
@@ -80,6 +132,220 @@ void test_interface_null_normals(const DataType& used_for_size) {
                                       {{{-1., 1.}}}, used_for_size);
   }
 }
+
+template <typename DataType>
+void test_one_form_time_component_difference(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 3;
+  MAKE_GENERATOR(generator);
+  const auto lapse =
+      TestHelpers::gr::random_lapse(make_not_null(&generator), used_for_size);
+  const auto shift = TestHelpers::gr::random_shift<spatial_dim>(
+      make_not_null(&generator), used_for_size);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<spatial_dim>(
+          make_not_null(&generator), used_for_size);
+  const auto interface_normal_vector =
+      random_unit_normal(make_not_null(&generator), spatial_metric);
+  auto interface_normal_one_form =
+      make_with_value<tnsr::i<DataType, spatial_dim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  raise_or_lower_index(make_not_null(&interface_normal_one_form),
+                       interface_normal_vector, spatial_metric);
+
+  const auto spacetime_normal_one_form =
+      gr::spacetime_normal_one_form<DataType, spatial_dim, Frame::Inertial>(
+          lapse);
+
+  auto incoming =
+      gr::interface_null_normal<DataType, spatial_dim, Frame::Inertial>(
+          spacetime_normal_one_form, interface_normal_one_form, shift, -1.0);
+  auto outgoing =
+      gr::interface_null_normal<DataType, spatial_dim, Frame::Inertial>(
+          spacetime_normal_one_form, interface_normal_one_form, shift, 1.0);
+
+  const auto shift_dot_interface_normal =
+      dot_product(shift, interface_normal_one_form);
+  const DataType expected_time_component_difference =
+      std::numbers::sqrt2 * get(shift_dot_interface_normal);
+  const DataType computed_time_component_difference =
+      outgoing.get(0) - incoming.get(0);
+  CHECK_ITERABLE_CUSTOM_APPROX(computed_time_component_difference,
+                               expected_time_component_difference,
+                               custom_approx);
+
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  const auto incoming_outgoing_difference =
+      tenex::evaluate<ti::a>(outgoing(ti::a) - incoming(ti::a));
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(spacetime_normal_vector, incoming_outgoing_difference)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+}
+
+template <size_t SpatialDim, typename DataType>
+void check_null_normal_contractions(
+    const tnsr::aa<DataType, SpatialDim, Frame::Inertial>& spacetime_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame::Inertial>&
+        inverse_spacetime_metric,
+    const tnsr::a<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_vector,
+    const tnsr::i<DataType, SpatialDim, Frame::Inertial>&
+        interface_unit_normal_one_form,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>&
+        interface_unit_normal_vector,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>& shift,
+    const DataType& used_for_size) {
+  const auto outgoing_one_form =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_one_form, interface_unit_normal_one_form, shift, 1.);
+  const auto incoming_one_form =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_one_form, interface_unit_normal_one_form, shift,
+          -1.);
+  const auto outgoing_vector =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_vector, interface_unit_normal_vector, 1.);
+  const auto incoming_vector =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_vector, interface_unit_normal_vector, -1.);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(outgoing_one_form, outgoing_one_form,
+                      inverse_spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(incoming_one_form, incoming_one_form,
+                      inverse_spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(outgoing_vector, outgoing_vector, spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(incoming_vector, incoming_vector, spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(outgoing_one_form, incoming_one_form,
+                      inverse_spacetime_metric)),
+      make_with_value<DataType>(used_for_size, -1.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(outgoing_vector, incoming_vector, spacetime_metric)),
+      make_with_value<DataType>(used_for_size, -1.0), custom_approx);
+
+  const auto extended_interface_vector = extend_spatial_vector_to_spacetime(
+      interface_unit_normal_vector, used_for_size);
+  const auto extended_interface_one_form = extend_spatial_one_form_to_spacetime(
+      interface_unit_normal_one_form, shift, used_for_size);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(extended_interface_vector, outgoing_one_form)),
+      make_with_value<DataType>(used_for_size, 1.0 / std::numbers::sqrt2),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(extended_interface_vector, incoming_one_form)),
+      make_with_value<DataType>(used_for_size, -1.0 / std::numbers::sqrt2),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(extended_interface_one_form, outgoing_vector)),
+      make_with_value<DataType>(used_for_size, 1.0 / std::numbers::sqrt2),
+      custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(extended_interface_one_form, incoming_vector)),
+      make_with_value<DataType>(used_for_size, -1.0 / std::numbers::sqrt2),
+      custom_approx);
+}
+
+template <size_t SpatialDim, typename DataType>
+void test_null_normal_contractions_random_background(
+    const DataType& used_for_size) {
+  MAKE_GENERATOR(generator);
+  const auto lapse =
+      TestHelpers::gr::random_lapse(make_not_null(&generator), used_for_size);
+  const auto shift = TestHelpers::gr::random_shift<SpatialDim>(
+      make_not_null(&generator), used_for_size);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<SpatialDim>(
+          make_not_null(&generator), used_for_size);
+
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  const auto spacetime_normal_one_form =
+      gr::spacetime_normal_one_form<DataType, SpatialDim, Frame::Inertial>(
+          lapse);
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+
+  const auto interface_unit_normal_vector =
+      random_unit_normal(make_not_null(&generator), spatial_metric);
+  auto interface_unit_normal_one_form =
+      make_with_value<tnsr::i<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  raise_or_lower_index(make_not_null(&interface_unit_normal_one_form),
+                       interface_unit_normal_vector, spatial_metric);
+
+  check_null_normal_contractions(
+      spacetime_metric, inverse_spacetime_metric, spacetime_normal_one_form,
+      spacetime_normal_vector, interface_unit_normal_one_form,
+      interface_unit_normal_vector, shift, used_for_size);
+}
+
+template <typename DataType>
+void test_null_normal_contractions_kerr(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 3;
+  const gr::Solutions::KerrSchild kerr_solution{
+      1.7, {{0.2, -0.4, 0.3}}, {{0.1, -0.2, 0.3}}};
+  MAKE_GENERATOR(generator);
+  const auto coords =
+      make_random_vector_in_magnitude_range_flat<DataType, spatial_dim,
+                                                 UpLo::Up, Frame::Inertial>(
+          make_not_null(&generator), used_for_size, 4.0, 6.0);
+
+  const auto vars = kerr_solution.variables(
+      coords, 0.0,
+      tmpl::list<
+          gr::Tags::Lapse<DataType>,
+          gr::Tags::Shift<DataType, spatial_dim, Frame::Inertial>,
+          gr::Tags::SpatialMetric<DataType, spatial_dim, Frame::Inertial>,
+          gr::Tags::InverseSpatialMetric<DataType, spatial_dim,
+                                         Frame::Inertial>>{});
+  const auto& lapse = get<gr::Tags::Lapse<DataType>>(vars);
+  const auto& shift =
+      get<gr::Tags::Shift<DataType, spatial_dim, Frame::Inertial>>(vars);
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<DataType, spatial_dim, Frame::Inertial>>(
+          vars);
+  const auto& inverse_spatial_metric = get<
+      gr::Tags::InverseSpatialMetric<DataType, spatial_dim, Frame::Inertial>>(
+      vars);
+  const auto spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+
+  const auto interface_unit_normal_vector =
+      random_unit_normal(make_not_null(&generator), spatial_metric);
+  auto interface_unit_normal_one_form =
+      make_with_value<tnsr::i<DataType, spatial_dim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  raise_or_lower_index(make_not_null(&interface_unit_normal_one_form),
+                       interface_unit_normal_vector, spatial_metric);
+
+  const auto spacetime_normal_one_form =
+      gr::spacetime_normal_one_form<DataType, spatial_dim, Frame::Inertial>(
+          lapse);
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  check_null_normal_contractions(
+      spacetime_metric, inverse_spacetime_metric, spacetime_normal_one_form,
+      spacetime_normal_vector, interface_unit_normal_one_form,
+      interface_unit_normal_vector, shift, used_for_size);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IntfcNullNormals",
@@ -90,4 +356,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IntfcNullNormals",
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
 
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_interface_null_normals, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_one_form_time_component_difference,
+                                    ());
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_null_normal_contractions_random_background, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_null_normal_contractions_kerr, ());
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ProjectionOperators.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ProjectionOperators.cpp
@@ -3,29 +3,104 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <cmath>
 #include <cstddef>
 #include <random>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.tpp"
-#include "Domain/CoordinateMaps/ProductMaps.hpp"
-#include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "Domain/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
-#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "Helpers/DataStructures/RandomUnitNormal.hpp"
+#include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InterfaceNullNormal.hpp"
+#include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 namespace {
+const Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame::Inertial>
+extend_spatial_vector_to_spacetime(
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>& spatial_vector,
+    const DataType& used_for_size) {
+  auto spacetime_vector =
+      make_with_value<tnsr::A<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    spacetime_vector.get(i + 1) = spatial_vector.get(i);
+  }
+  return spacetime_vector;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame::Inertial>
+extend_spatial_one_form_to_spacetime(
+    const tnsr::i<DataType, SpatialDim, Frame::Inertial>& spatial_one_form,
+    const tnsr::I<DataType, SpatialDim, Frame::Inertial>& shift,
+    const DataType& used_for_size) {
+  auto spacetime_one_form =
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    spacetime_one_form.get(i + 1) = spatial_one_form.get(i);
+  }
+  spacetime_one_form.get(0) = get(dot_product(shift, spatial_one_form));
+  return spacetime_one_form;
+}
+
+template <size_t SpatialDim, typename DataType>
+void check_aa_orthogonality(
+    const tnsr::aa<DataType, SpatialDim, Frame::Inertial>& projection_aa,
+    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_vector) {
+  const auto right_contraction = tenex::evaluate<ti::a>(
+      projection_aa(ti::a, ti::b) * spacetime_normal_vector(ti::B));
+  const auto left_contraction = tenex::evaluate<ti::b>(
+      spacetime_normal_vector(ti::A) * projection_aa(ti::a, ti::b));
+  const auto zero =
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame::Inertial>>(
+          get_size(get<0, 0>(projection_aa)), 0.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(right_contraction, zero, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(left_contraction, zero, custom_approx);
+}
+
+template <size_t SpatialDim, typename DataType>
+void check_ab_orthogonality(
+    const tnsr::Ab<DataType, SpatialDim, Frame::Inertial>& projection_ab,
+    const tnsr::a<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame::Inertial>&
+        spacetime_normal_vector) {
+  const auto lower_contraction = tenex::evaluate<ti::b>(
+      spacetime_normal_one_form(ti::a) * projection_ab(ti::A, ti::b));
+  const auto upper_contraction = tenex::evaluate<ti::A>(
+      projection_ab(ti::A, ti::b) * spacetime_normal_vector(ti::B));
+  const auto zero_one_form =
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame::Inertial>>(
+          get_size(get<0, 0>(projection_ab)), 0.0);
+  const auto zero_vector =
+      make_with_value<tnsr::A<DataType, SpatialDim, Frame::Inertial>>(
+          get_size(get<0, 0>(projection_ab)), 0.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(lower_contraction, zero_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(upper_contraction, zero_vector, custom_approx);
+}
+
 template <size_t SpatialDim, typename DataType>
 void test_projection_operator(const DataType& used_for_size) {
   {
@@ -78,7 +153,8 @@ void test_projection_operator(const DataType& used_for_size) {
     tnsr::aa<DataType, SpatialDim, Frame::Inertial> (*f)(
         const tnsr::aa<DataType, SpatialDim, Frame::Inertial>&,
         const tnsr::a<DataType, SpatialDim, Frame::Inertial>&,
-        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&) =
+        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&) =
         &gr::transverse_projection_operator<DataType, SpatialDim,
                                             Frame::Inertial>;
     pypp::check_with_random_values<1>(
@@ -91,7 +167,8 @@ void test_projection_operator(const DataType& used_for_size) {
         const tnsr::A<DataType, SpatialDim, Frame::Inertial>&,
         const tnsr::a<DataType, SpatialDim, Frame::Inertial>&,
         const tnsr::I<DataType, SpatialDim, Frame::Inertial>&,
-        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&) =
+        const tnsr::i<DataType, SpatialDim, Frame::Inertial>&,
+        const tnsr::I<DataType, SpatialDim, Frame::Inertial>&) =
         &gr::transverse_projection_operator<DataType, SpatialDim,
                                             Frame::Inertial>;
     pypp::check_with_random_values<1>(
@@ -99,34 +176,276 @@ void test_projection_operator(const DataType& used_for_size) {
         "projection_operator_transverse_to_interface_mixed", {{{-1., 1.}}},
         used_for_size);
   }
+
+  const auto data_size = get_size(used_for_size);
+  MAKE_GENERATOR(generator);
+  const auto lapse =
+      TestHelpers::gr::random_lapse(make_not_null(&generator), used_for_size);
+  const auto shift = TestHelpers::gr::random_shift<SpatialDim>(
+      make_not_null(&generator), used_for_size);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<SpatialDim>(
+          make_not_null(&generator), used_for_size);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+
+  const auto spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  const auto spacetime_normal_one_form =
+      gr::spacetime_normal_one_form<DataType, SpatialDim, Frame::Inertial>(
+          lapse);
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+
+  const auto interface_unit_normal_vector =
+      random_unit_normal(make_not_null(&generator), spatial_metric);
+  auto interface_unit_normal_one_form =
+      make_with_value<tnsr::i<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  raise_or_lower_index(make_not_null(&interface_unit_normal_one_form),
+                       interface_unit_normal_vector, spatial_metric);
+
+  const auto projection_aa = gr::transverse_projection_operator(
+      spacetime_metric, spacetime_normal_one_form,
+      interface_unit_normal_one_form, shift);
+  check_aa_orthogonality(projection_aa, spacetime_normal_vector);
+
+  tnsr::aa<DataType, SpatialDim, Frame::Inertial> projection_aa_not_null(
+      data_size);
+  gr::transverse_projection_operator(
+      make_not_null(&projection_aa_not_null), spacetime_metric,
+      spacetime_normal_one_form, interface_unit_normal_one_form, shift);
+  check_aa_orthogonality(projection_aa_not_null, spacetime_normal_vector);
+
+  const auto projection_ab = gr::transverse_projection_operator(
+      spacetime_normal_vector, spacetime_normal_one_form,
+      interface_unit_normal_vector, interface_unit_normal_one_form, shift);
+  check_ab_orthogonality(projection_ab, spacetime_normal_one_form,
+                         spacetime_normal_vector);
+
+  tnsr::Ab<DataType, SpatialDim, Frame::Inertial> projection_ab_not_null(
+      data_size);
+  gr::transverse_projection_operator(
+      make_not_null(&projection_ab_not_null), spacetime_normal_vector,
+      spacetime_normal_one_form, interface_unit_normal_vector,
+      interface_unit_normal_one_form, shift);
+  check_ab_orthogonality(projection_ab_not_null, spacetime_normal_one_form,
+                         spacetime_normal_vector);
+
+  const auto outgoing_null_one_form =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_one_form, interface_unit_normal_one_form, shift,
+          1.0);
+  const auto incoming_null_one_form =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_one_form, interface_unit_normal_one_form, shift,
+          -1.0);
+  const auto outgoing_null_vector =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_vector, interface_unit_normal_vector, 1.0);
+  const auto incoming_null_vector =
+      gr::interface_null_normal<DataType, SpatialDim, Frame::Inertial>(
+          spacetime_normal_vector, interface_unit_normal_vector, -1.0);
+
+  const auto contract_aa_right = [&](const auto& vector) {
+    return tenex::evaluate<ti::a>(projection_aa(ti::a, ti::b) * vector(ti::B));
+  };
+  const auto contract_aa_left = [&](const auto& vector) {
+    return tenex::evaluate<ti::b>(vector(ti::A) * projection_aa(ti::a, ti::b));
+  };
+  const auto contract_ab_left = [&](const auto& one_form) {
+    return tenex::evaluate<ti::b>(one_form(ti::a) *
+                                  projection_ab(ti::A, ti::b));
+  };
+  const auto zero_spacetime_one_form =
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame::Inertial>>(data_size,
+                                                                      0.0);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_aa_right(outgoing_null_vector),
+                               zero_spacetime_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_aa_right(incoming_null_vector),
+                               zero_spacetime_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_aa_left(outgoing_null_vector),
+                               zero_spacetime_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_aa_left(incoming_null_vector),
+                               zero_spacetime_one_form, custom_approx);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_ab_left(outgoing_null_one_form),
+                               zero_spacetime_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_ab_left(incoming_null_one_form),
+                               zero_spacetime_one_form, custom_approx);
+
+  const auto interface_normal_one_form = extend_spatial_one_form_to_spacetime(
+      interface_unit_normal_one_form, shift, used_for_size);
+  const auto interface_normal_vector = extend_spatial_vector_to_spacetime(
+      interface_unit_normal_vector, used_for_size);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_aa_right(interface_normal_vector),
+                               zero_spacetime_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_aa_left(interface_normal_vector),
+                               zero_spacetime_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(contract_ab_left(interface_normal_one_form),
+                               zero_spacetime_one_form, custom_approx);
+
+  const auto trace_aa = tenex::evaluate(inverse_spacetime_metric(ti::A, ti::B) *
+                                        projection_aa(ti::a, ti::b));
+  const auto trace_ab = tenex::evaluate(projection_ab(ti::A, ti::a));
+  const auto expected_trace =
+      make_with_value<Scalar<DataType>>(used_for_size, SpatialDim - 1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(trace_aa, expected_trace, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(trace_ab, expected_trace, custom_approx);
+
+  const auto raised_projection_aa = tenex::evaluate<ti::A, ti::b>(
+      inverse_spacetime_metric(ti::A, ti::C) * projection_aa(ti::c, ti::b));
+  CHECK_ITERABLE_CUSTOM_APPROX(raised_projection_aa, projection_ab,
+                               custom_approx);
+
+  const auto idempotent_projection_ab = tenex::evaluate<ti::A, ti::b>(
+      projection_ab(ti::A, ti::c) * projection_ab(ti::C, ti::b));
+  CHECK_ITERABLE_CUSTOM_APPROX(idempotent_projection_ab, projection_ab,
+                               custom_approx);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(outgoing_null_one_form, outgoing_null_one_form,
+                      inverse_spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(incoming_null_one_form, incoming_null_one_form,
+                      inverse_spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(outgoing_null_vector, outgoing_null_vector,
+                      spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(dot_product(incoming_null_vector, incoming_null_vector,
+                      spacetime_metric)),
+      make_with_value<DataType>(used_for_size, 0.0), custom_approx);
+}
+
+template <size_t SpatialDim, typename DataType>
+void test_projection_operator_spatial(const DataType& used_for_size) {
+  MAKE_GENERATOR(generator);
+  const auto spatial_metric =
+      TestHelpers::gr::random_spatial_metric<SpatialDim>(
+          make_not_null(&generator), used_for_size);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+
+  const auto interface_unit_normal_vector =
+      random_unit_normal(make_not_null(&generator), spatial_metric);
+  auto interface_unit_normal_one_form =
+      make_with_value<tnsr::i<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  raise_or_lower_index(make_not_null(&interface_unit_normal_one_form),
+                       interface_unit_normal_vector, spatial_metric);
+
+  const auto projection_II = gr::transverse_projection_operator(
+      inverse_spatial_metric, interface_unit_normal_vector);
+  const auto projection_ii = gr::transverse_projection_operator(
+      spatial_metric, interface_unit_normal_one_form);
+  const auto projection_Ij = gr::transverse_projection_operator(
+      interface_unit_normal_vector, interface_unit_normal_one_form);
+
+  auto projection_II_not_null =
+      make_with_value<tnsr::II<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  gr::transverse_projection_operator(make_not_null(&projection_II_not_null),
+                                     inverse_spatial_metric,
+                                     interface_unit_normal_vector);
+  CHECK_ITERABLE_CUSTOM_APPROX(projection_II_not_null, projection_II,
+                               custom_approx);
+
+  auto projection_ii_not_null =
+      make_with_value<tnsr::ii<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  gr::transverse_projection_operator(make_not_null(&projection_ii_not_null),
+                                     spatial_metric,
+                                     interface_unit_normal_one_form);
+  CHECK_ITERABLE_CUSTOM_APPROX(projection_ii_not_null, projection_ii,
+                               custom_approx);
+
+  auto projection_Ij_not_null =
+      make_with_value<tnsr::Ij<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  gr::transverse_projection_operator(make_not_null(&projection_Ij_not_null),
+                                     interface_unit_normal_vector,
+                                     interface_unit_normal_one_form);
+  CHECK_ITERABLE_CUSTOM_APPROX(projection_Ij_not_null, projection_Ij,
+                               custom_approx);
+
+  const auto zero_vector =
+      make_with_value<tnsr::I<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+  const auto zero_one_form =
+      make_with_value<tnsr::i<DataType, SpatialDim, Frame::Inertial>>(
+          used_for_size, 0.0);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      tenex::evaluate<ti::I>(projection_II(ti::I, ti::J) *
+                             interface_unit_normal_one_form(ti::j)),
+      zero_vector, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      tenex::evaluate<ti::J>(interface_unit_normal_one_form(ti::i) *
+                             projection_II(ti::I, ti::J)),
+      zero_vector, custom_approx);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      tenex::evaluate<ti::i>(projection_ii(ti::i, ti::j) *
+                             interface_unit_normal_vector(ti::J)),
+      zero_one_form, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      tenex::evaluate<ti::j>(interface_unit_normal_vector(ti::I) *
+                             projection_ii(ti::i, ti::j)),
+      zero_one_form, custom_approx);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      tenex::evaluate<ti::I>(projection_Ij(ti::I, ti::j) *
+                             interface_unit_normal_vector(ti::J)),
+      zero_vector, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      tenex::evaluate<ti::j>(interface_unit_normal_one_form(ti::i) *
+                             projection_Ij(ti::I, ti::j)),
+      zero_one_form, custom_approx);
+
+  const auto trace_II = tenex::evaluate(spatial_metric(ti::i, ti::j) *
+                                        projection_II(ti::I, ti::J));
+  const auto trace_ii = tenex::evaluate(inverse_spatial_metric(ti::I, ti::J) *
+                                        projection_ii(ti::i, ti::j));
+  const auto trace_Ij = tenex::evaluate(projection_Ij(ti::I, ti::i));
+  const auto expected_trace =
+      make_with_value<Scalar<DataType>>(used_for_size, SpatialDim - 1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(trace_II, expected_trace, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(trace_ii, expected_trace, custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(trace_Ij, expected_trace, custom_approx);
+
+  const auto idempotent_projection_Ij = tenex::evaluate<ti::I, ti::j>(
+      projection_Ij(ti::I, ti::k) * projection_Ij(ti::K, ti::j));
+  CHECK_ITERABLE_CUSTOM_APPROX(idempotent_projection_Ij, projection_Ij,
+                               custom_approx);
+
+  const auto raised_projection_ii = tenex::evaluate<ti::I, ti::j>(
+      inverse_spatial_metric(ti::I, ti::K) * projection_ii(ti::k, ti::j));
+  CHECK_ITERABLE_CUSTOM_APPROX(raised_projection_ii, projection_Ij,
+                               custom_approx);
 }
 }  // namespace
 
 namespace {
-using Affine = domain::CoordinateMaps::Affine;
-using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 using frame = Frame::Inertial;
 constexpr size_t SpatialDim = 3;
 
-// Test projection operators by comparing to values from SpEC
-void test_spatial_projection_tensors_3D(
-    const size_t grid_size_each_dimension,
-    const std::array<double, 3>& lower_bound,
-    const std::array<double, 3>& upper_bound) {
+// Compare with fixed reference values from SpEC on a
+// 3D mesh with 3x3x3 grid points.
+void compare_spatial_projection_tensors_with_spec() {
+  constexpr size_t grid_size_each_dimension = 3;
+  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
   // Setup grid
   Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
-  const auto coord_map =
-      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
-          Affine3D{
-              Affine{-1., 1., lower_bound[0], upper_bound[0]},
-              Affine{-1., 1., lower_bound[1], upper_bound[1]},
-              Affine{-1., 1., lower_bound[2], upper_bound[2]},
-          });
-
   // Setup coordinates
-  const auto x_logical = logical_coordinates(mesh);
-  const auto x = coord_map(x_logical);
   const Direction<SpatialDim> direction(1, Side::Upper);  // +y direction
   const size_t slice_grid_points =
       mesh.extents().slice_away(direction.dimension()).product();
@@ -190,8 +509,8 @@ void test_spatial_projection_tensors_3D(
   }
 
   // Compare values returned to those from SpEC
-  CHECK_ITERABLE_APPROX(local_spatial_projection_IJ,
-                        spec_spatial_projection_IJ);
+  CHECK_ITERABLE_CUSTOM_APPROX(local_spatial_projection_IJ,
+                               spec_spatial_projection_IJ, custom_approx);
 
   // 2. Projection ij
   auto local_spatial_metric =
@@ -236,8 +555,8 @@ void test_spatial_projection_tensors_3D(
   }
 
   // Compare values returned to those from SpEC
-  CHECK_ITERABLE_APPROX(local_spatial_projection_ij,
-                        spec_spatial_projection_ij);
+  CHECK_ITERABLE_CUSTOM_APPROX(local_spatial_projection_ij,
+                               spec_spatial_projection_ij, custom_approx);
 
   // 3. Projection Ij
   auto local_spatial_projection_Ij =
@@ -265,8 +584,8 @@ void test_spatial_projection_tensors_3D(
   }
 
   // Compare values returned to those from SpEC
-  CHECK_ITERABLE_APPROX(local_spatial_projection_Ij,
-                        spec_spatial_projection_Ij);
+  CHECK_ITERABLE_CUSTOM_APPROX(local_spatial_projection_Ij,
+                               spec_spatial_projection_Ij, custom_approx);
 }
 }  // namespace
 
@@ -278,10 +597,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.ProjectionOps",
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
 
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_projection_operator, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_projection_operator_spatial,
+                                    (1, 2, 3));
 
-  const size_t grid_size = 3;
-  const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};
-  const std::array<double, 3> upper_bound{{300., 0.5, 0.5}};
-
-  test_spatial_projection_tensors_3D(grid_size, lower_bound, upper_bound);
+  compare_spatial_projection_tensors_with_spec();
 }


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug that affects Bjorhus boundary conditions. The issue is that boundary conditions use the normal to the boundary $s_a$, which must be orthogonal to the normal to the time slice $n^a$, which requires that $s_t = s_i \beta^i$, where $\beta^i$ is the shift. But before this fix, this code assumed $s_t=0$.

### Note on AI usage
I used OpenAI Codex  to prepare this PR as follows: 
* I used Codex to design and execute a comparison test. The test evolves a mass=1, spin=0, center=0,0,0 Kerr-Schild black hole on a single spherical shell element in both SpEC and SpECTRE, taking a single fixed time step of size 0.01. Codex then created python scripts to test if the spacetime metric, pi, phi, and the inertial coordinates agree up to roundoff at times 0.0 and 0.01. Codex identified and prepared an initial draft fix that enabled this comparison test to pass.
* I inspected the code by hand to confirm that Codex was correct in identifying the bug.
* I then went back and forth with Codex, asking it to make a second draft of the fix that also included unit tests that would have caught the failure. Codex verified that the test failed on develop, implemented the fix, then verified that the new unit tests pass.
* Codex generated all of the code in this PR based on the design I requested.
* I went through one round of review, checking every line of code and then requesting changes as I thought best. I did not identify any code that appeared to duplicate known algorithms or public code outside of the spectre repository.
* I verified that the PR functions as expected by repeating the spec vs spectre comparison that led to the bug discovery.
* Codex assisted in diagnosing some CI failures (e.g. clang-tidy) in earlier versions of the branch this PR is based on, and Codex implemented the fixes for those failures.
* In response to feedback from human reviewers, I will either update the code by hand or respond ensure that an AI agent appropriately and correctly responds.

After the above process, I think this is ready for a look by a second reviewer.

I welcome feedback, both with the code in this PR and the process of using AI agents for spectre development. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->