### PR TITLE
Add NullSlicingBlock for GSF

### DIFF
--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/Tags.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/Tags.hpp
@@ -7,6 +7,9 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
 
 /// \cond
 class ComplexDataVector;
@@ -20,10 +23,27 @@ class DataVector;
  *
  * \see GrSelfForce::FirstOrderSystem
  */
-namespace GrSelfForce {}
+namespace GrSelfForce {
+
+namespace OptionTags {
+
+struct OptionGroup {
+  static std::string name() { return "GrSelfForce"; }
+  static constexpr Options::String help =
+      "Options for the GR self-force system";
+};
+
+struct NullSlicingBlocks {
+  using group = OptionGroup;
+  using type = std::vector<std::string>;
+  static constexpr Options::String help =
+      "The blocks in which to use null slicing (vtu-slicing).";
+};
+
+}  // namespace OptionTags
 
 /// Tags for the GrSelfForce system.
-namespace GrSelfForce::Tags {
+namespace Tags {
 
 /*!
  * \brief The complex m-mode field $(\Psi_m)_{ab}$.
@@ -123,5 +143,22 @@ struct SingularField : db::SimpleTag {
 struct BoyerLindquistRadius : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
+/*!
+ * \brief Blocks in which we use null slicing (vtu-slicing).
+ */
+struct NullSlicingBlocks : db::SimpleTag {
+  using type = std::vector<size_t>;
+  using option_tags = tmpl::list<OptionTags::NullSlicingBlocks,
+                                 domain::OptionTags::DomainCreator<2>>;
+  static constexpr bool pass_metavariables = false;
+  static type create_from_options(
+      const std::vector<std::string>& null_slicing_blocks,
+      const std::unique_ptr<DomainCreator<2>>& domain_creator) {
+    return domain::block_ids_from_names(null_slicing_blocks,
+                                        domain_creator->block_names(),
+                                        domain_creator->block_groups());
+  }
+};
 
-}  // namespace GrSelfForce::Tags
+}  // namespace Tags
+}  // namespace GrSelfForce

--- a/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Creators/DomainCreator.hpp"

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(
   PRIVATE
   DataStructures
   DataStructuresHelpers
+  DomainCreators
+  DomainStructure
+  Options
   GrSelfForce
   )
 

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Test_Tags.cpp
@@ -3,14 +3,40 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
 #include <string>
+#include <vector>
 
+#include "Domain/Creators/AlignedLattice.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 
 namespace GrSelfForce {
+namespace {
 
-SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
+void test_null_slicing_tag_logic() {
+  INFO("Testing NullSlicingBlocks structure");
+  const std::array<std::vector<double>, 2> coords{
+      {{0.0, 0.25, 0.5}, {0.0, 0.5}}};
+  using Region = domain::creators::RefinementRegion<2>;
+  const std::unique_ptr<DomainCreator<2>> lattice =
+      std::make_unique<domain::creators::AlignedLattice<2>>(
+          std::array<std::vector<double>, 2>{{{0., 0.25, 0.5}, {0., 0.5}}},
+          std::array<size_t, 2>{{0, 0}}, std::array<size_t, 2>{{3, 2}},
+          std::vector<Region>{Region{{0, 0}, {1, 1}, {0, 1}}},
+          std::vector<Region>{}, std::vector<std::array<size_t, 2>>{},
+          std::array<bool, 2>{{false, false}}, Options::Context{});
+
+  const std::vector<std::string> blocks{"Block(0,0)", "Block(1,0)"};
+  const std::vector<size_t> result =
+      Tags::NullSlicingBlocks::create_from_options(blocks, lattice);
+  const std::vector<size_t> expected{0, 1};
+  CHECK(result == expected);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.GrSelfForce.Tags",
+                  "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Tags::MMode>("MMode");
   TestHelpers::db::test_simple_tag<Tags::Alpha>("Alpha");
   TestHelpers::db::test_simple_tag<Tags::Beta>("Beta");
@@ -21,6 +47,10 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.Tags", "[Unit][Elliptic]") {
   TestHelpers::db::test_simple_tag<Tags::SingularField>("SingularField");
   TestHelpers::db::test_simple_tag<Tags::BoyerLindquistRadius>(
       "BoyerLindquistRadius");
+  TestHelpers::db::test_simple_tag<Tags::NullSlicingBlocks>(
+      "NullSlicingBlocks");
+
+  test_null_slicing_tag_logic();
 }
 
 }  // namespace GrSelfForce

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
@@ -49,6 +49,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.ScalarSelfForce.Tags",
   TestHelpers::db::test_simple_tag<Tags::BoostFunction>("BoostFunction");
   TestHelpers::db::test_simple_tag<Tags::BoostFunctionDeriv>(
       "BoostFunctionDeriv");
+  TestHelpers::db::test_simple_tag<Tags::NullSlicingBlocks>(
+      "NullSlicingBlocks");
 
   test_null_slicing_tag_logic();
 }


### PR DESCRIPTION
## Proposed changes

- Add NullSlicingBlock for gravitational self-force 
- This mirrors my [previous PR for scalar case](https://github.com/sxs-collaboration/spectre/pull/7091/changes#diff-1a9fe3ef61cec5c92ccd15031e1b91f9413bb40dc3b7bda78a8e910eadaca099R154-R159). 
(They should have been combined together. Sorry for multiple short PRs.) 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
