### PR TITLE
Add distributions and singularity positions to rectilinear domains

### DIFF
--- a/src/Domain/Creators/AlignedLattice.cpp
+++ b/src/Domain/Creators/AlignedLattice.cpp
@@ -34,6 +34,9 @@ std::ostream& operator<<(std::ostream& /*s*/,
 template <size_t Dim>
 AlignedLattice<Dim>::AlignedLattice(
     std::array<std::vector<double>, Dim> block_bounds,
+    std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+        distributions,
+    std::array<std::vector<double>, Dim> singularity_positions,
     std::array<size_t, Dim> initial_refinement_levels,
     std::array<size_t, Dim> initial_number_of_grid_points,
     std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -41,6 +44,7 @@ AlignedLattice<Dim>::AlignedLattice(
     std::vector<std::array<size_t, Dim>> blocks_to_exclude,
     std::array<bool, Dim> is_periodic_in, const Options::Context& context)
     : block_bounds_(std::move(block_bounds)),
+      distributions_(std::move(distributions)),
       is_periodic_in_(is_periodic_in),
       initial_refinement_levels_(initial_refinement_levels),
       initial_number_of_grid_points_(initial_number_of_grid_points),
@@ -50,6 +54,56 @@ AlignedLattice<Dim>::AlignedLattice(
       number_of_blocks_by_dim_{map_array(
           block_bounds_,
           [](const std::vector<double>& v) { return v.size() - 1; })} {
+  for (size_t d = 0; d < Dim; ++d) {
+    const size_t num_blocks_in_dim = gsl::at(block_bounds_, d).size() - 1;
+    if (not gsl::at(distributions_, d).empty() and
+        gsl::at(distributions_, d).size() != num_blocks_in_dim) {
+      PARSE_ERROR(context,
+                  "Specify a 'Distributions' for every block in dimension "
+                      << d << ", or specify none. You specified "
+                      << gsl::at(distributions_, d).size()
+                      << " items, but the domain has " << num_blocks_in_dim
+                      << " blocks in this dimension.");
+    }
+    if (not gsl::at(singularity_positions, d).empty() and
+        gsl::at(singularity_positions, d).size() != num_blocks_in_dim) {
+      PARSE_ERROR(context,
+                  "Specify a 'SingularityPositions' for every block in "
+                  "dimension "
+                      << d << ", or specify none. You specified "
+                      << gsl::at(singularity_positions, d).size()
+                      << " items, but the domain has " << num_blocks_in_dim
+                      << " blocks in this dimension.");
+    }
+    if (not gsl::at(distributions_, d).empty() and
+        gsl::at(singularity_positions, d).empty()) {
+      PARSE_ERROR(context,
+                  "In dimension " << d
+                                  << ", 'Distributions' were specified but "
+                                     "'SingularityPositions' were not. When "
+                                     "specifying 'Distributions', you must "
+                                     "also specify 'SingularityPositions' for "
+                                     "all blocks in that dimension.");
+    }
+    gsl::at(singularity_positions_, d)
+        .assign(gsl::at(singularity_positions, d).begin(),
+                gsl::at(singularity_positions, d).end());
+    for (size_t b = 0; b < gsl::at(singularity_positions, d).size(); ++b) {
+      const double sing_pos = gsl::at(singularity_positions, d)[b];
+      const double lower = gsl::at(block_bounds_, d)[b];
+      const double upper = gsl::at(block_bounds_, d)[b + 1];
+      if (sing_pos >= lower and sing_pos <= upper) {
+        PARSE_ERROR(context,
+                    "The 'SingularityPositions' value "
+                        << sing_pos << " for block " << b << " in dimension "
+                        << d << " falls inside the block interval [" << lower
+                        << ", " << upper
+                        << "]. The singularity position must be outside the "
+                           "block.");
+      }
+    }
+  }
+
   if (not blocks_to_exclude_.empty() and
       alg::any_of(is_periodic_in_, [](const bool t) { return t; })) {
     PARSE_ERROR(context,
@@ -81,6 +135,9 @@ AlignedLattice<Dim>::AlignedLattice(
 template <size_t Dim>
 AlignedLattice<Dim>::AlignedLattice(
     std::array<std::vector<double>, Dim> block_bounds,
+    std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+        distributions,
+    std::array<std::vector<double>, Dim> singularity_positions,
     std::array<size_t, Dim> initial_refinement_levels,
     std::array<size_t, Dim> initial_number_of_grid_points,
     std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -93,7 +150,8 @@ AlignedLattice<Dim>::AlignedLattice(
         boundary_conditions,
     const Options::Context& context)
     : AlignedLattice(
-          std::move(block_bounds), initial_refinement_levels,
+          std::move(block_bounds), std::move(distributions),
+          std::move(singularity_positions), initial_refinement_levels,
           initial_number_of_grid_points, std::move(refined_refinement),
           std::move(refined_grid_points), std::move(blocks_to_exclude),
           make_array<Dim>(false), context) {
@@ -154,7 +212,7 @@ Domain<Dim> AlignedLattice<Dim>::create_domain() const {
       number_of_blocks_by_dim_, block_bounds_,
       {std::vector<Index<Dim>>(blocks_to_exclude_.begin(),
                                blocks_to_exclude_.end())},
-      {}, is_periodic_in_, {}, false);
+      {}, is_periodic_in_, {}, distributions_, singularity_positions_);
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/AlignedLattice.hpp
+++ b/src/Domain/Creators/AlignedLattice.hpp
@@ -25,7 +25,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
+class Interval;
 template <typename Map1, typename Map2>
 class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
@@ -97,22 +97,36 @@ template <size_t Dim>
 template <size_t Dim>
 class AlignedLattice : public DomainCreator<Dim> {
  public:
-  using maps_list = tmpl::list<
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::Affine>,
-      domain::CoordinateMap<
-          Frame::BlockLogical, Frame::Inertial,
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>>,
-      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                            CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>>>;
+  using maps_list =
+      tmpl::list<domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                                       CoordinateMaps::Interval>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>>>;
 
   struct BlockBounds {
     using type = std::array<std::vector<double>, Dim>;
     static constexpr Options::String help = {
         "Coordinates of block boundaries in each dimension."};
+  };
+
+  struct Distributions {
+    using type =
+        std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>;
+    static constexpr Options::String help = {
+        "Grid point distribution in each dimension."};
+  };
+
+  struct SingularityPositions {
+    using type = std::array<std::vector<double>, Dim>;
+    static constexpr Options::String help = {
+        "Singularity positions in each dimension."};
   };
 
   struct IsPeriodicIn {
@@ -153,8 +167,8 @@ class AlignedLattice : public DomainCreator<Dim> {
 
   template <typename Metavariables>
   using options = tmpl::list<
-      BlockBounds, InitialLevels, InitialGridPoints, RefinedLevels,
-      RefinedGridPoints, BlocksToExclude,
+      BlockBounds, Distributions, SingularityPositions, InitialLevels,
+      InitialGridPoints, RefinedLevels, RefinedGridPoints, BlocksToExclude,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -175,17 +189,24 @@ class AlignedLattice : public DomainCreator<Dim> {
       "will trigger an error, as periodic boundary\n"
       "conditions for this domain with holes is not supported."};
 
-  AlignedLattice(std::array<std::vector<double>, Dim> block_bounds,
-                 std::array<size_t, Dim> initial_refinement_levels,
-                 std::array<size_t, Dim> initial_number_of_grid_points,
-                 std::vector<RefinementRegion<Dim>> refined_refinement,
-                 std::vector<RefinementRegion<Dim>> refined_grid_points,
-                 std::vector<std::array<size_t, Dim>> blocks_to_exclude,
-                 std::array<bool, Dim> is_periodic_in = make_array<Dim>(false),
-                 const Options::Context& context = {});
+  AlignedLattice(
+      std::array<std::vector<double>, Dim> block_bounds,
+      std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+          distributions,
+      std::array<std::vector<double>, Dim> singularity_positions,
+      std::array<size_t, Dim> initial_refinement_levels,
+      std::array<size_t, Dim> initial_number_of_grid_points,
+      std::vector<RefinementRegion<Dim>> refined_refinement,
+      std::vector<RefinementRegion<Dim>> refined_grid_points,
+      std::vector<std::array<size_t, Dim>> blocks_to_exclude,
+      std::array<bool, Dim> is_periodic_in = make_array<Dim>(false),
+      const Options::Context& context = {});
 
   AlignedLattice(
       std::array<std::vector<double>, Dim> block_bounds,
+      std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+          distributions,
+      std::array<std::vector<double>, Dim> singularity_positions,
       std::array<size_t, Dim> initial_refinement_levels,
       std::array<size_t, Dim> initial_number_of_grid_points,
       std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -201,6 +222,9 @@ class AlignedLattice : public DomainCreator<Dim> {
   template <typename BoundaryConditionsBase>
   AlignedLattice(
       std::array<std::vector<double>, Dim> block_bounds,
+      std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+          distributions,
+      std::array<std::vector<double>, Dim> singularity_positions,
       std::array<size_t, Dim> initial_refinement_levels,
       std::array<size_t, Dim> initial_number_of_grid_points,
       std::vector<RefinementRegion<Dim>> refined_refinement,
@@ -213,9 +237,11 @@ class AlignedLattice : public DomainCreator<Dim> {
                  Dim>
           boundary_conditions,
       const Options::Context& context = {})
-      : AlignedLattice(std::move(block_bounds), initial_refinement_levels,
-                       initial_number_of_grid_points, refined_refinement,
-                       refined_grid_points, blocks_to_exclude,
+      : AlignedLattice(std::move(block_bounds), std::move(distributions),
+                       std::move(singularity_positions),
+                       initial_refinement_levels, initial_number_of_grid_points,
+                       refined_refinement, refined_grid_points,
+                       blocks_to_exclude,
                        Rectilinear<Dim>::transform_boundary_conditions(
                            std::move(boundary_conditions)),
                        context) {}
@@ -243,6 +269,9 @@ class AlignedLattice : public DomainCreator<Dim> {
  private:
   std::array<std::vector<double>, Dim> block_bounds_{
       make_array<Dim, std::vector<double>>({})};
+  std::array<std::vector<domain::CoordinateMaps::Distribution>, Dim>
+      distributions_{};
+  std::array<std::vector<std::optional<double>>, Dim> singularity_positions_{};
   std::array<bool, Dim> is_periodic_in_{make_array<Dim>(false)};
   std::array<size_t, Dim> initial_refinement_levels_{
       make_array<Dim>(std::numeric_limits<size_t>::max())};

--- a/src/Domain/Creators/RotatedBricks.hpp
+++ b/src/Domain/Creators/RotatedBricks.hpp
@@ -22,7 +22,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
+class Interval;
 template <size_t VolumeDim>
 class DiscreteRotation;
 template <typename Map1, typename Map2, typename Map3>
@@ -104,13 +104,15 @@ class RotatedBricks : public DomainCreator<3> {
   using maps_list = tmpl::list<
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>>,
+                                CoordinateMaps::Interval,
+                                CoordinateMaps::Interval,
+                                CoordinateMaps::Interval>>,
       domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
                             CoordinateMaps::DiscreteRotation<3>,
                             CoordinateMaps::ProductOf3Maps<
-                                CoordinateMaps::Affine, CoordinateMaps::Affine,
-                                CoordinateMaps::Affine>>>;
+                                CoordinateMaps::Interval,
+                                CoordinateMaps::Interval,
+                                CoordinateMaps::Interval>>>;
 
   struct LowerBound {
     using type = std::array<double, 3>;

--- a/src/Domain/Creators/RotatedIntervals.hpp
+++ b/src/Domain/Creators/RotatedIntervals.hpp
@@ -24,7 +24,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
+class Interval;
 template <size_t VolumeDim>
 class DiscreteRotation;
 }  // namespace CoordinateMaps
@@ -44,7 +44,8 @@ class RotatedIntervals : public DomainCreator<1> {
  public:
   using maps_list = tmpl::list<domain::CoordinateMap<
       Frame::BlockLogical, Frame::Inertial,
-      domain::CoordinateMaps::DiscreteRotation<1>, CoordinateMaps::Affine>>;
+      domain::CoordinateMaps::DiscreteRotation<1>,
+      CoordinateMaps::Interval>>;
 
   struct LowerBound {
     using type = std::array<double, 1>;

--- a/src/Domain/Creators/RotatedRectangles.hpp
+++ b/src/Domain/Creators/RotatedRectangles.hpp
@@ -22,7 +22,7 @@
 /// \cond
 namespace domain {
 namespace CoordinateMaps {
-class Affine;
+class Interval;
 template <size_t VolumeDim>
 class DiscreteRotation;
 template <typename Map1, typename Map2>
@@ -56,13 +56,13 @@ class RotatedRectangles : public DomainCreator<2> {
   using maps_list =
       tmpl::list<domain::CoordinateMap<
                      Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                    CoordinateMaps::Affine>>,
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>>,
                  domain::CoordinateMap<
                      Frame::BlockLogical, Frame::Inertial,
                      CoordinateMaps::DiscreteRotation<2>,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                    CoordinateMaps::Affine>>>;
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Interval,
+                                                    CoordinateMaps::Interval>>>;
 
   struct LowerBound {
     using type = std::array<double, 2>;

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -1317,6 +1317,10 @@ maps_for_rectilinear_domains(
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude,
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions,
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions,
     const bool use_equiangular_map) {
   for (size_t d = 0; d < VolumeDim; d++) {
     ASSERT(gsl::at(block_demarcations, d).size() == domain_extents[d] + 1,
@@ -1330,6 +1334,9 @@ maps_for_rectilinear_domains(
            domain_extents, block_indices_to_exclude)) {
     std::array<double, VolumeDim> lower_bounds{};
     std::array<double, VolumeDim> upper_bounds{};
+    std::array<domain::CoordinateMaps::Distribution, VolumeDim>
+        distributions_i{};
+    std::array<std::optional<double>, VolumeDim> singularity_positions_i{};
     for (size_t d = 0; d < VolumeDim; d++) {
       gsl::at(lower_bounds, d) =
           gsl::at(gsl::at(block_demarcations, d), block_index[d]);
@@ -1337,19 +1344,36 @@ maps_for_rectilinear_domains(
           gsl::at(gsl::at(block_demarcations, d), block_index[d] + 1);
       ASSERT(gsl::at(upper_bounds, d) > gsl::at(lower_bounds, d),
              "The block demarcations must be strictly increasing.");
+      if (gsl::at(distributions, d).empty()) {
+        gsl::at(distributions_i, d) =
+            domain::CoordinateMaps::Distribution::Linear;
+      } else {
+        gsl::at(distributions_i, d) = gsl::at(distributions, d)[block_index[d]];
+      }
+      if (gsl::at(singularity_positions, d).empty()) {
+        gsl::at(singularity_positions_i, d) = std::nullopt;
+      } else {
+        gsl::at(singularity_positions_i, d) =
+            gsl::at(singularity_positions, d)[block_index[d]];
+      }
+    }
+    using Interval = domain::CoordinateMaps::Interval;
+    std::array<Interval, VolumeDim> interval_maps{};
+    for (size_t d = 0; d < VolumeDim; d++) {
+      gsl::at(interval_maps, d) = Interval{-1.0,
+                                           1.0,
+                                           gsl::at(lower_bounds, d),
+                                           gsl::at(upper_bounds, d),
+                                           gsl::at(distributions_i, d),
+                                           gsl::at(singularity_positions_i, d)};
     }
     if (not use_equiangular_map) {
-      using Affine = domain::CoordinateMaps::Affine;
-      std::array<Affine, VolumeDim> affine_maps{};
-      for (size_t d = 0; d < VolumeDim; d++) {
-        gsl::at(affine_maps, d) = Affine{-1.0, 1.0, gsl::at(lower_bounds, d),
-                                         gsl::at(upper_bounds, d)};
-      }
       if (not orientations_of_all_blocks.empty()) {
         maps.push_back(product_of_1d_maps<TargetFrame>(
-            affine_maps, orientations_of_all_blocks[block_orientation_index]));
+            interval_maps,
+            orientations_of_all_blocks[block_orientation_index]));
       } else {
-        maps.push_back(product_of_1d_maps<TargetFrame>(affine_maps));
+        maps.push_back(product_of_1d_maps<TargetFrame>(interval_maps));
       }
     } else {
       using Equiangular = domain::CoordinateMaps::Equiangular;
@@ -1420,6 +1444,10 @@ Domain<VolumeDim> rectilinear_domain(
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
     const std::array<bool, VolumeDim>& dimension_is_periodic,
     const std::vector<PairOfFaces>& identifications,
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions,
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions,
     const bool use_equiangular_map) {
   std::vector<Block<VolumeDim>> blocks{};
   auto corners_of_all_blocks =
@@ -1433,7 +1461,8 @@ Domain<VolumeDim> rectilinear_domain(
   }
   auto maps = maps_for_rectilinear_domains<Frame::Inertial>(
       domain_extents, block_demarcations, block_indices_to_exclude,
-      rotations_of_all_blocks, use_equiangular_map);
+      rotations_of_all_blocks, distributions, singularity_positions,
+      use_equiangular_map);
   for (size_t i = 0; i < corners_of_all_blocks.size(); i++) {
     corners_of_all_blocks[i] =
         discrete_rotation(rotations_of_all_blocks[i], corners_of_all_blocks[i]);
@@ -1588,6 +1617,10 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
       const std::vector<Index<DIM(data)>>& block_indices_to_exclude,        \
       const std::vector<OrientationMap<DIM(data)>>&                         \
           orientations_of_all_blocks,                                       \
+      const std::array<std::vector<domain::CoordinateMaps::Distribution>,   \
+                       DIM(data)>& distributions,                           \
+      const std::array<std::vector<std::optional<double>>, DIM(data)>&      \
+          singularity_positions,                                            \
       const bool use_equiangular_map);                                      \
   template std::array<size_t, two_to_the(DIM(data))> discrete_rotation(     \
       const OrientationMap<DIM(data)>& orientation,                         \
@@ -1600,6 +1633,10 @@ INSTANTIATE_MAPS_FUNCTIONS(((Affine2d), (Affine3d), (Equiangular3d),
           orientations_of_all_blocks,                                       \
       const std::array<bool, DIM(data)>& dimension_is_periodic,             \
       const std::vector<PairOfFaces>& identifications,                      \
+      const std::array<std::vector<domain::CoordinateMaps::Distribution>,   \
+                       DIM(data)>& distributions,                           \
+      const std::array<std::vector<std::optional<double>>, DIM(data)>&      \
+          singularity_positions,                                            \
       const bool use_equiangular_map);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1_st, 2_st, 3_st))

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -393,6 +393,10 @@ auto maps_for_rectilinear_domains(
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
         {},
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions = {},
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions = {},
     bool use_equiangular_map = false)
     -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
         Frame::BlockLogical, TargetFrame, VolumeDim>>>;
@@ -426,6 +430,10 @@ Domain<VolumeDim> rectilinear_domain(
     const std::array<bool, VolumeDim>& dimension_is_periodic =
         make_array<VolumeDim>(false),
     const std::vector<PairOfFaces>& identifications = {},
+    const std::array<std::vector<domain::CoordinateMaps::Distribution>,
+                     VolumeDim>& distributions = {},
+    const std::array<std::vector<std::optional<double>>, VolumeDim>&
+        singularity_positions = {},
     bool use_equiangular_map = false);
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/RadiallyCompressedCoordinates.hpp
+++ b/src/Domain/RadiallyCompressedCoordinates.hpp
@@ -126,13 +126,17 @@ struct RadiallyCompressedCoordinatesOptions : db::SimpleTag {
   static type create_from_options(type value) { return value; };
 };
 
-/// @{
 /*!
  * \brief Coordinates suitable for visualizing large radii by compressing them
  * logarithmically or inversely.
  *
  * The coordinate map reduces to the identity if no options for radially
  * compressed coordinates were specified in the input file.
+ *
+ * The template parameter `RadialDim` on the compute tag determines which
+ * dimensions to compress. If `RadialDim` is `void`, all dimensions are
+ * compressed radially (Cartesian coordinates). If `RadialDim` is a
+ * `tmpl::size_t`, only that dimension is compressed.
  *
  * \see radially_compressed_coordinates
  */
@@ -141,7 +145,8 @@ struct RadiallyCompressedCoordinates : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim, CoordsFrame>;
 };
 
-template <size_t Dim, typename CoordsFrame>
+/// \copydoc RadiallyCompressedCoordinates
+template <size_t Dim, typename CoordsFrame, typename RadialDim = void>
 struct RadiallyCompressedCoordinatesCompute
     : RadiallyCompressedCoordinates<Dim, CoordsFrame>,
       db::ComputeTag {
@@ -155,15 +160,25 @@ struct RadiallyCompressedCoordinatesCompute
       const std::optional<domain::RadiallyCompressedCoordinatesOptions>&
           options) {
     if (options.has_value()) {
-      radially_compressed_coordinates(result, coords, options->inner_radius,
-                                      options->outer_radius,
-                                      options->compression);
+      if constexpr (std::is_same_v<RadialDim, void>) {
+        radially_compressed_coordinates(result, coords, options->inner_radius,
+                                        options->outer_radius,
+                                        options->compression);
+      } else {
+        *result = coords;
+        // Only compress the specified radial dimension
+        tnsr::I<DataVector, 1, CoordsFrame> result_radial{};
+        get<0>(result_radial).set_data_ref(&get<RadialDim::value>(*result));
+        radially_compressed_coordinates(
+            make_not_null(&result_radial),
+            tnsr::I<DataVector, 1, CoordsFrame>{get<RadialDim::value>(coords)},
+            options->inner_radius, options->outer_radius, options->compression);
+      }
     } else {
       *result = coords;
     }
   }
 };
-/// @}
 
 }  // namespace Tags
 }  // namespace domain

--- a/src/Elliptic/Executables/SelfForce/GeneralRelativity/SolveGrSelfForce.hpp
+++ b/src/Elliptic/Executables/SelfForce/GeneralRelativity/SolveGrSelfForce.hpp
@@ -68,14 +68,17 @@ struct Metavariables {
       tmpl::list<GrSelfForce::Tags::SingularField,
                  GrSelfForce::Tags::BoyerLindquistRadius>,
       typename solver::observe_fields,
-      tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>;
+      tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
+                 domain::Tags::RadiallyCompressedCoordinatesCompute<
+                     2, Frame::Inertial, tmpl::size_t<0>>>>;
   using observer_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                  ::Events::Tags::ObserverDetInvJacobianCompute<
                      Frame::ElementLogical, Frame::Inertial>>;
 
   // Collect all items to store in the cache.
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::RadiallyCompressedCoordinatesOptions>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/src/Elliptic/Executables/SelfForce/Scalar/SolveScalarSelfForce.hpp
+++ b/src/Elliptic/Executables/SelfForce/Scalar/SolveScalarSelfForce.hpp
@@ -70,14 +70,17 @@ struct Metavariables {
       tmpl::list<ScalarSelfForce::Tags::SingularField,
                  ScalarSelfForce::Tags::BoyerLindquistRadius>,
       typename solver::observe_fields,
-      tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>>>;
+      tmpl::list<domain::Tags::Coordinates<volume_dim, Frame::Inertial>,
+                 domain::Tags::RadiallyCompressedCoordinatesCompute<
+                     2, Frame::Inertial, tmpl::size_t<0>>>>;
   using observer_compute_tags =
       tmpl::list<::Events::Tags::ObserverMeshCompute<volume_dim>,
                  ::Events::Tags::ObserverDetInvJacobianCompute<
                      Frame::ElementLogical, Frame::Inertial>>;
 
   // Collect all items to store in the cache.
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::RadiallyCompressedCoordinatesOptions>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -47,6 +47,8 @@ DomainCreator:
     # steps.  (The speeds are larger on the left, so the element size
     # differences have to be exagerated more than expected.)
     BlockBounds: [[-1.0, 0.3, 0.5, 0.7, 0.9, 1.0]]
+    Distributions: [[]]
+    SingularityPositions: [[]]
     InitialLevels: [0]
     InitialGridPoints: [7]
     RefinedLevels:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -46,6 +46,8 @@ DomainCreator:
     BlockBounds: [[0.0, 33.853, 13541.2],
                   [-1.0, 1.0],
                   [-1.0, 1.0]]
+    Distributions: [[], [], []]
+    SingularityPositions: [[], [], []]
     InitialGridPoints: [1, 1, 1]
     InitialLevels: [1, 0, 0]
     RefinedLevels:

--- a/tests/InputFiles/SelfForce/GrCircularOrbit.yaml
+++ b/tests/InputFiles/SelfForce/GrCircularOrbit.yaml
@@ -26,9 +26,19 @@ DomainCreator:
     # Order of dimensions is (r_*, theta)
     BlockBounds:
       # Puncture position is at r_* = 12.775940471833115
-      - [-50., 0., 25.55188094366623, 350.] # r_*
+      - [-50., 0., &worldtube_right 25.55188094366623, &outer_radius 350.] # r_*
       # theta
       - [0., 1., 2.1415926536, 3.1415926536]
+    Distributions:
+      # r_*
+      - [Linear, Linear, &outer_shell_distribution Inverse]
+      # theta
+      - [Linear, Linear, Linear]
+    SingularityPositions:
+      # r_*
+      - [-51., -51., 0.]
+      # theta
+      - [-1., 0., 0.]
     InitialGridPoints: [4, 4]
     InitialLevels: [0, 0]
     RefinedGridPoints: []
@@ -151,11 +161,17 @@ EventsAndTriggersAtIterations:
           VariablesToObserve:
             - MMode
             - BoyerLindquistRadius
+            - RadiallyCompressedCoordinates
           BlocksToObserve: All
           InterpolateToMesh: None
           ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+
+RadiallyCompressedCoordinates:
+  InnerRadius: *worldtube_right
+  OuterRadius: *outer_radius
+  Compression: *outer_shell_distribution
 
 BuildMatrix:
   MatrixSubfileName: None

--- a/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
+++ b/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
@@ -42,8 +42,18 @@ DomainCreator:
     # Order of dimensions is (r_*, cos(theta))
     BlockBounds:
       # Puncture position is at r_* = 12.775940471833115
-      - [-50., 0., 25.55188094366623, 350.] # r_*
+      - [-50., 0., &worldtube_right 25.55188094366623, &outer_radius 350.] # r_*
       - [-1., -0.5, 0.5, 1.]  # cos(theta)
+    Distributions:
+      # r_*
+      - [Linear, Linear, &outer_shell_distribution Inverse]
+      # cos(theta)
+      - [Linear, Linear, Linear]
+    SingularityPositions:
+      # r_*
+      - [-51., -51., 0.]
+      # os(theta)
+      - [-2., -2., -2.]
     InitialGridPoints: [4, 4]
     InitialLevels: [0, 0]
     RefinedGridPoints: []
@@ -177,11 +187,17 @@ EventsAndTriggersAtIterations:
           VariablesToObserve:
             - MMode
             - BoyerLindquistRadius
+            - RadiallyCompressedCoordinates
           BlocksToObserve: All
           InterpolateToMesh: None
           ProjectToMesh: None
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
+
+RadiallyCompressedCoordinates:
+  InnerRadius: *worldtube_right
+  OuterRadius: *outer_radius
+  Compression: *outer_shell_distribution
 
 BuildMatrix:
   MatrixSubfileName: None

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -17,6 +17,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/Creators/AlignedLattice.hpp"
@@ -113,7 +114,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     CAPTURE(use_boundary_condition);
     const auto domain_creator_1d = make_domain_creator<1>(
         "AlignedLattice:\n"
-        "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n" +
+        "  BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
+        "  Distributions: [[Inverse, Linear, Linear, Linear]]\n"
+        "  SingularityPositions: [[0.0, 0.0, 0.0, 0.0]]\n" +
             std::string{use_boundary_condition ? ""
                                                : "  IsPeriodicIn: [false]\n"} +
             "  InitialGridPoints: [3]\n"
@@ -133,7 +136,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
 
     const auto domain_creator_2d = make_domain_creator<2>(
         "AlignedLattice:\n"
-        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n" +
+        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+        "  Distributions: [[Inverse, Linear], [Linear, Linear, Linear]]\n"
+        "  SingularityPositions: [[0.0, 0.0], [-1.0, -1.0, -1.0]]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false]\n"} +
@@ -153,7 +158,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
 
     const auto domain_creator_3d = make_domain_creator<3>(
         "AlignedLattice:\n"
-        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n" +
+        "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+        "  Distributions: [[], [], []]\n"
+        "  SingularityPositions: [[], [], []]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false, false]\n"} +
@@ -174,7 +181,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     const auto cubical_shell_domain = make_domain_creator<3>(
         "AlignedLattice:\n"
         "  BlockBounds: [[0.1, 2.6, 5.1, 6.0], [-0.4, 3.2, 6.2, 7.0], "
-        "[-0.2, 3.2, 4.0, 5.2]]\n" +
+        "[-0.2, 3.2, 4.0, 5.2]]\n"
+        "  Distributions: [[], [], []]\n"
+        "  SingularityPositions: [[], [], []]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false, false]\n"} +
@@ -196,7 +205,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
     const auto unit_cubical_shell_domain = make_domain_creator<3>(
         "AlignedLattice:\n"
         "  BlockBounds: [[-1.5, -0.5, 0.5, 1.5], [-1.5, -0.5, 0.5, 1.5], "
-        "[-1.5, -0.5, 0.5, 1.5]]\n" +
+        "[-1.5, -0.5, 0.5, 1.5]]\n"
+        "  Distributions: [[], [], []]\n"
+        "  SingularityPositions: [[], [], []]\n" +
             std::string{use_boundary_condition
                             ? ""
                             : "  IsPeriodicIn: [false, false, false]\n"} +
@@ -224,6 +235,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
               2, domain::creators::AlignedLattice<2>>>(
       "AlignedLattice:\n"
       "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+      "  Distributions: [[], []]\n"
+      "  SingularityPositions: [[], []]\n"
       "  IsPeriodicIn: [false, true]\n"
       "  InitialGridPoints: [3, 4]\n"
       "  InitialLevels: [2, 1]\n"
@@ -245,6 +258,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
               3, domain::creators::AlignedLattice<3>>>(
       "AlignedLattice:\n"
       "  BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+      "  Distributions: [[], [], []]\n"
+      "  SingularityPositions: [[], [], []]\n"
       "  IsPeriodicIn: [false, true, false]\n"
       "  InitialGridPoints: [3, 4, 5]\n"
       "  InitialLevels: [2, 1, 0]\n"
@@ -271,6 +286,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
                 2, domain::creators::AlignedLattice<2>>>(
         "AlignedLattice:\n"
         "  BlockBounds: [[70, 71, 72, 73], [90, 91, 92, 93]]\n"
+        "  Distributions: [[], []]\n"
+        "  SingularityPositions: [[], []]\n"
         "  IsPeriodicIn: [false, false]\n"
         "  InitialGridPoints: [2, 3]\n"
         "  InitialLevels: [0, 0]\n"
@@ -326,6 +343,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
                 2, domain::creators::AlignedLattice<2>>>(
         "AlignedLattice:\n"
         "  BlockBounds: [[70, 71, 72, 73], [90, 91, 92, 93]]\n"
+        "  Distributions: [[], []]\n"
+        "  SingularityPositions: [[], []]\n"
         "  IsPeriodicIn: [false, false]\n"
         "  InitialGridPoints: [10, 10]\n"
         "  InitialLevels: [2, 5]\n"
@@ -373,8 +392,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
                                     {{1.5, -0.5, 0.5, 1.5}},
                                     {{-1.5, -0.5, 0.5, 1.5}}}},
-                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
-                                  {{{{1, 1, 1}}}}, {{true, false, false}},
+                                  {{{}, {}, {}}}, {{{}, {}, {}}}, {{1, 1, 1}},
+                                  {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+                                  {{true, false, false}},
                                   Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot exclude blocks as well as have periodic boundary"));
@@ -382,8 +402,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
                                     {{1.5, -0.5, 0.5, 1.5}},
                                     {{-1.5, -0.5, 0.5, 1.5}}}},
-                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
-                                  {{{{1, 1, 1}}}}, {{false, true, false}},
+                                  {{{}, {}, {}}}, {{{}, {}, {}}}, {{1, 1, 1}},
+                                  {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+                                  {{false, true, false}},
                                   Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot exclude blocks as well as have periodic boundary"));
@@ -391,10 +412,31 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
       creators::AlignedLattice<3>({{{{-1.5, -0.5, 0.5, 1.5}},
                                     {{1.5, -0.5, 0.5, 1.5}},
                                     {{-1.5, -0.5, 0.5, 1.5}}}},
-                                  {{1, 1, 1}}, {{5, 5, 5}}, {}, {},
-                                  {{{{1, 1, 1}}}}, {{true, false, true}},
+                                  {{{}, {}, {}}}, {{{}, {}, {}}}, {{1, 1, 1}},
+                                  {{5, 5, 5}}, {}, {}, {{{{1, 1, 1}}}},
+                                  {{true, false, true}},
                                   Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot exclude blocks as well as have periodic boundary"));
+  // Distributions specified without SingularityPositions
+  CHECK_THROWS_WITH(
+      creators::AlignedLattice<1>(
+          {{{{-1.0, 0.0, 1.0}}}},
+          {{{{CoordinateMaps::Distribution::Inverse,
+              CoordinateMaps::Distribution::Linear}}}},
+          {{{}}}, {{1}}, {{5}}, {}, {}, {}, {{false}},
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "'Distributions' were specified but 'SingularityPositions' were "
+          "not"));
+  // SingularityPosition falls inside the block
+  CHECK_THROWS_WITH(
+      creators::AlignedLattice<1>(
+          {{{{-1.0, 1.0}}}},
+          {{{CoordinateMaps::Distribution::Inverse}}},
+          {{{0.5}}}, {{1}}, {{5}}, {}, {}, {}, {{false}},
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "falls inside the block interval"));
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -11,11 +11,10 @@
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
@@ -81,65 +80,72 @@ void test_rotated_bricks_construction(
                     "Block(1,1,0)"s, "Block(0,0,1)"s, "Block(1,0,1)"s,
                     "Block(0,1,1)"s, "Block(1,1,1)"s));
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Interval = CoordinateMaps::Interval;
+  using Interval3D =
+      CoordinateMaps::ProductOf3Maps<Interval, Interval, Interval>;
   using DiscreteRotation3D = CoordinateMaps::DiscreteRotation<3>;
   using TargetFrame =
       tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
                           Frame::Grid>;
 
-  const Affine lower_x_map(-1.0, 1.0, lower_bound[0], midpoint[0]);
-  const Affine upper_x_map(-1.0, 1.0, midpoint[0], upper_bound[0]);
-  const Affine lower_y_map(-1.0, 1.0, lower_bound[1], midpoint[1]);
-  const Affine upper_y_map(-1.0, 1.0, midpoint[1], upper_bound[1]);
-  const Affine lower_z_map(-1.0, 1.0, lower_bound[2], midpoint[2]);
-  const Affine upper_z_map(-1.0, 1.0, midpoint[2], upper_bound[2]);
+  const Interval lower_x_map(-1.0, 1.0, lower_bound[0], midpoint[0],
+                             CoordinateMaps::Distribution::Linear);
+  const Interval upper_x_map(-1.0, 1.0, midpoint[0], upper_bound[0],
+                             CoordinateMaps::Distribution::Linear);
+  const Interval lower_y_map(-1.0, 1.0, lower_bound[1], midpoint[1],
+                             CoordinateMaps::Distribution::Linear);
+  const Interval upper_y_map(-1.0, 1.0, midpoint[1], upper_bound[1],
+                             CoordinateMaps::Distribution::Linear);
+  const Interval lower_z_map(-1.0, 1.0, lower_bound[2], midpoint[2],
+                             CoordinateMaps::Distribution::Linear);
+  const Interval upper_z_map(-1.0, 1.0, midpoint[2], upper_bound[2],
+                             CoordinateMaps::Distribution::Linear);
 
   std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, TargetFrame, 3>>>
       coord_maps;
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
-          Affine3D(lower_x_map, lower_y_map, lower_z_map)));
+          Interval3D(lower_x_map, lower_y_map, lower_z_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
                Direction<3>::lower_xi()}}}},
-          Affine3D(upper_x_map, lower_y_map, lower_z_map)));
+          Interval3D(upper_x_map, lower_y_map, lower_z_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                Direction<3>::lower_eta()}}}},
-          Affine3D(lower_x_map, upper_y_map, lower_z_map)));
+          Interval3D(lower_x_map, upper_y_map, lower_z_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_zeta(), Direction<3>::lower_xi(),
                Direction<3>::lower_eta()}}}},
-          Affine3D(upper_x_map, upper_y_map, lower_z_map)));
+          Interval3D(upper_x_map, upper_y_map, lower_z_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
                Direction<3>::upper_zeta()}}}},
-          Affine3D(lower_x_map, lower_y_map, upper_z_map)));
+          Interval3D(lower_x_map, lower_y_map, upper_z_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
                Direction<3>::lower_xi()}}}},
-          Affine3D(upper_x_map, lower_y_map, upper_z_map)));
+          Interval3D(upper_x_map, lower_y_map, upper_z_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation3D{OrientationMap<3>{std::array<Direction<3>, 3>{
               {Direction<3>::upper_zeta(), Direction<3>::lower_xi(),
                Direction<3>::lower_eta()}}}},
-          Affine3D(lower_x_map, upper_y_map, upper_z_map)));
+          Interval3D(lower_x_map, upper_y_map, upper_z_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
-          Affine3D(upper_x_map, upper_y_map, upper_z_map)));
+          Interval3D(upper_x_map, upper_y_map, upper_z_map)));
 
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps, 10.0,

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -12,10 +12,10 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/OptionTags.hpp"
@@ -77,14 +77,16 @@ void test_rotated_intervals_construction(
               Frame::BlockLogical,
               tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
                                   Frame::Grid>>(
-              CoordinateMaps::Affine{-1., 1., lower_bound[0], midpoint[0]}),
+              CoordinateMaps::Interval{-1., 1., lower_bound[0], midpoint[0],
+                                   CoordinateMaps::Distribution::Linear}),
           make_coordinate_map_base<
               Frame::BlockLogical,
               tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
                                   Frame::Grid>>(
               CoordinateMaps::DiscreteRotation<1>{OrientationMap<1>{
                   std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}}},
