### PR TITLE
Add ApplyLinearized in ModifyBoundaryData

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Actions/ApplyOperator.hpp
@@ -298,18 +298,21 @@ template <typename System, bool Linearized, typename TemporalIdTag,
           typename FluxesArgsTags =
               elliptic::get_fluxes_argument_tags<System, Linearized>,
           typename SourcesArgsTags =
-              elliptic::get_sources_argument_tags<System, Linearized>>
+              elliptic::get_sources_argument_tags<System, Linearized>,
+          typename ModifyBoundaryDataArgsTags =
+              elliptic::get_modify_boundary_data_args_tags<System, Linearized>>
 struct ReceiveMortarDataAndApplyOperator;
 
 template <typename System, bool Linearized, typename TemporalIdTag,
           typename PrimalFieldsTag, typename PrimalFluxesTag,
           typename OperatorAppliedToFieldsTag, typename PrimalMortarFieldsTag,
           typename PrimalMortarFluxesTag, typename... FluxesArgsTags,
-          typename... SourcesArgsTags>
+          typename... SourcesArgsTags, typename... ModifyBoundaryDataArgsTags>
 struct ReceiveMortarDataAndApplyOperator<
     System, Linearized, TemporalIdTag, PrimalFieldsTag, PrimalFluxesTag,
     OperatorAppliedToFieldsTag, PrimalMortarFieldsTag, PrimalMortarFluxesTag,
