### PR TITLE
Fix link dependencies for ray tracer tests

### DIFF
--- a/tests/Unit/ParallelAlgorithms/RayTracer/BackgroundSpacetimes/CMakeLists.txt
+++ b/tests/Unit/ParallelAlgorithms/RayTracer/BackgroundSpacetimes/CMakeLists.txt
@@ -13,5 +13,14 @@ add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
 target_link_libraries(
   ${LIBRARY}
   PRIVATE
+  Domain
+  DomainCreators
+  DomainStructure
+  Framework
+  GeneralRelativity
+  GeneralRelativitySolutions
+  H5
   RayTracer
+  Spectral
+  Utilities
   )


### PR DESCRIPTION
## Proposed changes

Fix link dependencies for Test_RayTracerBackgroundSpacetimes

Caused by transitive dependencies changed in #7102

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
