### PR TITLE
Add Zernike GaussRadauUpper collocation and weights

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -13,7 +13,6 @@ spectre_target_sources(
   CardinalInterpolator.cpp
   CubicSpanInterpolator.cpp
   CubicSpline.cpp
-  InterpolationWeights.cpp
   IrregularInterpolant.cpp
   LinearLeastSquares.cpp
   LinearRegression.cpp
@@ -34,7 +33,6 @@ spectre_target_headers(
   CardinalInterpolator.hpp
   CubicSpanInterpolator.hpp
   CubicSpline.hpp
-  InterpolationWeights.hpp
   IrregularInterpolant.hpp
   LagrangePolynomial.hpp
   LinearLeastSquares.hpp

--- a/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.cpp
@@ -9,8 +9,8 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolationWeights.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/InterpolationWeights.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -37,7 +37,7 @@ std::array<Matrix, Dim> interpolation_matrices_impl(
         const DataVector xi =
             get<0>(logical_coordinates(source_mesh.slice_through(d)));
         gsl::at(interpolation_matrices, d) =
-            fornberg_interpolation_matrix(target_points.get(d), xi);
+            Spectral::fornberg_interpolation_matrix(target_points.get(d), xi);
         break;
       }
       case Spectral::Basis::SphericalHarmonic: {
@@ -47,7 +47,7 @@ std::array<Matrix, Dim> interpolation_matrices_impl(
                 get<0>(logical_coordinates(source_mesh.slice_through(d)));
             const DataVector cos_theta_source = cos(theta);
             const DataType cos_theta_target = cos(target_points.get(d));
-            const Matrix theta_matrix = fornberg_interpolation_matrix(
+            const Matrix theta_matrix = Spectral::fornberg_interpolation_matrix(
                 cos_theta_target, cos_theta_source);
             const size_t n_th = source_mesh.extents(d);
             gsl::at(interpolation_matrices, d)
@@ -76,8 +76,9 @@ std::array<Matrix, Dim> interpolation_matrices_impl(
               extended_phi_target[2 * k + 1] =
                   get_element(phi_target, k) + M_PI;
             }
-            gsl::at(interpolation_matrices, d) = fourier_interpolation_matrix(
-                extended_phi_target, source_mesh.extents(d));
+            gsl::at(interpolation_matrices, d) =
+                Spectral::fourier_interpolation_matrix(extended_phi_target,
+                                                       source_mesh.extents(d));
             break;
           }
           default:

--- a/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp
@@ -26,11 +26,11 @@ namespace intrp {
  * \details The one-dimensional matrices used to do the interpolation depend
  * upon the Spectral::Basis used in each dimension:
  * - For a Chebyshev or Legendre basis, the matrices are given by
- * intrp::fornberg_interpolation_matrix at the quadrature points of the
+ * Spectral::fornberg_interpolation_matrix at the quadrature points of the
  * source_mesh.  (These are equivalent to those returned by
  * Spectral::interpolation_matrix.)
  * - For a Fourier basis, the matrix is given by
- * intrp::fourier_interpolation_matrix at the quadrature points of the
+ * Spectral::fourier_interpolation_matrix at the quadrature points of the
  * source_mesh
  *
  */

--- a/src/NumericalAlgorithms/Spectral/BarycentricWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/BarycentricWeights.cpp
@@ -55,5 +55,11 @@ template const DataVector&
     barycentric_weights<Basis::Legendre, Quadrature::Gauss>(size_t);
 template const DataVector&
     barycentric_weights<Basis::Legendre, Quadrature::GaussLobatto>(size_t);
+template const DataVector&
+    barycentric_weights<Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t);
+template const DataVector&
+    barycentric_weights<Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t);
+template const DataVector&
+    barycentric_weights<Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t);
 }  // namespace detail
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/BasisFunctionValue.hpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctionValue.hpp
@@ -18,4 +18,11 @@ namespace Spectral {
  */
 template <Basis BasisType, typename T>
 T compute_basis_function_value(size_t k, const T& x);
+
+/*!
+ * \brief Compute the function values of the basis function \f$\Phi^m_k(x)\f$
+ * (zero-indexed).
+ */
+template <Basis BasisType, typename T>
+T compute_basis_function_value(size_t k, size_t m, const T& x);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/Zernike.cpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/Zernike.cpp
@@ -5,10 +5,21 @@
 
 #include <cmath>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/Blaze/IntegerPow.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionNormalizationSquare.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Jacobi.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
+#include "NumericalAlgorithms/Spectral/InterpolationWeights.hpp"
+#include "NumericalAlgorithms/Spectral/InverseWeightFunctionValues.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -62,6 +73,13 @@ T Q(const size_t n, const size_t m, const T& r) {
   return Qnm;
 }
 
+// Pi(r) := Q^0_m(r)
+template <size_t Dim, typename T>
+T Pi(const size_t m, const T& r) {
+  ASSERT(m > 1, "Pi: m must be at least two, got m = " << m);
+  return Q<Dim>(m, 0, r) - Q<Dim>(m - 2, 0, r);
+}
+
 template <size_t Dim>
 double I(const size_t n, const size_t m) {
   static_assert(Dim == 1 or Dim == 2 or Dim == 3);
@@ -75,6 +93,69 @@ double I(const size_t n, const size_t m) {
     result *= (2. * ii + betaM - 3.) / (2. * ii + betaM + 1.);
   }
   return result;
+}
+
+template <size_t Dim>
+std::pair<DataVector, DataVector>
+compute_collocation_points_and_weights_gauss_radau_impl(
+    const size_t num_points) {
+  // Implementing for true logical coordinates: [0,1]
+  static_assert(Dim == 1 or Dim == 2 or Dim == 3);
+  ASSERT(
+      num_points >= 1,
+      "Zernike-Gauss-Radau quadrature requires at least one collocation point");
+  const size_t poly_degree = num_points - 1;
+  DataVector x(num_points);
+  DataVector w(num_points);
+  switch (poly_degree) {
+    case 0:
+      x[0] = 1.0;
+      w[0] = I<Dim>(0, 0);
+      break;
+    default:
+      size_t root_index = 0;
+      // Find the collocation points by finding the roots of pi(m, r)
+      // We know there is a root at r = 1 (and don't want one at 0)
+      const size_t M = 2 * num_points;
+      const size_t num_intervals = M * M;
+      const double delta = 0.1 / static_cast<double>(num_intervals);
+      const double dr = (1. - 2. * delta) / static_cast<double>(num_intervals);
+
+      double r_left = delta;
+      double f_left = Pi<Dim>(M, r_left);
+      for (size_t i = 0; i < num_intervals; ++i) {
+        const double r_right = r_left + dr;
+        const double f_right = Pi<Dim>(M, r_right);
+
+        // Checking if root has been bracketed
+        if (f_left * f_right <= 0) {
+          const double root =
+              RootFinder::toms748([M](const double r) { return Pi<Dim>(M, r); },
+                                  r_left, r_right, f_left, f_right, 0.0,
+                                  4.0 * std::numeric_limits<double>::epsilon());
+          x[root_index] = root;
+          ++root_index;
+        }
+        r_left = r_right;
+        f_left = f_right;
+      }
+      ASSERT(num_points - 1 == root_index,
+             "Did not find all the roots of Pi, expect "
+                 << num_points - 1 << ", but got " << root_index);
+      x[num_points - 1] = 1.0;
+      // Computing quadrature weights
+      const auto mm = static_cast<double>(M);
+      constexpr double betaM = Dim == 1 ? 0.0 : (Dim == 2 ? 1.0 : 2.0);
+      for (size_t i = 0; i < num_points - 1; ++i) {
+        w[i] = 2. * (2. * mm + betaM - 3.) * square(x[i]) * I<Dim>(M - 2, 0) /
+               (mm * (mm + betaM - 1.) * square(Q<Dim>(M - 2, 0, x[i])));
+      }
+      w[num_points - 1] =
+          (2. * (2. * mm + betaM - 3.) * I<Dim>(M - 2, 0) /
+           (mm * (mm + betaM - 1.) * square(Q<Dim>(M - 2, 0, 1.0))));
+      break;
+  }
+  return std::make_pair(std::move(x), std::move(w));
 }
 }  // namespace
 
