### PR TITLE
Add Zernike nodal modal transformations

### DIFF
--- a/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
@@ -40,6 +40,37 @@ struct ModalToNodalMatrixGenerator {
     return vandermonde_matrix;
   }
 };
+
+template <Basis BasisType, Quadrature QuadratureType>
+struct TwoIndexedModalToNodalMatrixGenerator {
+  Matrix operator()(const size_t num_points, const size_t m,
+                    const size_t N) const {
+    // To obtain the Vandermonde matrix for Zernike bases, we need to compute
+    // the basis function values at the collocation points for a given angular
+    // index m up to a given maximum index N.
+    static_assert(BasisType == Basis::ZernikeB1 or
+                  BasisType == Basis::ZernikeB2 or
+                  BasisType == Basis::ZernikeB3);
+    ASSERT(N < 2 * num_points - 1,
+           "N must be less than 2 * num_points - 1, got N = "
+               << N << " for num_points = " << num_points);
+    ASSERT(m <= N, "m must be less than or equal to N, got m = "
+                       << m << " and N = " << N);
+    const auto& collocation_pts =
+        collocation_points<BasisType, QuadratureType>(num_points);
+    // note the integer division
+    const size_t spectral_size = (N - m) / 2 + 1;
+    Matrix vandermonde_matrix(num_points, spectral_size);
+    for (size_t j = m, k = 0; j <= N; ++k, j += 2) {
+      const auto& basis_function_values =
+          compute_basis_function_value<BasisType>(j, m, collocation_pts);
+      for (size_t i = 0; i < num_points; ++i) {
+        vandermonde_matrix(i, k) = basis_function_values[i];
+      }
+    }
+    return vandermonde_matrix;
+  }
+};
 }  // namespace
 
 PRECOMPUTED_SPECTRAL_QUANTITY(modal_to_nodal_matrix, Matrix,
@@ -51,6 +82,15 @@ SPECTRAL_QUANTITY_FOR_MESH(modal_to_nodal_matrix, Matrix)
 
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
+PRECOMPUTED_TWO_INDEXED_SPECTRAL_QUANTITY(modal_to_nodal_matrix, Matrix,
+                                          TwoIndexedModalToNodalMatrixGenerator)
+
+#undef PRECOMPUTED_TWO_INDEXED_SPECTRAL_QUANTITY
+
+TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH(modal_to_nodal_matrix, Matrix)
+
+#undef TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH
+
 template const Matrix&
     modal_to_nodal_matrix<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
 template const Matrix& modal_to_nodal_matrix<
@@ -60,11 +100,17 @@ template const Matrix&
 template const Matrix&
     modal_to_nodal_matrix<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);
 template const Matrix&
-modal_to_nodal_matrix<Basis::Fourier, Quadrature::Equiangular>(size_t);
+    modal_to_nodal_matrix<Basis::Fourier, Quadrature::Equiangular>(size_t);
 template const Matrix&
     modal_to_nodal_matrix<Basis::Legendre, Quadrature::Gauss>(size_t);
 template const Matrix&
     modal_to_nodal_matrix<Basis::Legendre, Quadrature::GaussLobatto>(size_t);
+template const Matrix& modal_to_nodal_matrix<
+    Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
+template const Matrix& modal_to_nodal_matrix<
+    Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
+template const Matrix& modal_to_nodal_matrix<
+    Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
 // Some compilers require these instantiations to exist
 template const Matrix& modal_to_nodal_matrix<Basis::FiniteDifference,
                                              Quadrature::CellCentered>(size_t);

