### PR TITLE
TensorYlm: Allow for Spherepack coefficients.

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlm.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlm.hpp
@@ -52,6 +52,27 @@
  * These quantities will be used in explicit formulas for transformations
  * between expansion coefficients.
  *
+ * ### Spherepack coefficients
+ *
+ * Instead of using the actual spherical-harmonic or
+ * spin-weighted spherical-harmonic coefficients $T^{B}_{\ell' m'}$ and
+ * $T^{\tilde A}_{\ell'm'}$, we often work with
+ * coefficients computed by Spherepack, which have a different normalization
+ * and phase than the standard coefficients.  While Spherepack internally
+ * stores real matrices it calls $a_{lm}$ and $b_{lm}$ (see Spherepack
+ * documentation for details), we simplify things by defining
+ * complex Spherepack coefficients
+ * ${\breve T}^{B}_{\ell' m'}$ and ${\breve T}^{\tilde A}_{\ell'm'}$ that
+ * have Spherepack normalization. These are related to the standard coefficients
+ * by
+ * \begin{align}
+ *  {\breve T}^{A}_{\ell m} &= (-1)^m \sqrt{\frac{2}{\pi}} T^{B}_{\ell m},\\
+ *  {\breve T}^{\tilde A}_{\ell m} &= (-1)^m \sqrt{\frac{2}{\pi}}
+ *  T^{\tilde A}_{\ell m}.
+ * \end{align}
+ * Some of the formulas below are slightly different when acting on
+ * Spherepack coefficients compared to standard coefficients.
+ *
  * ## Transformations
  *
  * We can define the following transformations between the expansion
@@ -98,7 +119,24 @@
  *
  * The functions FillCartToSphere and FillSphereToCart fill
  * sparse matrices that encode Eqs. $(\ref{eq:C2S})$ and
