### PR TITLE
Add ParaView connectivity for Fourier & Cylinders

### DIFF
--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -58,6 +58,7 @@ void append_element_extents_and_connectivity(
     const gsl::not_null<std::vector<int>*> total_connectivity,
     const gsl::not_null<std::vector<int>*> pole_connectivity,
     const gsl::not_null<std::vector<int>*> disk_connectivity,
+    const gsl::not_null<std::vector<int>*> cylinder_connectivity,
     const gsl::not_null<int*> total_points_so_far, const size_t dim,
     const ElementVolumeData& element) {
   // Process the element extents
@@ -109,12 +110,14 @@ void append_element_extents_and_connectivity(
     }
     return local_connectivity;
   }();
+  const int element_start = *total_points_so_far;
   *total_points_so_far += element_num_points;
   total_connectivity->insert(total_connectivity->end(), connectivity.begin(),
                              connectivity.end());
 
-  // If element is 2D and the bases are both SphericalHarmonic,
-  // then add extra connections to close the surface.
+  // 2D elements may require extra connections to close periodic/angular
+  // boundaries and fill any degenerate central region based on basis;
+  // generically do nothing
   if (dim == 2) {
     if (element.basis[0] == Spectral::Basis::SphericalHarmonic and
         element.basis[1] == Spectral::Basis::SphericalHarmonic) {
@@ -170,49 +173,151 @@ void append_element_extents_and_connectivity(
         pole_connectivity->push_back(bottom_second_point);
         pole_connectivity->push_back(bottom_third_point);
       }
-    } else if (element.basis[0] == Spectral::Basis::ZernikeB2 and
-               element.basis[1] == Spectral::Basis::ZernikeB2) {
-      const auto n_r = static_cast<int>(element.extents[0]);
-      const auto n_ph = static_cast<int>(element.extents[1]);
+    } else if ((element.basis[0] == Spectral::Basis::ZernikeB2 and
+                element.basis[1] == Spectral::Basis::ZernikeB2) or
+               element.basis[1] == Spectral::Basis::Fourier) {
+      ASSERT(element.basis[0] == Spectral::Basis::ZernikeB2 or
+                 (element.basis[0] == Spectral::Basis::Legendre or
+                  element.basis[0] == Spectral::Basis::Chebyshev),
+             "Adding connectivity for Fourier in the second dimension requires "
+             "the first dimension to be Legendre or Chebychev, got "
+                 << element.basis[0]);
+      const auto n_r = static_cast<int>(extents[0]);
+      const auto n_ph = static_cast<int>(extents[1]);
 
       // Connect max(phi) and min(phi) by adding more quads
       // to total_connectivity
       for (int j = 0; j < n_r - 1; ++j) {
-        total_connectivity->push_back(j);
-        total_connectivity->push_back(j + 1);
-        total_connectivity->push_back((n_ph - 1) * n_r + j + 1);
-        total_connectivity->push_back((n_ph - 1) * n_r + j);
+        total_connectivity->push_back(element_start + j);
+        total_connectivity->push_back(element_start + j + 1);
+        total_connectivity->push_back(element_start + (n_ph - 1) * n_r + j + 1);
+        total_connectivity->push_back(element_start + (n_ph - 1) * n_r + j);
       }
 
-      std::vector<int> inner_ring_points{};
-      inner_ring_points.reserve(static_cast<size_t>(n_ph));
-      for (int k = 0; k < n_ph; ++k) {
-        inner_ring_points.push_back(k * n_r);  // r = 0 for each phi slice
-      }
+      // For a filled disk (ZernikeB2), also fill the central hole with
+      // triangles using a recursive fan pattern over the minimum r ring points.
+      if (element.basis[0] == Spectral::Basis::ZernikeB2) {
+        std::vector<int> inner_ring_points{};
+        inner_ring_points.reserve(static_cast<size_t>(n_ph));
+        for (int k = 0; k < n_ph; ++k) {
+          // minimum r for each phi slice
+          inner_ring_points.push_back(element_start + k * n_r);
+        }
 
-      std::vector<int> new_points;
-      while (inner_ring_points.size() >= 3) {
-        new_points.clear();
-        new_points.push_back(inner_ring_points[0]);
-        for (size_t i = 0; i < inner_ring_points.size() - 2; i += 2) {
-          disk_connectivity->push_back(inner_ring_points[i]);
-          disk_connectivity->push_back(inner_ring_points[i + 1]);
-          disk_connectivity->push_back(inner_ring_points[i + 2]);
-          new_points.push_back(inner_ring_points[i + 2]);
+        std::vector<int> new_points;
+        while (inner_ring_points.size() >= 3) {
+          new_points.clear();
+          new_points.push_back(inner_ring_points[0]);
+          for (size_t i = 0; i < inner_ring_points.size() - 2; i += 2) {
+            disk_connectivity->push_back(inner_ring_points[i]);
+            disk_connectivity->push_back(inner_ring_points[i + 1]);
+            disk_connectivity->push_back(inner_ring_points[i + 2]);
+            new_points.push_back(inner_ring_points[i + 2]);
+          }
+          if (inner_ring_points.size() % 2 == 0) {
+            // Add triangle closing the ring: connects last two points back to
+            // first
+            disk_connectivity->push_back(
+                inner_ring_points[inner_ring_points.size() - 2]);
+            disk_connectivity->push_back(
+                inner_ring_points[inner_ring_points.size() - 1]);
+            disk_connectivity->push_back(inner_ring_points[0]);
+          }
+          inner_ring_points = std::move(new_points);
         }
-        if (inner_ring_points.size() % 2 == 0) {
-          // Add triangle closing the ring: connects last two points back to
-          // first
-          disk_connectivity->push_back(
-              inner_ring_points[inner_ring_points.size() - 2]);
-          disk_connectivity->push_back(
-              inner_ring_points[inner_ring_points.size() - 1]);
-          disk_connectivity->push_back(inner_ring_points[0]);
-        }
-        inner_ring_points = std::move(new_points);
       }
     }
-    // generically do nothing if not a sphere or disk
+  } else if (dim == 3) {
+    if ((element.basis[0] == Spectral::Basis::ZernikeB2 and
+         element.basis[1] == Spectral::Basis::ZernikeB2) or
+        element.basis[1] == Spectral::Basis::Fourier) {
+      ASSERT(element.basis[0] == Spectral::Basis::ZernikeB2 or
+                 ((element.basis[0] == Spectral::Basis::Legendre or
+                   element.basis[0] == Spectral::Basis::Chebyshev) and
+                  (element.basis[2] == Spectral::Basis::Legendre or
+                   element.basis[2] == Spectral::Basis::Chebyshev)),
+             "Adding connectivity for Fourier in the second dimension requires "
+             "the first and third dimensions to be Legendre or Chebychev, got "
+                 << element.basis[0] << ", " << element.basis[2]);
+      const auto n_r = static_cast<int>(extents[0]);
+      const auto n_ph = static_cast<int>(extents[1]);
+      const auto n_z = static_cast<int>(extents[2]);
+
+      // Helper: global point index for (i_r, i_phi, i_z)
+      const auto global_index = [&](int index_radius, int index_phi,
+                                    int index_z) {
+        return element_start + index_radius + n_r * index_phi +
+               n_r * n_ph * index_z;
+      };
+
+      // Close the phi seam: connect last phi strip (i_ph = n_ph-1) back to
+      // first (i_ph = 0) with hexahedra.
+      for (int j_r = 0; j_r < n_r - 1; ++j_r) {
+        for (int j_z = 0; j_z < n_z - 1; ++j_z) {
+          total_connectivity->push_back(global_index(j_r, n_ph - 1, j_z));
+          total_connectivity->push_back(global_index(j_r + 1, n_ph - 1, j_z));
+          total_connectivity->push_back(global_index(j_r + 1, 0, j_z));
+          total_connectivity->push_back(global_index(j_r, 0, j_z));
+          total_connectivity->push_back(global_index(j_r, n_ph - 1, j_z + 1));
+          total_connectivity->push_back(
+              global_index(j_r + 1, n_ph - 1, j_z + 1));
+          total_connectivity->push_back(global_index(j_r + 1, 0, j_z + 1));
+          total_connectivity->push_back(global_index(j_r, 0, j_z + 1));
+        }
+      }
+
+      // For a filled cylinder (ZernikeB2), fill the central hole with
+      // wedges between consecutive z layers.
+      if (element.basis[0] == Spectral::Basis::ZernikeB2) {
+        std::vector<int> ring_lo{};
+        std::vector<int> ring_hi{};
+        ring_lo.reserve(static_cast<size_t>(n_ph));
+        ring_hi.reserve(static_cast<size_t>(n_ph));
+        std::vector<int> new_lo{};
+        std::vector<int> new_hi{};
+        for (int j_z = 0; j_z < n_z - 1; ++j_z) {
+          ring_lo.clear();
+          ring_hi.clear();
+          // Collect the minimum r ring points in this z layer and the next
+          for (int k = 0; k < n_ph; ++k) {
+            ring_lo.push_back(global_index(0, k, j_z));
+            ring_hi.push_back(global_index(0, k, j_z + 1));
+          }
+
+          // Build wedge prisms using the same recursive fan as the 2D case,
+          // extruded between ring_lo and ring_hi.
+          while (ring_lo.size() >= 3) {
+            new_lo.clear();
+            new_hi.clear();
+            new_lo.push_back(ring_lo[0]);
+            new_hi.push_back(ring_hi[0]);
+            for (size_t i = 0; i < ring_lo.size() - 2; i += 2) {
+              // Wedge (triangular prism): bottom triangle (ring_lo) + top
+              // triangle (ring_hi), each 3 vertices = 6 total.
+              cylinder_connectivity->push_back(ring_lo[i]);
+              cylinder_connectivity->push_back(ring_lo[i + 1]);
+              cylinder_connectivity->push_back(ring_lo[i + 2]);
+              cylinder_connectivity->push_back(ring_hi[i]);
+              cylinder_connectivity->push_back(ring_hi[i + 1]);
+              cylinder_connectivity->push_back(ring_hi[i + 2]);
+              new_lo.push_back(ring_lo[i + 2]);
+              new_hi.push_back(ring_hi[i + 2]);
+            }
+            if (ring_lo.size() % 2 == 0) {
+              // Closing wedge connecting last two points back to first
+              cylinder_connectivity->push_back(ring_lo[ring_lo.size() - 2]);
+              cylinder_connectivity->push_back(ring_lo[ring_lo.size() - 1]);
+              cylinder_connectivity->push_back(ring_lo[0]);
+              cylinder_connectivity->push_back(ring_hi[ring_hi.size() - 2]);
+              cylinder_connectivity->push_back(ring_hi[ring_hi.size() - 1]);
+              cylinder_connectivity->push_back(ring_hi[0]);
+            }
+            ring_lo = std::move(new_lo);
+            ring_hi = std::move(new_hi);
+          }
+        }
+      }
+    }
   }
 }
 }  // namespace