--- a/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp
+++ b/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp
@@ -39,10 +39,34 @@ template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& modal_to_nodal_matrix(size_t num_points);
 
 /*!
+ * \brief %Matrix used to transform from the spectral coefficients (modes) of a
+ * function to its nodal coefficients. This two-index version is used for
+ * two-dimensional basis function (i.e. Zernike with GaussRadauUpper
+ * quadrature).
+ *
+ * For Zernike, \f$m\f$ is the angular index and \f$N\f$ is the
+ * maximum supported spectral index (usually taken to be the maximum value,
+ * \f$2 \, \texttt{num_points}-2\f$). Note that the size of a spectral space
+ * vector is \f$(N - m) / 2 + 1\f$, using integer division.
+ *
+ * \see modal_to_nodal_matrix(size_t)
+ */
+template <Basis BasisType, Quadrature QuadratureType>
+const Matrix& modal_to_nodal_matrix(size_t num_points, size_t m, size_t N);
+
+/*!
  * \brief Transformation matrix from modal to nodal coefficients for a
  * one-dimensional mesh.
  *
  * \see modal_to_nodal_matrix(size_t)
  */
 const Matrix& modal_to_nodal_matrix(const Mesh<1>& mesh);
+
+/*!
+ * \brief Transformation matrix from modal to nodal coefficients for a
+ * one-dimensional mesh with a Zernike basis.
+ *
+ * \see modal_to_nodal_matrix(size_t, size_t, size_t)
+ */
+const Matrix& modal_to_nodal_matrix(const Mesh<1>& mesh, size_t m, size_t N);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
@@ -9,6 +9,8 @@
 #include "DataStructures/Matrix.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctionNormalizationSquare.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
 #include "NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -16,6 +18,7 @@
 #include "NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/SpectralQuantityForMesh.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 
 namespace Spectral {
 namespace {
@@ -55,6 +58,38 @@ struct NodalToModalMatrixGenerator<BasisType, Quadrature::Gauss> {
     return vandermonde_inverse;
   }
 };
+
+template <Basis BasisType, Quadrature QuadratureType>
+struct TwoIndexedNodalToModalMatrixGenerator {
+  Matrix operator()(const size_t num_points, const size_t m,
+                    const size_t N) const {
+    // To obtain the Vandermonde matrix for Zernike bases, we need to compute
+    // the basis function values at the collocation points for a given angular
+    // index m up to a given maximum index N.
+    static_assert(BasisType == Basis::ZernikeB1 or
+                  BasisType == Basis::ZernikeB2 or
+                  BasisType == Basis::ZernikeB3);
+    ASSERT(N < 2 * num_points - 1,
+           "N must be less than 2 * num_points - 1, got N = "
+               << N << " for num_points = " << num_points);
+    ASSERT(m <= N, "m must be less than or equal to N, got m = "
+                       << m << " and N = " << N);
+    // note the integer division
+    const size_t spectral_size = (N - m) / 2 + 1;
+    const auto& [collocation_pts, weights] =
+        compute_collocation_points_and_weights<BasisType, QuadratureType>(
+            num_points);
+    Matrix inv_matrix(spectral_size, num_points);
+    for (size_t j = m, k = 0; j <= N; ++k, j += 2) {
+      const auto& basis_function_values =
+          compute_basis_function_value<BasisType>(j, m, collocation_pts);
+      for (size_t i = 0; i < num_points; ++i) {
+        inv_matrix(k, i) = basis_function_values[i] * weights[i];
+      }
+    }
+    return inv_matrix;
+  }
+};
 }  // namespace
 
 PRECOMPUTED_SPECTRAL_QUANTITY(nodal_to_modal_matrix, Matrix,
@@ -66,6 +101,15 @@ SPECTRAL_QUANTITY_FOR_MESH(nodal_to_modal_matrix, Matrix)
 
 #undef SPECTRAL_QUANTITY_FOR_MESH
 
+PRECOMPUTED_TWO_INDEXED_SPECTRAL_QUANTITY(nodal_to_modal_matrix, Matrix,
+                                          TwoIndexedNodalToModalMatrixGenerator)
+
+#undef PRECOMPUTED_TWO_INDEXED_SPECTRAL_QUANTITY
+
+TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH(nodal_to_modal_matrix, Matrix)
+
+#undef TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH
+
 template const Matrix&
     nodal_to_modal_matrix<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
 template const Matrix& nodal_to_modal_matrix<
@@ -75,11 +119,17 @@ template const Matrix&
 template const Matrix&
     nodal_to_modal_matrix<Basis::Chebyshev, Quadrature::GaussLobatto>(size_t);
 template const Matrix&
-nodal_to_modal_matrix<Basis::Fourier, Quadrature::Equiangular>(size_t);
+    nodal_to_modal_matrix<Basis::Fourier, Quadrature::Equiangular>(size_t);
 template const Matrix&
     nodal_to_modal_matrix<Basis::Legendre, Quadrature::Gauss>(size_t);
 template const Matrix&
     nodal_to_modal_matrix<Basis::Legendre, Quadrature::GaussLobatto>(size_t);
+template const Matrix& nodal_to_modal_matrix<
+    Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
+template const Matrix& nodal_to_modal_matrix<
+    Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
+template const Matrix& nodal_to_modal_matrix<
+    Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
 // Some compilers require these instantiations to exist
 template const Matrix& nodal_to_modal_matrix<Basis::FiniteDifference,
                                              Quadrature::CellCentered>(size_t);

--- a/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp
+++ b/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp
@@ -39,10 +39,34 @@ template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& nodal_to_modal_matrix(size_t num_points);
 
 /*!
+ * \brief %Matrix used to transform from the nodal coefficients of a function to
+ * its spectral coefficients (modes). This two-index version is used for
+ * two-dimensional basis function (i.e. Zernike with GaussRadauUpper
+ * quadrature).
+ *
+ * For Zernike, \f$m\f$ is the angular index and \f$N\f$ is the
+ * maximum supported spectral index (usually taken to be the maximum value,
+ * \f$2 \, \texttt{num_points}-2\f$). Note that the size of a spectral space
+ * vector is \f$(N - m) / 2 + 1\f$, using integer division.
+ *
+ * \see nodal_to_modal_matrix(size_t)
+ */
+template <Basis BasisType, Quadrature QuadratureType>
+const Matrix& nodal_to_modal_matrix(size_t num_points, size_t m, size_t N);
+
+/*!
  * \brief Transformation matrix from nodal to modal coefficients for a
  * one-dimensional mesh.
  *
  * \see nodal_to_modal_matrix(size_t)
  */
 const Matrix& nodal_to_modal_matrix(const Mesh<1>& mesh);
+
+/*!
+ * \brief Transformation matrix from nodal to modal coefficients for a
+ * one-dimensional mesh with a Zernike basis.
+ *
+ * \see nodal_to_modal_matrix(size_t, size_t, size_t)
+ */
+const Matrix& nodal_to_modal_matrix(const Mesh<1>& mesh, size_t m, size_t N);
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ModalToNodalMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ModalToNodalMatrix.cpp
@@ -10,10 +10,12 @@
 #include "Helpers/DataStructures/ApplyMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 
 namespace Spectral {
@@ -37,8 +39,43 @@ void test() {
     }
   }
 }