- * $(\ref{eq:S2C})$.
+ * $(\ref{eq:S2C})$. When working on Spherepack coefficients, the functions
+ * FillCartToSphere and FillSphereToCart instead
+ * fill sparse matrices that encode
+ * \begin{align}
+ *  {\breve T}^{\tilde B}_{\ell m} &= (-1)^m\sum_{A, \ell',m'\geq 0}(-1)^{m'}
+ *                  \left[
+ *              C_{\ell m A}^{\ell' m'\tilde{B}} T^A_{\ell' m'}
+ *               +{\hat C}_{\ell m A}^{\ell' m'\tilde{B}}
+ *                {\breve T}^A_{\ell' m'}{}^\star
+ *                \right]\label{eq:S2CSpherepack},\\
+ *  {\breve T}^{B}_{\ell m} &= (-1)^m\sum_{\tilde{A},\ell',m'\geq 0}(-1)^{m'}
+ *                  \left[
+ *                  C_{\ell m\tilde{A}}^{\ell' m' B}
+ *                  T^{\tilde A}_{\ell' m'}
+ *                  +{\hat C}_{\ell m\tilde{A}}^{\ell' m' B}
+ *                  {\breve T}^{\tilde A}_{\ell' m'}{}^\star
+ *                  \right]\label{eq:C2SSpherepack}.
+ * \end{align}
  *
  * ## Filtering
  *
@@ -154,6 +192,33 @@
  *                 (-1)^{m'}.
  * \end{align}
  *
- * The function FillFilter encapsulates Eq. $(\ref{eq:Filter})$.
+ * When filtering Spherepack coefficients, the expression is
+ * \begin{align}
+ * {\breve T}^{\tilde B}_{\ell m} &=
+ *           (-1)^m\sum_{{\tilde A}, \ell',m'\geq 0}(-1)^{m'}
+ *                  \left[
+ *              F_{\ell m {\tilde A}}^{\ell' m'\tilde{B}}
+ *                {\breve T}^{\tilde A}_{\ell' m'}
+ *               +{\hat F}_{\ell m {\tilde A}}^{\ell' m'\tilde{B}}
+ *               {\breve T}^{\tilde A}_{\ell' m'}{}^\star
+ *                \right]\label{eq:FilterSpherepack}.
+ * \end{align}
+ *
+ * The function FillFilter encapsulates Eq. $(\ref{eq:Filter})$ or
+ * Eq. $(\ref{eq:FilterSpherepack})$,
+ * depending what type of coefficients are being filtered.
  */
-namespace ylm::TensorYlm {}  // namespace ylm::TensorYlm
+namespace ylm::TensorYlm {
+
+/// Instances of this class are passed to FillFilter,
+/// FillCartToSphere, and FillSphereToCart to identify how the
+/// coefficients are normalized.  This makes a difference because the
+/// normalization is not just a constant factor.
+enum class CoefficientNormalization {
+  /// The standard normalization of the spherical-harmonic coefficients.
+  Standard,
+  /// The Spherepack normalization. Spherepack coefficients are standard
+  /// coefficients multiplied by $(-1)^m \sqrt{2/\pi}$.
+  Spherepack
+};
+}  // namespace ylm::TensorYlm

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmCartToSphere.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmCartToSphere.cpp
@@ -31,7 +31,8 @@ void inner_loops_one(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
                      const size_t dest_comp_index, const size_t ell_max,
                      const size_t l_dest, const int m_dest, const int mj,
                      const std::complex<double> kj, const int sign_ysb,
-                     WignerThreeJ& threej_m, WignerThreeJ& threej_s) {
+                     WignerThreeJ& threej_m, WignerThreeJ& threej_s,
+                     const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, dest_comp_index,
                             src_comp_index](const double element) {
     const size_t indx_dest =
@@ -45,10 +46,12 @@ void inner_loops_one(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
     const double sqterm =
         sqrt(0.5 * static_cast<double>((2 * l_dest + 1) * (2 * l_src + 1)));
     const int m_src = m_dest + mj;
+    const auto sign_m =
+        helpers::sign_m<double>(m_src + m_dest, coefficient_normalization);
 
     const int sign_m_src = (m_src % 2 == 0 ? 1 : -1);
-    const double coef_without_kj =
-        sqterm * sign_ysb * sign_m_src * threej_s(l_src) * threej_m(l_src);
+    const double coef_without_kj = sign_m * sqterm * sign_ysb * sign_m_src *
+                                   threej_s(l_src) * threej_m(l_src);
 
     if (m_src >= 0 and static_cast<size_t>(m_src) <= l_src) {
       // Main term.
@@ -131,7 +134,8 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
                      const int sign_ysb, std::vector<WignerThreeJ>& threej_uvs,
                      const double threej_ones_stilde_val,
                      const double ltilde_term, const int sign_stilde,
-                     const int sign_m_dest) {
+                     const int sign_m_dest,
+                     const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, src_comp_index,
                             dest_comp_index](const double element) {
     const size_t indx_dest =
@@ -145,6 +149,8 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
     for (int v = -1; v <= 1; v += 2, ++mtilde_indx) {
       if (static_cast<size_t>(std::abs(mtildes[mtilde_indx])) <= ltilde) {
         const int m_src = m_dest - mtildes[mtilde_indx];
+        const auto sign_m =
+            helpers::sign_m<double>(m_src + m_dest, coefficient_normalization);
         const int sign_m_src = (m_src % 2 == 0 ? 1 : -1);
         const std::complex<double> kj =
             helpers::bv_to_k(src_bvs[0], u) * helpers::bv_to_k(src_bvs[1], v);
@@ -156,8 +162,8 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
               0.5 *
               sqrt(static_cast<double>((2 * l_dest + 1) * (2 * l_src + 1)));
           const double coef_without_kj =
-              sign_ysb * ltilde_term * sqterm * sign_m_dest * sign_stilde *
-              threej_mtildes[mtilde_indx].value()(l_src) *
+              sign_m * sign_ysb * ltilde_term * sqterm * sign_m_dest *
+              sign_stilde * threej_mtildes[mtilde_indx].value()(l_src) *
               threej_uvs[mtilde_indx](ltilde) * threej_ells_stilde(l_src) *
               threej_ones_stilde_val * symm_factor;
 
@@ -249,7 +255,8 @@ void inner_loops_three(
     std::vector<std::optional<WignerThreeJ>>& threej_ells_stildes,
     std::vector<WignerThreeJ>& threej_uvs,
     std::vector<std::optional<WignerThreeJ>>& threej_ws, const int sign_ysb,
-    const int sign_m_dest) {
+    const int sign_m_dest,
+    const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, src_comp_index,
                             dest_comp_index](const double element) {
     const size_t indx_dest =
@@ -284,6 +291,8 @@ void inner_loops_three(
             const int mw = helpers::bv_to_m(src_bvs[0], w);
             if (mhat == mtildes[mtilde_indx] - mw) {
               const int m_src = m_dest - mhat;
+              const auto sign_m = helpers::sign_m<double>(
+                  m_src + m_dest, coefficient_normalization);
               const int sign_m_src = (m_src % 2 == 0 ? 1 : -1);
               const std::complex<double> kj =
                   helpers::bv_to_k(src_bvs[0], w) * kj12;
@@ -308,10 +317,11 @@ void inner_loops_three(
                     8.0);
 
                 const double coef_without_kj =
-                    sign_ysb * sign_m_dest * sign_stilde * ltilde_term *
-                    sqterm * threej_uv_val * threej_ones_stilde_val *
-                    threej_w_val * threej_ells_stilde_val *
-                    threej_ells_stot_val * threej_ems_val * symm_factor;
+                    sign_m * sign_ysb * sign_m_dest * sign_stilde *
+                    ltilde_term * sqterm * threej_uv_val *
+                    threej_ones_stilde_val * threej_w_val *
+                    threej_ells_stilde_val * threej_ells_stot_val *
+                    threej_ems_val * symm_factor;
 
                 if (m_src >= 0) {
                   // Main term.
@@ -388,8 +398,9 @@ void inner_loops_three(
 }  // namespace
 
 template <typename TensorStructure, typename SparseMatrixType>
-void fill_cart_to_sphere(const gsl::not_null<SparseMatrixType*> matrix,
-                      const size_t ell_max) {
+void fill_cart_to_sphere(
+    const gsl::not_null<SparseMatrixType*> matrix, const size_t ell_max,
+    const CoefficientNormalization coefficient_normalization) {
   static constexpr size_t num_independent_components = TensorStructure::size();
   static constexpr size_t rank = TensorStructure::rank();
   static constexpr auto tensor_index_list =
@@ -547,8 +558,8 @@ void fill_cart_to_sphere(const gsl::not_null<SparseMatrixType*> matrix,
         const auto m_dest = static_cast<int>(iter_dest.m());
         const int sign_m_dest = (m_dest % 2 == 0 ? 1 : -1);
         if constexpr (rank == 1) {
-          (void) sign_m_dest;
-          (void) src_multiplicity;
+          (void)sign_m_dest;
+          (void)src_multiplicity;
           const int sb = helpers::bv_to_s(dest_bvs[0]);
           if (static_cast<size_t>(std::abs(sb)) <= l_dest) {
             // threej_s is the first 3j symbol in Eq. (20)
@@ -560,7 +571,8 @@ void fill_cart_to_sphere(const gsl::not_null<SparseMatrixType*> matrix,
               const std::complex<double> kj = helpers::bv_to_k(src_bvs[0], j);
               inner_loops_one(filler, iter_src, iter_dest, src_comp_index,
                               dest_comp_index, ell_max, l_dest, m_dest, mj, kj,
-                              sign_ysb, threej_m, threej_s);
+                              sign_ysb, threej_m, threej_s,
+                              coefficient_normalization);
             }
           }
         } else if constexpr (rank == 2) {
@@ -592,7 +604,7 @@ void fill_cart_to_sphere(const gsl::not_null<SparseMatrixType*> matrix,
                               mtildes, threej_mtildes, threej_ells_stilde,
                               symm_factor, src_bvs, sign_ysb, threej_uvs,
                               threej_ones_stilde_val, ltilde_term, sign_stilde,
-                              sign_m_dest);
+                              sign_m_dest, coefficient_normalization);
             }
           }
         } else if constexpr (rank == 3) {
@@ -613,7 +625,8 @@ void fill_cart_to_sphere(const gsl::not_null<SparseMatrixType*> matrix,
                     dest_comp_index, ell_max, l_dest, m_dest, lhat, mhat, shat,
                     stilde, threej_ones_stilde, threej_ells_stot, threej_ems,
                     mtildes, src_bvs, src_multiplicity, threej_ells_stildes,
-                    threej_uvs, threej_ws, sign_ysb, sign_m_dest);
+                    threej_uvs, threej_ws, sign_ysb, sign_m_dest,
+                    coefficient_normalization);
               }
             }
           }
@@ -630,12 +643,13 @@ void fill_cart_to_sphere(const gsl::not_null<SparseMatrixType*> matrix,
 #define INSTANTIATE(_, data)                                             \
   template void fill_cart_to_sphere<typename TSTRUCT(data) < DataVector, \
                                     3>::structure >                      \
-      (gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max);       \
+      (gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max,        \
+       CoefficientNormalization coefficient_normalization);              \
   template void fill_cart_to_sphere<typename TSTRUCT(data) < DataVector, \
                                     3>::structure >                      \
       (gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>  \
            matrix,                                                       \
-       size_t ell_max);
+       size_t ell_max, CoefficientNormalization coefficient_normalization);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (tnsr::i, tnsr::ii, tnsr::ij, tnsr::ijk, tnsr::ijj))

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmCartToSphere.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmCartToSphere.hpp
@@ -15,10 +15,15 @@ namespace ylm::TensorYlm {
  * \brief Fills a sparse matrix that does a TensorYlm Cartesian
  * to Spherical operation.
  *
- * Assumes that the input, $T^{\tilde A}_{\ell' m'}$, is stored in a
+ * If the CoefficientNormalization parameter is set to Standard, then
+ * assumes that the input, $T^{\tilde A}_{\ell' m'}$, is stored in a
  * Tensor<DataVector>.  Multiplying the resulting
  * sparse matrix by the Tensor<DataVector> is equivalent to
  * evaluating the right-hand side of Eq. $(\ref{eq:C2S})$.
+ * If the CoefficientNormalization parameter is set to Spherepack, then
+ * assumes the matrix will multiply a Tensor<DataVector> containing
+ * ${\breve T}^{\tilde A}_{\ell' m'}$ and the transform operation is
+ * equivalent to Eq. $(\ref{eq:C2SSpherepack})$.
  *
  * We assume that the independent components of the Tensor<DataVector>
  * are stored contiguously in memory, in order of the `storage_index` of
@@ -175,10 +180,12 @@ namespace ylm::TensorYlm {
  *
  * \param matrix The sparse matrix to fill
  * \param ell_max The maximum ylm ell value
+ * \param coefficient_normalization Describes the normalization of coefficients.
  *
  */
 template <typename TensorStructure, typename SparseMatrixType>
 void fill_cart_to_sphere(gsl::not_null<SparseMatrixType*> matrix,
-                         size_t ell_max);
+                         size_t ell_max,
+                         CoefficientNormalization coefficient_normalization);
 
 }  // namespace ylm::TensorYlm

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.cpp
@@ -130,7 +130,8 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
                      const std::array<helpers::BasisVector, 2>& dest_bvs,
                      const double symm_factor, const double sign_y,
                      std::vector<WignerThreeJ>& threej_pqs,
-                     std::vector<WignerThreeJ>& threej_uvs) {
+                     std::vector<WignerThreeJ>& threej_uvs,
+                     const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, src_comp_index,
                             dest_comp_index](const double element) {
     const size_t indx_dest =
@@ -158,8 +159,10 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
                       helpers::bv_to_k(src_bvs[1], v) *
                       helpers::bv_to_k(dest_bvs[1], q);
                   const int m_src = mprime - mtilde;
+                  const auto sign_m = helpers::sign_m<double>(
+                      m_src + m_dest, coefficient_normalization);
                   const std::complex<double> coef3j =
-                      -coeflprime * coeflbar * sign_y * k_coefs;
+                      -coeflprime * coeflbar * sign_y * sign_m * k_coefs;
                   for (size_t l_dest = std::max(
                            std::max(static_cast<size_t>(
                                         abs(static_cast<int>(lprime) -
@@ -282,7 +285,8 @@ void inner_loops_three(
     const size_t src_multiplicity, std::vector<WignerThreeJ>& threej_pqs,
     std::vector<WignerThreeJ>& threej_uvs,
     std::vector<std::optional<WignerThreeJ>>& threej_ws,
-    std::vector<std::optional<WignerThreeJ>>& threej_rs, const double sign_y) {
+    std::vector<std::optional<WignerThreeJ>>& threej_rs, const double sign_y,
+    const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, src_comp_index,
                             dest_comp_index](const double element) {
     const size_t indx_dest =
@@ -326,9 +330,12 @@ void inner_loops_three(
                                        abs(mw - mtildes[mtilde_indx])))) and
                   lhat <= lbar + 1) {
                 const int m_src = mprime - mhat;
+                const auto sign_m = helpers::sign_m<double>(
+                    m_src + m_dest, coefficient_normalization);
                 const double sign_mtilde =
-                    ((mtildes[mtilde_indx] - mbars[mbar_indx]) % 2 == 0 ? 1.0
-                                                                        : -1.0);
+                    sign_m * ((mtildes[mtilde_indx] - mbars[mbar_indx]) % 2 == 0
+                                  ? 1.0
+                                  : -1.0);
                 const double coeflhat = 0.5 * static_cast<double>(2 * lhat + 1);
                 const double coeflbar = 0.5 * static_cast<double>(2 * lbar + 1);
                 const std::complex<double> k_coefs =
@@ -440,7 +447,8 @@ void inner_loops_three(
 template <typename TensorStructure, typename SparseMatrixType>
 void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
                  const size_t ell_max, const size_t number_of_ell_modes_to_kill,
-                 const std::optional<size_t> half_power) {
+                 const std::optional<size_t> half_power,
+                 const CoefficientNormalization coefficient_normalization) {
   static constexpr size_t num_independent_components = TensorStructure::size();
   static constexpr size_t rank = TensorStructure::rank();
   static constexpr double alpha = 36.0;
@@ -653,7 +661,9 @@ void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
                   std::complex<double> coefjp =
                       -coeflprime * helpers::bv_to_k(src_bvs[0], j) *
                       helpers::bv_to_k(dest_bvs[0], p) * sign_y;
-                  if ((mdest + msrc) % 2 != 0) {
+                  if (coefficient_normalization ==
+                          CoefficientNormalization::Standard and
+                      (mdest + msrc) % 2 != 0) {
                     coefjp *= -1.0;
                   }
                   inner_loops_one(filler, iter_src, iter_dest, src_comp_index,
@@ -682,7 +692,8 @@ void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
                                     lbar, mbar, mtilde, coeflbar, coeflprime,
                                     threej_lbar, threej_ltilde, mbars, mtildes,
                                     src_bvs, dest_bvs, symm_factor, sign_y,
-                                    threej_pqs, threej_uvs);
+                                    threej_pqs, threej_uvs,
+                                    coefficient_normalization);
                   }
                 }
               }
@@ -711,7 +722,7 @@ void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
                               threej_mcheck, mbar_indx, p, q, r, mr, mbars,
                               mtildes, src_bvs, dest_bvs, src_multiplicity,
                               threej_pqs, threej_uvs, threej_ws, threej_rs,
-                              sign_y);
+                              sign_y, coefficient_normalization);
                         }
                       }
                     }
@@ -730,17 +741,19 @@ void fill_filter(const gsl::not_null<SparseMatrixType*> matrix,
 // Explicit instantiations
 #define TSTRUCT(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                  \
-  template void                                                               \
-          fill_filter<typename TSTRUCT(data) < DataVector, 3>::structure >    \
-      (gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max,             \
-       size_t number_of_ell_modes_to_kill, std::optional<size_t> half_power); \
-  template void                                                               \
-          fill_filter<typename TSTRUCT(data) < DataVector, 3>::structure >    \
-      (gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>       \
-           matrix,                                                            \
-       size_t ell_max, size_t number_of_ell_modes_to_kill,                    \
-       std::optional<size_t> half_power);
+#define INSTANTIATE(_, data)                                                 \
+  template void                                                              \
+          fill_filter<typename TSTRUCT(data) < DataVector, 3>::structure >   \
+      (gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max,            \
+       size_t number_of_ell_modes_to_kill, std::optional<size_t> half_power, \
+       CoefficientNormalization coefficient_normalization);                  \
+  template void                                                              \
+          fill_filter<typename TSTRUCT(data) < DataVector, 3>::structure >   \
+      (gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>      \
+           matrix,                                                           \
+       size_t ell_max, size_t number_of_ell_modes_to_kill,                   \
+       std::optional<size_t> half_power,                                     \
+       CoefficientNormalization coefficient_normalization);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (tnsr::i, tnsr::ii, tnsr::ij, tnsr::ijk, tnsr::ijj))
@@ -751,6 +764,7 @@ GENERATE_INSTANTIATIONS(INSTANTIATE,
 // Instantiation for scalars.
 template void fill_filter<typename Scalar<DataVector>::structure>(
     gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max,
-    size_t number_of_ell_modes_to_kill, std::optional<size_t> half_power);
+    size_t number_of_ell_modes_to_kill, std::optional<size_t> half_power,
+    CoefficientNormalization coefficient_normalization);
 
 }  // namespace ylm::TensorYlm

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.hpp
@@ -16,10 +16,15 @@ namespace ylm::TensorYlm {
 /*!
  * \brief Fills a sparse matrix that does a TensorYlm filter operation.
  *
- * Assumes that $T^{\tilde A}_{\ell' m'}$ is stored in a
+ * If the CoefficientNormalization parameter is set to Standard, then
+ * assumes that $T^{\tilde A}_{\ell' m'}$ is stored in a
  * Tensor<DataVector>.  Multiplying (one plus) the resulting
  * sparse matrix by the Tensor<DataVector> is equivalent to
  * evaluating the right-hand side of Eq. $(\ref{eq:Filter})$.
+ * If the CoefficientNormalization parameter is set to Spherepack, then
+ * assumes the matrix will multiply a Tensor<DataVector> containing
+ * ${\breve T}^{\tilde A}_{\ell' m'}$ and the filter operation is equivalent to
+ * Eq. $(\ref{eq:FilterSpherepack})$.
  *
  * We assume that the independent components of the Tensor<DataVector>
  * are stored contiguously in memory, in order of the storage_index of
@@ -215,6 +220,7 @@ namespace ylm::TensorYlm {
  * \param ell_max The maximum ylm ell value.
  * \param number_of_ell_modes_to_kill How many top ell modes to set to zero.
  * \param half_power The half power $\sigma$ for more complicated filtering.
+ * \param coefficient_normalization Describes the normalization of coefficients.
  *
  *  If half_power is std::nullopt, implements a Heaviside filter.
  *  Otherwise, the filter is the more complicated one described in the
@@ -226,6 +232,7 @@ namespace ylm::TensorYlm {
 template <typename TensorStructure, typename SparseMatrixType>
 void fill_filter(gsl::not_null<SparseMatrixType*> matrix, size_t ell_max,
                  size_t number_of_ell_modes_to_kill,
-                 std::optional<size_t> half_power);
+                 std::optional<size_t> half_power,
+                 CoefficientNormalization coefficient_normalization);
 
 }  // namespace ylm::TensorYlm

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmHelpers.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmHelpers.hpp
@@ -39,4 +39,15 @@ int bv_to_s(BasisVector basis_vector);
 template <typename Symm>
 double get_symm_factor(size_t src_multiplicity, size_t lbar);
 
+/// Computes the (-1)^m factor that is used depending on whether the
+/// coefficient normalization is Spherepack.
+template <typename T>
+constexpr T sign_m(const int m,
+                   const CoefficientNormalization coefficient_normalization) {
+  return coefficient_normalization == CoefficientNormalization::Spherepack and
+                 m % 2 != 0
+             ? static_cast<T>(-1)
+             : static_cast<T>(1);
+}
+
 }  // namespace ylm::TensorYlm::helpers

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmSphereToCart.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmSphereToCart.cpp
@@ -33,7 +33,8 @@ void inner_loops_one(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
                      const int mj, const std::complex<double> kj,
                      WignerThreeJ& threej_m, WignerThreeJ& threej_s,
                      const int sign_m_dest, const int sign_delta_sb,
-                     const int sign_delta_sb_conj) {
+                     const int sign_delta_sb_conj,
+                     const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, dest_comp_index,
                             src_comp_index](const double element) {
     const size_t indx_dest =
@@ -43,6 +44,8 @@ void inner_loops_one(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
     filler.add(element, indx_dest, indx_src);
   };
   const int m_src = m_dest - mj;
+  const auto sign_m =
+      helpers::sign_m<int>(m_src + m_dest, coefficient_normalization);
   for (size_t l_src =
            std::max(static_cast<size_t>(abs(m_src)), threej_s.l1_min());
        (l_src <= threej_s.l1_max() and l_src <= ell_max); ++l_src) {
@@ -52,8 +55,8 @@ void inner_loops_one(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
     const int sign_conjA =
         ((static_cast<int>(l_src + l_dest) + 1 - scheck + m_src) % 2 == 0 ? 1
                                                                           : -1);
-    const int sign_plus_msrc_term = sign_m_dest * sign_delta_sb;
-    const int sign_min_msrc_term = sign_delta_sb_conj * sign_conjA;
+    const int sign_plus_msrc_term = sign_m_dest * sign_m * sign_delta_sb;
+    const int sign_min_msrc_term = sign_delta_sb_conj * sign_m * sign_conjA;
     if (m_src >= 0) {
       // Main term.
       if (kj.imag() == 0) {
@@ -135,7 +138,8 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
                      const std::array<helpers::BasisVector, 2>& dest_bvs,
                      std::vector<WignerThreeJ>& threej_pqs,
                      const double threej_ones_sbar_val, const int sign_sbar,
-                     const int sign_delta_sb, const int sign_delta_sb_conj) {
+                     const int sign_delta_sb, const int sign_delta_sb_conj,
+                     const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, src_comp_index,
                             dest_comp_index](const double element) {
     const size_t indx_dest =
@@ -149,6 +153,8 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
     for (int q = -1; q <= 1; q += 2, ++mbar_indx) {
       if (static_cast<size_t>(std::abs(mbars[mbar_indx])) <= lbar) {
         const int m_src = m_dest - mbars[mbar_indx];
+        const auto sign_m =
+            helpers::sign_m<double>(m_src + m_dest, coefficient_normalization);
         const int sign_m_src = (m_src % 2 == 0 ? 1 : -1);
         const std::complex<double> kj =
             helpers::bv_to_k(dest_bvs[0], p) * helpers::bv_to_k(dest_bvs[1], q);
@@ -164,7 +170,7 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
               sign_m_src * sign_delta_sb * sign_sbar;
           const int sign_min_msrc_term = sign_delta_sb_conj * sign_toprow;
           const double coef_without_kj =
-              sqterm * threej_ells_sbar(l_src) * threej_ones_sbar_val *
+              sign_m * sqterm * threej_ells_sbar(l_src) * threej_ones_sbar_val *
               threej_mbars[mbar_indx].value()(l_src) *
               threej_pqs[mbar_indx](lbar) * symm_factor *
               static_cast<double>(2 * lbar + 1);
@@ -243,23 +249,22 @@ void inner_loops_two(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
 // the main function, making the main function and this function more
 // readable.
 template <typename Symm>
-void inner_loops_three(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
-                       SpherepackIterator& iter_dest,
-                       const size_t src_comp_index,
-                       const size_t dest_comp_index, const size_t ell_max,
-                       const size_t l_dest, const int m_dest,
-                       const size_t lcheck, const int mcheck, const int sbar,
-                       const int scheck,
-                       std::vector<WignerThreeJ>& threej_ones_sbars,
-                       WignerThreeJ& threej_ssum, WignerThreeJ& threej_msdc,
-                       std::vector<std::optional<WignerThreeJ>>& threej_sb0s,
-                       std::vector<WignerThreeJ>& threej_pqs,
-                       std::vector<std::optional<WignerThreeJ>>& threej_rs,
-                       const std::vector<int>& mbars,
-                       const std::array<helpers::BasisVector, 3>& src_bvs,
-                       const std::array<helpers::BasisVector, 3>& dest_bvs,
-                       const size_t src_multiplicity, const int sign_all_s,
-                       const int sign_delta_sb, const int sign_delta_sb_conj) {
+void inner_loops_three(
+    SparseMatrixFiller& filler, SpherepackIterator& iter_src,
+    SpherepackIterator& iter_dest, const size_t src_comp_index,
+    const size_t dest_comp_index, const size_t ell_max, const size_t l_dest,
+    const int m_dest, const size_t lcheck, const int mcheck, const int sbar,
+    const int scheck, std::vector<WignerThreeJ>& threej_ones_sbars,
+    WignerThreeJ& threej_ssum, WignerThreeJ& threej_msdc,
+    std::vector<std::optional<WignerThreeJ>>& threej_sb0s,
+    std::vector<WignerThreeJ>& threej_pqs,
+    std::vector<std::optional<WignerThreeJ>>& threej_rs,
+    const std::vector<int>& mbars,
+    const std::array<helpers::BasisVector, 3>& src_bvs,
+    const std::array<helpers::BasisVector, 3>& dest_bvs,
+    const size_t src_multiplicity, const int sign_all_s,
+    const int sign_delta_sb, const int sign_delta_sb_conj,
+    const CoefficientNormalization coefficient_normalization) {
   const auto add_element = [&filler, &iter_src, &iter_dest, src_comp_index,
                             dest_comp_index](const double element) {
     const size_t indx_dest =
@@ -294,6 +299,8 @@ void inner_loops_three(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
             if (mcheck == mbars[mbar_indx] + mr) {
               const int m_src = m_dest - mcheck;
               const int sign_m_src = (m_src % 2 == 0 ? 1 : -1);
+              const auto sign_m = helpers::sign_m<double>(
+                  m_src + m_dest, coefficient_normalization);
               const std::complex<double> kj =
                   helpers::bv_to_k(dest_bvs[0], r) * kj12;
               const double threej_r_val =
@@ -316,7 +323,7 @@ void inner_loops_three(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
                 const int sign_toprow =
                     ((l_src + l_dest + 1) % 2 == 0 ? 1 : -1);
                 const double coef_without_kj =
-                    sqterm * threej_ones_sbar_val * threej_ssum_val *
+                    sign_m * sqterm * threej_ones_sbar_val * threej_ssum_val *
                     threej_pq_val * threej_r_val * threej_sb0_val *
                     threej_msdc_val * symm_factor * lbar_term;
                 const int sign_plus_msrc_term =
@@ -405,8 +412,9 @@ void inner_loops_three(SparseMatrixFiller& filler, SpherepackIterator& iter_src,
 }  // namespace
 
 template <typename TensorStructure, typename SparseMatrixType>
-void fill_sphere_to_cart(const gsl::not_null<SparseMatrixType*> matrix,
-                      const size_t ell_max) {
+void fill_sphere_to_cart(
+    const gsl::not_null<SparseMatrixType*> matrix, const size_t ell_max,
+    const CoefficientNormalization coefficient_normalization) {
   static constexpr size_t num_independent_components = TensorStructure::size();
   static constexpr size_t rank = TensorStructure::rank();
   static constexpr auto tensor_index_list =
@@ -586,7 +594,8 @@ void fill_sphere_to_cart(const gsl::not_null<SparseMatrixType*> matrix,
             inner_loops_one(filler, iter_src, iter_dest, src_comp_index,
                             dest_comp_index, ell_max, l_dest, m_dest, scheck,
                             mj, kj, threej_m, threej_s, sign_m_dest,
-                            sign_delta_sb, sign_delta_sb_conj);
+                            sign_delta_sb, sign_delta_sb_conj,
+                            coefficient_normalization);
           }
         } else if constexpr (rank == 2) {
           (void)scheck;  // unused for rank 2
@@ -618,7 +627,7 @@ void fill_sphere_to_cart(const gsl::not_null<SparseMatrixType*> matrix,
                               mbars, threej_mbars, threej_ells_sbar,
                               symm_factor, dest_bvs, threej_pqs,
                               threej_ones_sbar_val, sign_sbar, sign_delta_sb,
-                              sign_delta_sb_conj);
+                              sign_delta_sb_conj, coefficient_normalization);
             }
           }
         } else if constexpr (rank == 3) {
@@ -638,7 +647,7 @@ void fill_sphere_to_cart(const gsl::not_null<SparseMatrixType*> matrix,
                   threej_ones_sbars, threej_ssum, threej_msdc, threej_sb0s,
                   threej_pqs, threej_rs, mbars, src_bvs, dest_bvs,
                   src_multiplicity, sign_all_s, sign_delta_sb,
-                  sign_delta_sb_conj);
+                  sign_delta_sb_conj, coefficient_normalization);
             }
           }
         }
@@ -654,12 +663,13 @@ void fill_sphere_to_cart(const gsl::not_null<SparseMatrixType*> matrix,
 #define INSTANTIATE(_, data)                                             \
   template void fill_sphere_to_cart<typename TSTRUCT(data) < DataVector, \
                                     3>::structure >                      \
-      (gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max);       \
+      (gsl::not_null<SimpleSparseMatrix*> matrix, size_t ell_max,        \
+       CoefficientNormalization coefficient_normalization);              \
   template void fill_sphere_to_cart<typename TSTRUCT(data) < DataVector, \
                                     3>::structure >                      \
       (gsl::not_null<blaze::CompressedMatrix<double, blaze::rowMajor>*>  \
            matrix,                                                       \
-       size_t ell_max);
+       size_t ell_max, CoefficientNormalization coefficient_normalization);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE,
                         (tnsr::i, tnsr::ii, tnsr::ij, tnsr::ijk, tnsr::ijj))

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmSphereToCart.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmSphereToCart.hpp
@@ -12,13 +12,18 @@
 namespace ylm::TensorYlm {
 
 /*!
- * \brief Fills a sparse matrix that does a TensorYlm Cartesian
- * to Spherical operation.
+ * \brief Fills a sparse matrix that does a TensorYlm Spherical
+ * to Cartesian operation.
  *
- * Assumes that the input, $T^B_{\ell m}$, is stored in a
+ * If the CoefficientNormalization parameter is set to Standard, then
+ * assumes that the input, $T^B_{\ell m}$, is stored in a
  * Tensor<DataVector>.  Multiplying the resulting
  * sparse matrix by the Tensor<DataVector> is equivalent to
  * evaluating the right-hand side of Eq. $(\ref{eq:S2C})$.
+ * If the CoefficientNormalization parameter is set to Spherepack, then
+ * assumes the matrix will multiply a Tensor<DataVector> containing
+ * ${\breve T}^B_{\ell m}$ and the transform operation is
+ * equivalent to Eq. $(\ref{eq:S2CSpherepack})$.
  *
  * We assume that the independent components of the Tensor<DataVector>
  * are stored contiguously in memory, in order of the `storage_index` of
@@ -167,10 +172,12 @@ namespace ylm::TensorYlm {
  *
  * \param matrix The sparse matrix to fill
  * \param ell_max The maximum ylm ell value
+ * \param coefficient_normalization Describes the normalization of coefficients.
  *
  */
 template <typename TensorStructure, typename SparseMatrixType>
 void fill_sphere_to_cart(gsl::not_null<SparseMatrixType*> matrix,
-                         size_t ell_max);
+                         size_t ell_max,
+                         CoefficientNormalization coefficient_normalization);
 
 }  // namespace ylm::TensorYlm

--- a/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/Test_ApplyTensorYlmFilter.hpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/SphericalHarmonics/Test_ApplyTensorYlmFilter.hpp
@@ -18,6 +18,7 @@
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/TensorYlm.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/TensorYlmFilter.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -77,17 +78,22 @@ void test_apply_filter(const size_t num_to_kill) {
   SimpleSparseMatrix filter_matrix_ij;
   SimpleSparseMatrix filter_matrix_kii;
   fill_filter<Scalar<DataVector>::structure>(
-      make_not_null(&filter_matrix_scalar), ell_max, num_to_kill, std::nullopt);
+      make_not_null(&filter_matrix_scalar), ell_max, num_to_kill, std::nullopt,
+      CoefficientNormalization::Spherepack);
   fill_filter<tnsr::i<DataVector, 3>::structure>(
-      make_not_null(&filter_matrix_i), ell_max, num_to_kill, std::nullopt);
+      make_not_null(&filter_matrix_i), ell_max, num_to_kill, std::nullopt,
+      CoefficientNormalization::Spherepack);
   if constexpr (std::is_same_v<
                     VarsList, typename filter_detail::gh_spacetime_vars_list>) {
     fill_filter<tnsr::ii<DataVector, 3>::structure>(
-        make_not_null(&filter_matrix_ii), ell_max, num_to_kill, std::nullopt);
+        make_not_null(&filter_matrix_ii), ell_max, num_to_kill, std::nullopt,
+        CoefficientNormalization::Spherepack);
     fill_filter<tnsr::ij<DataVector, 3>::structure>(
-        make_not_null(&filter_matrix_ij), ell_max, num_to_kill, std::nullopt);
+        make_not_null(&filter_matrix_ij), ell_max, num_to_kill, std::nullopt,
+        CoefficientNormalization::Spherepack);
     fill_filter<tnsr::ijj<DataVector, 3>::structure>(
-        make_not_null(&filter_matrix_kii), ell_max, num_to_kill, std::nullopt);
+        make_not_null(&filter_matrix_kii), ell_max, num_to_kill, std::nullopt,
+        CoefficientNormalization::Spherepack);
   }
 
   // Make up bogus jacobians with random numbers, and make

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmCartToSphere.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmCartToSphere.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Structure.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/TensorYlmCartToSphere.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -39,7 +40,9 @@ std::string symm_to_string() {
 }
 
 template <typename TensorStructure, typename SparseMatrixType>
