### PR TITLE
Add None BC for GSF

### DIFF
--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/CMakeLists.txt
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Angular.cpp
+  None.cpp
   Sommerfeld.cpp
   )
 
@@ -18,6 +19,7 @@ spectre_target_headers(
   HEADERS
   Factory.hpp
   Angular.hpp
+  None.hpp
   Sommerfeld.hpp
   )
 

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Factory.hpp
@@ -4,12 +4,13 @@
 #pragma once
 
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Angular.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/None.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Sommerfeld.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace GrSelfForce::BoundaryConditions {
 
 /// The list of standard boundary conditions for the GR self-force system.
-using standard_boundary_conditions = tmpl::list<Angular, Sommerfeld>;
+using standard_boundary_conditions = tmpl::list<Angular, Sommerfeld, None>;
 
 }  // namespace GrSelfForce::BoundaryConditions

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/None.cpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/None.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/None.hpp"
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace GrSelfForce::BoundaryConditions {
+
+None::None(CkMigrateMessage* m) : Base(m) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> None::get_clone()
+    const {
+  return std::make_unique<None>(*this);
+}
+
+void None::apply(const gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> /*field*/,
+                 const gsl::not_null<
+                     tnsr::aa<ComplexDataVector, 3>*> /*n_dot_field_gradient*/,
+                 const GradTensorType& /*deriv_field*/) const {
+  // Nothing to do
+}
+
+void None::apply_linearized(
+    const gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> /*field_correction*/,
+    const gsl::not_null<tnsr::aa<ComplexDataVector, 3>*>
+    /*n_dot_field_gradient_correction*/,
+    const GradTensorType& /*deriv_field_correction*/) const {
+  // Nothing to do
+}
+
+bool operator==(const None& /*lhs*/, const None& /*rhs*/) { return true; }
+
+bool operator!=(const None& lhs, const None& rhs) { return not(lhs == rhs); }
+
+PUP::able::PUP_ID None::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace GrSelfForce::BoundaryConditions

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/None.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/None.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryConditionType.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GrSelfForce::BoundaryConditions {
+
+/*!
+ * \brief Applies no boundary condition at all. Used to impose nothing but
+ * regularity at the horizon in horizon-penetrating coordinates.
+ */
+class None : public elliptic::BoundaryConditions::BoundaryCondition<2> {
+ private:
+  using Base = elliptic::BoundaryConditions::BoundaryCondition<2>;
+  using GradTensorType =
+      TensorMetafunctions::prepend_spatial_index<tnsr::aa<ComplexDataVector, 3>,
+                                                 2, UpLo::Lo, Frame::Inertial>;
+
+ public:
+  static constexpr Options::String help =
+      "Applies no boundary condition at all. Used to impose nothing but "
+      "regularity at the horizon in horizon-penetrating coordinates.";
+  using options = tmpl::list<>;
+
+  None() = default;
+  None(const None&) = default;
+  None& operator=(const None&) = default;
+  None(None&&) = default;
+  None& operator=(None&&) = default;
+  ~None() override = default;
+
+  /// \cond
+  explicit None(CkMigrateMessage* m);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(None);
+  /// \endcond
+
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> get_clone()
+      const override;
+
+  std::vector<elliptic::BoundaryConditionType> boundary_condition_types()
+      const override {
+    return {elliptic::BoundaryConditionType::Neumann};
+  }
+
+  using argument_tags = tmpl::list<>;
+  using volume_tags = tmpl::list<>;
+
+  void apply(
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> field,
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> n_dot_field_gradient,
+      const GradTensorType& deriv_field) const;
+
+  using argument_tags_linearized = tmpl::list<>;
+  using volume_tags_linearized = tmpl::list<>;
+
+  void apply_linearized(
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*> field_correction,
+      gsl::not_null<tnsr::aa<ComplexDataVector, 3>*>
+          n_dot_field_gradient_correction,
+      const GradTensorType& deriv_field_correction) const;
+
+ private:
+  friend bool operator==(const None& lhs, const None& rhs);
+};
+
+bool operator!=(const None& lhs, const None& rhs);
+
+}  // namespace GrSelfForce::BoundaryConditions

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_GrSelfForceBoundaryConditions")
 
 set(LIBRARY_SOURCES
   Test_Angular.cpp
+  Test_None.cpp
   Test_Sommerfeld.cpp
   )
 

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Test_None.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Test_None.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <complex>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Elliptic/BoundaryConditions/ApplyBoundaryCondition.hpp"
+#include "Elliptic/BoundaryConditions/BoundaryCondition.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Factory.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/None.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GrSelfForce::BoundaryConditions {
+
+SPECTRE_TEST_CASE("Unit.GrSelfForce.BoundaryConditions.None",
+                  "[Unit][Elliptic]") {
+  // 1. Test factory-creation
+  const auto created = TestHelpers::test_factory_creation<
+      elliptic::BoundaryConditions::BoundaryCondition<2>, None>("None");
+  REQUIRE(dynamic_cast<const None*>(created.get()) != nullptr);
+  const auto& boundary_condition = dynamic_cast<const None&>(*created);
+  {
+    INFO("Semantics");
+    test_serialization(boundary_condition);
+    test_copy_semantics(boundary_condition);
+    auto move_boundary_condition = boundary_condition;
+    test_move_semantics(std::move(move_boundary_condition), boundary_condition);
+  }
+  {
+    INFO("Apply boundary condition");
+    const DataVector used_for_size(5);
+    auto field =
+        make_with_value<tnsr::aa<ComplexDataVector, 3>>(used_for_size, 1.2);
+    auto n_dot_field_gradient =
+        make_with_value<tnsr::aa<ComplexDataVector, 3>>(used_for_size, 3.4);
+    using GradTensorType = TensorMetafunctions::prepend_spatial_index<
+        tnsr::aa<ComplexDataVector, 3>, 2, UpLo::Lo, Frame::Inertial>;
+    auto deriv_field = make_with_value<GradTensorType>(used_for_size, 5.6);
+    const auto box = db::create<db::AddSimpleTags<>>();
+    using local_none_list = tmpl::list<None>;
+    elliptic::apply_boundary_condition<false, void, local_none_list>(
+        boundary_condition, box, Direction<2>::lower_xi(),
+        make_not_null(&field), make_not_null(&n_dot_field_gradient),
+        deriv_field);
+    for (size_t i = 0; i < field.size(); ++i) {
+      CHECK(field[i] == ComplexDataVector(5, 1.2));
+      CHECK(n_dot_field_gradient[i] == ComplexDataVector(5, 3.4));
+    }
+  }
+}
+
+}  // namespace GrSelfForce::BoundaryConditions


### PR DESCRIPTION
## Proposed changes

- Adding None BC for gravitational self force 
- This mirrors [my previous PR for scalar case ](https://github.com/sxs-collaboration/spectre/pull/7073/changes)
(They should have been combined together. Sorry for multiple short PRs.)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