+
+template <Basis basis, Quadrature quadrature>
+void test_two_indexed() {
+  static_assert(basis == Basis::ZernikeB1 or basis == Basis::ZernikeB2 or
+                basis == Basis::ZernikeB3);
+  CAPTURE(basis);
+  CAPTURE(quadrature);
+  for (size_t n = minimum_number_of_points<basis, quadrature>;
+       n <= maximum_number_of_points<basis>; ++n) {
+    CAPTURE(n);
+    const DataVector xi = collocation_points<basis, quadrature>(n);
+    for (size_t N = 0; N < 2 * n - 1; ++N) {
+      CAPTURE(N);
+      for (size_t m = 0; m <= N; ++m) {
+        CAPTURE(m);
+        const Matrix modal_to_nodal =
+            modal_to_nodal_matrix<basis, quadrature>(n, m, N);
+        // The spectal space is only odd or even modes, based on m parity
+        // Note the integer division
+        const size_t spectral_size = (N - m) / 2 + 1;
+        for (size_t k = m; k <= N; k += 2) {
+          CAPTURE(k);
+          const auto f_expected = compute_basis_function_value<basis>(k, m, xi);
+          DataVector f_k{spectral_size, 0.0};
+          // Index in this compressed space (of specific parity) must be mapped
+          const size_t index = (k - m) / 2;
+          f_k[index] = 1.0;
+          const auto f = apply_matrix(modal_to_nodal, f_k);
+          CHECK_ITERABLE_APPROX(f, f_expected);
+        }
+      }
+    }
+  }
+}
 }  // namespace
 