@@ -90,6 +171,157 @@ T Zernike<Dim>::basis_function_value(const size_t n, const size_t m,
   return Q<Dim>(n, m, static_cast<T>(0.5 * (xi + 1.0))) / sqrt(I<Dim>(n, m));
 }
 
+template <size_t Dim>
+std::pair<DataVector, DataVector>
+Zernike<Dim>::compute_collocation_points_and_weights(const size_t num_points) {
+  // Manually adding an affine coordinate map to shift logical coordinates
+  // from [0,1] -> [-1,1] (simpler to keep track of this than generalize the
+  // [-1,1] assumption scattered through the code)
+  auto [points, weights] =
+      compute_collocation_points_and_weights_gauss_radau_impl<Dim>(num_points);
+  points = 2.0 * points - 1.0;
+  // Don't need to modify weights as the affine shift is only external, you
+  // will only ever use weights on "real" [0,1] coordinates
+  return std::make_pair(points, weights);
+}
+
+template <size_t Dim>
+Matrix Zernike<Dim>::differentiation_matrix(const size_t num_points,
+                                            const Parity parity) {
+  ASSERT(parity != Parity::Uninitialized, "Passed parity must set");
+  // "missing" factor of 1/2 because logical coordinates have a Jacobian
+  // factor to go from [-1,1] -> [0,1]
+  const DataVector collocation_pts =
+      Zernike<Dim>::compute_collocation_points_and_weights(num_points).first +
+      1.0;
+  const size_t max_deriv = 1;
+  std::array<DataVector, max_deriv + 1> fornberg_weights{};
+  DataVector extended_collocation_pts(2 * num_points, 0.0);
+  Matrix extended_diff_matrix(num_points, 2 * num_points);
+  Matrix projector(2 * num_points, num_points, 0.0);
+  for (size_t i = 0; i < num_points; ++i) {
+    extended_collocation_pts[i] = collocation_pts[i];
+    extended_collocation_pts[i + num_points] = -collocation_pts[i];
+    projector(i, i) = 1.0;
+    projector(i + num_points, i) = parity == Parity::Odd ? -1.0 : 1.0;
+  }
+  for (size_t i = 0; i < num_points; ++i) {
+    Spectral::fornberg_derivative_interpolation_weights<max_deriv>(
+        make_not_null(&fornberg_weights), collocation_pts[i],
+        extended_collocation_pts);
+    for (size_t j = 0; j < 2 * num_points; ++j) {
+      extended_diff_matrix(i, j) = fornberg_weights[1][j];
+    }
+  }
+  return extended_diff_matrix * projector;
+}
+
+// Specializations of function templates defined in the Spectral directory
+
+template <>
+DataVector compute_basis_function_value<Basis::ZernikeB1>(
+    const size_t k, const size_t m, const DataVector& xi) {
+  return Zernike<1>::basis_function_value(k, m, xi);
+}
+
+template <>
+DataVector compute_basis_function_value<Basis::ZernikeB2>(
+    const size_t k, const size_t m, const DataVector& xi) {
+  return Zernike<2>::basis_function_value(k, m, xi);
+}
+
+template <>
+DataVector compute_basis_function_value<Basis::ZernikeB3>(
+    const size_t k, const size_t m, const DataVector& xi) {
+  return Zernike<3>::basis_function_value(k, m, xi);
+}
+
+// The bases orthonormal wrt n
+template <>
+double compute_basis_function_normalization_square<Basis::ZernikeB1>(
+    const size_t /*k*/) {
+  return 1.;
+}
+
+template <>
+double compute_basis_function_normalization_square<Basis::ZernikeB2>(
+    const size_t /*k*/) {
+  return 1.;
+}
+
+template <>
+double compute_basis_function_normalization_square<Basis::ZernikeB3>(
+    const size_t /*k*/) {
+  return 1.;
+}
+
+template <>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
+    Basis::ZernikeB1, Quadrature::GaussRadauUpper>(const size_t num_points) {
+  return Zernike<1>::compute_collocation_points_and_weights(num_points);
+}
+
+template <>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
+    Basis::ZernikeB2, Quadrature::GaussRadauUpper>(const size_t num_points) {
+  return Zernike<2>::compute_collocation_points_and_weights(num_points);
+}
+
+template <>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
+    Basis::ZernikeB3, Quadrature::GaussRadauUpper>(const size_t num_points) {
+  return Zernike<3>::compute_collocation_points_and_weights(num_points);
+}
+
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif
+// The following one-index basis function values need to be created so that
+// GetSpectralQuantityForMesh.hpp can correctly instantiate all things called
+// from SPECTRAL_QUANTITY_FOR_MESH that are genuinetly one-indexed
+// (e.g. collocation points and weights)
+template <Basis BasisType>
+Matrix spectral_indefinite_integral_matrix(size_t num_points);
+
+template <>
+Matrix spectral_indefinite_integral_matrix<Basis::ZernikeB1>(
+    const size_t /*num_points*/) {
+  ERROR("Indefinite integral matrix is not defined for ZernikeB1 basis");
+}
+template <>
+Matrix spectral_indefinite_integral_matrix<Basis::ZernikeB2>(
+    const size_t /*num_points*/) {
+  ERROR("Indefinite integral matrix is not defined for ZernikeB2 basis");
+}
+template <>
+Matrix spectral_indefinite_integral_matrix<Basis::ZernikeB3>(
+    const size_t /*num_points*/) {
+  ERROR("Indefinite integral matrix is not defined for ZernikeB3 basis");
+}
+
+template <>
+DataVector compute_basis_function_value<Basis::ZernikeB1>(
+    const size_t /*k*/, const DataVector& /*x*/) {
+  ERROR("Calling one-index Zernike basis function");
+}
+
+template <>
+DataVector compute_basis_function_value<Basis::ZernikeB2>(
+    const size_t /*k*/, const DataVector& /*x*/) {
+  ERROR("Calling one-index Zernike basis function");
+}
+
+template <>
+DataVector compute_basis_function_value<Basis::ZernikeB3>(
+    const size_t /*k*/, const DataVector& /*x*/) {
+  ERROR("Calling one-index Zernike basis function");
+}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define GET_TYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -100,4 +332,15 @@ T Zernike<Dim>::basis_function_value(const size_t n, const size_t m,
 GENERATE_INSTANTIATIONS(INSTANTIATE_BASIS_FUNCTION_VALUE, (1, 2, 3),
                         (double, DataVector))
 
+#undef INSTANTIATE_BASIS_FUNCTION_VALUE
+#undef GET_TYPE
+
+#define INSTANTIATE_DIFF_MATRICES(r, data)                        \
+  template Matrix Zernike<GET_DIM(data)>::differentiation_matrix( \
+      const size_t num_points, const Parity parity);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_DIFF_MATRICES, (1, 2, 3))
+
+#undef INSTANTIATE_DIFF_MATRICES
+#undef GET_DIM
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp
@@ -12,6 +12,7 @@ class DataVector;
 class Matrix;
 namespace Spectral {
 enum class Quadrature : uint8_t;
+enum class Parity : uint8_t;
 }  // namespace Spectral
 /// \endcond
 
