### PR TITLE
Add PPM reconstruction

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -610,6 +610,19 @@ eprint = {https://doi.org/10.1137/0916035}
   url        = "https://doi.org/10.1007/978-3-662-03882-6_2"
 }
 
+@ARTICLE{Colella1984,
+  author =       {{Colella}, P. and {Woodward}, Paul R.},
+  title =        "{The Piecewise Parabolic Method (PPM) for Gas-Dynamical
+                  Simulations}",
+  journal =      {Journal of Computational Physics},
+  keywords =     {Fluid Mechanics and Heat Transfer},
+  year =         1984,
+  month =        sep,
+  volume =       {54},
+  pages =        {174-201},
+  doi =          {10.1016/0021-9991(84)90143-8},
+}
+
 @ARTICLE{Cook1992,
   author =       {{Cook}, Gregory B. and {Shapiro}, Stuart L. and {Teukolsky},
                   Saul A.},

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   Filters.cpp
   MonotonisedCentral.cpp
   PositivityPreservingAdaptiveOrder.cpp
+  Ppm.cpp
   Reconstructor.cpp
   RegisterDerivedWithCharm.cpp
   Wcns5z.cpp
@@ -27,6 +28,7 @@ spectre_target_headers(
   FiniteDifference.hpp
   MonotonisedCentral.hpp
   PositivityPreservingAdaptiveOrder.hpp
+  Ppm.hpp
   ReconstructWork.hpp
   ReconstructWork.tpp
   Reconstructor.hpp

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp
@@ -5,5 +5,6 @@
 
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Ppm.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.hpp"

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Ppm.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Ppm.cpp
@@ -1,0 +1,337 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Ppm.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/NeutrinoSystems.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Ppm.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Unlimited.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::GhValenciaDivClean::fd {
+
+template <typename System>
+PpmPrim<System>::PpmPrim(
+    const ::VariableFixing::FixReconstructedStateToAtmosphere
+        fix_reconstructed_state_to_atmosphere,
+    const bool reconstruct_rho_times_temperature)
+    : fix_reconstructed_state_to_atmosphere_(
+          fix_reconstructed_state_to_atmosphere),
+      reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {}
+
+template <typename System>
+PpmPrim<System>::PpmPrim(CkMigrateMessage* const msg)
+    : Reconstructor<System>(msg) {}
+
+template <typename System>
+std::unique_ptr<Reconstructor<System>> PpmPrim<System>::get_clone() const {
+  return std::make_unique<PpmPrim>(*this);
+}
+
+template <typename System>
+void PpmPrim<System>::pup(PUP::er& p) {
+  Reconstructor<System>::pup(p);
+  p | fix_reconstructed_state_to_atmosphere_;
+  p | reconstruct_rho_times_temperature_;
+}
+
+template <typename System>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID PpmPrim<System>::my_PUP_ID = 0;
+
+template <typename System>
+template <size_t ThermodynamicDim, typename TagsList>
+void PpmPrim<System>::reconstruct(
+    const gsl::not_null<std::array<Variables<TagsList>, dim>*>
+        vars_on_lower_face,
+    const gsl::not_null<std::array<Variables<TagsList>, dim>*>
+        vars_on_upper_face,
+    const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
+    const Variables<typename System::variables_tag::type::tags_list>&
+        volume_spacetime_and_cons_vars,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const Element<dim>& element,
+    const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
+    const Mesh<dim>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const {
+  using ::VariableFixing::FixReconstructedStateToAtmosphere;
+  using prim_tags_for_reconstruction =
+      grmhd::GhValenciaDivClean::Tags::primitive_grmhd_reconstruction_tags;
+  using all_tags_for_reconstruction = grmhd::GhValenciaDivClean::Tags::
+      primitive_grmhd_and_spacetime_reconstruction_tags;
+
+  DirectionalIdMap<dim, Variables<all_tags_for_reconstruction>>
+      neighbor_variables_data{};
+  ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
+                                        ghost_data, ghost_zone_size(),
+                                        subcell_mesh);
+
+  reconstruct_prims_work<tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>>,
+                         prim_tags_for_reconstruction>(
+      vars_on_lower_face, vars_on_upper_face,
+      [](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+         const auto& volume_vars, const auto& ghost_cell_vars,
+         const auto& subcell_extents, const size_t number_of_variables) {
+        ::fd::reconstruction::ppm(upper_face_vars_ptr, lower_face_vars_ptr,
+                                  volume_vars, ghost_cell_vars, subcell_extents,
+                                  number_of_variables);
+      },
+      [](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+         const auto& volume_vars, const auto& ghost_cell_vars,
+         const auto& subcell_extents, const size_t number_of_variables) {
+        ::fd::reconstruction::unlimited<2>(
+            upper_face_vars_ptr, lower_face_vars_ptr, volume_vars,
+            ghost_cell_vars, subcell_extents, number_of_variables);
+      },
+      [](const auto vars_on_face_ptr) {
+        const auto& spacetime_metric =
+            get<gr::Tags::SpacetimeMetric<DataVector, 3>>(*vars_on_face_ptr);
+        auto& spatial_metric =
+            get<gr::Tags::SpatialMetric<DataVector, 3>>(*vars_on_face_ptr);
+        gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+        auto& inverse_spatial_metric =
+            get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                *vars_on_face_ptr);
+        auto& sqrt_det_spatial_metric =
+            get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(*vars_on_face_ptr);
+
+        determinant_and_inverse(make_not_null(&sqrt_det_spatial_metric),
+                                make_not_null(&inverse_spatial_metric),
+                                spatial_metric);
+        get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+
+        auto& shift = get<gr::Tags::Shift<DataVector, 3>>(*vars_on_face_ptr);
+        gr::shift(make_not_null(&shift), spacetime_metric,
+                  inverse_spatial_metric);
+        gr::lapse(
+            make_not_null(&get<gr::Tags::Lapse<DataVector>>(*vars_on_face_ptr)),
+            shift, spacetime_metric);
+      },
+      volume_prims, volume_spacetime_and_cons_vars, eos, element,
+      neighbor_variables_data, subcell_mesh, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature(),
+      (fix_reconstructed_state_to_atmosphere_ ==
+                   FixReconstructedStateToAtmosphere::Always or
+               fix_reconstructed_state_to_atmosphere_ ==
+                   FixReconstructedStateToAtmosphere::OnFdOnly
+           ? &fix_to_atmosphere
+           : nullptr));
+}
+
+template <typename System>
+template <size_t ThermodynamicDim, typename TagsList>
+void PpmPrim<System>::reconstruct_fd_neighbor(
+    const gsl::not_null<Variables<TagsList>*> vars_on_face,
+    const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
+    const Variables<
+        grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>&
+        subcell_volume_spacetime_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const Element<dim>& element,
+    const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
+    const Mesh<dim>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
+    const Direction<dim> direction_to_reconstruct) const {
+  using ::VariableFixing::FixReconstructedStateToAtmosphere;
+  using prim_tags_for_reconstruction =
+      grmhd::GhValenciaDivClean::Tags::primitive_grmhd_reconstruction_tags;
+  using all_tags_for_reconstruction = grmhd::GhValenciaDivClean::Tags::
+      primitive_grmhd_and_spacetime_reconstruction_tags;
+  reconstruct_fd_neighbor_work<Tags::spacetime_reconstruction_tags,
+                               prim_tags_for_reconstruction,
+                               all_tags_for_reconstruction>(
+      vars_on_face,
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Lower, ::fd::reconstruction::detail::PpmReconstructor>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Lower,
+            ::fd::reconstruction::detail::UnlimitedReconstructor<2>>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Upper, ::fd::reconstruction::detail::PpmReconstructor>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Upper,
+            ::fd::reconstruction::detail::UnlimitedReconstructor<2>>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      [](const auto vars_on_face_ptr) {
+        const auto& spacetime_metric =
+            get<gr::Tags::SpacetimeMetric<DataVector, 3>>(*vars_on_face_ptr);
+        auto& spatial_metric =
+            get<gr::Tags::SpatialMetric<DataVector, 3>>(*vars_on_face_ptr);
+        gr::spatial_metric(make_not_null(&spatial_metric), spacetime_metric);
+        auto& inverse_spatial_metric =
+            get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(
+                *vars_on_face_ptr);
+        auto& sqrt_det_spatial_metric =
+            get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(*vars_on_face_ptr);
+
+        determinant_and_inverse(make_not_null(&sqrt_det_spatial_metric),
+                                make_not_null(&inverse_spatial_metric),
+                                spatial_metric);
+        get(sqrt_det_spatial_metric) = sqrt(get(sqrt_det_spatial_metric));
+
+        auto& shift = get<gr::Tags::Shift<DataVector, 3>>(*vars_on_face_ptr);
+        gr::shift(make_not_null(&shift), spacetime_metric,
+                  inverse_spatial_metric);
+        gr::lapse(
+            make_not_null(&get<gr::Tags::Lapse<DataVector>>(*vars_on_face_ptr)),
+            shift, spacetime_metric);
+      },
+      subcell_volume_prims, subcell_volume_spacetime_metric, eos, element,
+      ghost_data, subcell_mesh, direction_to_reconstruct, ghost_zone_size(),
+      true, reconstruct_rho_times_temperature(),
+      (fix_reconstructed_state_to_atmosphere_ ==
+                   FixReconstructedStateToAtmosphere::Always or
+               fix_reconstructed_state_to_atmosphere_ ==
+                   FixReconstructedStateToAtmosphere::AtDgFdInterfaceOnly
+           ? &fix_to_atmosphere
+           : nullptr));
+}
+
+template <typename System>
+bool PpmPrim<System>::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
+}
+
+template <typename System>
+bool operator==(const PpmPrim<System>& lhs, const PpmPrim<System>& rhs) {
+  return lhs.fix_reconstructed_state_to_atmosphere_ ==
+             rhs.fix_reconstructed_state_to_atmosphere_ and
+         lhs.reconstruct_rho_times_temperature() ==
+             rhs.reconstruct_rho_times_temperature();
+}
+
+template <typename System>
+bool operator!=(const PpmPrim<System>& lhs, const PpmPrim<System>& rhs) {
+  return not(lhs == rhs);
+}
+
+#define NEUTRINO(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(r, data)                                         \
+  template class PpmPrim<GhValenciaDivClean::System<NEUTRINO(data)>>;  \
+  template bool operator==(                                            \
+      const PpmPrim<GhValenciaDivClean::System<NEUTRINO(data)>>& lhs,  \
+      const PpmPrim<GhValenciaDivClean::System<NEUTRINO(data)>>& rhs); \
+  template bool operator!=(                                            \
+      const PpmPrim<GhValenciaDivClean::System<NEUTRINO(data)>>& lhs,  \
+      const PpmPrim<GhValenciaDivClean::System<NEUTRINO(data)>>& rhs);
+GENERATE_INSTANTIATIONS(INSTANTIATION, GHMHD_NEUTRINOS)
+#undef INSTANTIATION
+#undef NEUTRINO
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define NEUTRINO(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void                                                                \
+  PpmPrim<GhValenciaDivClean::System<NEUTRINO(data)>>::reconstruct(            \
+      gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, 3>*>      \
+          vars_on_lower_face,                                                  \
+      gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, 3>*>      \
+          vars_on_upper_face,                                                  \
+      const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,            \
+      const Variables<typename GhValenciaDivClean::System<NEUTRINO(            \
+          data)>::variables_tag::type::tags_list>&                             \
+          volume_spacetime_and_cons_vars,                                      \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos,    \
+      const Element<3>& element,                                               \
+      const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&            \
+          ghost_data,                                                          \
+      const Mesh<3>& subcell_mesh,                                             \
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const;    \
+  template void PpmPrim<GhValenciaDivClean::System<NEUTRINO(data)>>::          \
+      reconstruct_fd_neighbor(                                                 \
+          gsl::not_null<Variables<tags_list_for_reconstruct_fd_neighbor>*>     \
+              vars_on_face,                                                    \
+          const Variables<hydro::grmhd_tags<DataVector>>&                      \
+              subcell_volume_prims,                                            \
+          const Variables<                                                     \
+              grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>& \
+              subcell_volume_spacetime_metric,                                 \
+          const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>&     \
+              eos,                                                             \
+          const Element<3>& element,                                           \
+          const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&        \
+              ghost_data,                                                      \
+          const Mesh<3>& subcell_mesh,                                         \
+          const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,       \
+          const Direction<3> direction_to_reconstruct) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), GHMHD_NEUTRINOS)
+
+#undef INSTANTIATION
+#undef THERMO_DIM
+#undef NEUTRINO
+}  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Ppm.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Ppm.hpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Element;
+template <size_t Dim>
+class ElementId;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
+/// \endcond
+
+namespace grmhd::GhValenciaDivClean::fd {
+/*!
+ * \brief PPM (Piecewise Parabolic Method) reconstruction on the GRMHD
+ * primitive variables (see ::fd::reconstruction::ppm() for details) and
+ * unlimited 3rd order (degree 2 polynomial) reconstruction on the metric
+ * variables.
+ *
+ * Only the spacetime metric is reconstructed when we and the neighboring
+ * element in the direction are doing FD. If we are doing DG and a neighboring
+ * element is doing FD, then the spacetime metric, \f$\Phi_{iab}\f$, and
+ * \f$\Pi_{ab}\f$ are all reconstructed since the Riemann solver on the DG
+ * element also needs to solve for the metric variables.
+ */
+template <typename System>
+class PpmPrim : public Reconstructor<System> {
+ public:
+  static constexpr size_t dim = 3;
+
+  struct AtmosphereTreatment {
+    using type = ::VariableFixing::FixReconstructedStateToAtmosphere;
+    static constexpr Options::String help = {
+        "What reconstructed states to fix to their atmosphere values."};
+  };
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
+
+  using options =
+      tmpl::list<AtmosphereTreatment, ReconstructRhoTimesTemperature>;
+  static constexpr Options::String help{
+      "PPM (Piecewise Parabolic Method) reconstruction scheme using primitive "
+      "variables and the metric variables."};
+
+  PpmPrim(::VariableFixing::FixReconstructedStateToAtmosphere
+              fix_reconstructed_state_to_atmosphere,
+          bool reconstruct_rho_times_temperature);
+
+  PpmPrim() = default;
+  PpmPrim(PpmPrim&&) = default;
+  PpmPrim& operator=(PpmPrim&&) = default;
+  PpmPrim(const PpmPrim&) = default;
+  PpmPrim& operator=(const PpmPrim&) = default;
+  ~PpmPrim() override = default;
+
+  explicit PpmPrim(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(Reconstructor<System>, PpmPrim);
+
+  auto get_clone() const -> std::unique_ptr<Reconstructor<System>> override;
+
+  static constexpr bool use_adaptive_order = false;
+
+  void pup(PUP::er& p) override;
+
+  size_t ghost_zone_size() const override { return 2; }
+
+  using reconstruction_argument_tags =
+      tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,
+                 typename System::variables_tag,
+                 hydro::Tags::GrmhdEquationOfState, domain::Tags::Element<dim>,
+                 evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
+                 evolution::dg::subcell::Tags::Mesh<dim>,
+                 ::Tags::VariableFixer<VariableFixing::FixToAtmosphere<dim>>>;
+
+  template <size_t ThermodynamicDim, typename TagsList>
+  void reconstruct(
+      gsl::not_null<std::array<Variables<TagsList>, dim>*> vars_on_lower_face,
+      gsl::not_null<std::array<Variables<TagsList>, dim>*> vars_on_upper_face,
+      const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
+      const Variables<typename System::variables_tag::type::tags_list>&
+          volume_spacetime_and_cons_vars,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const Element<dim>& element,
+      const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
+          ghost_data,
+      const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const;
+
+  /// Called by an element doing DG when the neighbor is doing subcell.
+  template <size_t ThermodynamicDim, typename TagsList>
+  void reconstruct_fd_neighbor(
+      gsl::not_null<Variables<TagsList>*> vars_on_face,
+      const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
+      const Variables<
+          grmhd::GhValenciaDivClean::Tags::spacetime_reconstruction_tags>&
+          subcell_volume_spacetime_metric,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const Element<dim>& element,
+      const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
+          ghost_data,
+      const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
+      Direction<dim> direction_to_reconstruct) const;
+
+  bool reconstruct_rho_times_temperature() const override;
+
+ private:
+  template <typename LocalSystem>
+  friend bool operator==(const PpmPrim<LocalSystem>& lhs,
+                         const PpmPrim<LocalSystem>& rhs);
+  template <typename LocalSystem>
+  friend bool operator!=(const PpmPrim<LocalSystem>& lhs,
+                         const PpmPrim<LocalSystem>& rhs);
+
+  ::VariableFixing::FixReconstructedStateToAtmosphere
+      fix_reconstructed_state_to_atmosphere_{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never};
+  bool reconstruct_rho_times_temperature_{false};
+};
+}  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Reconstructor.hpp
@@ -22,6 +22,8 @@ class MonotonisedCentralPrim;
 template <typename System>
 class PositivityPreservingAdaptiveOrderPrim;
 template <typename System>
+class PpmPrim;
+template <typename System>
 class Wcns5zPrim;
 /// \endcond
 
@@ -48,7 +50,7 @@ class Reconstructor : public PUP::able {
   using system = System;
   using creatable_classes =
       tmpl::list<MonotonisedCentralPrim<System>,
-                 PositivityPreservingAdaptiveOrderPrim<System>,
+                 PositivityPreservingAdaptiveOrderPrim<System>, PpmPrim<System>,
                  Wcns5zPrim<System>>;
 
   virtual std::unique_ptr<Reconstructor<System>> get_clone() const = 0;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/CMakeLists.txt
@@ -7,6 +7,7 @@ spectre_target_sources(
   MonotonicityPreserving5.cpp
   MonotonisedCentral.cpp
   PositivityPreservingAdaptiveOrder.cpp
+  Ppm.cpp
   Reconstructor.cpp
   RegisterDerivedWithCharm.cpp
   Wcns5z.cpp
@@ -22,6 +23,7 @@ spectre_target_headers(
   MonotonicityPreserving5.hpp
   MonotonisedCentral.hpp
   PositivityPreservingAdaptiveOrder.hpp
+  Ppm.hpp
   Reconstructor.hpp
   ReconstructWork.hpp
   ReconstructWork.tpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp
@@ -6,5 +6,6 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Ppm.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp"

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Ppm.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Ppm.cpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Ppm.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/NormalCovectorAndMagnitude.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp"
+#include "NumericalAlgorithms/FiniteDifference/NeighborDataAsVariables.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Ppm.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::fd {
+PpmPrim::PpmPrim(const bool reconstruct_rho_times_temperature)
+    : reconstruct_rho_times_temperature_(reconstruct_rho_times_temperature) {}
+
+PpmPrim::PpmPrim(CkMigrateMessage* const msg) : Reconstructor(msg) {}
+
+std::unique_ptr<Reconstructor> PpmPrim::get_clone() const {
+  return std::make_unique<PpmPrim>(*this);
+}
+
+void PpmPrim::pup(PUP::er& p) {
+  Reconstructor::pup(p);
+  p | reconstruct_rho_times_temperature_;
+}
+
+// NOLINTNEXTLINE
+PUP::able::PUP_ID PpmPrim::my_PUP_ID = 0;
+
+template <size_t ThermodynamicDim>
+void PpmPrim::reconstruct(
+    const gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, dim>*>
+        vars_on_lower_face,
+    const gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, dim>*>
+        vars_on_upper_face,
+    const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const Element<dim>& element,
+    const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
+    const Mesh<dim>& subcell_mesh) const {
+  DirectionalIdMap<dim, Variables<prims_to_reconstruct_tags>>
+      neighbor_variables_data{};
+  ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
+                                        ghost_data, ghost_zone_size(),
+                                        subcell_mesh);
+  reconstruct_prims_work<prims_to_reconstruct_tags>(
+      vars_on_lower_face, vars_on_upper_face,
+      [](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
+         const auto& volume_vars, const auto& ghost_cell_vars,
+         const auto& subcell_extents, const size_t number_of_variables) {
+        ::fd::reconstruction::ppm(upper_face_vars_ptr, lower_face_vars_ptr,
+                                  volume_vars, ghost_cell_vars, subcell_extents,
+                                  number_of_variables);
+      },
+      volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
+      ghost_zone_size(), true, reconstruct_rho_times_temperature());
+}
+
+template <size_t ThermodynamicDim>
+void PpmPrim::reconstruct_fd_neighbor(
+    const gsl::not_null<Variables<tags_list_for_reconstruct>*> vars_on_face,
+    const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const Element<dim>& element,
+    const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
+    const Mesh<dim>& subcell_mesh,
+    const Direction<dim> direction_to_reconstruct) const {
+  reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
+                               prims_to_reconstruct_tags>(
+      vars_on_face,
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Lower, ::fd::reconstruction::detail::PpmReconstructor>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      [](const auto tensor_component_on_face_ptr,
+         const auto& tensor_component_volume,
+         const auto& tensor_component_neighbor,
+         const Index<dim>& subcell_extents,
+         const Index<dim>& ghost_data_extents,
+         const Direction<dim>& local_direction_to_reconstruct) {
+        ::fd::reconstruction::reconstruct_neighbor<
+            Side::Upper, ::fd::reconstruction::detail::PpmReconstructor>(
+            tensor_component_on_face_ptr, tensor_component_volume,
+            tensor_component_neighbor, subcell_extents, ghost_data_extents,
+            local_direction_to_reconstruct);
+      },
+      subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
+      direction_to_reconstruct, ghost_zone_size(), true,
+      reconstruct_rho_times_temperature());
+}
+
+bool PpmPrim::reconstruct_rho_times_temperature() const {
+  return reconstruct_rho_times_temperature_;
+}
+
+bool operator==(const PpmPrim& lhs, const PpmPrim& rhs) {
+  return lhs.reconstruct_rho_times_temperature() ==
+         rhs.reconstruct_rho_times_temperature();
+}
+
+bool operator!=(const PpmPrim& lhs, const PpmPrim& rhs) {
+  return not(lhs == rhs);
+}
+
+#define THERMO_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                              \
+  template void PpmPrim::reconstruct(                                       \
+      gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, 3>*>   \
+          vars_on_lower_face,                                               \
+      gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, 3>*>   \
+          vars_on_upper_face,                                               \
+      const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,         \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
+      const Element<3>& element,                                            \
+      const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
+          ghost_data,                                                       \
+      const Mesh<3>& subcell_mesh) const;                                   \
+  template void PpmPrim::reconstruct_fd_neighbor(                           \
+      gsl::not_null<Variables<tags_list_for_reconstruct>*> vars_on_face,    \
+      const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims, \
+      const EquationsOfState::EquationOfState<true, THERMO_DIM(data)>& eos, \
+      const Element<3>& element,                                            \
+      const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
+          ghost_data,                                                       \
+      const Mesh<3>& subcell_mesh,                                          \
+      const Direction<3> direction_to_reconstruct) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef THERMO_DIM
+}  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Ppm.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Ppm.hpp
@@ -1,0 +1,147 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Element;
+template <size_t Dim>
+class ElementId;
+namespace EquationsOfState {
+template <bool IsRelativistic, size_t ThermodynamicDim>
+class EquationOfState;
+}  // namespace EquationsOfState
+template <size_t Dim>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+template <typename TagsList>
+class Variables;
+namespace evolution::dg::subcell {
+class GhostData;
+}  // namespace evolution::dg::subcell
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::fd {
+/*!
+ * \brief PPM (Piecewise Parabolic Method) reconstruction. See
+ * ::fd::reconstruction::ppm() for details.
+ */
+class PpmPrim : public Reconstructor {
+ private:
+  // pressure -> temperature
+  using prims_to_reconstruct_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::ElectronFraction<DataVector>,
+                 hydro::Tags::Temperature<DataVector>,
+                 hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>,
+                 hydro::Tags::MagneticField<DataVector, 3>,
+                 hydro::Tags::DivergenceCleaningField<DataVector>>;
+
+ public:
+  static constexpr size_t dim = 3;
+
+  struct ReconstructRhoTimesTemperature {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If 'true' then we reconstruct the rho*T, if 'false' we reconstruct "
+        "T."};
+  };
+
+  using options = tmpl::list<ReconstructRhoTimesTemperature>;
+  static constexpr Options::String help{
+      "PPM (Piecewise Parabolic Method) reconstruction scheme using primitive "
+      "variables."};
+
+  PpmPrim() = default;
+  PpmPrim(PpmPrim&&) = default;
+  PpmPrim& operator=(PpmPrim&&) = default;
+  PpmPrim(const PpmPrim&) = default;
+  PpmPrim& operator=(const PpmPrim&) = default;
+  ~PpmPrim() override = default;
+
+  explicit PpmPrim(bool reconstruct_rho_times_temperature);
+
+  explicit PpmPrim(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(Reconstructor, PpmPrim);
+
+  auto get_clone() const -> std::unique_ptr<Reconstructor> override;
+
+  static constexpr bool use_adaptive_order = false;
+
+  void pup(PUP::er& p) override;
+
+  size_t ghost_zone_size() const override { return 2; }
+
+  using reconstruction_argument_tags =
+      tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,
+                 hydro::Tags::GrmhdEquationOfState, domain::Tags::Element<dim>,
+                 evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
+                 evolution::dg::subcell::Tags::Mesh<dim>>;
+
+  template <size_t ThermodynamicDim>
+  void reconstruct(
+      gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, dim>*>
+          vars_on_lower_face,
+      gsl::not_null<std::array<Variables<tags_list_for_reconstruct>, dim>*>
+          vars_on_upper_face,
+      const Variables<hydro::grmhd_tags<DataVector>>& volume_prims,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const Element<dim>& element,
+      const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
+          ghost_data,
+      const Mesh<dim>& subcell_mesh) const;
+
+  /// Called by an element doing DG when the neighbor is doing subcell.
+  template <size_t ThermodynamicDim>
+  void reconstruct_fd_neighbor(
+      gsl::not_null<Variables<tags_list_for_reconstruct>*> vars_on_face,
+      const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+      const Element<dim>& element,
+      const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
+          ghost_data,
+      const Mesh<dim>& subcell_mesh,
+      Direction<dim> direction_to_reconstruct) const;
+
+  bool reconstruct_rho_times_temperature() const override;
+
+ private:
+  bool reconstruct_rho_times_temperature_{false};
+};
+
+bool operator==(const PpmPrim& lhs, const PpmPrim& rhs);
+
+bool operator!=(const PpmPrim& lhs, const PpmPrim& rhs);
+}  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp
@@ -14,6 +14,7 @@ namespace grmhd::ValenciaDivClean::fd {
 class MonotonicityPreserving5Prim;
 class MonotonisedCentralPrim;
 class PositivityPreservingAdaptiveOrderPrim;
+class PpmPrim;
 class Wcns5zPrim;
 /// \endcond
 
@@ -36,7 +37,7 @@ class Reconstructor : public PUP::able {
 
   using creatable_classes =
       tmpl::list<MonotonicityPreserving5Prim, MonotonisedCentralPrim,
-                 PositivityPreservingAdaptiveOrderPrim, Wcns5zPrim>;
+                 PositivityPreservingAdaptiveOrderPrim, PpmPrim, Wcns5zPrim>;
 
   virtual std::unique_ptr<Reconstructor> get_clone() const = 0;
 

--- a/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/src/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   Filter.cpp
   Minmod.cpp
   MonotonicityPreserving5.cpp
+  Ppm.cpp
   MonotonisedCentral.cpp
   NonUniform1D.cpp
   PartialDerivatives.cpp
@@ -41,6 +42,7 @@ spectre_target_headers(
   PartialDerivatives.hpp
   PartialDerivatives.tpp
   PositivityPreservingAdaptiveOrder.hpp
+  Ppm.hpp
   Reconstruct.hpp
   Reconstruct.tpp
   SecondPartialDerivatives.hpp

--- a/src/NumericalAlgorithms/FiniteDifference/Ppm.cpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Ppm.cpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/FiniteDifference/Ppm.hpp"
+
+#include <array>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+// NOLINTNEXTLINE(modernize-concat-nested-namespaces)
+namespace fd::reconstruction {
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct<PpmReconstructor>(                                 \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_upper_side_of_face_vars,                               \
+      gsl::not_null<std::array<gsl::span<double>, DIM(data)>*>                 \
+          reconstructed_lower_side_of_face_vars,                               \
+      const gsl::span<const double>& volume_vars,                              \
+      const DirectionMap<DIM(data), gsl::span<const double>>& ghost_cell_vars, \
+      const Index<DIM(data)>& volume_extents,                                  \
+      const size_t number_of_variables);
+
+namespace detail {
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+}  // namespace detail
+
+#undef INSTANTIATION
+
+#define SIDE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data)                                                 \
+  template void reconstruct_neighbor<SIDE(data), detail::PpmReconstructor>(    \
+      gsl::not_null<DataVector*> face_data, const DataVector& volume_data,     \
+      const DataVector& neighbor_data, const Index<DIM(data)>& volume_extents, \
+      const Index<DIM(data)>& ghost_data_extents,                              \
+      const Direction<DIM(data)>& direction_to_reconstruct);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (Side::Upper, Side::Lower))
+
+#undef INSTANTIATION
+#undef SIDE
+#undef DIM
+}  // namespace fd::reconstruction

--- a/src/NumericalAlgorithms/FiniteDifference/Ppm.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/Ppm.hpp
@@ -1,0 +1,114 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "NumericalAlgorithms/FiniteDifference/Reconstruct.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t Dim>
+class Direction;
+template <size_t Dim>
+class Index;
+/// \endcond
+
+namespace fd::reconstruction {
+namespace detail {
+struct PpmReconstructor {
+  SPECTRE_ALWAYS_INLINE static std::array<double, 2> pointwise(
+      const double* const q, const int stride) {
+    // Step 1: Unlimited quadratic (degree-2) interpolation
+    // u_L = u_{j-1/2} =  3/8 u_{j-1} + 3/4 u_j - 1/8 u_{j+1}
+    // u_R = u_{j+1/2} = -1/8 u_{j-1} + 3/4 u_j + 3/8 u_{j+1}
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const double u_jm1 = q[-stride];
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const double u_j = q[0];
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const double u_jp1 = q[stride];
+
+    double u_L = (0.375 * u_jm1) + (0.75 * u_j) - (0.125 * u_jp1);
+    double u_R = -(0.125 * u_jm1) + (0.75 * u_j) + (0.375 * u_jp1);
+
+    // Step 2: Colella & Woodward monotonicity limiter (§1.4, adapted to FD)
+    // If cell is a local extremum, set both face values to cell center.
+    if ((u_R - u_j) * (u_j - u_L) <= 0.0) {
+      return {{u_j, u_j}};
+    }
+
+    // Apply C&W limiter to prevent overshoot
+    const double delta = u_R - u_L;
+    const double u_6 = 6.0 * (u_j - (0.5 * (u_L + u_R)));
+
+    if (delta * (delta - u_6) < 0.0) {
+      u_L = (3.0 * u_j) - (2.0 * u_R);
+    }
+    if (delta * (delta + u_6) < 0.0) {
+      u_R = (3.0 * u_j) - (2.0 * u_L);
+    }
+
+    return {{u_L, u_R}};
+  }
+
+  SPECTRE_ALWAYS_INLINE static constexpr size_t stencil_width() { return 3; }
+};
+}  // namespace detail
+
+/*!
+ * \ingroup FiniteDifferenceGroup
+ * \brief Performs piecewise parabolic method (PPM) reconstruction on the
+ * `volume_vars` in each direction.
+ *
+ * On a 1d mesh we denote the solution at the \f$j\f$th point by \f$u_j\f$.
+ * The PPM reconstruction \cite Colella1984 uses a quadratic interpolation
+ * through three points to obtain interface values, which are then monotonicity
+ * limited.
+ *
+ * **Step 1: Unlimited quadratic interpolation**
+ *
+ * \f{align}
+ * u_{j-1/2} &= \frac{3}{8} u_{j-1} + \frac{3}{4} u_j - \frac{1}{8} u_{j+1}
+ * \\
+ * u_{j+1/2} &= -\frac{1}{8} u_{j-1} + \frac{3}{4} u_j + \frac{3}{8} u_{j+1}
+ * \f}
+ *
+ * **Step 2: Colella & Woodward monotonicity limiter**
+ *
+ * If the cell is a local extremum,
+ * \f$(u_{j+1/2} - u_j)(u_j - u_{j-1/2}) \le 0\f$,
+ * both face values are set to the cell center value \f$u_j\f$.
+ *
+ * Otherwise, define
+ * \f{align}
+ * \delta u_j &= u_{j+1/2} - u_{j-1/2} \\
+ * u_{6,j} &= 6\!\left(u_j - \frac{u_{j-1/2} + u_{j+1/2}}{2}\right)
+ * \f}
+ *
+ * and apply:
+ * - If \f$\delta u_j (\delta u_j - u_{6,j}) < 0\f$:
+ *   \f$u_{j-1/2} = 3 u_j - 2 u_{j+1/2}\f$
+ * - If \f$\delta u_j (\delta u_j + u_{6,j}) < 0\f$:
+ *   \f$u_{j+1/2} = 3 u_j - 2 u_{j-1/2}\f$
+ *
+ * \note This is a finite-difference variant operating on point values, not
+ * the finite-volume PPM of \cite Colella1984 which operates on cell averages.
+ */
+template <size_t Dim>
+void ppm(const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+  detail::reconstruct<detail::PpmReconstructor>(
+      reconstructed_upper_side_of_face_vars,
+      reconstructed_lower_side_of_face_vars, volume_vars, ghost_cell_vars,
+      volume_extents, number_of_variables);
+}
+}  // namespace fd::reconstruction

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   FiniteDifference/Test_Filters.cpp
   FiniteDifference/Test_MonotonisedCentral.cpp
   FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
+  FiniteDifference/Test_Ppm.cpp
   FiniteDifference/Test_Wcns5z.cpp
   Subcell/Test_FixConservativesAndComputePrims.cpp
   Subcell/Test_NeighborPackagedData.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Ppm.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Ppm.cpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Ppm.hpp"
+#include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/RadiationTransport/NoNeutrinos/System.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/PrimReconstructor.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.GhValenciaDivClean.Fd.PpmPrim",
+                  "[Unit][Evolution]") {
+  namespace helpers = TestHelpers::grmhd::GhValenciaDivClean::fd;
+  using NeutrinoTransportSystem = RadiationTransport::NoNeutrinos::System;
+  using System = grmhd::GhValenciaDivClean::System<NeutrinoTransportSystem>;
+
+  PUPable_reg(SINGLE_ARG(grmhd::GhValenciaDivClean::fd::PpmPrim<System>));
+  const auto ppm_from_options_base = TestHelpers::test_factory_creation<
+      grmhd::GhValenciaDivClean::fd::Reconstructor<System>,
+      grmhd::GhValenciaDivClean::fd::OptionTags::Reconstructor<System>>(
+      "PpmPrim:\n"
+      "  AtmosphereTreatment: Never\n"
+      "  ReconstructRhoTimesTemperature: false\n");
+  const auto ppm_deserialized =
+      serialize_and_deserialize(ppm_from_options_base);
+  auto* const ppm_from_options =
+      dynamic_cast<const grmhd::GhValenciaDivClean::fd::PpmPrim<System>*>(
+          ppm_deserialized.get());
+  REQUIRE(ppm_from_options != nullptr);
+  CHECK(
+      grmhd::GhValenciaDivClean::fd::PpmPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false} !=
+      grmhd::GhValenciaDivClean::fd::PpmPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false});
+  CHECK(
+      grmhd::GhValenciaDivClean::fd::PpmPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, false} !=
+      grmhd::GhValenciaDivClean::fd::PpmPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Always, true});
+  CHECK(*ppm_from_options ==
+        grmhd::GhValenciaDivClean::fd::PpmPrim<System>{
+            ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false});
+  test_move_semantics(
+      grmhd::GhValenciaDivClean::fd::PpmPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false},
+      grmhd::GhValenciaDivClean::fd::PpmPrim<System>{
+          ::VariableFixing::FixReconstructedStateToAtmosphere::Never, false});
+
+  helpers::test_prim_reconstructor(5, *ppm_from_options);
+}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   FiniteDifference/Test_MonotonicityPreserving5.cpp
   FiniteDifference/Test_MonotonisedCentral.cpp
   FiniteDifference/Test_PositivityPreservingAdaptiveOrder.cpp