-              CoordinateMaps::Affine{-1., 1., midpoint[0], upper_bound[0]})),
+              CoordinateMaps::Interval{-1., 1., midpoint[0], upper_bound[0],
+                                       CoordinateMaps::Distribution::Linear})),
       10.0, rotated_intervals.functions_of_time(),
       expected_grid_to_inertial_maps);
   TestHelpers::domain::creators::test_functions_of_time(

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -11,11 +11,10 @@
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/TimeDependent/Translation.hpp"
@@ -73,38 +72,42 @@ void test_rotated_rectangles_construction(
       rotated_rectangles.block_names() ==
       make_vector("Block(0,0)"s, "Block(1,0)"s, "Block(0,1)"s, "Block(1,1)"s));
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  using Interval = CoordinateMaps::Interval;
+  using Interval2D = CoordinateMaps::ProductOf2Maps<Interval, Interval>;
   using DiscreteRotation2D = CoordinateMaps::DiscreteRotation<2>;
   using TargetFrame =
       tmpl::conditional_t<sizeof...(FuncsOfTime) == 0, Frame::Inertial,
                           Frame::Grid>;
 
-  const Affine lower_x_map(-1.0, 1.0, lower_bound[0], midpoint[0]);
-  const Affine upper_x_map(-1.0, 1.0, midpoint[0], upper_bound[0]);
-  const Affine lower_y_map(-1.0, 1.0, lower_bound[1], midpoint[1]);
-  const Affine upper_y_map(-1.0, 1.0, midpoint[1], upper_bound[1]);
+  const Interval lower_x_map(-1.0, 1.0, lower_bound[0], midpoint[0],
+                              CoordinateMaps::Distribution::Linear);
+  const Interval upper_x_map(-1.0, 1.0, midpoint[0], upper_bound[0],
+                              CoordinateMaps::Distribution::Linear);
+  const Interval lower_y_map(-1.0, 1.0, lower_bound[1], midpoint[1],
+                              CoordinateMaps::Distribution::Linear);
+  const Interval upper_y_map(-1.0, 1.0, midpoint[1], upper_bound[1],
+                              CoordinateMaps::Distribution::Linear);
   std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, TargetFrame, 2>>>
       coord_maps;
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
-          Affine2D(lower_x_map, lower_y_map)));
+          Interval2D(lower_x_map, lower_y_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}}},
-          Affine2D(upper_x_map, lower_y_map)));
+          Interval2D(upper_x_map, lower_y_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}},
-          Affine2D(lower_x_map, upper_y_map)));
+          Interval2D(lower_x_map, upper_y_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::BlockLogical, TargetFrame>(
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}},
-          Affine2D(upper_x_map, upper_y_map)));
+          Interval2D(upper_x_map, upper_y_map)));
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps, 10.0,
                            rotated_rectangles.functions_of_time(),

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -365,7 +365,7 @@ void test_1d_rectilinear_domains() {
             {{Direction<1>::lower_xi()}}, {}, {{Direction<1>::upper_xi()}}};
     const auto domain = rectilinear_domain<1>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