@@ -34,5 +35,24 @@ class Zernike {
    */
   template <typename T>
   static T basis_function_value(size_t n, size_t m, const T& xi);
+
+  /*!
+   * \brief Collocation points \f${x_i}\f$ and quadrature weights \f${w_i}\f$
+   */
+  static std::pair<DataVector, DataVector>
+  compute_collocation_points_and_weights(size_t num_points);
+
+  /*!
+   * \brief Matrix \f$D_{i,j}\f$ used to obtain the first derivative for a
+   * given parity.
+   *
+   * Due to the clustering of Zernike collocation toward the upper side, the
+   * generic implementation of derivatives with barycentric weights yields
+   * large errors. By utilizing the fact that the Zernike bases' \f$m\f$
+   * corresponds to parity of representable functions, we can extend the
+   * function to negative \f$r\f$ before forming the matrix, greatly improving
+   * accuracy.
+   */
+  static Matrix differentiation_matrix(size_t num_points, Parity parity);
 };
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_sources(
   Filtering.cpp
   FiniteDifference.cpp
   IntegrationMatrix.cpp
+  InterpolationWeights.cpp
   InterpolationMatrix.cpp
   LinearFilteringMatrix.cpp
   LogicalCoordinates.cpp
@@ -51,6 +52,7 @@ spectre_target_headers(
   Filtering.hpp
   GetSpectralQuantityForMesh.hpp
   IntegrationMatrix.hpp
+  InterpolationWeights.hpp
   InterpolationMatrix.hpp
   InverseWeightFunctionValues.hpp
   Legendre.hpp

--- a/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
@@ -46,5 +46,11 @@ template const DataVector& collocation_points<Basis::FiniteDifference,
 template const DataVector& collocation_points<Basis::FiniteDifference,
                                               Quadrature::FaceCentered>(size_t);
 template const DataVector&
-collocation_points<Basis::Fourier, Quadrature::Equiangular>(size_t);
+    collocation_points<Basis::Fourier, Quadrature::Equiangular>(size_t);
+template const DataVector&
+    collocation_points<Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t);
+template const DataVector&
+    collocation_points<Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t);
+template const DataVector&
+    collocation_points<Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
@@ -37,4 +37,10 @@ template struct CollocationPointsAndWeightsGenerator<Basis::FiniteDifference,
                                                      Quadrature::FaceCentered>;
 template struct CollocationPointsAndWeightsGenerator<Basis::Fourier,
                                                      Quadrature::Equiangular>;
+template struct CollocationPointsAndWeightsGenerator<
+    Basis::ZernikeB1, Quadrature::GaussRadauUpper>;
+template struct CollocationPointsAndWeightsGenerator<
+    Basis::ZernikeB2, Quadrature::GaussRadauUpper>;
+template struct CollocationPointsAndWeightsGenerator<
+    Basis::ZernikeB3, Quadrature::GaussRadauUpper>;
 }  // namespace Spectral::detail

--- a/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.cpp
@@ -10,9 +10,12 @@
 #include "NumericalAlgorithms/Spectral/BarycentricWeights.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp"
+#include "NumericalAlgorithms/Spectral/InterpolationWeights.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/QuadratureWeights.hpp"
@@ -372,6 +375,25 @@ struct DifferentiationMatrixTransposeGenerator {
 };
 
 template <Basis BasisType, Quadrature QuadratureType>
