### PR TITLE
Add projection cases for Fourier and ZernikeB2 Equiangular

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -29,6 +29,56 @@
 #include "Utilities/StaticCache.hpp"
 
 namespace Spectral {
+namespace {
+void verify_meshes(const Mesh<1>& parent_mesh, const Mesh<1>& child_mesh,
+                   const SegmentSize size) {
+  constexpr size_t max_points_l = maximum_number_of_points<Basis::Legendre>;
+  constexpr size_t max_points_f = maximum_number_of_points<Basis::Fourier>;
+
+  // Legendre with Legendre (any segment size)
+  const bool both_legendre = parent_mesh.basis(0) == Basis::Legendre and
+                             child_mesh.basis(0) == Basis::Legendre;
+
+  // Fourier with Fourier (full segment only)
+  const bool both_fourier = parent_mesh.basis(0) == Basis::Fourier and
+                            child_mesh.basis(0) == Basis::Fourier and
+                            size == SegmentSize::Full;
+
+  // ZernikeB2 Equiangular with ZernikeB2 Equiangular (full segment only)
+  const bool both_zernike =
+      parent_mesh.basis(0) == Basis::ZernikeB2 and
+      parent_mesh.quadrature(0) == Quadrature::Equiangular and
+      child_mesh.basis(0) == Basis::ZernikeB2 and
+      child_mesh.quadrature(0) == Quadrature::Equiangular and
+      size == SegmentSize::Full;
+
+  // Fourier with ZernikeB2 Equiangular (full segment only)
+  const bool fourier_zernike =
+      parent_mesh.basis(0) == Basis::Fourier and
+      child_mesh.basis(0) == Basis::ZernikeB2 and
+      child_mesh.quadrature(0) == Quadrature::Equiangular and
+      size == SegmentSize::Full;
+
+  // ZernikeB2 Equiangular with Fourier (full segment only)
+  const bool zernike_fourier =
+      parent_mesh.basis(0) == Basis::ZernikeB2 and
+      parent_mesh.quadrature(0) == Quadrature::Equiangular and
+      child_mesh.basis(0) == Basis::Fourier and size == SegmentSize::Full;
+
+  ASSERT(both_legendre or both_fourier or both_zernike or fourier_zernike or
+             zernike_fourier,
+         "Unsupported projection combination. Supported: Legendre <-> Legendre "
+         "or Fourier <-> Fourier (where ZernikeB2 with Equiangular quadrature "
+         "also works) with no h-refinement (size must be Full). Got parent: "
+             << parent_mesh << ", child: " << child_mesh << ", size: " << size);
+
+  ASSERT((both_legendre and (parent_mesh.extents(0) <= max_points_l and
+                             child_mesh.extents(0) <= max_points_l)) or
+             (parent_mesh.extents(0) <= max_points_f and
+              child_mesh.extents(0) <= max_points_f),
+         "Mesh has more points than supported by its quadrature.");
+}
+}  // namespace
 
 template <size_t Dim>
 bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
@@ -45,13 +95,9 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                                                 const Mesh<1>& parent_mesh,
                                                 const SegmentSize size,
                                                 const bool operand_is_massive) {
-  constexpr size_t max_points = maximum_number_of_points<Basis::Legendre>;
-  ASSERT(parent_mesh.basis(0) == Basis::Legendre and
-             child_mesh.basis(0) == Basis::Legendre,
-         "Projections only implemented on Legendre basis");
-  ASSERT(parent_mesh.extents(0) <= max_points and
-             child_mesh.extents(0) <= max_points,
-         "Mesh has more points than supported by its quadrature.");
+  constexpr size_t max_points_l = maximum_number_of_points<Basis::Legendre>;
+  constexpr size_t max_points_f = maximum_number_of_points<Basis::Fourier>;
+  verify_meshes(parent_mesh, child_mesh, size);
 
   if (operand_is_massive) {
     ASSERT(parent_mesh.extents(0) <= child_mesh.extents(0),
@@ -60,78 +106,121 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                << parent_mesh.extents(0) << ")");
     // The restriction operator for massive quantities is just the interpolation
     // transpose
-    const static auto cache = make_static_cache<
+    const auto compute_matrix =
+        [](const Basis parent_basis, const Quadrature parent_quadrature,
+           const size_t parent_extent, const Basis child_basis,
+           const Quadrature child_quadrature, const size_t child_extent,
+           const SegmentSize local_child_size) -> Matrix {
+      const auto& prolongation_operator = projection_matrix_parent_to_child(
+          {parent_extent, parent_basis, parent_quadrature},
+          {child_extent, child_basis, child_quadrature}, local_child_size);
+      return blaze::trans(prolongation_operator);
+    };
+    const static auto cache_legendre = make_static_cache<
         CacheEnumeration<Quadrature, Quadrature::Gauss,
                          Quadrature::GaussLobatto>,
-        CacheRange<2_st, max_points + 1>,
+        CacheRange<2_st, max_points_l + 1>,
         CacheEnumeration<Quadrature, Quadrature::Gauss,
                          Quadrature::GaussLobatto>,
-        CacheRange<2_st, max_points + 1>,
+        CacheRange<2_st, max_points_l + 1>,
         CacheEnumeration<SegmentSize, SegmentSize::Full, SegmentSize::UpperHalf,
                          SegmentSize::LowerHalf>>(
-        [](const Quadrature child_quadrature, const size_t child_extent,
-           const Quadrature parent_quadrature, const size_t parent_extent,
-           const SegmentSize local_child_size) -> Matrix {
-          const auto& prolongation_operator = projection_matrix_parent_to_child(
-              {parent_extent, Spectral::Basis::Legendre, parent_quadrature},
-              {child_extent, Spectral::Basis::Legendre, child_quadrature},
-              local_child_size);
-          return blaze::trans(prolongation_operator);
+        [compute_matrix](const Quadrature q_parent, const size_t n_parent,
+                         const Quadrature q_child, const size_t n_child,
+                         const SegmentSize local_child_size) {
+          return compute_matrix(Basis::Legendre, q_parent, n_parent,
+                                Basis::Legendre, q_child, n_child,
+                                local_child_size);
         });
-    return cache(child_mesh.quadrature(0), child_mesh.extents(0),
-                 parent_mesh.quadrature(0), parent_mesh.extents(0), size);
+    const static auto cache_fourier =
+        make_static_cache<CacheRange<2_st, max_points_f + 1>,
+                          CacheRange<2_st, max_points_f + 1>>(
+            [compute_matrix](const size_t n_parent, const size_t n_child) {
+              return compute_matrix(Basis::Fourier, Quadrature::Equiangular,
+                                    n_parent, Basis::Fourier,
+                                    Quadrature::Equiangular, n_child,
+                                    SegmentSize::Full);
+            });
+    if (parent_mesh.basis(0) == Basis::Legendre) {
+      return cache_legendre(parent_mesh.quadrature(0), parent_mesh.extents(0),
+                            child_mesh.quadrature(0), child_mesh.extents(0),
+                            size);
+    } else {
+      // Both Fourier and ZernikeB2 get here
+      // In terms of angular interpolation, ZernikeB2 with Equiangular
+      // quadrature is identical to Fourier with Equiangular quadrature, so the
+      // matrices do not make a distinction
+      return cache_fourier(parent_mesh.extents(0), child_mesh.extents(0));
+    }
   }
 
   switch (size) {
     case SegmentSize::Full: {
-      const static auto cache =
+      const auto compute_matrix =
+          [](const Basis basis_element, const Quadrature quadrature_element,
+             const size_t extents_element, const Basis basis_mortar,
+             const Quadrature quadrature_mortar, const size_t extents_mortar) {
+            const Mesh<1> mesh_element(extents_element, basis_element,
+                                       quadrature_element);
+            const Mesh<1> mesh_mortar(extents_mortar, basis_mortar,
+                                      quadrature_mortar);
+
+            // The projection in spectral space is just a truncation
+            // of the modes.
+            const auto& spectral_to_grid_element =
+                modal_to_nodal_matrix(mesh_element);
+            const auto& grid_to_spectral_mortar =
+                nodal_to_modal_matrix(mesh_mortar);
+            const auto num_modes = std::min(extents_element, extents_mortar);
+            Matrix projection(extents_element, extents_mortar, 0.);
+            for (size_t i = 0; i < extents_element; ++i) {
+              for (size_t j = 0; j < extents_mortar; ++j) {
+                for (size_t k = 0; k < num_modes; ++k) {
+                  projection(i, j) += spectral_to_grid_element(i, k) *
+                                      grid_to_spectral_mortar(k, j);
+                }
+              }
+            }
+
+            return projection;
+          };
+      const static auto cache_legendre =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>,
+                            CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>>(
-              [](const Quadrature quadrature_element,
-                 const size_t extents_element,
-                 const Quadrature quadrature_mortar,
-                 const size_t extents_mortar) {
-                const Mesh<1> mesh_element(extents_element, Basis::Legendre,
-                                           quadrature_element);
-                const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
-                                          quadrature_mortar);
-
-                // The projection in spectral space is just a truncation
-                // of the modes.
-                const auto& spectral_to_grid_element =
-                    modal_to_nodal_matrix(mesh_element);
-                const auto& grid_to_spectral_mortar =
-                    nodal_to_modal_matrix(mesh_mortar);
-                const auto num_modes =
-                    std::min(extents_element, extents_mortar);
-                Matrix projection(extents_element, extents_mortar, 0.);
-                for (size_t i = 0; i < extents_element; ++i) {
-                  for (size_t j = 0; j < extents_mortar; ++j) {
-                    for (size_t k = 0; k < num_modes; ++k) {
-                      projection(i, j) += spectral_to_grid_element(i, k) *
-                                          grid_to_spectral_mortar(k, j);
-                    }
-                  }
-                }
-
-                return projection;
+                            CacheRange<2_st, max_points_l + 1>>(
+              [compute_matrix](const Quadrature q_parent, const size_t n_parent,
+                               const Quadrature q_child, const size_t n_child) {
+                return compute_matrix(Basis::Legendre, q_parent, n_parent,
+                                      Basis::Legendre, q_child, n_child);
               });
-      return cache(parent_mesh.quadrature(0), parent_mesh.extents(0),
-                   child_mesh.quadrature(0), child_mesh.extents(0));
+      const static auto cache_fourier =
+          make_static_cache<CacheRange<2_st, max_points_f + 1>,
+                            CacheRange<2_st, max_points_f + 1>>(
+              [compute_matrix](const size_t n_parent, const size_t n_child) {
+                return compute_matrix(Basis::Fourier, Quadrature::Equiangular,
+                                      n_parent, Basis::Fourier,
+                                      Quadrature::Equiangular, n_child);
+              });
+      if (parent_mesh.basis(0) == Basis::Legendre) {
+        return cache_legendre(parent_mesh.quadrature(0), parent_mesh.extents(0),
+                              child_mesh.quadrature(0), child_mesh.extents(0));
+      } else {
+        // Both Fourier and ZernikeB2 get here
+        return cache_fourier(parent_mesh.extents(0), child_mesh.extents(0));
+      }
     }
 
     case SegmentSize::UpperHalf: {
       const static auto cache = make_static_cache<
           CacheEnumeration<Quadrature, Quadrature::Gauss,
                            Quadrature::GaussLobatto>,
-          CacheRange<2_st, max_points + 1>,
+          CacheRange<2_st, max_points_l + 1>,
           CacheEnumeration<Quadrature, Quadrature::Gauss,
                            Quadrature::GaussLobatto>,
-          CacheRange<2_st, max_points + 1>>(
+          CacheRange<2_st, max_points_l + 1>>(
           [](const Quadrature quadrature_element, const size_t extents_element,
              const Quadrature quadrature_mortar, const size_t extents_mortar) {
             const Mesh<1> mesh_element(extents_element, Basis::Legendre,
@@ -163,7 +252,8 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
 
               for (size_t i = 1; i <= large_index - small_index; ++i) {
                 result *=
-                    1. + static_cast<double>(large_index + small_index + 1) / i;
+                    1. + static_cast<double>(large_index + small_index + 1) /
+                             static_cast<double>(i);
               }
               result /= pow(2., static_cast<int>(large_index) + 1);
               return result;
@@ -207,10 +297,10 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>,
+                            CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>>(
+                            CacheRange<2_st, max_points_l + 1>>(
               [](const Quadrature quadrature_element,
                  const size_t extents_element,
                  const Quadrature quadrature_mortar,
@@ -259,6 +349,11 @@ projection_matrix_child_to_parent(
     const auto child_mesh_slice = gsl::at(child_mesh_slices, d);
     const auto parent_mesh_slice = gsl::at(parent_mesh_slices, d);
     const auto child_size = gsl::at(child_sizes, d);
+    ASSERT(child_mesh_slice.basis(0) == Basis::Legendre or
+               child_size == SegmentSize::Full,
+           "The Fourier basis does not support h-refinement: SegmentSize must "
+           "be Full in dimension "
+               << d << ", but got " << child_size);
     if (child_size == SegmentSize::Full and
         child_mesh_slice == parent_mesh_slice) {
       // No projection necessary, keep matrix the identity in this dimension
@@ -273,22 +368,24 @@ projection_matrix_child_to_parent(
 const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
                                                 const Mesh<1>& child_mesh,
                                                 const SegmentSize size) {
-  constexpr size_t max_points = maximum_number_of_points<Basis::Legendre>;
-  ASSERT(child_mesh.basis(0) == Basis::Legendre and
-             parent_mesh.basis(0) == Basis::Legendre,
-         "Projections only implemented on Legendre basis");
-  ASSERT(child_mesh.extents(0) <= max_points and
-             parent_mesh.extents(0) <= max_points,
-         "Mesh has more points than supported by its quadrature. Has "
-             << child_mesh.extents(0) << " and max allowed is " << (max_points)
-             << " for the mortar mesh, while for the element mesh has "
-             << parent_mesh.extents(0) << " points.");
+  constexpr size_t max_points_l = maximum_number_of_points<Basis::Legendre>;
+  verify_meshes(parent_mesh, child_mesh, size);
+
+  // For Fourier with SegmentSize::Full, the element-to-mortar projection is
+  // the same spectral truncation/zero-padding as child_to_parent with roles
+  // swapped. Delegate to avoid duplicating the cached computation.
+  if (parent_mesh.basis(0) == Basis::Fourier or
+      parent_mesh.basis(0) == Basis::ZernikeB2) {
+    return projection_matrix_child_to_parent(parent_mesh, child_mesh,
+                                             SegmentSize::Full);
+  }
+
   ASSERT(child_mesh.extents(0) >= parent_mesh.extents(0),
          "Requested projection matrix to mortar with fewer points ("
              << child_mesh.extents(0) << ") than the element ("
              << parent_mesh.extents(0) << ")");
 
-  // Element-to-mortar projections are always interpolations.
+  // Element-to-mortar projections on Legendre meshes are interpolations.
   const auto make_interpolators = [](auto interval_transform) {
     return [interval_transform = std::move(interval_transform)](
                const Quadrature quadrature_mortar, const size_t extents_mortar,
@@ -311,10 +408,10 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>,
+                            CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>>(
+                            CacheRange<2_st, max_points_l + 1>>(
               make_interpolators([](const DataVector& x) { return x; }));
       return cache(child_mesh.quadrature(0), child_mesh.extents(0),
                    parent_mesh.quadrature(0), parent_mesh.extents(0));
@@ -324,10 +421,10 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>,
+                            CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>>(
+                            CacheRange<2_st, max_points_l + 1>>(
               make_interpolators([](const DataVector& x) {
                 return DataVector(0.5 * (x + 1.));
               }));
@@ -339,10 +436,10 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
       const static auto cache =
           make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>,
+                            CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
-                            CacheRange<2_st, max_points + 1>>(
+                            CacheRange<2_st, max_points_l + 1>>(
               make_interpolators([](const DataVector& x) {
                 return DataVector(0.5 * (x - 1.));
               }));
@@ -368,6 +465,11 @@ projection_matrix_parent_to_child(
     const auto child_mesh_slice = gsl::at(child_mesh_slices, d);
     const auto parent_mesh_slice = gsl::at(parent_mesh_slices, d);
     const auto child_size = gsl::at(child_sizes, d);
+    ASSERT(child_mesh_slice.basis(0) == Basis::Legendre or
+               child_size == SegmentSize::Full,
+           "The Fourier basis does not support h-refinement: SegmentSize must "
+           "be Full in dimension "
+               << d << ", but got " << child_size);
     if (child_size == SegmentSize::Full and
         child_mesh_slice == parent_mesh_slice) {
       // No projection necessary, keep matrix the identity in this dimension

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -8,9 +8,11 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp"
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/InterpolationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
@@ -601,6 +603,195 @@ void test_projection_matrices() {
   }
 }
 
+void test_fourier_p_projections() {
+  // Test both child_to_parent and parent_to_child projections for Fourier basis
+  // For Fourier basis, SegmentSize::Full only--Fourier does not support
+  // h-refinement
+  INFO("Fourier p-projections");
+  const auto local_approx = Approx::custom().scale(1.0).epsilon(1.0e-14);
+  constexpr size_t max_points_f =
+      Spectral::maximum_number_of_points<Spectral::Basis::Fourier>;
+  const std::vector<std::pair<unsigned, unsigned>> test_funcs = {
+      {1_st, 0_st}, {0_st, 1_st}, {1_st, 1_st}, {5_st, 4_st}, {13_st, 15_st}};
+
+  // source <= dest (prolongation)
+  constexpr size_t stride = 5;
+  for (size_t num_points_source = 2; num_points_source <= max_points_f;
+       num_points_source += stride) {
+    const Mesh<1> mesh_source(num_points_source, Spectral::Basis::Fourier,
+                              Spectral::Quadrature::Equiangular);
+    const auto& points_source = Spectral::collocation_points(mesh_source);
+    CAPTURE(mesh_source);
+    for (size_t num_points_dest = num_points_source + stride;
+         num_points_dest <= std::min(3 * num_points_source, max_points_f);
+         num_points_dest += stride) {
+      const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Fourier,
+                              Spectral::Quadrature::Equiangular);
+      const auto& points_dest = Spectral::collocation_points(mesh_dest);
+      CAPTURE(mesh_dest);
+
+      // Test child_to_parent (mortar to element)
+      const auto& projection_child_to_parent =
+          projection_matrix_child_to_parent(mesh_source, mesh_dest,
+                                            Spectral::SegmentSize::Full);
+      // Test parent_to_child (element to mortar)
+      const auto& projection_parent_to_child =
+          projection_matrix_parent_to_child(mesh_source, mesh_dest,
+                                            Spectral::SegmentSize::Full);
+
+      // For Fourier with SegmentSize::Full, these should be the same matrix
+      CHECK(&projection_child_to_parent == &projection_parent_to_child);
+
+      for (const auto& [pow_nx, pow_ny] : test_funcs) {
+        const size_t required_modes = pow_nx + pow_ny;
+        if (required_modes >= num_points_source / 2) {
+          continue;
+        }
+        CAPTURE(pow_nx);
+        CAPTURE(pow_ny);
+        const FourierTestFunctions::ProductOfPolynomials func(pow_nx, pow_ny);
+
+        const DataVector projected_data_ctp =
+            apply_matrix(projection_child_to_parent, func(points_source));
+        CHECK_ITERABLE_CUSTOM_APPROX(projected_data_ctp, func(points_dest),
+                                     local_approx);
+      }
+    }
+  }
+
+  // source > dest (restriction)
+  for (size_t num_points_dest = 2; num_points_dest <= max_points_f;
+       num_points_dest += stride) {
+    const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Fourier,
+                            Spectral::Quadrature::Equiangular);
+    CAPTURE(mesh_dest);
+    for (size_t num_points_source = num_points_dest + stride;
+         num_points_source <= std::min(3 * num_points_dest, max_points_f);
+         num_points_source += stride) {
+      const Mesh<1> mesh_source(num_points_source, Spectral::Basis::Fourier,
+                                Spectral::Quadrature::Equiangular);
+      const auto& points_source = Spectral::collocation_points(mesh_source);
+      CAPTURE(mesh_source);
+
+      // Test both projection functions
+      const auto& projection_child_to_parent =
+          projection_matrix_child_to_parent(mesh_source, mesh_dest,
+                                            Spectral::SegmentSize::Full);
+      const auto& projection_parent_to_child =
+          projection_matrix_parent_to_child(mesh_source, mesh_dest,
+                                            Spectral::SegmentSize::Full);
+
+      // For Fourier with SegmentSize::Full, these should be the same matrix
+      CHECK(&projection_child_to_parent == &projection_parent_to_child);
+
+      for (const auto& [pow_nx, pow_ny] : test_funcs) {
+        const size_t required_modes = pow_nx + pow_ny;
+        if (required_modes >= num_points_source / 2) {
+          continue;
+        }
+        CAPTURE(pow_nx);
+        CAPTURE(pow_ny);
+        const FourierTestFunctions::ProductOfPolynomials func(pow_nx, pow_ny);
+        const DataVector projected_data =
+            apply_matrix(projection_child_to_parent, func(points_source));
+        // Interpolate projected result back to the fine grid and measure the
+        // truncation error.
+        const DataVector interpolated_projected_data = apply_matrix(
+            Spectral::interpolation_matrix(mesh_dest, points_source),
+            projected_data);
+        const DataVector error =
+            interpolated_projected_data - func(points_source);
+        // The error must be L2-orthogonal to every basis function that fits
+        // in the destination mesh
+        for (size_t index = 0; index < num_points_dest; ++index) {
+          CAPTURE(index);
+          const DataVector basis_func_values =
+              Spectral::compute_basis_function_value<Spectral::Basis::Fourier>(
+                  index, points_source);
+          CHECK(definite_integral(error * basis_func_values, mesh_source) ==
+                local_approx(0.0));
+        }
+      }
+    }
+  }
+}
+
+void test_zernike_b2_fourier_equivalence() {
+  INFO("ZernikeB2-Fourier equivalence");
+  // Test that ZernikeB2 with Equiangular behaves identically to Fourier
+  const size_t parent_size = 5;
+  const size_t child_size = 9;
+  const Mesh<1> fourier_parent(parent_size, Spectral::Basis::Fourier,
+                               Spectral::Quadrature::Equiangular);
+  const Mesh<1> fourier_child(child_size, Spectral::Basis::Fourier,
+                              Spectral::Quadrature::Equiangular);
+  const Mesh<1> zernike_parent(parent_size, Spectral::Basis::ZernikeB2,
+                               Spectral::Quadrature::Equiangular);
+  const Mesh<1> zernike_child(child_size, Spectral::Basis::ZernikeB2,
+                              Spectral::Quadrature::Equiangular);
+
+  const auto& f_to_f_child_to_parent = projection_matrix_child_to_parent(
+      fourier_child, fourier_parent, Spectral::SegmentSize::Full);
+  const auto& f_to_z_child_to_parent = projection_matrix_child_to_parent(
+      fourier_child, zernike_parent, Spectral::SegmentSize::Full);
+  CHECK(&f_to_f_child_to_parent == &f_to_z_child_to_parent);
+  const auto& z_to_z_child_to_parent = projection_matrix_child_to_parent(
+      zernike_child, zernike_parent, Spectral::SegmentSize::Full);
+  CHECK(&f_to_f_child_to_parent == &z_to_z_child_to_parent);
+
+  const auto& f_to_f_parent_to_child = projection_matrix_child_to_parent(
+      fourier_parent, fourier_child, Spectral::SegmentSize::Full);
+  const auto& f_to_z_parent_to_child = projection_matrix_child_to_parent(
+      fourier_parent, zernike_child, Spectral::SegmentSize::Full);
+  CHECK(&f_to_f_parent_to_child == &f_to_z_parent_to_child);
+  const auto& z_to_z_parent_to_child = projection_matrix_child_to_parent(
+      zernike_parent, zernike_child, Spectral::SegmentSize::Full);
+  CHECK(&f_to_f_parent_to_child == &z_to_z_parent_to_child);
+}
+
+#ifdef SPECTRE_DEBUG
+void test_fourier_and_zernikeb2_asserts() {
+  {
+    INFO("Fourier h-refinement asserts");
+    const Mesh<1> mesh(5, Spectral::Basis::Fourier,
+                       Spectral::Quadrature::Equiangular);
+    CHECK_THROWS_WITH(projection_matrix_child_to_parent(
+                          mesh, mesh, Spectral::SegmentSize::UpperHalf),
+                      Catch::Matchers::ContainsSubstring(
+                          "Unsupported projection combination"));
+    CHECK_THROWS_WITH(projection_matrix_child_to_parent(
+                          mesh, mesh, Spectral::SegmentSize::LowerHalf),
+                      Catch::Matchers::ContainsSubstring(
+                          "Unsupported projection combination"));
+  }
+  {
+    INFO("ZernikeB2 projection asserts");
+
+    // Test that ZernikeB2 without Equiangular quadrature is rejected
+    const Mesh<1> zernike_gauss{4, Basis::ZernikeB2, Quadrature::Gauss};
+    const Mesh<1> fourier_mesh{4, Basis::Fourier, Quadrature::Equiangular};
+
+    CHECK_THROWS_WITH(projection_matrix_child_to_parent(
+                          zernike_gauss, fourier_mesh, SegmentSize::Full),
+                      Catch::Matchers::ContainsSubstring(
+                          "Unsupported projection combination"));
+
+    // Test that ZernikeB2 with h-refinement is rejected
+    const Mesh<1> zernike_equi{4, Basis::ZernikeB2, Quadrature::Equiangular};
+
+    CHECK_THROWS_WITH(projection_matrix_child_to_parent(
+                          zernike_equi, zernike_equi, SegmentSize::UpperHalf),
+                      Catch::Matchers::ContainsSubstring(
+                          "Unsupported projection combination"));
+
+    CHECK_THROWS_WITH(projection_matrix_child_to_parent(
+                          zernike_equi, zernike_equi, SegmentSize::LowerHalf),
+                      Catch::Matchers::ContainsSubstring(
+                          "Unsupported projection combination"));
+  }
+}
+#endif  // SPECTRE_DEBUG
+
 void test_hash() {
   CHECK(Spectral::MortarSizeHash<1>{}({}) == 0);
 
@@ -655,6 +846,14 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection",
   test_p_projection_matrices<1>();
   test_p_projection_matrices<2>();
   test_p_projection_matrices<3>();
+  test_projection_matrices<1>();
+  test_projection_matrices<2>();
+  test_projection_matrices<3>();
+  test_fourier_p_projections();
+  test_zernike_b2_fourier_equivalence();
+#ifdef SPECTRE_DEBUG
+  test_fourier_and_zernikeb2_asserts();
+#endif  // SPECTRE_DEBUG
   test_hash();
 }
 


### PR DESCRIPTION
## Proposed changes

To use disks / cylinders, there are abutting Fourier edges (no h-refinement allowed, just p)

In the filled disk, the angular direction is `ZernikeB2` basis with `Equiangular` quadrature. From the projection perspective, this can be treated as a `Fourier` basis.

Because the maximum number of allowed points is very large (and because adding Fourier and Equiangular to the inputs needlessly extends the cartesian products of possible inputs to the cache to the point that it fails to compile) a separate cache is made, similar to separate caches in #7128

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