+  FiniteDifference/Test_Ppm.cpp
   FiniteDifference/Test_Tag.cpp
   FiniteDifference/Test_Wcns5z.cpp
   Subcell/Test_ComputeFluxes.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_Ppm.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Test_Ppm.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Ppm.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp"
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GrMhd.ValenciaDivClean.Fd.PpmPrim",
+                  "[Unit][Evolution]") {
+  namespace helpers = TestHelpers::grmhd::ValenciaDivClean::fd;
+  // We only test reconstructing T because for low-order reconstructors this
+  // fails because the nonlinear terms (quadratics) aren't captured
+  // accurately enough.
+  const grmhd::ValenciaDivClean::fd::PpmPrim ppm_recons{false};
+  helpers::test_prim_reconstructor(5, ppm_recons);
+  const auto ppm_from_options_base = TestHelpers::test_factory_creation<
+      grmhd::ValenciaDivClean::fd::Reconstructor,
+      grmhd::ValenciaDivClean::fd::OptionTags::Reconstructor>(
+      "PpmPrim:\n"
+      "  ReconstructRhoTimesTemperature: false\n");
+  auto* const ppm_from_options =
+      dynamic_cast<const grmhd::ValenciaDivClean::fd::PpmPrim*>(
+          ppm_from_options_base.get());
+  REQUIRE(ppm_from_options != nullptr);
+  CHECK(*ppm_from_options == ppm_recons);
+  const grmhd::ValenciaDivClean::fd::PpmPrim ppm_recons_recon_T{true};
+  CHECK_FALSE(ppm_recons_recon_T == ppm_recons);
+}

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_NonUniform1D.cpp
   Test_PartialDerivatives.cpp
   Test_PositivityPreservingAdaptiveOrder.cpp