-void test_tensorylm_cart_to_sphere_vs_spec(const size_t ell_max) {
+void test_tensorylm_cart_to_sphere_vs_spec(
+    const size_t ell_max,
+    const ylm::TensorYlm::CoefficientNormalization coefficient_normalization) {
   // There are two "modes" for this test.  If test_all_elements is
   // true, it tests all the matrix elements vs SpEC, reading .txt
   // files that were output by SpEC. This test was done by Mark
@@ -436,37 +439,82 @@ void test_tensorylm_cart_to_sphere_vs_spec(const size_t ell_max) {
   }
 
   SparseMatrixType matrix;
-  ylm::TensorYlm::fill_cart_to_sphere<TensorStructure>(make_not_null(&matrix),
-                                                       ell_max);
+  ylm::TensorYlm::fill_cart_to_sphere<TensorStructure>(
+      make_not_null(&matrix), ell_max, coefficient_normalization);
+
   CAPTURE(matrix.size());
 
   // Loop over spec_matrix_elements and make sure all the cases agree.
-  for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
-    CAPTURE(spec_dest_indices[i]);
-    CAPTURE(spec_src_indices[i]);
-    CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
-          approx(spec_matrix_elements[i]));
+  if (coefficient_normalization ==
+      ylm::TensorYlm::CoefficientNormalization::Standard) {
+    for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
+      CAPTURE(spec_dest_indices[i]);
+      CAPTURE(spec_src_indices[i]);
+      CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
+            approx(spec_matrix_elements[i]));
+    }
+  } else {
+    CHECK(coefficient_normalization ==
+          ylm::TensorYlm::CoefficientNormalization::Spherepack);
+    // Here the expected coefficients are off by a factor of (-1)^{m+m'),
+    // So we must multiply the matrix elements by this factor.
+    // Most of the logic below is for recovering m and m' from the
+    // SparseMatrix indices.
+    ylm::SpherepackIterator src_iter(ell_max, ell_max, 1, false);
+    ylm::SpherepackIterator dest_iter(ell_max, ell_max, 1, false);
+    for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
+      CAPTURE(spec_dest_indices[i]);
+      CAPTURE(spec_src_indices[i]);
+      // We need to recover the azimuthal index m from the
+      // SparseMatrix indices.
+      //
+      // First compute offsets into arrays.
+      // The SparseMatrices are indexed by
+      // k = iter() + component_index*iter.spherepack_array_size()
+      // where iter is a SpherepackIterator.
+      // The offset is the value returned by iter().
+      const size_t dest_offset =
+          spec_dest_indices[i] % dest_iter.spherepack_array_size();
+      const size_t src_offset =
+          spec_src_indices[i] % src_iter.spherepack_array_size();
+      // Reset the iterators so we can query them for m and m'.
+      src_iter.set(src_iter.compact_index(src_offset).value());
+      dest_iter.set(dest_iter.compact_index(dest_offset).value());
+      // factor is (-1)^{m+m'}
+      const double factor =
+          ((src_iter.m() + dest_iter.m()) % 2 == 0 ? 1.0 : -1.0);
+      CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
+            approx(factor * spec_matrix_elements[i]));
+    }
   }
 }
 }  // namespace
 
 // For debug builds this test sometimes times out if you don't increase
 // the timeout.