+struct ParityBasedDifferentiationMatrixGenerator {
+  Matrix operator()(const size_t num_points, const Parity parity) const {
+    // We intentionally do not instantiate "normal" derivatives for Zernike
+    // bases due to their large errors
+    if constexpr (BasisType == Spectral::Basis::ZernikeB1) {
+      return Zernike<1>::differentiation_matrix(num_points, parity);
+    } else if constexpr (BasisType == Spectral::Basis::ZernikeB2) {
+      return Zernike<2>::differentiation_matrix(num_points, parity);
+    } else if constexpr (BasisType == Spectral::Basis::ZernikeB3) {
+      return Zernike<3>::differentiation_matrix(num_points, parity);
+    } else {
+      ERROR(
+          "Calling ParityBasedDifferentiationMatrixGenerator with a "
+          "non-Zernike basis: call non-parity generator");
+    }
+  }
+};
+
+template <Basis BasisType, Quadrature QuadratureType>
 struct WeakFluxDifferentiationMatrixGenerator {
   Matrix operator()(const size_t num_points) const {
     if (BasisType != Basis::Legendre) {
@@ -407,6 +429,11 @@ PRECOMPUTED_SPECTRAL_QUANTITY(weak_flux_differentiation_matrix, Matrix,
 
 #undef PRECOMPUTED_SPECTRAL_QUANTITY
 
+PRECOMPUTED_SPECTRAL_QUANTITY_WITH_PARITY(
+    differentiation_matrix, Matrix, ParityBasedDifferentiationMatrixGenerator)
+
+#undef PRECOMPUTED_SPECTRAL_QUANTITY_WITH_PARITY
+
 SPECTRAL_QUANTITY_FOR_MESH(differentiation_matrix, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(differentiation_matrix_transpose, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(weak_flux_differentiation_matrix, Matrix)
@@ -427,6 +454,14 @@ template const Matrix&
     differentiation_matrix<Basis::Legendre, Quadrature::Gauss>(size_t);
 template const Matrix&
     differentiation_matrix<Basis::Legendre, Quadrature::GaussLobatto>(size_t);
+
+template const Matrix& differentiation_matrix<
+    Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t, Parity);
+template const Matrix& differentiation_matrix<
+    Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t, Parity);
+template const Matrix& differentiation_matrix<
+    Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t, Parity);
+
 template const Matrix& weak_flux_differentiation_matrix<
     Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const Matrix& weak_flux_differentiation_matrix<

--- a/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp
+++ b/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp
@@ -12,6 +12,7 @@ class Mesh;
 namespace Spectral {
 enum class Basis : uint8_t;
 enum class Quadrature : uint8_t;
+enum class Parity : uint8_t;
 }  // namespace Spectral
 /// \endcond
 
@@ -37,6 +38,22 @@ const Matrix& differentiation_matrix(size_t num_points);
 template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& differentiation_matrix_transpose(size_t num_points);
 /// @}
+
+/*!
+ * \brief %Matrix used to compute the derivative of a function of known parity
+ *
+ * \details For the Zernike basis, defined on \f$[0,1]\f$, `GaussRadauUpper`
+ * quadratrue shifts the collocation points to the upper side, which
+ * contributes to inaccurate differentiation at the lower side due to the low
+ * density of points. By knowing the parity of functions in this basis as it
+ * has two indices, we can extend the function to the negative \f$r\f$,
+ * greatly reducing errors.
+ *
+ * \param num_points The number of collocation points
+ * \param parity The Parity of the function
+ */
+template <Basis BasisType, Quadrature QuadratureType>
+const Matrix& differentiation_matrix(size_t num_points, Parity parity);
 
 /// @{
 /*!

--- a/src/NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp
@@ -75,6 +75,36 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f, const Mesh<1>& mesh) {
         default:
           ERROR("Missing quadrature case for spectral quantity");
       }
+    case Basis::ZernikeB1:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::GaussRadauUpper:
+          return f(
+              std::integral_constant<Basis, Basis::ZernikeB1>{},
+              std::integral_constant<Quadrature, Quadrature::GaussRadauUpper>{},
+              num_points);
+        default:
+          ERROR("Missing quadrature case for spectral quantity");
+      }
+    case Basis::ZernikeB2:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::GaussRadauUpper:
+          return f(
+              std::integral_constant<Basis, Basis::ZernikeB2>{},
+              std::integral_constant<Quadrature, Quadrature::GaussRadauUpper>{},
+              num_points);
+        default:
+          ERROR("Missing quadrature case for spectral quantity");
+      }
+    case Basis::ZernikeB3:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::GaussRadauUpper:
+          return f(
+              std::integral_constant<Basis, Basis::ZernikeB3>{},
+              std::integral_constant<Quadrature, Quadrature::GaussRadauUpper>{},
+              num_points);
+        default:
+          ERROR("Missing quadrature case for spectral quantity");
+      }
     case Basis::FiniteDifference:
       switch (mesh.quadrature(0)) {
         case Quadrature::CellCentered:
@@ -102,4 +132,50 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f, const Mesh<1>& mesh) {
             << mesh.basis(0));
   }
 }
+
+template <typename F>
+decltype(auto) get_two_indexed_spectral_quantity_for_mesh(F&& f,
+                                                          const Mesh<1>& mesh,
+                                                          const size_t m,
+                                                          const size_t N) {
+  const auto num_points = mesh.extents(0);
+  switch (mesh.basis(0)) {
+    case Basis::ZernikeB1:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::GaussRadauUpper:
+          return f(
+              std::integral_constant<Basis, Basis::ZernikeB1>{},
+              std::integral_constant<Quadrature, Quadrature::GaussRadauUpper>{},
+              num_points, m, N);
+        default:
+          ERROR("Missing quadrature case for two-indexed spectral quantity");
+      }
+    case Basis::ZernikeB2:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::GaussRadauUpper:
+          return f(
+              std::integral_constant<Basis, Basis::ZernikeB2>{},
+              std::integral_constant<Quadrature, Quadrature::GaussRadauUpper>{},
+              num_points, m, N);
+        default:
+          ERROR("Missing quadrature case for two-indexed spectral quantity");
+      }
+    case Basis::ZernikeB3:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::GaussRadauUpper:
+          return f(
+              std::integral_constant<Basis, Basis::ZernikeB3>{},
+              std::integral_constant<Quadrature, Quadrature::GaussRadauUpper>{},
+              num_points, m, N);
+        default:
+          ERROR("Missing quadrature case for two-indexed spectral quantity");
+      }
+    default:
+      ERROR(
+          "Missing basis case for two-indexed spectral quantity. The "
+          "missing basis is: "
+          << mesh.basis(0));
+  }
+}
+
 }  // namespace Spectral::detail

--- a/src/NumericalAlgorithms/Spectral/InterpolationWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/InterpolationWeights.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "NumericalAlgorithms/Interpolation/InterpolationWeights.hpp"
+#include "NumericalAlgorithms/Spectral/InterpolationWeights.hpp"
 
 #include <cmath>
 #include <cstddef>
@@ -12,7 +12,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace intrp {
+namespace Spectral {
 template <typename TargetDataType>
 Matrix fornberg_interpolation_matrix(const TargetDataType& x_target,
                                      const DataVector& x_source) {
@@ -132,15 +132,18 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
 #undef INSTANTIATE
 
 #define DNUM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DNUM_PLUS_ONE(data) BOOST_PP_ADD(BOOST_PP_TUPLE_ELEM(0, data), 1)
 
-#define INSTANTIATE(_, data)                                               \
-  template void fornberg_derivative_interpolation_weights<DNUM(data)>(     \
-      const gsl::not_null<std::array<DataVector, DNUM(data) + 1>*> result, \
+#define INSTANTIATE(_, data)                                            \
+  template void fornberg_derivative_interpolation_weights<DNUM(data)>(  \
+      const gsl::not_null<std::array<DataVector, DNUM_PLUS_ONE(data)>*> \
+          result,                                                       \
       const double x_target, const DataVector& x_source);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3, 4))
 
-#undef DTYPE
+#undef DNUM
+#undef DNUM_PLUS_ONE
 #undef INSTANTIATE
 
-}  // namespace intrp
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/InterpolationWeights.hpp
+++ b/src/NumericalAlgorithms/Spectral/InterpolationWeights.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+
 #include "Utilities/Gsl.hpp"
 
 /// \cond
@@ -11,7 +12,7 @@ class DataVector;
 class Matrix;
 /// \endcond
 
-namespace intrp {
+namespace Spectral {
 /*!
  * \brief Computes the matrix for polynomial interpolation of a non-periodic
  * function known at the set of points \f$x_{source}\f$ to the set of points
@@ -72,4 +73,4 @@ void fornberg_derivative_interpolation_weights(
 template <typename TargetDataType>
 Matrix fourier_interpolation_matrix(const TargetDataType& x_target,
                                     size_t n_source_points);
-}  // namespace intrp
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
+++ b/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
@@ -97,6 +97,12 @@ void logical_coordinates(
         [[fallthrough]];
       case Spectral::Basis::Legendre:
         [[fallthrough]];
+      case Spectral::Basis::ZernikeB1:
+        [[fallthrough]];
+      case Spectral::Basis::ZernikeB2:
+        [[fallthrough]];
+      case Spectral::Basis::ZernikeB3:
+        [[fallthrough]];
       case Spectral::Basis::FiniteDifference: {
         const auto& collocation_points_in_this_dim =
             Spectral::collocation_points(mesh.slice_through(d));

--- a/src/NumericalAlgorithms/Spectral/LogicalCoordinates.hpp
+++ b/src/NumericalAlgorithms/Spectral/LogicalCoordinates.hpp
@@ -58,8 +58,13 @@ struct not_null;
  * corresponding to the Legendre Gauss points of \f$\cos \theta\f$ (and thus
  * have no points at the poles), while the azimuth has Equiangular quadrature
  * which are distributed uniformly including the left endpoint, but not the
- * right.  For the Cartoon basis, only one logical coordinate is allowed and it
- * is never used for computations.
+ * right. For the Cartoon basis, only one logical coordinate is allowed and it
+ * is never used for computations. The Zernike bases have the radial basis
+ * implemented such that the logical coordinates are \f$[-1, 1]\f$, while
+ * an affine map is internally used to go to \f$[0, 1]\f$, where these bases are
+ * defined. Being a scaled one-sided Jacobi polynomial, the gridpoint are
+ * shifted to upper \f$r\f$, and GaussRadauUpper quadrature has been implemented
+ * such that the lower edge does not have an end point but the upper does.
  *
  * \example
  * \snippet Test_LogicalCoordinates.cpp logical_coordinates_example

--- a/src/NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp
+++ b/src/NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp
@@ -20,6 +20,9 @@ constexpr size_t minimum_number_of_points(const Basis /*basis*/,
   } else if (quadrature == Quadrature::GaussLobatto) {
     return 2;
     // NOLINTNEXTLINE(bugprone-branch-clone)
+  } else if (quadrature == Quadrature::GaussRadauUpper) {
+    return 1;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (quadrature == Quadrature::CellCentered) {
     return 1;
     // NOLINTNEXTLINE(bugprone-branch-clone)

--- a/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
@@ -21,6 +21,9 @@ namespace {
 template <Basis BasisType, Quadrature QuadratureType>
 struct ModalToNodalMatrixGenerator {
   Matrix operator()(const size_t num_points) const {
+    ASSERT(BasisType != Basis::ZernikeB1 and BasisType != Basis::ZernikeB2 and
+               BasisType != Basis::ZernikeB3,
+           "Zernike basis should not call one-indexed ModalToNodal matrix");
     // To obtain the Vandermonde matrix we need to compute the basis function
     // values at the collocation points. Constructing the matrix proceeds
     // the same for any basis.
@@ -67,4 +70,10 @@ template const Matrix& modal_to_nodal_matrix<Basis::FiniteDifference,
                                              Quadrature::CellCentered>(size_t);
 template const Matrix& modal_to_nodal_matrix<Basis::FiniteDifference,
                                              Quadrature::FaceCentered>(size_t);
+template const Matrix& modal_to_nodal_matrix<
+    Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t);
+template const Matrix& modal_to_nodal_matrix<
+    Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t);
+template const Matrix& modal_to_nodal_matrix<
+    Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
@@ -85,4 +85,11 @@ template const Matrix& nodal_to_modal_matrix<Basis::FiniteDifference,
                                              Quadrature::CellCentered>(size_t);
 template const Matrix& nodal_to_modal_matrix<Basis::FiniteDifference,
                                              Quadrature::FaceCentered>(size_t);
+template const Matrix& nodal_to_modal_matrix<
+    Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t);
+template const Matrix& nodal_to_modal_matrix<
+    Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t);
+template const Matrix& nodal_to_modal_matrix<
+    Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t);
+
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp
+++ b/src/NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp
@@ -7,6 +7,7 @@
 
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/StaticCache.hpp"
 
@@ -39,6 +40,57 @@ const auto& precomputed_spectral_quantity(const size_t num_points) {
           SpectralQuantityGenerator{});
   return precomputed_data(num_points);
 }
+
+template <Basis BasisType, Quadrature QuadratureType,
+          typename SpectralQuantityGenerator>
+const auto& precomputed_spectral_quantity_with_parity(const size_t num_points,
+                                                      const Parity parity) {
+  constexpr size_t max_num_points =
+      Spectral::maximum_number_of_points<BasisType>;
+  constexpr size_t min_num_points =
+      Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+  ASSERT(num_points >= min_num_points,
+         "Tried to work with less than the minimum number of collocation "
+         "points for this quadrature.");
+  ASSERT(num_points <= max_num_points,
+         "Exceeded maximum number of collocation points.");
+  ASSERT(parity != Parity::Uninitialized,
+         "Tried to use a parity-based function without a definite parity");
+  // We compute the quantity for all possible `num_point`s the first time this
+  // function is called and keep the data around for the lifetime of the
+  // program. The computation is handled by the call operator of the
+  // `SpectralQuantityType` instance.
+  static const auto precomputed_data =
+      make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                        CacheEnumeration<Parity, Parity::Even, Parity::Odd>>(
+          SpectralQuantityGenerator{});
+  return precomputed_data(num_points, parity);
+}
+
+template <Basis BasisType, Quadrature QuadratureType,
+          typename SpectralQuantityGenerator>
+const auto& precomputed_two_indexed_spectral_quantity(const size_t num_points,
+                                           const size_t m, const size_t N) {
+  constexpr size_t max_num_points =
+      Spectral::maximum_number_of_points<BasisType>;
+  constexpr size_t min_num_points =
+      Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+  ASSERT(num_points >= min_num_points,
+         "Tried to work with less than the minimum number of collocation "
+         "points for this quadrature.");
+  ASSERT(num_points <= max_num_points,
+         "Exceeded maximum number of collocation points.");
+  // We compute the quantity for all possible `num_point`s the first time this
+  // function is called and keep the data around for the lifetime of the
+  // program. The computation is handled by the call operator of the
+  // `SpectralQuantityType` instance.
+  static const auto precomputed_data =
+      make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                        CacheRange<0_st, 2 * max_num_points - 1>,
+                        CacheRange<0_st, 2 * max_num_points - 1>>(
+          SpectralQuantityGenerator{});
+  return precomputed_data(num_points, m, N);
+}
 }  // namespace Spectral::detail
 
 // clang-tidy: Macro arguments should be in parentheses, but we want to append
