### PR TITLE
add RefineAtPuncture and RefineAtBoundary for GSF

### DIFF
--- a/src/Elliptic/Executables/SelfForce/GeneralRelativity/CMakeLists.txt
+++ b/src/Elliptic/Executables/SelfForce/GeneralRelativity/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
   ParallelSchwarz
   PhaseControl
   GrSelfForce
+  GrSelfForceAmrCriteria
   GrSelfForceAnalyticData
   GrSelfForceBoundaryConditions
   )

--- a/src/Elliptic/Executables/SelfForce/GeneralRelativity/SolveGrSelfForce.hpp
+++ b/src/Elliptic/Executables/SelfForce/GeneralRelativity/SolveGrSelfForce.hpp
@@ -14,6 +14,8 @@
 #include "Elliptic/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Elliptic/Executables/Solver.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/Actions/InitializeEffectiveSource.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtBoundary.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Angular.hpp"
 #include "Elliptic/Systems/SelfForce/GeneralRelativity/BoundaryConditions/Sommerfeld.hpp"
@@ -90,9 +92,13 @@ struct Metavariables {
         tmpl::pair<elliptic::BoundaryConditions::BoundaryCondition<volume_dim>,
                    tmpl::list<GrSelfForce::BoundaryConditions::Angular,
                               GrSelfForce::BoundaryConditions::Sommerfeld>>,
-        tmpl::pair<::amr::Criterion,
-                   ::amr::Criteria::standard_criteria<
-                       volume_dim, typename system::primal_fields>>,
+        tmpl::pair<
+            ::amr::Criterion,
+            tmpl::push_back<
+                ::amr::Criteria::standard_criteria<
+                    volume_dim, typename system::primal_fields>,
+                GrSelfForce::AmrCriteria::RefineAtPuncture,
+                GrSelfForce::AmrCriteria::RefineAtBoundary<volume_dim, 1>>>,
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
                        Events::Completion,

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/CMakeLists.txt
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/CMakeLists.txt
@@ -1,35 +1,39 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(LIBRARY GrSelfForce)
+set(LIBRARY GrSelfForceAmrCriteria)
 
 add_spectre_library(${LIBRARY})
 
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
-  Equations.cpp
+  RefineAtBoundary.cpp
+  RefineAtPuncture.cpp
   )
 
 spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
-  Equations.hpp
-  FirstOrderSystem.hpp
-  Tags.hpp
+  RefineAtBoundary.hpp
+  RefineAtPuncture.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  Amr
+  AmrCriteria
   DataStructures
   DomainStructure
-  ErrorHandling
+  Elliptic
+  InitialDataUtilities
+  Options
+  Parallel
+  Serialization
   Utilities
+  PRIVATE
+  Domain
+  GrSelfForceAnalyticData
   )