-// [[TimeOut, 20]]
+// [[TimeOut, 40]]
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmCartToSphere",
                   "[NumericalAlgorithms][Unit]") {
   const size_t ell_max = 8;
 
-  test_tensorylm_cart_to_sphere_vs_spec<
-      typename tnsr::i<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max);
-  test_tensorylm_cart_to_sphere_vs_spec<
-      typename tnsr::ii<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max);
-  test_tensorylm_cart_to_sphere_vs_spec<
-      typename tnsr::ij<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max);
-  test_tensorylm_cart_to_sphere_vs_spec<
-      typename tnsr::ijj<DataVector, 3>::structure, SimpleSparseMatrix>(
-      ell_max);
-  test_tensorylm_cart_to_sphere_vs_spec<
-      typename tnsr::ijk<DataVector, 3>::structure, SimpleSparseMatrix>(
-      ell_max);
+  for (const auto norm :
+       std::vector<ylm::TensorYlm::CoefficientNormalization>{
+           {ylm::TensorYlm::CoefficientNormalization::Standard,
+            ylm::TensorYlm::CoefficientNormalization::Spherepack}}) {
+    test_tensorylm_cart_to_sphere_vs_spec<
+        typename tnsr::i<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max,
+                                                                        norm);
+    test_tensorylm_cart_to_sphere_vs_spec<
+        typename tnsr::ii<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
+    test_tensorylm_cart_to_sphere_vs_spec<
+        typename tnsr::ij<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
+    test_tensorylm_cart_to_sphere_vs_spec<
+        typename tnsr::ijj<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
+    test_tensorylm_cart_to_sphere_vs_spec<
+        typename tnsr::ijk<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
+  }
 }

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmFilter.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmFilter.cpp
@@ -57,9 +57,10 @@ struct MyTag : db::SimpleTag {
 // Tests that applying the filter matrix is equivalent to doing a
 // cart-to-sphere, then a truncation filter, then a sphere-to-cart.
 template <typename TensorType>
-void test_filter_vs_transforms(const size_t ell_max,
-                               const size_t number_of_ell_modes_to_kill,
-                               const std::optional<size_t> half_power) {
+void test_filter_vs_transforms(
+    const size_t ell_max, const size_t number_of_ell_modes_to_kill,
+    const std::optional<size_t> half_power,
+    const ylm::TensorYlm::CoefficientNormalization coefficient_normalization) {
   ylm::SpherepackIterator it(ell_max, ell_max, 1, false);
   const size_t spectral_size = it.spherepack_array_size();
 
@@ -92,7 +93,7 @@ void test_filter_vs_transforms(const size_t ell_max,
     std::memcpy(B.data(), A.data(), A.size() * sizeof(double));
   } else {
     ylm::TensorYlm::fill_cart_to_sphere<typename TensorType::structure>(
-        make_not_null(&cart_to_sphere), ell_max);
+        make_not_null(&cart_to_sphere), ell_max, coefficient_normalization);
     cart_to_sphere.increment_multiply_on_right(make_not_null(&b_span), 0, 1,
                                                a_span, 0, 1);
   }
@@ -133,7 +134,7 @@ void test_filter_vs_transforms(const size_t ell_max,
     std::memcpy(C.data(), B.data(), B.size() * sizeof(double));
   } else {
     ylm::TensorYlm::fill_sphere_to_cart<typename TensorType::structure>(
-        make_not_null(&sphere_to_cart), ell_max);
+        make_not_null(&sphere_to_cart), ell_max, coefficient_normalization);
     sphere_to_cart.increment_multiply_on_right(make_not_null(&c_span), 0, 1,
                                                b_span, 0, 1);
   }
@@ -146,7 +147,7 @@ void test_filter_vs_transforms(const size_t ell_max,
   SimpleSparseMatrix filter_matrix;
   ylm::TensorYlm::fill_filter<typename TensorType::structure>(
       make_not_null(&filter_matrix), ell_max, number_of_ell_modes_to_kill,
-      half_power);
+      half_power, coefficient_normalization);
   filter_matrix.increment_multiply_on_right(make_not_null(&d_span), 0, 1,
                                             a_span, 0, 1);
 
@@ -168,9 +169,10 @@ void test_filter_vs_transforms(const size_t ell_max,
 }
 
 template <typename TensorStructure, typename SparseMatrixType>
-void test_tensorylm_filter_vs_spec(const size_t ell_max,
-                                   const size_t number_of_ell_modes_to_kill,
-                                   const std::optional<size_t> half_power) {
+void test_tensorylm_filter_vs_spec(
+    const size_t ell_max, const size_t number_of_ell_modes_to_kill,
+    const std::optional<size_t> half_power,
+    const ylm::TensorYlm::CoefficientNormalization coefficient_normalization) {
   // There are two "modes" for this test.  If test_all_elements is
   // true, it tests all the matrix elements vs SpEC, reading .txt
   // files that were output by SpEC. This test was done by Mark
@@ -1158,48 +1160,87 @@ void test_tensorylm_filter_vs_spec(const size_t ell_max,
 
   SparseMatrixType matrix;
   ylm::TensorYlm::fill_filter<TensorStructure>(
-      make_not_null(&matrix), ell_max, number_of_ell_modes_to_kill, half_power);
+      make_not_null(&matrix), ell_max, number_of_ell_modes_to_kill, half_power,
+      coefficient_normalization);
 
-  // Loop over spec_matrix_elements and make sure all the cases agree.
-  for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
-    CAPTURE(spec_dest_indices[i]);
-    CAPTURE(spec_src_indices[i]);
-    CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
-          approx(spec_matrix_elements[i]));
+  // Loop over spec_matrix_elements and make sure all the cases agree
+  if (coefficient_normalization ==
+      ylm::TensorYlm::CoefficientNormalization::Standard) {
+    for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
+      CAPTURE(spec_dest_indices[i]);
+      CAPTURE(spec_src_indices[i]);
+      CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
+            approx(spec_matrix_elements[i]));
+    }
+  } else {
+    CHECK(coefficient_normalization ==
+          ylm::TensorYlm::CoefficientNormalization::Spherepack);
+    // Here the expected coefficients are off by a factor of (-1)^{m+m'),
+    // So we must multiply the matrix elements by this factor.
+    // Most of the logic below is for recovering m and m' from the
+    // SparseMatrix indices.
+    ylm::SpherepackIterator src_iter(ell_max, ell_max, 1, false);
+    ylm::SpherepackIterator dest_iter(ell_max, ell_max, 1, false);
+    for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
+      CAPTURE(spec_dest_indices[i]);
+      CAPTURE(spec_src_indices[i]);
+      // We need to recover the azimuthal index m from the
+      // SparseMatrix indices.
+      //
+      // First compute offsets into arrays.
+      // The SparseMatrices are indexed by
+      // k = iter() + component_index*iter.spherepack_array_size()
+      // where iter is a SpherepackIterator.
+      // The offset is the value returned by iter().
+      const size_t dest_offset =
+          spec_dest_indices[i] % dest_iter.spherepack_array_size();
+      const size_t src_offset =
+          spec_src_indices[i] % src_iter.spherepack_array_size();
+      // Reset the iterators so we can query them for m and m'.
+      src_iter.set(src_iter.compact_index(src_offset).value());
+      dest_iter.set(dest_iter.compact_index(dest_offset).value());
+      // factor is (-1)^{m+m'}
+      const double factor =
+          ((src_iter.m() + dest_iter.m()) % 2 == 0 ? 1.0 : -1.0);
+      CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
+            approx(factor * spec_matrix_elements[i]));
+    }
   }
 }
 