@@ -51,4 +103,24 @@ const auto& precomputed_spectral_quantity(const size_t num_points) {
         BasisType, QuadratureType,                                \
         generator_name<BasisType, QuadratureType>>(/* NOLINT */   \
                                                    num_points);   \
+  }
+#define PRECOMPUTED_SPECTRAL_QUANTITY_WITH_PARITY(function_name, return_type, \
+                                                  generator_name)             \
+  template <Basis BasisType, Quadrature QuadratureType>                       \
+  const return_type& function_name(const size_t num_points,                   \
+                                   const Parity parity) {                     \
+    return Spectral::detail::precomputed_spectral_quantity_with_parity<       \
+        BasisType, QuadratureType,                                            \
+        generator_name<BasisType, QuadratureType>>(/* NOLINT */               \
+                                                   num_points, parity);       \
+  }
+#define PRECOMPUTED_TWO_INDEXED_SPECTRAL_QUANTITY(function_name, return_type, \
+                                                  generator_name)             \
+  template <Basis BasisType, Quadrature QuadratureType>                       \
+  const return_type& function_name(const size_t num_points, const size_t m,   \
+                                   const size_t N) {                          \
+    return Spectral::detail::precomputed_two_indexed_spectral_quantity<       \
+        BasisType, QuadratureType,                                            \
+        generator_name<BasisType, QuadratureType>>(/* NOLINT */               \
+                                                   num_points, m, N);         \
   }