-    tmpl::list<FluxesArgsTags...>, tmpl::list<SourcesArgsTags...>> {
+    tmpl::list<FluxesArgsTags...>, tmpl::list<SourcesArgsTags...>,
+    tmpl::list<ModifyBoundaryDataArgsTags...>> {
  private:
   static constexpr size_t Dim = System::volume_dim;
   using all_mortar_data_tag = ::Tags::Mortars<
@@ -416,7 +419,8 @@ struct ReceiveMortarDataAndApplyOperator<
         db::get<elliptic::dg::Tags::Massive>(box),
         db::get<elliptic::dg::Tags::Formulation>(box), temporal_id,
         fluxes_args_on_faces,
-        std::forward_as_tuple(db::get<SourcesArgsTags>(box)...));
+        std::forward_as_tuple(db::get<SourcesArgsTags>(box)...),
+        std::forward_as_tuple(db::get<ModifyBoundaryDataArgsTags>(box)...));
 
     // Increment temporal ID
     db::mutate<TemporalIdTag>(
@@ -552,7 +556,7 @@ template <typename System, typename FixedSourcesTag,
           typename SourcesArgsTags =
               elliptic::get_sources_argument_tags<System, false>,
           typename ModifyBoundaryDataArgsTags =
-              elliptic::get_modify_boundary_data_args_tags<System>>
+              elliptic::get_modify_boundary_data_args_tags<System, false>>
 struct ImposeInhomogeneousBoundaryConditionsOnSource;
 
 /// \cond

--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -522,7 +522,8 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
             typename... DerivVars, typename... PrimalFluxesVars,
             typename... PrimalMortarVars, typename... PrimalMortarFluxes,
             typename TemporalId, typename... FluxesArgs,
-            typename... SourcesArgs, typename DataIsZero = NoDataIsZero,
+            typename... SourcesArgs, typename... ModifyBoundaryDataArgs,
+            typename DataIsZero = NoDataIsZero,
             typename DirectionsPredicate = AllDirections>
   static void apply_operator(
       const gsl::not_null<Variables<tmpl::list<OperatorTags...>>*>
@@ -561,6 +562,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
       const TemporalId& /*temporal_id*/,
       const DirectionMap<Dim, std::tuple<FluxesArgs...>>& fluxes_args_on_faces,
       const std::tuple<SourcesArgs...>& sources_args,
+      const std::tuple<ModifyBoundaryDataArgs...>& modify_boundary_data_args,
       const DataIsZero& data_is_zero = NoDataIsZero{},
       const DirectionsPredicate& directions_predicate = AllDirections{}) {
     static_assert(
@@ -702,6 +704,45 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
 
       const auto face_mesh = mesh.slice_away(direction.dimension());
       auto [local_data, remote_data] = mortar_data.extract();
+
+      if (is_internal) {
+        if constexpr (Linearized and
+                      not std::is_same_v<typename System::modify_boundary_data,
+                                         void>) {
+          auto jump_field = Variables<tmpl::list<PrimalMortarVars...>>(
+              local_data.field_data
+                  .template extract_subset<tmpl::list<PrimalMortarVars...>>());
+
+          const auto add_jump_contribution = [](auto& lhs, const auto& rhs) {
+            for (size_t i = 0; i < lhs.size(); ++i) {
+              lhs[i] += rhs[i];
+            }
+          };
+
+          EXPAND_PACK_LEFT_TO_RIGHT(add_jump_contribution(
+              get<PrimalMortarVars>(jump_field),
+              get<PrimalMortarVars>(remote_data.field_data)));
+
+          jump_field *= 0.5;
+
+          std::apply(
+              [&remote_data = remote_data, &local_data = local_data,
+               mortar_id = mortar_id, &jump_field](const auto&... args) {
+                System::modify_boundary_data::apply_linearized(
+                    make_not_null(
+                        &get<PrimalMortarVars>(remote_data.field_data))...,
+                    make_not_null(&get<::Tags::NormalDotFlux<PrimalMortarVars>>(
+                        remote_data.field_data))...,
+                    make_not_null(
+                        &get<PrimalMortarVars>(local_data.field_data))...,
+                    make_not_null(&get<::Tags::NormalDotFlux<PrimalMortarVars>>(
+                        local_data.field_data))...,
+                    get<PrimalMortarVars>(jump_field)..., mortar_id, args...);
+              },
+              modify_boundary_data_args);
+        }
+      }
+
       const size_t face_num_points = face_mesh.number_of_grid_points();
       const auto& face_normal = face_normals.at(direction);
       const auto& face_normal_vector = face_normal_vectors.at(direction);
@@ -1098,7 +1139,7 @@ struct DgOperatorImpl<System, Linearized, tmpl::list<PrimalFields...>,
         face_normal_magnitudes, face_jacobians,
         face_jacobian_times_inv_jacobians, all_mortar_meshes, all_mortar_sizes,
         mortar_jacobians, penalty_factors, massive, formulation, temporal_id,
-        fluxes_args_on_faces, sources_args);
+        fluxes_args_on_faces, sources_args, modify_boundary_data_args);
     // Impose the nonlinear (constant) boundary contribution as fixed sources on
     // the RHS of the equations
     *fixed_sources -= operator_applied_to_zero_vars;

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/SubdomainOperator.hpp
@@ -30,6 +30,7 @@
 #include "Elliptic/DiscontinuousGalerkin/SubdomainOperator/Tags.hpp"
 #include "Elliptic/DiscontinuousGalerkin/Tags.hpp"
 #include "Elliptic/Systems/GetFluxesComputer.hpp"
+#include "Elliptic/Systems/GetModifyBoundaryData.hpp"
 #include "Elliptic/Systems/GetSourcesComputer.hpp"
 #include "Elliptic/Utilities/ApplyAt.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
@@ -183,6 +184,8 @@ struct SubdomainOperator
   using sources_args_tags =
       elliptic::get_sources_argument_tags<System, linearized>;
 
+  using modify_boundary_data_args_tags =
+      elliptic::get_modify_boundary_data_args_tags<System, linearized>;
   // We need the fluxes args also on interfaces (internal and external). The
   // volume tags are the subset that don't have to be taken from interfaces.
   using fluxes_args_volume_tags =
@@ -190,10 +193,13 @@ struct SubdomainOperator
 
   // These tags can be taken directly from the central element's DataBox, even
   // when evaluating neighbors
-  using args_tags_from_center = tmpl::remove_duplicates<tmpl::push_back<
+  using args_tags_from_center = tmpl::remove_duplicates<tmpl::append<
       elliptic::get_fluxes_const_global_cache_tags<System, linearized>,
       elliptic::get_sources_const_global_cache_tags<System, linearized>,
-      elliptic::dg::Tags::Massive, elliptic::dg::Tags::Formulation>>;
+      elliptic::get_modify_boundary_data_const_global_cache_tags<System,
+                                                                 linearized>,
+      tmpl::list<elliptic::dg::Tags::Massive,
+                 elliptic::dg::Tags::Formulation>>>;
 
   // Data on neighbors is stored in the central element's DataBox in
   // `LinearSolver::Schwarz::Tags::Overlaps` maps, so we wrap the argument tags
@@ -210,6 +216,8 @@ struct SubdomainOperator
       tmpl::transform<fluxes_args_tags, make_overlap_tag>;
   using sources_args_tags_overlap =
       tmpl::transform<sources_args_tags, make_overlap_tag>;
+  using modify_boundary_data_args_tags_overlap =
+      tmpl::transform<modify_boundary_data_args_tags, make_overlap_tag>;
   using fluxes_args_tags_overlap_faces = tmpl::transform<
       domain::make_faces_tags<Dim, fluxes_args_tags, fluxes_args_volume_tags>,
       make_overlap_tag>;
@@ -279,6 +287,8 @@ struct SubdomainOperator
         db::apply<tags_to_retrieve>(get_items, box);
     const auto fluxes_args = db::apply<fluxes_args_tags>(get_items, box);
     const auto sources_args = db::apply<sources_args_tags>(get_items, box);
+    const auto modify_boundary_data_args =
+        db::apply<modify_boundary_data_args_tags>(get_items, box);
     using FluxesArgs = std::decay_t<decltype(fluxes_args)>;
     DirectionMap<Dim, FluxesArgs> fluxes_args_on_faces{};
     for (const auto& direction : Direction<Dim>::all_directions()) {
@@ -623,7 +633,8 @@ struct SubdomainOperator
               make_not_null(&central_mortar_data_), operand.element_data,
               central_deriv_vars_, central_primal_fluxes_, args...);
         },