@@ -315,6 +420,7 @@ void VolumeData::write_volume_data(
   std::vector<int> total_connectivity;
   std::vector<int> pole_connectivity{};
   std::vector<int> disk_connectivity{};
+  std::vector<int> cylinder_connectivity{};
   std::vector<int> quadratures;
   std::vector<int> bases;
   // Keep a running count of the number of points so far to use as a global
@@ -335,7 +441,8 @@ void VolumeData::write_volume_data(
     const auto fill_and_write_contiguous_tensor_data =
         [&bases, &component_name, &dim, &elements, &grid_names, i,
          &observation_group, &quadratures, &total_connectivity,
-         &pole_connectivity, &disk_connectivity, &total_extents,
+         &pole_connectivity, &disk_connectivity, &cylinder_connectivity,
+         &total_extents,
          &total_points_so_far](const auto contiguous_tensor_data_ptr) {
           for (const auto& element : elements) {
             if (UNLIKELY(i == 0)) {
@@ -370,7 +477,8 @@ void VolumeData::write_volume_data(
 
               append_element_extents_and_connectivity(
                   &total_extents, &total_connectivity, &pole_connectivity,
-                  &disk_connectivity, &total_points_so_far, dim, element);
+                  &disk_connectivity, &cylinder_connectivity,
+                  &total_points_so_far, dim, element);
             }
             using type_from_variant = tmpl::conditional_t<
                 std::is_same_v<
@@ -453,6 +561,10 @@ void VolumeData::write_volume_data(
   if (not disk_connectivity.empty()) {
     h5::write_data(observation_group.id(), disk_connectivity,
                    {disk_connectivity.size()}, "disk_connectivity");
+  }
+  if (not cylinder_connectivity.empty()) {
+    h5::write_data(observation_group.id(), cylinder_connectivity,
+                   {cylinder_connectivity.size()}, "cylinder_connectivity");
   }
   // Store the serialized domain and functions of time at the subfile level
   if (serialized_domain.has_value() and
@@ -626,6 +738,7 @@ std::vector<std::string> VolumeData::list_tensor_components(
       "connectivity",
       "pole_connectivity",
       "disk_connectivity",
+      "cylinder_connectivity",
       "total_extents",
       "grid_names",
       "quadratures",

--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -33,6 +33,8 @@ def _list_tensor_components(observation):
         components.remove("pole_connectivity")
     if "disk_connectivity" in components:
         components.remove("disk_connectivity")
+    if "cylinder_connectivity" in components:
+        components.remove("cylinder_connectivity")
     if "tetrahedral_connectivity" in components:
         components.remove("tetrahedral_connectivity")
     components.remove("total_extents")
@@ -62,6 +64,7 @@ def _xmf_topology(
         "Quadrilateral": 4,
         "Tetrahedron": 4,
         "Triangle": 3,
+        "Wedge": 6,
     }[topology_type]
     num_cells = len(observation[connectivity_name]) // num_vertices
     xmf_topology = ET.Element(
@@ -167,6 +170,7 @@ def _xmf_grid(
     coordinates: str,
     filling_poles: bool = False,
     filling_disk_center: bool = False,
+    filling_cylinder_center: bool = False,
     use_tetrahedral_connectivity: bool = False,
 ) -> ET.Element:
     # Make sure the coordinates are found in the file. We assume there should
@@ -190,6 +194,16 @@ def _xmf_grid(
     if filling_poles:
         # Filling poles is currently supported for a 2D surface embedded in 3D
         assert "pole_connectivity" in observation and topo_dim == 2 and dim == 3
+
+    if filling_disk_center:
+        assert "disk_connectivity" in observation and topo_dim == 2 and dim == 2
+
+    if filling_cylinder_center:
+        assert (
+            "cylinder_connectivity" in observation
+            and topo_dim == 3
+            and dim == 3
+        )
 
     xmf_grid = ET.Element("Grid", Name=filename, GridType="Uniform")
 
@@ -229,6 +243,13 @@ def _xmf_grid(
                 observation,
                 topology_type="Triangle",
                 connectivity_name="disk_connectivity",
+                grid_path=grid_path,
+            )
+        elif filling_cylinder_center:
+            xmf_topology = _xmf_topology(
+                observation,
+                topology_type="Wedge",
+                connectivity_name="cylinder_connectivity",
                 grid_path=grid_path,
             )
         else:
@@ -505,6 +526,22 @@ def generate_xdmf(
                         temporal_id=temporal_id,
                         coordinates=coordinates,
                         filling_disk_center=True,
+                        use_tetrahedral_connectivity=(
+                            use_tetrahedral_connectivity
+                        ),
+                    )
+                )
+            # Fill cylinder center if cylinder_connectivity is present
+            if "cylinder_connectivity" in observation:
+                xmf_timestep_grid.append(
+                    _xmf_grid(
+                        observation,
+                        topo_dim=topo_dim,
+                        filename=filename_in_output,
+                        subfile_name=subfile_name,
+                        temporal_id=temporal_id,
+                        coordinates=coordinates,
+                        filling_cylinder_center=True,
                         use_tetrahedral_connectivity=(
                             use_tetrahedral_connectivity
                         ),

--- a/tests/Unit/IO/H5/Test_VolumeData.cpp
+++ b/tests/Unit/IO/H5/Test_VolumeData.cpp
@@ -694,6 +694,99 @@ void test_extend_connectivity_data() {
   }
 }
 
+void test_cylinder(const bool filled) {
+  // filled = true -> cylinder with ZernikeB2, close the angular edges with
+  // hexahedra, fill in the inner circle with wedges
+  // filled = false -> hollow cylinder with Fourier, just close the angular
+  // edges
+  const std::string h5_file_name("Unit.IO.H5.VolumeData.Cylinder.h5");
+  const uint32_t version_number = 4;
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+  const std::string grid_name{"Cylinder"};
+  const std::vector<size_t> observation_ids{99901};
+  const std::vector<double> observation_values{2.2};
+  const auto bases =
+      filled ? std::vector<Spectral::Basis>{Spectral::Basis::ZernikeB2,
+                                            Spectral::Basis::ZernikeB2,
+                                            Spectral::Basis::Legendre}
+             : std::vector<Spectral::Basis>{Spectral::Basis::Legendre,
+                                            Spectral::Basis::Fourier,
+                                            Spectral::Basis::Legendre};
+  const std::vector<Spectral::Quadrature> quadratures{
+      filled ? Spectral::Quadrature::GaussRadauUpper
+             : Spectral::Quadrature::GaussLobatto,
+      Spectral::Quadrature::Equiangular, Spectral::Quadrature::GaussLobatto};
+  const std::vector<size_t> extents{2, 7, 2};
+
+  // Not using values, just checking connectivity
+  const std::vector<DataVector> tensor_and_coord_data{
+      {28, 0.0}, {28, 0.0}, {28, 0.0}, {28, 0.0}};
+  const std::vector<TensorComponent> tensor_components{
+      {"InertialCoordinates_x", tensor_and_coord_data[0]},
+      {"InertialCoordinates_y", tensor_and_coord_data[1]},
+      {"InertialCoordinates_z", tensor_and_coord_data[2]},
+      {"TestScalar", tensor_and_coord_data[3]}};
+
+  {
+    h5::H5File<h5::AccessType::ReadWrite> cyl_file{h5_file_name};
+    auto& volume_file =
+        cyl_file.insert<h5::VolumeData>("/element_data", version_number);
+    volume_file.write_volume_data(
+        observation_ids[0], observation_values[0],
+        std::vector<ElementVolumeData>{
+            {grid_name, tensor_components, extents, bases, quadratures}});
+    cyl_file.close_current_object();
+  }
+
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> cyl_file{h5_file_name};
+    const auto& volume_file =
+        cyl_file.get<h5::VolumeData>("/element_data", version_number);
+    const auto h5_connectivity =
+        volume_file.get_tensor_component(99901, "connectivity").data;
+    const DataVector connectivity_data = get<0>(h5_connectivity);
+    cyl_file.close_current_object();
+
+    // clang-format off
+    const DataVector expected_connectivity{
+         0.,  1.,  3.,  2., 14., 15., 17., 16.,
+         2.,  3.,  5.,  4., 16., 17., 19., 18.,
+         4.,  5.,  7.,  6., 18., 19., 21., 20.,
+         6.,  7.,  9.,  8., 20., 21., 23., 22.,
+         8.,  9., 11., 10., 22., 23., 25., 24.,
+        10., 11., 13., 12., 24., 25., 27., 26.,
+        12., 13.,  1.,  0., 26., 27., 15., 14.};
+    // clang-format on
+    CHECK(connectivity_data == expected_connectivity);
+  }
+
+  if (filled) {
+    const h5::H5File<h5::AccessType::ReadOnly> cyl_file{h5_file_name};
+    const auto& volume_file =
+        cyl_file.get<h5::VolumeData>("/element_data", version_number);
+    const auto h5_wedge =
+        volume_file.get_tensor_component(99901, "cylinder_connectivity").data;
+    const DataVector wedge_data = get<0>(h5_wedge);
+    cyl_file.close_current_object();
+
+    // clang-format off
+    const DataVector expected_wedge{
+         0.,  2.,  4., 14., 16., 18.,
+         4.,  6.,  8., 18., 20., 22.,
+         8., 10., 12., 22., 24., 26.,
+         0.,  4.,  8., 14., 18., 22.,
+         8., 12.,  0., 22., 26., 14.};
+    // clang-format on
+    CHECK(wedge_data == expected_wedge);
+  }
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}
+
 void test_disk() {
   // The disk has some extra connectivity: one being to close the angular
   // edges, the other to fill in the inner circle
@@ -965,6 +1058,8 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeData", "[Unit][IO][H5]") {
   test_cartoon();
   test_strahlkorper();
   test_disk();
+  test_cylinder(true);
+  test_cylinder(false);
   test_extend_connectivity_data<1>();
   test_extend_connectivity_data<2>();
   test_extend_connectivity_data<3>();


### PR DESCRIPTION
## Proposed changes

Identical logic to disks (see #7113 for image of filling pattern), cylinders need their angular sides to be closed and their inner hole to be filled. All now in 3D.

Changes from #7113:
- Support Fourier in a hollow disk
- Support multiple elements (there is a global offset in counting I forgot)
- Generalize the Disk & Fourier to 3D cylinders and hollow cylinders

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