-void test(const std::optional<size_t>& half_power) {
+void test(
+    const std::optional<size_t>& half_power,
+    const ylm::TensorYlm::CoefficientNormalization coefficient_normalization) {
   const size_t ell_max = 8;
   const size_t num_to_kill = 4;
 
   test_tensorylm_filter_vs_spec<typename tnsr::i<DataVector, 3>::structure,
-                                SimpleSparseMatrix>(ell_max, num_to_kill,
-                                                    half_power);
+                                SimpleSparseMatrix>(
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_tensorylm_filter_vs_spec<typename tnsr::ii<DataVector, 3>::structure,
-                                SimpleSparseMatrix>(ell_max, num_to_kill,
-                                                    half_power);
+                                SimpleSparseMatrix>(
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_tensorylm_filter_vs_spec<typename tnsr::ij<DataVector, 3>::structure,
-                                SimpleSparseMatrix>(ell_max, num_to_kill,
-                                                    half_power);
+                                SimpleSparseMatrix>(
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_tensorylm_filter_vs_spec<typename tnsr::ijj<DataVector, 3>::structure,
-                                SimpleSparseMatrix>(ell_max, num_to_kill,
-                                                    half_power);
+                                SimpleSparseMatrix>(
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_tensorylm_filter_vs_spec<typename tnsr::ijk<DataVector, 3>::structure,
-                                SimpleSparseMatrix>(ell_max, num_to_kill,
-                                                    half_power);
+                                SimpleSparseMatrix>(
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_filter_vs_transforms<typename tnsr::i<DataVector, 3>>(
-      ell_max, num_to_kill, half_power);
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_filter_vs_transforms<typename tnsr::ii<DataVector, 3>>(
-      ell_max, num_to_kill, half_power);
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_filter_vs_transforms<typename tnsr::ij<DataVector, 3>>(
-      ell_max, num_to_kill, half_power);
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_filter_vs_transforms<typename tnsr::ijj<DataVector, 3>>(
-      ell_max, num_to_kill, half_power);
+      ell_max, num_to_kill, half_power, coefficient_normalization);
   test_filter_vs_transforms<typename tnsr::ijk<DataVector, 3>>(
-      ell_max, num_to_kill, half_power);
-  test_filter_vs_transforms<Scalar<DataVector>>(ell_max, num_to_kill,
-                                                half_power);
+      ell_max, num_to_kill, half_power, coefficient_normalization);
+  test_filter_vs_transforms<Scalar<DataVector>>(
+      ell_max, num_to_kill, half_power, coefficient_normalization);
 }
 }  // namespace
 
@@ -1208,16 +1249,32 @@ void test(const std::optional<size_t>& half_power) {
 // timeout to 120.  Release builds are still under 10 seconds (barely).  The
 // function test_filter_vs_transforms is much slower than
 // test_tensorylm_filter_vs_spec, so we increase the timeout to 360.
-// Test then split in half to allow running in parallel.
+// Test then split in fourths to allow running in parallel.
 
 // [[TimeOut, 180]]
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmFilter1",
                   "[NumericalAlgorithms][Unit]") {
-  test(std::optional<size_t>());
+  test(std::optional<size_t>(),
+       ylm::TensorYlm::CoefficientNormalization::Standard);
 }
 
 // [[TimeOut, 180]]
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmFilter2",
                   "[NumericalAlgorithms][Unit]") {
-  test(std::optional<size_t>(28));
+  test(std::optional<size_t>(28),
+       ylm::TensorYlm::CoefficientNormalization::Standard);
+}
+
+// [[TimeOut, 180]]
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmFilter3",
+                  "[NumericalAlgorithms][Unit]") {
+  test(std::optional<size_t>(),
+       ylm::TensorYlm::CoefficientNormalization::Spherepack);
+}
+
+// [[TimeOut, 180]]
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmFilter4",
+                  "[NumericalAlgorithms][Unit]") {
+  test(std::optional<size_t>(28),
+       ylm::TensorYlm::CoefficientNormalization::Spherepack);
 }

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmSphereToCart.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmSphereToCart.cpp
@@ -42,7 +42,7 @@ std::string symm_to_string() {
   return "";
 }
 