-        box, temporal_id, fluxes_args_on_faces, sources_args, data_is_zero);
+        box, temporal_id, fluxes_args_on_faces, sources_args,
+        modify_boundary_data_args, data_is_zero);
     // Apply on neighbors
     for (const auto& [direction, neighbors] : central_element.neighbors()) {
       for (const auto& neighbor_id : neighbors) {
@@ -661,6 +672,9 @@ struct SubdomainOperator
             },
             box, overlap_id, temporal_id, fluxes_args_on_overlap_faces,
             elliptic::util::apply_at<sources_args_tags_overlap,
+                                     args_tags_from_center>(get_items, box,
+                                                            overlap_id),
+            elliptic::util::apply_at<modify_boundary_data_args_tags_overlap,
                                      args_tags_from_center>(get_items, box,
                                                             overlap_id),
             data_is_zero);

--- a/src/Elliptic/Systems/GetModifyBoundaryData.hpp
+++ b/src/Elliptic/Systems/GetModifyBoundaryData.hpp
@@ -11,14 +11,26 @@ namespace elliptic {
 namespace detail {
 struct NoModifyBoundaryData {
   using argument_tags = tmpl::list<>;
+  using argument_tags_linearized = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
 };
 }  // namespace detail
 
 /// The `argument_tags` of the `System::modify_boundary_data`, or an empty list
 /// if `System::modify_boundary_data` is `void`.
 template <typename System>
-using get_modify_boundary_data_args_tags = typename tmpl::conditional_t<
+using get_modify_boundary_data = tmpl::conditional_t<
     std::is_same_v<typename System::modify_boundary_data, void>,
-    detail::NoModifyBoundaryData,
-    typename System::modify_boundary_data>::argument_tags;
+    detail::NoModifyBoundaryData, typename System::modify_boundary_data>;
+
+template <typename System, bool Linearized>
+using get_modify_boundary_data_args_tags = tmpl::conditional_t<
+    Linearized,
+    typename get_modify_boundary_data<System>::argument_tags_linearized,
+    typename get_modify_boundary_data<System>::argument_tags>;
+
+template <typename System, bool Linearized>
+using get_modify_boundary_data_const_global_cache_tags =
+    typename get_modify_boundary_data<System>::const_global_cache_tags;
+
 }  // namespace elliptic

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/InitializeEffectiveSource.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/InitializeEffectiveSource.hpp
@@ -73,7 +73,8 @@ struct InitializeEffectiveSource : tt::ConformsTo<::amr::protocols::Projector> {
 
  public:  // Iterable action
   using const_global_cache_tags =
-      tmpl::list<elliptic::dg::Tags::Massive, BackgroundTag>;
+      tmpl::list<elliptic::dg::Tags::Massive, BackgroundTag,
+                 Tags::NullSlicingBlocks<Dim>>;
   using simple_tags =
       tmpl::list<fixed_sources_tag, singular_vars_tag,
                  ::Tags::Mortars<singular_vars_on_mortars_tag, Dim>,

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.cpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.cpp
@@ -43,6 +43,13 @@ tnsr::I<double, 2> CircularOrbit::puncture_position() const {
   return tnsr::I<double, 2>{{{r_star, M_PI_2}}};
 }
 
+double CircularOrbit::omega() const {
+  const double M = black_hole_mass_;
+  const double a = black_hole_spin_ * M;
+  const double r_0 = orbital_radius_;
+  return 1. / (a + sqrt(cube(r_0) / M));
+}
+
 // Background
 tuples::TaggedTuple<Tags::Alpha, Tags::Beta, Tags::GammaRstar, Tags::GammaTheta>
 CircularOrbit::variables(const tnsr::I<DataVector, 2>& x,
@@ -52,8 +59,7 @@ CircularOrbit::variables(const tnsr::I<DataVector, 2>& x,
   const double M = black_hole_mass_;
   const double r_plus = M * (1. + sqrt(1. - square(black_hole_spin_)));
   const double r_minus = M * (1. - sqrt(1. - square(black_hole_spin_)));
-  const double r_0 = orbital_radius_;
-  const double omega = 1. / (a + sqrt(cube(r_0) / M));
+  const double omega = this->omega();
   const auto& r_star = get<0>(x);
   const auto& theta = get<1>(x);
   const DataVector cos_theta = cos(theta);

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.hpp
@@ -88,6 +88,7 @@ class CircularOrbit : public elliptic::analytic_data::Background,
   double black_hole_mass() const { return black_hole_mass_; }
   double black_hole_spin() const { return black_hole_spin_; }
   double orbital_radius() const { return orbital_radius_; }
+  double omega() const;
   int m_mode_number() const { return m_mode_number_; }
 
   using background_tags =

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
@@ -25,7 +25,9 @@ target_link_libraries(
   PUBLIC
   DataStructures
   DomainStructure
+  EffectiveSource
   ErrorHandling
+  GrSelfForceAnalyticData
   Utilities
   )
 

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/Equations.cpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/Equations.cpp
@@ -3,11 +3,14 @@
 
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/Equations.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.hpp"
+#include "Utilities/Algorithm.hpp"
 
 namespace GrSelfForce {
 
@@ -100,6 +103,35 @@ void ModifyBoundaryData::apply(
   for (size_t i = 0; i < singular_field.size(); ++i) {
     (*field)[i] += sign * singular_field[i];
     (*n_dot_flux)[i] -= sign * singular_field_n_dot_flux[i];
+  }
+}
+
+void ModifyBoundaryData::apply_linearized(
+    const gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> /*field_remote*/,
+    const gsl::not_null<tnsr::aa<ComplexDataVector, 3>*>
+        n_dot_field_gradient_remote,
+    const gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> /*field_local*/,
+    const gsl::not_null<
+        tnsr::aa<ComplexDataVector, 3>*> /*n_dot_field_gradient_local*/,
+    const tnsr::aa<ComplexDataVector, 3>& avg_field,
+    const DirectionalId<Dim>& mortar_id, const Element<Dim>& element,
+    const std::vector<size_t>& null_slicing_blocks,
+    const elliptic::analytic_data::Background& background) {
+  if (alg::found(null_slicing_blocks, element.id().block_id()) ==
+      alg::found(null_slicing_blocks, mortar_id.id().block_id())) {
+    // Both elements use the same slicing. Nothing to do.
+    return;
+  }
+  // Apply the jump in the field gradient across the boundary to handle
+  // vtu-slicing. The signs are all the same (on both sides of the boundary and
+  // at both transition points).
+  const auto& circular_orbit =
+      dynamic_cast<const GrSelfForce::AnalyticData::CircularOrbit&>(background);
+  const double omega = circular_orbit.omega();
+  const double m_mode_number = circular_orbit.m_mode_number();
+  for (size_t j = 0; j < n_dot_field_gradient_remote->size(); ++j) {
+    (*n_dot_field_gradient_remote)[j] -=
+        std::complex<double>(0.0, m_mode_number * omega) * (avg_field)[j];
   }
 }
 

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/Equations.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/Equations.hpp
@@ -11,9 +11,12 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/Tags.hpp"
+#include "Elliptic/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
@@ -121,6 +124,14 @@ struct ModifyBoundaryData {
       tmpl::list<Tags::FieldIsRegularized,
                  ::Tags::Mortars<Tags::FieldIsRegularized, Dim>,
                  ::Tags::Mortars<singular_vars_on_mortars_tag, Dim>>;
+
+ public:
+  using argument_tags_linearized = tmpl::list<
+      domain::Tags::Element<Dim>, Tags::NullSlicingBlocks<Dim>,
+      elliptic::Tags::Background<elliptic::analytic_data::Background>>;
+  using const_global_cache_tags = tmpl::list<
+      Tags::NullSlicingBlocks<Dim>,
+      elliptic::Tags::Background<elliptic::analytic_data::Background>>;
   static void apply(
       gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> field,
       gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> n_dot_flux,
@@ -128,6 +139,16 @@ struct ModifyBoundaryData {
       const DirectionalIdMap<Dim, bool>& neighbors_field_is_regularized,
       const DirectionalIdMap<Dim, typename singular_vars_on_mortars_tag::type>&
           singular_vars_on_mortars);
+  static void apply_linearized(
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> field_remote,
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*>
+          n_dot_field_gradient_remote,
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> field_local,
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> n_dot_field_gradient_local,
+      const tnsr::aa<ComplexDataVector, 3>& avg_field,
+      const DirectionalId<Dim>& mortar_id, const Element<Dim>& element,
+      const std::vector<size_t>& null_slicing_blocks,
+      const elliptic::analytic_data::Background& background);
 };
 
 }  // namespace GrSelfForce

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/Tags.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/Tags.hpp
@@ -7,6 +7,9 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
 
 /// \cond
 class ComplexDataVector;
@@ -20,10 +23,27 @@ class DataVector;
  *
  * \see GrSelfForce::FirstOrderSystem
  */
-namespace GrSelfForce {}
+namespace GrSelfForce {
+
+namespace OptionTags {
+
+struct OptionGroup {
+  static std::string name() { return "GrSelfForce:"; }
+  static constexpr Options::String help =
+      "Options for the GR self-force system";
+};
+
+struct NullSlicingBlocks {
+  using group = OptionGroup;
+  using type = std::vector<std::string>;
+  static constexpr Options::String help =
+      "The blocks in which to use null slicing (vtu-slicing).";
+};
+
+}  // namespace OptionTags
 
 /// Tags for the GrSelfForce system.
-namespace GrSelfForce::Tags {
+namespace Tags {
 
 /*!
  * \brief The complex m-mode field $(\Psi_m)_{ab}$.
@@ -123,5 +143,25 @@ struct SingularField : db::SimpleTag {
 struct BoyerLindquistRadius : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
+/*!
+ * \brief Blocks in which we use null slicing (vtu-slicing).
+ */
+template <size_t Dim>
+struct NullSlicingBlocks : db::SimpleTag {
+  using type = std::vector<size_t>;
+  using option_tags = tmpl::list<OptionTags::NullSlicingBlocks,
+                                 domain::OptionTags::DomainCreator<Dim>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const std::vector<std::string>& null_slicing_blocks,
+      const std::unique_ptr<DomainCreator<Dim>>& domain_creator) {
+    const auto ids_set = domain::block_ids_from_names(
+        null_slicing_blocks, domain_creator->block_names(),
+        domain_creator->block_groups());
+    return {ids_set.begin(), ids_set.end()};
+  }
+};
 
-}  // namespace GrSelfForce::Tags
+
+}  // namespace Tags
+}  // namespace GrSelfForce

--- a/src/Elliptic/Systems/SelfForce/Scalar/Actions/InitializeEffectiveSource.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Actions/InitializeEffectiveSource.hpp
@@ -73,7 +73,8 @@ struct InitializeEffectiveSource : tt::ConformsTo<::amr::protocols::Projector> {
 
  public:  // Iterable action
   using const_global_cache_tags =
-      tmpl::list<elliptic::dg::Tags::Massive, BackgroundTag>;
+      tmpl::list<elliptic::dg::Tags::Massive, BackgroundTag,
+                 Tags::NullSlicingBlocks<Dim>>;
   using simple_tags =
       tmpl::list<fixed_sources_tag, singular_vars_tag,
                  ::Tags::Mortars<singular_vars_on_mortars_tag, Dim>,

--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
@@ -60,6 +60,13 @@ tnsr::I<double, 2> CircularOrbit::puncture_position() const {
   return tnsr::I<double, 2>{{{r_star, 0.}}};
 }
 
+double CircularOrbit::omega() const {
+  const double M = black_hole_mass_;
+  const double a = black_hole_spin_ * M;
+  const double r_0 = orbital_radius_;
+  return 1. / (a + sqrt(cube(r_0) / M));
+}
+
 // Background
 tuples::TaggedTuple<Tags::Alpha, Tags::Beta, Tags::Gamma>
 CircularOrbit::variables(
@@ -69,8 +76,7 @@ CircularOrbit::variables(
   const double M = black_hole_mass_;
   const double r_plus = M * (1. + sqrt(1. - square(black_hole_spin_)));
   const double r_minus = M * (1. - sqrt(1. - square(black_hole_spin_)));
-  const double r_0 = orbital_radius_;
-  const double omega = 1. / (a + sqrt(cube(r_0) / M));
+  const double omega = this->omega();
   const auto& r_star = get<0>(x);
   const auto& cos_theta = get<1>(x);
   const DataVector r_minus_r_plus =

--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.hpp
@@ -162,6 +162,7 @@ class CircularOrbit : public elliptic::analytic_data::Background,
   double black_hole_mass() const { return black_hole_mass_; }
   double black_hole_spin() const { return black_hole_spin_; }
   double orbital_radius() const { return orbital_radius_; }
+  double omega() const;
   int m_mode_number() const { return m_mode_number_; }
   std::optional<std::array<double, 4>> hyperboloidal_slicing_transitions()
       const {

--- a/src/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
+++ b/src/Elliptic/Systems/SelfForce/Scalar/CMakeLists.txt
@@ -25,7 +25,9 @@ target_link_libraries(
   PUBLIC
   DataStructures
   DomainStructure
+  EffectiveSource
   ErrorHandling
+  ScalarSelfForceAnalyticData
   Utilities
   )
 

--- a/src/Elliptic/Systems/SelfForce/Scalar/Equations.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Equations.cpp
@@ -3,6 +3,7 @@
 
 #include "Elliptic/Systems/SelfForce/Scalar/Equations.hpp"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/ComplexDataVector.hpp"
@@ -11,6 +12,8 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.hpp"
+#include "Utilities/Algorithm.hpp"
 
 namespace ScalarSelfForce {
 
@@ -84,6 +87,34 @@ void ModifyBoundaryData::apply(
           singular_vars_on_mortars.at(mortar_id));
   get(*field) += sign * get(singular_field);
   get(*n_dot_flux) -= sign * get(singular_field_n_dot_flux);
+}
+
+void ModifyBoundaryData::apply_linearized(
+    const gsl::not_null<Scalar<ComplexDataVector>*> /*field_remote*/,
+    const gsl::not_null<
+        Scalar<ComplexDataVector>*> n_dot_field_gradient_remote,
+    const gsl::not_null<Scalar<ComplexDataVector>*> /*field_local*/,
+    const gsl::not_null<
+        Scalar<ComplexDataVector>*> /*n_dot_field_gradient_local*/,
+    const Scalar<ComplexDataVector>& avg_field,
+    const DirectionalId<Dim>& mortar_id, const Element<Dim>& element,
+    const std::vector<size_t>& null_slicing_blocks,
+    const elliptic::analytic_data::Background& background) {
+  if (alg::found(null_slicing_blocks, element.id().block_id()) ==
+      alg::found(null_slicing_blocks, mortar_id.id().block_id())) {
+    // Both elements use the same slicing. Nothing to do.
+    return;
+  }
+  // Apply the jump in the field gradient across the boundary to handle
+  // vtu-slicing. The signs are all the same (on both sides of the boundary and
+  // at both transition points).
+  const auto& circular_orbit =
+      dynamic_cast<const ScalarSelfForce::AnalyticData::CircularOrbit&>(
+          background);
+  const double omega = circular_orbit.omega();
+  const double m_mode_number = circular_orbit.m_mode_number();
+  get(*n_dot_field_gradient_remote) -=
+      std::complex<double>(0.0, m_mode_number * omega) * get(avg_field);
 }
 
 }  // namespace ScalarSelfForce

--- a/src/Elliptic/Systems/SelfForce/Scalar/Equations.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Equations.hpp
@@ -11,9 +11,12 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Domain/Tags.hpp"
 #include "Elliptic/Systems/SelfForce/Scalar/Tags.hpp"
+#include "Elliptic/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
@@ -105,6 +108,13 @@ struct ModifyBoundaryData {
       tmpl::list<Tags::FieldIsRegularized,
                  ::Tags::Mortars<Tags::FieldIsRegularized, Dim>,
                  ::Tags::Mortars<singular_vars_on_mortars_tag, Dim>>;
+ public:
+  using argument_tags_linearized = tmpl::list<
+      domain::Tags::Element<Dim>, Tags::NullSlicingBlocks<Dim>,
+      elliptic::Tags::Background<elliptic::analytic_data::Background>>;
+  using const_global_cache_tags = tmpl::list<
+      Tags::NullSlicingBlocks<Dim>,
+      elliptic::Tags::Background<elliptic::analytic_data::Background>>;
   static void apply(
       gsl::not_null<Scalar<ComplexDataVector>*> field,
       gsl::not_null<Scalar<ComplexDataVector>*> n_dot_flux,
@@ -112,6 +122,15 @@ struct ModifyBoundaryData {
       const DirectionalIdMap<Dim, bool>& neighbors_field_is_regularized,
       const DirectionalIdMap<Dim, typename singular_vars_on_mortars_tag::type>&
           singular_vars_on_mortars);
+  static void apply_linearized(
+      gsl::not_null<Scalar<ComplexDataVector>*> field_remote,
+      gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient_remote,
+      gsl::not_null<Scalar<ComplexDataVector>*> field_local,
+      gsl::not_null<Scalar<ComplexDataVector>*> n_dot_field_gradient_local,
+      const Scalar<ComplexDataVector>& avg_field,
+      const DirectionalId<Dim>& mortar_id, const Element<Dim>& element,
+      const std::vector<size_t>& null_slicing_blocks,
+      const elliptic::analytic_data::Background& background);
 };
 
 }  // namespace ScalarSelfForce

--- a/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
@@ -151,17 +151,19 @@ struct BoyerLindquistRadius : db::SimpleTag {
 /*!
  * \brief Blocks in which we use null slicing (vtu-slicing).
  */
+template <size_t Dim>
 struct NullSlicingBlocks : db::SimpleTag {
-  using type = std::set<size_t>;
+  using type = std::vector<size_t>;
   using option_tags = tmpl::list<OptionTags::NullSlicingBlocks,
-                                 domain::OptionTags::DomainCreator<2>>;
+                                 domain::OptionTags::DomainCreator<Dim>>;
   static constexpr bool pass_metavariables = false;
   static type create_from_options(
       const std::vector<std::string>& null_slicing_blocks,
-      const std::unique_ptr<DomainCreator<2>>& domain_creator) {
-    return domain::block_ids_from_names(null_slicing_blocks,
-                                        domain_creator->block_names(),
-                                        domain_creator->block_groups());
+      const std::unique_ptr<DomainCreator<Dim>>& domain_creator) {
+    const auto ids_set = domain::block_ids_from_names(
+        null_slicing_blocks, domain_creator->block_names(),
+        domain_creator->block_groups());
+    return {ids_set.begin(), ids_set.end()};
   }
 };
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -419,12 +419,13 @@ struct ElementArray {
 
   using background_tag =
       elliptic::Tags::Background<elliptic::analytic_data::Background>;
+  using null_slicing_tag = ScalarSelfForce::Tags::NullSlicingBlocks<Dim>;
 
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<Dim>;
   using const_global_cache_tags =
-      tmpl::list<domain::Tags::Domain<Dim>, background_tag>;
+      tmpl::list<domain::Tags::Domain<Dim>, background_tag, null_slicing_tag>;
 
   // These tags are communicated on subdomain overlaps to initialize the
   // subdomain geometry. AMR updates these tags, so we have to communicate them
@@ -624,6 +625,7 @@ void test_subdomain_operator(
         domain::Tags::Domain<Dim>, domain::Tags::FunctionsOfTimeInitialize,
         domain::Tags::ExternalBoundaryConditions<Dim>,
         elliptic::Tags::Background<elliptic::analytic_data::Background>,
+        ScalarSelfForce::Tags::NullSlicingBlocks<Dim>,
         LinearSolver::Schwarz::Tags::MaxOverlap<DummyOptionsGroup>,
         logging::Tags::Verbosity<DummyOptionsGroup>,
         elliptic::dg::Tags::PenaltyParameter, elliptic::dg::Tags::Massive,
@@ -634,6 +636,7 @@ void test_subdomain_operator(
         std::move(domain), domain_creator.functions_of_time(),
         std::move(boundary_conditions),
         std::make_unique<RandomBackground<Dim>>(),
+        std::vector<size_t>{},
         max_overlap.has_value() ? std::optional<size_t>(overlap) : std::nullopt,
         ::Verbosity::Verbose, penalty_parameter, use_massive_dg_operator,
         quadrature, ::dg::Formulation::StrongInertial, std::move(amr_criteria),

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -166,6 +166,7 @@ struct ProjectMetavars : tt::ConformsTo<::amr::protocols::Projector> {
       // correctly by the testing framework
       Parallel::Tags::GlobalCache<Metavariables>>;
   using argument_tags = tmpl::list<>;
+  using argument_tags_linearized = tmpl::list<>;
   template <typename... AmrData>
   static void apply(
       const gsl::not_null<Parallel::GlobalCache<Metavariables>**> /*cache*/,
@@ -227,6 +228,7 @@ struct ModifiedPoissonSystem
     using argument_tags = tmpl::list<
         domain::Tags::Element<Dim>,
         ::Tags::Mortars<domain::Tags::Coordinates<Dim, Frame::Inertial>, Dim>>;
+    using argument_tags_linearized = tmpl::list<>;
     static void apply(
         const gsl::not_null<Scalar<DataVector>*> field,
         const gsl::not_null<Scalar<DataVector>*> normal_dot_flux,
@@ -254,6 +256,14 @@ struct ModifiedPoissonSystem
       // computed using the neighbor's face normal
       get(*normal_dot_flux) -= sign * singular_normal_dot_flux;
     }
+    static void apply_linearized(
+        const gsl::not_null<Scalar<DataVector>*> /*field_remote*/,
+        const gsl::not_null<
+            Scalar<DataVector>*> /*n_dot_field_gradient_remote*/,
+        const gsl::not_null<Scalar<DataVector>*> /*field_local*/,
+        const gsl::not_null<Scalar<DataVector>*> /*n_dot_field_gradient_local*/,
+        const Scalar<DataVector>& /*avg_field*/,
+        const DirectionalId<Dim>& /*mortar_id*/, const auto&... /*args*/) {}
   };
 };
 

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
@@ -41,7 +41,9 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<2>;
-  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<2>>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<2>,
+                 GrSelfForce::Tags::NullSlicingBlocks<2>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
@@ -93,11 +95,12 @@ SPECTRE_TEST_CASE("Unit.GrSelfForce.Actions.InitializeEffectiveSource",
       tuples::TaggedTuple<background_tag, domain::Tags::Domain<2>,
                           domain::Tags::FunctionsOfTimeInitialize,
                           elliptic::dg::Tags::Massive,
-                          elliptic::dg::Tags::Quadrature>{
+                          elliptic::dg::Tags::Quadrature,
+                          GrSelfForce::Tags::NullSlicingBlocks<2>>{
           std::make_unique<GrSelfForce::AnalyticData::CircularOrbit>(1.0, 0.0,
                                                                      6.0, 1),
           domain_creator.create_domain(), domain_creator.functions_of_time(),
-          false, Spectral::Quadrature::GaussLobatto}};
+          false, Spectral::Quadrature::GaussLobatto, std::vector<size_t>{}}};
   const ::Tags::Mortars<domain::Tags::Coordinates<2, Frame::Inertial>, 2>::type
       empty_mortar_coords{};
   ActionTesting::emplace_component_and_initialize<element_array>(

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(
   PRIVATE
   DataStructures
   DataStructuresHelpers
+  DomainCreators
+  DomainStructure
+  Options
   GrSelfForce
   )
 

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Test_Tags.cpp
@@ -3,12 +3,43 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
 #include <string>
+#include <vector>
 
+#include "Domain/Creators/AlignedLattice.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace GrSelfForce {
+namespace {
+
+void test_null_slicing_tag_logic() {
+  INFO("Testing NullSlicingBlocks structure");
+  const std::array<std::vector<double>, 2> coords{
+    {{0.0, 0.25, 0.5}, {0.0, 0.5}}};
+  using Region = domain::creators::RefinementRegion<2>;
+  const std::unique_ptr<DomainCreator<2>> lattice =
+    std::make_unique<domain::creators::AlignedLattice<2>>(
+        std::array<std::vector<double>, 2>{
+            {{0., 0.25, 0.5}, {0., 0.5}}},
+        std::array<size_t, 2>{{0, 0}},
+        std::array<size_t, 2>{{3, 2}},
+        std::vector<Region>{
+            Region{{0, 0}, {1, 1}, {0, 1}}},
+        std::vector<Region>{},
+        std::vector<std::array<size_t, 2>>{},
+        std::array<bool, 2>{{false, false}},
+        Options::Context{});
+
+  const std::vector<std::string> blocks{
+    "Block(0,0)", "Block(1,0)"};
+  const std::vector<size_t> result =
+    Tags::NullSlicingBlocks<2>::create_from_options(blocks, lattice);
+  const std::vector<size_t> expected{0, 1};
+  CHECK(result == expected);
+}
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Tags::MMode>("MMode");
@@ -21,6 +52,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Tags::SingularField>("SingularField");
   TestHelpers::db::test_simple_tag<Tags::BoyerLindquistRadius>(
       "BoyerLindquistRadius");
+
+  test_null_slicing_tag_logic();
 }
 
 }  // namespace GrSelfForce

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
@@ -41,7 +41,9 @@ struct ElementArray {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementId<2>;
-  using const_global_cache_tags = tmpl::list<domain::Tags::Domain<2>>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::Domain<2>,
+                 ScalarSelfForce::Tags::NullSlicingBlocks<2>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<
           Parallel::Phase::Initialization,
@@ -93,11 +95,12 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.Actions.InitializeEffectiveSource",
       tuples::TaggedTuple<background_tag, domain::Tags::Domain<2>,
                           domain::Tags::FunctionsOfTimeInitialize,
                           elliptic::dg::Tags::Massive,
-                          elliptic::dg::Tags::Quadrature>{
+                          elliptic::dg::Tags::Quadrature,
+                          ScalarSelfForce::Tags::NullSlicingBlocks<2>>{
           std::make_unique<ScalarSelfForce::AnalyticData::CircularOrbit>(
               1.0, 0.0, 6.0, 1, std::nullopt),
           domain_creator.create_domain(), domain_creator.functions_of_time(),
-          false, Spectral::Quadrature::GaussLobatto}};
+          false, Spectral::Quadrature::GaussLobatto, std::vector<size_t>{}}};
   const ::Tags::Mortars<domain::Tags::Coordinates<2, Frame::Inertial>, 2>::type
       empty_mortar_coords{};
   ActionTesting::emplace_component_and_initialize<element_array>(

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
@@ -17,32 +17,26 @@ namespace {
 void test_null_slicing_tag_logic() {
   INFO("Testing NullSlicingBlocks structure");
   const std::array<std::vector<double>, 2> coords{
-    {{0.0, 0.25, 0.5}, {0.0, 0.5}}};
+      {{0.0, 0.25, 0.5}, {0.0, 0.5}}};
   using Region = domain::creators::RefinementRegion<2>;
   const std::unique_ptr<DomainCreator<2>> lattice =
-    std::make_unique<domain::creators::AlignedLattice<2>>(
-        std::array<std::vector<double>, 2>{
-            {{0., 0.25, 0.5}, {0., 0.5}}},
-        std::array<size_t, 2>{{0, 0}},
-        std::array<size_t, 2>{{3, 2}},
-        std::vector<Region>{
-            Region{{0, 0}, {1, 1}, {0, 1}}},
-        std::vector<Region>{},
-        std::vector<std::array<size_t, 2>>{},
-        std::array<bool, 2>{{false, false}},
-        Options::Context{});
+      std::make_unique<domain::creators::AlignedLattice<2>>(
+          std::array<std::vector<double>, 2>{{{0., 0.25, 0.5}, {0., 0.5}}},
+          std::array<size_t, 2>{{0, 0}}, std::array<size_t, 2>{{3, 2}},
+          std::vector<Region>{Region{{0, 0}, {1, 1}, {0, 1}}},
+          std::vector<Region>{}, std::vector<std::array<size_t, 2>>{},
+          std::array<bool, 2>{{false, false}}, Options::Context{});
 
-  const std::vector<std::string> blocks{
-    "Block(0,0)", "Block(1,0)"};
-  const std::set<size_t> result =
-      Tags::NullSlicingBlocks::create_from_options(blocks, lattice);
-  const std::set<size_t> expected{0, 1};
+  const std::vector<std::string> blocks{"Block(0,0)", "Block(1,0)"};
+  const std::vector<size_t> result =
+      Tags::NullSlicingBlocks<2>::create_from_options(blocks, lattice);
+  const std::vector<size_t> expected{0, 1};
   CHECK(result == expected);
 }
 }  // namespace
 
-SPECTRE_TEST_CASE(
-    "Unit.Elliptic.Systems.ScalarSelfForce.Tags", "[Unit][Elliptic]") {
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.ScalarSelfForce.Tags",
+                  "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Tags::MMode>("MMode");
   TestHelpers::db::test_simple_tag<Tags::Alpha>("Alpha");
   TestHelpers::db::test_simple_tag<Tags::Beta>("Beta");


### PR DESCRIPTION
## Proposed changes

- Implemented vtu jump for scalar self force.
- Added apply_linearized inside ModifyBoundaryData 
- Changes inside DgOperator and SubdomainOperator to take apply_linearized 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
