### PR TITLE
Add Fourier to ExponentialFilter

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp
@@ -58,6 +58,13 @@ const Matrix& Exponential<FilterIndex>::filter_matrix(
              << ".\nUse a different FilterIndex if you need a filter with new "
                 "parameters\n");
 
+  const auto compute_filter = [alpha = alpha_, half_power = half_power_](
+                                  const size_t extents,
+                                  const Spectral::Basis basis,
+                                  const Spectral::Quadrature quadrature) {
+    return Spectral::filtering::exponential_filter(
+        Mesh<1>{extents, basis, quadrature}, alpha, half_power);
+  };
   const static auto cache = make_static_cache<
       CacheRange<1_st,
                  Spectral::maximum_number_of_points<Spectral::Basis::Legendre> +
@@ -68,12 +75,16 @@ const Matrix& Exponential<FilterIndex>::filter_matrix(
                        Spectral::Quadrature::GaussLobatto,
                        Spectral::Quadrature::AxialSymmetry,
                        Spectral::Quadrature::SphericalSymmetry>>(
-      [alpha = alpha_, half_power = half_power_](
-          const size_t extents, const Spectral::Basis basis,
-          const Spectral::Quadrature quadrature) {
-        return Spectral::filtering::exponential_filter(
-            Mesh<1>{extents, basis, quadrature}, alpha, half_power);
+      compute_filter);
+  const static auto fourier_cache = make_static_cache<CacheRange<
+      1_st, Spectral::maximum_number_of_points<Spectral::Basis::Fourier> + 1>>(
+      [compute_filter](const size_t extents) {
+        return compute_filter(extents, Spectral::Basis::Fourier,
+                              Spectral::Quadrature::Equiangular);
       });
+  if (mesh.basis(0) == Spectral::Basis::Fourier) {
+    return fourier_cache(mesh.extents(0));
+  }
   return cache(mesh.extents(0), mesh.basis(0), mesh.quadrature(0));
 }
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -186,10 +186,13 @@ void test_exponential_filter_action(const double alpha,
   using component = Component<metavariables>;
 
   // Division by Dim to reduce time of test
+  const size_t max_pts =
+      BasisType == Spectral::Basis::Fourier
+          ? Spectral::maximum_number_of_points<BasisType> / (3 * Dim)
+          : Spectral::maximum_number_of_points<BasisType> / Dim;
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       num_pts < Spectral::maximum_number_of_points<BasisType> / Dim;
-       ++num_pts) {
+       num_pts < max_pts; ++num_pts) {
     CAPTURE(num_pts);
     const Mesh<Dim> mesh(num_pts, BasisType, QuadratureType);
 
@@ -276,6 +279,9 @@ void invoke_test_exponential_filter_action(const double alpha,
                                  FilterIndividually>(alpha, half_power, enable);
   test_exponential_filter_action<Dim, Spectral::Basis::Chebyshev,
                                  Spectral::Quadrature::Gauss,
+                                 FilterIndividually>(alpha, half_power, enable);
+  test_exponential_filter_action<Dim, Spectral::Basis::Fourier,
+                                 Spectral::Quadrature::Equiangular,
                                  FilterIndividually>(alpha, half_power, enable);
 }
 


### PR DESCRIPTION
## Proposed changes

Because the maximum number of allowed points is very large (and because adding Fourier and Equiangular to the inputs needlessly extends the cartesian products of possible inputs to the cache to the point that it fails to compile) a separate cache is made, similar to separate caches in #7127

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
