### PR TITLE
Make python test char speed calculation calls consistent

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DemandOutgoingCharSpeeds.py
@@ -1,16 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+import Evolution.Systems.GeneralizedHarmonic.TestFunctions as ght
 import numpy as np
 
 
 def characteristic_speeds(gamma_1, lapse, shift, unit_normal_one_form):
-    shift_dot_normal = np.dot(shift, unit_normal_one_form)
     return [
-        -(1.0 + gamma_1) * shift_dot_normal,
-        -shift_dot_normal,
-        -shift_dot_normal + lapse,
-        -shift_dot_normal - lapse,
+        ght.char_speed_upsi(gamma_1, lapse, shift, unit_normal_one_form),
+        ght.char_speed_uzero(gamma_1, lapse, shift, unit_normal_one_form),
+        ght.char_speed_uplus(gamma_1, lapse, shift, unit_normal_one_form),
+        ght.char_speed_uminus(gamma_1, lapse, shift, unit_normal_one_form),
     ]
 
 
@@ -22,19 +22,54 @@ def error(
     lapse,
     shift,
 ):
-    speeds = characteristic_speeds(
-        gamma_1, lapse, shift, outward_directed_normal_covector
-    )
+    if face_mesh_velocity is not None:
+        char_speeds = [
+            ght.char_speed_upsi_moving_mesh(
+                gamma_1,
+                lapse,
+                shift,
+                outward_directed_normal_covector,
+                face_mesh_velocity,
+            ),
+            ght.char_speed_uzero_moving_mesh(
+                gamma_1,
+                lapse,
+                shift,
+                outward_directed_normal_covector,
+                face_mesh_velocity,
+            ),
+            ght.char_speed_uplus_moving_mesh(
+                gamma_1,
+                lapse,
+                shift,
+                outward_directed_normal_covector,
+                face_mesh_velocity,
+            ),
+            ght.char_speed_uminus_moving_mesh(
+                gamma_1,
+                lapse,
+                shift,
+                outward_directed_normal_covector,
+                face_mesh_velocity,
+            ),
+        ]
+    else:
+        char_speeds = [
+            ght.char_speed_upsi(
+                gamma_1, lapse, shift, outward_directed_normal_covector
+            ),
+            ght.char_speed_uzero(
+                gamma_1, lapse, shift, outward_directed_normal_covector
+            ),
+            ght.char_speed_uplus(
+                gamma_1, lapse, shift, outward_directed_normal_covector
+            ),
+            ght.char_speed_uminus(
+                gamma_1, lapse, shift, outward_directed_normal_covector
+            ),
+        ]
     for i in range(4):
-        if face_mesh_velocity is not None:
-            speeds[i] -= np.dot(
-                outward_directed_normal_covector, face_mesh_velocity
-            )
-            speeds[0] -= (
-                np.dot(outward_directed_normal_covector, face_mesh_velocity)
-                * gamma_1
-            )
-        if speeds[i] < 0.0:
+        if char_speeds[i] < 0.0:
             return "DemandOutgoingCharSpeeds boundary condition violated"
     return None
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DemandOutgoingCharSpeeds.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DemandOutgoingCharSpeeds.cpp
@@ -31,7 +31,9 @@ void test() {
       gh::BoundaryConditions::DemandOutgoingCharSpeeds<Dim>,
       gh::BoundaryConditions::BoundaryCondition<Dim>, gh::System<Dim>,
       tmpl::list<gh::BoundaryCorrections::UpwindPenalty<Dim>>>(
-      make_not_null(&gen), "DemandOutgoingCharSpeeds",
+      make_not_null(&gen),
+      "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions."
+      "DemandOutgoingCharSpeeds",
       tuples::TaggedTuple<helpers::Tags::PythonFunctionForErrorMessage<>>{
           "error"},
       "DemandOutgoingCharSpeeds:\n", Index<Dim - 1>{Dim == 1 ? 0 : 5},
@@ -43,8 +45,7 @@ void test() {
 SPECTRE_TEST_CASE(
     "Unit.GeneralizedHarmonic.BoundaryConditions.DemandOutgoingCharSpeeds",
     "[Unit][Evolution]") {
-  pypp::SetupLocalPythonEnvironment local_python_env{
-      "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/"};
+  const pypp::SetupLocalPythonEnvironment local_python_env{""};
   test<1>();
   test<2>();
   test<3>();


### PR DESCRIPTION
## Proposed changes

Reducing the number of places this result is calculated

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