+  Test_Ppm.cpp
   Test_SecondPartialDerivatives.cpp
   Test_Unlimited.cpp
   Test_Wcns5z.cpp

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Ppm.py
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Ppm.py
@@ -1,0 +1,48 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import Reconstruction
+
+
+def ppm(u_l_in, u_j, u_r_in):
+    # Step 1: Unlimited quadratic (degree-2) interpolation
+    u_L = (0.375 * u_l_in) + (0.75 * u_j) - (0.125 * u_r_in)
+    u_R = -(0.125 * u_l_in) + (0.75 * u_j) + (0.375 * u_r_in)
+
+    # Step 2: Colella & Woodward monotonicity limiter
+    # Local extremum check: if cell is extremum, return cell center values
+    if (u_R - u_j) * (u_j - u_L) <= 0.0:
+        return (u_j, u_j)
+
+    # Apply C&W limiter to prevent overshoot
+    delta = u_R - u_L
+    u_6 = 6.0 * (u_j - 0.5 * (u_L + u_R))
+
+    if delta * (delta - u_6) < 0.0:
+        u_L = (3.0 * u_j) - (2.0 * u_R)
+    if delta * (delta + u_6) < 0.0:
+        u_R = (3.0 * u_j) - (2.0 * u_L)
+
+    return (u_L, u_R)
+
+
+def test_ppm(u, extents, dim):
+    def compute_face_values(
+        recons_upper_of_cell, recons_lower_of_cell, v, i, j, k, dim_to_recons
+    ):
+        if dim_to_recons == 0:
+            (u_l, u_r) = ppm(v[i - 1, j, k], v[i, j, k], v[i + 1, j, k])
+            recons_lower_of_cell.append(u_l)
+            recons_upper_of_cell.append(u_r)
+        if dim_to_recons == 1:
+            (u_l, u_r) = ppm(v[i, j - 1, k], v[i, j, k], v[i, j + 1, k])
+            recons_lower_of_cell.append(u_l)
+            recons_upper_of_cell.append(u_r)
+        if dim_to_recons == 2:
+            (u_l, u_r) = ppm(v[i, j, k - 1], v[i, j, k], v[i, j, k + 1])
+            recons_lower_of_cell.append(u_l)
+            recons_upper_of_cell.append(u_r)
+
+    return Reconstruction.reconstruct(
+        u, extents, dim, [1, 1, 1], compute_face_values
+    )

