### PR TITLE
Add ParaView connectivity for disks

### DIFF
--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -57,6 +57,7 @@ void append_element_extents_and_connectivity(
     const gsl::not_null<std::vector<size_t>*> total_extents,
     const gsl::not_null<std::vector<int>*> total_connectivity,
     const gsl::not_null<std::vector<int>*> pole_connectivity,
+    const gsl::not_null<std::vector<int>*> disk_connectivity,
     const gsl::not_null<int*> total_points_so_far, const size_t dim,
     const ElementVolumeData& element) {
   // Process the element extents
@@ -115,62 +116,103 @@ void append_element_extents_and_connectivity(
   // If element is 2D and the bases are both SphericalHarmonic,
   // then add extra connections to close the surface.
   if (dim == 2) {
-    if (not(element.basis[0] == Spectral::Basis::SphericalHarmonic and
-            element.basis[1] == Spectral::Basis::SphericalHarmonic)) {
-      return;
+    if (element.basis[0] == Spectral::Basis::SphericalHarmonic and
+        element.basis[1] == Spectral::Basis::SphericalHarmonic) {
+      // Extents are (l+1, 2l+1)
+      const int l = static_cast<int>(element.extents[0] - 1);
+
+      // Connect max(phi) and min(phi) by adding more quads
+      // to total_connectivity
+      for (int j = 0; j < l; ++j) {
+        total_connectivity->push_back(j);
+        total_connectivity->push_back(j + 1);
+        total_connectivity->push_back(2 * l * (l + 1) + j + 1);
+        total_connectivity->push_back((2 * l) * (l + 1) + j);
+      }
+
+      // Add a new connectivity output for filling the poles
+      // First, get the points at min(theta), which define the
+      // boundary of the top pole to fill, and the points at
+      // max(theta), which define the boundary of the bottom
+      // pole to fill. Note: points are stored with theta
+      // varying faster than phi.
+      std::vector<int> top_pole_points{};
+      std::vector<int> bottom_pole_points{};
+      for (int k = 0; k < (2 * l + 1); ++k) {
+        top_pole_points.push_back(k * (l + 1));
+        bottom_pole_points.push_back(k * (l + 1) + l);
+      }
+
+      const size_t number_of_pole_points = top_pole_points.size();
+      if (number_of_pole_points < 3) {
+        ERROR_NO_TRACE(
+            "Cannot write a 2D surface to file with l=0. Must have at least "
+            "l=1.");
+      }
+
+      // Fill poles with triangles in a fan pattern. Choose the root point that
+      // is common with all triangles to be the first point for each pole
+      const int top_root_point = top_pole_points[0];
+      const int bottom_root_point = bottom_pole_points[0];
+
+      // We end such that the last triangle we make has indices (0, N-2, N-1)
+      // given number_of_pole_points = N
+      for (size_t i = 1; i <= number_of_pole_points - 2; i++) {
+        const int top_second_point = gsl::at(top_pole_points, i);
+        const int top_third_point = gsl::at(top_pole_points, i + 1);
+        const int bottom_second_point = gsl::at(bottom_pole_points, i);
+        const int bottom_third_point = gsl::at(bottom_pole_points, i + 1);
+
+        pole_connectivity->push_back(top_root_point);
+        pole_connectivity->push_back(top_second_point);
+        pole_connectivity->push_back(top_third_point);
+        pole_connectivity->push_back(bottom_root_point);
+        pole_connectivity->push_back(bottom_second_point);
+        pole_connectivity->push_back(bottom_third_point);
+      }
+    } else if (element.basis[0] == Spectral::Basis::ZernikeB2 and
+               element.basis[1] == Spectral::Basis::ZernikeB2) {
+      const auto n_r = static_cast<int>(element.extents[0]);
+      const auto n_ph = static_cast<int>(element.extents[1]);
+
+      // Connect max(phi) and min(phi) by adding more quads
+      // to total_connectivity
+      for (int j = 0; j < n_r - 1; ++j) {
+        total_connectivity->push_back(j);
+        total_connectivity->push_back(j + 1);
+        total_connectivity->push_back((n_ph - 1) * n_r + j + 1);
+        total_connectivity->push_back((n_ph - 1) * n_r + j);
+      }
+
+      std::vector<int> inner_ring_points{};
+      inner_ring_points.reserve(static_cast<size_t>(n_ph));
+      for (int k = 0; k < n_ph; ++k) {
+        inner_ring_points.push_back(k * n_r);  // r = 0 for each phi slice
+      }
+
+      std::vector<int> new_points;
+      while (inner_ring_points.size() >= 3) {
+        new_points.clear();
+        new_points.push_back(inner_ring_points[0]);
+        for (size_t i = 0; i < inner_ring_points.size() - 2; i += 2) {
+          disk_connectivity->push_back(inner_ring_points[i]);
+          disk_connectivity->push_back(inner_ring_points[i + 1]);
+          disk_connectivity->push_back(inner_ring_points[i + 2]);
+          new_points.push_back(inner_ring_points[i + 2]);
+        }
+        if (inner_ring_points.size() % 2 == 0) {
+          // Add triangle closing the ring: connects last two points back to
+          // first
+          disk_connectivity->push_back(
+              inner_ring_points[inner_ring_points.size() - 2]);
+          disk_connectivity->push_back(
+              inner_ring_points[inner_ring_points.size() - 1]);
+          disk_connectivity->push_back(inner_ring_points[0]);
+        }
+        inner_ring_points = std::move(new_points);
+      }
     }
-    // Extents are (l+1, 2l+1)
-    const int l = static_cast<int>(element.extents[0] - 1);
-
-    // Connect max(phi) and min(phi) by adding more quads
-    // to total_connectivity
-    for (int j = 0; j < l; ++j) {
-      total_connectivity->push_back(j);
-      total_connectivity->push_back(j + 1);
-      total_connectivity->push_back(2 * l * (l + 1) + j + 1);
-      total_connectivity->push_back((2 * l) * (l + 1) + j);
-    }
-
-    // Add a new connectivity output for filling the poles
-    // First, get the points at min(theta), which define the
-    // boundary of the top pole to fill, and the points at
-    // max(theta), which define the boundary of the bottom
-    // pole to fill. Note: points are stored with theta
-    // varying faster than phi.
-    std::vector<int> top_pole_points{};
-    std::vector<int> bottom_pole_points{};
-    for (int k = 0; k < (2 * l + 1); ++k) {
-      top_pole_points.push_back(k * (l + 1));
-      bottom_pole_points.push_back(k * (l + 1) + l);
-    }
-
-    const size_t number_of_pole_points = top_pole_points.size();
-    if (number_of_pole_points < 3) {
-      ERROR_NO_TRACE(
-          "Cannot write a 2D surface to file with l=0. Must have at least "
-          "l=1.");
-    }
-
-    // Fill poles with triangles in a fan pattern. Choose the root point that is
-    // common with all triangles to be the first point for each pole
-    const int top_root_point = top_pole_points[0];
-    const int bottom_root_point = bottom_pole_points[0];
-
-    // We end such that the last triangle we make has indices (0, N-2, N-1)
-    // given number_of_pole_points = N
-    for (size_t i = 1; i <= number_of_pole_points - 2; i++) {
-      int top_second_point = gsl::at(top_pole_points, i);
-      int top_third_point = gsl::at(top_pole_points, i + 1);
-      int bottom_second_point = gsl::at(bottom_pole_points, i);
-      int bottom_third_point = gsl::at(bottom_pole_points, i + 1);
-
-      pole_connectivity->push_back(top_root_point);
-      pole_connectivity->push_back(top_second_point);
-      pole_connectivity->push_back(top_third_point);
-      pole_connectivity->push_back(bottom_root_point);
-      pole_connectivity->push_back(bottom_second_point);
-      pole_connectivity->push_back(bottom_third_point);
-    }
+    // generically do nothing if not a sphere or disk
   }
 }
 }  // namespace
@@ -272,6 +314,7 @@ void VolumeData::write_volume_data(
   std::string grid_names;
   std::vector<int> total_connectivity;
   std::vector<int> pole_connectivity{};
+  std::vector<int> disk_connectivity{};
   std::vector<int> quadratures;
   std::vector<int> bases;
   // Keep a running count of the number of points so far to use as a global
@@ -292,7 +335,7 @@ void VolumeData::write_volume_data(
     const auto fill_and_write_contiguous_tensor_data =
         [&bases, &component_name, &dim, &elements, &grid_names, i,
          &observation_group, &quadratures, &total_connectivity,
-         &pole_connectivity, &total_extents,
+         &pole_connectivity, &disk_connectivity, &total_extents,
          &total_points_so_far](const auto contiguous_tensor_data_ptr) {
           for (const auto& element : elements) {
             if (UNLIKELY(i == 0)) {
@@ -327,7 +370,7 @@ void VolumeData::write_volume_data(
 
               append_element_extents_and_connectivity(
                   &total_extents, &total_connectivity, &pole_connectivity,
-                  &total_points_so_far, dim, element);
+                  &disk_connectivity, &total_points_so_far, dim, element);
             }
             using type_from_variant = tmpl::conditional_t<
                 std::is_same_v<
@@ -406,6 +449,10 @@ void VolumeData::write_volume_data(
   if (not pole_connectivity.empty()) {
     h5::write_data(observation_group.id(), pole_connectivity,
                    {pole_connectivity.size()}, "pole_connectivity");
+  }
+  if (not disk_connectivity.empty()) {
+    h5::write_data(observation_group.id(), disk_connectivity,
+                   {disk_connectivity.size()}, "disk_connectivity");
   }
   // Store the serialized domain and functions of time at the subfile level
   if (serialized_domain.has_value() and
@@ -576,9 +623,15 @@ std::vector<std::string> VolumeData::list_tensor_components(
                       "ObservationId" + std::to_string(observation_id));
   // Remove names that are not tensor components
   const std::unordered_set<std::string> non_tensor_components{
-      "connectivity", "pole_connectivity", "total_extents",
-      "grid_names",   "quadratures",       "bases",
-      "domain",       "functions_of_time"};
+      "connectivity",
+      "pole_connectivity",
+      "disk_connectivity",
+      "total_extents",
+      "grid_names",
+      "quadratures",
+      "bases",
+      "domain",
+      "functions_of_time"};
   tensor_components.erase(
       alg::remove_if(tensor_components,
                      [&non_tensor_components](const std::string& name) {

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -31,6 +31,8 @@ def _list_tensor_components(observation):
     components.remove("connectivity")
     if "pole_connectivity" in components:
         components.remove("pole_connectivity")
+    if "disk_connectivity" in components:
+        components.remove("disk_connectivity")
     if "tetrahedral_connectivity" in components:
         components.remove("tetrahedral_connectivity")
     components.remove("total_extents")
@@ -164,6 +166,7 @@ def _xmf_grid(
     temporal_id: str,
     coordinates: str,
     filling_poles: bool = False,
+    filling_disk_center: bool = False,
     use_tetrahedral_connectivity: bool = False,
 ) -> ET.Element:
     # Make sure the coordinates are found in the file. We assume there should
@@ -221,20 +224,27 @@ def _xmf_grid(
                 grid_path=grid_path,
             )
     else:
-        # Cover volume
-        if use_tetrahedral_connectivity:
-            topology_type = {3: "Tetrahedron", 2: "Triangle"}[topo_dim]
-            connectivity_name = "tetrahedral_connectivity"
+        if filling_disk_center:
+            xmf_topology = _xmf_topology(
+                observation,
+                topology_type="Triangle",
+                connectivity_name="disk_connectivity",
+                grid_path=grid_path,
+            )
         else:
-            topology_type = {3: "Hexahedron", 2: "Quadrilateral"}[topo_dim]
-            connectivity_name = "connectivity"
-
-        xmf_topology = _xmf_topology(
-            observation,
-            topology_type=topology_type,
-            connectivity_name=connectivity_name,
-            grid_path=grid_path,
-        )
+            # Cover volume
+            if use_tetrahedral_connectivity:
+                topology_type = {3: "Tetrahedron", 2: "Triangle"}[topo_dim]
+                connectivity_name = "tetrahedral_connectivity"
+            else:
+                topology_type = {3: "Hexahedron", 2: "Quadrilateral"}[topo_dim]
+                connectivity_name = "connectivity"
+            xmf_topology = _xmf_topology(
+                observation,
+                topology_type=topology_type,
+                connectivity_name=connectivity_name,
+                grid_path=grid_path,
+            )
     xmf_grid.append(xmf_topology)
 
     # Write geometry
@@ -479,6 +489,22 @@ def generate_xdmf(
                         temporal_id=temporal_id,
                         coordinates=coordinates,
                         filling_poles=True,
+                        use_tetrahedral_connectivity=(
+                            use_tetrahedral_connectivity
+                        ),
+                    )
+                )
+            # Fill disk center if disk_connectivity is present
+            if "disk_connectivity" in observation:
+                xmf_timestep_grid.append(
+                    _xmf_grid(
+                        observation,
+                        topo_dim=topo_dim,
+                        filename=filename_in_output,
+                        subfile_name=subfile_name,
+                        temporal_id=temporal_id,
+                        coordinates=coordinates,
+                        filling_disk_center=True,
                         use_tetrahedral_connectivity=(
                             use_tetrahedral_connectivity
                         ),

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -694,6 +694,101 @@ void test_extend_connectivity_data() {
   }
 }
 
+void test_disk() {
+  // The disk has some extra connectivity: one being to close the angular
+  // edges, the other to fill in the inner circle
+  const std::string h5_file_name("Unit.IO.H5.VolumeData.Disk.h5");
+  const uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+  const std::string grid_name{"Disk"};
+  const std::vector<size_t> observation_ids{12354};
+  const std::vector<double> observation_values{1.1};
+  const std::vector<Spectral::Basis> bases{2, Spectral::Basis::ZernikeB2};
+  const std::vector<Spectral::Quadrature> quadratures{
+      {Spectral::Quadrature::GaussRadauUpper,
+       Spectral::Quadrature::Equiangular}};
+  const std::vector<size_t> extents{2, 7};
+
+  // Not using values, just checking connectivity
+  const std::vector<DataVector> tensor_and_coord_data{
+      {14, 0.0}, {14, 0.0}, {14, 0.0}};
+  const std::vector<TensorComponent> tensor_components{
+      {"InertialCoordinates_x", tensor_and_coord_data[0]},
+      {"InertialCoordinates_y", tensor_and_coord_data[1]},
+      {"TestScalar", tensor_and_coord_data[2]}};
+
+  {
+    h5::H5File<h5::AccessType::ReadWrite> disk_file{h5_file_name};
+    auto& volume_file =
+        disk_file.insert<h5::VolumeData>("/element_data", version_number);
+    volume_file.write_volume_data(
+        observation_ids[0], observation_values[0],
+        std::vector<ElementVolumeData>{
+            {grid_name, tensor_components, extents, bases, quadratures}});
+    disk_file.close_current_object();
+
+    // Open the read volume file and check that the observation id and values
+    // are correct.
+    const auto& volume_file_read =
+        disk_file.get<h5::VolumeData>("/element_data", version_number);
+    const auto read_observation_ids = volume_file_read.list_observation_ids();
+    CHECK(read_observation_ids == std::vector<size_t>{12354});
+    CHECK(volume_file_read.get_observation_value(observation_ids[0]) ==
+          observation_values[0]);
+  }
+
+  // Check pole connectivity
+  DataVector connectivity_data{};
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> disk_file{h5_file_name};
+    const auto& volume_file =
+        disk_file.get<h5::VolumeData>("/element_data", version_number);
+    const auto h5_connectivity =
+        volume_file.get_tensor_component(12354, "disk_connectivity").data;
+    connectivity_data = get<0>(h5_connectivity);
+    disk_file.close_current_object();
+  }
+  // clang-format off
+  DataVector expected_connectivity = {{
+      0.,  2.,  4.,
+      4.,  6.,  8.,
+      8., 10., 12.,
+      0.,  4.,  8.,
+      8., 12.,  0.}};
+  // clang-format on
+
+  CHECK(connectivity_data == expected_connectivity);
+
+  // Check angular-side connectivity
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> disk_file{h5_file_name};
+    const auto& volume_file =
+        disk_file.get<h5::VolumeData>("/element_data", version_number);
+    const auto h5_connectivity =
+        volume_file.get_tensor_component(12354, "connectivity").data;
+    connectivity_data = get<0>(h5_connectivity);
+    disk_file.close_current_object();
+  }
+  // clang-format off
+  expected_connectivity = DataVector{
+     0.,  1.,  3.,  2.,
+     2.,  3.,  5.,  4.,
+     4.,  5.,  7.,  6.,
+     6.,  7.,  9.,  8.,
+     8.,  9., 11., 10.,
+    10., 11., 13., 12.,
+     0.,  1., 13., 12.};
+  // clang-format on
+
+  CHECK(connectivity_data == expected_connectivity);
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}
+
 void test_cartoon() {
   // For a 2D computational domain Cartoon-basis evolution, we only want to
   // write 2D data despite the simulation being 3D. This tests the appropriate
@@ -869,6 +964,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   test<std::vector<float>>();
   test_cartoon();
   test_strahlkorper();
+  test_disk();
   test_extend_connectivity_data<1>();
   test_extend_connectivity_data<2>();
   test_extend_connectivity_data<3>();


### PR DESCRIPTION
## Proposed changes

For 2D filled disks (Zernike radially and Fourier angularly), Paraview needs extra connectivity:
 1. Close the angular edges (so it doesn't look like pac-man)
 2. Fill in the $r < r_\mathrm{smallest\ collocation\ point}$ region. The method used is what SpEC uses: it fills in with the smallest possible triangles around the edges of the circle, resulting in one or two big triangles to take up most of the space (This does have visual artifacts but its not terrible).

Example image
<img width="200" height="203" alt="image" src="https://github.com/user-attachments/assets/e15be4f5-3dcc-483f-8f9d-06409b71bab9" />


<!--
At a high level, describe what this PR does.
-→

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-→
<!-- UPGRADE INSTRUCTIONS -→

<!-- UPGRADE INSTRUCTIONS -→

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-→