-template<typename TensorType>
+template <typename TensorType>
 struct MyTag : db::SimpleTag {
   using type = TensorType;
   static std::string name() {
@@ -51,7 +51,9 @@ struct MyTag : db::SimpleTag {
 };
 
 template <typename TensorType>
-void test_inverse(const size_t ell_max) {
+void test_inverse(
+    const size_t ell_max,
+    const ylm::TensorYlm::CoefficientNormalization coefficient_normalization) {
   ylm::SpherepackIterator it(ell_max, ell_max, 1, false);
   const size_t spectral_size = it.spherepack_array_size();
 
@@ -83,7 +85,7 @@ void test_inverse(const size_t ell_max) {
   gsl::span<double> b_span(B.data(), B.size());
   SimpleSparseMatrix cart_to_sphere;
   ylm::TensorYlm::fill_cart_to_sphere<typename TensorType::structure>(
-      make_not_null(&cart_to_sphere), ell_max);
+      make_not_null(&cart_to_sphere), ell_max, coefficient_normalization);
   cart_to_sphere.increment_multiply_on_right(make_not_null(&b_span), 0, 1,
                                              a_span, 0, 1);
 
@@ -91,7 +93,7 @@ void test_inverse(const size_t ell_max) {
   gsl::span<double> c_span(C.data(), C.size());
   SimpleSparseMatrix sphere_to_cart;
   ylm::TensorYlm::fill_sphere_to_cart<typename TensorType::structure>(
-      make_not_null(&sphere_to_cart), ell_max);
+      make_not_null(&sphere_to_cart), ell_max, coefficient_normalization);
   sphere_to_cart.increment_multiply_on_right(make_not_null(&c_span), 0, 1,
                                              b_span, 0, 1);
   // C should equal A.
@@ -105,7 +107,9 @@ void test_inverse(const size_t ell_max) {
 }
 
 template <typename TensorStructure, typename SparseMatrixType>
-void test_tensorylm_sphere_to_cart_vs_spec(const size_t ell_max) {
+void test_tensorylm_sphere_to_cart_vs_spec(
+    const size_t ell_max,
+    const ylm::TensorYlm::CoefficientNormalization coefficient_normalization) {
   // There are two "modes" for this test.  If test_all_elements is
   // true, it tests all the matrix elements vs SpEC, reading .txt
   // files that were output by SpEC. This test was done by Mark
@@ -566,41 +570,85 @@ void test_tensorylm_sphere_to_cart_vs_spec(const size_t ell_max) {
   }
 
   SparseMatrixType matrix;
-  ylm::TensorYlm::fill_sphere_to_cart<TensorStructure>(make_not_null(&matrix),
-                                                       ell_max);
+  ylm::TensorYlm::fill_sphere_to_cart<TensorStructure>(
+      make_not_null(&matrix), ell_max, coefficient_normalization);
   CAPTURE(symm_to_string<TensorStructure>());
 
   // Loop over spec_matrix_elements and make sure all the cases agree.
-  for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
-    CAPTURE(spec_dest_indices[i]);
-    CAPTURE(spec_src_indices[i]);
-    CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
-          approx(spec_matrix_elements[i]));
+  if (coefficient_normalization ==
+      ylm::TensorYlm::CoefficientNormalization::Standard) {
+    for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
+      CAPTURE(spec_dest_indices[i]);
+      CAPTURE(spec_src_indices[i]);
+      CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
+            approx(spec_matrix_elements[i]));
+    }
+  } else {
+    CHECK(coefficient_normalization ==
+          ylm::TensorYlm::CoefficientNormalization::Spherepack);
+    // Here the expected coefficients are off by a factor of (-1)^{m+m'),
+    // So we must multiply the matrix elements by this factor.
+    // Most of the logic below is for recovering m and m' from the
+    // SparseMatrix indices.
+    ylm::SpherepackIterator src_iter(ell_max, ell_max, 1, false);
+    ylm::SpherepackIterator dest_iter(ell_max, ell_max, 1, false);
+    for (size_t i = 0; i < spec_matrix_elements.size(); ++i) {
+      CAPTURE(spec_dest_indices[i]);
+      CAPTURE(spec_src_indices[i]);
+      // We need to recover the azimuthal index m from the
+      // SparseMatrix indices.
+      //
+      // First compute offsets into arrays.
+      // The SparseMatrices are indexed by
+      // k = iter() + component_index*iter.spherepack_array_size()
+      // where iter is a SpherepackIterator.
+      // The offset is the value returned by iter().
+      const size_t dest_offset =
+          spec_dest_indices[i] % dest_iter.spherepack_array_size();
+      const size_t src_offset =
+          spec_src_indices[i] % src_iter.spherepack_array_size();
+      // Reset the iterators so we can query them for m and m'.
+      src_iter.set(src_iter.compact_index(src_offset).value());
+      dest_iter.set(dest_iter.compact_index(dest_offset).value());
+      // factor is (-1)^{m+m'}
+      const double factor =
+          ((src_iter.m() + dest_iter.m()) % 2 == 0 ? 1.0 : -1.0);
+      CHECK(matrix(spec_dest_indices[i], spec_src_indices[i]) ==
+            approx(factor * spec_matrix_elements[i]));
+    }
   }
 }
 }  // namespace
 
-// [[TimeOut, 40]]
+// [[TimeOut, 80]]
 SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmSphereToCart",
                   "[NumericalAlgorithms][Unit]") {
   const size_t ell_max = 8;
 
-  test_tensorylm_sphere_to_cart_vs_spec<
-      typename tnsr::i<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max);
-  test_tensorylm_sphere_to_cart_vs_spec<
-      typename tnsr::ii<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max);
-  test_tensorylm_sphere_to_cart_vs_spec<
-      typename tnsr::ij<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max);
-  test_tensorylm_sphere_to_cart_vs_spec<
-      typename tnsr::ijj<DataVector, 3>::structure, SimpleSparseMatrix>(
-      ell_max);
-  test_tensorylm_sphere_to_cart_vs_spec<
-      typename tnsr::ijk<DataVector, 3>::structure, SimpleSparseMatrix>(
-      ell_max);
+  for (const auto norm :
+       std::vector<ylm::TensorYlm::CoefficientNormalization>{
+           {ylm::TensorYlm::CoefficientNormalization::Standard,
+            ylm::TensorYlm::CoefficientNormalization::Spherepack}}) {
+    test_tensorylm_sphere_to_cart_vs_spec<
+        typename tnsr::i<DataVector, 3>::structure, SimpleSparseMatrix>(ell_max,
+                                                                        norm);
+    test_tensorylm_sphere_to_cart_vs_spec<
+        typename tnsr::ii<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
+    test_tensorylm_sphere_to_cart_vs_spec<
+        typename tnsr::ij<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
+    test_tensorylm_sphere_to_cart_vs_spec<
+        typename tnsr::ijj<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
+    test_tensorylm_sphere_to_cart_vs_spec<
+        typename tnsr::ijk<DataVector, 3>::structure, SimpleSparseMatrix>(
+        ell_max, norm);
 
-  test_inverse<typename tnsr::i<DataVector, 3>>(ell_max);
-  test_inverse<typename tnsr::ii<DataVector, 3>>(ell_max);
-  test_inverse<typename tnsr::ij<DataVector, 3>>(ell_max);
-  test_inverse<typename tnsr::ijj<DataVector, 3>>(ell_max);
-  test_inverse<typename tnsr::ijk<DataVector, 3>>(ell_max);
+    test_inverse<typename tnsr::i<DataVector, 3>>(ell_max, norm);
+    test_inverse<typename tnsr::ii<DataVector, 3>>(ell_max, norm);
+    test_inverse<typename tnsr::ij<DataVector, 3>>(ell_max, norm);
+    test_inverse<typename tnsr::ijj<DataVector, 3>>(ell_max, norm);
+    test_inverse<typename tnsr::ijk<DataVector, 3>>(ell_max, norm);
+  }
 }


### PR DESCRIPTION
Previously all the TensorYlm functions operated on standard spherical harmonic coefficients, which differ from Spherepack coefficients by factors of (-1)^m * const.

## Proposed changes

Adds an enum that specifies what type of coefficients the various TensorYlm functions are expected to operate on.

apply_tensor_ylm_filter now chooses the correct type of coefficients (i.e. spherepack ones).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

Need to pass in the new enum to ylm::TensorYlm::fill* functions.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