--- a/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Ppm.cpp
+++ b/tests/Unit/NumericalAlgorithms/FiniteDifference/Test_Ppm.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Framework/Pypp.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Exact.hpp"
+#include "Helpers/NumericalAlgorithms/FiniteDifference/Python.hpp"
+#include "NumericalAlgorithms/FiniteDifference/Ppm.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test() {
+  const auto recons =
+      [](const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_upper_side_of_face_vars,
+         const gsl::not_null<std::array<gsl::span<double>, Dim>*>
+             reconstructed_lower_side_of_face_vars,
+         const gsl::span<const double>& volume_vars,
+         const DirectionMap<Dim, gsl::span<const double>>& ghost_cell_vars,
+         const Index<Dim>& volume_extents, const size_t number_of_variables) {
+        fd::reconstruction::ppm(reconstructed_upper_side_of_face_vars,
+                                reconstructed_lower_side_of_face_vars,
+                                volume_vars, ghost_cell_vars, volume_extents,
+                                number_of_variables);
+      };
+  const auto recons_neighbor_data =
+      [](const gsl::not_null<DataVector*> face_data,
+         const DataVector& volume_data, const DataVector& neighbor_data,
+         const Index<Dim>& volume_extents, const Index<Dim>& ghost_data_extents,
+         const Direction<Dim>& direction_to_reconstruct) {
+        if (direction_to_reconstruct.side() == Side::Upper) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Upper, fd::reconstruction::detail::PpmReconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct);
+        }
+        if (direction_to_reconstruct.side() == Side::Lower) {
+          fd::reconstruction::reconstruct_neighbor<
+              Side::Lower, fd::reconstruction::detail::PpmReconstructor>(
+              face_data, volume_data, neighbor_data, volume_extents,
+              ghost_data_extents, direction_to_reconstruct);
+        }
+      };
+  TestHelpers::fd::reconstruction::test_reconstruction_is_exact_if_in_basis<
+      Dim>(1, 4, 3, recons, recons_neighbor_data);
+  TestHelpers::fd::reconstruction::test_with_python(
+      Index<Dim>{4}, 3, "Ppm", "test_ppm", recons, recons_neighbor_data);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.FiniteDifference.Ppm", "[Unit][NumericalAlgorithms]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env(
+      "NumericalAlgorithms/FiniteDifference/");
+  test<1>();
+  test<2>();
+  test<3>();
+}


### PR DESCRIPTION
## Proposed changes

Implements a finite-difference Piecewise Parabolic Method (PPM) reconstructor using degree-2 quadratic interpolation through three point values, followed by the Colella & Woodward (1984) §1.4 monotonicity limiter adapted for FD point values (not FV cell averages).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
