### PR TITLE
Add distributions and singularity positions to rectilinear domains

### DIFF
--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -34,6 +34,9 @@ std::ostream& operator<<(std::ostream& /*s*/,
 template <size_t Dim>
 AlignedLattice<Dim>::AlignedLattice(
     std::array<std::vector<double>, Dim> block_bounds,
+    std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+        distributions,
+    std::array<std::vector<double>, Dim> singularity_positions,
     std::array<size_t, Dim> initial_refinement_levels,
     std::array<size_t, Dim> initial_number_of_grid_points,
     std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -41,6 +44,7 @@ AlignedLattice<Dim>::AlignedLattice(
     std::vector<std::array<size_t, Dim>> blocks_to_exclude,
     std::array<bool, Dim> is_periodic_in, const Options::Context& context)
     : block_bounds_(std::move(block_bounds)),
+      distributions_(std::move(distributions)),
       is_periodic_in_(is_periodic_in),
       initial_refinement_levels_(initial_refinement_levels),
       initial_number_of_grid_points_(initial_number_of_grid_points),
@@ -50,6 +54,18 @@ AlignedLattice<Dim>::AlignedLattice(
       number_of_blocks_by_dim_{map_array(
           block_bounds_,
           [](const std::vector<double>& v) { return v.size() - 1; })} {
+  for (size_t d = 0; d < Dim; ++d) {
+    if (gsl::at(singularity_positions, d).empty()) {
+      gsl::at(singularity_positions_, d) = {};
+      continue;
+    }
+    std::vector<std::optional<double>> singularity_positions_in_dim;
+    for (const double position : gsl::at(singularity_positions, d)) {
+      singularity_positions_in_dim.emplace_back(position);
+    }
+    gsl::at(singularity_positions_, d) =
+        std::move(singularity_positions_in_dim);
+  }
   if (not blocks_to_exclude_.empty() and
       alg::any_of(is_periodic_in_, [](const bool t) { return t; })) {
     PARSE_ERROR(context,
@@ -81,6 +97,9 @@ AlignedLattice<Dim>::AlignedLattice(
 template <size_t Dim>
 AlignedLattice<Dim>::AlignedLattice(
     std::array<std::vector<double>, Dim> block_bounds,
+    std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+        distributions,
+    std::array<std::vector<double>, Dim> singularity_positions,
     std::array<size_t, Dim> initial_refinement_levels,
     std::array<size_t, Dim> initial_number_of_grid_points,
     std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -93,7 +112,8 @@ AlignedLattice<Dim>::AlignedLattice(
         boundary_conditions,
     const Options::Context& context)
     : AlignedLattice(
-          std::move(block_bounds), initial_refinement_levels,
+          std::move(block_bounds), std::move(distributions),
+          std::move(singularity_positions), initial_refinement_levels,
           initial_number_of_grid_points, std::move(refined_refinement),
           std::move(refined_grid_points), std::move(blocks_to_exclude),
           make_array<Dim>(false), context) {
@@ -154,7 +174,7 @@ Domain<Dim> AlignedLattice<Dim>::create_domain() const {
       number_of_blocks_by_dim_, block_bounds_,
       {std::vector<Index<Dim>>(blocks_to_exclude_.begin(),
                                blocks_to_exclude_.end())},
-      {}, is_periodic_in_, {}, false);
+      {}, is_periodic_in_, {}, distributions_, singularity_positions_);
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -115,6 +115,26 @@ class AlignedLattice : public DomainCreator<Dim> {
         "Coordinates of block boundaries in each dimension."};
   };
 
+  struct Distributions {
+    using type =
+        std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>;
+    static constexpr Options::String help = {
+        "Grid point distribution in each dimension."};
+    static type default_value() {
+      return make_array<Dim>(
+          std::vector<domain::CoordinateMaps::Distribution>{});
+    }
+  };
+
+  struct SingularityPositions {
+    using type = std::array<std::vector<double>, Dim>;
+    static constexpr Options::String help = {
+        "Singularity positions in each dimension."};
+    static type default_value() {
+      return make_array<Dim>(std::vector<double>{});
+    }
+  };
+
   struct IsPeriodicIn {
     using type = std::array<bool, Dim>;
     static constexpr Options::String help = {
@@ -153,8 +173,8 @@ class AlignedLattice : public DomainCreator<Dim> {
 
   template <typename Metavariables>
   using options = tmpl::list<
-      BlockBounds, InitialLevels, InitialGridPoints, RefinedLevels,
-      RefinedGridPoints, BlocksToExclude,
+      BlockBounds, Distributions, SingularityPositions, InitialLevels,
+      InitialGridPoints, RefinedLevels, RefinedGridPoints, BlocksToExclude,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -175,17 +195,24 @@ class AlignedLattice : public DomainCreator<Dim> {
       "will trigger an error, as periodic boundary\n"
       "conditions for this domain with holes is not supported."};
 
-  AlignedLattice(std::array<std::vector<double>, Dim> block_bounds,
-                 std::array<size_t, Dim> initial_refinement_levels,
-                 std::array<size_t, Dim> initial_number_of_grid_points,
-                 std::vector<RefinementRegion<Dim>> refined_refinement,
-                 std::vector<RefinementRegion<Dim>> refined_grid_points,
-                 std::vector<std::array<size_t, Dim>> blocks_to_exclude,
-                 std::array<bool, Dim> is_periodic_in = make_array<Dim>(false),
-                 const Options::Context& context = {});
+  AlignedLattice(
+      std::array<std::vector<double>, Dim> block_bounds,
+      std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+          distributions,
+      std::array<std::vector<double>, Dim> singularity_positions,
+      std::array<size_t, Dim> initial_refinement_levels,
+      std::array<size_t, Dim> initial_number_of_grid_points,
+      std::vector<RefinementRegion<Dim>> refined_refinement,
+      std::vector<RefinementRegion<Dim>> refined_grid_points,
+      std::vector<std::array<size_t, Dim>> blocks_to_exclude,
+      std::array<bool, Dim> is_periodic_in = make_array<Dim>(false),
+      const Options::Context& context = {});
 
   AlignedLattice(
       std::array<std::vector<double>, Dim> block_bounds,
+      std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+          distributions,
+      std::array<std::vector<double>, Dim> singularity_positions,
       std::array<size_t, Dim> initial_refinement_levels,
       std::array<size_t, Dim> initial_number_of_grid_points,
       std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -201,6 +228,9 @@ class AlignedLattice : public DomainCreator<Dim> {
   template <typename BoundaryConditionsBase>
   AlignedLattice(
       std::array<std::vector<double>, Dim> block_bounds,
+      std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+          distributions,
+      std::array<std::vector<double>, Dim> singularity_positions,
       std::array<size_t, Dim> initial_refinement_levels,
       std::array<size_t, Dim> initial_number_of_grid_points,
       std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -213,9 +243,11 @@ class AlignedLattice : public DomainCreator<Dim> {
                  Dim>
           boundary_conditions,
       const Options::Context& context = {})
-      : AlignedLattice(std::move(block_bounds), initial_refinement_levels,
-                       initial_number_of_grid_points, refined_refinement,
-                       refined_grid_points, blocks_to_exclude,
+      : AlignedLattice(std::move(block_bounds), std::move(distributions),
+                       std::move(singularity_positions),
+                       initial_refinement_levels, initial_number_of_grid_points,
+                       refined_refinement, refined_grid_points,
+                       blocks_to_exclude,
                        Rectilinear<Dim>::transform_boundary_conditions(
                            std::move(boundary_conditions)),
                        context) {}
@@ -243,6 +275,9 @@ class AlignedLattice : public DomainCreator<Dim> {
  private:
   std::array<std::vector<double>, Dim> block_bounds_{
       make_array<Dim, std::vector<double>>({})};
+  std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+      distributions_{};
+  std::array<std::vector<std::optional<double>>, Dim> singularity_positions_{};
   std::array<bool, Dim> is_periodic_in_{make_array<Dim>(false)};
   std::array<size_t, Dim> initial_refinement_levels_{
       make_array<Dim>(std::numeric_limits<size_t>::max())};

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -1317,6 +1317,10 @@ maps_for_rectilinear_domains(
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude,
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions,
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions,
     const bool use_equiangular_map) {
   for (size_t d = 0; d < VolumeDim; d++) {
     ASSERT(gsl::at(block_demarcations, d).size() == domain_extents[d] + 1,
@@ -1330,6 +1334,9 @@ maps_for_rectilinear_domains(
            domain_extents, block_indices_to_exclude)) {
     std::array<double, VolumeDim> lower_bounds{};
     std::array<double, VolumeDim> upper_bounds{};
+    std::array<domain::CoordinateMaps::Distribution, VolumeDim>
+        distributions_i{};
+    std::array<std::optional<double>, VolumeDim> singularity_positions_i{};
     for (size_t d = 0; d < VolumeDim; d++) {
       gsl::at(lower_bounds, d) =
           gsl::at(gsl::at(block_demarcations, d), block_index[d]);
@@ -1337,6 +1344,28 @@ maps_for_rectilinear_domains(
           gsl::at(gsl::at(block_demarcations, d), block_index[d] + 1);
       ASSERT(gsl::at(upper_bounds, d) > gsl::at(lower_bounds, d),
              "The block demarcations must be strictly increasing.");
+      if (gsl::at(distributions, d).empty()) {
+        gsl::at(distributions_i, d) =
+            domain::CoordinateMaps::Distribution::Linear;
+      } else {
+        gsl::at(distributions_i, d) = gsl::at(distributions, d)[block_index[d]];
+      }
+      if (gsl::at(singularity_positions, d).empty()) {
+        gsl::at(singularity_positions_i, d) = std::nullopt;
+      } else {
+        gsl::at(singularity_positions_i, d) =
+            gsl::at(singularity_positions, d)[block_index[d]];
+      }
+    }
+    using Interval = domain::CoordinateMaps::Interval;
+    std::array<Interval, VolumeDim> interval_maps{};
+    for (size_t d = 0; d < VolumeDim; d++) {
+      gsl::at(interval_maps, d) = Interval{-1.0,
+                                           1.0,
+                                           gsl::at(lower_bounds, d),
+                                           gsl::at(upper_bounds, d),
+                                           gsl::at(distributions_i, d),
+                                           gsl::at(singularity_positions_i, d)};
     }
     if (not use_equiangular_map) {
       using Affine = domain::CoordinateMaps::Affine;
@@ -1420,6 +1449,10 @@ Domain<VolumeDim> rectilinear_domain(
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
     const std::array<bool, VolumeDim>& dimension_is_periodic,
     const std::vector<PairOfFaces>& identifications,
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions,
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions,
     const bool use_equiangular_map) {
   std::vector<Block<VolumeDim>> blocks{};
   auto corners_of_all_blocks =
@@ -1433,7 +1466,8 @@ Domain<VolumeDim> rectilinear_domain(
   }
   auto maps = maps_for_rectilinear_domains<Frame::Inertial>(
       domain_extents, block_demarcations, block_indices_to_exclude,
-      rotations_of_all_blocks, use_equiangular_map);
+      rotations_of_all_blocks, distributions, singularity_positions,
+      use_equiangular_map);
   for (size_t i = 0; i < corners_of_all_blocks.size(); i++) {
     corners_of_all_blocks[i] =
         discrete_rotation(rotations_of_all_blocks[i], corners_of_all_blocks[i]);
@@ -1588,6 +1622,10 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
       const std::vector<Index<DIM(data)>>& block_indices_to_exclude,        \
       const std::vector<OrientationMap<DIM(data)>>&                         \
           orientations_of_all_blocks,                                       \
+      const std::array<std::vector<domain::CoordinateMaps::Distribution>,   \
+                       DIM(data)>& distributions,                           \
+      const std::array<std::vector<std::optional<double>>, DIM(data)>&      \
+          singularity_positions,                                            \
       const bool use_equiangular_map);                                      \
   template std::array<size_t, two_to_the(DIM(data))> discrete_rotation(     \
       const OrientationMap<DIM(data)>& orientation,                         \
@@ -1600,6 +1638,10 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
           orientations_of_all_blocks,                                       \
       const std::array<bool, DIM(data)>& dimension_is_periodic,             \
       const std::vector<PairOfFaces>& identifications,                      \
+      const std::array<std::vector<domain::CoordinateMaps::Distribution>,   \
+                       DIM(data)>& distributions,                           \
+      const std::array<std::vector<std::optional<double>>, DIM(data)>&      \
+          singularity_positions,                                            \
       const bool use_equiangular_map);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1_st, 2_st, 3_st))

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -393,6 +393,10 @@ auto maps_for_rectilinear_domains(
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
         {},
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions = {},
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions = {},
     bool use_equiangular_map = false)
     -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
         Frame::BlockLogical, TargetFrame, VolumeDim>>>;
@@ -426,6 +430,10 @@ Domain<VolumeDim> rectilinear_domain(
     const std::array<bool, VolumeDim>& dimension_is_periodic =
         make_array<VolumeDim>(false),
     const std::vector<PairOfFaces>& identifications = {},
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions = {},
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions = {},
     bool use_equiangular_map = false);
 
 /// \ingroup ComputationalDomainGroup

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -113,7 +113,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     CAPTURE(use_boundary_condition);
     const auto domain_creator_1d = make_domain_creator<1>(
         "AlignedLattice:\n"
-        "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n" +
+        "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
+        "  Distributions: [[Inverse]]\n"
+        "  SingularityPositions: [[0.0]]\n" +
             std::string{use_boundary_condition ? ""
                                                : "  IsPeriodicIn: [false]\n"} +
             "  InitialGridPoints: [3]\n"
@@ -133,7 +135,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
 
     const auto domain_creator_2d = make_domain_creator<2>(
         "AlignedLattice:\n"
-        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n" +
+        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+        "  Distributions: [[Inverse], [Linear]]\n"
+        "  SingularityPositions: [[0.0], []]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false]\n"} +
@@ -153,7 +157,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
 
     const auto domain_creator_3d = make_domain_creator<3>(
         "AlignedLattice:\n"
-        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n" +
+        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+        "  Distributions: [[], [], []]\n"
+        "  SingularityPositions: [[], [], []]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false, false]\n"} +
@@ -174,7 +180,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     const auto cubical_shell_domain = make_domain_creator<3>(
         "AlignedLattice:\n"
         "  BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
-        "[-0.2, 3.2, 4.0, 5.2]]\n" +
+        "[-0.2, 3.2, 4.0, 5.2]]\n"
+        "  Distributions: [[], [], []]\n"
+        "  SingularityPositions: [[], [], []]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false, false]\n"} +
@@ -196,7 +204,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     const auto unit_cubical_shell_domain = make_domain_creator<3>(
         "AlignedLattice:\n"
         "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
-        "[-1.5, -0.5, 0.5, 1.5]]\n" +
+        "[-1.5, -0.5, 0.5, 1.5]]\n"
+        "  Distributions: [[], [], []]\n"
+        "  SingularityPositions: [[], [], []]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false, false]\n"} +
@@ -224,6 +234,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
               2, domain::creators::AlignedLattice<2>>>(
       "AlignedLattice:\n"
       "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+      "  Distributions: [[], []]\n"
+      "  SingularityPositions: [[], []]\n"
       "  IsPeriodicIn: [false, true]\n"
       "  InitialGridPoints: [3, 4]\n"
       "  InitialLevels: [2, 1]\n"
@@ -245,6 +257,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
               3, domain::creators::AlignedLattice<3>>>(
       "AlignedLattice:\n"
       "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+      "  Distributions: [[], [], []]\n"
+      "  SingularityPositions: [[], [], []]\n"
       "  IsPeriodicIn: [false, true, false]\n"
       "  InitialGridPoints: [3, 4, 5]\n"
       "  InitialLevels: [2, 1, 0]\n"
@@ -271,6 +285,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
                 2, domain::creators::AlignedLattice<2>>>(
         "AlignedLattice:\n"
         "  BlockBounds: [[70, 71, 72, 73], [90, 91, 92, 93]]\n"
+        "  Distributions: [[], []]\n"
+        "  SingularityPositions: [[], []]\n"
         "  IsPeriodicIn: [false, false]\n"
         "  InitialGridPoints: [2, 3]\n"
         "  InitialLevels: [0, 0]\n"
@@ -326,6 +342,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
                 2, domain::creators::AlignedLattice<2>>>(
         "AlignedLattice:\n"
         "  BlockBounds: [[70, 71, 72, 73], [90, 91, 92, 93]]\n"
+        "  Distributions: [[], []]\n"
+        "  SingularityPositions: [[], []]\n"
         "  IsPeriodicIn: [false, false]\n"
         "  InitialGridPoints: [10, 10]\n"
         "  InitialLevels: [2, 5]\n"
@@ -373,8 +391,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
                                     {{1.5, -0.5, 0.5, 1.5}},
                                     {{-1.5, -0.5, 0.5, 1.5}}}},
-                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
-                                  {{{{1, 1, 1}}}}, {{true, false, false}},
+                                  {{{}, {}, {}}}, {{{}, {}, {}}}, {{1, 1, 1}},
+                                  {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+                                  {{true, false, false}},
                                   Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot exclude blocks as well as have periodic boundary"));
@@ -382,8 +401,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
                                     {{1.5, -0.5, 0.5, 1.5}},
                                     {{-1.5, -0.5, 0.5, 1.5}}}},
-                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
-                                  {{{{1, 1, 1}}}}, {{false, true, false}},
+                                  {{{}, {}, {}}}, {{{}, {}, {}}}, {{1, 1, 1}},
+                                  {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+                                  {{false, true, false}},
                                   Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot exclude blocks as well as have periodic boundary"));
@@ -391,8 +411,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
                                     {{1.5, -0.5, 0.5, 1.5}},
                                     {{-1.5, -0.5, 0.5, 1.5}}}},
-                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
-                                  {{{{1, 1, 1}}}}, {{true, false, true}},
+                                  {{{}, {}, {}}}, {{{}, {}, {}}}, {{1, 1, 1}},
+                                  {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+                                  {{true, false, true}},
                                   Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot exclude blocks as well as have periodic boundary"));

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -364,7 +364,7 @@ void test_1d_rectilinear_domains() {
             {{Direction<1>::lower_xi()}}, {}, {{Direction<1>::upper_xi()}}};
     const auto domain = rectilinear_domain<1>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
-        {}, {}, {{false}}, {}, true);
+        {}, {}, {{false}}, {}, {}, {}, true);
     const OrientationMap<1> aligned = OrientationMap<1>::create_aligned();
     std::vector<DirectionMap<1, BlockNeighbors<1>>> expected_block_neighbors{
         {{Direction<1>::upper_xi(), {1, aligned}}},
@@ -390,7 +390,7 @@ void test_1d_rectilinear_domains() {
     const auto domain = rectilinear_domain<1>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, std::vector<OrientationMap<1>>{aligned, antialigned, aligned},
-        {{false}}, {}, true);
+        {{false}}, {}, {}, {}, true);
     std::vector<DirectionMap<1, BlockNeighbors<1>>> expected_block_neighbors{
         {{Direction<1>::upper_xi(), {1, antialigned}}},
         {{Direction<1>::lower_xi(), {2, antialigned}},

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -1388,7 +1388,7 @@ void test_maps_for_rectilinear_domains() {
       affine_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
-          {Index<1>{0}}, {}, false);
+          {Index<1>{0}}, {}, {}, {}, false);
   const auto expected_affine_maps_1d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 1.7, 2.0});
@@ -1401,7 +1401,7 @@ void test_maps_for_rectilinear_domains() {
       equiangular_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
-          {Index<1>{1}}, {}, true);
+          {Index<1>{1}}, {}, {}, {}, true);
   const auto expected_equiangular_maps_1d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular{-1., 1., 0.0, 0.5}, Equiangular{-1., 1., 1.7, 2.0});
@@ -1415,7 +1415,7 @@ void test_maps_for_rectilinear_domains() {
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
-          {Index<2>{}}, {}, false);
+          {Index<2>{}}, {}, {}, {}, false);
   const auto expected_affine_maps_2d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Affine2D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0}},
@@ -1434,7 +1434,7 @@ void test_maps_for_rectilinear_domains() {
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
-          {Index<2>{2, 1}}, {}, true);
+          {Index<2>{2, 1}}, {}, {}, {}, true);
   const auto expected_equiangular_maps_2d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular2D{Equiangular{-1., 1., 0.0, 0.5},
@@ -1458,7 +1458,7 @@ void test_maps_for_rectilinear_domains() {
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
-          {Index<3>{}}, {}, false);
+          {Index<3>{}}, {}, {}, {}, false);
   // [show_maps_for_rectilinear_domains]
   const auto expected_affine_maps_3d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
@@ -1480,7 +1480,7 @@ void test_maps_for_rectilinear_domains() {
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
-          {Index<3>{0, 0, 0}}, {}, true);
+          {Index<3>{0, 0, 0}}, {}, {}, {}, true);
   const auto expected_equiangular_maps_3d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular3D{Equiangular{-1., 1., 0.5, 2.0},
@@ -1579,7 +1579,7 @@ void test_set_cartesian_periodic_boundaries_2() {
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks, std::array<bool, 2>{{true, false}}, {},
-      false);
+      {}, {}, false);
 
   const std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
@@ -1587,7 +1587,7 @@ void test_set_cartesian_periodic_boundaries_2() {
           Index<2>{2, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
-          {}, orientations_of_all_blocks, false);
+          {}, orientations_of_all_blocks, {}, {}, false);
 
   for (size_t i = 0; i < domain.blocks().size(); i++) {
     CAPTURE(i);
@@ -1616,7 +1616,7 @@ void test_set_cartesian_periodic_boundaries_3() {
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks, std::array<bool, 2>{{true, true}}, {},
-      false);
+      {}, {}, false);
 
   const std::vector<DirectionMap<2, BlockNeighbors<2>>>
       expected_block_neighbors{
@@ -1642,7 +1642,7 @@ void test_set_cartesian_periodic_boundaries_3() {
           Index<2>{2, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
-          {}, orientations_of_all_blocks, false);
+          {}, orientations_of_all_blocks, {}, {}, false);
 
   for (size_t i = 0; i < domain.blocks().size(); i++) {
     CAPTURE(i);

--- a/tests/Unit/Domain/Test_ElementDistribution.cpp
+++ b/tests/Unit/Domain/Test_ElementDistribution.cpp
@@ -31,7 +31,8 @@ namespace {
 void test_uniform_cost_function() {
   // AlignedLattice with differently-refined Elements
   const auto domain_creator = domain::creators::AlignedLattice<2>(
-      {{{{70, 71, 72, 73}}, {{90, 92, 95, 99}}}}, {{2, 5}}, {{3, 3}},
+      {{{{70, 71, 72, 73}}, {{90, 92, 95, 99}}}}, {{{}, {}}}, {{{}, {}}},
+      {{2, 5}}, {{3, 3}},
       {{{{{1, 0}}, {{3, 2}}, {{3, 5}}}, {{{2, 1}}, {{3, 3}}, {{4, 6}}}}},
       {{{{{1, 0}}, {{3, 2}}, {{4, 5}}}, {{{2, 1}}, {{3, 3}}, {{6, 7}}}}}, {});
 
@@ -52,24 +53,24 @@ void test_uniform_cost_function() {
 // functions
 void test_weighted_cost_function(const domain::ElementWeight element_weight) {
   const auto domain_creator1 = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 1.0, 2.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}},
-      {{4, 4, 4}}, {}, {}, {});
+      {{{{0.0, 1.0, 2.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 1, 0}}, {{4, 4, 4}}, {}, {}, {});
   const auto domain1 = domain_creator1.create_domain();
   const auto& blocks1 = domain1.blocks();
 
   // Block size and grid points are the same as blocks in `domain1`, but
   // refinement levels are different
   const auto domain_creator2 = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 3, 2}}, {{4, 4, 4}},
-      {}, {}, {});
+      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 3, 2}}, {{4, 4, 4}}, {}, {}, {});
   const auto domain2 = domain_creator2.create_domain();
   const auto& blocks2 = domain2.blocks();
 
   // Block size and refinement levels are the same as blocks in `domain1`, but
   // grid points are different
   const auto domain_creator3 = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}}, {{4, 3, 2}},
-      {}, {}, {});
+      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 1, 0}}, {{4, 3, 2}}, {}, {}, {});
   const auto domain3 = domain_creator3.create_domain();
   const auto& blocks3 = domain2.blocks();
 
@@ -511,14 +512,15 @@ SPECTRE_TEST_CASE("Unit.Domain.ElementDistribution", "[Domain][Unit]") {
 
   // 1D, single block
   const auto lattice_1d = domain::creators::AlignedLattice<1>(
-      {{{{0.0, 1.0}}}}, {{4}}, {{6}}, {}, {}, {});
+      {{{{0.0, 1.0}}}}, {{{}}}, {{{}}}, {{4}}, {{6}}, {}, {}, {});
   // 2D
   const auto lattice_2d = domain::creators::AlignedLattice<2>(
-      {{{{0.0, 0.3}}, {{0.0, 0.8, 2.5, 4.9}}}}, {{2, 3}}, {{4, 5}}, {}, {}, {});
+      {{{{0.0, 0.3}}, {{0.0, 0.8, 2.5, 4.9}}}}, {{{}, {}}}, {{{}, {}}},
+      {{2, 3}}, {{4, 5}}, {}, {}, {});
   // 3D
   const auto lattice_3d = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 0.6}}, {{0.0, 0.4, 0.7}}, {{0.0, 0.3}}}}, {{2, 1, 3}},