--- a/src/NumericalAlgorithms/Spectral/QuadratureWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/QuadratureWeights.cpp
@@ -56,21 +56,27 @@ SPECTRAL_QUANTITY_FOR_MESH(quadrature_weights, DataVector)
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
 template const DataVector&
-quadrature_weights<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
+    quadrature_weights<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
 template const DataVector&
-quadrature_weights<Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
+    quadrature_weights<Basis::Cartoon, Quadrature::SphericalSymmetry>(size_t);
 template const DataVector&
-quadrature_weights<Basis::Chebyshev, Quadrature::Gauss>(size_t);
+    quadrature_weights<Basis::Chebyshev, Quadrature::Gauss>(size_t);
 template const DataVector&
-quadrature_weights<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);
+    quadrature_weights<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);
 template const DataVector&
-quadrature_weights<Basis::Legendre, Quadrature::Gauss>(size_t);
+    quadrature_weights<Basis::Legendre, Quadrature::Gauss>(size_t);
 template const DataVector&
-quadrature_weights<Basis::Legendre, Quadrature::GaussLobatto>(size_t);
+    quadrature_weights<Basis::Legendre, Quadrature::GaussLobatto>(size_t);
 template const DataVector&
-quadrature_weights<Basis::FiniteDifference, Quadrature::CellCentered>(size_t);
+    quadrature_weights<Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t);
 template const DataVector&
-quadrature_weights<Basis::FiniteDifference, Quadrature::FaceCentered>(size_t);
+    quadrature_weights<Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t);
 template const DataVector&
-quadrature_weights<Basis::Fourier, Quadrature::Equiangular>(size_t);
+    quadrature_weights<Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t);
+template const DataVector& quadrature_weights<Basis::FiniteDifference,
+                                              Quadrature::CellCentered>(size_t);
+template const DataVector& quadrature_weights<Basis::FiniteDifference,
+                                              Quadrature::FaceCentered>(size_t);
+template const DataVector&
+    quadrature_weights<Basis::Fourier, Quadrature::Equiangular>(size_t);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SpectralQuantityForMesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/SpectralQuantityForMesh.hpp
@@ -15,5 +15,18 @@
                                decltype(quadrature)::value>(num_points); \
         },                                                               \
         mesh);                                                           \
+    }
+
+#define TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH(function_name, return_type)   \
+  const return_type& function_name(const Mesh<1>& mesh, const size_t m,      \
+                                   const size_t N) {                         \
+    return Spectral::detail::get_two_indexed_spectral_quantity_for_mesh(     \
+        [](const auto basis, const auto quadrature, const size_t num_points, \
+           const size_t mm, const size_t NN) -> const return_type& {         \
+          return function_name</* NOLINT */ decltype(basis)::value,          \
+                               decltype(quadrature)::value>(num_points, mm,  \
+                                                            NN);             \
+        },                                                                   \
+        mesh, m, N);                                                         \
   }
 /// \endcond

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -9,7 +9,6 @@ set(LIBRARY_SOURCES
   Test_BarycentricRational.cpp
   Test_CardinalInterpolator.cpp
   Test_CubicSpline.cpp
-  Test_InterpolationWeights.cpp
   Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp
   Test_MultiLinearSpanInterpolation.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Test_IndefiniteIntegral.cpp
   Test_IntegrationMatrix.cpp
   Test_InterpolationMatrix.cpp
+  Test_InterpolationWeights.cpp
   Test_Legendre.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LIBRARY_SOURCES
   Test_QuadratureWeights.cpp
   Test_SegmentSize.cpp
   Test_Spectral.cpp
+  Test_ZernikeGaussRadauUpper.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_BasisFunctionNormalizationSquare.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_BasisFunctionNormalizationSquare.cpp
@@ -38,6 +38,33 @@ void test() {
     }
   }
 }
+
+template <Basis basis, Quadrature quadrature>
+void test_two_index() {
+  static_assert(basis == Basis::ZernikeB1 or basis == Basis::ZernikeB2 or
+                basis == Basis::ZernikeB3);
+  const auto custom_approx = Approx::custom().epsilon(1e-12);
+  CAPTURE(basis);
+  CAPTURE(quadrature);
+  for (size_t n = minimum_number_of_points<basis, quadrature>;
+       n <= maximum_number_of_points<basis>; ++n) {
+    CAPTURE(n);
+    const auto& [xi, w] =
+        compute_collocation_points_and_weights<basis, quadrature>(n);
+    const size_t k_max = n < 2 ? 0 : n - 2;
+    for (size_t k = 0; k <= k_max; ++k) {
+      CAPTURE(k);
+      for (size_t m = k % 2; m <= k; m += 2) {
+        CAPTURE(m);
+        const auto f = compute_basis_function_value<basis>(k, m, xi);
+        const double expected = sum(square(f) * w);
+        CHECK_ITERABLE_CUSTOM_APPROX(
+            expected, compute_basis_function_normalization_square<basis>(k),
+            custom_approx);
+      }
+    }
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.BasisFunctionNormalizationSquare",
@@ -47,5 +74,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.BasisFunctionNormalizationSquare",
   test<Basis::Chebyshev, Quadrature::Gauss>();
   test<Basis::Chebyshev, Quadrature::GaussLobatto>();
   test<Basis::Fourier, Quadrature::Equiangular>();
+  test_two_index<Basis::ZernikeB1, Quadrature::GaussRadauUpper>();
+  test_two_index<Basis::ZernikeB2, Quadrature::GaussRadauUpper>();
+  test_two_index<Basis::ZernikeB3, Quadrature::GaussRadauUpper>();
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_CollocationPointsAndWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_CollocationPointsAndWeights.cpp
@@ -38,6 +38,38 @@ void test() {
     }
   }
 }