-        {}, {}, {{false}}, {}, true);
+        {}, {}, {{false}}, {}, {}, {}, true);
     const OrientationMap<1> aligned = OrientationMap<1>::create_aligned();
     std::vector<DirectionMap<1, BlockNeighbors<1>>> expected_block_neighbors{
         {{Direction<1>::upper_xi(), {1, aligned}}},
@@ -391,7 +391,7 @@ void test_1d_rectilinear_domains() {
     const auto domain = rectilinear_domain<1>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, std::vector<OrientationMap<1>>{aligned, antialigned, aligned},
-        {{false}}, {}, true);
+        {{false}}, {}, {}, {}, true);
     std::vector<DirectionMap<1, BlockNeighbors<1>>> expected_block_neighbors{
         {{Direction<1>::upper_xi(), {1, antialigned}}},
         {{Direction<1>::lower_xi(), {2, antialigned}},

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -13,13 +13,13 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
@@ -1374,9 +1374,10 @@ void test_discrete_rotation_corner_numbers() {
 }
 
 void test_maps_for_rectilinear_domains() {
-  using Affine = CoordinateMaps::Affine;
-  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Interval = CoordinateMaps::Interval;
+  using Interval2D = CoordinateMaps::ProductOf2Maps<Interval, Interval>;
+  using Interval3D =
+      CoordinateMaps::ProductOf3Maps<Interval, Interval, Interval>;
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular2D =
       CoordinateMaps::ProductOf2Maps<Equiangular, Equiangular>;
@@ -1385,15 +1386,19 @@ void test_maps_for_rectilinear_domains() {
 
   const std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 1>>>
-      affine_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
+      interval_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
-          {Index<1>{0}}, {}, false);
-  const auto expected_affine_maps_1d =
+          {Index<1>{0}}, {}, {}, {}, false);
+  const auto expected_interval_maps_1d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 1.7, 2.0});
-  for (size_t i = 0; i < affine_maps_1d.size(); i++) {
-    CHECK(*affine_maps_1d[i] == *expected_affine_maps_1d[i]);
+          Interval{-1., 1., 0.5, 1.7,
+                   domain::CoordinateMaps::Distribution::Linear},
+          Interval{-1., 1., 1.7, 2.0,
+                   domain::CoordinateMaps::Distribution::Linear});
+
+  for (size_t i = 0; i < interval_maps_1d.size(); i++) {
+    CHECK(*interval_maps_1d[i] == *expected_interval_maps_1d[i]);
   }
 
   const std::vector<std::unique_ptr<
