### PR TITLE
Add ApproxMaxRelativeDeltaR

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -44,11 +44,13 @@ namespace ControlErrors {
 template <size_t DerivOrder, ::domain::ObjectLabel Horizon>
 Size<DerivOrder, Horizon>::Size(
     const int max_times, const double smooth_avg_timescale_frac,
+    const std::optional<double> approx_max_relative_delta_r,
     TimescaleTuner<true> smoother_tuner,
     std::unique_ptr<size::State> initial_state,
     std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options,
     std::optional<DeltaRDriftInwardOptions> delta_r_drift_inward_options)
     : smoother_tuner_(std::move(smoother_tuner)),
+      approx_max_relative_delta_r_(approx_max_relative_delta_r),
       delta_r_drift_outward_options_(delta_r_drift_outward_options),
       delta_r_drift_inward_options_(delta_r_drift_inward_options) {
   if (not smoother_tuner_.timescales_have_been_set()) {
@@ -104,6 +106,7 @@ Size<DerivOrder, Horizon>& Size<DerivOrder, Horizon>::operator=(
   smoother_tuner_ = rhs.smoother_tuner_;
   horizon_coef_averager_ = rhs.horizon_coef_averager_;
   info_ = rhs.info_;
+  approx_max_relative_delta_r_ = rhs.approx_max_relative_delta_r_;
   char_speed_predictor_ = rhs.char_speed_predictor_;
   comoving_char_speed_predictor_ = rhs.comoving_char_speed_predictor_;
   delta_radius_predictor_ = rhs.delta_radius_predictor_;
@@ -147,6 +150,7 @@ void Size<DerivOrder, Horizon>::pup(PUP::er& p) {
   p | smoother_tuner_;
   p | horizon_coef_averager_;
   p | info_;
+  p | approx_max_relative_delta_r_;
   p | char_speed_predictor_;
   p | comoving_char_speed_predictor_;
   p | delta_radius_predictor_;

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -187,6 +187,15 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
         "Average timescale fraction for smoothing horizon measurements."};
   };
 
+  struct ApproxMaxRelativeDeltaR {
+    using type = Options::Auto<double, Options::AutoLabel::None>;
+    static constexpr Options::String help{
+        "The control system encourages (but does not enforce) the difference "
+        "between the horizon and the excision surface to remain within this "
+        "fraction of the horizon radius. Specify 'None' to disable this "
+        "feature."};
+  };
+
   struct SmootherTuner {
     using type = TimescaleTuner<true>;
     static constexpr Options::String help{
@@ -274,8 +283,9 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
 
   using options =
       tmpl::list<MaxNumTimesForZeroCrossingPredictor,
-                 SmoothAvgTimescaleFraction, SmootherTuner, InitialState,
-                 DeltaRDriftOutwardOptions, DeltaRDriftInwardOptions>;
+                 SmoothAvgTimescaleFraction, ApproxMaxRelativeDeltaR,
+                 SmootherTuner, InitialState, DeltaRDriftOutwardOptions,
+                 DeltaRDriftInwardOptions>;
   static constexpr Options::String help{
       "Computes the control error for size control. Will also write a "
       "diagnostics file if the control systems are allowed to write data to "
@@ -301,6 +311,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
    * is moved inside this class.
    */
   Size(const int max_times, const double smooth_avg_timescale_frac,
+       const std::optional<double> approx_max_relative_delta_r,
        TimescaleTuner<true> smoother_tuner,
        std::unique_ptr<size::State> initial_state,
        std::optional<DeltaRDriftOutwardOptions> delta_r_drift_outward_options,
@@ -547,6 +558,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
         make_not_null(&drift_limit_char_speed_predictor_),
         make_not_null(&drift_limit_delta_radius_predictor_), time,
         control_error_delta_r, control_error_delta_r_outward,
+        approx_max_relative_delta_r_,
         delta_r_drift_outward_options_.has_value()
             ? std::optional<double>(delta_r_drift_outward_options_.value()
                                         .max_allowed_radial_distance)
@@ -609,6 +621,7 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
   TimescaleTuner<true> smoother_tuner_{};
   Averager<DerivOrder> horizon_coef_averager_{};
   size::Info info_{};
+  std::optional<double> approx_max_relative_delta_r_{};
   intrp::ZeroCrossingPredictor char_speed_predictor_{};
   intrp::ZeroCrossingPredictor comoving_char_speed_predictor_{};
   intrp::ZeroCrossingPredictor delta_radius_predictor_{};

--- a/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
+++ b/src/ControlSystem/ControlErrors/Size/DeltaR.cpp
@@ -35,6 +35,13 @@ std::string DeltaR::update(const gsl::not_null<Info*> info,
   // Note that delta_radius_is_in_danger and char_speed_is_in_danger
   // can be different for different States.
 
+  // min_time_scale_for_delta_radius_expanding_too_far might be
+  // made an input file option in the future.
+  // The value 1.0 is chosen because we don't want the timescale to become
+  // so small that it slows down the simulation, and timescales on the order
+  // of unity should be good enough for the purposes here.
+  constexpr double min_time_scale_for_delta_radius_expanding_too_far = 1.0;
+
   // The value of 0.99 was chosen by trial and error in SpEC.
   // It should be slightly less than unity but nothing should be
   // sensitive to small changes in this value.
@@ -109,13 +116,53 @@ std::string DeltaR::update(const gsl::not_null<Info*> info,
     // The value of 0.99 below was chosen arbitrarily in SpEC and never
     // needed to be changed.
     constexpr double delta_r_state_decrease_factor = 0.99;
-    info->suggested_time_scale =
-        info->damping_time * delta_r_state_decrease_factor;
     ss << "Current state DeltaR. Min comoving char speed "
        << update_args.min_comoving_char_speed
        << " > 0 and abs(control_error_delta_r) "
        << std::abs(update_args.control_error_delta_r) << " > threshold "
        << delta_r_control_error_threshold << ". Staying in DeltaR.\n";
+
+    // spherepack_factor is needed because horizon_00 is a
+    // spherepack coefficient, not a spherical harmonic coefficient.
+    const double spherepack_factor = sqrt(0.5 * M_PI);
+    const double Y00 = 0.25 * M_2_SQRTPI;
+    const double horizon_average_radius =
+        spherepack_factor * update_args.horizon_00 * Y00;
+    // max_relative_deltar_violation is the ratio of rel_delta_r to
+    // max_rel_delta_r.  We try to keep it small.
+    const double max_relative_delta_r_violation =
+        update_args.approx_max_relative_delta_r.has_value()
+            ? update_args.average_radial_distance.value() /
+                  (horizon_average_radius *
+                   update_args.approx_max_relative_delta_r.value())
+            : 0.0;
+    // We may want to make allowed_violation an input parameter.
+    const double allowed_violation = 0.05;
+    if (max_relative_delta_r_violation > 1.0) {
+      info->suggested_time_scale =
+          std::min(min_time_scale_for_delta_radius_expanding_too_far,
+                   info->damping_time * delta_r_state_decrease_factor);
+      ss << " Above approx_max_relative_delta_r threshold.\n";
+    } else if (max_relative_delta_r_violation < allowed_violation or
+               min_time_scale_for_delta_radius_expanding_too_far >
+                   info->damping_time * delta_r_state_decrease_factor) {
+      info->suggested_time_scale =
+          info->damping_time * delta_r_state_decrease_factor;
+      ss << " Timescale decrease by factor of " << delta_r_state_decrease_factor
+         << ". max_relative_delta_r_violation = "
+         << max_relative_delta_r_violation << ".\n";
+    } else {
+      // timescale varies linearly with
+      // (max_relative_delta_r_violation-allowed_violation)
+      info->suggested_time_scale =
+          info->damping_time * delta_r_state_decrease_factor +
+          ((max_relative_delta_r_violation - allowed_violation) /
+           (1.0 - allowed_violation)) *
+              (min_time_scale_for_delta_radius_expanding_too_far -
+               info->damping_time * delta_r_state_decrease_factor);
+      ss << " Timescale set by max_relative_delta_r_violation = "
+         << max_relative_delta_r_violation << ".\n";
+    }
     ss << " Suggested timescale = " << info->suggested_time_scale;
   } else if (should_transition_from_state_delta_r_to_inward_drift(
                  crossing_time_info.t_drift_limit, info->damping_time,

--- a/src/ControlSystem/ControlErrors/Size/Error.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.cpp
@@ -44,6 +44,7 @@ ErrorDiagnostics control_error(
         predictor_drift_limit_delta_radius,
     const double time, const double control_error_delta_r,
     const std::optional<double> control_error_delta_r_outward,
+    const std::optional<double> approx_max_relative_delta_r,
     const std::optional<double> max_allowed_radial_distance,
     const std::optional<double> inward_drift_velocity,
     const std::optional<double> min_allowed_radial_distance,
@@ -249,9 +250,13 @@ ErrorDiagnostics control_error(
   // average_radial_distance, but all the logic other than those
   // changes remains unchanged.
   // Such a change is possible to make, but we do not (yet) make it here.
+  //
+  // We also compute average_radial distance if approx_max_relative_delta_r
+  // has a value.
   const std::optional<double> average_radial_distance =
       (max_allowed_radial_distance.has_value() or
-       min_allowed_radial_distance.has_value())
+       min_allowed_radial_distance.has_value() or
+       approx_max_relative_delta_r.has_value())
           ? std::optional<double>(
                 gr::surfaces::surface_integral_of_scalar(
                     area_element, radial_distance, excision_boundary) /
@@ -264,7 +269,7 @@ ErrorDiagnostics control_error(
       info,
       StateUpdateArgs{min_char_speed, min_comoving_char_speed, horizon_00,
                       control_error_delta_r, average_radial_distance,
-                      max_allowed_radial_distance,
+                      max_allowed_radial_distance, approx_max_relative_delta_r,
                       avg_distorted_normal_dot_unit_coord_vector,
                       inward_drift_velocity, min_allowed_radial_distance,
                       min_allowed_char_speed,
@@ -316,6 +321,7 @@ ErrorDiagnostics control_error(
           predictor_drift_limit_delta_radius,                                  \
       double time, double control_error_delta_r,                               \
       std::optional<double> control_error_delta_r_outward,                     \
+      std::optional<double> approx_max_relative_delta_r,                       \
       std::optional<double> max_allowed_radial_distance,                       \
       std::optional<double> inward_drift_velocity,                             \
       std::optional<double> min_allowed_radial_distance,                       \

--- a/src/ControlSystem/ControlErrors/Size/Error.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Error.hpp
@@ -170,6 +170,7 @@ ErrorDiagnostics control_error(
         predictor_drift_limit_delta_radius,
     double time, double control_error_delta_r,
     std::optional<double> control_error_delta_r_outward,
+    std::optional<double> approx_max_relative_delta_r,
     std::optional<double> max_allowed_radial_distance,
     std::optional<double> inward_drift_velocity,
     std::optional<double> min_allowed_radial_distance,

--- a/src/ControlSystem/ControlErrors/Size/State.hpp
+++ b/src/ControlSystem/ControlErrors/Size/State.hpp
@@ -38,15 +38,22 @@ struct StateUpdateArgs {
   /// is in state Label::DeltaR.
   /// This is Q in Eq. 96 of \cite Hemberger2012jz.
   double control_error_delta_r;
-  /// average_radial_distance is the average distance between the horizon and
-  /// the excision boundary. Used only for state DeltaRDriftOutward.
-  /// If std::nullopt, then DeltaRDriftOutward will not be used.
+  /// average_radial_distance is the average distance between the
+  /// horizon and the excision boundary. Used for state
+  /// DeltaRDriftOutward, for DeltaRDriftInward, and for reducing
+  /// timescale when horizon is too large.
   std::optional<double> average_radial_distance;
   /// max_allowed_radial_distance is the minimum distance between the horizon
   /// and the excision boundary that will trigger state
   /// Label::DeltaRDriftOutward.  If std::nullopt, then DeltaRDriftOutward
   /// will never be triggered.
   std::optional<double> max_allowed_radial_distance;
+  /// approx_max_relative_delta_r is the maximum value that the
+  /// control system encourages (but does not enforce) for relative
+  /// delta r.  It does this encouragement by decreasing the timescale
+  /// where appropriate. If std::nullopt, then no such encouragement
+  /// is done.
+  std::optional<double> approx_max_relative_delta_r;
   /// avg_distorted_normal_dot_unit_coord_vector is the same quantity as
   /// ControlErrorArgs::avg_distorted_normal_dot_unit_coord_vector.
   double avg_distorted_normal_dot_unit_coord_vector;

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -655,6 +655,7 @@ ControlSystems:
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
       DeltaRDriftInwardOptions: None
+      ApproxMaxRelativeDeltaR: None
       InitialState: Initial
       SmootherTuner:
         InitialTimescales: *SizeATimescale
@@ -678,6 +679,7 @@ ControlSystems:
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
       DeltaRDriftInwardOptions: None
+      ApproxMaxRelativeDeltaR: None
       InitialState: Initial
       SmootherTuner:
         InitialTimescales: *SizeBTimescale

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -419,6 +419,7 @@ ControlSystems:
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
       DeltaRDriftInwardOptions: None
+      ApproxMaxRelativeDeltaR: None
       InitialState: DeltaR
       SmootherTuner:
         InitialTimescales: [0.02]

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -441,6 +441,7 @@ ControlSystems:
       SmoothAvgTimescaleFraction: 0.25
       DeltaRDriftOutwardOptions: None
       DeltaRDriftInwardOptions: None
+      ApproxMaxRelativeDeltaR: None
       InitialState: Initial
       SmootherTuner:
         InitialTimescales: [0.2]

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeControlStates.cpp
@@ -42,6 +42,7 @@ struct TestParams {
   double min_char_speed{0.01};
   double min_comoving_char_speed{-0.02};
   double control_err_delta_r{0.03};
+  std::optional<double> approx_max_relative_delta_r{};
   std::optional<double> max_allowed_radial_distance{1.e100};
   // By default here we turn off state DeltaRDriftInward
   // by setting the following two options to nullopt.
@@ -70,6 +71,8 @@ void do_test(const TestParams& test_params,
   CAPTURE(test_params.min_char_speed);
   CAPTURE(test_params.min_comoving_char_speed);
   CAPTURE(test_params.control_err_delta_r);
+  CAPTURE(test_params.approx_max_relative_delta_r);
+  CAPTURE(test_params.average_radial_distance);
   CAPTURE(test_params.max_allowed_radial_distance);
   CAPTURE(test_params.min_allowed_radial_distance);
   CAPTURE(test_params.min_allowed_char_speed);
@@ -96,6 +99,7 @@ void do_test(const TestParams& test_params,
       test_params.control_err_delta_r,
       test_params.average_radial_distance,
       test_params.max_allowed_radial_distance,
+      test_params.approx_max_relative_delta_r,
       test_params.avg_distorted_normal_dot_unit_coord_vector,
       test_params.inward_drift_velocity,
       test_params.min_allowed_radial_distance,
@@ -140,7 +144,13 @@ void do_test(const TestParams& test_params,
   CHECK(info.damping_time == test_params.damping_time);
   CHECK(info.target_char_speed == expected_target_char_speed);
   CHECK(info.target_drift_velocity == target_drift_velocity);
-  CHECK(info.suggested_time_scale == expected_suggested_time_scale);
+  if(info.suggested_time_scale.has_value()
+     and expected_suggested_time_scale.has_value()) {
+    CHECK(info.suggested_time_scale.value() ==
+          approx(expected_suggested_time_scale.value()));
+  } else {
+    CHECK(info.suggested_time_scale == expected_suggested_time_scale);
+  }
   CHECK(info.discontinuous_change_has_occurred ==
         expected_discontinuous_change_has_occurred);
 
@@ -420,6 +430,41 @@ void test_size_control_update() {
           control_system::size::States::DeltaR>(
       test_params, false, 0.99 * test_params.damping_time,
       test_params.original_target_char_speed);
+
+  // Should change suggested time scale but to the value of
+  // min_time_scale_for_delta_radius_expanding_too_far in DeltaR.cpp
+  const double min_time_scale_for_delta_radius_expanding_too_far = 1.0;
+  const double allowed_violation = 0.05;
+  test_params.approx_max_relative_delta_r = 0.001;
+  test_params.damping_time = 10.0;
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, min_time_scale_for_delta_radius_expanding_too_far,
+      test_params.original_target_char_speed);
+
+  // Should change suggested time scale but to the value of
+  // 0.5*min_time_scale_for_delta_radius_expanding_too_far in DeltaR.cpp
+  //
+  // This complicated formula comes from solving the expression in DeltaR.cpp
+  // for the approx_max_relative_delta_r that will give a timescale of
+  // 0.5 * test_params.damping_time
+  // The 2.01 comes from the excision boundary radius in the grid frame
+  // as specified in test_params above.
+  test_params.approx_max_relative_delta_r =
+      test_params.average_radial_distance.value() /
+      (2.01 *
+       (allowed_violation +
+        (1.0 - allowed_violation) *
+            (0.5 * test_params.damping_time - 0.99 * test_params.damping_time) /
+            (min_time_scale_for_delta_radius_expanding_too_far -
+             0.99 * test_params.damping_time)));
+  do_test<control_system::size::States::DeltaR,
+          control_system::size::States::DeltaR>(
+      test_params, false, 0.5 * test_params.damping_time,
+      test_params.original_target_char_speed);
+  // Restore old values
+  test_params.approx_max_relative_delta_r = std::nullopt;
+  test_params.damping_time = 0.1;
 
   // Should do nothing
   test_params.control_err_delta_r = 1.e-4;

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -136,9 +136,9 @@ void test_size_error_horizon_higher_res_than_excision() {
           make_not_null(&predictor_drift_limit_char_speed),
           make_not_null(&predictor_drift_limit_delta_radius), 0.0, 0.0,
           std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-          horizon.coefficients()[0], 0.0, horizon, excision_boundary, lapse,
-          frame_components_of_grid_shift, spatial_metric,
-          inverse_spatial_metric, deriv_comoving_char_speed),
+          std::nullopt, horizon.coefficients()[0], 0.0, horizon,
+          excision_boundary, lapse, frame_components_of_grid_shift,
+          spatial_metric, inverse_spatial_metric, deriv_comoving_char_speed),
       Catch::Matchers::ContainsSubstring(
           "excision boundary resolution is at least as high"));
 }
@@ -168,6 +168,7 @@ void test_size_error_one_step(
   const double initial_damping_time = 0.1;
   const double initial_target_drift_velocity = 0.0;
   const double initial_suggested_time_scale = 0.0;
+  const std::optional<double> approx_max_relative_delta_r{};
   // Set max_allowed_radial_distance so that State::DeltaRDriftOutward
   // does not transition to DeltaR with the chosen radial_distance of 0.5
   // below. This is fine-tuned.
@@ -298,12 +299,12 @@ void test_size_error_one_step(
       make_not_null(&info), predictor_char_speed, predictor_comoving_char_speed,
       predictor_delta_radius, predictor_drift_limit_char_speed,
       predictor_drift_limit_delta_radius, time, control_error_delta_r,
-      control_error_delta_r_outward, max_allowed_radial_distance,
-      inward_drift_velocity, min_allowed_radial_distance,
-      min_allowed_char_speed, horizon.coefficients()[0],
-      time_deriv_horizon.coefficients()[0], horizon, excision_boundary, lapse,
-      shifty_quantity, spatial_metric, inverse_spatial_metric,
-      deriv_comoving_char_speed);
+      control_error_delta_r_outward, approx_max_relative_delta_r,
+      max_allowed_radial_distance, inward_drift_velocity,
+      min_allowed_radial_distance, min_allowed_char_speed,
+      horizon.coefficients()[0], time_deriv_horizon.coefficients()[0], horizon,
+      excision_boundary, lapse, shifty_quantity, spatial_metric,
+      inverse_spatial_metric, deriv_comoving_char_speed);
 
   // Check error and parts of info.
   //
@@ -332,6 +333,7 @@ void test_size_error_one_step(
         "SmoothAvgTimescaleFraction: 0.25\n"
         "DeltaRDriftOutwardOptions: None\n"
         "DeltaRDriftInwardOptions: None\n"
+        "ApproxMaxRelativeDeltaR: None\n"
         "InitialState: Initial\n"
         "SmootherTuner:\n"
         "  InitialTimescales: 0.2\n"


### PR DESCRIPTION
## Proposed changes

Add a new option to size control: ApproxMaxRelativeDeltaR.

This is intended to prevent the problem in #6928

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The yaml file for the control system needs a new option `ApproxMaxRelativeDeltaR` which can be set to None for no changes; otherwise set to the maximum desired RelativeDeltaR.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