+
+template <Basis basis>
+void test_radial_zernike() {
+  // Needs its own test because radial zernike has two indices
+  // Second index m must match parity of k, and satisfy m <= k
+  // Checking \int_0^1 Q^m_n Q^m_{n'} \propto \delta_{n,n'} (no constraint on m)
+  const auto quadrature = Quadrature::GaussRadauUpper;
+  CAPTURE(basis);
+  CAPTURE(quadrature);
+  const Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+  for (size_t n = minimum_number_of_points<basis, quadrature>;
+       n <= maximum_number_of_points<basis>; ++n) {
+    CAPTURE(n);
+    const auto& [xi, w] =
+        compute_collocation_points_and_weights<basis, quadrature>(n);
+    const size_t k_max = n - 1;
+    CAPTURE(k_max);
+    for (size_t k = 1; k <= k_max; ++k) {
+      CAPTURE(k);
+      for (size_t j = k % 2; j < k; j += 2) {
+        CAPTURE(j);
+        for (size_t m = k % 2; m <= j; m += 2) {
+          CAPTURE(m);
+          const auto f_m_k = compute_basis_function_value<basis>(k, m, xi);
+          const auto f_m_j = compute_basis_function_value<basis>(j, m, xi);
+          const double should_be_zero = sum(f_m_j * f_m_k * w);
+          CHECK_ITERABLE_CUSTOM_APPROX(should_be_zero, 0.0, custom_approx);
+        }
+      }
+    }
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.CollocationPointsAndWeights",
@@ -47,5 +79,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.CollocationPointsAndWeights",
   test<Basis::Chebyshev, Quadrature::Gauss>();
   test<Basis::Chebyshev, Quadrature::GaussLobatto>();
   test<Basis::Fourier, Quadrature::Equiangular>();
+  test_radial_zernike<Basis::ZernikeB1>();
+  test_radial_zernike<Basis::ZernikeB2>();
+  test_radial_zernike<Basis::ZernikeB3>();
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_DifferentiationMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_DifferentiationMatrix.cpp
@@ -12,6 +12,7 @@
 #include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 
 namespace Spectral {
@@ -31,6 +32,23 @@ void test() {
     CHECK_ITERABLE_CUSTOM_APPROX(should_be_zero, zero, custom_approx);
   }
 }
+
+template <Basis basis, Quadrature quadrature>
+void test_with_parity() {
+  CAPTURE(basis);
+  CAPTURE(quadrature);
+  const auto custom_approx = Approx::custom().epsilon(5.0e-13).scale(1.0);
+  for (size_t n = minimum_number_of_points<basis, quadrature>;
+       n <= maximum_number_of_points<basis>; ++n) {
+    CAPTURE(n);
+    const Matrix& m_even =
+        differentiation_matrix<basis, quadrature>(n, Parity::Even);
+    const DataVector one{n, 1.0};
+    const DataVector should_be_zero = apply_matrix(m_even, one);
+    const DataVector zero{n, 0.0};
+    CHECK_ITERABLE_CUSTOM_APPROX(should_be_zero, zero, custom_approx);
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.DifferentiationMatrix",
@@ -39,6 +57,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.DifferentiationMatrix",
   test<Basis::Legendre, Quadrature::GaussLobatto>();
   test<Basis::Chebyshev, Quadrature::Gauss>();
   test<Basis::Chebyshev, Quadrature::GaussLobatto>();
-  test<Basis::Fourier, Quadrature::Equiangular>();
+  test_with_parity<Basis::ZernikeB1, Quadrature::GaussRadauUpper>();
+  test_with_parity<Basis::ZernikeB2, Quadrature::GaussRadauUpper>();
+  test_with_parity<Basis::ZernikeB3, Quadrature::GaussRadauUpper>();
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_IntegrationMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_IntegrationMatrix.cpp
@@ -49,6 +49,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.IntegrationMatrix",
   test<Basis::Legendre, Quadrature::GaussLobatto>();
   test<Basis::Chebyshev, Quadrature::Gauss>();
   test<Basis::Chebyshev, Quadrature::GaussLobatto>();
+  // no known form of an integraion matrix for Zernike
   // there is no integration matrix for Fourier
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_InterpolationWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_InterpolationWeights.cpp
@@ -12,9 +12,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolationWeights.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/InterpolationMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/InterpolationWeights.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -41,12 +41,12 @@ void test_fornberg_matrix(const gsl::not_null<std::mt19937*> generator) {
           const Matrix spectral_matrix =
               Spectral::interpolation_matrix(mesh, x_target);
           const Matrix fornberg_matrix =
-              intrp::fornberg_interpolation_matrix(x_target, get<0>(xi));
+              Spectral::fornberg_interpolation_matrix(x_target, get<0>(xi));
           CHECK(fornberg_matrix.rows() == n_target_points);
           CHECK(fornberg_matrix.columns() == n_source_points);
           CHECK(spectral_matrix == fornberg_matrix);
           if (n_target_points == 1) {
-            CHECK(intrp::fornberg_interpolation_matrix(
+            CHECK(Spectral::fornberg_interpolation_matrix(
                       x_target[0], get<0>(xi)) == fornberg_matrix);
           }
         }
@@ -68,7 +68,7 @@ void test_fornberg_derivative_coefficients(
                        Spectral::Quadrature::Gauss};
     const auto xi = logical_coordinates(mesh);
     for (auto x_target : x_targets) {
-      intrp::fornberg_derivative_interpolation_weights<max_derivative>(
+      Spectral::fornberg_derivative_interpolation_weights<max_derivative>(
           make_not_null(&fornberg_weights), x_target, get<0>(xi));
       double coefficient = 1.0;
       auto power = static_cast<int>(n_source_points - 1);
@@ -77,9 +77,9 @@ void test_fornberg_derivative_coefficients(
         const double result = std::inner_product(
             function.begin(), function.end(),
             gsl::at(fornberg_weights, derivative).begin(), 0.0);
-        CHECK(
-            approx(result) ==
-            coefficient * pow(x_target, power - static_cast<int>(derivative)));
+        CHECK(approx(result) ==
+              coefficient *
+                  pow(x_target, power - static_cast<int>(derivative)));
         coefficient *= power - static_cast<int>(derivative);
       }
     }
@@ -101,7 +101,7 @@ void test_fourier_matrix(const gsl::not_null<std::mt19937*> generator) {
         generator, make_not_null(&phi_distribution), n_target_points);
     const DataVector f_target = f_periodic(x_target);
     const Matrix m =
-        intrp::fourier_interpolation_matrix(x_target, n_source_points);
+        Spectral::fourier_interpolation_matrix(x_target, n_source_points);
     DataVector f_interp{n_target_points};
     dgemv_('N', n_target_points, n_source_points, 1.0, m.data(),
            n_target_points, f_source.data(), 1, 0.0, f_interp.data(), 1);
@@ -109,8 +109,8 @@ void test_fourier_matrix(const gsl::not_null<std::mt19937*> generator) {
       CHECK_THAT(f_interp[k], Catch::Matchers::WithinAbs(f_target[k], 1.e-13));
     }
     if (n_target_points == 1) {
-      CHECK(intrp::fourier_interpolation_matrix(x_target[0], n_source_points) ==
-            m);
+      CHECK(Spectral::fourier_interpolation_matrix(x_target[0],
+                                                   n_source_points) == m);
     }
   }
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LogicalCoordinates.cpp
@@ -44,9 +44,27 @@ void test_spherical_logical_coords() {
   }
 }
 
+void test_radial_zernike_logical_coords() {
+  for (const auto& basis :
+       {Spectral::Basis::ZernikeB1, Spectral::Basis::ZernikeB2,
+        Spectral::Basis::ZernikeB3}) {
+    for (size_t n = 2; n < 5; ++n) {
+      const Mesh<1> mesh{n, basis, Spectral::Quadrature::GaussRadauUpper};
+      const auto xi = logical_coordinates(mesh);
+      CHECK(get<0>(xi)[n - 1] == approx(1.0));
+      if (n >= 4) {
+        // logical coordinates in [-1, 1] (with the mapping to [0, 1]
+        // internally taken care of)
+        CHECK(get<0>(xi)[0] < 0.0);
+      }
+    }
+  }
+}
+
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.LogicalCoordinates",
                   "[Domain][Unit]") {
   test_spherical_logical_coords();
+  test_radial_zernike_logical_coords();
   using Affine2d =
       domain::CoordinateMaps::ProductOf2Maps<domain::CoordinateMaps::Affine,
                                              domain::CoordinateMaps::Affine>;

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_QuadratureWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_QuadratureWeights.cpp
@@ -26,8 +26,23 @@ void test() {
     const DataVector& weights_m = quadrature_weights(mesh);
     CHECK(weights_n == weights_m);
     CHECK(weights_n.data() == weights_m.data());
-    // The integral of a constant is xi.  The definite integral is thus 2.
-    CHECK(sum(weights_n) == approx(2.0));
+    if constexpr (basis == Basis::ZernikeB1) {
+      // The integral of a constant is xi. Actual logical coordinates from
+      // [0,1], with a orthogonality weighting of 1, thus 1.
+      CHECK(sum(weights_n) == approx(1.0));
+    } else if constexpr (basis == Basis::ZernikeB2) {
+      // The integral of a constant is xi. Actual logical coordinates from
+      // [0,1], with a orthogonality weighting of r, thus 1/2.
+      CHECK(sum(weights_n) == approx(0.5));
+    } else if constexpr (basis == Basis::ZernikeB3) {
+      // The integral of a constant is xi. Actual logical coordinates from
+      // [0,1], with a orthogonality weighting of r^2, thus 1/3.
+      CHECK(sum(weights_n) == approx(1. / 3.));
+    } else {
+      // The integral of a constant is xi.  Logical coordintes from [-1, 1].
+      // The definite integral is thus 2.
+      CHECK(sum(weights_n) == approx(2.0));
+    }
   }
 }
 }  // namespace
@@ -38,5 +53,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.QuadratureWeights",
   test<Basis::Legendre, Quadrature::GaussLobatto>();
   test<Basis::Chebyshev, Quadrature::Gauss>();
   test<Basis::Chebyshev, Quadrature::GaussLobatto>();
+  test<Basis::ZernikeB1, Quadrature::GaussRadauUpper>();
+  test<Basis::ZernikeB2, Quadrature::GaussRadauUpper>();
+  test<Basis::ZernikeB3, Quadrature::GaussRadauUpper>();
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeGaussRadauUpper.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeGaussRadauUpper.cpp
@@ -1,0 +1,130 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/Blaze/IntegerPow.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Helpers/DataStructures/ApplyMatrix.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Jacobi.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
+#include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/QuadratureWeights.hpp"
+
+namespace {
+template <size_t Dim>
+void test_derivatives(const size_t num_points) {
+  const Approx custom_approx =
+      num_points > 9 ? Approx::custom().epsilon(1.0e-12).scale(1.0)
+                      : Approx::custom().epsilon(1.0e-13).scale(1.0);
+  // Testing differeniation for polynomials exactly representable, so
+  // up to power = num_points
+  constexpr Spectral::Basis basis = Dim == 1   ? Spectral::Basis::ZernikeB1
+                                    : Dim == 2 ? Spectral::Basis::ZernikeB2
+                                               : Spectral::Basis::ZernikeB3;
+  CAPTURE(basis);
+  CAPTURE(num_points);
+  const Mesh<1> mesh{num_points, basis, Spectral::Quadrature::GaussRadauUpper};
+  const auto coords = logical_coordinates(mesh);
+  const DataVector r = 0.5 * (get<0>(coords) + 1.0);
+  const auto f = [](const size_t power, const DataVector& x) {
+    return integer_pow(x, static_cast<int>(power));
+  };
+  const auto d_f = [](const size_t power, const DataVector& x) {
+    return static_cast<double>(power) *
+           integer_pow(x, static_cast<int>(power) - 1);
+  };
+  auto& diff_matrix_even =
+      Spectral::differentiation_matrix<basis,
+                                       Spectral::Quadrature::GaussRadauUpper>(
+          num_points, Spectral::Parity::Even);
+  auto& diff_matrix_odd =
+      Spectral::differentiation_matrix<basis,
+                                       Spectral::Quadrature::GaussRadauUpper>(
+          num_points, Spectral::Parity::Odd);
+  for (size_t power = 0; power <= num_points; ++power) {
+    CAPTURE(power);
+
+    DataVector my_function(num_points);
+    my_function = f(power, r);
+
+    DataVector expected_derivative(num_points);
+    expected_derivative =
+        power > 0 ? d_f(power, r) : DataVector(num_points, 0.0);
+
+    DataVector evaluated_derivative(num_points);
+    // manually inserting 2 from above affine map (handled automatically
+    // in partial_derivatives())
+    evaluated_derivative =
+        2.0 * (power % 2 == 0 ? apply_matrix(diff_matrix_even, my_function)
+                              : apply_matrix(diff_matrix_odd, my_function));
+    CHECK_ITERABLE_CUSTOM_APPROX(evaluated_derivative, expected_derivative,
+                                 custom_approx);
+  }
+}
+
+template <size_t Dim>
+void test_weight_at_upper() {
+  // used in dg::lift_flux()
+  static_assert(Dim == 1 or Dim == 2 or Dim == 3);
+  const Spectral::Quadrature quadrature{Spectral::Quadrature::GaussRadauUpper};
+  constexpr Spectral::Basis basis = Dim == 1   ? Spectral::Basis::ZernikeB1
+                                    : Dim == 2 ? Spectral::Basis::ZernikeB2
+                                               : Spectral::Basis::ZernikeB3;
+  CAPTURE(basis);
+  auto weight_at_upper = [](const size_t num_points) {
+    if constexpr (Dim == 1) {
+      return 1. / static_cast<double>(num_points * (2 * num_points - 1));
+    } else if constexpr (Dim == 2) {
+      return 1. / static_cast<double>(2 * square(num_points));
+    } else {
+      return 1. / static_cast<double>(num_points * (2 * num_points + 1));
+    }
+  };
+
+  for (size_t n = 2; n < Spectral::maximum_number_of_points<basis>; ++n) {
+    CAPTURE(n);
+    const DataVector& weights =
+        Spectral::quadrature_weights<basis, quadrature>(n);
+    CHECK(weights[n - 1] == approx(weight_at_upper(n)));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.Spectral.ZernikeGaussRadauUpper.PointsAndWeights",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  // Being unaware of tabulated points and weights for Zernike
+  // basis functions specifically with Gauss-Radau quadrature, we
+  // test whether the basis can correctly take the derivatives of exactly
+  // representable function
+  for (size_t i = 1;
+       i <= Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB2>;
+       ++i) {
+    test_derivatives<1>(i);
+    test_derivatives<2>(i);
+    test_derivatives<3>(i);
+  }
+  test_weight_at_upper<1>();
+  test_weight_at_upper<2>();
+  test_weight_at_upper<3>();
+}


### PR DESCRIPTION
## Proposed changes

The main goal of this is to add Zernike with GaussRadauUpper collocation points and weights. 

The first commit moves `InterpolationWeights.c??` from the `intrp` to `Spectral` namespace so it can be used in `DifferentiationMatrix.cpp` and avoid circular dependancies.

The second commit is some infrastructure to deal with the fact that these are inherently a 2-indexed basis.

~~As a note, the Zernike-specific differentiation matrix (similarly for interpolation, though not included here) is defined in the DifferentiationMatrix.cpp file, whereas Fourier stores is basis-specific things in Fourier.cpp (see #7093 for how I thought of modifying Fourier to have the DifferentiationMatrix.cpp call into Fourier.cpp's version). Not sure which is preferred, but I would appreciate thoughts~~ Things agree with how Fourier does it

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