@@ -1401,7 +1406,7 @@ void test_maps_for_rectilinear_domains() {
       equiangular_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
-          {Index<1>{1}}, {}, true);
+          {Index<1>{1}}, {}, {}, {}, true);
   const auto expected_equiangular_maps_1d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular{-1., 1., 0.0, 0.5}, Equiangular{-1., 1., 1.7, 2.0});
@@ -1411,21 +1416,40 @@ void test_maps_for_rectilinear_domains() {
 
   const std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
-      affine_maps_2d = maps_for_rectilinear_domains<Frame::Inertial>(
+      interval_maps_2d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
-          {Index<2>{}}, {}, false);
-  const auto expected_affine_maps_2d =
+          {Index<2>{}}, {}, {}, {}, false);
+  const auto expected_interval_maps_2d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Affine2D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0}},
-          Affine2D{Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 0.0, 1.0}},
-          Affine2D{Affine{-1., 1., 1.7, 2.0}, Affine{-1., 1., 0.0, 1.0}},
-          Affine2D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 1.0, 2.0}},
-          Affine2D{Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 1.0, 2.0}},
-          Affine2D{Affine{-1., 1., 1.7, 2.0}, Affine{-1., 1., 1.0, 2.0}});
-  for (size_t i = 0; i < affine_maps_2d.size(); i++) {
-    CHECK(*affine_maps_2d[i] == *expected_affine_maps_2d[i]);
+          Interval2D{Interval{-1., 1., 0.0, 0.5,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 0.0, 1.0,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval2D{Interval{-1., 1., 0.5, 1.7,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 0.0, 1.0,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval2D{Interval{-1., 1., 1.7, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 0.0, 1.0,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval2D{Interval{-1., 1., 0.0, 0.5,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 1.0, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval2D{Interval{-1., 1., 0.5, 1.7,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 1.0, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval2D{Interval{-1., 1., 1.7, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 1.0, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear}});
+
+  for (size_t i = 0; i < interval_maps_2d.size(); i++) {
+    CHECK(*interval_maps_2d[i] == *expected_interval_maps_2d[i]);
   }
 
   const std::vector<std::unique_ptr<
@@ -1434,7 +1458,7 @@ void test_maps_for_rectilinear_domains() {
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
-          {Index<2>{2, 1}}, {}, true);
+          {Index<2>{2, 1}}, {}, {}, {}, true);
   const auto expected_equiangular_maps_2d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular2D{Equiangular{-1., 1., 0.0, 0.5},
@@ -1454,24 +1478,41 @@ void test_maps_for_rectilinear_domains() {
   // [show_maps_for_rectilinear_domains]
   const std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>>
-      affine_maps_3d = maps_for_rectilinear_domains<Frame::Inertial>(
+      interval_maps_3d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
-          {Index<3>{}}, {}, false);
+          {Index<3>{}}, {}, {}, {}, false);
   // [show_maps_for_rectilinear_domains]
-  const auto expected_affine_maps_3d =
+  const auto expected_interval_maps_3d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          Affine3D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0},
-                   Affine{-1., 1., -0.4, 0.3}},
-          Affine3D{Affine{-1., 1., 0.5, 2.0}, Affine{-1., 1., 0.0, 1.0},
-                   Affine{-1., 1., -0.4, 0.3}},
-          Affine3D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 1.0, 2.0},
-                   Affine{-1., 1., -0.4, 0.3}},
-          Affine3D{Affine{-1., 1., 0.5, 2.0}, Affine{-1., 1., 1.0, 2.0},
-                   Affine{-1., 1., -0.4, 0.3}});
-  for (size_t i = 0; i < affine_maps_3d.size(); i++) {
-    CHECK(*affine_maps_3d[i] == *expected_affine_maps_3d[i]);
+          Interval3D{Interval{-1., 1., 0.0, 0.5,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 0.0, 1.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., -0.4, 0.3,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval3D{Interval{-1., 1., 0.5, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 0.0, 1.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., -0.4, 0.3,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval3D{Interval{-1., 1., 0.0, 0.5,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 1.0, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., -0.4, 0.3,
+                              domain::CoordinateMaps::Distribution::Linear}},
+          Interval3D{Interval{-1., 1., 0.5, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., 1.0, 2.0,
+                              domain::CoordinateMaps::Distribution::Linear},
+                     Interval{-1., 1., -0.4, 0.3,
+                              domain::CoordinateMaps::Distribution::Linear}});
+
+  for (size_t i = 0; i < interval_maps_3d.size(); i++) {
+    CHECK(*interval_maps_3d[i] == *expected_interval_maps_3d[i]);
   }
 
   const std::vector<std::unique_ptr<
@@ -1480,7 +1521,7 @@ void test_maps_for_rectilinear_domains() {
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
-          {Index<3>{0, 0, 0}}, {}, true);
+          {Index<3>{0, 0, 0}}, {}, {}, {}, true);
   const auto expected_equiangular_maps_3d =
       make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
           Equiangular3D{Equiangular{-1., 1., 0.5, 2.0},
@@ -1579,7 +1620,7 @@ void test_set_cartesian_periodic_boundaries_2() {
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks, std::array<bool, 2>{{true, false}}, {},
-      false);
+      {}, {}, false);
 
   const std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 2>>>
@@ -1587,7 +1628,7 @@ void test_set_cartesian_periodic_boundaries_2() {
           Index<2>{2, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
-          {}, orientations_of_all_blocks, false);
+          {}, orientations_of_all_blocks, {}, {}, false);
 
   for (size_t i = 0; i < domain.blocks().size(); i++) {
     CAPTURE(i);
@@ -1615,8 +1656,8 @@ void test_set_cartesian_periodic_boundaries_3() {
   const auto domain = rectilinear_domain<2>(
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
-      {}, orientations_of_all_blocks, std::array<bool, 2>{{true, true}}, {},
-      false);
+      {}, orientations_of_all_blocks, std::array<bool, 2>{{true, true}}, {}, {},
+      {}, false);
 
   const std::vector<DirectionMap<2, BlockNeighbors<2>>>
       expected_block_neighbors{
@@ -1642,7 +1683,7 @@ void test_set_cartesian_periodic_boundaries_3() {
           Index<2>{2, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
-          {}, orientations_of_all_blocks, false);
+          {}, orientations_of_all_blocks, {}, {}, false);
 
   for (size_t i = 0; i < domain.blocks().size(); i++) {
     CAPTURE(i);

--- a/tests/Unit/Domain/Test_ElementDistribution.cpp
+++ b/tests/Unit/Domain/Test_ElementDistribution.cpp
@@ -31,7 +31,8 @@ namespace {
 void test_uniform_cost_function() {
   // AlignedLattice with differently-refined Elements
   const auto domain_creator = domain::creators::AlignedLattice<2>(
-      {{{{70, 71, 72, 73}}, {{90, 92, 95, 99}}}}, {{2, 5}}, {{3, 3}},
+      {{{{70, 71, 72, 73}}, {{90, 92, 95, 99}}}}, {{{}, {}}}, {{{}, {}}},
+      {{2, 5}}, {{3, 3}},
       {{{{{1, 0}}, {{3, 2}}, {{3, 5}}}, {{{2, 1}}, {{3, 3}}, {{4, 6}}}}},
       {{{{{1, 0}}, {{3, 2}}, {{4, 5}}}, {{{2, 1}}, {{3, 3}}, {{6, 7}}}}}, {});
 
@@ -52,24 +53,24 @@ void test_uniform_cost_function() {
 // functions
 void test_weighted_cost_function(const domain::ElementWeight element_weight) {
   const auto domain_creator1 = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 1.0, 2.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}},
-      {{4, 4, 4}}, {}, {}, {});
+      {{{{0.0, 1.0, 2.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 1, 0}}, {{4, 4, 4}}, {}, {}, {});
   const auto domain1 = domain_creator1.create_domain();
   const auto& blocks1 = domain1.blocks();
 
   // Block size and grid points are the same as blocks in `domain1`, but
   // refinement levels are different
   const auto domain_creator2 = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 3, 2}}, {{4, 4, 4}},
-      {}, {}, {});
+      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 3, 2}}, {{4, 4, 4}}, {}, {}, {});
   const auto domain2 = domain_creator2.create_domain();
   const auto& blocks2 = domain2.blocks();
 
   // Block size and refinement levels are the same as blocks in `domain1`, but
   // grid points are different
   const auto domain_creator3 = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{2, 1, 0}}, {{4, 3, 2}},
-      {}, {}, {});
+      {{{{0.0, 1.0}}, {{0.0, 1.0}}, {{0.0, 1.0}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 1, 0}}, {{4, 3, 2}}, {}, {}, {});
   const auto domain3 = domain_creator3.create_domain();
   const auto& blocks3 = domain2.blocks();
 
@@ -511,14 +512,15 @@ SPECTRE_TEST_CASE("Unit.Domain.ElementDistribution", "[Domain][Unit]") {
 
   // 1D, single block
   const auto lattice_1d = domain::creators::AlignedLattice<1>(
-      {{{{0.0, 1.0}}}}, {{4}}, {{6}}, {}, {}, {});
+      {{{{0.0, 1.0}}}}, {{{}}}, {{{}}}, {{4}}, {{6}}, {}, {}, {});
   // 2D
   const auto lattice_2d = domain::creators::AlignedLattice<2>(
-      {{{{0.0, 0.3}}, {{0.0, 0.8, 2.5, 4.9}}}}, {{2, 3}}, {{4, 5}}, {}, {}, {});
+      {{{{0.0, 0.3}}, {{0.0, 0.8, 2.5, 4.9}}}}, {{{}, {}}}, {{{}, {}}},
+      {{2, 3}}, {{4, 5}}, {}, {}, {});
   // 3D
   const auto lattice_3d = domain::creators::AlignedLattice<3>(
-      {{{{0.0, 0.6}}, {{0.0, 0.4, 0.7}}, {{0.0, 0.3}}}}, {{2, 1, 3}},
-      {{5, 4, 5}}, {}, {}, {});
+      {{{{0.0, 0.6}}, {{0.0, 0.4, 0.7}}, {{0.0, 0.3}}}}, {{{}, {}, {}}},
+      {{{}, {}, {}}}, {{2, 1, 3}}, {{5, 4, 5}}, {}, {}, {});
 
   // Test element distribution construction logic
 

--- a/tests/Unit/Domain/Test_RadiallyCompressedCoordinates.cpp
+++ b/tests/Unit/Domain/Test_RadiallyCompressedCoordinates.cpp
@@ -118,6 +118,29 @@ void test_radially_compressed_coordinates(
   }
 }
 
+void test_index_specific_compression() {
+  INFO("Testing index-specific radial compression");
+  const size_t Dim = 2;
+  using Frame = Frame::Inertial;
+  const double inner_radius = 10.0;
+  const double outer_radius = 100.0;
+  const auto distribution = CoordinateMaps::Distribution::Logarithmic;
+  const tnsr::I<DataVector, Dim, Frame> coords{
+      {{DataVector{50.0}, DataVector{1.5}}}};
+  using radial_dim = tmpl::size_t<0>;
+  using compute_tag =
+      Tags::RadiallyCompressedCoordinatesCompute<Dim, Frame, radial_dim>;
+  const std::optional<RadiallyCompressedCoordinatesOptions> options{
+      {inner_radius, outer_radius, distribution}};
+  tnsr::I<DataVector, Dim, Frame> result{static_cast<size_t>(1)};
+  compute_tag::function(make_not_null(&result), coords, options);
+  CHECK(get<1>(result)[0] == 1.5);
+  CHECK(get<0>(result)[0] < 50.0);
+  CHECK(get<0>(result)[0] > inner_radius);
+  TestHelpers::db::test_compute_tag<compute_tag>(
+      "RadiallyCompressedCoordinates");
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.RadiallyCompressedCoordinates",
@@ -131,6 +154,7 @@ SPECTRE_TEST_CASE("Unit.Domain.RadiallyCompressedCoordinates",
   test_radially_compressed_coordinates(
       CoordinateMaps::Distribution::Logarithmic);
   test_radially_compressed_coordinates(CoordinateMaps::Distribution::Inverse);
+  test_index_specific_compression();
 }
 
 }  // namespace domain

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -1024,6 +1024,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           elliptic::BoundaryConditionType::Dirichlet);
       const domain::creators::AlignedLattice<1> domain_creator{
           {{{-2., 0., 2.}}},
+          {},
+          {},
           {{0}},
           {{3}},
           {{{{1}}, {{2}}, {{1}}}},  // Refine once in block 1
@@ -1055,6 +1057,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
       const domain::creators::AlignedLattice<2> domain_creator{
           // Start with 4 unrefined blocks
           {{{-2., 0., 2.}, {-2., 0., 2.}}},
+          {},
+          {},
           {{0, 0}},
           {{3, 3}},
           // Refine once in eta in upper-right block in sketch above
@@ -1073,6 +1077,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.SubdomainOperator", "[Unit][Elliptic]") {
           elliptic::BoundaryConditionType::Dirichlet);
       const domain::creators::AlignedLattice<3> domain_creator{
           {{{-2., 0., 2.}, {-2., 0., 2.}, {-2., 0., 2.}}},
+          {},
+          {},
           {{0, 0, 0}},
           {{3, 3, 3}},
           {{{{1, 0, 0}}, {{2, 1, 1}}, {{0, 1, 1}}}},

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -1126,6 +1126,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
       const domain::creators::AlignedLattice<2> domain_creator{
           // Start with 2 unrefined blocks
           {{{0., 0.25, 0.5}, {0., 0.5}}},
+          {},
+          {},
           {{0, 0}},
           {{3, 2}},
           // Refine once in eta in left block in sketch above
@@ -1230,6 +1232,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
               elliptic::BoundaryConditionType::Dirichlet};
       const domain::creators::AlignedLattice<2> domain_creator{
           {{{0., 0.25, 0.5}, {0., 0.5}}},
+          {},
+          {},
           {{1, 1}},
           {{12, 12}},
           {{{{0, 0}}, {{1, 1}}, {{1, 2}}}},
@@ -1268,6 +1272,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
             elliptic::BoundaryConditionType::Dirichlet};
     const domain::creators::AlignedLattice<2> domain_creator{
         {{{0., 0.25, 0.5}, {0., 0.5}}},
+        {},
+        {},
         {{1, 1}},
         {{12, 12}},
         {{{{0, 0}}, {{1, 1}}, {{1, 2}}}},
@@ -1483,6 +1489,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
     // solve for u_R.
     const domain::creators::AlignedLattice<2> domain_creator{
         {{{0., 0.5, 1.}, {0., 1.}}},
+        {},
+        {},
         {{1, 1}},
         {{12, 12}},
         {},

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/Actions/Test_InitializeEffectiveSource.cpp
@@ -83,7 +83,7 @@ SPECTRE_TEST_CASE("Unit.GrSelfForce.Actions.InitializeEffectiveSource",
   domain::creators::register_derived_with_charm();
   register_factory_classes_with_charm<Metavariables>();
   const domain::creators::AlignedLattice<2> domain_creator{
-      {{{-20., 0., 20.}, {0., M_PI}}}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
+      {{{-20., 0., 20.}, {0., M_PI}}}, {}, {}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
   const auto element_regularized =
       ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{2, 1}}}};
   const auto element_unregularized =

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Actions/Test_InitializeEffectiveSource.cpp
@@ -83,7 +83,7 @@ SPECTRE_TEST_CASE("Unit.ScalarSelfForce.Actions.InitializeEffectiveSource",
   domain::creators::register_derived_with_charm();
   register_factory_classes_with_charm<Metavariables>();
   const domain::creators::AlignedLattice<2> domain_creator{
-      {{{-20., 0., 20.}, {-1., 1.}}}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
+      {{{-20., 0., 20.}, {-1., 1.}}}, {}, {}, {{2, 2}}, {{4, 4}}, {}, {}, {}};
   const auto element_regularized =
       ElementId<2>{1, {{SegmentId{2, 0}, SegmentId{2, 1}}}};
   const auto element_unregularized =

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/Test_Tags.cpp
@@ -22,7 +22,9 @@ void test_null_slicing_tag_logic() {
   const std::unique_ptr<DomainCreator<2>> lattice =
       std::make_unique<domain::creators::AlignedLattice<2>>(
           std::array<std::vector<double>, 2>{{{0., 0.25, 0.5}, {0., 0.5}}},
-          std::array<size_t, 2>{{0, 0}}, std::array<size_t, 2>{{3, 2}},
+          std::array<std::vector<domain::CoordinateMaps::Distribution>, 2>{},
+          std::array<std::vector<double>, 2>{}, std::array<size_t, 2>{{0, 0}},
+          std::array<size_t, 2>{{3, 2}},
           std::vector<Region>{Region{{0, 0}, {1, 1}, {0, 1}}},
           std::vector<Region>{}, std::vector<std::array<size_t, 2>>{},
           std::array<bool, 2>{{false, false}}, Options::Context{});

--- a/tests/Unit/Evolution/DgSubcell/Test_DisableLts.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_DisableLts.cpp
@@ -41,7 +41,10 @@ void test(const size_t block, const size_t segment) {
   const ElementId<Dim> id(block, segments);
 
   const domain::creators::AlignedLattice<Dim> domain_creator(
-      make_array<Dim>(make_vector(0.0, 1.0, 2.0)), make_array<Dim>(1_st),
+      make_array<Dim>(make_vector(0.0, 1.0, 2.0)),
+      make_array<Dim>(std::vector<domain::CoordinateMaps::Distribution>{}),
+      make_array<Dim>(std::vector<double>{}),
+      make_array<Dim>(1_st),
       make_array<Dim>(6_st), {}, {}, {});
   const auto domain = domain_creator.create_domain();
   const auto element = domain::create_initial_element(


### PR DESCRIPTION
## Proposed changes
-  Added distribution and singularity positions to rectilinear domain in order to enable 1/r mapping, which is useful for self force project. 
- Updated RadiallyCompressedCoordinates to support a specific RadialDim 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