-      {{5, 4, 5}}, {}, {}, {});
+      {{{{0.0, 0.6}}, {{0.0, 0.4, 0.7}}, {{0.0, 0.3}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 1, 3}}, {{5, 4, 5}}, {}, {}, {});
 
   // Test element distribution construction logic
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -1021,6 +1021,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           elliptic::BoundaryConditionType::Dirichlet);
       const domain::creators::AlignedLattice<1> domain_creator{
           {{{-2., 0., 2.}}},
+          {},
+          {},
           {{0}},
           {{3}},
           {{{{1}}, {{2}}, {{1}}}},  // Refine once in block 1
@@ -1052,6 +1054,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
       const domain::creators::AlignedLattice<2> domain_creator{
           // Start with 4 unrefined blocks
           {{{-2., 0., 2.}, {-2., 0., 2.}}},
+          {},
+          {},
           {{0, 0}},
           {{3, 3}},
           // Refine once in eta in upper-right block in sketch above
@@ -1070,6 +1074,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           elliptic::BoundaryConditionType::Dirichlet);
       const domain::creators::AlignedLattice<3> domain_creator{
           {{{-2., 0., 2.}, {-2., 0., 2.}, {-2., 0., 2.}}},
+          {},
+          {},
           {{0, 0, 0}},
           {{3, 3, 3}},
           {{{{1, 0, 0}}, {{2, 1, 1}}, {{0, 1, 1}}}},

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -1126,6 +1126,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
       const domain::creators::AlignedLattice<2> domain_creator{
           // Start with 2 unrefined blocks
           {{{0., 0.25, 0.5}, {0., 0.5}}},
+          {},
+          {},
           {{0, 0}},
           {{3, 2}},
           // Refine once in eta in left block in sketch above
@@ -1230,6 +1232,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
               elliptic::BoundaryConditionType::Dirichlet};
       const domain::creators::AlignedLattice<2> domain_creator{
           {{{0., 0.25, 0.5}, {0., 0.5}}},
+          {},
+          {},
           {{1, 1}},
           {{12, 12}},
           {{{{0, 0}}, {{1, 1}}, {{1, 2}}}},
@@ -1268,6 +1272,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
             elliptic::BoundaryConditionType::Dirichlet};
     const domain::creators::AlignedLattice<2> domain_creator{
         {{{0., 0.25, 0.5}, {0., 0.5}}},
+        {},
+        {},
         {{1, 1}},
         {{12, 12}},
         {{{{0, 0}}, {{1, 1}}, {{1, 2}}}},
@@ -1483,6 +1489,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
     // solve for u_R.
     const domain::creators::AlignedLattice<2> domain_creator{
         {{{0., 0.5, 1.}, {0., 1.}}},
+        {},
+        {},
         {{1, 1}},
         {{12, 12}},
         {},

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
@@ -83,7 +83,7 @@ SPECTRE_TEST_CASE("Unit.GrSelfForce.Actions.InitializeEffectiveSource",
   domain::creators::register_derived_with_charm();
   register_factory_classes_with_charm<Metavariables>();
   const domain::creators::AlignedLattice<2> domain_creator{
-      {{{-20., 0., 20.}, {0., M_PI}}}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
+      {{{-20., 0., 20.}, {0., M_PI}}}, {}, {}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
   const auto element_regularized =
       ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{2, 1}}}};
   const auto element_unregularized =

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
@@ -83,7 +83,7 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.Actions.InitializeEffectiveSource",
   domain::creators::register_derived_with_charm();
   register_factory_classes_with_charm<Metavariables>();
   const domain::creators::AlignedLattice<2> domain_creator{
-      {{{-20., 0., 20.}, {-1., 1.}}}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
+      {{{-20., 0., 20.}, {-1., 1.}}}, {}, {}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
   const auto element_regularized =
       ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{2, 1}}}};
   const auto element_unregularized =

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
@@ -22,7 +22,9 @@ void test_null_slicing_tag_logic() {
   const std::unique_ptr<DomainCreator<2>> lattice =
       std::make_unique<domain::creators::AlignedLattice<2>>(
           std::array<std::vector<double>, 2>{{{0., 0.25, 0.5}, {0., 0.5}}},
-          std::array<size_t, 2>{{0, 0}}, std::array<size_t, 2>{{3, 2}},
+          std::array<std::vector<domain::CoordinateMaps::Distribution>, 2>{},
+          std::array<std::vector<double>, 2>{}, std::array<size_t, 2>{{0, 0}},
+          std::array<size_t, 2>{{3, 2}},
           std::vector<Region>{Region{{0, 0}, {1, 1}, {0, 1}}},
           std::vector<Region>{}, std::vector<std::array<size_t, 2>>{},
           std::array<bool, 2>{{false, false}}, Options::Context{});

--- a/tests/Unit/Evolution/DgSubcell/Test_DisableLts.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_DisableLts.cpp
@@ -41,7 +41,10 @@ void test(const size_t block, const size_t segment) {
   const ElementId<Dim> id(block, segments);
 
   const domain::creators::AlignedLattice<Dim> domain_creator(
-      make_array<Dim>(make_vector(0.0, 1.0, 2.0)), make_array<Dim>(1_st),
+      make_array<Dim>(make_vector(0.0, 1.0, 2.0)),
+      make_array<Dim>(std::vector<domain::CoordinateMaps::Distribution>{}),
+      make_array<Dim>(std::vector<double>{}),
+      make_array<Dim>(1_st),
       make_array<Dim>(6_st), {}, {}, {});
   const auto domain = domain_creator.create_domain();
   const auto element = domain::create_initial_element(


### PR DESCRIPTION
## Proposed changes

- Adds support for custom coordinate distributions and singularity positions to the AlignedLattice creator and rectilinear_domain helpers. 
- This enables the use of inverse maps in the outer regions of the domain (specifically, useful for self-force project)

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
