### PR TITLE
Add Zernike GaussRadau weights to `lift_flux`

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -36,6 +37,9 @@ namespace dg {
 /// diagonalization of the mass matrix and its implications,
 /// \cite Teukolsky2015ega, especially Section 3.
 ///
+/// This function is implemented to handle Legendre, Chebyshev, and Zernike
+/// bases.
+///
 /// \note The result is still provided only on the boundary grid.  The
 /// values away from the boundary are zero and are not stored.
 template <typename... BoundaryCorrectionTags>
@@ -43,33 +47,81 @@ void lift_flux(
     const gsl::not_null<Variables<tmpl::list<BoundaryCorrectionTags...>>*>
         boundary_correction_terms,
     const size_t extent_perpendicular_to_boundary,
-    const Scalar<DataVector>& magnitude_of_face_normal) {
-  // For an Nth degree basis (i.e., one with N+1 basis functions), the LGL
-  // weights are:
-  //   w_i = 2 / ((N + 1) * N * (P_{N}(xi_i))^2)
-  // and so at the end points (xi = +/- 1) we get:
-  //   w_0 = 2 / ((N + 1) * N)
-  //   w_N = 2 / ((N + 1) * N)
-  // The negative sign comes from bringing the boundary correction over to the
-  // RHS of the equal sign (e.g. `du/dt=Source - div Flux - boundary corr`),
-  // while the magnitude of the normal vector above accounts for the ratios of
-  // spatial metrics and Jacobians.
-  *boundary_correction_terms *=
-      -0.5 *
-      static_cast<double>((extent_perpendicular_to_boundary *
-                           (extent_perpendicular_to_boundary - 1))) *
-      get(magnitude_of_face_normal);
+    const Scalar<DataVector>& magnitude_of_face_normal,
+    const Spectral::Basis basis = Spectral::Basis::Legendre) {
+  if (basis == Spectral::Basis::Legendre) {
+    // For an Nth degree basis (i.e., one with N+1 basis functions), the LGL
+    // weights are:
+    //   w_i = 2 / ((N + 1) * N * (P_{N}(xi_i))^2)
+    // and so at the end points (xi = +/- 1) we get:
+    //   w_0 = 2 / ((N + 1) * N)
+    //   w_N = 2 / ((N + 1) * N)
+    // The negative sign comes from bringing the boundary correction over to the
+    // RHS of the equal sign (e.g. `du/dt=Source - div Flux - boundary corr`),
+    // while the magnitude of the normal vector above accounts for the ratios of
+    // spatial metrics and Jacobians.
+    *boundary_correction_terms *=
+        -0.5 *
+        static_cast<double>((extent_perpendicular_to_boundary *
+                             (extent_perpendicular_to_boundary - 1))) *
+        get(magnitude_of_face_normal);
+  } else if (basis == Spectral::Basis::Chebyshev) {
+    // Chebyshev with GaussLobotto, with N grid points, has the weight at
+    // the upper and lower sides
+    // w_0 = 1 / ((N - 1)^2 - a)
+    // w_N = 1 / ((N - 1)^2 - a)
+    // where a = 0 if N is even, else it is 1
+    // The negative sign follows from the Legendre discussion
+    *boundary_correction_terms *=
+        -static_cast<double>((extent_perpendicular_to_boundary - 1) *
+                                 (extent_perpendicular_to_boundary - 1) -
+                             extent_perpendicular_to_boundary % 2) *
+        get(magnitude_of_face_normal);
+  } else if (basis == Spectral::Basis::ZernikeB1) {
+    // ZernikeB1 with GaussRadauUpper, with N grid points, has the weight at
+    // the upper side
+    // w_N = 1 / (N * (2 * N - 1))
+    // The negative sign follows from the Legendre discussion
+    *boundary_correction_terms *=
+        -1.0 *
+        static_cast<double>((extent_perpendicular_to_boundary *
+                             (2 * extent_perpendicular_to_boundary - 1))) *
+        get(magnitude_of_face_normal);
+  } else if (basis == Spectral::Basis::ZernikeB2) {
+    // ZernikeB2 with GaussRadauUpper, with N grid points, has the weight at
+    // the upper side
+    // w_N = 1 / (2 * N^2)
+    // The negative sign follows from the Legendre discussion
+    *boundary_correction_terms *=
+        -1.0 *
+        static_cast<double>((2 * extent_perpendicular_to_boundary *
+                             extent_perpendicular_to_boundary)) *
+        get(magnitude_of_face_normal);
+  } else if (basis == Spectral::Basis::ZernikeB3) {
+    // ZernikeB3 with GaussRadauUpper, with N grid points, has the weight at
+    // the upper side
+    // w_N = 1 / (N * (2 * N + 1))
+    // The negative sign follows from the Legendre discussion
+    *boundary_correction_terms *=
+        -1.0 *
+        static_cast<double>((extent_perpendicular_to_boundary *
+                             (2 * extent_perpendicular_to_boundary + 1))) *
+        get(magnitude_of_face_normal);
+  } else {
+    ERROR("Got unexpected basis " << basis);
+  }
 }
 
 template <typename... FluxTags>
 auto lift_flux(Variables<tmpl::list<FluxTags...>> flux,
                const size_t extent_perpendicular_to_boundary,
-               const Scalar<DataVector>& magnitude_of_face_normal)
+               const Scalar<DataVector>& magnitude_of_face_normal,
+               const Spectral::Basis basis = Spectral::Basis::Legendre)
     -> Variables<tmpl::list<db::remove_tag_prefix<FluxTags>...>> {
   Variables<tmpl::list<db::remove_tag_prefix<FluxTags>...>> lifted_data(
       std::move(flux));
   lift_flux(make_not_null(&lifted_data), extent_perpendicular_to_boundary,
-            magnitude_of_face_normal);
+            magnitude_of_face_normal, basis);
   return lifted_data;
 }
 /// @}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -37,32 +38,86 @@ struct Var : db::SimpleTag {
 
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
                   "[Unit][NumericalAlgorithms]") {
-  const Mesh<2> mesh{
-      {{3, 5}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
+  {
+    INFO("Testing with I1");
+    for (const auto& basis :
+         {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+      CAPTURE(basis);
 
-  using Affine = domain::CoordinateMaps::Affine;
-  const Affine xi_map(-1., 1., -5., 7.);
-  const Affine eta_map(-1., 1., 2., 5.);
-  const auto coordinate_map =
-      domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
-          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
-                                                                 eta_map));
-  const double element_length = (eta_map(std::array<double, 1>{{1.}}) -
-                                 eta_map(std::array<double, 1>{{-1.}}))[0];
+      const Mesh<2> mesh{{{3, 5}}, basis, Spectral::Quadrature::GaussLobatto};
 
-  const double weight = Spectral::quadrature_weights(mesh.slice_through(1))[0];
-  const auto boundary_mesh = mesh.slice_through(0);
+      using Affine = domain::CoordinateMaps::Affine;
+      const Affine xi_map(-1., 1., -5., 7.);
+      const Affine eta_map(-1., 1., 2., 5.);
+      const auto coordinate_map =
+          domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+              domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
+                                                                     eta_map));
+      const double element_length = (eta_map(std::array<double, 1>{{1.}}) -
+                                     eta_map(std::array<double, 1>{{-1.}}))[0];
 
-  const auto magnitude_of_face_normal = magnitude(unnormalized_face_normal(
-      boundary_mesh, coordinate_map, Direction<2>::lower_eta()));
+      const double weight =
+          Spectral::quadrature_weights(mesh.slice_through(1))[0];
+      const auto boundary_mesh = mesh.slice_through(0);
 
-  Variables<tmpl::list<Tags::NormalDotNumericalFlux<Var>>> flux(
-      boundary_mesh.number_of_grid_points());
-  get(get<Tags::NormalDotNumericalFlux<Var>>(flux)) = DataVector({2., 3., 5.});
+      const auto magnitude_of_face_normal = magnitude(unnormalized_face_normal(
+          boundary_mesh, coordinate_map, Direction<2>::lower_eta()));
 
-  const Variables<tmpl::list<Var>> expected =
-      -2. / (element_length * weight) * flux;
+      Variables<tmpl::list<Tags::NormalDotNumericalFlux<Var>>> flux(
+          boundary_mesh.number_of_grid_points());
+      get(get<Tags::NormalDotNumericalFlux<Var>>(flux)) =
+          DataVector({2., 3., 5.});
 
-  CHECK(dg::lift_flux(flux, mesh.extents(1), magnitude_of_face_normal) ==
-        expected);
+      const Variables<tmpl::list<Var>> expected =
+          -2. / (element_length * weight) * flux;
+
+      CAPTURE(dg::lift_flux(flux, mesh.extents(1), magnitude_of_face_normal,
+                            mesh.basis(1)));
+      CAPTURE(expected);
+      CHECK_VARIABLES_APPROX(
+          dg::lift_flux(flux, mesh.extents(1), magnitude_of_face_normal, basis),
+          expected);
+    }
+  }
+  {
+    INFO("Testing with Zernike");
+    for (const auto& basis :
+         {Spectral::Basis::ZernikeB1, Spectral::Basis::ZernikeB2,
+          Spectral::Basis::ZernikeB3}) {
+      CAPTURE(basis);
+      const Mesh<2> mesh{{3, 5},
+                         {basis, Spectral::Basis::Legendre},
+                         {Spectral::Quadrature::GaussRadauUpper,
+                          Spectral::Quadrature::GaussLobatto}};
+
+      using Affine = domain::CoordinateMaps::Affine;
+      const Affine xi_map(-1., 1., 0, 7.);
+      const Affine eta_map(-1., 1., 2., 5.);
+      const auto coordinate_map =
+          domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+              domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
+                                                                     eta_map));
+      const double element_length = (xi_map(std::array<double, 1>{{1.}}) -
+                                     xi_map(std::array<double, 1>{{-1.}}))[0];
+
+      const double weight =
+          Spectral::quadrature_weights(mesh.slice_through(0))[2];
+      const auto boundary_mesh = mesh.slice_through(1);
+
+      const auto magnitude_of_face_normal = magnitude(unnormalized_face_normal(
+          boundary_mesh, coordinate_map, Direction<2>::upper_xi()));
+
+      Variables<tmpl::list<Tags::NormalDotNumericalFlux<Var>>> flux(
+          boundary_mesh.number_of_grid_points());
+      get(get<Tags::NormalDotNumericalFlux<Var>>(flux)) =
+          DataVector({2., 3., 5., 8., 6.});
+
+      const Variables<tmpl::list<Var>> expected =
+          -2. / (element_length * weight) * flux;
+
+      CHECK_VARIABLES_APPROX(
+          dg::lift_flux(flux, mesh.extents(0), magnitude_of_face_normal, basis),
+          expected);
+    }
+  }
 }


### PR DESCRIPTION
## Proposed changes

When a Zernike basis with GaussRadauUpper collocation is used, we have a collocation point at $\xi = 1$ and therefore want to just lift the flux. This generalizes the `lift_flux()` function from just Legendre to also include Zernike (the call in `ApplyBoundaryCorrections.hpp` will need to be updated).

Depends on #7096

As a note, #7096 further tests these weights are correct.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