+// [[TimeOut, 30]]
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ModalToNodalMatrix",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   test<Basis::Legendre, Quadrature::Gauss>();
@@ -46,5 +83,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ModalToNodalMatrix",
   test<Basis::Chebyshev, Quadrature::Gauss>();
   test<Basis::Chebyshev, Quadrature::GaussLobatto>();
   test<Basis::Fourier, Quadrature::Equiangular>();
+  test_two_indexed<Basis::ZernikeB1, Quadrature::GaussRadauUpper>();
+  test_two_indexed<Basis::ZernikeB2, Quadrature::GaussRadauUpper>();
+  test_two_indexed<Basis::ZernikeB3, Quadrature::GaussRadauUpper>();
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_NodalToModalMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_NodalToModalMatrix.cpp
@@ -37,8 +37,46 @@ void test() {
     }
   }
 }
+
+template <Basis basis, Quadrature quadrature>
+void test_two_indexed() {
+  static_assert(basis == Basis::ZernikeB1 or basis == Basis::ZernikeB2 or
+                basis == Basis::ZernikeB3);
+  CAPTURE(basis);
+  CAPTURE(quadrature);
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
+  for (size_t n = minimum_number_of_points<basis, quadrature>;
+       n <= maximum_number_of_points<basis>; ++n) {
+    CAPTURE(n);
+    const DataVector xi = collocation_points<basis, quadrature>(n);
+    for (size_t N = 0; N < 2 * n - 1; ++N) {
+      CAPTURE(N);
+      for (size_t m = 0; m <= N; ++m) {
+        CAPTURE(m);
+        const Matrix nodal_to_modal =
+            nodal_to_modal_matrix<basis, quadrature>(n, m, N);
+        // The spectal space is only odd or even modes, based on m parity
+        // Note the integer division
+        const size_t spectral_size = (N - m) / 2 + 1;
+        for (size_t k = m; k <= N; k += 2) {
+          CAPTURE(k);
+          const auto f = compute_basis_function_value<basis>(k, m, xi);
+          const auto f_k = apply_matrix(nodal_to_modal, f);
+          DataVector f_k_expected{spectral_size, 0.0};
+          // Index in this compressed space (of specific parity) must be
+          // mapped
+          const size_t index = (k - m) / 2;
+          f_k_expected[index] = 1.0;
+          CHECK_ITERABLE_CUSTOM_APPROX(f_k, f_k_expected, custom_approx);
+        }
+      }
+    }
+  }
+}
+
 }  // namespace
 
+// [[TimeOut, 30]]
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.NodalToModalMatrix",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   test<Basis::Legendre, Quadrature::Gauss>();
@@ -46,5 +84,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.NodalToModalMatrix",
   test<Basis::Chebyshev, Quadrature::Gauss>();
   test<Basis::Chebyshev, Quadrature::GaussLobatto>();
   test<Basis::Fourier, Quadrature::Equiangular>();
