### PR TITLE
Fix bug if make_static_cache passed an lvalue ref

### DIFF
--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -438,8 +438,8 @@ class StaticCache {
 /// Create a StaticCache, inferring the cached type from the generator.
 template <typename... Ranges, typename Generator>
 auto make_static_cache(Generator&& generator) {
-  using CachedType = std::remove_cv_t<decltype(generator(
+  using CachedType = std::remove_cvref_t<decltype(generator(
       std::declval<typename Ranges::value_type>()...))>;
-  return StaticCache<std::remove_cv_t<Generator>, CachedType, Ranges...>(
+  return StaticCache<std::remove_cvref_t<Generator>, CachedType, Ranges...>(
       std::forward<Generator>(generator));
 }

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -208,4 +208,30 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
           5)),
       Catch::Matchers::ContainsSubstring("Index out of range: 3 <= 5 < 5"));
 #endif
+
+  // Test that the passed callable is stored, so we don't get a
+  // dangling reference in the usual case that the cache outlives its
+  // calling scope.
+  {
+    struct StoreTest {
+      int value{};
+      int operator()() const { return value; }
+    };
+
+    StoreTest callable{5};
+    const auto cache_from_lvalue = make_static_cache(callable);
+    callable.value = 8;
+    CHECK(cache_from_lvalue() == 5);
+  }
+
+  // Test that the cache caches values, even if the callable returns
+  // by reference
+  {
+    int value = 5;
+    const auto cache_returned_ref =
+        make_static_cache([&value]() -> const int& { return value; });
+    CHECK(cache_returned_ref() == 5);
+    value = 8;
+    CHECK(cache_returned_ref() == 5);
+  }
 }


### PR DESCRIPTION
The stored generator ended up as a reference, which was usually dangling because the cache is intended to be stores in a static variable but the generator generally wasn't.  The correct behavior is to copy the generator.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