-
-add_subdirectory(Actions)
-add_subdirectory(AmrCriteria)
-add_subdirectory(AnalyticData)
-add_subdirectory(BoundaryConditions)

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtBoundary.cpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtBoundary.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtBoundary.hpp"
+
+namespace GrSelfForce::AmrCriteria {
+
+// template <size_t Dim, size_t DimToRefine>
+// RefineAtBoundary<Dim, DimToRefine>::RefineAtBoundary(CkMigrateMessage* msg)
+//     : Criterion(msg) {}
+
+// template class RefineAtBoundary<1, 0>;
+template class RefineAtBoundary<2, 0>;
+template class RefineAtBoundary<2, 1>;
+// template class RefineAtBoundary<3, 0>;
+// template class RefineAtBoundary<3, 1>;
+// template class RefineAtBoundary<3, 2>;
+
+}  // namespace GrSelfForce::AmrCriteria

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtBoundary.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtBoundary.hpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Domain/Tags.hpp"
+#include "Options/String.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+namespace GrSelfForce::AmrCriteria {
+/*!
+ * \brief Split boundary elements in the direction of the boundary
+ *
+ * Useful to refine poles like $\theta=0,\pi$.
+ */
+template <size_t Dim, size_t DimToRefine>
+class RefineAtBoundary : public amr::Criterion {
+  static_assert(Dim == 2,
+                "This specific implementation is tailored for Dim == 2");
+  static_assert(DimToRefine < Dim);
+
+ public:
+  using options = tmpl::list<>;
+
+  static constexpr Options::String help = {
+      "Split boundary elements in the direction of the boundary. Useful to "
+      "refine poles like theta=0,pi."};
+
+  RefineAtBoundary() = default;
+
+  /// \cond
+  explicit RefineAtBoundary(CkMigrateMessage* msg) : amr::Criterion(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(RefineAtBoundary);  // NOLINT
+  /// \endcond
+
+  amr::Criteria::Type type() override { return amr::Criteria::Type::h; }
+
+  static std::string name() {
+    if constexpr (DimToRefine == 0) {
+      return "RefineAtBoundaryX";
+    } else if constexpr (DimToRefine == 1) {
+      return "RefineAtBoundaryY";
+    } else {
+      return "RefineAtBoundaryZ";
+    }
+  }
+
+  std::string observation_name() override { return name(); }
+
+  using compute_tags_for_observation_box = tmpl::list<>;
+  using argument_tags = tmpl::list<domain::Tags::Element<2>>;
+
+  template <typename Metavariables>
+  std::array<amr::Flag, 2> operator()(
+      const Element<2>& element,
+      Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<2>& /*element_id*/) const {
+    const auto& external_boundaries = element.external_boundaries();
+    auto result = make_array<2>(amr::Flag::DoNothing);
+    if (external_boundaries.count(Direction<2>{DimToRefine, Side::Lower}) ==
+            1 or
+        external_boundaries.count(Direction<2>{DimToRefine, Side::Upper}) ==
+            1) {
+      get<DimToRefine>(result) = amr::Flag::Split;
+    }
+    return result;
+  }
+};
+
+/// \cond
+template <size_t Dim, size_t DimToRefine>
+PUP::able::PUP_ID RefineAtBoundary<Dim, DimToRefine>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace GrSelfForce::AmrCriteria

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.cpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace GrSelfForce::AmrCriteria {
+
+std::array<amr::Flag, 2> RefineAtPuncture::impl(
+    const elliptic::analytic_data::Background& background,
+    const Domain<2>& domain, const ElementId<2>& element_id) {
+  const auto circular_orbit_ptr =
+      dynamic_cast<const GrSelfForce::AnalyticData::CircularOrbit*>(
+          &background);
+  if (circular_orbit_ptr == nullptr) {
+    ERROR(
+        "RefineAtPuncture only works with 'CircularOrbit'. "
+        "See GrSelfForce::AmrCriteria::RefineAtPuncture for details.");
+  }
+  const auto puncture_position = circular_orbit_ptr->puncture_position();
+  // Split (h-refine) the element if it contains the puncture
+  const auto& block = domain.blocks()[element_id.block_id()];
+  // Check if the puncture is in the block
+  auto block_logical_coords =
+      block_logical_coordinates_single_point(puncture_position, block);
+  if (not block_logical_coords.has_value()) {
+    return make_array<2>(amr::Flag::DoNothing);
+  }
+  if (not element_logical_coordinates(*block_logical_coords, element_id)) {
+    return make_array<2>(amr::Flag::DoNothing);
+  }
+  return make_array<2>(amr::Flag::Split);
+}
+
+PUP::able::PUP_ID RefineAtPuncture::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace GrSelfForce::AmrCriteria

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.cpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.cpp
@@ -37,6 +37,11 @@ std::array<amr::Flag, 2> RefineAtPuncture::impl(
   if (not block_logical_coords.has_value()) {
     return make_array<2>(amr::Flag::DoNothing);
   }
+  for (size_t d=0; d<2; ++d) {
+    if (abs(block_logical_coords->get(d)) < 1e-10) {
+      block_logical_coords->get(d) = 0.;
+    }
+  }
   if (not element_logical_coordinates(*block_logical_coords, element_id)) {
     return make_array<2>(amr::Flag::DoNothing);
   }

--- a/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.hpp
+++ b/src/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Tags.hpp"
+#include "Options/String.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GrSelfForce::AmrCriteria {
+
+/*!
+ * \brief h-refine (split) elements containing a puncture
+ *
+ * This refinement scheme is expected to yield exponential convergence, despite
+ * the presence of the C^2 punctures.
+ */
+class RefineAtPuncture : public amr::Criterion {
+ public:
+  using options = tmpl::list<>;
+
+  static constexpr Options::String help = {
+      "h-refine (split) elements containing a puncture."};
+
+  RefineAtPuncture() = default;
+
+  /// \cond
+  explicit RefineAtPuncture(CkMigrateMessage* msg) : Criterion(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(RefineAtPuncture);  // NOLINT
+  /// \endcond
+
+  amr::Criteria::Type type() override { return amr::Criteria::Type::h; }
+
+  std::string observation_name() override { return "RefineAtPuncture"; }
+
+  using argument_tags = tmpl::list<
+      elliptic::Tags::Background<elliptic::analytic_data::Background>,
+      domain::Tags::Domain<2>>;
+  using compute_tags_for_observation_box = tmpl::list<>;
+
+  template <typename Metavariables>
+  std::array<amr::Flag, 2> operator()(
+      const elliptic::analytic_data::Background& background,
+      const Domain<2>& domain, Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ElementId<2>& element_id) const {
+    return impl(background, domain, element_id);
+  }
+
+ private:
+  static std::array<amr::Flag, 2> impl(
+      const elliptic::analytic_data::Background& background,
+      const Domain<2>& domain, const ElementId<2>& element_id);
+};
+
+}  // namespace GrSelfForce::AmrCriteria

--- a/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/RefineAtPuncture.cpp
@@ -32,10 +32,15 @@ std::array<amr::Flag, 2> RefineAtPuncture::impl(
   // Split (h-refine) the element if it contains the puncture
   const auto& block = domain.blocks()[element_id.block_id()];
   // Check if the puncture is in the block
-  const auto block_logical_coords =
+  auto block_logical_coords =
       block_logical_coordinates_single_point(puncture_position, block);
   if (not block_logical_coords.has_value()) {
     return make_array<2>(amr::Flag::DoNothing);
+  }
+  for (size_t d=0; d<2; ++d) {
+    if (abs(block_logical_coords->get(d)) < 1e-10) {
+      block_logical_coords->get(d) = 0.;
+    }
   }
   if (not element_logical_coordinates(*block_logical_coords, element_id)) {
     return make_array<2>(amr::Flag::DoNothing);

--- a/tests/InputFiles/SelfForce/GrCircularOrbit.yaml
+++ b/tests/InputFiles/SelfForce/GrCircularOrbit.yaml
@@ -78,8 +78,9 @@ DomainCreator:
 Amr:
   Verbosity: Debug
   Criteria:
-    # - RefineAtPuncture
+    - RefineAtPuncture
     - IncreaseResolution
+    - RefineAtBoundaryY
   EnableInBlocks: All
   Policies:
     Isotropy: Anisotropic

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_GrSelfForceAmrCriteria")
+
+set(LIBRARY_SOURCES
+  Test_RefineAtBoundary.cpp
+  Test_RefineAtPunctures.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  Amr
+  AmrCriteria
+  DataStructures
+  DomainCreators
+  DomainStructure
+  Options
+  Parallel
+  GrSelfForceAmrCriteria
+  GrSelfForceAnalyticData
+  Utilities
+  )

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/Test_RefineAtBoundary.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/Test_RefineAtBoundary.cpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtBoundary.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GrSelfForce::AmrCriteria {
+
+namespace {
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 2;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion, tmpl::list<RefineAtBoundary<2, 1>>>>;
+  };
+};
+
+void test_criterion() {
+  const auto created =
+      TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
+                                 Metavariables>("RefineAtBoundaryY");
+  REQUIRE(dynamic_cast<const RefineAtBoundary<2, 1>*>(created.get()) !=
+          nullptr);
+  const auto& criterion = serialize_and_deserialize(
+      dynamic_cast<const RefineAtBoundary<2, 1>&>(*created));
+
+  {
+    INFO("Evaluate");
+    const ElementId<2> element_id{0};
+    auto databox = db::create<tmpl::list<domain::Tags::Element<2>>>(
+            Element<2>{element_id, DirectionMap<2, Neighbors<2>>{}});
+    const ObservationBox<tmpl::list<>,
+                         db::DataBox<tmpl::list<domain::Tags::Element<2>>>>
+        box{make_not_null(&databox)};
+
+    Parallel::GlobalCache<Metavariables> empty_cache{};
+
+    {
+      INFO("Element with boundary");
+      const auto expected_flags =
+          std::array<amr::Flag, 2>{{amr::Flag::DoNothing, amr::Flag::Split}};
+      auto flags = criterion.evaluate(box, empty_cache, element_id);
+      CHECK(flags == expected_flags);
+    }
+    {
+      INFO("Element without boundary");
+      DirectionMap<2, Neighbors<2>> neighbors{};
+      const ElementId<2> neighbor_id{0};
+      const OrientationMap<2> identity_orientation{std::array<Direction<2>, 2>{
+          {Direction<2>{0, Side::Upper}, Direction<2>{1, Side::Upper}}}};
+
+      neighbors.emplace(Direction<2>::lower_eta(),
+                        Neighbors<2>{{neighbor_id}, identity_orientation});
+      neighbors.emplace(Direction<2>::upper_eta(),
+                        Neighbors<2>{{neighbor_id}, identity_orientation});
+auto internal_databox = db::create<tmpl::list<domain::Tags::Element<2>>>(
+          Element<2>{element_id, std::move(neighbors)});
+const ObservationBox<tmpl::list<>,
+                           db::DataBox<tmpl::list<domain::Tags::Element<2>>>>
+          internal_box{make_not_null(&internal_databox)};
+      const auto expected_internal_flags = make_array<2>(amr::Flag::DoNothing);
+      CHECK(criterion.evaluate(internal_box, empty_cache, element_id) ==
+            expected_internal_flags);
+    }
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.GrSelfForce.AmrCriteria.RefineAtBoundary",
+                  "[Unit][ParallelAlgorithms]") {
+  register_factory_classes_with_charm<Metavariables>();
+  test_criterion();
+}
+
+}  // namespace GrSelfForce::AmrCriteria

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/Test_RefineAtPunctures.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/Test_RefineAtPunctures.cpp
@@ -1,0 +1,117 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/ObservationBox.hpp"
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Creators/Rectilinear.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AmrCriteria/RefineAtPuncture.hpp"
+#include "Elliptic/Systems/SelfForce/GeneralRelativity/AnalyticData/CircularOrbit.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Criterion.hpp"
+#include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace GrSelfForce::AmrCriteria {
+
+namespace {
+
+struct Metavariables {
+  static constexpr size_t volume_dim = 2;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<amr::Criterion,
+                   tmpl::list<GrSelfForce::AmrCriteria::RefineAtPuncture>>>;
+  };
+};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+struct OtherBackground : elliptic::analytic_data::Background,
+                         elliptic::analytic_data::InitialGuess {
+  OtherBackground() = default;
+  explicit OtherBackground(CkMigrateMessage* /*m*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(OtherBackground);
+};
+
+PUP::able::PUP_ID OtherBackground::my_PUP_ID = 0;  // NOLINT
+#pragma GCC diagnostic pop
+
+void test_criterion(
+    std::unique_ptr<elliptic::analytic_data::Background> background) {
+  const auto created =
+      TestHelpers::test_creation<std::unique_ptr<amr::Criterion>,
+                                 Metavariables>("RefineAtPuncture");
+  REQUIRE(dynamic_cast<const RefineAtPuncture*>(created.get()) != nullptr);
+  const auto& criterion = serialize_and_deserialize(
+      dynamic_cast<const RefineAtPuncture&>(*created));
+
+  {
+    INFO("Evaluate");
+    using background_tag =
+        elliptic::Tags::Background<elliptic::analytic_data::Background>;
+
+    const domain::creators::Rectangle domain_creator{
+        {{10., 0.}}, {{15., 2.}}, {{2, 2}}, {{3, 3}}, {{false, false}}};
+    auto databox =
+        db::create<tmpl::list<background_tag, domain::Tags::Domain<2>>>(
+            std::move(background), domain_creator.create_domain());
+    const ObservationBox<
+        tmpl::list<>,
+        db::DataBox<tmpl::list<background_tag, domain::Tags::Domain<2>>>>
+        box{make_not_null(&databox)};
+    Parallel::GlobalCache<Metavariables> empty_cache{};
+
+    {
+      INFO("Element with puncture within");
+      const ElementId<2> element_id{0, {{{2, 2}, {2, 3}}}};
+      const auto expected_flags = make_array<2>(amr::Flag::Split);
+      auto flags = criterion.evaluate(box, empty_cache, element_id);
+      CHECK(flags == expected_flags);
+    }
+    {
+      INFO("Elements without puncture");
+      const auto expected_flags = make_array<2>(amr::Flag::DoNothing);
+      for (const auto& element_id : {ElementId<2>{0, {{{2, 1}, {2, 0}}}},
+                                     ElementId<2>{0, {{{2, 3}, {2, 3}}}},
+                                     ElementId<2>{0, {{{2, 3}, {2, 0}}}},
+                                     ElementId<2>{0, {{{2, 0}, {2, 3}}}}}) {
+        auto flags = criterion.evaluate(box, empty_cache, element_id);
+        CHECK(flags == expected_flags);
+      }
+    }
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.GrSelfForce.AmrCriteria.RefineAtPuncture",
+                  "[Unit][ParallelAlgorithms]") {
+  register_factory_classes_with_charm<Metavariables>();
+  test_criterion(std::make_unique<GrSelfForce::AnalyticData::CircularOrbit>(
+      // Only orbital radius is relevant for the test
+      1.0, 0.5, /* orbital radius */ 10.0, 2));
+  CHECK_THROWS_WITH(test_criterion(std::make_unique<OtherBackground>()),
+                    Catch::Matchers::ContainsSubstring(
+                        "RefineAtPuncture only works with 'CircularOrbit'."));
+}
+
+}  // namespace GrSelfForce::AmrCriteria

--- a/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Systems/SelfForce/GeneralRelativity/CMakeLists.txt
@@ -19,4 +19,5 @@ target_link_libraries(
 
 add_subdirectory(Actions)
 add_subdirectory(AnalyticData)
+add_subdirectory(AmrCriteria)
 add_subdirectory(BoundaryConditions)

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/Test_RefineAtPunctures.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AmrCriteria/Test_RefineAtPunctures.cpp
@@ -99,6 +99,38 @@ void test_criterion(
       }
     }
   }
+  {
+    INFO("Evaluate_roundoff");
+    using background_tag =
+        elliptic::Tags::Background<elliptic::analytic_data::Background>;
+    const double offset = 1e-11;
+    const domain::creators::Rectangle domain_creator_for_roundoff{
+        {{10., -1.0 + offset}},
+        {{15., 1.0 + offset}},
+        {{1, 1}},
+        {{3, 3}},
+        {{false, false}}};
+    auto databox_for_roundoff =
+        db::create<tmpl::list<background_tag, domain::Tags::Domain<2>>>(
+            std::unique_ptr<elliptic::analytic_data::Background>{
+                std::make_unique<ScalarSelfForce::AnalyticData::CircularOrbit>(
+                    1.0, 0.0, 10.0, 2, std::nullopt, false)},
+            domain_creator_for_roundoff.create_domain());
+    const ObservationBox<
+        tmpl::list<>,
+        db::DataBox<tmpl::list<background_tag, domain::Tags::Domain<2>>>>
+        box2{make_not_null(&databox_for_roundoff)};
+    Parallel::GlobalCache<Metavariables> empty_cache{};
+    {
+      INFO("Verify both elements share the puncture");
+      const auto expected_flags = make_array<2>(amr::Flag::Split);
+      for (const auto& element_id : {ElementId<2>{0, {{{1, 1}, {1, 0}}}},
+                                     ElementId<2>{0, {{{1, 1}, {1, 1}}}}}) {
+        auto flags = criterion.evaluate(box2, empty_cache, element_id);
+        CHECK(flags == expected_flags);
+      }
+    }
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes
- This PR contains two commits 
- 1st (and main) commit: Added RefineAtPuncture and RefineAtBoundary for GSF 
- 2nd commit: Fixed roundoff error for RefineAtPuncture, both for SSF and GSF. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
