### PR TITLE
Fix python function for Test_DemandOutgoingCharSpeeds

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
@@ -30,9 +30,10 @@ def error(
             speeds[i] -= np.dot(
                 outward_directed_normal_covector, face_mesh_velocity
             )
-            speeds[0] -= np.dot(
-                outward_directed_normal_covector, face_mesh_velocity
-            ) * (1 + gamma_1)
+            speeds[0] -= (
+                np.dot(outward_directed_normal_covector, face_mesh_velocity)
+                * gamma_1
+            )
         if speeds[i] < 0.0:
             return "DemandOutgoingCharSpeeds boundary condition violated"
     return None


### PR DESCRIPTION
For a moving mesh the zeroth char speed was computed incorrectly.

Appears to have been incorrectly changed in #7062 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