+  test_two_indexed<Basis::ZernikeB1, Quadrature::GaussRadauUpper>();
+  test_two_indexed<Basis::ZernikeB2, Quadrature::GaussRadauUpper>();
+  test_two_indexed<Basis::ZernikeB3, Quadrature::GaussRadauUpper>();
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeGaussRadauUpper.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeGaussRadauUpper.cpp
@@ -35,7 +35,7 @@ template <size_t Dim>
 void test_derivatives(const size_t num_points) {
   const Approx custom_approx =
       num_points > 9 ? Approx::custom().epsilon(1.0e-12).scale(1.0)
-                      : Approx::custom().epsilon(1.0e-13).scale(1.0);
+                     : Approx::custom().epsilon(1.0e-13).scale(1.0);
   // Testing differeniation for polynomials exactly representable, so
   // up to power = num_points
   constexpr Spectral::Basis basis = Dim == 1   ? Spectral::Basis::ZernikeB1
@@ -79,6 +79,50 @@ void test_derivatives(const size_t num_points) {
                               : apply_matrix(diff_matrix_odd, my_function));
     CHECK_ITERABLE_CUSTOM_APPROX(evaluated_derivative, expected_derivative,
                                  custom_approx);
+  }
+}
+
+template <size_t Dim>
+void test_transform_identity() {
+  static_assert(Dim == 1 or Dim == 2 or Dim == 3);
+  const Spectral::Quadrature quadrature{Spectral::Quadrature::GaussRadauUpper};
+  constexpr Spectral::Basis basis = Dim == 1   ? Spectral::Basis::ZernikeB1
+                                    : Dim == 2 ? Spectral::Basis::ZernikeB2
+                                               : Spectral::Basis::ZernikeB3;
+  CAPTURE(basis);
+  const Approx custom_approx = Approx::custom().epsilon(2.0e-12).scale(1.0);
+  for (size_t n = 2; n <= Spectral::maximum_number_of_points<basis> / 2; ++n) {
+    for (size_t N = 0; N < 2 * n - 1; ++N) {
+      CAPTURE(N);
+      const DataVector xi = Spectral::collocation_points<basis, quadrature>(n);
+      CAPTURE(0.5 * (xi + 1.0));
+      for (size_t m = 0; m < N; ++m) {
+        CAPTURE(m);
+        // Note the integer division
+        const size_t spectral_size = (N - m) / 2 + 1;
+        Matrix identity(spectral_size, spectral_size, 0.0);
+        for (size_t i = 0; i < spectral_size; ++i) {
+          identity(i, i) = 1.0;
+        }
+        const Matrix modal_to_nodal =
+            Spectral::modal_to_nodal_matrix<basis, quadrature>(n, m, N);
+        const Matrix nodal_to_modal =
+            Spectral::nodal_to_modal_matrix<basis, quadrature>(n, m, N);
+        // Going from M->N->N is the identity as a matrix
+        CHECK_ITERABLE_CUSTOM_APPROX(nodal_to_modal * modal_to_nodal, identity,
+                                     custom_approx);
+        for (size_t k = m; k <= N; k += 2) {
+          CAPTURE(k);
+          const auto f =
+              Spectral::compute_basis_function_value<basis>(k, m, xi);
+          // Going from N->M->N is the identity operation, but not is not the
+          // identity when viewed as a matrix, so testing bases are invariant
+          CHECK_ITERABLE_CUSTOM_APPROX(
+              apply_matrix(modal_to_nodal, apply_matrix(nodal_to_modal, f)), f,
+              custom_approx);
+        }
+      }
+    }
   }
 }
 
@@ -127,4 +171,13 @@ SPECTRE_TEST_CASE(
   test_weight_at_upper<1>();
   test_weight_at_upper<2>();
   test_weight_at_upper<3>();
+}
+
+// [[TimeOut, 30]]
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.Spectral.ZernikeGaussRadauUpper.SpectralTransforms",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  test_transform_identity<1>();
+  test_transform_identity<2>();
+  test_transform_identity<3>();
 }


### PR DESCRIPTION
## Proposed changes

Because Zernike bases have two indices, there is extra freedom in the size of the spectral space. The NodalToModal and ModalToNodal transformations therefore have extra parameters. But the transformation itself is standard.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
